### PR TITLE
fix(tui): retain poll pause session identity

### DIFF
--- a/app/attach_reentry_test.go
+++ b/app/attach_reentry_test.go
@@ -66,9 +66,9 @@ func TestHandleEnter_SecondEnterDuringAttachDoesNotScheduleSecondAttach(t *testi
 	swapRemoteDetachResetWriter(t, &out)
 
 	attaches := 0
-	swapAttachOverlayCallbackFn(t, func(m *home, title, label, traceSuffix string, _ func() (chan struct{}, error)) tea.Cmd {
+	swapAttachOverlayCallbackFn(t, func(m *home, target sessionActionTarget, label, traceSuffix string, _ func() (chan struct{}, error)) tea.Cmd {
 		attaches++
-		return m.attachOverlayCallback(title, label, traceSuffix, func() (chan struct{}, error) {
+		return m.attachOverlayCallback(target, label, traceSuffix, func() (chan struct{}, error) {
 			ch := make(chan struct{})
 			close(ch) // detach immediately, synchronously, no real PTY
 			return ch, nil
@@ -115,9 +115,9 @@ func TestHandleEnter_CanceledAttachHelpDoesNotWedgeGuard(t *testing.T) {
 	var out bytes.Buffer
 	swapRemoteDetachResetWriter(t, &out)
 	attaches := 0
-	swapAttachOverlayCallbackFn(t, func(m *home, title, label, traceSuffix string, _ func() (chan struct{}, error)) tea.Cmd {
+	swapAttachOverlayCallbackFn(t, func(m *home, target sessionActionTarget, label, traceSuffix string, _ func() (chan struct{}, error)) tea.Cmd {
 		attaches++
-		return m.attachOverlayCallback(title, label, traceSuffix, func() (chan struct{}, error) {
+		return m.attachOverlayCallback(target, label, traceSuffix, func() (chan struct{}, error) {
 			ch := make(chan struct{})
 			close(ch)
 			return ch, nil

--- a/app/attach_terminal_handover_test.go
+++ b/app/attach_terminal_handover_test.go
@@ -68,7 +68,7 @@ func TestAttachOverlayCallback_ReleasesTerminalAroundTheAttach(t *testing.T) {
 	ch := make(chan struct{})
 	done := make(chan tea.Cmd, 1)
 	go func() {
-		done <- h.attachOverlayCallback("t1", "test-attach", "", func() (chan struct{}, error) {
+		done <- h.attachOverlayCallback(testAttachTarget(h, "t1"), "test-attach", "", func() (chan struct{}, error) {
 			rec.record("attach")
 			return ch, nil
 		})
@@ -121,7 +121,7 @@ func TestAttachOverlayCallback_ReclaimsTerminalWhenAttachFails(t *testing.T) {
 	var out bytes.Buffer
 	swapRemoteDetachResetWriter(t, &out)
 
-	cmd := h.attachOverlayCallback("t1", "test-attach", "", func() (chan struct{}, error) {
+	cmd := h.attachOverlayCallback(testAttachTarget(h, "t1"), "test-attach", "", func() (chan struct{}, error) {
 		rec.record("attach")
 		return nil, assert.AnError
 	})
@@ -330,7 +330,7 @@ func TestAttachOwnsTheTerminalAlone(t *testing.T) {
 	callbackDone := make(chan struct{})
 	go func() {
 		defer close(callbackDone)
-		h.attachOverlayCallback("t1", "test-attach", "", func() (chan struct{}, error) {
+		h.attachOverlayCallback(testAttachTarget(h, "t1"), "test-attach", "", func() (chan struct{}, error) {
 			go func() {
 				var got []byte
 				buf := make([]byte, 32) // the attach pump's read size

--- a/app/attached_pause_test.go
+++ b/app/attached_pause_test.go
@@ -11,8 +11,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session/git"
 )
+
+func testAttachTarget(h *home, title string) sessionActionTarget {
+	return sessionActionTarget{title: title, repoID: h.repoID}
+}
 
 // assertPostDetachRepaintSequence pins that a post-detach cmd is the uniform
 // tea.Sequence(tea.ClearScreen, repaintAfterDetachMsg) the callback now returns
@@ -129,7 +134,7 @@ func TestAttachOverlayCallback_ClearsFlagOnDetach(t *testing.T) {
 
 	done := make(chan tea.Cmd, 1)
 	go func() {
-		done <- h.attachOverlayCallback("t1", "test-attach", " title=t1", attach)
+		done <- h.attachOverlayCallback(testAttachTarget(h, "t1"), "test-attach", " title=t1", attach)
 	}()
 
 	// While the callback is blocked on <-ch the flag must be set.
@@ -163,7 +168,7 @@ func TestAttachOverlayCallback_LeavesFlagAloneWhenAttachErrors(t *testing.T) {
 	attachErr := errors.New("simulated attach failure")
 	attach := func() (chan struct{}, error) { return nil, attachErr }
 
-	cmd := h.attachOverlayCallback("t1", "test-attach", "", attach)
+	cmd := h.attachOverlayCallback(testAttachTarget(h, "t1"), "test-attach", "", attach)
 
 	assert.Nil(t, cmd, "attachOverlayCallback must return nil when attach fails")
 	assert.False(t, h.attached.Load(),
@@ -180,14 +185,16 @@ func TestAttachOverlayCallback_LeavesFlagAloneWhenAttachErrors(t *testing.T) {
 // on the model under test and no real daemon is contacted.
 func TestAttachOverlayCallback_PausesAndResumesDaemonPoll(t *testing.T) {
 	h := newTestHome(t)
+	target := sessionActionTarget{id: "alpha-id", title: "alpha", repoID: h.repoID}
 
 	var mu sync.Mutex
-	var pausedTitle, resumedTitle string
+	var pausedRequest daemon.PauseStatusPollRequest
+	var resumedRequest daemon.ResumeStatusPollRequest
 	var pauseCount, resumeCount int
 	pausedNow := make(chan struct{}, 1)
-	h.pauseStatusPoll = func(title, _ string) error {
+	h.pauseStatusPoll = func(request daemon.PauseStatusPollRequest) error {
 		mu.Lock()
-		pausedTitle = title
+		pausedRequest = request
 		pauseCount++
 		mu.Unlock()
 		select {
@@ -196,9 +203,9 @@ func TestAttachOverlayCallback_PausesAndResumesDaemonPoll(t *testing.T) {
 		}
 		return nil
 	}
-	h.resumeStatusPoll = func(title, _ string) error {
+	h.resumeStatusPoll = func(request daemon.ResumeStatusPollRequest) error {
 		mu.Lock()
-		resumedTitle = title
+		resumedRequest = request
 		resumeCount++
 		mu.Unlock()
 		return nil
@@ -209,7 +216,7 @@ func TestAttachOverlayCallback_PausesAndResumesDaemonPoll(t *testing.T) {
 
 	done := make(chan tea.Cmd, 1)
 	go func() {
-		done <- h.attachOverlayCallback("alpha", "test-attach", "", attach)
+		done <- h.attachOverlayCallback(target, "test-attach", "", attach)
 	}()
 
 	// The pause must fire while the user is still attached — i.e. before we
@@ -220,7 +227,8 @@ func TestAttachOverlayCallback_PausesAndResumesDaemonPoll(t *testing.T) {
 		t.Fatal("PauseStatusPoll was not called before detach — the daemon poll must pause on attach")
 	}
 	mu.Lock()
-	require.Equal(t, "alpha", pausedTitle, "pause must target the attached instance's title")
+	require.Equal(t, target.pauseStatusPollRequest(), pausedRequest,
+		"pause must retain the attached session's stable identity")
 	require.Positive(t, pauseCount, "pause must fire on attach")
 	require.Zero(t, resumeCount, "resume must not fire while still attached")
 	mu.Unlock()
@@ -236,7 +244,8 @@ func TestAttachOverlayCallback_PausesAndResumesDaemonPoll(t *testing.T) {
 		return resumeCount > 0
 	}, time.Second, time.Millisecond, "ResumeStatusPoll must fire on detach")
 	mu.Lock()
-	assert.Equal(t, "alpha", resumedTitle, "resume must target the detached instance's title")
+	assert.Equal(t, target.resumeStatusPollRequest(), resumedRequest,
+		"resume must release the exact stable lease acquired on attach")
 	mu.Unlock()
 
 	require.False(t, h.attached.Load(), "attached flag must clear on detach")
@@ -260,7 +269,7 @@ func TestAttachOverlayCallback_ResumeOrderedAfterLastPause(t *testing.T) {
 	releasePause := make(chan struct{})
 	firstPause := true
 
-	h.pauseStatusPoll = func(_, _ string) error {
+	h.pauseStatusPoll = func(daemon.PauseStatusPollRequest) error {
 		// Only gate the FIRST pause (the on-attach one) so the test can hold a
 		// pause RPC "in flight" across the detach and prove resume waits for it.
 		mu.Lock()
@@ -279,7 +288,7 @@ func TestAttachOverlayCallback_ResumeOrderedAfterLastPause(t *testing.T) {
 		mu.Unlock()
 		return nil
 	}
-	h.resumeStatusPoll = func(_, _ string) error {
+	h.resumeStatusPoll = func(daemon.ResumeStatusPollRequest) error {
 		mu.Lock()
 		order = append(order, "resume")
 		mu.Unlock()
@@ -290,7 +299,7 @@ func TestAttachOverlayCallback_ResumeOrderedAfterLastPause(t *testing.T) {
 	attach := func() (chan struct{}, error) { return ch, nil }
 	done := make(chan tea.Cmd, 1)
 	go func() {
-		done <- h.attachOverlayCallback("alpha", "test-attach", "", attach)
+		done <- h.attachOverlayCallback(testAttachTarget(h, "alpha"), "test-attach", "", attach)
 	}()
 
 	// Wait until the on-attach pause is in-flight (blocked on releasePause).
@@ -333,15 +342,15 @@ func TestAttachOverlayCallback_ResumeOrderedAfterLastPause(t *testing.T) {
 // callback still returns the repaint cmd and clears m.attached via its defer.
 func TestAttachOverlayCallback_AttachSucceedsWhenPauseErrors(t *testing.T) {
 	h := newTestHome(t)
-	h.pauseStatusPoll = func(string, string) error { return errors.New("daemon down") }
-	h.resumeStatusPoll = func(string, string) error { return errors.New("daemon down") }
+	h.pauseStatusPoll = func(daemon.PauseStatusPollRequest) error { return errors.New("daemon down") }
+	h.resumeStatusPoll = func(daemon.ResumeStatusPollRequest) error { return errors.New("daemon down") }
 
 	ch := make(chan struct{})
 	attach := func() (chan struct{}, error) { return ch, nil }
 
 	done := make(chan tea.Cmd, 1)
 	go func() {
-		done <- h.attachOverlayCallback("alpha", "test-attach", "", attach)
+		done <- h.attachOverlayCallback(testAttachTarget(h, "alpha"), "test-attach", "", attach)
 	}()
 
 	require.Eventually(t, func() bool { return h.attached.Load() },

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -106,8 +106,8 @@ func newTestHome(t *testing.T) *home {
 		// Per-home fields (not shared globals), so parallel tests can't race each
 		// other's swaps; tests exercising the pause/resume path assign their own
 		// recorders to h.pauseStatusPoll / h.resumeStatusPoll.
-		pauseStatusPoll:  func(string, string) error { return nil },
-		resumeStatusPoll: func(string, string) error { return nil },
+		pauseStatusPoll:  func(daemon.PauseStatusPollRequest) error { return nil },
+		resumeStatusPoll: func(daemon.ResumeStatusPollRequest) error { return nil },
 		store:            proj,
 		repoID:           repoID,
 	}

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -775,6 +775,7 @@ func (m *home) attachInstanceTab(instance *session.Instance, tabIdx int, agentLa
 	// instance + repoID are captured here at keypress so a deferred attach (help
 	// overlay open) targets the captured session, not a drifted selection (#716).
 	repoID := m.repoID
+	target := captureSessionActionTarget(instance, repoID)
 	attach := func() (chan struct{}, error) {
 		// Address the attach by the tab's stable id (#1738) so a reorder/close can't
 		// misroute the full-screen stream; empty falls back to the ordinal.
@@ -783,7 +784,7 @@ func (m *home) attachInstanceTab(instance *session.Instance, tabIdx int, agentLa
 	}
 	return m.showHelpScreen(helpAttach(instance, tabIdx), func() tea.Cmd {
 		return m.beginAttachTransition(func() tea.Cmd {
-			return attachOverlayCallbackFn(m, instance.Title, label, "", attach)
+			return attachOverlayCallbackFn(m, target, label, "", attach)
 		})
 	})
 }

--- a/app/handle_actions_test.go
+++ b/app/handle_actions_test.go
@@ -44,8 +44,8 @@ func TestHandleEnterAttachesCapturedInstanceAfterSelectionDrift(t *testing.T) {
 	// into the attach closure at Enter-press time (#716), so a title of
 	// "instance-b" here would mean the code re-read the drifted live selection.
 	var attachedTitle string
-	swapAttachOverlayCallbackFn(t, func(m *home, title, label, traceSuffix string, _ func() (chan struct{}, error)) tea.Cmd {
-		attachedTitle = title
+	swapAttachOverlayCallbackFn(t, func(m *home, target sessionActionTarget, label, traceSuffix string, _ func() (chan struct{}, error)) tea.Cmd {
+		attachedTitle = target.title
 		return nil
 	})
 
@@ -76,7 +76,7 @@ func TestFirstRunAttachHelpEscCancelsAttach(t *testing.T) {
 	h.sidebar.SetSelectedInstance(0)
 
 	attached := 0
-	swapAttachOverlayCallbackFn(t, func(m *home, title, label, traceSuffix string, attach func() (chan struct{}, error)) tea.Cmd {
+	swapAttachOverlayCallbackFn(t, func(m *home, target sessionActionTarget, label, traceSuffix string, attach func() (chan struct{}, error)) tea.Cmd {
 		attached++
 		return nil
 	})

--- a/app/handle_enter_remote_terminal_test.go
+++ b/app/handle_enter_remote_terminal_test.go
@@ -35,7 +35,7 @@ func (remoteFakeBackend) Capabilities() session.Capabilities {
 // closure with one that detaches immediately (a pre-closed channel), so the real
 // post-detach lifecycle runs synchronously without a tmux client or a remote
 // terminal_cmd PTY.
-func swapAttachOverlayCallbackFn(t *testing.T, fn func(*home, string, string, string, func() (chan struct{}, error)) tea.Cmd) {
+func swapAttachOverlayCallbackFn(t *testing.T, fn func(*home, sessionActionTarget, string, string, func() (chan struct{}, error)) tea.Cmd) {
 	t.Helper()
 	prev := attachOverlayCallbackFn
 	attachOverlayCallbackFn = fn
@@ -83,8 +83,8 @@ func driveHandleEnterAttach(t *testing.T, terminalTab, remote bool) (tea.Cmd, st
 
 	var out bytes.Buffer
 	swapRemoteDetachResetWriter(t, &out)
-	swapAttachOverlayCallbackFn(t, func(m *home, title, label, traceSuffix string, _ func() (chan struct{}, error)) tea.Cmd {
-		return m.attachOverlayCallback(title, label, traceSuffix, func() (chan struct{}, error) {
+	swapAttachOverlayCallbackFn(t, func(m *home, target sessionActionTarget, label, traceSuffix string, _ func() (chan struct{}, error)) tea.Cmd {
+		return m.attachOverlayCallback(target, label, traceSuffix, func() (chan struct{}, error) {
 			ch := make(chan struct{})
 			close(ch) // detach immediately, synchronously, no real PTY
 			return ch, nil
@@ -208,8 +208,8 @@ func TestHandleEnter_RemotePanePreviewTriggersFullScreenAttach(t *testing.T) {
 	// instead of the test's terminal.
 	var out bytes.Buffer
 	swapRemoteDetachResetWriter(t, &out)
-	swapAttachOverlayCallbackFn(t, func(m *home, title, label, traceSuffix string, _ func() (chan struct{}, error)) tea.Cmd {
-		return m.attachOverlayCallback(title, label, traceSuffix, func() (chan struct{}, error) {
+	swapAttachOverlayCallbackFn(t, func(m *home, target sessionActionTarget, label, traceSuffix string, _ func() (chan struct{}, error)) tea.Cmd {
+		return m.attachOverlayCallback(target, label, traceSuffix, func() (chan struct{}, error) {
 			ch := make(chan struct{})
 			close(ch) // detach immediately, synchronously, no real PTY
 			return ch, nil

--- a/app/home_attach.go
+++ b/app/home_attach.go
@@ -8,6 +8,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/apiclient"
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
@@ -155,7 +156,7 @@ func SetAttachStreamFnForTest(fn func(context.Context, string, string, string, i
 // terminal-tab) all funnel through one place — and so the pause-while-attached
 // gating + the flag-clears-on-error path are testable without spinning up
 // a real WS stream.
-func (m *home) attachOverlayCallback(title, label, traceSuffix string, attach func() (chan struct{}, error)) tea.Cmd {
+func (m *home) attachOverlayCallback(target sessionActionTarget, label, traceSuffix string, attach func() (chan struct{}, error)) tea.Cmd {
 	detachTraceMark(label + "-onDismiss-entry" + traceSuffix)
 	// Snapshot the terminal-write seam ONCE, here, before the attach starts —
 	// same rule as the per-home seams captured below and as apiclient's attach
@@ -188,16 +189,15 @@ func (m *home) attachOverlayCallback(title, label, traceSuffix string, attach fu
 	// heartbeat renews the daemon's lease-bounded pause until detach; the pause
 	// is best-effort so a down/slow daemon never disturbs the attach.
 	//
-	// Capture the seams + repoID off the home HERE, on the event loop, before
+	// Capture the seams off the home HERE, on the event loop, before
 	// any goroutine spawns: the seams are per-home fields (not shared globals)
 	// precisely so the goroutines never read home state a sibling test could
 	// reassign under `go test -parallel -race` (the #964 / #960-PR4 race class).
 	pause := m.pauseStatusPoll
 	resume := m.resumeStatusPoll
-	repoID := m.repoID
 	pauseDone := make(chan struct{})
 	heartbeatExited := make(chan struct{})
-	go runStatusPollPauseHeartbeat(pause, title, repoID, pauseDone, heartbeatExited)
+	go runStatusPollPauseHeartbeat(pause, target.pauseStatusPollRequest(), pauseDone, heartbeatExited)
 
 	m.attached.Store(true)
 	defer m.attached.Store(false)
@@ -217,7 +217,7 @@ func (m *home) attachOverlayCallback(title, label, traceSuffix string, attach fu
 	// never blocks on the wait or the RPC — attach/detach responsiveness is the
 	// whole point of #1160.
 	close(pauseDone)
-	go runStatusPollResume(resume, title, repoID, heartbeatExited)
+	go runStatusPollResume(resume, target.resumeStatusPollRequest(), heartbeatExited)
 	detachStart := time.Now()
 	detachTraceMark(label + "-<-ch-unblocked" + traceSuffix)
 	m.attachTransitioning = false
@@ -337,18 +337,18 @@ const statusPollRenewInterval = 1 * time.Second
 
 // runStatusPollPauseHeartbeat pauses the daemon's capture-pane poll for the
 // attached instance and renews that lease every statusPollRenewInterval until
-// done closes (detach), then closes exited. pause + repoID are captured off the
+// done closes (detach), then closes exited. pause + request are captured off the
 // event loop by the caller so this goroutine never touches shared home state
 // (#964 race class). Every RPC is best-effort — a down/slow daemon logs and
 // continues, never disturbing the attach (worst case the daemon keeps polling,
 // the pre-#1160 behavior). Because pause() is called SYNCHRONOUSLY in the loop,
 // once this goroutine returns no pause RPC is in-flight or pending, so exited
 // firing is the signal a following resume can safely win the wire.
-func runStatusPollPauseHeartbeat(pause func(title, repoID string) error, title, repoID string, done <-chan struct{}, exited chan<- struct{}) {
+func runStatusPollPauseHeartbeat(pause func(daemon.PauseStatusPollRequest) error, request daemon.PauseStatusPollRequest, done <-chan struct{}, exited chan<- struct{}) {
 	defer close(exited)
 	send := func() {
-		if err := pause(title, repoID); err != nil {
-			log.ErrorLog.Printf("failed to pause daemon status poll for %q: %v", title, err)
+		if err := pause(request); err != nil {
+			log.ErrorLog.Printf("failed to pause daemon status poll for %q: %v", request.Title, err)
 		}
 	}
 	send() // pause immediately on attach, before the first renew tick
@@ -368,12 +368,12 @@ func runStatusPollPauseHeartbeat(pause func(title, repoID string) error, title, 
 // resumes immediately rather than after the lease expires (#1160). It waits for
 // heartbeatExited FIRST so the resume RPC strictly follows the heartbeat's final
 // pause() — guaranteeing resume wins over any in-flight pause instead of racing
-// it (Greptile P). resume + repoID are captured off the event loop by the
+// it (Greptile P). resume + request are captured off the event loop by the
 // caller (#964 race class). Best-effort; the caller runs this on its own
 // goroutine so the detach hot path never blocks on the wait or the RPC.
-func runStatusPollResume(resume func(title, repoID string) error, title, repoID string, heartbeatExited <-chan struct{}) {
+func runStatusPollResume(resume func(daemon.ResumeStatusPollRequest) error, request daemon.ResumeStatusPollRequest, heartbeatExited <-chan struct{}) {
 	<-heartbeatExited
-	if err := resume(title, repoID); err != nil {
-		log.ErrorLog.Printf("failed to resume daemon status poll for %q: %v", title, err)
+	if err := resume(request); err != nil {
+		log.ErrorLog.Printf("failed to resume daemon status poll for %q: %v", request.Title, err)
 	}
 }

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -109,8 +109,8 @@ type home struct {
 	// seams; the goroutine captures them into locals at spawn so it never touches
 	// shared home state mid-flight. Default to pauseStatusPollThroughDaemon /
 	// resumeStatusPollThroughDaemon in production; tests assign fakes directly.
-	pauseStatusPoll  func(title, repoID string) error
-	resumeStatusPoll func(title, repoID string) error
+	pauseStatusPoll  func(daemon.PauseStatusPollRequest) error
+	resumeStatusPoll func(daemon.ResumeStatusPollRequest) error
 	// releaseTerminal / restoreTerminal hand the REAL terminal to a full-screen
 	// attach and take it back (#2157). They are Bubble Tea's own
 	// Program.ReleaseTerminal / RestoreTerminal, wired in Run; PER-home fields
@@ -305,9 +305,9 @@ type home struct {
 	// only; the pane's green frame and the status bar mirror it.
 	interactive bool
 
-	// interactivePauseTitle is the session whose #1160 capture-poll pause lease
+	// interactivePauseTarget is the session whose #1160 capture-poll pause lease
 	// this TUI currently holds because the user is typing into it through the
-	// FOCUSED embedded interactive pane (#1586). Empty when not interactively
+	// FOCUSED embedded interactive pane (#1586). Zero when not interactively
 	// focused on a local session. Holding the lease makes the daemon treat the
 	// session as attached and DEFER automated task deliveries (cron/watch) into
 	// it, so a scheduled prompt can't paste into and submit the user's
@@ -316,8 +316,8 @@ type home struct {
 	// the preview tick and released when interactive mode ends;
 	// interactivePauseAt throttles the renew to statusPollRenewInterval.
 	// Event-loop only.
-	interactivePauseTitle string
-	interactivePauseAt    time.Time
+	interactivePauseTarget sessionActionTarget
+	interactivePauseAt     time.Time
 
 	// initialPaneOpened latches the one-time startup auto-open: the first
 	// instance selection opens its pane so the workspace isn't empty on

--- a/app/interactive_defer_test.go
+++ b/app/interactive_defer_test.go
@@ -71,6 +71,59 @@ func TestInteractivePollPause_HoldsLeaseForFocusedInteractivePane(t *testing.T) 
 	assert.Empty(t, h.interactivePauseTitle)
 }
 
+// TestInteractivePollPause_SameTitleReplacementTransfersLease is the #2358
+// fail-first. A capture-poll lease belongs to the session being edited, not to
+// its reusable title: when a snapshot replaces the focused pane binding with a
+// different same-title session, the old lease must be released and the new
+// identity paused immediately. Comparing only titles mistakes the replacement
+// for a renewal of the old session and does neither.
+func TestInteractivePollPause_SameTitleReplacementTransfersLease(t *testing.T) {
+	h, original := liveTestHome(t)
+	stubLiveTermFactory(t)
+	h.syncLiveTermPane()
+
+	var mu sync.Mutex
+	var paused, resumed []string
+	h.pauseStatusPoll = func(title, _ string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		paused = append(paused, title)
+		return nil
+	}
+	h.resumeStatusPoll = func(title, _ string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		resumed = append(resumed, title)
+		return nil
+	}
+	run := func(cmd tea.Cmd) {
+		if cmd != nil {
+			_ = cmd()
+		}
+	}
+
+	h.setInteractive(true)
+	run(h.interactivePollPauseCmd())
+	require.Equal(t, original.Title, h.interactivePauseTitle, "precondition: original lease is retained")
+
+	replacement := startedLocalInstance(t, "replacement")
+	replacement.Title = original.Title
+	require.NotEqual(t, original.ID, replacement.ID, "replacement must have a distinct stable identity")
+	require.Equal(t, original.Title, replacement.Title, "replacement must reuse the exact title")
+	require.True(t, h.store.ReplaceInstanceByTitle(original.Title, replacement))
+	require.Same(t, replacement, h.focusedOpenPane().Instance(), "focused pane must now bind the replacement")
+	require.True(t, h.interactive, "replacement must occur while the pane remains interactive")
+	require.Equal(t, original.Title, h.interactivePauseTitle, "old title-only lease must still be retained")
+	h.interactivePauseAt = time.Now() // stay inside the title-only renewal throttle
+
+	run(h.interactivePollPauseCmd())
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, paused, 2, "replacement identity must acquire its own pause immediately")
+	require.Len(t, resumed, 1, "the original identity's pause must be released")
+}
+
 // TestInteractivePollPause_NoLeaseWhileFullScreenAttached pins that the
 // embedded-interactive hold yields to full-screen attach, which runs its own
 // pause heartbeat (attachOverlayCallback): while m.attached is set the embedded

--- a/app/interactive_defer_test.go
+++ b/app/interactive_defer_test.go
@@ -8,6 +8,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/daemon"
 )
 
 // TestInteractivePollPause_HoldsLeaseForFocusedInteractivePane is the
@@ -25,16 +27,16 @@ func TestInteractivePollPause_HoldsLeaseForFocusedInteractivePane(t *testing.T) 
 
 	var mu sync.Mutex
 	var paused, resumed []string
-	h.pauseStatusPoll = func(title, _ string) error {
+	h.pauseStatusPoll = func(request daemon.PauseStatusPollRequest) error {
 		mu.Lock()
 		defer mu.Unlock()
-		paused = append(paused, title)
+		paused = append(paused, request.Title)
 		return nil
 	}
-	h.resumeStatusPoll = func(title, _ string) error {
+	h.resumeStatusPoll = func(request daemon.ResumeStatusPollRequest) error {
 		mu.Lock()
 		defer mu.Unlock()
-		resumed = append(resumed, title)
+		resumed = append(resumed, request.Title)
 		return nil
 	}
 	run := func(cmd tea.Cmd) {
@@ -53,7 +55,7 @@ func TestInteractivePollPause_HoldsLeaseForFocusedInteractivePane(t *testing.T) 
 	h.setInteractive(true)
 	run(h.interactivePollPauseCmd())
 	assert.Equal(t, []string{inst.Title}, pausedSnap(), "entering an interactive pane holds the target's lease")
-	assert.Equal(t, inst.Title, h.interactivePauseTitle)
+	assert.Equal(t, inst.ID, h.interactivePauseTarget.id)
 
 	// Still interactive within the renew window → throttled, no extra RPC.
 	run(h.interactivePollPauseCmd())
@@ -68,7 +70,7 @@ func TestInteractivePollPause_HoldsLeaseForFocusedInteractivePane(t *testing.T) 
 	h.setInteractive(false)
 	run(h.interactivePollPauseCmd())
 	assert.Equal(t, []string{inst.Title}, resumedSnap(), "leaving interactive releases the lease")
-	assert.Empty(t, h.interactivePauseTitle)
+	assert.True(t, h.interactivePauseTarget.isZero())
 }
 
 // TestInteractivePollPause_SameTitleReplacementTransfersLease is the #2358
@@ -83,17 +85,18 @@ func TestInteractivePollPause_SameTitleReplacementTransfersLease(t *testing.T) {
 	h.syncLiveTermPane()
 
 	var mu sync.Mutex
-	var paused, resumed []string
-	h.pauseStatusPoll = func(title, _ string) error {
+	var paused []daemon.PauseStatusPollRequest
+	var resumed []daemon.ResumeStatusPollRequest
+	h.pauseStatusPoll = func(request daemon.PauseStatusPollRequest) error {
 		mu.Lock()
 		defer mu.Unlock()
-		paused = append(paused, title)
+		paused = append(paused, request)
 		return nil
 	}
-	h.resumeStatusPoll = func(title, _ string) error {
+	h.resumeStatusPoll = func(request daemon.ResumeStatusPollRequest) error {
 		mu.Lock()
 		defer mu.Unlock()
-		resumed = append(resumed, title)
+		resumed = append(resumed, request)
 		return nil
 	}
 	run := func(cmd tea.Cmd) {
@@ -104,7 +107,7 @@ func TestInteractivePollPause_SameTitleReplacementTransfersLease(t *testing.T) {
 
 	h.setInteractive(true)
 	run(h.interactivePollPauseCmd())
-	require.Equal(t, original.Title, h.interactivePauseTitle, "precondition: original lease is retained")
+	require.Equal(t, original.ID, h.interactivePauseTarget.id, "precondition: original lease is retained")
 
 	replacement := startedLocalInstance(t, "replacement")
 	replacement.Title = original.Title
@@ -113,7 +116,7 @@ func TestInteractivePollPause_SameTitleReplacementTransfersLease(t *testing.T) {
 	require.True(t, h.store.ReplaceInstanceByTitle(original.Title, replacement))
 	require.Same(t, replacement, h.focusedOpenPane().Instance(), "focused pane must now bind the replacement")
 	require.True(t, h.interactive, "replacement must occur while the pane remains interactive")
-	require.Equal(t, original.Title, h.interactivePauseTitle, "old title-only lease must still be retained")
+	require.Equal(t, original.ID, h.interactivePauseTarget.id, "old identity lease must still be retained")
 	h.interactivePauseAt = time.Now() // stay inside the title-only renewal throttle
 
 	run(h.interactivePollPauseCmd())
@@ -122,6 +125,8 @@ func TestInteractivePollPause_SameTitleReplacementTransfersLease(t *testing.T) {
 	defer mu.Unlock()
 	require.Len(t, paused, 2, "replacement identity must acquire its own pause immediately")
 	require.Len(t, resumed, 1, "the original identity's pause must be released")
+	require.Equal(t, []string{original.ID, replacement.ID}, []string{paused[0].ID, paused[1].ID})
+	require.Equal(t, original.ID, resumed[0].ID)
 }
 
 // TestInteractivePollPause_NoLeaseWhileFullScreenAttached pins that the
@@ -135,13 +140,13 @@ func TestInteractivePollPause_NoLeaseWhileFullScreenAttached(t *testing.T) {
 
 	var mu sync.Mutex
 	var paused []string
-	h.pauseStatusPoll = func(title, _ string) error {
+	h.pauseStatusPoll = func(request daemon.PauseStatusPollRequest) error {
 		mu.Lock()
 		defer mu.Unlock()
-		paused = append(paused, title)
+		paused = append(paused, request.Title)
 		return nil
 	}
-	h.resumeStatusPoll = func(string, string) error { return nil }
+	h.resumeStatusPoll = func(daemon.ResumeStatusPollRequest) error { return nil }
 
 	h.setInteractive(true)
 	h.attached.Store(true) // full-screen attach owns the lease now
@@ -151,5 +156,5 @@ func TestInteractivePollPause_NoLeaseWhileFullScreenAttached(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	assert.Empty(t, paused, "the embedded path must not pause while full-screen attached")
-	assert.Empty(t, h.interactivePauseTitle)
+	assert.True(t, h.interactivePauseTarget.isZero())
 }

--- a/app/interactive_test.go
+++ b/app/interactive_test.go
@@ -422,7 +422,7 @@ func TestEnterOnRemotePaneFallsBackToFullScreenAttach(t *testing.T) {
 	openTestPane(t, h, inst, 0)
 
 	attached := 0
-	swapAttachOverlayCallbackFn(t, func(m *home, title, label, traceSuffix string, _ func() (chan struct{}, error)) tea.Cmd {
+	swapAttachOverlayCallbackFn(t, func(m *home, target sessionActionTarget, label, traceSuffix string, _ func() (chan struct{}, error)) tea.Cmd {
 		attached++
 		return nil
 	})
@@ -440,7 +440,7 @@ func TestAttachKeyKeepsFullScreenAttach(t *testing.T) {
 		helpTypeInteractive{}.mask()|helpTypeInstanceAttach{}.mask()))
 
 	attached := 0
-	swapAttachOverlayCallbackFn(t, func(m *home, title, label, traceSuffix string, _ func() (chan struct{}, error)) tea.Cmd {
+	swapAttachOverlayCallbackFn(t, func(m *home, target sessionActionTarget, label, traceSuffix string, _ func() (chan struct{}, error)) tea.Cmd {
 		attached++
 		return nil
 	})

--- a/app/live_termpane.go
+++ b/app/live_termpane.go
@@ -230,49 +230,48 @@ func (m *home) paneIsPreviewing(p *store.OpenPane) bool {
 func (m *home) interactivePollPauseCmd() tea.Cmd {
 	// The session the user is actively typing into in-pane, if any. Interactive
 	// mode is only ever true while the FOCUSED pane has a live attachment, whose
-	// instance is a local, started session, so its title keys the same daemon pause
-	// map full-screen attach uses.
-	want := ""
+	// instance is a local, started session. Capture the same stable identity the
+	// full-screen attach heartbeat uses; title is only legacy/display context.
+	want := sessionActionTarget{}
 	if m.interactive && !m.attached.Load() {
 		if p := m.focusedOpenPane(); p != nil {
 			if inst := p.Instance(); inst != nil {
-				want = inst.Title
+				want = captureSessionActionTarget(inst, m.repoID)
 			}
 		}
 	}
 
-	// Capture the seams + repoID on the event loop before any goroutine reads them
+	// Capture the seams on the event loop before any goroutine reads them
 	// (the #964 per-home-field discipline).
-	repoID := m.repoID
 	pause := m.pauseStatusPoll
 	resume := m.resumeStatusPoll
 
-	if want == "" {
-		if m.interactivePauseTitle == "" {
+	if want.isZero() {
+		if m.interactivePauseTarget.isZero() {
 			return nil
 		}
 		// Interactive ended (or focus left the pane): release the lease now so the
 		// daemon resumes delivering into the session immediately.
-		release := m.interactivePauseTitle
-		m.interactivePauseTitle = ""
+		release := m.interactivePauseTarget.resumeStatusPollRequest()
+		m.interactivePauseTarget = sessionActionTarget{}
 		m.interactivePauseAt = time.Time{}
 		return func() tea.Msg {
-			_ = resume(release, repoID)
+			_ = resume(release)
 			return nil
 		}
 	}
 
-	if want != m.interactivePauseTitle {
+	if !want.sameIdentity(m.interactivePauseTarget) {
 		// Newly interactive on this session (or the focused session changed): release
 		// any previous hold and pause the new target.
-		prev := m.interactivePauseTitle
-		m.interactivePauseTitle = want
+		prev := m.interactivePauseTarget
+		m.interactivePauseTarget = want
 		m.interactivePauseAt = time.Now()
 		return func() tea.Msg {
-			if prev != "" {
-				_ = resume(prev, repoID)
+			if !prev.isZero() {
+				_ = resume(prev.resumeStatusPollRequest())
 			}
-			_ = pause(want, repoID)
+			_ = pause(want.pauseStatusPollRequest())
 			return nil
 		}
 	}
@@ -284,7 +283,7 @@ func (m *home) interactivePollPauseCmd() tea.Cmd {
 	}
 	m.interactivePauseAt = time.Now()
 	return func() tea.Msg {
-		_ = pause(want, repoID)
+		_ = pause(want.pauseStatusPollRequest())
 		return nil
 	}
 }

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -1281,9 +1281,9 @@ func TestPane_EnterAttachTargetFollowsFocusContext(t *testing.T) {
 	h.cancelPanePreview(false)
 
 	var attachedLabel, attachedTitle string
-	swapAttachOverlayCallbackFn(t, func(m *home, title, label, traceSuffix string, _ func() (chan struct{}, error)) tea.Cmd {
-		attachedLabel, attachedTitle = label, title
-		return m.attachOverlayCallback(title, label, traceSuffix, func() (chan struct{}, error) {
+	swapAttachOverlayCallbackFn(t, func(m *home, target sessionActionTarget, label, traceSuffix string, _ func() (chan struct{}, error)) tea.Cmd {
+		attachedLabel, attachedTitle = label, target.title
+		return m.attachOverlayCallback(target, label, traceSuffix, func() (chan struct{}, error) {
 			ch := make(chan struct{})
 			close(ch) // detach immediately — no real PTY
 			return ch, nil

--- a/app/remote_detach_reset_test.go
+++ b/app/remote_detach_reset_test.go
@@ -30,7 +30,7 @@ func runAttachOverlayCallback(t *testing.T, h *home) tea.Cmd {
 	ch := make(chan struct{})
 	done := make(chan tea.Cmd, 1)
 	go func() {
-		done <- h.attachOverlayCallback("t1", "test-attach", "", func() (chan struct{}, error) {
+		done <- h.attachOverlayCallback(testAttachTarget(h, "t1"), "test-attach", "", func() (chan struct{}, error) {
 			return ch, nil
 		})
 	}()
@@ -186,7 +186,7 @@ func TestAttachOverlayCallback_NoResetWhenAttachErrors(t *testing.T) {
 	var out bytes.Buffer
 	swapRemoteDetachResetWriter(t, &out)
 
-	cmd := h.attachOverlayCallback("t1", "test-attach", "", func() (chan struct{}, error) {
+	cmd := h.attachOverlayCallback(testAttachTarget(h, "t1"), "test-attach", "", func() (chan struct{}, error) {
 		return nil, assert.AnError
 	})
 

--- a/app/session_action_target.go
+++ b/app/session_action_target.go
@@ -26,6 +26,23 @@ func captureSessionActionTarget(inst *session.Instance, repoID string) sessionAc
 	}
 }
 
+func (target sessionActionTarget) isZero() bool {
+	return target.id == "" && target.title == "" && target.repoID == "" && target.createdAt.IsZero()
+}
+
+// sameIdentity compares the immutable part of two retained targets. A stable ID
+// is authoritative; pre-ID records fall back to the same non-zero CreatedAt
+// policy resolveSessionActionTarget uses.
+func (target sessionActionTarget) sameIdentity(other sessionActionTarget) bool {
+	if target.repoID != other.repoID {
+		return false
+	}
+	if target.id != "" || other.id != "" {
+		return target.id != "" && target.id == other.id
+	}
+	return target.title == other.title && !target.createdAt.IsZero() && target.createdAt.Equal(other.createdAt)
+}
+
 // resolveSessionActionTarget resolves target only inside the project that
 // captured it. A non-empty ID is authoritative and never falls back to title.
 // Legacy records use the same non-zero CreatedAt fallback as snapshot
@@ -67,6 +84,14 @@ func (target sessionActionTarget) restoreRequest() daemon.RestoreSessionRequest 
 
 func (target sessionActionTarget) setPRInfoRequest(info session.PRInfoData) daemon.SetPRInfoRequest {
 	return daemon.SetPRInfoRequest{ID: target.id, Title: target.title, RepoID: target.repoID, PRInfo: info}
+}
+
+func (target sessionActionTarget) pauseStatusPollRequest() daemon.PauseStatusPollRequest {
+	return daemon.PauseStatusPollRequest{ID: target.id, Title: target.title, RepoID: target.repoID}
+}
+
+func (target sessionActionTarget) resumeStatusPollRequest() daemon.ResumeStatusPollRequest {
+	return daemon.ResumeStatusPollRequest{ID: target.id, Title: target.title, RepoID: target.repoID}
 }
 
 func (target sessionActionTarget) handoffRequest(to string) daemon.HandoffSessionRequest {

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -290,15 +290,15 @@ var (
 // swap under `go test -parallel -race` (the #964 / #960-PR4 snapshot-fetcher
 // race). The seams live per-home instead; tests assign a fake to
 // h.pauseStatusPoll / h.resumeStatusPoll directly.
-func pauseStatusPollThroughDaemon(title, repoID string) error {
+func pauseStatusPollThroughDaemon(request daemon.PauseStatusPollRequest) error {
 	return withDaemonHTTP(func(c *apiclient.Client) error {
-		return c.PauseStatusPoll(daemon.PauseStatusPollRequest{Title: title, RepoID: repoID})
+		return c.PauseStatusPoll(request)
 	})
 }
 
-func resumeStatusPollThroughDaemon(title, repoID string) error {
+func resumeStatusPollThroughDaemon(request daemon.ResumeStatusPollRequest) error {
 	return withDaemonHTTP(func(c *apiclient.Client) error {
-		return c.ResumeStatusPoll(daemon.ResumeStatusPollRequest{Title: title, RepoID: repoID})
+		return c.ResumeStatusPoll(request)
 	})
 }
 

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -72,7 +72,7 @@ func (s *controlServer) PauseStatusPoll(req PauseStatusPollRequest, resp *PauseS
 		return err
 	}
 	if s.manager != nil {
-		s.manager.PauseStatusPoll(req.RepoID, req.Title)
+		s.manager.PauseStatusPoll(req.RepoID, req.Title, req.ID)
 	}
 	resp.OK = true
 	return nil
@@ -85,7 +85,7 @@ func (s *controlServer) ResumeStatusPoll(req ResumeStatusPollRequest, resp *Resu
 		return err
 	}
 	if s.manager != nil {
-		s.manager.ResumeStatusPoll(req.RepoID, req.Title)
+		s.manager.ResumeStatusPoll(req.RepoID, req.Title, req.ID)
 	}
 	resp.OK = true
 	return nil

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -438,8 +438,8 @@ type SetPRInfoResponse struct {
 
 // PauseStatusPollRequest asks the daemon to pause its per-instance capture-pane
 // liveness poll for ONE session while a TUI is attached full-screen to it
-// (#1160, Fix A follow-up to #1157). Title selects the session; RepoID scopes
-// the lookup like the other sessions verbs. There is deliberately NO
+// (#1160, Fix A follow-up to #1157). ID identifies the lease owner when
+// present; legacy clients fall back to {Title, RepoID}. There is deliberately NO
 // client-supplied duration: the daemon always applies its own fixed
 // statusPollLease, so a misbehaving or crashed client can never silence an
 // instance for an unbounded time. The TUI renews the lease with a heartbeat
@@ -447,6 +447,9 @@ type SetPRInfoResponse struct {
 type PauseStatusPollRequest struct {
 	Title  string `json:"title"`
 	RepoID string `json:"repo_id"`
+	// ID is the attached session's stable id. Keying the lease by identity keeps
+	// an old heartbeat from pausing a different session that reused the title.
+	ID string `json:"id"`
 }
 
 type PauseStatusPollResponse struct {
@@ -459,6 +462,8 @@ type PauseStatusPollResponse struct {
 type ResumeStatusPollRequest struct {
 	Title  string `json:"title"`
 	RepoID string `json:"repo_id"`
+	// ID is the stable lease key; see PauseStatusPollRequest.ID.
+	ID string `json:"id"`
 }
 
 type ResumeStatusPollResponse struct {

--- a/daemon/defer_attached_test.go
+++ b/daemon/defer_attached_test.go
@@ -27,7 +27,7 @@ func TestDeliverPrompt_DefersWhileTargetAttached(t *testing.T) {
 
 	// A TUI attaches full-screen to the target: the daemon's pause-poll lease is
 	// the "attached" signal (#1160) the defer reuses.
-	manager.PauseStatusPoll(repoID, "captain")
+	manager.PauseStatusPoll(repoID, "captain", "")
 
 	status, err := manager.DeliverPrompt(DeliverPromptRequest{
 		Title:              "captain",
@@ -47,7 +47,7 @@ func TestDeliverPrompt_DefersWhileTargetAttached(t *testing.T) {
 	}
 
 	// On detach the very same delivery lands normally.
-	manager.ResumeStatusPoll(repoID, "captain")
+	manager.ResumeStatusPoll(repoID, "captain", "")
 	status, err = manager.DeliverPrompt(DeliverPromptRequest{
 		Title:              "captain",
 		RepoPath:           repoPath,
@@ -76,7 +76,7 @@ func TestDeliverPrompt_ManualSendDeliversWhileTargetAttached(t *testing.T) {
 	backend := recordingBackend{readyFakeBackend{session.NewFakeBackend()}, rec}
 	registerStarted(t, manager, repoID, repoPath, "captain", backend, true, session.Running)
 
-	manager.PauseStatusPoll(repoID, "captain")
+	manager.PauseStatusPoll(repoID, "captain", "")
 
 	status, err := manager.DeliverPrompt(DeliverPromptRequest{
 		Title:    "captain",

--- a/daemon/defer_attached_wait_paths_test.go
+++ b/daemon/defer_attached_wait_paths_test.go
@@ -35,7 +35,7 @@ func TestDeliverPrompt_ReemergingRootDefersWhileAttached(t *testing.T) {
 
 	// A TUI attaches full-screen to root before it exists — the pause-poll lease
 	// is keyed by (repoID, title) and needs no live session.
-	manager.PauseStatusPoll(repo.ID, session.RootSessionTitle)
+	manager.PauseStatusPoll(repo.ID, session.RootSessionTitle, "")
 
 	// A short while into the delivery's wait, the ensure loop re-materializes root
 	// in place. The delivery must then DEFER (attached), not send.
@@ -100,7 +100,7 @@ func TestDeliverPrompt_ConcurrentCreateDefersWhileAttached(t *testing.T) {
 	manager.mu.Unlock()
 
 	// A TUI attaches BEFORE the session exists.
-	manager.PauseStatusPoll(repo.ID, "captain")
+	manager.PauseStatusPoll(repo.ID, "captain", "")
 
 	var wg sync.WaitGroup
 	var status string

--- a/daemon/delivery.go
+++ b/daemon/delivery.go
@@ -89,7 +89,21 @@ func (e *notAttemptedError) Is(target error) bool { return target == errNotAttem
 // user is typing in (#1638). Only automated deliveries set DeferWhileAttached; a
 // manual send-prompt is an explicit user action and still lands immediately.
 func (m *Manager) deferWhileAttached(repoID string, req DeliverPromptRequest) bool {
-	return req.DeferWhileAttached && m.isPollPaused(repoID, req.Title)
+	if !req.DeferWhileAttached {
+		return false
+	}
+	// DeliverPrompt addresses the row by title, but the pause lease belongs to
+	// its stable identity. Resolve only the already-tracked row here; an absent
+	// row cannot be attached, while legacy ID-less pauses still use the title
+	// fallback inside isPollPaused.
+	m.mu.Lock()
+	instance := m.instances[daemonInstanceKey(repoID, req.Title)]
+	id := ""
+	if instance != nil {
+		id = instance.ID
+	}
+	m.mu.Unlock()
+	return m.isPollPaused(repoID, req.Title, id)
 }
 
 // DeliverPrompt delivers a prompt to a target session, auto-creating that

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -153,9 +153,10 @@ type Manager struct {
 	instanceOpLocks map[string]*sync.Mutex
 
 	// pausedPolls records sessions whose daemon capture-pane liveness poll is
-	// paused while a TUI is attached full-screen to them (#1160), keyed by
-	// daemon instance key → lease expiry. Guarded by pausedMu, a DEDICATED
-	// mutex (NOT m.mu): refreshInstanceStatus deliberately snapshots under m.mu
+	// paused while a TUI is attached full-screen to them (#1160), keyed by stable
+	// session ID when the client has one and by daemon instance key only for
+	// legacy ID-less callers. Guarded by pausedMu, a DEDICATED mutex (NOT m.mu):
+	// refreshInstanceStatus deliberately snapshots under m.mu
 	// and then runs each slow tmux probe with m.mu RELEASED so a hung probe
 	// can't block unrelated RPCs — the pause check runs inside that lock-free
 	// window, so reusing m.mu would reintroduce exactly the contention the
@@ -166,14 +167,13 @@ type Manager struct {
 	pausedPolls map[string]time.Time
 	// taskRunProbeDue schedules the backstop observation for a PAUSED session whose
 	// task run is still in flight (#1892). Guarded by pausedMu (the same lock as
-	// pausedPolls) but keyed by remoteLossKey — the stable instance ID — NOT by
-	// pausedPolls' daemonInstanceKey: taskRunBackstopDue is its only writer and keys
-	// it that way, so a same-title successor never inherits a predecessor's stale due
-	// time. An attach suppresses the liveness probe, and the cap's slot is released
+	// pausedPolls) but keyed by remoteLossKey — the stable instance ID — rather
+	// than the legacy daemon-instance-key lease fallback. An attach suppresses the
+	// liveness probe, and the cap's slot is released
 	// by observing the agent go idle — so without a bounded backstop a user watching
 	// their own task run silently stalls the task. Entries live only while the
 	// session is paused: ResumeStatusPoll drops one on a clean detach (matching the
-	// writer's key), and sweepTaskRunProbeDue reclaims any whose lease lapsed or
+	// writer's key), and sweepPausedPollState reclaims any whose lease lapsed or
 	// whose session was torn down, so the map tracks pausedPolls and never grows
 	// unbounded over the daemon's lifetime (#2015).
 	taskRunProbeDue map[string]time.Time

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -42,21 +42,32 @@ var nowFunc = time.Now
 // A var so tests can shrink it; production never reassigns.
 var taskRunPollBackstop = 30 * time.Second
 
-// RefreshStatuses recomputes every started instance's status the way the TUI
-// metadata tick used to (#935) and persists each transition through the
-// targeted single-writer path. With the daemon the sole owner of session state
-// (#960 PR 4/5), status is authoritative HERE and projected to the TUI via
-// Snapshot — the TUI no longer computes it. Called once per poll from RunDaemon.
-//
-// The instance list is snapshotted under m.mu, then each instance's (possibly
-// slow) tmux probes run with the lock released so a hung capture-pane can't
-// block unrelated manager RPCs.
+const (
+	statusPollIDPrefix    = "id:"
+	statusPollTitlePrefix = "title:"
+)
+
+func statusPollIDKey(id string) string { return statusPollIDPrefix + id }
+
+func statusPollTitleKey(repoID, title string) string {
+	return statusPollTitlePrefix + daemonInstanceKey(repoID, title)
+}
+
+// statusPollLeaseKey makes stable identity the default lease namespace. The
+// title key remains only for ID-less legacy clients.
+func statusPollLeaseKey(repoID, title, id string) string {
+	if id != "" {
+		return statusPollIDKey(id)
+	}
+	return statusPollTitleKey(repoID, title)
+}
+
 // PauseStatusPoll pauses the daemon's capture-pane liveness poll for one
 // attached session for statusPollLease from now (#1160). Renewing (the TUI's
-// heartbeat) just pushes the expiry out; the pause is per-instance, so every
-// other session keeps refreshing during the attach.
-func (m *Manager) PauseStatusPoll(repoID, title string) {
-	key := daemonInstanceKey(repoID, title)
+// heartbeat) just pushes the expiry out; the pause is per stable identity, so a
+// same-title successor never inherits the old attach's lease (#2358).
+func (m *Manager) PauseStatusPoll(repoID, title, id string) {
+	key := statusPollLeaseKey(repoID, title, id)
 	m.pausedMu.Lock()
 	m.pausedPolls[key] = nowFunc().Add(statusPollLease)
 	m.pausedMu.Unlock()
@@ -66,15 +77,13 @@ func (m *Manager) PauseStatusPoll(repoID, title string) {
 // resumes on the next tick rather than waiting out the lease (#1160).
 //
 // It also frees the session's backstop-timer entry (#2015). That entry is keyed
-// by remoteLossKey (the stable instance ID), NOT the daemonInstanceKey pausedPolls
-// uses — taskRunBackstopDue is its only writer and keys it that way — so the
-// delete must resolve the instance to match the writer; deleting under the pause
-// key was a silent no-op that leaked one entry per probed-while-paused session.
-// sweepTaskRunProbeDue reclaims any entry this cannot (a crashed TUI that never
+// by remoteLossKey (the stable instance ID), so an ID-bearing resume can delete
+// it directly. Legacy title-only callers resolve the tracked instance as before.
+// sweepPausedPollState reclaims any entry this cannot (a crashed TUI that never
 // resumes, a session torn down mid-pause), so a lookup miss here is harmless.
-func (m *Manager) ResumeStatusPoll(repoID, title string) {
-	key := daemonInstanceKey(repoID, title)
-	probeKey := m.taskRunProbeKey(repoID, title)
+func (m *Manager) ResumeStatusPoll(repoID, title, id string) {
+	key := statusPollLeaseKey(repoID, title, id)
+	probeKey := m.taskRunProbeKey(repoID, title, id)
 	m.pausedMu.Lock()
 	delete(m.pausedPolls, key)
 	if probeKey != "" {
@@ -87,7 +96,10 @@ func (m *Manager) ResumeStatusPoll(repoID, title string) {
 // instance ID) for a tracked session, or "" when the session is no longer tracked
 // (already torn down; the sweep drops any orphaned entry). Reads m.instances under
 // m.mu and is never called with pausedMu held, so the two locks stay unnested.
-func (m *Manager) taskRunProbeKey(repoID, title string) string {
+func (m *Manager) taskRunProbeKey(repoID, title, id string) string {
+	if id != "" {
+		return id
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if inst := m.instances[daemonInstanceKey(repoID, title)]; inst != nil {
@@ -118,48 +130,64 @@ func (m *Manager) taskRunBackstopDue(key string) bool {
 	return true
 }
 
-// sweepTaskRunProbeDue drops backstop-timer entries whose session is no longer
-// PAUSED (#2015): a clean detach already reclaims its own via ResumeStatusPoll,
-// but a crashed TUI that never resumes (its lease lapses) and a session killed or
-// archived mid-pause both strand an entry with nothing left to delete it. The
-// entry is armed and read ONLY in refreshInstanceStatus's paused branch, so once
-// the pause is gone it is dead weight; without this GC the map grows one entry per
-// distinct task session ever probed-while-paused and never shrinks over the
-// daemon's lifetime. Called once per poll from RefreshStatuses, beside the sibling
-// sweepRemoteLossStates.
+// sweepPausedPollState drops expired pause leases and backstop-timer entries
+// whose session is no longer PAUSED (#2015): a clean detach already reclaims
+// its own via ResumeStatusPoll, but a crashed TUI that never resumes and a
+// session killed mid-pause leave no caller to clean up. A backstop entry is
+// armed and read ONLY in refreshInstanceStatus's paused branch, so once the
+// pause is gone it is dead weight; without this GC both maps grow across old
+// session identities. Called once per poll from RefreshStatuses, beside the
+// sibling sweepRemoteLossStates.
 //
 // That sibling keys garbage on "session gone", but a session stays live across a
-// detach, so this keys garbage on "not currently paused" instead. taskRunProbeDue
-// is keyed by remoteLossKey (the stable instance ID) while pausedPolls is keyed by
-// daemonInstanceKey, so the live set is bridged by walking m.instances. m.mu and
-// pausedMu are taken SEPARATELY, never nested — the poll deliberately keeps them
-// apart so a slow probe under one can't block RPCs behind the other (see
-// pausedPolls' field doc).
-func (m *Manager) sweepTaskRunProbeDue() {
+// detach, so this keys garbage on "not currently paused" instead.
+// taskRunProbeDue is keyed by remoteLossKey (the stable instance ID), while
+// pausedPolls also admits a legacy title key, so the live set is bridged by
+// walking m.instances. m.mu and pausedMu are taken SEPARATELY, never nested —
+// the poll deliberately keeps them apart so a slow probe under one can't block
+// RPCs behind the other (see pausedPolls' field doc).
+func (m *Manager) sweepPausedPollState() {
+	now := nowFunc()
 	m.pausedMu.Lock()
+	// Stable IDs make lease ownership safe under title reuse, but they also make
+	// every session lifetime a distinct map key. Reclaim expired leases even when
+	// their session was deleted and will never call isPollPaused again.
+	for key, expiry := range m.pausedPolls {
+		if !now.Before(expiry) {
+			delete(m.pausedPolls, key)
+		}
+	}
 	empty := len(m.taskRunProbeDue) == 0
 	m.pausedMu.Unlock()
 	if empty {
 		return // nothing armed: skip the instance walk in the common case
 	}
 
-	type keyPair struct{ daemonKey, probeKey string }
+	type keyPair struct {
+		repoID   string
+		title    string
+		id       string
+		probeKey string
+	}
 	m.mu.Lock()
 	pairs := make([]keyPair, 0, len(m.instances))
 	for key, inst := range m.instances {
 		repoID, _ := splitDaemonInstanceKey(key)
-		pairs = append(pairs, keyPair{daemonKey: key, probeKey: remoteLossKey(repoID, inst)})
+		pairs = append(pairs, keyPair{
+			repoID: repoID, title: inst.Title, id: inst.ID,
+			probeKey: remoteLossKey(repoID, inst),
+		})
 	}
 	m.mu.Unlock()
 
-	now := nowFunc()
+	now = nowFunc()
 	m.pausedMu.Lock()
 	defer m.pausedMu.Unlock()
 	live := make(map[string]struct{}, len(m.pausedPolls))
 	for _, p := range pairs {
 		// An expired lease is treated as unpaused even before isPollPaused lazily
 		// deletes it, so the entry is reclaimed the same tick the lease lapses.
-		if expiry, ok := m.pausedPolls[p.daemonKey]; ok && now.Before(expiry) {
+		if m.pollLeaseActiveLocked(p.repoID, p.title, p.id, now) {
 			live[p.probeKey] = struct{}{}
 		}
 	}
@@ -175,18 +203,30 @@ func (m *Manager) sweepTaskRunProbeDue() {
 // crashed TUI that never sent Resume auto-resumes within one lease — the
 // crash-safety property that keeps a pause from ever permanently blinding the
 // daemon.
-func (m *Manager) isPollPaused(repoID, title string) bool {
-	key := daemonInstanceKey(repoID, title)
+func (m *Manager) isPollPaused(repoID, title, id string) bool {
 	m.pausedMu.Lock()
 	defer m.pausedMu.Unlock()
-	expiry, ok := m.pausedPolls[key]
-	if !ok {
-		return false
+	return m.pollLeaseActiveLocked(repoID, title, id, nowFunc())
+}
+
+// pollLeaseActiveLocked checks the stable-ID lease first, then the explicit
+// title fallback written only by legacy clients. Expired entries are reclaimed
+// lazily. The caller holds pausedMu.
+func (m *Manager) pollLeaseActiveLocked(repoID, title, id string, now time.Time) bool {
+	keys := []string{statusPollTitleKey(repoID, title)}
+	if id != "" {
+		keys = append([]string{statusPollIDKey(id)}, keys...)
 	}
-	if nowFunc().Before(expiry) {
-		return true
+	for _, key := range keys {
+		expiry, ok := m.pausedPolls[key]
+		if !ok {
+			continue
+		}
+		if now.Before(expiry) {
+			return true
+		}
+		delete(m.pausedPolls, key)
 	}
-	delete(m.pausedPolls, key) // lease lapsed — lazy GC, then poll as normal
 	return false
 }
 
@@ -238,6 +278,12 @@ func (m *Manager) observeTaskRunWhilePaused(repoID, key string, instance *sessio
 	m.persistPollChange(repoID, instance, before, beforeReset, projectionChanged)
 }
 
+// RefreshStatuses recomputes every started instance's status the way the TUI
+// metadata tick used to (#935) and persists each transition through the
+// targeted single-writer path. With the daemon the sole owner of session state
+// (#960 PR 4/5), status is authoritative here and projected to the TUI via
+// Snapshot. The instance list is snapshotted under m.mu, then each slow probe
+// runs with that lock released so it cannot block unrelated manager RPCs.
 func (m *Manager) RefreshStatuses() {
 	type entry struct {
 		repoID   string
@@ -255,7 +301,7 @@ func (m *Manager) RefreshStatuses() {
 	// the pass that creates it (#1794), and backstop timers for sessions no longer
 	// paused (#2015) — both maps the poll itself populates.
 	m.sweepRemoteLossStates()
-	m.sweepTaskRunProbeDue()
+	m.sweepPausedPollState()
 
 	for _, e := range entries {
 		m.refreshInstanceStatus(e.repoID, e.instance)
@@ -348,7 +394,7 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		m.clearRemoteLoss(key)
 		return
 	}
-	if m.isPollPaused(repoID, instance.Title) {
+	if m.isPollPaused(repoID, instance.Title, instance.ID) {
 		// EXCEPT when a task run is still in flight: the concurrency cap (#1892)
 		// releases that run's slot when the agent goes idle, and this poll is the
 		// only thing that can see that happen. Left un-probed for the whole attach,

--- a/daemon/status_pause_test.go
+++ b/daemon/status_pause_test.go
@@ -35,7 +35,7 @@ func TestRefreshStatuses_PausedInstanceSkipsProbe(t *testing.T) {
 	registerStarted(t, manager, repoID, repoPath, "attached-x", deadTmuxBackend{session.NewFakeBackend()}, true, session.Running)
 	registerStarted(t, manager, repoID, repoPath, "sibling-y", deadTmuxBackend{session.NewFakeBackend()}, true, session.Running)
 
-	manager.PauseStatusPoll(repoID, "attached-x")
+	manager.PauseStatusPoll(repoID, "attached-x", "")
 
 	manager.RefreshStatuses()
 
@@ -57,7 +57,7 @@ func TestRefreshStatuses_PausedDeadInstanceNotMarkedLost(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	registerStarted(t, manager, repoID, repoPath, "dead-but-paused", deadTmuxBackend{session.NewFakeBackend()}, true, session.Running)
 
-	manager.PauseStatusPoll(repoID, "dead-but-paused")
+	manager.PauseStatusPoll(repoID, "dead-but-paused", "")
 
 	manager.RefreshStatuses()
 
@@ -67,6 +67,69 @@ func TestRefreshStatuses_PausedDeadInstanceNotMarkedLost(t *testing.T) {
 	}
 	if got := inst.GetStatus(); got != session.Running {
 		t.Fatalf("paused instance status = %v, want Running untouched", got)
+	}
+}
+
+// TestRefreshStatuses_IDPauseDoesNotTransferToSameTitleReplacement is the
+// daemon half of #2358. A heartbeat retained by an old attached session must
+// not blind a different session that later reuses its title. The replacement's
+// dead backend is therefore probed and marked Lost immediately, while the old
+// ID-keyed lease remains independently resumable.
+func TestRefreshStatuses_IDPauseDoesNotTransferToSameTitleReplacement(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	original := registerStarted(t, manager, repoID, repoPath, "reused", deadTmuxBackend{session.NewFakeBackend()}, true, session.Running)
+	manager.PauseStatusPoll(repoID, original.Title, original.ID)
+
+	replacement := registerStarted(t, manager, repoID, repoPath, "reused", deadTmuxBackend{session.NewFakeBackend()}, true, session.Running)
+	if original.ID == replacement.ID {
+		t.Fatal("replacement must have a distinct stable ID")
+	}
+
+	if manager.isPollPaused(repoID, replacement.Title, replacement.ID) {
+		t.Fatal("same-title replacement inherited the original session's pause lease")
+	}
+	manager.RefreshStatuses()
+	if got := replacement.GetStatus(); got != session.Lost {
+		t.Fatalf("replacement status = %v, want Lost — the old ID's lease must not suppress its probe", got)
+	}
+
+	manager.ResumeStatusPoll(repoID, original.Title, original.ID)
+	if manager.isPollPaused(repoID, original.Title, original.ID) {
+		t.Fatal("the original ID-keyed lease must remain independently resumable")
+	}
+}
+
+// TestResumeStatusPoll_StaleIDKeepsReplacementLease proves a late detach from
+// the old session cannot clear a newer same-title session's lease. Both IDs may
+// coexist briefly while attach goroutines settle, so resume deletes exactly one
+// stable key rather than the reusable title.
+func TestResumeStatusPoll_StaleIDKeepsReplacementLease(t *testing.T) {
+	manager, repoID, _ := newStatusTestManager(t)
+	manager.PauseStatusPoll(repoID, "reused", "old-id")
+	manager.PauseStatusPoll(repoID, "reused", "new-id")
+
+	manager.ResumeStatusPoll(repoID, "reused", "old-id")
+	if !manager.isPollPaused(repoID, "reused", "new-id") {
+		t.Fatal("stale resume cleared the replacement session's independent lease")
+	}
+}
+
+// TestRefreshStatuses_ReclaimsExpiredIDLeaseAfterSessionGone pins the bounded
+// storage side of ID-keyed leases. A deleted session is never polled again, so
+// lazy cleanup in isPollPaused cannot see its key; the refresh sweep must still
+// remove the entry once the server-side lease expires.
+func TestRefreshStatuses_ReclaimsExpiredIDLeaseAfterSessionGone(t *testing.T) {
+	advance := withFrozenClock(t)
+	manager, repoID, _ := newStatusTestManager(t)
+	manager.PauseStatusPoll(repoID, "gone", "gone-id")
+	advance(statusPollLease + time.Second)
+
+	manager.RefreshStatuses()
+	manager.pausedMu.Lock()
+	_, retained := manager.pausedPolls[statusPollIDKey("gone-id")]
+	manager.pausedMu.Unlock()
+	if retained {
+		t.Fatal("expired stable-ID pause lease was retained after its session disappeared")
 	}
 }
 
@@ -80,10 +143,10 @@ func TestRefreshStatuses_LeaseExpiryDetectsRealDeath(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	registerStarted(t, manager, repoID, repoPath, "crashed-tui", deadTmuxBackend{session.NewFakeBackend()}, true, session.Running)
 
-	manager.PauseStatusPoll(repoID, "crashed-tui")
+	manager.PauseStatusPoll(repoID, "crashed-tui", "")
 
 	// Still within the lease: the dead instance is protected.
-	if !manager.isPollPaused(repoID, "crashed-tui") {
+	if !manager.isPollPaused(repoID, "crashed-tui", "") {
 		t.Fatal("instance should be paused immediately after PauseStatusPoll")
 	}
 	manager.RefreshStatuses()
@@ -95,7 +158,7 @@ func TestRefreshStatuses_LeaseExpiryDetectsRealDeath(t *testing.T) {
 	// Advance past the lease: the crashed TUI never renewed, so the pause must
 	// have lapsed and real death must now be detected.
 	advance(statusPollLease + time.Second)
-	if manager.isPollPaused(repoID, "crashed-tui") {
+	if manager.isPollPaused(repoID, "crashed-tui", "") {
 		t.Fatal("pause must auto-expire after statusPollLease — a crashed TUI can never permanently blind the daemon")
 	}
 	manager.RefreshStatuses()
@@ -112,13 +175,13 @@ func TestResumeStatusPoll_ClearsPauseImmediately(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	registerStarted(t, manager, repoID, repoPath, "detached", deadTmuxBackend{session.NewFakeBackend()}, true, session.Running)
 
-	manager.PauseStatusPoll(repoID, "detached")
-	if !manager.isPollPaused(repoID, "detached") {
+	manager.PauseStatusPoll(repoID, "detached", "")
+	if !manager.isPollPaused(repoID, "detached", "") {
 		t.Fatal("instance should be paused after PauseStatusPoll")
 	}
 
-	manager.ResumeStatusPoll(repoID, "detached")
-	if manager.isPollPaused(repoID, "detached") {
+	manager.ResumeStatusPoll(repoID, "detached", "")
+	if manager.isPollPaused(repoID, "detached", "") {
 		t.Fatal("ResumeStatusPoll must clear the pause immediately, not wait out the lease")
 	}
 
@@ -143,7 +206,7 @@ func TestControlServer_PauseResumeStatusPoll(t *testing.T) {
 	if !pauseResp.OK {
 		t.Fatal("PauseStatusPoll must ack OK")
 	}
-	if !manager.isPollPaused(repoID, "s") {
+	if !manager.isPollPaused(repoID, "s", "") {
 		t.Fatal("PauseStatusPoll RPC must pause the instance via the manager")
 	}
 
@@ -154,7 +217,7 @@ func TestControlServer_PauseResumeStatusPoll(t *testing.T) {
 	if !resumeResp.OK {
 		t.Fatal("ResumeStatusPoll must ack OK")
 	}
-	if manager.isPollPaused(repoID, "s") {
+	if manager.isPollPaused(repoID, "s", "") {
 		t.Fatal("ResumeStatusPoll RPC must clear the pause via the manager")
 	}
 }

--- a/daemon/status_probedue_leak_test.go
+++ b/daemon/status_probedue_leak_test.go
@@ -60,14 +60,14 @@ func TestResumeStatusPoll_FreesTaskRunProbeDueEntry(t *testing.T) {
 
 	// Attach: pause the poll, then one refresh ARMS the backstop timer (the first
 	// paused tick only arms; see taskRunBackstopDue).
-	manager.PauseStatusPoll(repoID, "attached-run")
+	manager.PauseStatusPoll(repoID, "attached-run", "")
 	manager.RefreshStatuses()
 	if n := probeDueLen(manager); n != 1 {
 		t.Fatalf("after arming, taskRunProbeDue size = %d, want 1 (a paused task run must arm its backstop)", n)
 	}
 
 	// Detach: a clean ResumeStatusPoll must reclaim the armed entry.
-	manager.ResumeStatusPoll(repoID, "attached-run")
+	manager.ResumeStatusPoll(repoID, "attached-run", "")
 	if n := probeDueLen(manager); n != 0 {
 		t.Fatalf("after clean detach, taskRunProbeDue size = %d, want 0 — the entry leaked (#2015: cleanup keyed by the wrong function)", n)
 	}
@@ -83,7 +83,7 @@ func TestRefreshStatuses_SweepsLapsedTaskRunProbeDue(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	registerTaskRun(t, manager, repoID, repoPath, "crashed-attach")
 
-	manager.PauseStatusPoll(repoID, "crashed-attach")
+	manager.PauseStatusPoll(repoID, "crashed-attach", "")
 	manager.RefreshStatuses() // arms
 	if n := probeDueLen(manager); n != 1 {
 		t.Fatalf("after arming, taskRunProbeDue size = %d, want 1", n)
@@ -105,7 +105,7 @@ func TestRefreshStatuses_SweepsTornDownTaskRunProbeDue(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	registerTaskRun(t, manager, repoID, repoPath, "torn-down")
 
-	manager.PauseStatusPoll(repoID, "torn-down")
+	manager.PauseStatusPoll(repoID, "torn-down", "")
 	manager.RefreshStatuses() // arms
 	if n := probeDueLen(manager); n != 1 {
 		t.Fatalf("after arming, taskRunProbeDue size = %d, want 1", n)

--- a/daemon/status_remote_test.go
+++ b/daemon/status_remote_test.go
@@ -713,9 +713,9 @@ func TestRefreshStatuses_AttachBreaksTheDebounceRun(t *testing.T) {
 	}
 
 	// The user attaches. The poll is paused for the duration and observes nothing.
-	manager.PauseStatusPoll(repoID, title)
+	manager.PauseStatusPoll(repoID, title, "")
 	manager.RefreshStatuses()
-	manager.ResumeStatusPoll(repoID, title)
+	manager.ResumeStatusPoll(repoID, title, "")
 
 	// One blip after detach.
 	manager.RefreshStatuses()

--- a/daemon/watch_concurrency_attach_test.go
+++ b/daemon/watch_concurrency_attach_test.go
@@ -76,8 +76,8 @@ func TestAttachedTaskRunReleasesItsSlotOnCompletion(t *testing.T) {
 	}
 
 	// The user attaches full-screen and the TUI starts renewing the pause.
-	manager.PauseStatusPoll(repo.ID, data.Title)
-	if !manager.isPollPaused(repo.ID, data.Title) {
+	manager.PauseStatusPoll(repo.ID, data.Title, "")
+	if !manager.isPollPaused(repo.ID, data.Title, "") {
 		t.Fatal("precondition: the attach must actually pause the poll")
 	}
 
@@ -91,8 +91,8 @@ func TestAttachedTaskRunReleasesItsSlotOnCompletion(t *testing.T) {
 	// The attach continues — renewed, so the lease never lapses. The backstop is
 	// what has to save this; the pause itself never will.
 	advance(taskRunPollBackstop + time.Second)
-	manager.PauseStatusPoll(repo.ID, data.Title)
-	if !manager.isPollPaused(repo.ID, data.Title) {
+	manager.PauseStatusPoll(repo.ID, data.Title, "")
+	if !manager.isPollPaused(repo.ID, data.Title, "") {
 		t.Fatal("precondition: the TUI renews the lease, so the poll stays paused — this bug is not fixed by the lease lapsing")
 	}
 	manager.RefreshStatuses()
@@ -133,11 +133,11 @@ func TestAttachedTaskRunKeepsItsSlotWhileWorking(t *testing.T) {
 
 	// A working agent: the pane keeps changing.
 	inst.SetBackend(busyFakeBackend{session.NewFakeBackend()})
-	manager.PauseStatusPoll(repo.ID, data.Title)
+	manager.PauseStatusPoll(repo.ID, data.Title, "")
 
 	for i := 0; i < 3; i++ {
 		advance(taskRunPollBackstop + time.Second)
-		manager.PauseStatusPoll(repo.ID, data.Title)
+		manager.PauseStatusPoll(repo.ID, data.Title, "")
 		manager.RefreshStatuses()
 	}
 	if !inst.TaskRunActive() {
@@ -181,10 +181,10 @@ func TestAttachedTaskRunIsNeverMarkedLost(t *testing.T) {
 	// no dead session could serve. The normal poll marks this Lost; the backstop
 	// must not.
 	inst.SetBackend(deadTmuxBackend{session.NewFakeBackend()})
-	manager.PauseStatusPoll(repo.ID, data.Title)
+	manager.PauseStatusPoll(repo.ID, data.Title, "")
 	for i := 0; i < 3; i++ {
 		advance(taskRunPollBackstop + time.Second)
-		manager.PauseStatusPoll(repo.ID, data.Title)
+		manager.PauseStatusPoll(repo.ID, data.Title, "")
 		manager.RefreshStatuses()
 	}
 	if got := inst.GetStatus(); got == session.Lost {


### PR DESCRIPTION
## Summary

- capture one immutable session target for full-screen attach and embedded interactive-mode pause leases
- send typed Pause/Resume requests carrying stable session ID, title, and repo scope through one shared constructor
- key daemon pause leases by stable ID, with the old title key retained only as an explicit legacy fallback
- make automated-delivery deferral and liveness polling resolve the current row's ID before consulting the lease
- reclaim expired ID-keyed leases even after their session disappears

## Reproduction

The fail-first keeps an embedded pane interactive, swaps its binding to a different session with the exact same title, and immediately asks the pause coordinator to reconcile. Before the fix, title equality hid the replacement: the old lease stayed retained, no resume was sent, and the new session never acquired its own lease.

The daemon regressions prove both sides of the identity boundary: an old ID-keyed heartbeat cannot suppress a same-title replacement's liveness probe, and a late resume for the old ID cannot clear the replacement's independent lease. The full-screen attach regression also asserts that pause and resume carry the exact captured ID.

## Scope

This is the final pause-heartbeat slice of #2358. Full-screen attach and embedded interactive mode share one lease namespace and one failure shape, so they are fixed together. Title-only behavior remains solely for older ID-less clients; current TUI emitters never use it.

## Exact-head gates

Commit: `63ea944e275d35b3862f9c186c46095bb79f1d0e`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (clean)
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container`

All passed on that exact head.

— Captain Claude
