### PR TITLE
fix(tui): sentence-case kill confirmation warnings

### DIFF
--- a/app/kill_confirm.go
+++ b/app/kill_confirm.go
@@ -141,10 +141,10 @@ func killConfirmationWarning(wt string) string {
 	out, err := runKillGit(wt, "status", "--porcelain", "--untracked-files=normal")
 	if err != nil {
 		log.WarningLog.Printf("could not verify worktree status for %s before kill: %v", wt, err)
-		return fmt.Sprintf("WARNING: Could not verify worktree status (%v); it may contain uncommitted changes that will be lost!", err)
+		return fmt.Sprintf("Warning: Could not verify worktree status (%v); it may contain uncommitted changes that will be lost!", err)
 	}
 	if len(strings.TrimSpace(string(out))) > 0 {
-		return "WARNING: This worktree has uncommitted changes that will be lost!"
+		return "Warning: This worktree has uncommitted changes that will be lost!"
 	}
 	return ""
 }

--- a/app/kill_confirmation_copy_test.go
+++ b/app/kill_confirmation_copy_test.go
@@ -1,0 +1,83 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKillConfirmationWarningUsesSentenceCaseAtCompactSizes(t *testing.T) {
+	cases := []struct {
+		name     string
+		prepare  func(*testing.T, string)
+		expected []string
+	}{
+		{
+			name: "dirty worktree",
+			prepare: func(t *testing.T, wt string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(filepath.Join(wt, "untracked.txt"), []byte("work\n"), 0o644))
+			},
+			expected: []string{"Warning: This worktree has uncommitted changes that will be lost!"},
+		},
+		{
+			name: "unverifiable worktree",
+			prepare: func(t *testing.T, wt string) {
+				t.Helper()
+				indexPath := killGit(t, wt, "rev-parse", "--git-path", "index")
+				if !filepath.IsAbs(indexPath) {
+					indexPath = filepath.Join(wt, indexPath)
+				}
+				require.NoError(t, os.WriteFile(indexPath, []byte("broken"), 0o644))
+			},
+			expected: []string{
+				"Warning: Could not verify worktree status",
+				"it may contain uncommitted changes that will be lost!",
+			},
+		},
+	}
+
+	for _, size := range []struct {
+		width  int
+		height int
+	}{
+		{width: 80, height: 24},
+		{width: 72, height: 20},
+	} {
+		for _, tc := range cases {
+			t.Run(fmt.Sprintf("%s-%dx%d", tc.name, size.width, size.height), func(t *testing.T) {
+				repoDir, baseSHA := initBaseRepo(t)
+				wt := addWorktree(t, repoDir, baseSHA, "dev/kill-copy")
+				tc.prepare(t, wt)
+				inst := startedWorktreeInstance(t, "kill-copy", repoDir, wt, "dev/kill-copy", baseSHA)
+
+				h := newTestHome(t)
+				h.store.AddInstance(inst)
+				h.sidebar.SetSelectedInstance(0)
+				_ = h.selectionChanged()
+				resizeHome(h, size.width, size.height)
+
+				killKey := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")}
+				_, _ = h.Update(killKey)
+				_, _ = h.Update(killKey)
+				require.Equal(t, stateConfirm, h.state, "D opens the production kill confirmation")
+				require.NotNil(t, h.confirmationOverlay)
+
+				view := h.View()
+				requireViewSized(t, view, size.width, size.height)
+				copy := flatten(view)
+				for _, expected := range tc.expected {
+					assert.Contains(t, copy, expected,
+						"%dx%d: the data-loss warning follows the TUI sentence-case convention", size.width, size.height)
+				}
+				assert.NotContains(t, copy, "WARNING:",
+					"%dx%d: the data-loss warning must not caps-shout", size.width, size.height)
+			})
+		}
+	}
+}


### PR DESCRIPTION
Closes #2385

## What changed

- Render both dirty-worktree kill warning variants with the sentence-case label `Warning:`.
- Preserve the `[!]` marker, data-loss wording, confirmation key, and all teardown behavior.
- Add a root-TUI regression that drives the real `D` key path into the production confirmation overlay for both a dirty worktree and an unverifiable worktree at 80×24 and 72×20. The test never confirms or dispatches teardown.

## Fail-first reproduction

With production copy unchanged, all four root-render cases failed and showed the caps-shouting forms:

- `WARNING: This worktree has uncommitted changes that will be lost!`
- `WARNING: Could not verify worktree status (exit status 128); it may contain uncommitted changes that will be lost!`

After changing only the two labels, every root view remains exactly terminal-sized and renders the sentence-case forms in full.

## Validation

Exact pushed head: `ad38e677f417bfdd0bc9cac76e8417c5e4d1ad20`

- focused root-render and existing kill-warning tests
- `scripts/gen-docs.sh` with a clean diff
- `golangci-lint run --timeout=3m --fast`
- clean `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...` with no output
- `scripts/lint-file-length.sh`
- `make test-container`
