### PR TITLE
fix(docker): bind restored cleanup to its engine

### DIFF
--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -70,6 +70,11 @@ const (
 	// `docker ps -aq -f label=af.session` (documented in docs/backends.md). The
 	// runtime reaps by container ID; the label is for operators.
 	dockerSessionLabel = "af.session"
+	// dockerEngineIDFormat selects the daemon's stable, non-secret identity from
+	// `docker info`. Cleanup tombstones persist this value so a daemon restart
+	// cannot redirect `docker rm -f` to whichever engine the client happens to
+	// target later (#2382).
+	dockerEngineIDFormat = "{{.ID}}"
 )
 
 // docker command timeouts. Provisioning steps (run/clone/cp/exec) get a generous
@@ -217,7 +222,9 @@ type dockerProvisioner struct {
 	afBin   string
 	program string
 
-	containerID string
+	containerID        string
+	engineID           string
+	verifyEngineOnReap bool
 
 	// reap memoizes across the repeated Kill retries and the Kill-vs-provision-
 	// failure race, but only for a reap that COMPLETED: reaped latches on success
@@ -235,6 +242,11 @@ type dockerProvisioner struct {
 // session needs. Each step wraps docker's combined output in the error so a
 // failure is self-diagnosing.
 func (p *dockerProvisioner) provision() (ProvisionResult, error) {
+	engineID, err := p.currentEngineID(dockerShortStepTimeout)
+	if err != nil {
+		return ProvisionResult{}, fmt.Errorf("backend=docker: cannot establish the Docker cleanup target before creating a container: %w", err)
+	}
+	p.engineID = engineID
 	if err := p.runContainer(); err != nil {
 		return ProvisionResult{}, err
 	}
@@ -270,7 +282,10 @@ func (p *dockerProvisioner) provision() (ProvisionResult, error) {
 			containerID:        p.containerID,
 			remoteAgentBackend: remoteAgentBackend{reap: teardown},
 			provisioner:        p,
-			cleanup:            &DockerRuntimeCleanupData{ContainerID: p.containerID},
+			cleanup: &DockerRuntimeCleanupData{
+				ContainerID: p.containerID,
+				EngineID:    p.engineID,
+			},
 		},
 		Endpoint: endpoint,
 		Teardown: teardown,
@@ -485,6 +500,27 @@ func (p *dockerProvisioner) reap() error {
 	// opposite things for the record (#2049).
 	ctx, cancel := context.WithTimeout(context.Background(), dockerReapTimeout)
 	defer cancel()
+	if p.verifyEngineOnReap {
+		if strings.TrimSpace(p.engineID) == "" {
+			reapErr := fmt.Errorf("%w: backend=docker: refusing to reap container %s for session %q because its cleanup handle predates Docker engine identity tracking; inspect the original Docker engine and remove the container manually",
+				ErrWorkspaceStateUnknown, p.shortID(), p.spec.Title)
+			log.WarningLog.Printf("%v", reapErr)
+			return reapErr
+		}
+		currentEngineID, err := currentDockerEngineID(ctx)
+		if err != nil {
+			reapErr := fmt.Errorf("%w: backend=docker: cannot verify the Docker engine before reaping container %s for session %q; restore Docker access and retry: %v",
+				ErrWorkspaceStateUnknown, p.shortID(), p.spec.Title, err)
+			log.WarningLog.Printf("%v", reapErr)
+			return reapErr
+		}
+		if currentEngineID != p.engineID {
+			reapErr := fmt.Errorf("%w: backend=docker: refusing to reap container %s for session %q because the current Docker engine is %q, but the cleanup handle belongs to %q; select the original Docker context or DOCKER_HOST and retry",
+				ErrWorkspaceStateUnknown, p.shortID(), p.spec.Title, currentEngineID, p.engineID)
+			log.WarningLog.Printf("%v", reapErr)
+			return reapErr
+		}
+	}
 	out, err := dockerExec(ctx, "rm", "-f", p.containerID)
 	if err == nil {
 		p.reaped = true
@@ -511,6 +547,31 @@ func (p *dockerProvisioner) reap() error {
 	p.reapErr = reapErr
 	log.WarningLog.Printf("%v", reapErr)
 	return reapErr
+}
+
+// currentEngineID returns the daemon identity that the provisioner's Docker
+// client currently targets. New containers record it before `docker run`, and
+// restored reapers prove the same identity again before issuing the destructive
+// command. It deliberately stores no endpoint, context path, or credential.
+func (p *dockerProvisioner) currentEngineID(timeout time.Duration) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return currentDockerEngineID(ctx)
+}
+
+func currentDockerEngineID(ctx context.Context) (string, error) {
+	out, err := dockerExec(ctx, "info", "--format", dockerEngineIDFormat)
+	if err != nil {
+		return "", fmt.Errorf("`docker info` could not report the engine identity: %w", err)
+	}
+	id := strings.TrimSpace(string(out))
+	if id == "" {
+		return "", errors.New("`docker info` returned an empty engine identity")
+	}
+	if len(id) > 256 || len(strings.Fields(id)) != 1 {
+		return "", errors.New("`docker info` returned a malformed engine identity")
+	}
+	return id, nil
 }
 
 // docker runs `docker <args...>` with a timeout and returns its combined output.

--- a/session/backend_docker_reap_unknown_test.go
+++ b/session/backend_docker_reap_unknown_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 )
 
+const dockerReapTestEngineID = "engine-reap-test"
+
 // #2049: a wedged / timed-out `docker rm -f` reap actually LEAKED a container, but
 // the reap returned a PLAIN error. KillSession/deleteSessionRecord classify a
 // teardown by session.TeardownStateUnknown — retain on ErrWorkspaceStateUnknown /
@@ -41,13 +43,16 @@ func withShortDockerReapTimeout(t *testing.T, d time.Duration) {
 // fix reap returned a plain error and TeardownStateUnknown was false.
 func TestDockerReapTimeoutIsWorkspaceStateUnknown(t *testing.T) {
 	withShortDockerReapTimeout(t, 150*time.Millisecond)
-	restore := SetDockerExecForTest(func(ctx context.Context, _ ...string) ([]byte, error) {
+	restore := SetDockerExecForTest(func(ctx context.Context, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "info" {
+			return []byte(dockerReapTestEngineID + "\n"), nil
+		}
 		<-ctx.Done()
 		return nil, ctx.Err()
 	})
 	defer restore()
 
-	p := &dockerProvisioner{spec: ProvisionSpec{Title: "wedged"}, containerID: "deadbeefcafe0000"}
+	p := &dockerProvisioner{spec: ProvisionSpec{Title: "wedged"}, containerID: "deadbeefcafe0000", engineID: dockerReapTestEngineID}
 
 	done := make(chan error, 1)
 	go func() { done <- p.reap() }()
@@ -78,12 +83,15 @@ func TestDockerReapTimeoutIsWorkspaceStateUnknown(t *testing.T) {
 // the "No such container" (already-gone) case wedge the record forever.
 func TestDockerReapReportedErrorStaysKnown(t *testing.T) {
 	withShortDockerReapTimeout(t, 5*time.Second) // never reached; the fake answers instantly
-	restore := SetDockerExecForTest(func(_ context.Context, _ ...string) ([]byte, error) {
+	restore := SetDockerExecForTest(func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "info" {
+			return []byte(dockerReapTestEngineID + "\n"), nil
+		}
 		return []byte("Error: No such container: deadbeef"), fmt.Errorf("exit status 1")
 	})
 	defer restore()
 
-	p := &dockerProvisioner{spec: ProvisionSpec{Title: "answered"}, containerID: "deadbeefcafe0000"}
+	p := &dockerProvisioner{spec: ProvisionSpec{Title: "answered"}, containerID: "deadbeefcafe0000", engineID: dockerReapTestEngineID}
 	err := p.reap()
 	if err == nil {
 		t.Fatal("a failed `docker rm -f` must return an error")
@@ -100,12 +108,15 @@ func TestDockerReapReportedErrorStaysKnown(t *testing.T) {
 // nil, so the WaitDelay/timeout plumbing never turns a successful `docker rm -f`
 // into a phantom leak report.
 func TestDockerReapSuccessReturnsNil(t *testing.T) {
-	restore := SetDockerExecForTest(func(_ context.Context, _ ...string) ([]byte, error) {
+	restore := SetDockerExecForTest(func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "info" {
+			return []byte(dockerReapTestEngineID + "\n"), nil
+		}
 		return []byte("deadbeefcafe0000\n"), nil
 	})
 	defer restore()
 
-	p := &dockerProvisioner{spec: ProvisionSpec{Title: "clean"}, containerID: "deadbeefcafe0000"}
+	p := &dockerProvisioner{spec: ProvisionSpec{Title: "clean"}, containerID: "deadbeefcafe0000", engineID: dockerReapTestEngineID}
 	if err := p.reap(); err != nil {
 		t.Fatalf("a successful reap must return nil, got %v", err)
 	}
@@ -136,14 +147,17 @@ func reapWithin(t *testing.T, p *dockerProvisioner, guard time.Duration) error {
 func TestDockerReapTimeoutIsReRunnable(t *testing.T) {
 	withShortDockerReapTimeout(t, 150*time.Millisecond)
 	var calls int32
-	restore := SetDockerExecForTest(func(ctx context.Context, _ ...string) ([]byte, error) {
+	restore := SetDockerExecForTest(func(ctx context.Context, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "info" {
+			return []byte(dockerReapTestEngineID + "\n"), nil
+		}
 		atomic.AddInt32(&calls, 1)
 		<-ctx.Done()
 		return nil, ctx.Err()
 	})
 	defer restore()
 
-	p := &dockerProvisioner{spec: ProvisionSpec{Title: "wedged"}, containerID: "deadbeefcafe0000"}
+	p := &dockerProvisioner{spec: ProvisionSpec{Title: "wedged"}, containerID: "deadbeefcafe0000", engineID: dockerReapTestEngineID}
 
 	first := reapWithin(t, p, 10*time.Second)
 	if !errors.Is(first, ErrWorkspaceStateUnknown) {
@@ -181,7 +195,10 @@ func TestDockerReapTimeoutThenSuccessClears(t *testing.T) {
 	var wedged atomic.Bool
 	var calls int32
 	wedged.Store(true)
-	restore := SetDockerExecForTest(func(ctx context.Context, _ ...string) ([]byte, error) {
+	restore := SetDockerExecForTest(func(ctx context.Context, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "info" {
+			return []byte(dockerReapTestEngineID + "\n"), nil
+		}
 		atomic.AddInt32(&calls, 1)
 		if wedged.Load() {
 			<-ctx.Done()
@@ -191,7 +208,7 @@ func TestDockerReapTimeoutThenSuccessClears(t *testing.T) {
 	})
 	defer restore()
 
-	p := &dockerProvisioner{spec: ProvisionSpec{Title: "recovers"}, containerID: "deadbeefcafe0000"}
+	p := &dockerProvisioner{spec: ProvisionSpec{Title: "recovers"}, containerID: "deadbeefcafe0000", engineID: dockerReapTestEngineID}
 
 	if err := reapWithin(t, p, 10*time.Second); !errors.Is(err, ErrWorkspaceStateUnknown) {
 		t.Fatalf("first (wedged) reap must be unknown, got %v", err)

--- a/session/backend_docker_test.go
+++ b/session/backend_docker_test.go
@@ -54,6 +54,8 @@ func TestDockerProvision_CreateThenFail_ReapsContainer(t *testing.T) {
 	defer SetDockerExecForTest(func(_ context.Context, args ...string) ([]byte, error) {
 		calls = append(calls, append([]string(nil), args...))
 		switch args[0] {
+		case "info":
+			return []byte("engine-create-fail\n"), nil
 		case "run":
 			// Container CREATED (id on stdout) but the start step fails → non-zero exit.
 			return createThenFailRunOutput(), fmt.Errorf("exit status 125")
@@ -70,6 +72,46 @@ func TestDockerProvision_CreateThenFail_ReapsContainer(t *testing.T) {
 	require.Truef(t, sawDockerRm(calls, dockerCreatedID),
 		"#2008: created-then-failed container %s was not reaped (`docker rm -f` never issued); docker calls=%v",
 		dockerCreatedID, calls)
+}
+
+func TestDockerProvisionPersistsEngineIdentityForCleanup(t *testing.T) {
+	const engineID = "engine-that-created-container"
+	defer SetDockerExecForTest(func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) == 0 {
+			return nil, fmt.Errorf("missing docker command")
+		}
+		switch args[0] {
+		case "info":
+			return []byte(engineID + "\n"), nil
+		case "run":
+			return []byte(dockerCreatedID + "\n"), nil
+		case "cp":
+			return nil, nil
+		case "port":
+			return []byte("127.0.0.1:49152\n"), nil
+		case "exec":
+			if len(args) >= 4 && args[2] == "cat" && args[3] == dockerBannerPath {
+				return []byte(`{"addr":":8000","token":"test-only","title":"engine-bound"}`), nil
+			}
+			return nil, nil
+		default:
+			return nil, fmt.Errorf("unexpected docker command: %v", args)
+		}
+	})()
+
+	p := &dockerProvisioner{
+		spec:  ProvisionSpec{Title: "engine-bound", CloneURL: "file:///repo"},
+		image: "image:latest",
+		afBin: "/tmp/test-af",
+	}
+	result, err := p.provision()
+	require.NoError(t, err)
+	backend, ok := result.Backend.(*dockerBackend)
+	require.Truef(t, ok, "provisioned backend type = %T, want *dockerBackend", result.Backend)
+	require.NotNil(t, backend.cleanup)
+	assert.Equal(t, dockerCreatedID, backend.cleanup.ContainerID)
+	assert.Equal(t, engineID, backend.cleanup.EngineID,
+		"cleanup handle must bind the container to the Docker engine that created it")
 }
 
 // TestRunContainer_CapturesCreatedIDOnError pins the fix at its source: even when

--- a/session/runtime_cleanup.go
+++ b/session/runtime_cleanup.go
@@ -24,6 +24,9 @@ type RuntimeCleanupData struct {
 
 type DockerRuntimeCleanupData struct {
 	ContainerID string `json:"container_id"`
+	// EngineID is Docker's stable, non-secret daemon ID. Empty means a legacy
+	// tombstone that cannot be targeted safely and must fail closed.
+	EngineID string `json:"engine_id,omitempty"`
 }
 
 type SSHRuntimeCleanupData struct {
@@ -122,13 +125,24 @@ func restoreRuntimeCleanup(title, backendType string, data *RuntimeCleanupData) 
 		if data.Docker == nil || strings.TrimSpace(data.Docker.ContainerID) == "" {
 			return nil, nil, fmt.Errorf("docker cleanup handle has no container id")
 		}
-		p := &dockerProvisioner{spec: ProvisionSpec{Title: title}, containerID: data.Docker.ContainerID}
+		if strings.TrimSpace(data.Docker.EngineID) == "" {
+			return nil, nil, fmt.Errorf("docker cleanup handle has no engine identity (legacy record); select the original Docker context or DOCKER_HOST before repairing the record")
+		}
+		p := &dockerProvisioner{
+			spec:               ProvisionSpec{Title: title},
+			containerID:        data.Docker.ContainerID,
+			engineID:           data.Docker.EngineID,
+			verifyEngineOnReap: true,
+		}
 		teardown := p.reap
 		return &dockerBackend{
 			remoteAgentBackend: remoteAgentBackend{reap: teardown},
 			containerID:        p.containerID,
 			provisioner:        p,
-			cleanup:            &DockerRuntimeCleanupData{ContainerID: p.containerID},
+			cleanup: &DockerRuntimeCleanupData{
+				ContainerID: p.containerID,
+				EngineID:    p.engineID,
+			},
 		}, teardown, nil
 	case "ssh":
 		if data.SSH == nil || strings.TrimSpace(data.SSH.Config.Host) == "" || strings.TrimSpace(data.SSH.SessionDir) == "" {

--- a/session/runtime_cleanup_test.go
+++ b/session/runtime_cleanup_test.go
@@ -132,7 +132,10 @@ func TestRuntimeCleanupHandleRoundTripsEveryOffBoxBackend(t *testing.T) {
 			name: "docker",
 			backend: &dockerBackend{
 				provisioner: &dockerProvisioner{containerID: "sha256:cleanup-container"},
-				cleanup:     &DockerRuntimeCleanupData{ContainerID: "sha256:cleanup-container"},
+				cleanup: &DockerRuntimeCleanupData{
+					ContainerID: "sha256:cleanup-container",
+					EngineID:    "engine-cleanup",
+				},
 			},
 		},
 		{
@@ -198,6 +201,122 @@ func TestRuntimeCleanupHandleRoundTripsEveryOffBoxBackend(t *testing.T) {
 				t.Fatalf("cleanup handle changed across restart:\n got %#v\nwant %#v", roundTrip, stored.RuntimeCleanup)
 			}
 		})
+	}
+}
+
+func restoreDockerTombstoneForTest(t *testing.T, engineID string) *Instance {
+	t.Helper()
+	restored, err := FromInstanceData(InstanceData{
+		ID:          "docker-tombstone-id",
+		Title:       "docker-tombstone",
+		Path:        "/repo",
+		BackendType: "docker",
+		UserKilled:  true,
+		RuntimeCleanup: &RuntimeCleanupData{Docker: &DockerRuntimeCleanupData{
+			ContainerID: "sha256:cleanup-container",
+			EngineID:    engineID,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("restore docker tombstone: %v", err)
+	}
+	return restored
+}
+
+func TestRestoredDockerCleanupRefusesDifferentEngine(t *testing.T) {
+	restored := restoreDockerTombstoneForTest(t, "engine-a")
+	var calls [][]string
+	restoreExec := SetDockerExecForTest(func(_ context.Context, args ...string) ([]byte, error) {
+		calls = append(calls, append([]string(nil), args...))
+		if len(args) > 0 && args[0] == "info" {
+			return []byte("engine-b\n"), nil
+		}
+		return []byte("sha256:cleanup-container\n"), nil
+	})
+	defer restoreExec()
+
+	err := restored.Kill()
+	if !errors.Is(err, ErrWorkspaceStateUnknown) {
+		t.Fatalf("cleanup on a different Docker engine must retain the tombstone as unknown, got %v", err)
+	}
+	for _, call := range calls {
+		if len(call) > 0 && call[0] == "rm" {
+			t.Fatalf("cleanup targeted a container before proving the Docker engine identity: calls=%v", calls)
+		}
+	}
+}
+
+func TestRestoredDockerCleanupReapsMatchingEngine(t *testing.T) {
+	restored := restoreDockerTombstoneForTest(t, "engine-a")
+	var calls [][]string
+	restoreExec := SetDockerExecForTest(func(_ context.Context, args ...string) ([]byte, error) {
+		calls = append(calls, append([]string(nil), args...))
+		if len(args) > 0 && args[0] == "info" {
+			return []byte("engine-a\n"), nil
+		}
+		return []byte("sha256:cleanup-container\n"), nil
+	})
+	defer restoreExec()
+
+	if err := restored.Kill(); err != nil {
+		t.Fatalf("cleanup on the recorded Docker engine failed: %v", err)
+	}
+	if len(calls) != 2 || len(calls[0]) == 0 || calls[0][0] != "info" || len(calls[1]) == 0 || calls[1][0] != "rm" {
+		t.Fatalf("restored cleanup calls=%v, want identity probe followed by rm", calls)
+	}
+}
+
+func TestRestoredDockerCleanupRetriesIdentityProbe(t *testing.T) {
+	restored := restoreDockerTombstoneForTest(t, "engine-a")
+	var infoCalls, rmCalls int
+	restoreExec := SetDockerExecForTest(func(_ context.Context, args ...string) ([]byte, error) {
+		if len(args) == 0 {
+			return nil, errors.New("missing docker command")
+		}
+		switch args[0] {
+		case "info":
+			infoCalls++
+			if infoCalls == 1 {
+				return nil, errors.New("docker daemon temporarily unavailable")
+			}
+			return []byte("engine-a\n"), nil
+		case "rm":
+			rmCalls++
+			return []byte("sha256:cleanup-container\n"), nil
+		default:
+			return nil, errors.New("unexpected docker command")
+		}
+	})
+	defer restoreExec()
+
+	if err := restored.Kill(); !errors.Is(err, ErrWorkspaceStateUnknown) {
+		t.Fatalf("an unverifiable Docker target must retain the tombstone, got %v", err)
+	}
+	if rmCalls != 0 {
+		t.Fatalf("identity-probe failure still issued docker rm %d time(s)", rmCalls)
+	}
+	if err := restored.Kill(); err != nil {
+		t.Fatalf("cleanup did not retry after Docker identity became verifiable: %v", err)
+	}
+	if infoCalls != 2 || rmCalls != 1 {
+		t.Fatalf("retry work: info=%d rm=%d, want 2/1", infoCalls, rmCalls)
+	}
+}
+
+func TestLegacyDockerCleanupWithoutEngineIdentityFailsClosed(t *testing.T) {
+	restored := restoreDockerTombstoneForTest(t, "")
+	var calls int
+	restoreExec := SetDockerExecForTest(func(_ context.Context, _ ...string) ([]byte, error) {
+		calls++
+		return nil, nil
+	})
+	defer restoreExec()
+
+	if err := restored.Kill(); !errors.Is(err, ErrWorkspaceStateUnknown) {
+		t.Fatalf("legacy Docker tombstone without engine identity must remain retryable, got %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("legacy Docker tombstone guessed a target and invoked Docker %d time(s)", calls)
 	}
 }
 


### PR DESCRIPTION
## Outcome

Docker cleanup tombstones now persist the non-secret daemon ID that created their container. A restored reaper verifies that exact ID before issuing `docker rm -f`; a different, unavailable, malformed, or legacy target returns `ErrWorkspaceStateUnknown`, retains the tombstone, and never guesses.

Transient identity-probe failures are not latched, so a later retry can verify the original engine and reap normally. Live provision-failure cleanup keeps its existing path; the new proof is scoped to the restored path that lost its original client binding.

## Regression coverage

- engine A tombstone restored under engine B: no `rm`
- engine A tombstone restored under engine A: identity probe then `rm`
- transient identity lookup failure: retained, then successfully retried
- legacy tombstone without an engine ID: fail closed with no Docker call
- successful provisioning persists the daemon ID into cleanup storage
- existing Docker timeout/answered-error/retry taxonomy remains green

## Exact-head local gates

Head: `20529fa5e2d00062d2cf1d5b7da87f8ff0055871`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- generated artifacts regenerated with no drift

Closes #2382.

— Captain Claude
