### PR TITLE
fix(tui): sentence-case hooks overlay title

### DIFF
--- a/app/layout_cutover_test.go
+++ b/app/layout_cutover_test.go
@@ -251,22 +251,34 @@ func TestLayoutCutover_DegradationLadder(t *testing.T) {
 // (#1024 PR 4 — hooks lost their persistent sidebar slot); Esc closes it and
 // returns to the workspace.
 func TestLayoutCutover_HooksOverlay(t *testing.T) {
-	h := newTestHome(t)
-	resizeHome(h, 100, 30)
-	h.hooksPane.SetCommands([]string{"make setup"})
+	for _, size := range []struct {
+		name   string
+		width  int
+		height int
+	}{
+		{name: "80x24", width: 80, height: 24},
+		{name: "72x20", width: 72, height: 20},
+	} {
+		t.Run(size.name, func(t *testing.T) {
+			h := newTestHome(t)
+			resizeHome(h, size.width, size.height)
+			h.hooksPane.SetCommands([]string{"make setup"})
 
-	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("e")}, keys.KeyHooks)
-	require.Equal(t, stateHooks, h.state)
-	require.True(t, h.hooksPane.HasFocus(), "the editor opens with input focus")
+			_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("e")}, keys.KeyHooks)
+			require.Equal(t, stateHooks, h.state)
+			require.True(t, h.hooksPane.HasFocus(), "the editor opens with input focus")
 
-	view := h.View()
-	requireViewSized(t, view, 100, 30)
-	assert.Contains(t, view, "Post-Worktree Hooks", "the overlay hosts the existing editor")
-	assert.Contains(t, view, "make setup")
+			view := h.View()
+			requireViewSized(t, view, size.width, size.height)
+			assert.Contains(t, view, "Post-worktree hooks", "the overlay title follows sentence case")
+			assert.NotContains(t, view, "Post-Worktree Hooks", "the overlay title must not use title case")
+			assert.Contains(t, view, "make setup")
 
-	_, _ = h.handleStateHooks(tea.KeyMsg{Type: tea.KeyEsc})
-	assert.Equal(t, stateDefault, h.state, "Esc closes the overlay")
-	assert.NotContains(t, h.View(), "Post-Worktree Hooks")
+			_, _ = h.handleStateHooks(tea.KeyMsg{Type: tea.KeyEsc})
+			assert.Equal(t, stateDefault, h.state, "Esc closes the overlay")
+			assert.NotContains(t, h.View(), "Post-worktree hooks")
+		})
+	}
 }
 
 // TestLayoutCutover_TaskKeysOpenOverlay: m opens the task manager overlay,

--- a/app/tinyclip_overlay_test.go
+++ b/app/tinyclip_overlay_test.go
@@ -78,7 +78,7 @@ func TestTinyClipHooksOverlayFits(t *testing.T) {
 	view := h.View()
 	requireViewSized(t, view, 40, 10)
 	plain := xansi.Strip(view)
-	assert.Contains(t, plain, "Post-Worktree Hooks")
+	assert.Contains(t, plain, "Post-worktree hooks")
 	assert.Contains(t, plain, "enter save")
 	assert.Contains(t, plain, "esc cancel")
 }

--- a/ui/hooks_pane.go
+++ b/ui/hooks_pane.go
@@ -166,7 +166,7 @@ func (h *HooksPane) String() string {
 	descStyle := lipgloss.NewStyle().Foreground(t.ForegroundDim).Italic(true)
 
 	var b strings.Builder
-	b.WriteString(tStyle.Render("Post-Worktree Hooks"))
+	b.WriteString(tStyle.Render("Post-worktree hooks"))
 	b.WriteString("\n")
 	b.WriteString(descStyle.Render("Commands run async in new worktrees"))
 	b.WriteString("\n\n")


### PR DESCRIPTION
Closes #2391

## What changed

- Render the hooks editor title as `Post-worktree hooks`, matching the sentence-case convention in CLAUDE.md.
- Expand the production root-overlay regression to 80×24 and 72×20 and reject the title-case form.
- Keep the existing 40×10 clamping regression synchronized with the visible copy.

## Fail-first reproduction

With production copy unchanged, the root test failed at both sizes and rendered `Post-Worktree Hooks`. At 80×24 the editor is a centered modal; at 72×20 it safely expands to the full root view. The fixed title remains fully visible in both layouts, and focus/edit/save behavior is unchanged.

## Validation

Exact pushed head: `20ced6ebe27fb4a9db47479a322ec532ece1006d`

- focused 80×24, 72×20, and 40×10 root overlay regressions
- `scripts/gen-docs.sh` with a clean diff
- `golangci-lint run --timeout=3m --fast`
- clean `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...` with no output
- `scripts/lint-file-length.sh`
- `make test-container`
