### PR TITLE
fix(tui): sentence-case interactive help copy

### DIFF
--- a/app/help.go
+++ b/app/help.go
@@ -248,7 +248,7 @@ func (h helpTypeInteractive) toContent() string {
 	content := lipgloss.JoinVertical(lipgloss.Left,
 		titleStyle.Render("Interactive pane"),
 		"",
-		descStyle.Render("You are typing INTO this pane's terminal: every key — including tab —"),
+		descStyle.Render("You are typing into this pane's terminal: every key — including tab —"),
 		descStyle.Render("goes to the agent/shell. The pane's frame turns green while it has the"),
 		descStyle.Render("keyboard, and the instances rail stays visible."),
 		"",

--- a/app/interactive_test.go
+++ b/app/interactive_test.go
@@ -454,22 +454,42 @@ func TestAttachKeyKeepsFullScreenAttach(t *testing.T) {
 }
 
 func TestFirstInteractiveEntryShowsHelpScreenOnce(t *testing.T) {
-	h, _ := liveTestHome(t)
-	_, _ = stubLiveTermFactory(t)
+	for _, size := range []struct {
+		name   string
+		width  int
+		height int
+	}{
+		{name: "80x24", width: 80, height: 24},
+		{name: "72x20", width: 72, height: 20},
+	} {
+		t.Run(size.name, func(t *testing.T) {
+			h, _ := liveTestHome(t)
+			_, _ = stubLiveTermFactory(t)
+			resizeHome(h, size.width, size.height)
 
-	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+			_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
 
-	require.Equal(t, stateHelp, h.state, "first Enter must show the interactive help screen")
-	require.NotNil(t, h.textOverlay)
-	assert.Contains(t, h.textOverlay.Render(), "ctrl+]",
-		"the help screen must lead with the escape hatch (RFC §5.7)")
-	assert.False(t, h.interactive, "activation waits for the overlay dismissal")
+			require.Equal(t, stateHelp, h.state, "first Enter must show the interactive help screen")
+			require.NotNil(t, h.textOverlay)
+			view := h.View()
+			requireViewSized(t, view, size.width, size.height)
+			copy := flatten(view)
+			assert.Contains(t, copy, "You are typing into this pane's",
+				"the help screen follows the TUI sentence-case convention")
+			assert.Contains(t, copy, "terminal: every key",
+				"the wrapped sentence remains visible at compact widths")
+			assert.NotContains(t, copy, "typing INTO", "the help screen must not caps-shout")
+			assert.Contains(t, copy, "ctrl+]",
+				"the help screen must lead with the escape hatch (RFC §5.7)")
+			assert.False(t, h.interactive, "activation waits for the overlay dismissal")
 
-	// Any key dismisses the overlay; the deferred activation then runs.
-	_, cmd := h.handleHelpState(tea.KeyMsg{Type: tea.KeyEnter})
-	require.Equal(t, stateDefault, h.state)
-	runHermeticCmd(t, h, cmd, 0)
-	assert.True(t, h.interactive, "dismissing the help screen must complete the activation")
+			// Any key dismisses the overlay; the deferred activation then runs.
+			_, cmd := h.handleHelpState(tea.KeyMsg{Type: tea.KeyEnter})
+			require.Equal(t, stateDefault, h.state)
+			runHermeticCmd(t, h, cmd, 0)
+			assert.True(t, h.interactive, "dismissing the help screen must complete the activation")
+		})
+	}
 }
 
 func TestWheelIsInertWhileInteractive(t *testing.T) {


### PR DESCRIPTION
Closes #2392

## What changed

- Render the one-time interactive-pane help as `You are typing into this pane's terminal` instead of caps-shouting `INTO`.
- Expand the existing production first-entry regression to root renders at 80×24 and 72×20.
- Preserve the help gate, pane focus, deferred activation, escape-hatch copy, and post-dismiss interactive transition.

## Fail-first reproduction

With production copy unchanged, the root test failed at both sizes and rendered `You are typing INTO this pane's terminal`. At 72×20 the overlay wraps the sentence across rows; the regression pins both visible fragments and rejects the uppercase form. After the one-word change, both exactly-sized root views pass and interactive activation still waits for dismissal.

## Validation

Exact pushed head: `f98ddd1b3c79d1ef6da06f965a9cb71c4cf63243`

- focused first-interactive-entry root regression
- `scripts/gen-docs.sh` with a clean diff
- `golangci-lint run --timeout=3m --fast`
- clean `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...` with no output
- `scripts/lint-file-length.sh`
- `make test-container`
