### PR TITLE
test(web): settle the event-stream outage gap

### DIFF
--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -5981,18 +5981,47 @@ test("#1813: a close+recreate of the same name mid-edit renames NOTHING — neve
     const input = win.locator(".af-tabbar .af-tab-edit");
     await expect(input, "a double-click on a renameable tab must open an inline edit").toBeVisible();
     await input.fill(TYPED);
+    const editedPane = win.locator(".af-term-host .af-pane");
+    await expect(editedPane, "the edited tab must own the one visible pane").toHaveCount(1);
+    const editedPaneID = await editedPane.getAttribute("data-tab-id");
+    expect(editedPaneID, "the edited pane must expose the tab's stable id").toMatch(/\S/);
 
     // The gap: retries are refused, then the live socket is dropped. Neither the close
     // nor the recreate below is delivered as an event — delivered live they would each
     // repaint the bar and settle the edit early, which is the (already-covered) path
     // above, not this one.
     await cdp.send("Network.setBlockedURLs", { urls: ["*/v1/events*"] });
-    await win.evaluate(() => {
+    const eventSocketClose = await win.evaluate(async () => {
       const w = window as unknown as { __afEventSockets: WebSocket[] };
-      for (const ws of w.__afEventSockets) {
-        ws.close();
-      }
+      await Promise.all(
+        w.__afEventSockets.map(
+          (ws) =>
+            new Promise<void>((resolve) => {
+              if (ws.readyState === WebSocket.CLOSED) {
+                resolve();
+                return;
+              }
+              ws.addEventListener("close", () => resolve(), { once: true });
+              if (ws.readyState === WebSocket.CONNECTING || ws.readyState === WebSocket.OPEN) {
+                ws.close();
+              }
+            }),
+        ),
+      );
+      return {
+        closed: WebSocket.CLOSED,
+        states: w.__afEventSockets.map((ws) => ws.readyState),
+      };
     });
+    expect(eventSocketClose.states, "the test must capture the live event socket").not.toHaveLength(0);
+    expect(
+      eventSocketClose.states.every((state) => state === eventSocketClose.closed),
+      `the event gap must exist before daemon mutations; socket states=${JSON.stringify(eventSocketClose.states)}`,
+    ).toBe(true);
+    await expect(
+      win.locator(".af-live-pip"),
+      "the client must enter reconnecting state while the events endpoint stays blocked",
+    ).toHaveClass(/af-live-reconnecting/);
     af("sessions", "tab-delete", SESSION_ORDER, "--name", VICTIM);
     af("sessions", "tab-create", SESSION_ORDER, "--command", "sleep 300", "--name", VICTIM);
 
@@ -6006,9 +6035,22 @@ test("#1813: a close+recreate of the same name mid-edit renames NOTHING — neve
     });
     await cdp.send("Network.setBlockedURLs", { urls: [] });
     await resync;
-    // ...and the fetch's own promise chain (body read → store.set → update) has run, so
-    // the identity cache really does hold the replacement by the time Enter commits.
-    await win.evaluate(() => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(() => r(null)))));
+    // waitForResponse resolves at the response headers, before the app necessarily
+    // reads the body and applies it. Poll the pane's production identity instead: it
+    // changes only when the reconnect Snapshot has reached store.set → split reconcile,
+    // so Enter below cannot race a stale client cache under a loaded test box (#2387).
+    await expect
+      .poll(
+        async () => {
+          const id = await editedPane.getAttribute("data-tab-id");
+          return id !== null && id !== "" && id !== editedPaneID;
+        },
+        {
+          message: "the reconnect Snapshot must bind the pane to the replacement tab id",
+          timeout: 15_000,
+        },
+      )
+      .toBe(true);
 
     // The bar held still across all of it — the precondition the bug needs, asserted
     // rather than assumed: had the roster change repainted, the input would be gone and


### PR DESCRIPTION
Closes #2387.

## Problem

The close-and-recreate browser regression crossed two asynchronous boundaries without waiting for either one to settle:

- it invoked `WebSocket.close()` and immediately mutated the daemon; the fail-first assertion observed the socket still in `CLOSING` state (`readyState = 2`), so an event could still rebuild the tab bar
- after reconnect it treated response headers as an applied Snapshot; under full-suite load, Enter could run before the response body reached the client store

Those races made this correctness test fail intermittently across unrelated PRs.

## Fix

- await the real `close` event for every captured event socket
- assert that the test captured a socket and that every socket is actually closed
- wait for the production reconnecting state while the events endpoint remains blocked
- only then delete and recreate the same-named tab
- poll the pane's production `data-tab-id` until the reconnect Snapshot has installed the replacement identity before committing the edit

This adds no retry, timeout increase, sleep, or production behavior change.

## Verification

- fail-before: the pre-mutation socket-state assertion reported `[2]` (`CLOSING`)
- focused real-browser case passes after awaiting the close boundary
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make web-test` (415 tests)
- `make lint-file-length`
- `make web-build` (clean committed bundle)
- `make test-container`
- `make web-selftest-container` (117 real-browser cases)
