### PR TITLE
security(webtab): clean bootstrap credentials before render

### DIFF
--- a/daemon/webtab_path_encoding_test.go
+++ b/daemon/webtab_path_encoding_test.go
@@ -88,7 +88,7 @@ func TestWebTabProxy_PreservesEscapedSpecialChars(t *testing.T) {
 // TestWebTabProxy_ForwardsQueryButNotTheDaemonToken pins the query half of the
 // mirror: the app's own parameters reach the dev server untouched, while the
 // daemon's credential — which authorized the iframe's navigation and means nothing
-// upstream — is stripped before the hop. The daemon's credential rides its OWN
+// upstream — is stripped by the bootstrap redirect before the hop. The daemon's credential rides its OWN
 // param (af_webtab_token), so the app's params are stripped-proof even when one of
 // them is literally named access_token (the P1 token-conflation fix).
 func TestWebTabProxy_ForwardsQueryButNotTheDaemonToken(t *testing.T) {
@@ -98,7 +98,9 @@ func TestWebTabProxy_ForwardsQueryButNotTheDaemonToken(t *testing.T) {
 	// The target carries its OWN access_token — a real case (a dev app that proxies
 	// an authenticated API, or signs its asset URLs) — alongside doc, and the daemon
 	// appends its own af_webtab_token last.
-	rec := proxyGet(t, mux, id, tabID, "viewer.html?doc=123&access_token=app-value&af_webtab_token=daemon-tok")
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v1/webtab/%s/%s/viewer.html?doc=123&access_token=app-value&af_webtab_token=daemon-tok", id, tabID), nil)
+	_, rec := followWebTabTokenBootstrap(t, mux, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
 	}
@@ -133,13 +135,12 @@ func TestWebTabProxy_AppAccessTokenAuthorizesOnBothPostures(t *testing.T) {
 		}
 		authed := withAuth(mux, gate, nil)
 
-		rec := httptest.NewRecorder()
 		// The app's access_token comes FIRST — the position that made TokenFromRequest
 		// read it as the daemon credential and 401 the iframe before the fix.
 		req := httptest.NewRequest(http.MethodGet,
 			fmt.Sprintf("/v1/webtab/%s/%s/api?access_token=app-value&af_webtab_token=secret-tok", id, tabID), nil)
 		req.RemoteAddr = "172.17.0.4:54321"
-		authed.ServeHTTP(rec, req)
+		_, rec := followWebTabTokenBootstrap(t, authed, req)
 
 		if rec.Code != http.StatusOK {
 			t.Fatalf("status = %d, want 200 — the app's own access_token was read as the daemon credential (body: %s)",
@@ -195,11 +196,10 @@ func TestWebTabProxy_EncodedTokenKeyIsAuthedAndStripped(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			rec := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet,
 				fmt.Sprintf("/v1/webtab/%s/%s/api?doc=123&%s", id, tabID, tc.spelling), nil)
 			req.RemoteAddr = "172.17.0.4:54321"
-			authed.ServeHTTP(rec, req)
+			_, rec := followWebTabTokenBootstrap(t, authed, req)
 
 			// Every spelling the gate accepts must reach the upstream at all...
 			if rec.Code != http.StatusOK {
@@ -234,7 +234,9 @@ func TestWebTabProxy_PreservesSignedQueryByteForByte(t *testing.T) {
 
 	// Keys deliberately NOT in sorted order, a %20 that must not become +, and the
 	// daemon token wedged in the MIDDLE to prove the strip is positional-safe.
-	rec := proxyGet(t, mux, id, tabID, "sign?z=1&af_webtab_token=tok&a=hello%20world&sig=abc")
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v1/webtab/%s/%s/sign?z=1&af_webtab_token=tok&a=hello%%20world&sig=abc", id, tabID), nil)
+	_, rec := followWebTabTokenBootstrap(t, mux, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
 	}

--- a/daemon/webtab_proxy.go
+++ b/daemon/webtab_proxy.go
@@ -299,7 +299,7 @@ func (m *Manager) stopVSCodeIfUnwanted(instance *session.Instance, key, title st
 	return err
 }
 
-// webTabProxyHandler reverse-proxies GET /v1/webtab/{sessionId}/{tabId}/{rest...}
+// webTabProxyHandler reverse-proxies /v1/webtab/{sessionId}/{tabId}/{rest...}
 // to the tab's loopback dev-server target ON THE DAEMON MACHINE. This is what
 // makes a localhost dev-server preview visible to a REMOTE web-UI viewer (over
 // Tailscale/SSH): the browser fetches this same-origin daemon path, the daemon
@@ -341,6 +341,19 @@ func (m *Manager) stopVSCodeIfUnwanted(instance *session.Instance, key, title st
 // exemption (#1697) honored and the webtabTokenCookie fallback for iframe
 // sub-resource requests.
 func (cs *controlServer) webTabProxyHandler(w http.ResponseWriter, r *http.Request) {
+	// A network browser can authorize an iframe's first navigation only through a
+	// query parameter. Treat that parameter as a ONE-HOP bootstrap transport, not
+	// as part of the preview app's address: store the already-authenticated value
+	// in an HttpOnly cookie, then redirect to the exact same browser path with every
+	// decoded spelling of only our private parameter removed.
+	//
+	// This runs before manager access by design. Resolving a VS Code target may
+	// START the editor, and arbitrary preview code must never run while its own
+	// window.location still contains the daemon bearer. The clean cookie-backed
+	// follow-up is the first request allowed to resolve or contact any target.
+	if cleanWebTabTokenBootstrap(w, r) {
+		return
+	}
 	if cs.manager == nil {
 		writeHTTPError(w, r, http.StatusServiceUnavailable, fmt.Errorf("daemon has no session manager"))
 		return
@@ -464,29 +477,6 @@ func (cs *controlServer) webTabProxyHandler(w http.ResponseWriter, r *http.Reque
 	if err != nil {
 		writeHTTPError(w, r, http.StatusInternalServerError, fmt.Errorf("invalid web tab target: %w", err))
 		return
-	}
-
-	// On the TCP listener a network peer authorized this top-level request via the
-	// af_webtab_token query (an iframe src cannot set the Authorization header).
-	// Persist the credential it PRESENTED — the header or that private query param,
-	// never an existing cookie — as a path-scoped cookie, so the framed app's
-	// sub-resource GETs, which carry neither header nor query, stay authorized.
-	// Reading only the presented credential keeps this from re-issuing Set-Cookie on
-	// every cookie-authorized sub-resource. Loopback peers present none and need
-	// none, so nothing is set for them.
-	presented := agentproto.BearerToken(r.Header.Get(agentproto.AuthHeader))
-	if presented == "" {
-		presented = r.URL.Query().Get(webtabTokenQueryParam)
-	}
-	if presented != "" {
-		http.SetCookie(w, &http.Cookie{
-			Name:     webtabTokenCookie,
-			Value:    presented,
-			Path:     webtabPathPrefix,
-			HttpOnly: true,
-			Secure:   requestIsHTTPS(r),
-			SameSite: http.SameSiteStrictMode,
-		})
 	}
 
 	// The path prefix this tab's cookies are scoped under. Upstream Set-Cookie
@@ -646,6 +636,43 @@ func (cs *controlServer) webTabProxyHandler(w http.ResponseWriter, r *http.Reque
 		},
 	}
 	proxy.ServeHTTP(w, r)
+}
+
+// cleanWebTabTokenBootstrap persists a credential presented directly by the
+// caller and, when the private query transport is present, redirects to the same
+// request URI without it. It reports whether it wrote that redirect.
+//
+// The caller is behind withAuth, so a query value reaching this point has already
+// been compared with the daemon's token. Existing cookie-authorized requests do
+// not reissue the cookie: only a credential PRESENTED in the header or query does.
+func cleanWebTabTokenBootstrap(w http.ResponseWriter, r *http.Request) bool {
+	presented := agentproto.BearerToken(r.Header.Get(agentproto.AuthHeader))
+	if presented == "" {
+		presented = r.URL.Query().Get(webtabTokenQueryParam)
+	}
+	if presented != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     webtabTokenCookie,
+			Value:    presented,
+			Path:     webtabPathPrefix,
+			HttpOnly: true,
+			Secure:   requestIsHTTPS(r),
+			SameSite: http.SameSiteStrictMode,
+		})
+	}
+
+	cleanRawQuery := stripRawQueryParam(r.URL.RawQuery, webtabTokenQueryParam)
+	if cleanRawQuery == r.URL.RawQuery {
+		return false
+	}
+
+	cleanURL := *r.URL
+	cleanURL.RawQuery = cleanRawQuery
+	cleanURL.ForceQuery = false
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Referrer-Policy", "no-referrer")
+	http.Redirect(w, r, cleanURL.RequestURI(), http.StatusTemporaryRedirect)
+	return true
 }
 
 // forwardAppCookies forwards the dev app's cookies upstream while stripping the

--- a/daemon/webtab_proxy_test.go
+++ b/daemon/webtab_proxy_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/config"
@@ -91,6 +92,40 @@ func proxyGet(t *testing.T, mux *http.ServeMux, sessionID, tabID, sub string) *h
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/v1/webtab/%s/%s/%s", sessionID, tabID, sub), nil)
 	mux.ServeHTTP(rec, req)
 	return rec
+}
+
+// followWebTabTokenBootstrap drives the two browser requests made when an iframe
+// src carries the daemon's private query credential: the 307 that stores the
+// HttpOnly cookie and removes the query parameter, then the clean cookie-backed
+// GET that may reach the preview app.
+func followWebTabTokenBootstrap(
+	t *testing.T, handler http.Handler, req *http.Request,
+) (bootstrap, clean *httptest.ResponseRecorder) {
+	t.Helper()
+	bootstrap = httptest.NewRecorder()
+	handler.ServeHTTP(bootstrap, req)
+	if bootstrap.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("bootstrap status = %d, want 307 (body: %s)", bootstrap.Code, bootstrap.Body.String())
+	}
+	location := bootstrap.Header().Get("Location")
+	redirectURL, err := url.Parse(location)
+	if err != nil {
+		t.Fatalf("parse bootstrap Location %q: %v", location, err)
+	}
+	if redirectURL.Query().Has(webtabTokenQueryParam) {
+		t.Fatalf("bootstrap Location %q still exposes %s", location, webtabTokenQueryParam)
+	}
+	cookie := cookieNamed(bootstrap, webtabTokenCookie)
+	if cookie == nil {
+		t.Fatal("bootstrap did not set the web-tab token cookie")
+	}
+
+	cleanReq := httptest.NewRequest(http.MethodGet, location, nil)
+	cleanReq.RemoteAddr = req.RemoteAddr
+	cleanReq.AddCookie(cookie)
+	clean = httptest.NewRecorder()
+	handler.ServeHTTP(clean, cleanReq)
+	return bootstrap, clean
 }
 
 // TestWebTabProxy_RejectsArchivedSession is the #1809 follow-up gate: archive now
@@ -321,24 +356,26 @@ func TestWebTabProxy_MirrorsSubdirectoryTarget(t *testing.T) {
 	}
 }
 
-// TestWebTabProxy_RootRedirectsToTargetPath verifies the other half of the mirror
-// model: a bare hit on the tab root is redirected to the target's own path, so the
-// browser's URL starts mirroring upstream from the first navigation and the
-// ?af_webtab_token that authorized it survives the hop.
+// TestWebTabProxy_RootRedirectsToTargetPath verifies that the credential cleanup
+// and path-mirror redirects compose: first the private query is removed in place,
+// then the clean cookie-backed request is sent to the target's own path.
 func TestWebTabProxy_RootRedirectsToTargetPath(t *testing.T) {
 	upstream := newStaticFileUpstream(t, "doc", "css", "shared")
 	mux, id, tabID := newWebTabProxyFixture(t, upstream.URL+"/app/viewer.html")
 
-	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet,
 		fmt.Sprintf("/v1/webtab/%s/%s/?af_webtab_token=tok", id, tabID), nil)
-	mux.ServeHTTP(rec, req)
+	bootstrap, clean := followWebTabTokenBootstrap(t, mux, req)
 
-	if rec.Code != http.StatusFound {
-		t.Fatalf("root: status = %d, want 302 (body: %s)", rec.Code, rec.Body.String())
+	wantCleanRoot := fmt.Sprintf("/v1/webtab/%s/%s/", id, tabID)
+	if got := bootstrap.Header().Get("Location"); got != wantCleanRoot {
+		t.Fatalf("bootstrap Location = %q, want %q", got, wantCleanRoot)
 	}
-	want := fmt.Sprintf("/v1/webtab/%s/%s/app/viewer.html?af_webtab_token=tok", id, tabID)
-	if got := rec.Header().Get("Location"); got != want {
+	if clean.Code != http.StatusFound {
+		t.Fatalf("clean root: status = %d, want 302 (body: %s)", clean.Code, clean.Body.String())
+	}
+	want := fmt.Sprintf("/v1/webtab/%s/%s/app/viewer.html", id, tabID)
+	if got := clean.Header().Get("Location"); got != want {
 		t.Fatalf("root: Location = %q, want %q", got, want)
 	}
 }
@@ -382,10 +419,11 @@ func TestMirrorRootRedirect(t *testing.T) {
 		// Root targets already mirror themselves — no redirect, no loop.
 		{target: "http://localhost:8899", wantRedir: false},
 		{target: "http://localhost:8899/", wantRedir: false},
-		// The token that authorized the top-level navigation rides along.
+		// Ordinary app query bytes ride along. The daemon token is already removed
+		// before this helper can run.
 		{
-			target: "http://localhost:8899/app/viewer.html", rawQuery: "af_webtab_token=tok",
-			want: prefix + "/app/viewer.html?af_webtab_token=tok", wantRedir: true,
+			target: "http://localhost:8899/app/viewer.html", rawQuery: "doc=hello%20world",
+			want: prefix + "/app/viewer.html?doc=hello%20world", wantRedir: true,
 		},
 	}
 	for _, tc := range cases {
@@ -536,6 +574,120 @@ func TestWebTabProxy_SetsScopedTokenCookie(t *testing.T) {
 	}
 }
 
+// TestWebTabProxy_QueryTokenIsOnlyABootstrapCredential pins the browser-facing
+// half of the token boundary. The private query parameter may authorize exactly
+// one request, but application code must never render at that credential-bearing
+// URL: the handler first stores the credential in an HttpOnly cookie and redirects
+// to the same path with only its own parameter removed. The clean, cookie-backed
+// follow-up is the first request allowed to reach the preview app.
+func TestWebTabProxy_QueryTokenIsOnlyABootstrapCredential(t *testing.T) {
+	var upstreamCalls atomic.Int32
+	seenQuery := make(chan string, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls.Add(1)
+		seenQuery <- r.URL.RawQuery
+		fmt.Fprint(w, "app-rendered")
+	}))
+	defer upstream.Close()
+	mux, id, tabID := newWebTabProxyFixture(t, upstream.URL)
+
+	bootstrapPath := fmt.Sprintf(
+		"/v1/webtab/%s/%s/?doc=hello%%20world&af%%5Fwebtab%%5Ftoken=fixture-token&z=1",
+		id, tabID,
+	)
+	bootstrap := httptest.NewRecorder()
+	mux.ServeHTTP(bootstrap, httptest.NewRequest(http.MethodGet, bootstrapPath, nil))
+
+	if bootstrap.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("bootstrap status = %d, want 307 (body: %s)", bootstrap.Code, bootstrap.Body.String())
+	}
+	if got := upstreamCalls.Load(); got != 0 {
+		t.Fatalf("bootstrap reached the preview app %d time(s), want 0", got)
+	}
+	wantLocation := fmt.Sprintf("/v1/webtab/%s/%s/?doc=hello%%20world&z=1", id, tabID)
+	if got := bootstrap.Header().Get("Location"); got != wantLocation {
+		t.Fatalf("bootstrap Location = %q, want %q", got, wantLocation)
+	}
+	if strings.Contains(bootstrap.Header().Get("Location"), "fixture-token") ||
+		strings.Contains(bootstrap.Body.String(), "fixture-token") {
+		t.Fatal("bootstrap credential is readable in the redirect URL or body")
+	}
+	if got := bootstrap.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("bootstrap Cache-Control = %q, want no-store", got)
+	}
+	if got := bootstrap.Header().Get("Referrer-Policy"); got != "no-referrer" {
+		t.Fatalf("bootstrap Referrer-Policy = %q, want no-referrer", got)
+	}
+	cookie := cookieNamed(bootstrap, webtabTokenCookie)
+	if cookie == nil || !cookie.HttpOnly {
+		t.Fatalf("bootstrap cookie = %+v, want an HttpOnly token cookie", cookie)
+	}
+
+	clean := httptest.NewRecorder()
+	cleanReq := httptest.NewRequest(http.MethodGet, wantLocation, nil)
+	cleanReq.AddCookie(cookie)
+	mux.ServeHTTP(clean, cleanReq)
+	if clean.Code != http.StatusOK {
+		t.Fatalf("clean follow-up status = %d, want 200 (body: %s)", clean.Code, clean.Body.String())
+	}
+	if got := upstreamCalls.Load(); got != 1 {
+		t.Fatalf("clean follow-up reached the preview app %d time(s), want 1", got)
+	}
+	if got := <-seenQuery; got != "doc=hello%20world&z=1" {
+		t.Fatalf("upstream RawQuery = %q, want exact clean app query", got)
+	}
+}
+
+// TestWebTabProxy_QueryTokenCleanupKeepsMirroredPath ensures a non-root target
+// cannot bypass the bootstrap boundary. The redirect stays on the exact mirrored
+// path and preserves the app's raw query bytes and order; it does not bounce via
+// the tab root or the upstream target URL.
+func TestWebTabProxy_QueryTokenCleanupKeepsMirroredPath(t *testing.T) {
+	var upstreamCalls atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls.Add(1)
+		fmt.Fprintf(w, "path=%s query=%s", r.URL.EscapedPath(), r.URL.RawQuery)
+	}))
+	defer upstream.Close()
+	mux, id, tabID := newWebTabProxyFixture(t, upstream.URL+"/app/viewer.html")
+
+	path := fmt.Sprintf(
+		"/v1/webtab/%s/%s/app/viewer.html?z=1&af_webtab_token=fixture-token&a=hello%%20world",
+		id, tabID,
+	)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+
+	if rec.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("bootstrap status = %d, want 307 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := upstreamCalls.Load(); got != 0 {
+		t.Fatalf("bootstrap reached the preview app %d time(s), want 0", got)
+	}
+	want := fmt.Sprintf("/v1/webtab/%s/%s/app/viewer.html?z=1&a=hello%%20world", id, tabID)
+	if got := rec.Header().Get("Location"); got != want {
+		t.Fatalf("bootstrap Location = %q, want %q", got, want)
+	}
+}
+
+// TestWebTabProxy_QueryTokenCleansBeforeTargetResolution pins the ordering that
+// matters for VS Code tabs: resolving their target can start an editor. Even a
+// server with no manager must perform the credential cleanup first, so no target
+// lookup or application process can precede the clean browser URL.
+func TestWebTabProxy_QueryTokenCleansBeforeTargetResolution(t *testing.T) {
+	mux := newHTTPMux(&controlServer{})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/v1/webtab/session/tab/?af_webtab_token=fixture-token", nil))
+
+	if rec.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("status = %d, want 307 before the missing-manager check (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Location"); got != "/v1/webtab/session/tab/" {
+		t.Fatalf("Location = %q, want the clean request path", got)
+	}
+}
+
 // TestWebTabProxy_TokenCookieSecureTracksScheme is the #1808 regression test.
 //
 // The daemon serves PLAIN HTTP, and a browser silently DROPS a Secure cookie
@@ -596,8 +748,9 @@ func TestWebTabProxy_TokenCookieSecureTracksScheme(t *testing.T) {
 
 // TestWebTabProxy_RemotePeerSubResourcesAuthorize is the end-to-end #1808 proof at
 // the gate: a NETWORK peer over plain HTTP with require_token=true authorizes the
-// top-level navigation with ?af_webtab_token, and the cookie it gets back then
-// authorizes the iframe's sub-resource GETs — which carry neither header nor query.
+// top-level navigation with ?af_webtab_token. The handler cleans that URL before
+// application code renders, and the cookie it gets back then authorizes both the
+// clean navigation and iframe sub-resource GETs — which carry neither header nor query.
 // Before the fix the cookie was Secure, the browser dropped it, and every one of
 // those 401'd.
 func TestWebTabProxy_RemotePeerSubResourcesAuthorize(t *testing.T) {
@@ -616,16 +769,15 @@ func TestWebTabProxy_RemotePeerSubResourcesAuthorize(t *testing.T) {
 	authed := withAuth(mux, gate, nil)
 
 	// 1. The top-level navigation authorizes via ?af_webtab_token (an iframe src
-	//    cannot set a header) and gets the cookie back.
-	rec := httptest.NewRecorder()
+	//    cannot set a header), gets the cookie, and follows the clean URL.
 	req := httptest.NewRequest(http.MethodGet,
 		fmt.Sprintf("/v1/webtab/%s/%s/?af_webtab_token=secret-tok", id, tabID), nil)
 	req.RemoteAddr = "172.17.0.4:54321"
-	authed.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("top-level nav: status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	bootstrap, clean := followWebTabTokenBootstrap(t, authed, req)
+	if clean.Code != http.StatusOK {
+		t.Fatalf("clean top-level nav: status = %d, want 200 (body: %s)", clean.Code, clean.Body.String())
 	}
-	cookie := cookieNamed(rec, webtabTokenCookie)
+	cookie := cookieNamed(bootstrap, webtabTokenCookie)
 	if cookie == nil {
 		t.Fatal("no af_webtab_token cookie for the token-authorized navigation")
 	}

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -1705,6 +1705,36 @@ test("web tab (feat): a local dev-server preview is daemon-proxied and rendered 
   await expect(page.frameLocator(".af-webframe").locator("#marker")).toHaveText(WEBTAB_LOCAL_MARKER, {
     timeout: 15_000,
   });
+
+  // The daemon credential is allowed in an iframe src only as a one-hop bootstrap
+  // transport. Drive that path with an inert fixture value, observe the redirect,
+  // and then ask the framed document what URL arbitrary preview JavaScript sees.
+  // The app must render only after the private parameter has disappeared.
+  const bootstrapSeen = page.waitForResponse(
+    (response) => response.url().includes("af_webtab_token=browser-fixture") && response.status() === 307,
+  );
+  await frame.evaluate((node) => {
+    const iframe = node as HTMLIFrameElement;
+    const bootstrap = new URL(iframe.src);
+    bootstrap.searchParams.set("af_webtab_token", "browser-fixture");
+    bootstrap.searchParams.set("_af_bootstrap_probe", "clean-hop");
+    iframe.src = `${bootstrap.pathname}${bootstrap.search}`;
+  });
+  await bootstrapSeen;
+  await expect(page.frameLocator(".af-webframe").locator("#marker")).toHaveText(WEBTAB_LOCAL_MARKER, {
+    timeout: 15_000,
+  });
+  await expect
+    .poll(() => page.frameLocator(".af-webframe").locator("html").evaluate(() => window.location.href))
+    .toContain("_af_bootstrap_probe=clean-hop");
+  const renderedAddress = await page
+    .frameLocator(".af-webframe")
+    .locator("html")
+    .evaluate(() => ({ href: window.location.href, referrer: document.referrer }));
+  expect(new URL(renderedAddress.href).searchParams.get("_af_bootstrap_probe")).toBe("clean-hop");
+  expect(new URL(renderedAddress.href).searchParams.has("af_webtab_token")).toBe(false);
+  expect(renderedAddress.href).not.toContain("browser-fixture");
+  expect(renderedAddress.referrer).not.toContain("browser-fixture");
 });
 
 test("web tab (#1806/#1811): a Vite-shaped subdirectory app previews, and its absolute-path asset 404s instead of getting the SPA shell", REAL_FIXTURE, async () => {


### PR DESCRIPTION
Closes #2395.

## What changed

- Treat `af_webtab_token` as a one-hop bootstrap transport: set the existing HttpOnly cookie, then return a 307 to the exact same escaped path with every decoded spelling of only that private query key removed.
- Run that cleanup before manager access or target resolution, so a VS Code target cannot start and a preview server cannot be contacted while application JavaScript can still read the daemon credential from its own URL.
- Preserve the application query byte-for-byte, add `no-store` and `no-referrer` on the bootstrap response, and retain header/cookie and subresource behavior.
- Replace the older tests that deliberately carried the credential through redirects with root, mirrored-path, encoded-key, remote-peer, no-target-resolution, and browser-visible final-URL coverage.

The browser test uses only an inert fixture string. No live credential value was inspected, printed, or recorded while reproducing or verifying this issue.

## Fail-first

Before the implementation, both new handler regressions returned `200` and executed the preview app on the credential-bearing URL. The root case rendered `app-rendered`; the mirrored-path case reached `/app/viewer.html` with the app query. Both now return the clean bootstrap redirect with zero upstream calls.

## Gates

Exact pushed head: `799ab1dd1d96b0c5492ff6e600d62452e619f03f`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (empty)
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make docs` (no generated drift)
- `make web-build` (no committed bundle drift)
- `make web-test` (415 passed)
- `make web-selftest-container` (117 passed)

— Captain Claude
