### PR TITLE
web: add session create remote hook option

### DIFF
--- a/parity/honesty_test.go
+++ b/parity/honesty_test.go
@@ -113,7 +113,7 @@ func TestDerivationSeesWebCreateOptions(t *testing.T) {
 			"parser is blind again; if the feature was reverted, flip the inventory cell back.")
 	}
 	// Still not sent — the remaining half of the create-option gap.
-	for _, f := range []string{"force_remote", "in_place"} {
+	for _, f := range []string{"in_place"} {
 		if contains(sent, f) {
 			t.Errorf("web CreateSession now sends %q — update session.create.opt.* and "+
 				"field_coverage.web_rpcs.CreateSession in the same change.", f)

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -117,8 +117,8 @@
         "pointer": "keys/keys.go:153 (N) -> app/handle_input.go:207 ForceRemote"
       },
       "web": {
-        "status": "no",
-        "pointer": "web/src/api.ts:251-264 never sends force_remote"
+        "status": "yes",
+        "pointer": "web/src/api.ts:351,363-371 createSession force_remote; web/src/modals.ts remote hooks checkbox"
       },
       "cli": {
         "status": "yes",
@@ -126,7 +126,7 @@
       },
       "verdict": "real-gap",
       "issue": "#1933",
-      "notes": "TUI is 'partial' because ForceRemote resolves to the hook backend ONLY (session/instance_factory.go:106-108) — N cannot reach docker or ssh. The web has no remote affordance at all; this is the gap the owner reported."
+      "notes": "TUI remains partial (legacy ForceRemote-only selector), CLI reaches remote via --backend hook, and web now has parity for this one option. The capability is still a real gap across all three surfaces."
     },
     {
       "id": "session.create.opt.inplace",
@@ -1968,9 +1968,6 @@
         },
         "in_place": {
           "gap": "session.create.opt.inplace"
-        },
-        "force_remote": {
-          "gap": "session.create.opt.remote"
         }
       },
       "CreateTab": {

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6270,8 +6270,11 @@ async function createSession(input, token2) {
     program: input.program,
     prompt: input.prompt
   };
+  if (input.forceRemote === true) {
+    body.force_remote = true;
+  }
   const backend = (input.backend ?? "").trim();
-  if (backend !== "") {
+  if (!input.forceRemote && backend !== "") {
     body.backend = backend;
   }
   const resp = await af("CreateSession", body, token2);
@@ -6636,12 +6639,15 @@ function newSessionModal(projects, defaultProject2, callbacks) {
   projectSelect.addEventListener("change", () => loadCatalogsFor(projectSelect.value));
   const promptArea = h("textarea", { class: "af-input af-textarea", placeholder: "Initial prompt (optional)", rows: 3 });
   promptArea.setAttribute("aria-label", "Initial prompt");
+  const forceRemoteCheckbox = h("input", { type: "checkbox" });
+  forceRemoteCheckbox.setAttribute("aria-label", "Create on remote hooks backend");
   body.append(
     field("Title", titleInput),
     field("Project", projectSelect),
     field("Program", programSelect),
     field("Backend", backendSelect),
     backendHint,
+    field("Remote hooks", forceRemoteCheckbox),
     field("Prompt", promptArea)
   );
   renderPrograms();
@@ -6662,7 +6668,8 @@ function newSessionModal(projects, defaultProject2, callbacks) {
       prompt: promptArea.value,
       // REPO_DEFAULT ("") when the user did not choose — createSession then omits
       // `backend` entirely and the repo's config decides (#1933).
-      backend: backendSelect.value
+      backend: backendSelect.value,
+      forceRemote: forceRemoteCheckbox.checked
     });
   });
   queueMicrotask(() => titleInput.focus());

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "58ea0e763e45";
+const VERSION = "4063af4cd3d7";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -97,6 +97,28 @@ test("createSession omits backend when the field is absent altogether", async ()
   assert.equal("backend" in cap.body, false, "an undefined backend is the same 'let the repo decide' as an empty one");
 });
 
+test("createSession sends force_remote when requested", async () => {
+  const cap = stubFetch();
+  await createSession(createInput({ forceRemote: true }), "tok");
+
+  assert.equal(cap.body.force_remote, true, "remote checkbox must become force_remote on the API");
+});
+
+test("createSession does not send backend when force_remote is true", async () => {
+  const cap = stubFetch();
+  await createSession(createInput({ forceRemote: true, backend: "hook" }), "tok");
+
+  assert.equal("backend" in cap.body, false, "force_remote alone must determine hook routing");
+});
+
+test("createSession omits force_remote when disabled", async () => {
+  const cap = stubFetch();
+  await createSession(createInput({ forceRemote: false }), "tok");
+  await createSession(createInput(), "tok");
+
+  assert.equal("force_remote" in cap.body, false, "explicit false leaves force_remote absent");
+});
+
 test("listBackends asks the daemon for the picked repo's catalog", async () => {
   const cap = stubFetch();
   await listBackends("/repos/af", "tok");

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -333,6 +333,9 @@ export interface CreateSessionInput {
    *  choose, and createSession then sends NO backend so the repo's own config
    *  decides. */
   backend?: string;
+  /** Whether to force the remote hook backend (`af sessions create --backend hook` /
+   *  the TUI's `N new remote`, regardless of repo default or selected backend). */
+  forceRemote?: boolean;
 }
 
 /** Lists the runtimes a session in this repo can be created on, whether the repo's
@@ -363,13 +366,21 @@ export async function createSession(input: CreateSessionInput, token: string): P
     program: input.program,
     prompt: input.prompt,
   };
+
+  if (input.forceRemote === true) {
+    body.force_remote = true;
+  }
+
   // `backend` is sent ONLY when the user picked one. Sending "local" for an
   // unspecified choice would look equivalent and is not: an explicit backend wins
   // over the repo's `backend` config key, so it would silently override the repo
   // default that `af sessions create` (with no --backend) honours. Absent is the
   // only way to mean "let the repo decide" (#1933).
   const backend = (input.backend ?? "").trim();
-  if (backend !== "") {
+  // When forcing remote, drop the backend choice so ForceRemote remains source of
+  // truth (#1933). `backend` is explicit and has precedence over ForceRemote in
+  // backend resolution; this keeps the wire shape in parity with TUI behavior.
+  if (!input.forceRemote && backend !== "") {
     body.backend = backend;
   }
   const resp = await af<{ instance: SessionData }>("CreateSession", body, token);

--- a/web/src/modals.ts
+++ b/web/src/modals.ts
@@ -312,12 +312,16 @@ export function newSessionModal(
   const promptArea = h("textarea", { class: "af-input af-textarea", placeholder: "Initial prompt (optional)", rows: 3 });
   promptArea.setAttribute("aria-label", "Initial prompt");
 
+  const forceRemoteCheckbox = h("input", { type: "checkbox" });
+  forceRemoteCheckbox.setAttribute("aria-label", "Create on remote hooks backend");
+
   body.append(
     field("Title", titleInput),
     field("Project", projectSelect),
     field("Program", programSelect),
     field("Backend", backendSelect),
     backendHint,
+    field("Remote hooks", forceRemoteCheckbox),
     field("Prompt", promptArea),
   );
 
@@ -341,6 +345,7 @@ export function newSessionModal(
       // REPO_DEFAULT ("") when the user did not choose — createSession then omits
       // `backend` entirely and the repo's config decides (#1933).
       backend: backendSelect.value,
+      forceRemote: forceRemoteCheckbox.checked,
     });
   });
 


### PR DESCRIPTION
## Surface parity gap closed
- Closes parity gap: session.create.opt.remote (web side missing)
- Implemented remote-hook create option in the existing web path: New Session modal checkbox -> CreateSessionInput.forceRemote -> createSession now sends force_remote and suppresses explicit backend when force mode is enabled.
- Updated ledger parity/inventory.json:
  - session.create.opt.remote.web status -> yes with updated pointer
  - removed field_coverage.web_rpcs.CreateSession.force_remote gap declaration (now sent)
  - session.create.opt.remote remains verdict: real-gap because TUI is still partial
- Ran full gate suite on commit 7d638f80 and all pass.

## Gates
- golangci-lint run --timeout=3m --fast
- gofmt -l .
- go build ./...
- make test-container
- deadcode -test ./...
- scripts/lint-file-length.sh

Signed-off-by: Captain Claude
