### PR TITLE
fix(daemon): release the cap slot held by a tombstoned ghost (#2418)

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -512,7 +512,15 @@ func refreshDaemonInstances(existing map[string]*session.Instance) (map[string]*
 				// TaskRunActive on that transition, but keep this raw-row projection
 				// defensive for a record written by an intermediate/older build: a
 				// contradictory stale bit must not wedge max_concurrent_runs forever.
-				if item.TaskID != "" && item.TaskRunActive && !item.StartupStateUnknown {
+				// UserKilled is terminal in the same way and matters more here, because
+				// the ghost path is the one place its slot can never be released
+				// otherwise: holdsTaskRunSlot already frees a tombstoned INSTANCE (via
+				// canAutoRestoreLostSession — "finish-this-kill, never restore-this"),
+				// but the bit is only cleared by finishing the kill, and finishUserKill
+				// runs against m.instances, which is exactly where a ghost is absent. A
+				// tombstoned row that stops loading would therefore hold its slot for
+				// good and park every later event for that task (#2418).
+				if item.TaskID != "" && item.TaskRunActive && !item.StartupStateUnknown && !item.UserKilled {
 					ghostTaskRuns[taskRunReservationKey(repoID, item.TaskID)]++
 					log.WarningLog.Printf("watch task %s: session %q failed to load but its run is still counted against max_concurrent_runs (#1892); kill or repair the session to release its slot", item.TaskID, item.Title)
 				}

--- a/daemon/watch_concurrency_ghost_test.go
+++ b/daemon/watch_concurrency_ghost_test.go
@@ -207,6 +207,72 @@ func TestStartupUnknownGhostDoesNotHoldTaskRunSlot(t *testing.T) {
 	}
 }
 
+// TestUserKilledGhostDoesNotHoldTaskRunSlot covers the kill tombstone (#1108) on
+// the raw-row path. The loaded-instance half already frees this slot —
+// holdsTaskRunSlot defers to canAutoRestoreLostSession, which refuses a UserKilled
+// record ("finish-this-kill, never restore-this"). Ghost accounting reads storage
+// directly, so it has to reach the same verdict on its own or the two halves
+// disagree about the same session.
+//
+// Disagreeing here is unrecoverable rather than merely wrong. A tombstone is
+// cleared by FINISHING the kill, and finishUserKill only ever runs against an
+// instance in m.instances — the one place a ghost is by definition absent. So the
+// bit that would release the slot can only be cleared by the path the row cannot
+// reach, and the cap stays at its limit for as long as the row is unloadable:
+// every later event for that task parks forever. That is the same
+// wedged-cap failure TestGhostTaskRunReleasesWhenItsRunIsOver and
+// TestStartupUnknownGhostDoesNotHoldTaskRunSlot exist to prevent, arrived at
+// through the third terminal marker (#2418).
+func TestUserKilledGhostDoesNotHoldTaskRunSlot(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	const title = "tombstoned-ghost"
+	// The wedge as it reaches disk: the user killed the session, so the tombstone
+	// is committed, but the run marker was never cleared — the kill did not get to
+	// finish. Nothing in the row can ever clear it once the row stops loading.
+	if err := appendInstanceData(repo.ID, session.InstanceData{
+		ID:            "tombstoned-id",
+		TaskID:        "task1",
+		Title:         title,
+		Path:          repoPath,
+		Status:        session.Lost,
+		Liveness:      session.LiveLost,
+		TaskRunActive: true,
+		UserKilled:    true,
+		BackendType:   "local",
+		Worktree:      session.GitWorktreeData{RepoPath: repoPath},
+	}); err != nil {
+		t.Fatalf("append tombstoned row: %v", err)
+	}
+	failLoadFor(t, title)
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := manager.RestoreInstances(); err != nil {
+		t.Fatalf("RestoreInstances: %v", err)
+	}
+	manager.mu.Lock()
+	_, live := manager.instances[daemonInstanceKey(repo.ID, title)]
+	counted := manager.countTaskRunsLocked(repo.ID, "task1")
+	admitErr := manager.admitTaskRunLocked(repo.ID, "task1", 1)
+	manager.mu.Unlock()
+	if live {
+		t.Fatal("precondition: the row must have failed to materialize for this to test a ghost")
+	}
+	if counted != 0 {
+		t.Fatalf("tombstoned ghost consumed %d task slot(s); an explicit kill releases the cap", counted)
+	}
+	if admitErr != nil {
+		t.Fatalf("tombstoned ghost wedged the task's cap — no later event can ever land: %v", admitErr)
+	}
+}
+
 // TestGhostTaskRunClearsWhenTheRowLoadsAgain: the ghost set is a projection,
 // rebuilt every refresh — not bookkeeping. A row that starts loading again must
 // stop being a ghost, or its slot would be held twice: once by the ghost and once


### PR DESCRIPTION
Fixes #2418.

## The bug

A task-spawned session that the user killed, and which then failed to load, held its `max_concurrent_runs` slot **forever**. The task sits at its limit and every later event parks, with no way back short of hand-editing or deleting the row.

Verified live on `master` (`6f90d5b1`) before fixing — this report is not stale.

## Why it wedges permanently

The two halves of the concurrency counter disagreed about the same session.

The **loaded-instance** half already frees this slot. `holdsTaskRunSlot` defers to `canAutoRestoreLostSession`, which refuses a `UserKilled` record outright — the existing test says it plainly: *"a UserKilled record means finish-this-kill, never restore-this; it must not hold a slot"* (`daemon/watch_concurrency_lost_test.go:212`).

**Ghost** accounting reads raw storage, because the row never became an `Instance` at all, so it reaches its own verdict independently — and that verdict ignored the tombstone.

What makes the disagreement unrecoverable rather than merely wrong is *which* half is missing it. `TaskRunActive` is cleared by **finishing** the kill, and `finishUserKill` only ever runs against an instance in `m.instances` — the one place a ghost is by definition absent. So the bit that would release the slot can only be cleared by the path the row cannot reach. The slot stays held for exactly as long as the row stays unloadable, which for a vanished worktree or an unresolvable backend is indefinitely.

## The fix

One clause, on the raw-row path, next to the `StartupStateUnknown` guard that is already there for the same reason:

```go
if item.TaskID != "" && item.TaskRunActive && !item.StartupStateUnknown && !item.UserKilled {
```

A terminal marker has to release the cap even when the row behind it can no longer be loaded. That is now true of all three terminal markers the ghost path can see.

## Test

`TestUserKilledGhostDoesNotHoldTaskRunSlot`, modeled on the `StartupStateUnknown` sibling next to it. It drives the real production path — `appendInstanceData` → `NewManager` → `RestoreInstances` → `refreshDaemonInstances` → `countTaskRunsLocked` → `admitTaskRunLocked` — with the load forced to fail exactly as a broken row does in production.

It asserts the consequence that actually bites the user, not just the counter: `admitTaskRunLocked` must let the next event land.

Watched it fail first, on the reported symptom:

```
--- FAIL: TestUserKilledGhostDoesNotHoldTaskRunSlot (0.03s)
    watch_concurrency_ghost_test.go:269: tombstoned ghost consumed 1 task slot(s); an explicit kill releases the cap
```

## Adjacent-call-site audit

`daemon/daemon.go:523` is the **only** raw-row projection of task-run activity. Every other consumer of `TaskRunActive` goes through `LifecycleView`/`holdsTaskRunSlot`, which already handles the tombstone via `canAutoRestoreLostSession`. No other site needed the same clause.

## Gate

- `gofmt -l .` clean · `go build ./...` clean
- `golangci-lint run --timeout=3m --fast` clean
- `deadcode -test ./...` clean
- `scripts/lint-file-length.sh` passed (985 files)
- Full suite via `make test-container` on the pushed head — SHA noted in a follow-up comment

## Review

The codex GitHub app is rate-limited until Jul 28. Requesting once; if it stays silent I'll say so explicitly on this PR rather than implying a clean review, and Captain Claude runs an independent review on this exact head before merge.

— Captain Claude
