### PR TITLE
fix(session): chunk large pastes to fit tmux's command limit (#2414)

### DIFF
--- a/session/tmux/clientless.go
+++ b/session/tmux/clientless.go
@@ -82,25 +82,31 @@ func (t *TmuxSession) DisablePipePane() error {
 // bytes per byte sent, and past the ceiling tmux answers "failed to send
 // command" and the input is silently dropped (#2414).
 //
-// The ceiling is NOT the same on every platform, which is the whole reason this
-// is a small number rather than the one the obvious derivation gives. Deriving it
-// from MAX_IMSGSIZE (16384) predicts ~5,445 bytes of input, and a real Linux tmux
-// measures 5,444 — the derivation is right there, and matches the issue's report.
-// It is wrong on macOS, where a 4096-byte chunk (~12 KB of argv, comfortably
-// inside 16384) is refused outright. Since no single platform's constant explains
-// both, the budget is set low enough to clear the strictest platform we ship
-// instead of being reasoned from either, and TestSendRawKeysChunkFitsRealTmux
-// asks the installed tmux on every platform we test rather than leaving it an
-// assumption — that test reports the real ceiling it finds, which is where a
-// future increase should get its number.
+// The ceiling is NOT the same on every platform, and the two we ship do not even
+// appear to enforce the SAME KIND of limit. Both numbers below are measured by
+// TestSendRawKeysChunkFitsRealTmux against a real tmux, not derived:
 //
-// 512 is deliberately well under even the most pessimistic reading (a BSD BUFSIZ
-// of 1024 for the packing buffer would put the true ceiling near 1 KB of argv).
-// Margin is nearly free here: spending fewer bytes per command costs only extra
+//   - Linux accepts 5,444 bytes of input in one command. That is a BYTE limit,
+//     and MAX_IMSGSIZE (16384) predicts it almost exactly at ~3 bytes per input
+//     byte — the same ~5,446-byte boundary the issue reported.
+//   - macOS accepts 996. That is not a byte limit at all: 996 payload arguments
+//     plus this command's 4 fixed ones is exactly 1000, so what binds there looks
+//     like a cap on the NUMBER of arguments, and it bites at a fifth of Linux's
+//     byte-derived ceiling.
+//
+// So the budget is deliberately not reasoned from either mechanism — a model that
+// explains one platform silently mispredicts the other, which is exactly how the
+// first cut of this fix (4096, derived from MAX_IMSGSIZE) shipped a chunk macOS
+// refuses outright. 512 bytes of argv is ~160 input bytes, roughly a sixth of the
+// stricter ceiling under EITHER reading: ~164 arguments against a ~1000-argument
+// cap, or 512 bytes against a ~3 KB byte cap.
+//
+// Margin is nearly free. Spending fewer bytes per command costs only extra
 // round-trips on a paste — a 6 KB paste lands in ~40 commands, tens of
 // milliseconds — and costs nothing at all on the interactive path this function
 // mostly serves, where a keystroke is one to three bytes and always fit in a
-// single command anyway.
+// single command anyway. A future increase should take its number from what that
+// test measures, and must clear the stricter platform, not the local one.
 const sendRawKeysArgvBudget = 512
 
 // sendRawKeysChunkSize is how many input bytes fit in one command for THIS

--- a/session/tmux/clientless.go
+++ b/session/tmux/clientless.go
@@ -75,28 +75,53 @@ func (t *TmuxSession) DisablePipePane() error {
 	return nil
 }
 
-// sendRawKeysMaxChunk bounds how many INPUT bytes go into one `send-keys -H`
-// command, because tmux bounds the command itself. The client packs a command
-// into a single MSG_COMMAND imsg — NUL-terminated argv plus a 16-byte header —
-// and rejects anything over MAX_IMSGSIZE (16384). `-H` spends one 2-char
-// argument per input byte, so a command costs ~3 bytes per byte sent and the
-// limit lands at ~5,445 bytes of input; past that tmux answers "failed to send
+// sendRawKeysArgvBudget is how many bytes of packed argv one `send-keys -H`
+// command may spend. tmux bounds the command itself: the client packs it into a
+// single fixed-size buffer as NUL-terminated argv and refuses anything larger,
+// and `-H` spends one 2-char argument per input byte — so a command costs ~3
+// bytes per byte sent, and past the ceiling tmux answers "failed to send
 // command" and the input is silently dropped (#2414).
 //
-// 4096 leaves ~4 KB of headroom over that ceiling, which is what absorbs the
-// part of the budget that is not the payload: the session name is an argument
-// too, and a repo-scoped name is unbounded in principle. Bigger chunks would
-// buy nothing — the cost here is per-byte, not per-command.
-const sendRawKeysMaxChunk = 4096
+// The ceiling is NOT the same on every platform, which is the whole reason this
+// is a small number rather than the one the obvious derivation gives. Deriving it
+// from MAX_IMSGSIZE (16384) predicts ~5,445 bytes of input, and a real Linux tmux
+// measures 5,444 — the derivation is right there, and matches the issue's report.
+// It is wrong on macOS, where a 4096-byte chunk (~12 KB of argv, comfortably
+// inside 16384) is refused outright. Since no single platform's constant explains
+// both, the budget is set low enough to clear the strictest platform we ship
+// instead of being reasoned from either, and TestSendRawKeysChunkFitsRealTmux
+// asks the installed tmux on every platform we test rather than leaving it an
+// assumption — that test reports the real ceiling it finds, which is where a
+// future increase should get its number.
+//
+// 512 is deliberately well under even the most pessimistic reading (a BSD BUFSIZ
+// of 1024 for the packing buffer would put the true ceiling near 1 KB of argv).
+// Margin is nearly free here: spending fewer bytes per command costs only extra
+// round-trips on a paste — a 6 KB paste lands in ~40 commands, tens of
+// milliseconds — and costs nothing at all on the interactive path this function
+// mostly serves, where a keystroke is one to three bytes and always fit in a
+// single command anyway.
+const sendRawKeysArgvBudget = 512
+
+// sendRawKeysChunkSize is how many input bytes fit in one command for THIS
+// session, after the fixed arguments are paid for. The session name is an
+// argument too and a repo-scoped name has no fixed length, so it is subtracted
+// rather than assumed small — a long project path must not silently push the
+// command over the budget.
+func (t *TmuxSession) sendRawKeysChunkSize() int {
+	fixed := len("send-keys") + 1 + len("-t") + 1 + len(exactTarget(t.sanitizedName)) + 1 + len("-H") + 1
+	// 3 bytes per input byte: two hex digits and the argument's NUL.
+	return max(1, (sendRawKeysArgvBudget-fixed)/3)
+}
 
 // SendRawKeys writes verbatim input bytes to the pane using `send-keys -H`
 // (hex-encoded), so arbitrary control bytes (arrow keys, Ctrl sequences) land
 // exactly as typed — the interactive multi-writer input path. Empty input is a
 // no-op.
 //
-// Input larger than sendRawKeysMaxChunk is split across several commands. A web
-// terminal delivers a paste as ONE frame (xterm.js hands the whole thing to a
-// single onData), so without this an ordinary pasted stack trace or code block
+// Input larger than one command's budget is split across several. A web terminal
+// delivers a paste as ONE frame (xterm.js hands the whole thing to a single
+// onData), so without this an ordinary pasted stack trace or code block
 // exceeded tmux's command limit and never reached the pane (#2414). Splitting is
 // safe because this is a byte STREAM, not a message: the chunks preserve order
 // and content exactly, so a receiving application's parser cannot tell where the
@@ -120,8 +145,9 @@ const sendRawKeysMaxChunk = 4096
 // — rather than leaving a second, subtler way for a wedged server to park a
 // goroutine.
 func (t *TmuxSession) SendRawKeys(b []byte) error {
+	chunk := t.sendRawKeysChunkSize()
 	for len(b) > 0 {
-		n := min(len(b), sendRawKeysMaxChunk)
+		n := min(len(b), chunk)
 		if err := t.sendRawKeysChunk(b[:n]); err != nil {
 			return err
 		}
@@ -130,7 +156,7 @@ func (t *TmuxSession) SendRawKeys(b []byte) error {
 	return nil
 }
 
-// sendRawKeysChunk issues one `send-keys -H` for at most sendRawKeysMaxChunk
+// sendRawKeysChunk issues one `send-keys -H` for at most sendRawKeysChunkSize
 // bytes. The caller guarantees the size bound; this owns the argv shape, the
 // deadline, and the error classification for a single command.
 func (t *TmuxSession) sendRawKeysChunk(b []byte) error {

--- a/session/tmux/clientless.go
+++ b/session/tmux/clientless.go
@@ -75,21 +75,65 @@ func (t *TmuxSession) DisablePipePane() error {
 	return nil
 }
 
+// sendRawKeysMaxChunk bounds how many INPUT bytes go into one `send-keys -H`
+// command, because tmux bounds the command itself. The client packs a command
+// into a single MSG_COMMAND imsg — NUL-terminated argv plus a 16-byte header —
+// and rejects anything over MAX_IMSGSIZE (16384). `-H` spends one 2-char
+// argument per input byte, so a command costs ~3 bytes per byte sent and the
+// limit lands at ~5,445 bytes of input; past that tmux answers "failed to send
+// command" and the input is silently dropped (#2414).
+//
+// 4096 leaves ~4 KB of headroom over that ceiling, which is what absorbs the
+// part of the budget that is not the payload: the session name is an argument
+// too, and a repo-scoped name is unbounded in principle. Bigger chunks would
+// buy nothing — the cost here is per-byte, not per-command.
+const sendRawKeysMaxChunk = 4096
+
 // SendRawKeys writes verbatim input bytes to the pane using `send-keys -H`
 // (hex-encoded), so arbitrary control bytes (arrow keys, Ctrl sequences) land
 // exactly as typed — the interactive multi-writer input path. Empty input is a
 // no-op.
 //
-// Bounded by tmuxCommandTimeout (#1787). This runs on the WS reader goroutine,
-// which holds no broker lock, so a stall here is milder than the pipe-pane pair
-// above — it strands one connection's input loop rather than the session's
-// capture transitions. It is bounded anyway to keep ONE invariant over the whole
-// clientless channel — no tmux command on the WS data path is unbounded — rather
-// than leaving a second, subtler way for a wedged server to park a goroutine.
+// Input larger than sendRawKeysMaxChunk is split across several commands. A web
+// terminal delivers a paste as ONE frame (xterm.js hands the whole thing to a
+// single onData), so without this an ordinary pasted stack trace or code block
+// exceeded tmux's command limit and never reached the pane (#2414). Splitting is
+// safe because this is a byte STREAM, not a message: the chunks preserve order
+// and content exactly, so a receiving application's parser cannot tell where the
+// boundaries fell — including one landing inside a bracketed-paste marker. The
+// TUI attach path already relied on exactly this, reading stdin in 32-byte
+// chunks (apiclient/attach.go), which is the only reason it never hit the limit.
+//
+// A chunked send is NOT atomic, and deliberately fails loudly rather than
+// partially: on a chunk error it stops and propagates, so the caller sees a
+// failed send instead of a success that delivered a truncated paste (the silent
+// prompt-corruption class of #1982/#2099). Concurrent writers were already
+// interleaved at frame granularity — the broker's input path takes no lock and
+// the TUI path has always sent many small frames — so this adds no ordering
+// guarantee that callers previously had.
+//
+// Each chunk is bounded by tmuxCommandTimeout (#1787). This runs on the WS reader
+// goroutine, which holds no broker lock, so a stall here is milder than the
+// pipe-pane pair above — it strands one connection's input loop rather than the
+// session's capture transitions. It is bounded anyway to keep ONE invariant over
+// the whole clientless channel — no tmux command on the WS data path is unbounded
+// — rather than leaving a second, subtler way for a wedged server to park a
+// goroutine.
 func (t *TmuxSession) SendRawKeys(b []byte) error {
-	if len(b) == 0 {
-		return nil
+	for len(b) > 0 {
+		n := min(len(b), sendRawKeysMaxChunk)
+		if err := t.sendRawKeysChunk(b[:n]); err != nil {
+			return err
+		}
+		b = b[n:]
 	}
+	return nil
+}
+
+// sendRawKeysChunk issues one `send-keys -H` for at most sendRawKeysMaxChunk
+// bytes. The caller guarantees the size bound; this owns the argv shape, the
+// deadline, and the error classification for a single command.
+func (t *TmuxSession) sendRawKeysChunk(b []byte) error {
 	args := make([]string, 0, len(b)+4)
 	args = append(args, "send-keys", "-t", exactTarget(t.sanitizedName), "-H")
 	for _, c := range b {

--- a/session/tmux/clientless_paste_test.go
+++ b/session/tmux/clientless_paste_test.go
@@ -64,24 +64,16 @@ func recordingExecutor(rec *recordedArgs) cmd.Executor {
 	}
 }
 
-// packedArgvBytes models what tmux actually measures. The client packs the
-// command into a single MSG_COMMAND imsg as NUL-terminated argv strings, and the
-// whole message — payload plus the 16-byte imsg header — must fit in
-// MAX_IMSGSIZE (16384). argv[0] here is the "tmux" binary name exec prepends,
-// which is not sent, so it is excluded.
+// packedArgvBytes is the size the command spends against sendRawKeysArgvBudget:
+// NUL-terminated argv, excluding argv[0] (the "tmux" binary name exec prepends,
+// which is not part of the command tmux packs).
 func packedArgvBytes(args []string) int {
-	total := imsgHeaderBytes + msgCommandHeaderBytes
+	total := 0
 	for _, a := range args[1:] {
-		total += len(a) + 1 // trailing NUL
+		total += len(a) + 1
 	}
 	return total
 }
-
-const (
-	imsgHeaderBytes       = 16
-	msgCommandHeaderBytes = 8 // struct msg_command_data { int argc; }, padded
-	maxIMsgSize           = 16384
-)
 
 // decodeHexPayload extracts the input bytes a `send-keys -H` argv carries, and
 // asserts the command's shape: the exact-match target and the -H flag must be
@@ -117,6 +109,12 @@ func decodeHexPayload(t *testing.T, args []string) []byte {
 
 const testPasteSession = "af2414-paste"
 
+// testChunkSize is the chunk the mock-backed tests' session gets.
+func testChunkSize() int {
+	return NewTmuxSessionFromSanitizedNameWithDeps(
+		testPasteSession, "sh", MakePtyFactory(), recordingExecutor(&recordedArgs{})).sendRawKeysChunkSize()
+}
+
 // TestSendRawKeysChunksLargePastes is the #2414 regression. A 6 KB paste — an
 // ordinary pasted stack trace or code block — must reach the pane. Before the
 // fix SendRawKeys emitted ONE command carrying 6144 hex arguments, ~18.5 KB
@@ -142,7 +140,7 @@ func TestSendRawKeysChunksLargePastes(t *testing.T) {
 	}
 	// Straddle a chunk boundary with bracketed-paste markers so a chunker that
 	// tried to be clever about escape sequences is caught here.
-	copy(payload[sendRawKeysMaxChunk-3:], []byte("\x1b[200~hello\x1b[201~"))
+	copy(payload[ts.sendRawKeysChunkSize()-3:], []byte("\x1b[200~hello\x1b[201~"))
 
 	if err := ts.SendRawKeys(payload); err != nil {
 		t.Fatalf("SendRawKeys(6KB): %v", err)
@@ -154,15 +152,43 @@ func TestSendRawKeysChunksLargePastes(t *testing.T) {
 	}
 	var got []byte
 	for i, args := range issued {
-		if n := packedArgvBytes(args); n >= maxIMsgSize {
-			t.Fatalf("chunk %d packs to %d bytes, at or over tmux's %d-byte command limit — tmux rejects this",
-				i, n, maxIMsgSize)
+		if n := packedArgvBytes(args); n > sendRawKeysArgvBudget {
+			t.Fatalf("chunk %d packs to %d bytes, over the %d-byte budget a command may spend",
+				i, n, sendRawKeysArgvBudget)
 		}
 		got = append(got, decodeHexPayload(t, args)...)
 	}
 	if !bytes.Equal(got, payload) {
 		t.Fatalf("chunking did not preserve the byte stream: got %d bytes, want %d (first difference at %d)",
 			len(got), len(payload), firstDiff(got, payload))
+	}
+}
+
+// TestSendRawKeysChunkSizeAccountsForTheSessionName pins the part of the budget
+// that is not payload. The session name is an argument too, and a repo-scoped
+// name has no fixed length, so a long project path must shrink the chunk rather
+// than silently push the command over.
+func TestSendRawKeysChunkSizeAccountsForTheSessionName(t *testing.T) {
+	short := NewTmuxSessionFromSanitizedNameWithDeps("af_x", "sh", MakePtyFactory(), recordingExecutor(&recordedArgs{}))
+	long := NewTmuxSessionFromSanitizedNameWithDeps(
+		"af_"+strings.Repeat("verylongprojectname", 8), "sh", MakePtyFactory(), recordingExecutor(&recordedArgs{}))
+
+	if long.sendRawKeysChunkSize() >= short.sendRawKeysChunkSize() {
+		t.Fatalf("a longer session name must buy a smaller chunk: short=%d long=%d",
+			short.sendRawKeysChunkSize(), long.sendRawKeysChunkSize())
+	}
+	for _, ts := range []*TmuxSession{short, long} {
+		rec := &recordedArgs{}
+		sized := NewTmuxSessionFromSanitizedNameWithDeps(ts.sanitizedName, "sh", MakePtyFactory(), recordingExecutor(rec))
+		if err := sized.SendRawKeys(bytes.Repeat([]byte("q"), 4*sendRawKeysArgvBudget)); err != nil {
+			t.Fatalf("SendRawKeys: %v", err)
+		}
+		for i, args := range rec.all() {
+			if n := packedArgvBytes(args); n > sendRawKeysArgvBudget {
+				t.Fatalf("session %q chunk %d packs to %d bytes, over the %d-byte budget",
+					ts.sanitizedName, i, n, sendRawKeysArgvBudget)
+			}
+		}
 	}
 }
 
@@ -186,7 +212,7 @@ func TestSendRawKeysKeepsSmallInputInOneCommand(t *testing.T) {
 	}{
 		{"single keystroke", []byte("a")},
 		{"arrow key", []byte("\x1b[A")},
-		{"at the chunk limit", bytes.Repeat([]byte("x"), sendRawKeysMaxChunk)},
+		{"at the chunk limit", bytes.Repeat([]byte("x"), testChunkSize())},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			rec := &recordedArgs{}
@@ -245,7 +271,7 @@ func TestSendRawKeysStopsOnChunkFailure(t *testing.T) {
 	}
 	ts := NewTmuxSessionFromSanitizedNameWithDeps(testPasteSession, "sh", MakePtyFactory(), ex)
 
-	err := ts.SendRawKeys(bytes.Repeat([]byte("y"), 5*sendRawKeysMaxChunk))
+	err := ts.SendRawKeys(bytes.Repeat([]byte("y"), 5*testChunkSize()))
 	if err == nil {
 		t.Fatal("a failed chunk must not report success — that is silent paste truncation")
 	}
@@ -255,6 +281,61 @@ func TestSendRawKeysStopsOnChunkFailure(t *testing.T) {
 	if n := len(rec.all()); n != 2 {
 		t.Fatalf("issued %d send-keys commands, want 2 (stop at the first failure)", n)
 	}
+}
+
+// TestSendRawKeysChunkFitsRealTmux is the guard that keeps sendRawKeysArgvBudget
+// a checked fact rather than an assumption, and it exists because the assumption
+// was wrong once already.
+//
+// The budget was first derived from MAX_IMSGSIZE (16384), which the issue's Linux
+// measurement corroborates exactly. macOS refuses far sooner — a 4096-byte chunk,
+// ~12 KB of argv and comfortably inside 16384, fails there — so no single
+// platform's constant can be reasoned from. Only asking the tmux that is actually
+// installed settles it, and it must be asked on every platform we ship rather
+// than on whichever one a developer happens to use.
+//
+// On failure it binary-searches the real ceiling and reports it, so the fix is
+// the measured number rather than another guess. It logs that number on success
+// too: the headroom is the thing worth watching, and a budget that has quietly
+// crept up to the edge should be visible before it starts dropping pastes.
+func TestSendRawKeysChunkFitsRealTmux(t *testing.T) {
+	testguard.IsolateTmux(t)
+
+	const name = "af2414-budget"
+	ex := cmd.MakeExecutor()
+	if out, err := exec.Command("tmux", "new-session", "-d", "-s", name, "sh").CombinedOutput(); err != nil {
+		t.Fatalf("new-session: %v: %s", err, out)
+	}
+	t.Cleanup(func() { _ = ex.Run(exec.Command("tmux", "kill-session", "-t", "="+name)) })
+
+	ts := NewTmuxSessionFromSanitizedNameWithDeps(name, "sh", MakePtyFactory(), ex)
+	chunk := ts.sendRawKeysChunkSize()
+
+	// One command carrying a full chunk: exactly what SendRawKeys emits for any
+	// input at or over the chunk size.
+	if err := ts.sendRawKeysChunk(bytes.Repeat([]byte("x"), chunk)); err != nil {
+		t.Errorf("this tmux rejects a full %d-byte chunk (budget %d): %v", chunk, sendRawKeysArgvBudget, err)
+		t.Fatalf("largest chunk this tmux actually accepts is %d bytes — lower sendRawKeysArgvBudget to about %d",
+			maxAcceptedChunk(ts, chunk), 3*maxAcceptedChunk(ts, chunk))
+	}
+	t.Logf("tmux accepted a full %d-byte chunk (argv budget %d); largest accepted chunk here is %d bytes",
+		chunk, sendRawKeysArgvBudget, maxAcceptedChunk(ts, 1<<16))
+}
+
+// maxAcceptedChunk binary-searches the largest single send-keys chunk this tmux
+// accepts, between 1 and hi. Reported rather than asserted on: the number is
+// platform-specific, and the point is to inform the budget, not to pin it.
+func maxAcceptedChunk(ts *TmuxSession, hi int) int {
+	lo := 0
+	for lo < hi {
+		mid := (lo + hi + 1) / 2
+		if ts.sendRawKeysChunk(bytes.Repeat([]byte("x"), mid)) == nil {
+			lo = mid
+		} else {
+			hi = mid - 1
+		}
+	}
+	return lo
 }
 
 // TestRealSendRawKeysDeliversLargePaste drives a REAL tmux. The mock above

--- a/session/tmux/clientless_paste_test.go
+++ b/session/tmux/clientless_paste_test.go
@@ -24,11 +24,14 @@ import (
 // accepted by the WebSocket and then dropped by tmux, never appearing in the
 // terminal.
 //
-// That limit is platform-specific, which is why the tests below assert against
+// That limit is platform-specific — and the two platforms we ship do not even
+// enforce the same KIND of limit — which is why the tests below assert against
 // sendRawKeysArgvBudget rather than any derived constant, and why
 // TestSendRawKeysChunkFitsRealTmux measures the real ceiling instead of trusting
-// one. On Linux it is MAX_IMSGSIZE (16384), giving the ~5,445-byte input the
-// issue reported and the 5,444 that test measures. macOS refuses far sooner.
+// one. Measured: Linux accepts 5,444 input bytes (a byte limit, MAX_IMSGSIZE at
+// ~3 bytes per input byte, matching the issue's report); macOS accepts 996,
+// which with this command's 4 fixed arguments is exactly 1000 — an argument
+// COUNT cap, not a byte one.
 //
 // The TUI attach path never hit this only because apiclient/attach.go reads
 // stdin in 32-byte chunks and so already sends many small frames. Chunking

--- a/session/tmux/clientless_paste_test.go
+++ b/session/tmux/clientless_paste_test.go
@@ -301,29 +301,37 @@ func TestSendRawKeysStopsOnChunkFailure(t *testing.T) {
 func TestSendRawKeysChunkFitsRealTmux(t *testing.T) {
 	testguard.IsolateTmux(t)
 
+	// The pane runs `cat >/dev/null` rather than a shell: the search below sends
+	// tens of KB of filler, and a shell would echo every byte back through the
+	// pane and its line editor for no benefit to what is being measured.
 	const name = "af2414-budget"
 	ex := cmd.MakeExecutor()
-	if out, err := exec.Command("tmux", "new-session", "-d", "-s", name, "sh").CombinedOutput(); err != nil {
+	if out, err := exec.Command("tmux", "new-session", "-d", "-s", name, "cat >/dev/null").CombinedOutput(); err != nil {
 		t.Fatalf("new-session: %v: %s", err, out)
 	}
 	t.Cleanup(func() { _ = ex.Run(exec.Command("tmux", "kill-session", "-t", "="+name)) })
 
-	ts := NewTmuxSessionFromSanitizedNameWithDeps(name, "sh", MakePtyFactory(), ex)
+	ts := NewTmuxSessionFromSanitizedNameWithDeps(name, "cat", MakePtyFactory(), ex)
 	chunk := ts.sendRawKeysChunkSize()
 
 	// One command carrying a full chunk: exactly what SendRawKeys emits for any
 	// input at or over the chunk size.
-	if err := ts.sendRawKeysChunk(bytes.Repeat([]byte("x"), chunk)); err != nil {
-		t.Errorf("this tmux rejects a full %d-byte chunk (budget %d): %v", chunk, sendRawKeysArgvBudget, err)
-		t.Fatalf("largest chunk this tmux actually accepts is %d bytes — lower sendRawKeysArgvBudget to about %d",
-			maxAcceptedChunk(ts, chunk), 3*maxAcceptedChunk(ts, chunk))
+	err := ts.sendRawKeysChunk(bytes.Repeat([]byte("x"), chunk))
+	// Search once, and report either way. The bound is generous enough to reveal
+	// a ceiling well above ours (Linux measures 5444) without spending the search
+	// on sizes no budget would ever want.
+	ceiling := maxAcceptedChunk(ts, 8192)
+	if err != nil {
+		t.Fatalf("this tmux rejects a full %d-byte chunk (argv budget %d): %v\n"+
+			"largest chunk it actually accepts is %d bytes — lower sendRawKeysArgvBudget to about %d",
+			chunk, sendRawKeysArgvBudget, err, ceiling, 3*ceiling)
 	}
 	t.Logf("tmux accepted a full %d-byte chunk (argv budget %d); largest accepted chunk here is %d bytes",
-		chunk, sendRawKeysArgvBudget, maxAcceptedChunk(ts, 1<<16))
+		chunk, sendRawKeysArgvBudget, ceiling)
 }
 
 // maxAcceptedChunk binary-searches the largest single send-keys chunk this tmux
-// accepts, between 1 and hi. Reported rather than asserted on: the number is
+// accepts, between 0 and hi. Reported rather than asserted on: the number is
 // platform-specific, and the point is to inform the budget, not to pin it.
 func maxAcceptedChunk(ts *TmuxSession, hi int) int {
 	lo := 0

--- a/session/tmux/clientless_paste_test.go
+++ b/session/tmux/clientless_paste_test.go
@@ -1,0 +1,319 @@
+package tmux
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/cmd"
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+)
+
+// #2414: the web terminal delivers a paste as ONE xterm.js onData call and
+// forwards it as one InputFrame, so SendRawKeys received the whole payload at
+// once. It rendered one hex argument per byte into a single `send-keys -H`, and
+// tmux rejects a command whose packed argv exceeds its ~16 KB imsg limit — which
+// a paste crosses at ~5,446 bytes. The paste was accepted by the WebSocket and
+// then dropped by tmux, so it simply never appeared in the terminal.
+//
+// The TUI attach path never hit this only because apiclient/attach.go reads
+// stdin in 32-byte chunks and so already sends many small frames. Chunking
+// inside SendRawKeys gives every caller that same property.
+
+// recordedArgs collects the argv of every tmux command an executor is handed.
+// It is safe for concurrent use so the concurrency test below can share one.
+type recordedArgs struct {
+	mu   sync.Mutex
+	args [][]string
+}
+
+func (r *recordedArgs) record(args []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.args = append(r.args, append([]string(nil), args...))
+}
+
+func (r *recordedArgs) all() [][]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([][]string, len(r.args))
+	copy(out, r.args)
+	return out
+}
+
+// recordingExecutor captures each command's argv and reports success, standing
+// in for a healthy tmux without spawning one.
+func recordingExecutor(rec *recordedArgs) cmd.Executor {
+	return cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			rec.record(c.Args)
+			return nil
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			rec.record(c.Args)
+			return nil, nil
+		},
+	}
+}
+
+// packedArgvBytes models what tmux actually measures. The client packs the
+// command into a single MSG_COMMAND imsg as NUL-terminated argv strings, and the
+// whole message — payload plus the 16-byte imsg header — must fit in
+// MAX_IMSGSIZE (16384). argv[0] here is the "tmux" binary name exec prepends,
+// which is not sent, so it is excluded.
+func packedArgvBytes(args []string) int {
+	total := imsgHeaderBytes + msgCommandHeaderBytes
+	for _, a := range args[1:] {
+		total += len(a) + 1 // trailing NUL
+	}
+	return total
+}
+
+const (
+	imsgHeaderBytes       = 16
+	msgCommandHeaderBytes = 8 // struct msg_command_data { int argc; }, padded
+	maxIMsgSize           = 16384
+)
+
+// decodeHexPayload extracts the input bytes a `send-keys -H` argv carries, and
+// asserts the command's shape: the exact-match target and the -H flag must be
+// present on EVERY chunk, not just the first.
+func decodeHexPayload(t *testing.T, args []string) []byte {
+	t.Helper()
+	if len(args) < 5 || args[1] != "send-keys" {
+		t.Fatalf("not a send-keys command: %v", args[:min(6, len(args))])
+	}
+	if targetOf(args) != "="+testPasteSession+":" {
+		t.Fatalf("chunk lost its exact-match target (#1006): got %q", targetOf(args))
+	}
+	hexStart := -1
+	for i, a := range args {
+		if a == "-H" {
+			hexStart = i + 1
+			break
+		}
+	}
+	if hexStart < 0 {
+		t.Fatalf("chunk lost its -H flag: %v", args[:min(6, len(args))])
+	}
+	var out []byte
+	for _, a := range args[hexStart:] {
+		b, err := hex.DecodeString(a)
+		if err != nil || len(b) != 1 {
+			t.Fatalf("bad hex argument %q: %v", a, err)
+		}
+		out = append(out, b[0])
+	}
+	return out
+}
+
+const testPasteSession = "af2414-paste"
+
+// TestSendRawKeysChunksLargePastes is the #2414 regression. A 6 KB paste — an
+// ordinary pasted stack trace or code block — must reach the pane. Before the
+// fix SendRawKeys emitted ONE command carrying 6144 hex arguments, ~18.5 KB
+// packed, which tmux rejects outright; the assertion below on packed size is
+// what fails first.
+//
+// The reassembly check is the other half, and the one that matters for
+// correctness rather than mere delivery: chunking is only safe because it
+// preserves the byte stream exactly, so concatenating the chunks in order must
+// reproduce the input byte-for-byte. That is what keeps bracketed-paste markers
+// (ESC[200~ … ESC[201~) intact even when a chunk boundary falls inside one — the
+// receiving application parses a stream, not discrete messages.
+func TestSendRawKeysChunksLargePastes(t *testing.T) {
+	rec := &recordedArgs{}
+	ts := NewTmuxSessionFromSanitizedNameWithDeps(testPasteSession, "sh", MakePtyFactory(), recordingExecutor(rec))
+
+	// Deliberately not uniform filler: a repeating pattern with high bytes and
+	// control characters would let a chunker that dropped or reordered a chunk
+	// still produce a byte-identical result.
+	payload := make([]byte, 6*1024)
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+	// Straddle a chunk boundary with bracketed-paste markers so a chunker that
+	// tried to be clever about escape sequences is caught here.
+	copy(payload[sendRawKeysMaxChunk-3:], []byte("\x1b[200~hello\x1b[201~"))
+
+	if err := ts.SendRawKeys(payload); err != nil {
+		t.Fatalf("SendRawKeys(6KB): %v", err)
+	}
+
+	issued := rec.all()
+	if len(issued) < 2 {
+		t.Fatalf("6KB paste went out as %d command(s); it must be chunked to stay under tmux's limit", len(issued))
+	}
+	var got []byte
+	for i, args := range issued {
+		if n := packedArgvBytes(args); n >= maxIMsgSize {
+			t.Fatalf("chunk %d packs to %d bytes, at or over tmux's %d-byte command limit — tmux rejects this",
+				i, n, maxIMsgSize)
+		}
+		got = append(got, decodeHexPayload(t, args)...)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("chunking did not preserve the byte stream: got %d bytes, want %d (first difference at %d)",
+			len(got), len(payload), firstDiff(got, payload))
+	}
+}
+
+func firstDiff(a, b []byte) int {
+	for i := 0; i < len(a) && i < len(b); i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return min(len(a), len(b))
+}
+
+// TestSendRawKeysKeepsSmallInputInOneCommand guards the other direction. Ordinary
+// interactive typing is one or a few bytes per call and is by far the hottest
+// path through here; chunking must not turn a keystroke into extra tmux
+// round-trips.
+func TestSendRawKeysKeepsSmallInputInOneCommand(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   []byte
+	}{
+		{"single keystroke", []byte("a")},
+		{"arrow key", []byte("\x1b[A")},
+		{"at the chunk limit", bytes.Repeat([]byte("x"), sendRawKeysMaxChunk)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &recordedArgs{}
+			ts := NewTmuxSessionFromSanitizedNameWithDeps(testPasteSession, "sh", MakePtyFactory(), recordingExecutor(rec))
+			if err := ts.SendRawKeys(tc.in); err != nil {
+				t.Fatalf("SendRawKeys: %v", err)
+			}
+			issued := rec.all()
+			if len(issued) != 1 {
+				t.Fatalf("got %d commands for a %d-byte input, want 1", len(issued), len(tc.in))
+			}
+			if got := decodeHexPayload(t, issued[0]); !bytes.Equal(got, tc.in) {
+				t.Fatalf("payload changed: got %q want %q", got, tc.in)
+			}
+		})
+	}
+}
+
+// TestSendRawKeysEmptyInputSendsNothing pins the documented no-op.
+func TestSendRawKeysEmptyInputSendsNothing(t *testing.T) {
+	rec := &recordedArgs{}
+	ts := NewTmuxSessionFromSanitizedNameWithDeps(testPasteSession, "sh", MakePtyFactory(), recordingExecutor(rec))
+	if err := ts.SendRawKeys(nil); err != nil {
+		t.Fatalf("SendRawKeys(nil): %v", err)
+	}
+	if n := len(rec.all()); n != 0 {
+		t.Fatalf("empty input issued %d commands, want 0", n)
+	}
+}
+
+// TestSendRawKeysStopsOnChunkFailure is the failure-mode half. A chunked send is
+// no longer atomic, so a mid-stream failure means an unknown PREFIX landed. The
+// one thing that must NOT happen is the silent-truncation class of #1982/#2099:
+// the error has to propagate so the caller sees a failed send rather than a
+// success that delivered half a paste. It must also stop rather than keep
+// hammering a session that just reported gone.
+func TestSendRawKeysStopsOnChunkFailure(t *testing.T) {
+	rec := &recordedArgs{}
+	boom := errors.New("send-keys refused")
+	calls := 0
+	ex := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			// has-session is the ExistsOrUnknown probe on the error path; let it
+			// answer "exists" so the failure stays a plain send error.
+			if len(c.Args) > 1 && c.Args[1] == "has-session" {
+				return nil
+			}
+			rec.record(c.Args)
+			calls++
+			if calls == 2 {
+				return boom
+			}
+			return nil
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) { return nil, nil },
+	}
+	ts := NewTmuxSessionFromSanitizedNameWithDeps(testPasteSession, "sh", MakePtyFactory(), ex)
+
+	err := ts.SendRawKeys(bytes.Repeat([]byte("y"), 5*sendRawKeysMaxChunk))
+	if err == nil {
+		t.Fatal("a failed chunk must not report success — that is silent paste truncation")
+	}
+	if !errors.Is(err, boom) {
+		t.Fatalf("underlying tmux error must survive wrapping: got %v", err)
+	}
+	if n := len(rec.all()); n != 2 {
+		t.Fatalf("issued %d send-keys commands, want 2 (stop at the first failure)", n)
+	}
+}
+
+// TestRealSendRawKeysDeliversLargePaste drives a REAL tmux. The mock above
+// asserts the argv we build stays inside the limit we believe tmux enforces; only
+// a real server proves that belief. It is the report's own repro: before the fix
+// this returns "failed to send command" for a 6 KB payload.
+//
+// The payload is delivered into `cat > file` rather than to a shell prompt, and
+// is newline-terminated in 64-byte lines: the pane is a real tty in canonical
+// mode, where a single line longer than the terminal's edit buffer would be
+// truncated by the LINE DISCIPLINE — a limit that has nothing to do with the
+// tmux one under test and would otherwise confound it.
+func TestRealSendRawKeysDeliversLargePaste(t *testing.T) {
+	testguard.IsolateTmux(t)
+
+	const name = "af2414-real-paste"
+	ex := cmd.MakeExecutor()
+	if err := ex.Run(exec.Command("tmux", "new-session", "-d", "-s", name, "sh")); err != nil {
+		t.Fatalf("new-session: %v", err)
+	}
+	t.Cleanup(func() { _ = ex.Run(exec.Command("tmux", "kill-session", "-t", "="+name)) })
+
+	ts := NewTmuxSessionFromSanitizedNameWithDeps(name, "sh", MakePtyFactory(), ex)
+	out := filepath.Join(t.TempDir(), "pasted.txt")
+
+	// Let the shell reach its prompt before redirecting, so the redirect command
+	// is not swallowed by a still-initializing pane.
+	if err := ts.SendRawKeys([]byte("cat > " + out + "\n")); err != nil {
+		t.Fatalf("start cat: %v", err)
+	}
+	waitFor(t, func() bool {
+		_, err := os.Stat(out)
+		return err == nil
+	}, "cat never opened "+out+": the pane program did not start")
+
+	var payload strings.Builder
+	for i := 0; payload.Len() < 6*1024; i++ {
+		fmt.Fprintf(&payload, "line %04d %s\n", i, strings.Repeat("z", 48))
+	}
+	want := payload.String()
+
+	if err := ts.SendRawKeys([]byte(want)); err != nil {
+		t.Fatalf("SendRawKeys(%d bytes) against a real tmux: %v — large pastes must be chunked", len(want), err)
+	}
+	// Ctrl-D closes cat's stdin so it flushes and exits.
+	if err := ts.SendRawKeys([]byte{0x04}); err != nil {
+		t.Fatalf("send EOT: %v", err)
+	}
+
+	waitFor(t, func() bool {
+		got, err := os.ReadFile(out)
+		return err == nil && len(got) >= len(want)
+	}, fmt.Sprintf("only part of the %d-byte paste reached the pane", len(want)))
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read pasted file: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("paste arrived corrupted: got %d bytes want %d (first difference at %d)",
+			len(got), len(want), firstDiff(got, []byte(want)))
+	}
+}

--- a/session/tmux/clientless_paste_test.go
+++ b/session/tmux/clientless_paste_test.go
@@ -20,16 +20,24 @@ import (
 // #2414: the web terminal delivers a paste as ONE xterm.js onData call and
 // forwards it as one InputFrame, so SendRawKeys received the whole payload at
 // once. It rendered one hex argument per byte into a single `send-keys -H`, and
-// tmux rejects a command whose packed argv exceeds its ~16 KB imsg limit — which
-// a paste crosses at ~5,446 bytes. The paste was accepted by the WebSocket and
-// then dropped by tmux, so it simply never appeared in the terminal.
+// tmux refuses a command whose packed argv exceeds its limit — so the paste was
+// accepted by the WebSocket and then dropped by tmux, never appearing in the
+// terminal.
+//
+// That limit is platform-specific, which is why the tests below assert against
+// sendRawKeysArgvBudget rather than any derived constant, and why
+// TestSendRawKeysChunkFitsRealTmux measures the real ceiling instead of trusting
+// one. On Linux it is MAX_IMSGSIZE (16384), giving the ~5,445-byte input the
+// issue reported and the 5,444 that test measures. macOS refuses far sooner.
 //
 // The TUI attach path never hit this only because apiclient/attach.go reads
 // stdin in 32-byte chunks and so already sends many small frames. Chunking
 // inside SendRawKeys gives every caller that same property.
 
 // recordedArgs collects the argv of every tmux command an executor is handed.
-// It is safe for concurrent use so the concurrency test below can share one.
+// The mutex is not for the tests here, which are single-goroutine: it is so a
+// later test that does drive SendRawKeys concurrently can share a recorder
+// without the recorder itself being the race it would be trying to find.
 type recordedArgs struct {
 	mu   sync.Mutex
 	args [][]string


### PR DESCRIPTION
Fixes #2414.

## Verified against master first

The report reproduces on current `master`: `SendRawKeys` in `session/tmux/clientless.go` still renders one hex argument per input byte into a single `send-keys -H`, with no bound on the input. Not stale.

## The bug

The web terminal delivers a paste as one xterm.js `onData` call and forwards it as a single `InputFrame`, so `SendRawKeys` receives the whole payload at once. `-H` spends one 2-char argument per input byte, so the command costs ~3 bytes per byte sent, and tmux rejects a command whose packed argv exceeds `MAX_IMSGSIZE` (16384) — which a paste crosses at ~5,446 bytes.

The result is a silent drop: the WebSocket accepts the input, tmux refuses the command, and the paste never appears in the terminal. An ordinary pasted stack trace or code block is well past the threshold.

The TUI attach path never hit this only because `apiclient/attach.go` reads stdin in 32-byte chunks and so already sent many small frames.

## The fix

Split input into 4 KB chunks inside `SendRawKeys`, so every interactive caller stays under the limit rather than each client having to know about it. 4096 leaves ~4 KB of headroom over the ~5,445-byte ceiling, which absorbs the part of the budget that is not payload — the session name is an argument too, and a repo-scoped name is unbounded in principle.

Chunking is safe here because this is a byte **stream**, not a message: chunks preserve order and content exactly, so a receiving application's parser cannot tell where the boundaries fell — including one landing inside a bracketed-paste marker.

**Failure mode is deliberate.** A chunked send is no longer atomic, so it fails loudly rather than partially: a chunk error stops the loop and propagates, leaving the caller with a failed send instead of a success that delivered half a paste — the silent-truncation class of #1982/#2099. Concurrent writers were already interleaved at frame granularity (the broker's input path takes no lock, and the TUI path has always sent many small frames), so no ordering guarantee callers previously had is lost.

## Tests (fail first)

Both new assertions fail on the pre-fix code, for the right reasons:

```
--- FAIL: TestSendRawKeysChunksLargePastes
    6KB paste went out as 1 command(s); it must be chunked to stay under tmux's limit
--- FAIL: TestSendRawKeysStopsOnChunkFailure
    a failed chunk must not report success — that is silent paste truncation
```

- `TestSendRawKeysChunksLargePastes` — a 6 KB paste goes out as several commands, each packing under tmux's 16384-byte limit (modelling tmux's real accounting: NUL-terminated argv plus the imsg header), and concatenating them reproduces the input byte-for-byte. The payload is a non-uniform pattern with bracketed-paste markers straddling a chunk boundary, so a chunker that dropped, reordered, or "cleverly" split around escape sequences is caught.
- `TestSendRawKeysKeepsSmallInputInOneCommand` — the hot path (a keystroke, an arrow key, exactly-at-the-limit) still costs one command.
- `TestSendRawKeysStopsOnChunkFailure` — a mid-stream failure propagates and stops, rather than reporting success on a truncated paste.
- `TestRealSendRawKeysDeliversLargePaste` — drives a **real** tmux on a private server (`testguard.IsolateTmux`) through the report's own repro. The mocks can only assert the limit we *believe* tmux enforces; this proves it. Payload goes into `cat > file` in 64-byte lines so the tty line discipline (a different limit, at a different layer) cannot confound the one under test.

## Adjacent call-site audit

`SendRawKeys` was the only site building argv from unbounded input (`%02x` appears exactly once in the tree). The other `send-keys` callers — `TapEnter`, `TapDAndEnter`, `tapPromptKeys`, and submit's `C-u`/`Enter` — pass fixed key names, and the prompt-delivery path streams its payload through `load-buffer`'s **stdin** rather than argv, which is why it was never subject to this limit.

## Known adjacent limit, deliberately not changed here

The daemon's PTY WebSocket does not call `SetReadLimit`, so it takes coder/websocket's 32 KB default: a paste larger than ~32 KB is still dropped, one layer earlier. That is a different limit with a ~6x higher threshold, and raising it is a per-connection memory-bound decision that deserves its own issue rather than riding along on this one. Filing separately if it proves to matter in practice.

## Gate

- `go build ./...`, `gofmt -l .`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean.
- `make test-container` on this head — result reported in a follow-up comment.

## Review

Requesting the codex GitHub app below. It is rate-limited until Jul 28; if it does not answer I will say so explicitly and Captain Claude will run an independent review on this exact head before any merge. Not merging unreviewed.

— Captain Claude
