### PR TITLE
security(config): judge config-set exposure inside the lock (#2412)

### DIFF
--- a/config/authposture_test.go
+++ b/config/authposture_test.go
@@ -177,8 +177,9 @@ func TestExposureWarningAgreesWithTheDaemonNotice(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				cfg := DefaultConfig()
 				cfg.RequireToken = requireToken
+				cfg.ListenAddr = addr
 
-				warned := exposureWarning(cfg, "listen_addr", addr) != ""
+				warned := exposureWarning(cfg, "listen_addr") != ""
 
 				noticedCfg := DefaultConfig()
 				noticedCfg.ListenAddr = addr

--- a/config/configset.go
+++ b/config/configset.go
@@ -193,9 +193,16 @@ type SetResult struct {
 	Warnings []string `json:"warnings,omitempty"`
 }
 
-// exposureWarning returns a warning when the config that RESULTS from this set
-// serves an unauthenticated control plane to the network — the combination of a
+// exposureWarning returns a warning when cfg — the config that RESULTS from
+// this set, parsed from the bytes about to be written — serves an
+// unauthenticated control plane to the network, i.e. the combination of a
 // non-loopback listen_addr and require_token = false.
+//
+// cfg is the OUTCOME, not the starting point: it already carries the value
+// being written, so nothing is spliced in here. That is deliberate (#2412) —
+// splicing meant taking the other half of the pairing from a config loaded
+// before the file lock, which two racing writers could each read stale. See
+// scalarWrite.apply.
 //
 // It exists because this is now easy to do by accident. Before `listen_addr`
 // became settable, exposing the listener took a deliberate hand-edit; now it is
@@ -217,28 +224,26 @@ type SetResult struct {
 // and the daemon repeats it once when the listener binds (startHTTPServer) — it
 // no longer forecasts a failure, because there is not going to be one.
 //
-// Both directions of the pairing are checked, because either key can create the
+// Both directions of the pairing warn, because either key can create the
 // exposure: pointing listen_addr at the network while the token is off, or
-// turning the token off while listen_addr is already on the network.
+// turning the token off while listen_addr is already on the network. Setting
+// any OTHER key stays silent even on an already-exposed config — this speaks to
+// the change the user just made, and warning on every unrelated `config set`
+// would train them to ignore it.
 //
 // The exposure test is ListenerServesUnauthenticatedNetwork — the SAME predicate
 // the daemon's refusal uses, itself built on the IsLoopbackListenAddr the token
 // gate derives from. Two definitions of "is this exposed" drifting apart is
 // precisely how a security check rots, so there is only one.
-func exposureWarning(cfg *Config, key, canonical string) string {
+func exposureWarning(cfg *Config, key string) string {
 	if cfg == nil {
 		return ""
 	}
-	addr, tokenRequired := cfg.ListenAddr, cfg.RequireToken
-	switch key {
-	case "listen_addr":
-		addr = canonical
-	case "require_token":
-		tokenRequired = canonical == "true"
-	default:
+	if key != "listen_addr" && key != "require_token" {
 		return ""
 	}
-	if !ListenerServesUnauthenticatedNetwork(addr, tokenRequired) {
+	addr := cfg.ListenAddr
+	if !ListenerServesUnauthenticatedNetwork(addr, cfg.RequireToken) {
 		return ""
 	}
 	return fmt.Sprintf("WARNING: %s is reachable from the network and require_token is false, which puts a "+
@@ -291,12 +296,10 @@ func SetGlobalConfigValue(key, rawValue string) (*SetResult, error) {
 
 	// Ensure config.toml exists (migrating a legacy config.json if needed) and
 	// that the current config actually loads, so a later parse failure is
-	// unambiguously our edit's fault, not a pre-existing broken file. The loaded
-	// config is KEPT: exposureWarning needs the values this write lands on to
-	// judge the resulting posture — a listen_addr write is only dangerous in the
-	// company of require_token = false, and vice versa.
-	currentCfg, err := LoadConfig()
-	if err != nil {
+	// unambiguously our edit's fault, not a pre-existing broken file. This is a
+	// PRECONDITION only — the loaded values are deliberately not carried into the
+	// write. See scalarWrite.apply for why (#2412).
+	if _, err := LoadConfig(); err != nil {
 		return nil, fmt.Errorf("refusing to write: the current config does not load: %w", err)
 	}
 	configDir, err := GetConfigDir()
@@ -306,31 +309,86 @@ func SetGlobalConfigValue(key, rawValue string) (*SetResult, error) {
 	tomlPath := filepath.Join(configDir, TomlConfigFileName)
 	prettyPath := prettyHomePath(tomlPath)
 
+	write := scalarWrite{key: key, section: section, leaf: leaf, canonical: canonical, encoded: encoded}
+
 	var result *SetResult
 	writeErr := WithFileLock(tomlPath, func() error {
-		current, err := os.ReadFile(tomlPath)
-		if err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("failed to read %s: %w", prettyPath, err)
-		}
-		updated := setTOMLScalar(string(current), section, leaf, encoded)
-		updated = setTOMLScalar(updated, "", SchemaVersionField, strconv.Itoa(GlobalConfigSchemaVersion))
-
-		// Final gate: the edited bytes must parse and validate exactly as the
-		// loader would, so `config set` can never leave an unloadable config.
-		if _, err := parseConfigTOML([]byte(updated), prettyPath); err != nil {
-			return fmt.Errorf("internal error: edited config would not load (no changes written): %w", err)
-		}
-		if err := AtomicWriteFile(tomlPath, []byte(updated), 0644); err != nil {
-			return err
-		}
-		result = &SetResult{Key: key, Value: canonical, Path: tomlPath, RequiresRestart: true}
-		if w := exposureWarning(currentCfg, key, canonical); w != "" {
-			result.Warnings = append(result.Warnings, w)
-		}
-		return nil
+		var err error
+		result, err = write.apply(tomlPath, prettyPath)
+		return err
 	})
 	if writeErr != nil {
 		return nil, writeErr
+	}
+	return result, nil
+}
+
+// scalarWrite is one validated, canonicalized `config set` edit, ready to apply
+// to config.toml.
+type scalarWrite struct {
+	// key is the user-facing key ("listen_addr", "program_overrides.claude").
+	key string
+	// section is the TOML table the key lives under ("" = the root block).
+	section string
+	// leaf is the key within that section.
+	leaf string
+	// canonical is the scalar's canonical string form, echoed back to the user.
+	canonical string
+	// encoded is its TOML encoding — the bytes that actually land in the file.
+	encoded string
+}
+
+// apply is SetGlobalConfigValue's critical section: re-read config.toml, make
+// the surgical edit, prove the result still loads, write it, and judge the
+// exposure of the config that results. Callers must hold the config.toml file
+// lock.
+//
+// Everything here reads the file as it exists INSIDE the lock, including the
+// exposure judgment. That last part is the #2412 fix and it is load-bearing:
+// the warning used to be computed from a *Config loaded before the lock was
+// taken, while the bytes being edited were re-read inside it. Since the
+// exposure is a PAIRING — a non-loopback listen_addr together with
+// require_token = false — judging it needs the value of the key the caller is
+// NOT setting, and that value came from the stale pre-lock snapshot.
+//
+// Two processes racing could therefore each turn on one half of the exposure
+// and each see the other half as it was before the race: `af config set
+// listen_addr 0.0.0.0:8443` reads require_token = true, `af config set
+// require_token false` reads a loopback listen_addr, both exit 0 silently, and
+// the config left on disk serves an unauthenticated control plane with nobody
+// having been told. The daemon is not a backstop — it emits its own notice only
+// when it binds, so an already-running daemon says nothing until the next
+// restart.
+//
+// Judging the RESULT rather than reconstructing it also removes the
+// reconstruction: exposureWarning no longer has to splice the written value
+// into a snapshot of the other one, because parseConfigTOML has already
+// produced the exact config this write lands on. Whichever racer writes second
+// now sees the full pairing and warns.
+func (w scalarWrite) apply(tomlPath, prettyPath string) (*SetResult, error) {
+	current, err := os.ReadFile(tomlPath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to read %s: %w", prettyPath, err)
+	}
+	updated := setTOMLScalar(string(current), w.section, w.leaf, w.encoded)
+	updated = setTOMLScalar(updated, "", SchemaVersionField, strconv.Itoa(GlobalConfigSchemaVersion))
+
+	// Final gate: the edited bytes must parse and validate exactly as the loader
+	// would, so `config set` can never leave an unloadable config. The parsed
+	// result is also the config this write RESULTS in — the same values
+	// LoadConfig will return for these bytes, since it reaches this very
+	// function (parseLoadedConfigTOML adds provenance, not values) — so it is
+	// what the exposure judgment below is made against.
+	resulting, err := parseConfigTOML([]byte(updated), prettyPath)
+	if err != nil {
+		return nil, fmt.Errorf("internal error: edited config would not load (no changes written): %w", err)
+	}
+	if err := AtomicWriteFile(tomlPath, []byte(updated), 0644); err != nil {
+		return nil, err
+	}
+	result := &SetResult{Key: w.key, Value: w.canonical, Path: tomlPath, RequiresRestart: true}
+	if warn := exposureWarning(resulting, w.key); warn != "" {
+		result.Warnings = append(result.Warnings, warn)
 	}
 	return result, nil
 }

--- a/config/configset_exposure_race_test.go
+++ b/config/configset_exposure_race_test.go
@@ -1,0 +1,220 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestExposureWarningJudgesTheFileInsideTheLock is #2412.
+//
+// `af config set` re-reads config.toml inside the file lock to make its surgical
+// edit, but it used to judge the exposure warning from a *Config loaded BEFORE
+// the lock. The exposure is a PAIRING — a non-loopback listen_addr together with
+// require_token = false — so judging it needs the value of the key the caller is
+// not setting, and that value came from the stale pre-lock snapshot.
+//
+// This test recreates the window directly rather than racing for it: it captures
+// what a pre-lock LoadConfig returns, lets a competing writer change the OTHER
+// half of the pairing on disk, and only then applies the write. The old code
+// answered from the captured snapshot and stayed silent; the fix answers from
+// the bytes it is about to write.
+//
+// The stakes are that silence. Both racers can exit 0 with nothing printed, and
+// the daemon is not a backstop — it emits its own notice only when it binds, so
+// an already-running daemon says nothing until the next restart. The config left
+// on disk serves DeliverPrompt, which runs instructions through the user's
+// agents, to anyone who can route to it.
+func TestExposureWarningJudgesTheFileInsideTheLock(t *testing.T) {
+	cases := []struct {
+		name string
+		// seed is the config both processes start from: safe, loopback-bound,
+		// token required.
+		seed string
+		// competing is what the other process leaves on disk while this one is
+		// between its pre-lock load and its locked read.
+		competing string
+		// key/value is what this process then writes — the other half of the
+		// exposure.
+		key, value string
+	}{
+		{
+			name:      "listen_addr write lands on a token that was turned off",
+			seed:      "default_program = 'claude'\nlisten_addr = '127.0.0.1:8443'\nrequire_token = true\n",
+			competing: "default_program = 'claude'\nlisten_addr = '127.0.0.1:8443'\nrequire_token = false\n",
+			key:       "listen_addr",
+			value:     "0.0.0.0:8443",
+		},
+		{
+			name:      "require_token write lands on a listener that moved to the network",
+			seed:      "default_program = 'claude'\nlisten_addr = '127.0.0.1:8443'\nrequire_token = true\n",
+			competing: "default_program = 'claude'\nlisten_addr = '0.0.0.0:8443'\nrequire_token = true\n",
+			key:       "require_token",
+			value:     "false",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tomlPath := writeTempConfig(t, c.seed)
+
+			// What SetGlobalConfigValue loads before it takes the lock. Nothing
+			// is exposed yet, and this snapshot is what the pre-#2412 warning was
+			// computed from.
+			preLock, err := LoadConfig()
+			if err != nil {
+				t.Fatalf("loading the seed config: %v", err)
+			}
+			if ListenerServesUnauthenticatedNetwork(preLock.ListenAddr, preLock.RequireToken) {
+				t.Fatal("premise broken: the seed config is already exposed, so this test cannot " +
+					"distinguish a stale judgment from a fresh one")
+			}
+
+			// The other process wins the window and commits its half of the
+			// pairing. In production it held the same lock to do this; here the
+			// lock is uncontended because we are standing in for the moment just
+			// after it released.
+			if err := os.WriteFile(tomlPath, []byte(c.competing), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			section, leaf, spec, ok := resolveSettable(c.key)
+			if !ok {
+				t.Fatalf("premise broken: %q is not settable", c.key)
+			}
+			canonical, encoded, err := canonicalizeScalar(spec.kind, c.value)
+			if err != nil {
+				t.Fatalf("canonicalizing %s=%q: %v", c.key, c.value, err)
+			}
+			write := scalarWrite{key: c.key, section: section, leaf: leaf, canonical: canonical, encoded: encoded}
+
+			var res *SetResult
+			if err := WithFileLock(tomlPath, func() error {
+				var applyErr error
+				res, applyErr = write.apply(tomlPath, prettyHomePath(tomlPath))
+				return applyErr
+			}); err != nil {
+				t.Fatalf("applying %s=%q: %v", c.key, c.value, err)
+			}
+
+			// The write must have produced a genuinely exposed config — otherwise
+			// there would be nothing to warn about and the assertion below would
+			// pass for the wrong reason.
+			after, err := LoadConfig()
+			if err != nil {
+				t.Fatalf("reloading after the write: %v", err)
+			}
+			if !ListenerServesUnauthenticatedNetwork(after.ListenAddr, after.RequireToken) {
+				t.Fatalf("premise broken: after setting %s=%q the config is listen_addr=%q "+
+					"require_token=%v, which is not exposed", c.key, c.value, after.ListenAddr, after.RequireToken)
+			}
+
+			if len(res.Warnings) == 0 {
+				t.Fatalf("setting %s=%q made the control plane unauthenticated on the network "+
+					"(listen_addr=%q, require_token=%v) and printed NOTHING.\n\n"+
+					"The warning was judged from the config loaded before the file lock "+
+					"(listen_addr=%q, require_token=%v), not from the file this write actually "+
+					"landed on. Judge the exposure from the bytes being written (#2412).",
+					c.key, c.value, after.ListenAddr, after.RequireToken,
+					preLock.ListenAddr, preLock.RequireToken)
+			}
+			if w := res.Warnings[0]; !strings.Contains(w, "af config set require_token true") {
+				t.Errorf("the warning must say how to fix it, got: %s", w)
+			}
+		})
+	}
+}
+
+// TestExposureWarningStaysSilentWhenTheRaceLeavesItSafe is the other half: the
+// fix must not warn merely because it now looks at fresh bytes. A competing
+// writer that makes the config SAFER — or one that leaves an exposure this write
+// then closes — must still exit quiet, or the warning becomes noise and gets
+// ignored, which is the same outcome as not printing it.
+func TestExposureWarningStaysSilentWhenTheRaceLeavesItSafe(t *testing.T) {
+	cases := []struct {
+		name       string
+		seed       string
+		competing  string
+		key, value string
+	}{
+		{
+			name:      "competing writer turned the token back on",
+			seed:      "default_program = 'claude'\nlisten_addr = '127.0.0.1:8443'\nrequire_token = false\n",
+			competing: "default_program = 'claude'\nlisten_addr = '127.0.0.1:8443'\nrequire_token = true\n",
+			key:       "listen_addr",
+			value:     "0.0.0.0:8443",
+		},
+		{
+			name:      "this write is the one that closes the exposure",
+			seed:      "default_program = 'claude'\nlisten_addr = '127.0.0.1:8443'\nrequire_token = false\n",
+			competing: "default_program = 'claude'\nlisten_addr = '0.0.0.0:8443'\nrequire_token = false\n",
+			key:       "listen_addr",
+			value:     "127.0.0.1:8443",
+		},
+		{
+			name:      "an unrelated key never speaks, even on an exposed config",
+			seed:      "default_program = 'claude'\nlisten_addr = '127.0.0.1:8443'\nrequire_token = true\n",
+			competing: "default_program = 'claude'\nlisten_addr = '0.0.0.0:8443'\nrequire_token = false\n",
+			key:       "auto_update",
+			value:     "true",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tomlPath := writeTempConfig(t, c.seed)
+			if _, err := LoadConfig(); err != nil {
+				t.Fatalf("loading the seed config: %v", err)
+			}
+			if err := os.WriteFile(tomlPath, []byte(c.competing), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			section, leaf, spec, ok := resolveSettable(c.key)
+			if !ok {
+				t.Fatalf("premise broken: %q is not settable", c.key)
+			}
+			canonical, encoded, err := canonicalizeScalar(spec.kind, c.value)
+			if err != nil {
+				t.Fatalf("canonicalizing %s=%q: %v", c.key, c.value, err)
+			}
+			write := scalarWrite{key: c.key, section: section, leaf: leaf, canonical: canonical, encoded: encoded}
+
+			var res *SetResult
+			if err := WithFileLock(tomlPath, func() error {
+				var applyErr error
+				res, applyErr = write.apply(tomlPath, prettyHomePath(tomlPath))
+				return applyErr
+			}); err != nil {
+				t.Fatalf("applying %s=%q: %v", c.key, c.value, err)
+			}
+
+			if len(res.Warnings) != 0 {
+				t.Errorf("setting %s=%q warned, but the resulting config is not an unauthenticated "+
+					"network listener: %v", c.key, c.value, res.Warnings)
+			}
+		})
+	}
+}
+
+// TestSetGlobalConfigValueWarnsFromTheWrittenFile pins the wiring end to end:
+// SetGlobalConfigValue's warning must come from scalarWrite.apply's judgment of
+// the file, so the two cannot drift apart while the unit test above keeps
+// passing. It sets the second half of an exposure that is already half-present
+// on disk — the case where reconstructing from a pre-lock snapshot and reading
+// the file happen to agree, so this stays honest about what it covers: the
+// plumbing, not the race.
+func TestSetGlobalConfigValueWarnsFromTheWrittenFile(t *testing.T) {
+	writeTempConfig(t, "default_program = 'claude'\nlisten_addr = '0.0.0.0:8443'\nrequire_token = true\n")
+
+	res, err := SetGlobalConfigValue("require_token", "false")
+	if err != nil {
+		t.Fatalf("set require_token=false: %v", err)
+	}
+	if len(res.Warnings) == 0 {
+		t.Fatal("turning the token off on a network-bound listener must warn")
+	}
+	if w := res.Warnings[0]; !strings.Contains(w, "0.0.0.0:8443") {
+		t.Errorf("the warning must name the address that is exposed, got: %s", w)
+	}
+}

--- a/config/configset_test.go
+++ b/config/configset_test.go
@@ -575,13 +575,19 @@ func TestSetGlobalConfigValueWarnsOnTokenlessNetworkListener(t *testing.T) {
 // webListenerPolicy also uses); two definitions drifting apart is exactly how a
 // security check rots, so this fails if a second one is ever introduced.
 func TestExposureWarningUsesTheDaemonsLoopbackPredicate(t *testing.T) {
-	cfg := DefaultConfig()
-	cfg.RequireToken = false
+	// cfg is the config the write RESULTS in, so the address under test is the
+	// one it already carries (#2412).
+	resulting := func(addr string) *Config {
+		cfg := DefaultConfig()
+		cfg.RequireToken = false
+		cfg.ListenAddr = addr
+		return cfg
+	}
 	for _, addr := range []string{"127.0.0.1:8443", "[::1]:8443", "localhost:8443"} {
 		if !IsLoopbackListenAddr(addr) {
 			t.Fatalf("precondition: %q should be loopback", addr)
 		}
-		if w := exposureWarning(cfg, "listen_addr", addr); w != "" {
+		if w := exposureWarning(resulting(addr), "listen_addr"); w != "" {
 			t.Errorf("%q is loopback — no exposure warning expected, got: %s", addr, w)
 		}
 	}
@@ -589,7 +595,7 @@ func TestExposureWarningUsesTheDaemonsLoopbackPredicate(t *testing.T) {
 		if IsLoopbackListenAddr(addr) {
 			t.Fatalf("precondition: %q should NOT be loopback", addr)
 		}
-		if w := exposureWarning(cfg, "listen_addr", addr); w == "" {
+		if w := exposureWarning(resulting(addr), "listen_addr"); w == "" {
 			t.Errorf("%q is network-reachable with require_token=false — expected a warning", addr)
 		}
 	}


### PR DESCRIPTION
## Summary

`af config set` re-read `config.toml` inside the file lock to make its surgical edit, but judged the tokenless-network-listener warning from a `*Config` loaded **before** the lock. The exposure is a pairing — a non-loopback `listen_addr` together with `require_token = false` — so judging it needs the value of the key the caller is *not* setting, and that value came from the stale pre-lock snapshot.

Two processes racing therefore each saw the other's half as it was before the race: `af config set listen_addr 0.0.0.0:8443` read `require_token = true`, `af config set require_token false` read a loopback `listen_addr`, both exited 0 silently, and the config left on disk served an unauthenticated control plane with nobody having been told.

The daemon is not a backstop. It emits its own notice only when it binds, so an already-running daemon says nothing until the next restart. The API this listener serves includes `DeliverPrompt`, which types instructions into a running agent and submits them.

## Report verification

Verified against `master` @ `6f90d5b1` before writing any code — the report is **accurate and current**:

- `config/configset.go:298` loaded `currentCfg` before the lock; `:311` correctly re-read the raw bytes inside it; `:327` passed the **pre-lock** config to `exposureWarning`.
- `exposureWarning` spliced only the key being written and took the other half from that stale config, exactly as reported.

## Fix

Extract the critical section into `scalarWrite.apply` and judge the exposure from the config `parseConfigTOML` **already** produces as the "this still loads" gate — the exact config the write results in. `LoadConfig` stays, as a precondition only.

That removes the reconstruction as well: `exposureWarning` no longer splices the written value into a snapshot of the other one, because the parsed result already carries it. Whichever racer writes second now sees the full pairing and warns. The one that writes first genuinely was not exposed at its write time, so its silence is correct — the exposure cannot come into being with nobody told.

`parseConfigTOML` is the same function `LoadConfig` reaches for these bytes (`parseLoadedConfigTOML` adds provenance, not values), so the judged config is the one the daemon will load.

### Adjacent call-site audit

`withGlobalConfigLock` (`config/config_save.go:40-45`) already treats its pre-lock `LoadConfig` as a precondition only, discards the value, and documents re-reading inside the lock with `loadConfigLocked`. `configset.go` was the **lone** site that carried the loaded values into the critical section. It now matches the pattern that was already in-tree.

## Fail-first

The window is recreated directly rather than raced for, so the test is deterministic — no sleeps, no goroutines, no timing luck that could silently stop covering the bug. It captures what a pre-lock `LoadConfig` returns, lets a competing writer change the other half of the pairing on disk, and only then applies the write.

Watched fail with the pre-fix logic reinstated inside the new structure, **both directions**:

```
--- FAIL: TestExposureWarningJudgesTheFileInsideTheLock/listen_addr_write_lands_on_a_token_that_was_turned_off
    setting listen_addr="0.0.0.0:8443" made the control plane unauthenticated on the
    network (listen_addr="0.0.0.0:8443", require_token=false) and printed NOTHING.
    The warning was judged from the config loaded before the file lock
    (listen_addr="127.0.0.1:8443", require_token=true), not from the file this write
    actually landed on.
--- FAIL: TestExposureWarningJudgesTheFileInsideTheLock/require_token_write_lands_on_a_listener_that_moved_to_the_network
    setting require_token="false" made the control plane unauthenticated on the
    network (listen_addr="0.0.0.0:8443", require_token=false) and printed NOTHING.
```

Green after the fix. Both premises are asserted in-test (the seed is provably not exposed; the result provably is), so neither case can pass for the wrong reason.

Negative controls, so the fix cannot buy the warning with noise — a warning nobody reads is the same outcome as no warning:

- a competing writer that turns the token back on → silent
- a write that *closes* an existing exposure → silent
- an unrelated key on an already-exposed config → silent

## Verification

Exact pushed head: `5834a7cb`

- `go build ./...`
- `gofmt -l .` (no output)
- `golangci-lint run --timeout=3m --fast`
- `deadcode -test ./...` (no output)
- `scripts/lint-file-length.sh` (985 files, 0 grandfathered)
- `make test-container`
- `go test ./config/` green, including the pre-existing `TestSetGlobalConfigValueWarnsOnTokenlessNetworkListener` and `TestExposureWarningAgreesWithTheDaemonNotice` (both updated to the new `exposureWarning` signature; what they pin — that the set-time warning and the daemon notice fire on exactly the same configs — is unchanged)

No user-visible copy or behavior change other than the warning now firing when it should.

Closes #2412
