### PR TITLE
fix(daemon): share one trust-prompt agent gate (#2416)

### DIFF
--- a/daemon/configagent.go
+++ b/daemon/configagent.go
@@ -301,14 +301,14 @@ func configAgentCodexReceiptHome(program, workingDir string) (string, error) {
 // dismissConfigAgentTrustPrompt clears the agent's first-run trust dialog, the
 // same loop task.StartAndSendPrompt runs for a normal session.
 //
-// The per-agent gate is tmux.ProgramHasTrustPrompt — the same call
+// The per-agent gate is tmux.ProgramNeedsTrustDismissal — the same call
 // LocalBackend.CheckAndHandleTrustPrompt makes, not a copy of its list. This
 // used to enumerate the agents here under a comment claiming it mirrored that
 // one, and it had already drifted: opencode was missing, so a config agent
 // would hang on a dialog a normal session cleared (#2416).
 func dismissConfigAgentTrustPrompt(ctx context.Context, target task.TrustPromptTarget) error {
-	if !tmux.ProgramHasTrustPrompt(target.ResolvedAgent()) {
-		return nil // nothing to dismiss for this program
+	if !tmux.ProgramNeedsTrustDismissal(target.ResolvedAgent()) {
+		return nil // AF has no dismissal to run for this program
 	}
 	return task.DismissTrustPrompt(ctx, target)
 }

--- a/daemon/configagent.go
+++ b/daemon/configagent.go
@@ -304,8 +304,10 @@ func configAgentCodexReceiptHome(program, workingDir string) (string, error) {
 // The per-agent gate is tmux.ProgramNeedsTrustDismissal — the same call
 // LocalBackend.CheckAndHandleTrustPrompt makes, not a copy of its list. This
 // used to enumerate the agents here under a comment claiming it mirrored that
-// one, and it had already drifted: opencode was missing, so a config agent
-// would hang on a dialog a normal session cleared (#2416).
+// one, and it had already drifted: opencode was missing (#2416). The cost was
+// not a hang — isReadyContent's opencode arm treats the dialog as ready, so the
+// spawn proceeded and delivered the briefing INTO the undismissed dialog, which
+// is #729's signature.
 func dismissConfigAgentTrustPrompt(ctx context.Context, target task.TrustPromptTarget) error {
 	if !tmux.ProgramNeedsTrustDismissal(target.ResolvedAgent()) {
 		return nil // AF has no dismissal to run for this program

--- a/daemon/configagent.go
+++ b/daemon/configagent.go
@@ -301,16 +301,14 @@ func configAgentCodexReceiptHome(program, workingDir string) (string, error) {
 // dismissConfigAgentTrustPrompt clears the agent's first-run trust dialog, the
 // same loop task.StartAndSendPrompt runs for a normal session.
 //
-// The per-agent gate mirrors LocalBackend.CheckAndHandleTrustPrompt
-// (session/backend_local.go): only the known agents have a trust dialog, and
-// asking a non-agent command about one would tap Enter into an arbitrary
-// program. The decision is keyed off the RESOLVED agent for the same reason it
-// is there.
+// The per-agent gate is tmux.ProgramHasTrustPrompt — the same call
+// LocalBackend.CheckAndHandleTrustPrompt makes, not a copy of its list. This
+// used to enumerate the agents here under a comment claiming it mirrored that
+// one, and it had already drifted: opencode was missing, so a config agent
+// would hang on a dialog a normal session cleared (#2416).
 func dismissConfigAgentTrustPrompt(ctx context.Context, target task.TrustPromptTarget) error {
-	switch target.ResolvedAgent() {
-	case tmux.ProgramClaude, tmux.ProgramCodex, tmux.ProgramAider, tmux.ProgramGemini, tmux.ProgramAmp:
-	default:
-		return nil // not a known agent: it has no trust dialog to dismiss
+	if !tmux.ProgramHasTrustPrompt(target.ResolvedAgent()) {
+		return nil // nothing to dismiss for this program
 	}
 	return task.DismissTrustPrompt(ctx, target)
 }

--- a/daemon/configagent_trust_test.go
+++ b/daemon/configagent_trust_test.go
@@ -95,3 +95,69 @@ func TestDismissConfigAgentTrustPrompt_SkipsNonAgents(t *testing.T) {
 		t.Fatalf("Enter must never be tapped into a non-agent program, got %d checks", target.checks)
 	}
 }
+
+// TestDismissConfigAgentTrustPrompt_ClearsEveryTrustPromptAgent is the #2416
+// regression.
+//
+// This gate used to be its own hand-copied list of agents under a comment
+// claiming it mirrored LocalBackend.CheckAndHandleTrustPrompt. It had drifted:
+// opencode was added to that gate in #1959 and never here, so an opencode config
+// agent took the default branch, never ran the dismissal loop, and would hang on
+// a dialog a normal session cleared — the #729 defect class the comment was
+// written to prevent.
+//
+// The case runs over the shared gate rather than a literal list, so it covers
+// whatever agents are classified as prompting today, and a future agent that
+// starts prompting is covered the moment it is classified.
+//
+// What is asserted is the gate, not the loop: each pane is given no dialog, so
+// DismissTrustPrompt makes exactly one check and returns without a readiness
+// wait. One check means the agent reached the loop; zero is the defect
+// signature. The loop's own behaviour — budget, re-wait, bound — is held by the
+// two claude cases above, and per-agent ready glyphs belong to task's tests
+// rather than being restated here.
+func TestDismissConfigAgentTrustPrompt_ClearsEveryTrustPromptAgent(t *testing.T) {
+	covered := 0
+	for _, agent := range tmux.SupportedPrograms {
+		if !tmux.ProgramHasTrustPrompt(agent) {
+			continue
+		}
+		covered++
+		t.Run(agent, func(t *testing.T) {
+			target := &fakeTrustTarget{agent: agent}
+			if err := dismissConfigAgentTrustPrompt(context.Background(), target); err != nil {
+				t.Fatalf("config agent must run %s's trust-dismissal loop, got: %v", agent, err)
+			}
+			if target.checks != 1 {
+				t.Fatalf("expected %s's pane to be checked once for a trust dialog, got %d checks", agent, target.checks)
+			}
+		})
+	}
+	if covered == 0 {
+		t.Fatal("no agent is classified as having a trust prompt; the gate under test is vacuous")
+	}
+}
+
+// TestDismissConfigAgentTrustPrompt_SkipsAgentsWithNoDialog is the other half of
+// #2416: closing the drift must not over-correct into dismissing for an agent
+// whose modal AF already suppresses at launch. devin is launched with
+// --respect-workspace-trust false (#2410), so there is no dialog — and Enter
+// tapped at its composer would submit whatever is sitting there.
+func TestDismissConfigAgentTrustPrompt_SkipsAgentsWithNoDialog(t *testing.T) {
+	for _, agent := range tmux.SupportedPrograms {
+		if tmux.ProgramHasTrustPrompt(agent) {
+			continue
+		}
+		t.Run(agent, func(t *testing.T) {
+			// prompts: 1 so a pane that IS asked would answer "dialog present" and
+			// be counted — the check has to be able to fail.
+			target := &fakeTrustTarget{agent: agent, prompts: 1}
+			if err := dismissConfigAgentTrustPrompt(context.Background(), target); err != nil {
+				t.Fatalf("%s has no trust dialog to dismiss, got: %v", agent, err)
+			}
+			if target.checks != 0 {
+				t.Fatalf("Enter must never be tapped into %s's composer, got %d checks", agent, target.checks)
+			}
+		})
+	}
+}

--- a/daemon/configagent_trust_test.go
+++ b/daemon/configagent_trust_test.go
@@ -99,15 +99,16 @@ func TestDismissConfigAgentTrustPrompt_SkipsNonAgents(t *testing.T) {
 	}
 }
 
-// TestDismissConfigAgentTrustPrompt_ClearsEveryTrustPromptAgent is the #2416
+// TestDismissConfigAgentTrustPrompt_ChecksEveryAgentInTheGate is the #2416
 // regression.
 //
 // This gate used to be its own hand-copied list of agents under a comment
 // claiming it mirrored LocalBackend.CheckAndHandleTrustPrompt. It had drifted:
 // opencode was added to that gate in #1959 and never here, so an opencode config
-// agent took the default branch, never ran the dismissal loop, and would hang on
-// a dialog a normal session cleared — the #729 defect class the comment was
-// written to prevent.
+// agent took the default branch and never ran the dismissal loop. It did not
+// hang — isReadyContent's opencode arm calls the dialog ready, so the spawn went
+// on to deliver the briefing into it. That is the #729 defect class the comment
+// was written to prevent.
 //
 // The case runs over the shared gate rather than a literal list, so it covers
 // whatever agents are in the gate today, and a future agent is covered the
@@ -123,11 +124,10 @@ func TestDismissConfigAgentTrustPrompt_SkipsNonAgents(t *testing.T) {
 // two claude cases above, and per-agent ready glyphs belong to task's tests
 // rather than being restated here.
 func TestDismissConfigAgentTrustPrompt_ChecksEveryAgentInTheGate(t *testing.T) {
-	// Compress the retry delay: if the gate regresses, a pane whose ready glyph
-	// this fake does not render would otherwise burn the readiness timeout before
-	// reporting, turning a clear failure into a slow and misleading one.
-	defer task.SetTrustPromptTimingForTest(time.Nanosecond)()
-
+	// No timing seam needed: prompts is zero, so the first check ends the loop
+	// and the readiness re-wait is never reached. (Compressing it would not help
+	// anyway — SetTrustPromptTimingForTest moves the poll interval, not
+	// WaitForReadyOn's deadline; see the context bound on the sibling case.)
 	covered := 0
 	for _, agent := range tmux.SupportedPrograms {
 		if !tmux.ProgramNeedsTrustDismissal(agent) {
@@ -151,12 +151,11 @@ func TestDismissConfigAgentTrustPrompt_ChecksEveryAgentInTheGate(t *testing.T) {
 
 // TestDismissConfigAgentTrustPrompt_SkipsAgentsOutsideTheGate is the other half
 // of #2416: closing the drift must not over-correct into driving a dismissal
-// loop for an agent AF has no dismissal for. devin is the current member — AF
-// has no predicate for its workspace-trust modal, so a check could only ever
-// come back empty while the pane is treated as still-prompting.
+// loop for an agent AF has no dismissal for. devin is the current member — the
+// only predicate membership would run for it is DocTrustPromptPresent, which
+// cannot match its modal wording, so the loop buys no dismissal and leaves only
+// that predicate's false-positive exposure on live panes (#1952).
 func TestDismissConfigAgentTrustPrompt_SkipsAgentsOutsideTheGate(t *testing.T) {
-	defer task.SetTrustPromptTimingForTest(time.Nanosecond)()
-
 	covered := 0
 	for _, agent := range tmux.SupportedPrograms {
 		if tmux.ProgramNeedsTrustDismissal(agent) {

--- a/daemon/configagent_trust_test.go
+++ b/daemon/configagent_trust_test.go
@@ -167,11 +167,22 @@ func TestDismissConfigAgentTrustPrompt_SkipsAgentsOutsideTheGate(t *testing.T) {
 			// prompts: 1 so a pane that IS asked would answer "dialog present" and
 			// be counted — the check has to be able to fail.
 			target := &fakeTrustTarget{agent: agent, prompts: 1}
-			if err := dismissConfigAgentTrustPrompt(context.Background(), target); err != nil {
-				t.Fatalf("%s is outside the trust-dismissal gate, got: %v", agent, err)
-			}
+			// A regressed gate would enter the loop and then block in the readiness
+			// re-wait, because this fake renders claude's glyph and no other
+			// agent's. SetTrustPromptTimingForTest compresses the poll interval but
+			// not WaitForReadyOn's 60s deadline, so bound it here instead;
+			// WaitForReadyOn observes cancellation at the top of each iteration.
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			err := dismissConfigAgentTrustPrompt(ctx, target)
+			// Assert the checks BEFORE the error: on a regression both fire, and
+			// this is the one that names the actual defect. Leading with err would
+			// report a readiness timeout and send the next reader to the wrong file.
 			if target.checks != 0 {
 				t.Fatalf("%s's pane must not be driven through the dismissal loop, got %d checks", agent, target.checks)
+			}
+			if err != nil {
+				t.Fatalf("%s is outside the trust-dismissal gate, got: %v", agent, err)
 			}
 		})
 	}

--- a/daemon/configagent_trust_test.go
+++ b/daemon/configagent_trust_test.go
@@ -24,7 +24,10 @@ type fakeTrustTarget struct {
 func (f *fakeTrustTarget) ResolvedAgent() string { return f.agent }
 
 // PreviewContent renders claude's ready glyph, so the readiness re-wait between
-// dismissals returns on its first poll instead of dominating the test.
+// dismissals returns on its first poll instead of dominating the test. It is
+// claude's glyph specifically: isReadyContent keys on a different one per agent,
+// so any case that drives another agent THROUGH a dismissal must either supply
+// that agent's glyph or avoid reaching the re-wait at all.
 func (f *fakeTrustTarget) PreviewContent(context.Context) (string, error) { return "❯", nil }
 
 func (f *fakeTrustTarget) HooksDone() <-chan struct{} { return nil }
@@ -107,8 +110,11 @@ func TestDismissConfigAgentTrustPrompt_SkipsNonAgents(t *testing.T) {
 // written to prevent.
 //
 // The case runs over the shared gate rather than a literal list, so it covers
-// whatever agents are classified as prompting today, and a future agent that
-// starts prompting is covered the moment it is classified.
+// whatever agents are in the gate today, and a future agent is covered the
+// moment it is classified into it. That does make the SELECTION circular — this
+// cannot catch a wrong classification, only a call site that stopped delegating.
+// The non-circular half is the literal table in
+// TestProgramNeedsTrustDismissal_ClassifiesEverySupportedAgent.
 //
 // What is asserted is the gate, not the loop: each pane is given no dialog, so
 // DismissTrustPrompt makes exactly one check and returns without a readiness
@@ -116,10 +122,15 @@ func TestDismissConfigAgentTrustPrompt_SkipsNonAgents(t *testing.T) {
 // signature. The loop's own behaviour — budget, re-wait, bound — is held by the
 // two claude cases above, and per-agent ready glyphs belong to task's tests
 // rather than being restated here.
-func TestDismissConfigAgentTrustPrompt_ClearsEveryTrustPromptAgent(t *testing.T) {
+func TestDismissConfigAgentTrustPrompt_ChecksEveryAgentInTheGate(t *testing.T) {
+	// Compress the retry delay: if the gate regresses, a pane whose ready glyph
+	// this fake does not render would otherwise burn the readiness timeout before
+	// reporting, turning a clear failure into a slow and misleading one.
+	defer task.SetTrustPromptTimingForTest(time.Nanosecond)()
+
 	covered := 0
 	for _, agent := range tmux.SupportedPrograms {
-		if !tmux.ProgramHasTrustPrompt(agent) {
+		if !tmux.ProgramNeedsTrustDismissal(agent) {
 			continue
 		}
 		covered++
@@ -134,30 +145,40 @@ func TestDismissConfigAgentTrustPrompt_ClearsEveryTrustPromptAgent(t *testing.T)
 		})
 	}
 	if covered == 0 {
-		t.Fatal("no agent is classified as having a trust prompt; the gate under test is vacuous")
+		t.Fatal("no agent is in the trust-dismissal gate; the case under test is vacuous")
 	}
 }
 
-// TestDismissConfigAgentTrustPrompt_SkipsAgentsWithNoDialog is the other half of
-// #2416: closing the drift must not over-correct into dismissing for an agent
-// whose modal AF already suppresses at launch. devin is launched with
-// --respect-workspace-trust false (#2410), so there is no dialog — and Enter
-// tapped at its composer would submit whatever is sitting there.
-func TestDismissConfigAgentTrustPrompt_SkipsAgentsWithNoDialog(t *testing.T) {
+// TestDismissConfigAgentTrustPrompt_SkipsAgentsOutsideTheGate is the other half
+// of #2416: closing the drift must not over-correct into driving a dismissal
+// loop for an agent AF has no dismissal for. devin is the current member — AF
+// has no predicate for its workspace-trust modal, so a check could only ever
+// come back empty while the pane is treated as still-prompting.
+func TestDismissConfigAgentTrustPrompt_SkipsAgentsOutsideTheGate(t *testing.T) {
+	defer task.SetTrustPromptTimingForTest(time.Nanosecond)()
+
+	covered := 0
 	for _, agent := range tmux.SupportedPrograms {
-		if tmux.ProgramHasTrustPrompt(agent) {
+		if tmux.ProgramNeedsTrustDismissal(agent) {
 			continue
 		}
+		covered++
 		t.Run(agent, func(t *testing.T) {
 			// prompts: 1 so a pane that IS asked would answer "dialog present" and
 			// be counted — the check has to be able to fail.
 			target := &fakeTrustTarget{agent: agent, prompts: 1}
 			if err := dismissConfigAgentTrustPrompt(context.Background(), target); err != nil {
-				t.Fatalf("%s has no trust dialog to dismiss, got: %v", agent, err)
+				t.Fatalf("%s is outside the trust-dismissal gate, got: %v", agent, err)
 			}
 			if target.checks != 0 {
-				t.Fatalf("Enter must never be tapped into %s's composer, got %d checks", agent, target.checks)
+				t.Fatalf("%s's pane must not be driven through the dismissal loop, got %d checks", agent, target.checks)
 			}
 		})
+	}
+	// Without this, reclassifying the last excluded agent would retire the
+	// over-correction half of #2416 to a green test with zero assertions.
+	if covered == 0 {
+		t.Fatal("every supported agent is now in the gate; this case asserts nothing — " +
+			"delete it deliberately or restore an excluded agent")
 	}
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,11 +127,16 @@ environment whose access matches the risk.
 
 Agent Factory still dismisses a supported agent's one-time workspace trust
 dialog during first-run setup. That only gets a new session to a usable prompt;
-it does not approve later tool calls or actions. (**Devin** is the exception: af
-launches it with `--respect-workspace-trust false` so its workspace-trust modal
-never appears — af created and owns the worktree, so it is already trusted.
-Include the flag yourself if you set a custom `program_overrides.devin`, or af
-appends it for you when your override omits it.)
+it does not approve later tool calls or actions.
+
+**Devin** is the exception: af suppresses the dialog at launch instead of
+dismissing it, appending `--respect-workspace-trust false` — af created and owns
+the worktree, so it is already trusted. Your own value wins if you set one, so
+include the flag in a custom `program_overrides.devin` only when you want to
+choose it; af appends it when your override omits it. Two cases fall outside that
+suppression and will show devin's modal, which af has no dismissal for: setting
+`--respect-workspace-trust true` explicitly, and agent-assisted `af config` when
+`default_program` is devin ([#2435](https://github.com/sachiniyer/agent-factory/issues/2435)).
 
 Codex's **additional safety checks** model-routing picker is separate from
 approval and sandbox flags. The daemon recognizes the known

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -800,20 +800,13 @@ func (b *LocalBackend) CheckAndHandleTrustPrompt(i *Instance) bool {
 	// never gets an agent's trust-prompt handling (#1116/#1131 defect class),
 	// while restored sessions with legacy free-form Program values (e.g.
 	// "/home/foo/bin/claude") still get it — same persisted-state class of
-	// regression as #677. Codex was added in #729: it was previously excluded
-	// here, so a codex trust/confirmation dialog was never dismissed even
-	// though isReadyContent could surface it.
-	// opencode has NO trust gate of its own (a fresh `git init` repo goes straight
-	// to its composer, verified on 0.0.0-main-202604230742), so it lands in
-	// CheckAndHandleTrustPrompt's generic doc-trust branch and no-ops harmlessly.
-	// It answers true anyway: an agent silently missing from the gate is the #729
-	// defect (codex was excluded, so its dialog was surfaced by isReadyContent but
-	// never dismissed).
+	// regression as #677.
 	//
-	// The membership answer itself lives in tmux.ProgramHasTrustPrompt, which the
-	// daemon's config-agent spawn calls too. This site used to hold the list and
-	// the daemon's a copy of it; the copy drifted and lost opencode (#2416).
-	if tmux.ProgramHasTrustPrompt(i.ResolvedAgent()) {
+	// Which agents are in the set, and why, lives with the gate itself in
+	// tmux.ProgramNeedsTrustDismissal — the daemon's config-agent spawn calls the
+	// same function. This site used to hold the list and the daemon's a copy of
+	// it; the copy drifted and lost opencode (#2416).
+	if tmux.ProgramNeedsTrustDismissal(i.ResolvedAgent()) {
 		return ts.CheckAndHandleTrustPrompt()
 	}
 	return false

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -806,11 +806,14 @@ func (b *LocalBackend) CheckAndHandleTrustPrompt(i *Instance) bool {
 	// opencode has NO trust gate of its own (a fresh `git init` repo goes straight
 	// to its composer, verified on 0.0.0-main-202604230742), so it lands in
 	// CheckAndHandleTrustPrompt's generic doc-trust branch and no-ops harmlessly.
-	// It is listed anyway: this is the one site enumerating every agent, and an
-	// agent silently missing from it is the #729 defect (codex was excluded here,
-	// so its dialog was surfaced by isReadyContent but never dismissed).
-	switch i.ResolvedAgent() {
-	case tmux.ProgramClaude, tmux.ProgramCodex, tmux.ProgramAider, tmux.ProgramGemini, tmux.ProgramAmp, tmux.ProgramOpencode:
+	// It answers true anyway: an agent silently missing from the gate is the #729
+	// defect (codex was excluded, so its dialog was surfaced by isReadyContent but
+	// never dismissed).
+	//
+	// The membership answer itself lives in tmux.ProgramHasTrustPrompt, which the
+	// daemon's config-agent spawn calls too. This site used to hold the list and
+	// the daemon's a copy of it; the copy drifted and lost opencode (#2416).
+	if tmux.ProgramHasTrustPrompt(i.ResolvedAgent()) {
 		return ts.CheckAndHandleTrustPrompt()
 	}
 	return false

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -45,29 +45,40 @@ func IsSupportedProgram(name string) bool {
 	return false
 }
 
-// ProgramHasTrustPrompt reports whether an agent can raise a first-run
-// trust/permission dialog that AF has to dismiss before the pane is usable.
+// ProgramNeedsTrustDismissal reports whether AF should run its trust-dismissal
+// check against a pane running this agent.
+//
+// It is deliberately NOT named "has a trust prompt": amp and opencode are in the
+// set without a known dialog of their own. The question this answers is whether
+// AF looks, and looking is close to free — TmuxSession.CheckAndHandleTrustPrompt
+// injects nothing unless it positively identifies a dialog it knows how to
+// clear. Being wrongly OUT of the set is the expensive direction: the pane sits
+// on an undismissed dialog until the readiness wait times out.
 //
 // This is the ONE gate. Both dismissal sites call it instead of enumerating the
 // agents themselves: LocalBackend.CheckAndHandleTrustPrompt (a live session) and
 // dismissConfigAgentTrustPrompt (a config-agent spawn). Two hand-copied lists
 // under a "mirrors the other one" comment is exactly what #2416 was — opencode
-// was added to the session gate in #1959 and missed in the daemon's, so a config
-// agent would hang on a dialog a normal session clears. #2097 was the same drift
-// over the retry budget, and #729 was codex missing from the enumeration
-// entirely. The answer has to come from one place or it drifts again.
+// was added to the session gate in #1959 and missed in the daemon's. #2097 was
+// the same drift over the retry budget, and #729 was codex missing from the
+// enumeration entirely. The answer has to come from one place or it drifts again.
 //
-// The name is the RESOLVED agent, so a program_overrides entry pointing an agent
-// name at some other binary never inherits an agent's trust handling
-// (#1116/#1131). A non-agent answers false: tapping Enter into an arbitrary
-// program is the harm this gate exists to prevent.
+// The argument is the RESOLVED agent, so a program_overrides entry pointing an
+// agent name at some other binary never inherits an agent's trust handling
+// (#1116/#1131). A non-agent answers false: running a dismissal loop against an
+// arbitrary program is the harm this gate exists to prevent.
 //
-// devin is deliberately absent. AF launches it with `--respect-workspace-trust
-// false`, so its modal never renders (#2410) — there is nothing to dismiss, and
-// a dismissal loop would tap Enter into a live composer.
-// TestProgramHasTrustPrompt_ClassifiesEverySupportedAgent forces a new agent to
-// record which side it is on rather than defaulting quietly into this one.
-func ProgramHasTrustPrompt(program string) bool {
+// devin is out of the set because AF has no predicate that identifies its
+// workspace-trust modal. Looking would cost a check that can never match, and
+// #2410 declined to treat an unclearable dialog as handled for the same reason
+// isReadyContent has no devin trust arm — that is the #729 trap. Note this is
+// NOT the same claim as "devin never shows the modal": normal sessions suppress
+// it with --respect-workspace-trust false, but that flag is injected by
+// injectSystemPrompt, which the config-agent spawn path does not call (#2435).
+//
+// TestProgramNeedsTrustDismissal_ClassifiesEverySupportedAgent forces a new agent
+// to record which side it is on rather than defaulting quietly out of the set.
+func ProgramNeedsTrustDismissal(program string) bool {
 	switch program {
 	case ProgramClaude, ProgramCodex, ProgramAider, ProgramGemini, ProgramAmp, ProgramOpencode:
 		return true

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -50,10 +50,24 @@ func IsSupportedProgram(name string) bool {
 //
 // It is deliberately NOT named "has a trust prompt": amp and opencode are in the
 // set without a known dialog of their own. The question this answers is whether
-// AF looks, and looking is close to free — TmuxSession.CheckAndHandleTrustPrompt
-// injects nothing unless it positively identifies a dialog it knows how to
-// clear. Being wrongly OUT of the set is the expensive direction: the pane sits
-// on an undismissed dialog until the readiness wait times out.
+// AF looks.
+//
+// Both ways of being wrong cost something, and neither is free:
+//
+//   - Wrongly OUT: every agent in the set also has a trust arm in isReadyContent,
+//     so a pane showing the dialog reads as READY. Nothing then clears it and the
+//     briefing is typed into the modal. That is #729's actual signature, not a
+//     hang — codex was excluded here, its dialog was surfaced by isReadyContent,
+//     and the prompt went into it. #2416 put opencode in the same state.
+//   - Wrongly IN: membership subjects live panes to DocTrustPromptPresent on the
+//     daemon's one-second poll, and a false positive there types 'D'+Enter into a
+//     running agent that asked nothing — re-firing every tick the phrase stays on
+//     screen (#1952). See that predicate's own doc in start.go; it is deliberately
+//     conservative for exactly this reason.
+//
+// So a new agent belongs in the set once its first-run behaviour is characterized,
+// not by default in either direction. Guess IN and you may inject keystrokes into
+// live sessions; guess OUT and you may hand a briefing to a modal.
 //
 // This is the ONE gate. Both dismissal sites call it instead of enumerating the
 // agents themselves: LocalBackend.CheckAndHandleTrustPrompt (a live session) and
@@ -69,12 +83,18 @@ func IsSupportedProgram(name string) bool {
 // arbitrary program is the harm this gate exists to prevent.
 //
 // devin is out of the set because AF has no predicate that identifies its
-// workspace-trust modal. Looking would cost a check that can never match, and
-// #2410 declined to treat an unclearable dialog as handled for the same reason
-// isReadyContent has no devin trust arm — that is the #729 trap. Note this is
-// NOT the same claim as "devin never shows the modal": normal sessions suppress
-// it with --respect-workspace-trust false, but that flag is injected by
-// injectSystemPrompt, which the config-agent spawn path does not call (#2435).
+// workspace-trust modal ("Do you trust the authors of this directory?"). The only
+// check membership would run for it is DocTrustPromptPresent, which cannot ever
+// true-positive on that wording — so the set would buy no dismissal at all and
+// only the false-positive exposure above. #2410 declined to treat an unclearable
+// dialog as handled for the same reason, which is the #729 trap.
+//
+// This is NOT the claim that devin never shows the modal. Two paths arm it:
+// the config-agent spawn, which never calls injectSystemPrompt and so never gets
+// --respect-workspace-trust false (#2435); and any session whose
+// program_overrides.devin already carries the flag, since devinCarriesWorkspaceTrustFlag
+// deliberately lets a user's explicit value win. Closing those needs an anchored
+// devin predicate, not a change here.
 //
 // TestProgramNeedsTrustDismissal_ClassifiesEverySupportedAgent forces a new agent
 // to record which side it is on rather than defaulting quietly out of the set.

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -45,6 +45,36 @@ func IsSupportedProgram(name string) bool {
 	return false
 }
 
+// ProgramHasTrustPrompt reports whether an agent can raise a first-run
+// trust/permission dialog that AF has to dismiss before the pane is usable.
+//
+// This is the ONE gate. Both dismissal sites call it instead of enumerating the
+// agents themselves: LocalBackend.CheckAndHandleTrustPrompt (a live session) and
+// dismissConfigAgentTrustPrompt (a config-agent spawn). Two hand-copied lists
+// under a "mirrors the other one" comment is exactly what #2416 was — opencode
+// was added to the session gate in #1959 and missed in the daemon's, so a config
+// agent would hang on a dialog a normal session clears. #2097 was the same drift
+// over the retry budget, and #729 was codex missing from the enumeration
+// entirely. The answer has to come from one place or it drifts again.
+//
+// The name is the RESOLVED agent, so a program_overrides entry pointing an agent
+// name at some other binary never inherits an agent's trust handling
+// (#1116/#1131). A non-agent answers false: tapping Enter into an arbitrary
+// program is the harm this gate exists to prevent.
+//
+// devin is deliberately absent. AF launches it with `--respect-workspace-trust
+// false`, so its modal never renders (#2410) — there is nothing to dismiss, and
+// a dismissal loop would tap Enter into a live composer.
+// TestProgramHasTrustPrompt_ClassifiesEverySupportedAgent forces a new agent to
+// record which side it is on rather than defaulting quietly into this one.
+func ProgramHasTrustPrompt(program string) bool {
+	switch program {
+	case ProgramClaude, ProgramCodex, ProgramAider, ProgramGemini, ProgramAmp, ProgramOpencode:
+		return true
+	}
+	return false
+}
+
 // TmuxSession represents a managed tmux session
 type TmuxSession struct {
 	// Initialized by NewTmuxSession

--- a/session/tmux/trust_prompt_gate_test.go
+++ b/session/tmux/trust_prompt_gate_test.go
@@ -1,0 +1,64 @@
+package tmux
+
+import "testing"
+
+// TestProgramHasTrustPrompt_ClassifiesEverySupportedAgent is the drift lock for
+// #2416.
+//
+// The bug was not that opencode was hard to classify — it was that the answer
+// lived in two hand-copied switch statements, so adding an agent to one and
+// forgetting the other was a silent, shippable mistake. It shipped twice: codex
+// (#729) and opencode (#1959 → #2416).
+//
+// The gate is one function now, but a new agent still defaults quietly to false.
+// This table is the forcing function: it must name every entry of
+// SupportedPrograms, so adding an agent fails here until someone states which
+// side it is on. Do not fix a failure by deleting the row — decide, then record
+// the decision with the reason.
+func TestProgramHasTrustPrompt_ClassifiesEverySupportedAgent(t *testing.T) {
+	classified := map[string]bool{
+		// Has a real first-run dialog AF answers.
+		ProgramClaude: true,
+		ProgramCodex:  true,
+		ProgramAider:  true,
+		ProgramGemini: true,
+		// No dialog of its own; falls through to the generic doc-trust branch and
+		// no-ops. Classified true so it can never go missing the way it did in
+		// #2416 — the harm there was the omission, not the dismissal.
+		ProgramAmp:      true,
+		ProgramOpencode: true,
+		// AF launches devin with --respect-workspace-trust false, so the modal
+		// never renders (#2410). There is nothing to dismiss, and running the
+		// dismissal loop anyway would tap Enter into a live composer.
+		ProgramDevin: false,
+	}
+
+	for _, program := range SupportedPrograms {
+		want, named := classified[program]
+		if !named {
+			t.Errorf("supported agent %q is not classified for trust prompts; "+
+				"decide whether it raises a first-run dialog and add it to this table", program)
+			continue
+		}
+		if got := ProgramHasTrustPrompt(program); got != want {
+			t.Errorf("ProgramHasTrustPrompt(%q) = %t, want %t", program, got, want)
+		}
+	}
+
+	for program := range classified {
+		if !IsSupportedProgram(program) {
+			t.Errorf("classified program %q is no longer a supported agent; drop its row", program)
+		}
+	}
+}
+
+// TestProgramHasTrustPrompt_RejectsNonAgents holds the invariant the gate exists
+// for: anything that is not a known agent gets no dismissal loop, because
+// tapping Enter into an arbitrary program is the harm (#1116/#1131).
+func TestProgramHasTrustPrompt_RejectsNonAgents(t *testing.T) {
+	for _, program := range []string{"", "bash", "vim", "claude-wrapper", "/opt/bin/notclaude"} {
+		if ProgramHasTrustPrompt(program) {
+			t.Errorf("ProgramHasTrustPrompt(%q) = true, want false for a non-agent", program)
+		}
+	}
+}

--- a/session/tmux/trust_prompt_gate_test.go
+++ b/session/tmux/trust_prompt_gate_test.go
@@ -2,46 +2,54 @@ package tmux
 
 import "testing"
 
-// TestProgramHasTrustPrompt_ClassifiesEverySupportedAgent is the drift lock for
-// #2416.
+// TestProgramNeedsTrustDismissal_ClassifiesEverySupportedAgent is the drift lock
+// for #2416.
 //
 // The bug was not that opencode was hard to classify — it was that the answer
 // lived in two hand-copied switch statements, so adding an agent to one and
 // forgetting the other was a silent, shippable mistake. It shipped twice: codex
 // (#729) and opencode (#1959 → #2416).
 //
-// The gate is one function now, but a new agent still defaults quietly to false.
-// This table is the forcing function: it must name every entry of
-// SupportedPrograms, so adding an agent fails here until someone states which
-// side it is on. Do not fix a failure by deleting the row — decide, then record
-// the decision with the reason.
-func TestProgramHasTrustPrompt_ClassifiesEverySupportedAgent(t *testing.T) {
+// The gate is one function now, but a new agent still defaults quietly to false,
+// and false is the expensive direction: the pane sits on an undismissed dialog
+// until readiness times out. This table is the forcing function — it must name
+// every entry of SupportedPrograms, so adding an agent fails here until someone
+// states which side it is on. Do not fix a failure by deleting the row; decide,
+// then record the decision with the reason.
+func TestProgramNeedsTrustDismissal_ClassifiesEverySupportedAgent(t *testing.T) {
 	classified := map[string]bool{
-		// Has a real first-run dialog AF answers.
+		// Dialogs AF positively identifies and clears: claude's trust/MCP screens,
+		// codex's directory-trust and safety-buffering modals, and the generic
+		// doc-trust dialog DocTrustPromptPresent scopes to aider/gemini.
 		ProgramClaude: true,
 		ProgramCodex:  true,
 		ProgramAider:  true,
 		ProgramGemini: true,
-		// No dialog of its own; falls through to the generic doc-trust branch and
-		// no-ops. Classified true so it can never go missing the way it did in
-		// #2416 — the harm there was the omission, not the dismissal.
+		// In the set without a known dialog of their own. opencode is verified to
+		// go straight to its composer in a fresh repo (0.0.0-main-202604230742);
+		// amp's first-run behaviour is not characterized here. Both are in anyway:
+		// the check injects nothing unless it identifies a dialog it can clear, so
+		// looking is close to free, while being wrongly OUT is how #729 and #2416
+		// both shipped.
 		ProgramAmp:      true,
 		ProgramOpencode: true,
-		// AF launches devin with --respect-workspace-trust false, so the modal
-		// never renders (#2410). There is nothing to dismiss, and running the
-		// dismissal loop anyway would tap Enter into a live composer.
+		// Out because AF has no predicate that identifies devin's workspace-trust
+		// modal — the check could never match it, and treating an unclearable
+		// dialog as handled is the #729 trap (#2410 declined it for the same
+		// reason isReadyContent has no devin trust arm). This is NOT the claim
+		// that the modal never appears: see #2435.
 		ProgramDevin: false,
 	}
 
 	for _, program := range SupportedPrograms {
 		want, named := classified[program]
 		if !named {
-			t.Errorf("supported agent %q is not classified for trust prompts; "+
-				"decide whether it raises a first-run dialog and add it to this table", program)
+			t.Errorf("supported agent %q is not classified for trust dismissal; "+
+				"decide whether AF should check its pane for a dialog and add it to this table", program)
 			continue
 		}
-		if got := ProgramHasTrustPrompt(program); got != want {
-			t.Errorf("ProgramHasTrustPrompt(%q) = %t, want %t", program, got, want)
+		if got := ProgramNeedsTrustDismissal(program); got != want {
+			t.Errorf("ProgramNeedsTrustDismissal(%q) = %t, want %t", program, got, want)
 		}
 	}
 
@@ -52,13 +60,13 @@ func TestProgramHasTrustPrompt_ClassifiesEverySupportedAgent(t *testing.T) {
 	}
 }
 
-// TestProgramHasTrustPrompt_RejectsNonAgents holds the invariant the gate exists
-// for: anything that is not a known agent gets no dismissal loop, because
-// tapping Enter into an arbitrary program is the harm (#1116/#1131).
-func TestProgramHasTrustPrompt_RejectsNonAgents(t *testing.T) {
+// TestProgramNeedsTrustDismissal_RejectsNonAgents holds the invariant the gate
+// exists for: anything that is not a known agent gets no dismissal loop, because
+// driving one against an arbitrary program is the harm (#1116/#1131).
+func TestProgramNeedsTrustDismissal_RejectsNonAgents(t *testing.T) {
 	for _, program := range []string{"", "bash", "vim", "claude-wrapper", "/opt/bin/notclaude"} {
-		if ProgramHasTrustPrompt(program) {
-			t.Errorf("ProgramHasTrustPrompt(%q) = true, want false for a non-agent", program)
+		if ProgramNeedsTrustDismissal(program) {
+			t.Errorf("ProgramNeedsTrustDismissal(%q) = true, want false for a non-agent", program)
 		}
 	}
 }

--- a/task/runner.go
+++ b/task/runner.go
@@ -209,12 +209,19 @@ func isReadyContent(content, agent string) bool {
 		// and claude's "❯" (U+276F). Matched on the raw pane like codex's glyph
 		// (devin does not split the glyph with color escapes), so no ANSI strip.
 		//
-		// Deliberately NO isDocTrustPrompt arm (unlike the file-seam agents): af
-		// launches devin with --respect-workspace-trust false (injectSystemPrompt),
-		// so devin's interactive workspace-trust modal never appears, and af wires
-		// no devin trust dismissal. Treating a trust/doc prompt as ready without an
-		// anchored way to clear it is the #729 trap — af would type the first prompt
-		// into an undismissed modal. The "❭" composer is the only ready signal.
+		// Deliberately NO isDocTrustPrompt arm (unlike the file-seam agents),
+		// because af wires no devin trust dismissal: tmux.ProgramNeedsTrustDismissal
+		// excludes devin, as DocTrustPromptPresent cannot match its modal wording.
+		// Treating a trust/doc prompt as ready without an anchored way to clear it
+		// is the #729 trap — af would type the first prompt into an undismissed
+		// modal. The "❭" composer is the only ready signal.
+		//
+		// Note the modal CAN appear. af normally launches devin with
+		// --respect-workspace-trust false, but that is injected by
+		// injectSystemPrompt, which the config-agent spawn path does not call
+		// (#2435), and a program_overrides.devin carrying the flag explicitly wins
+		// over the injection. Omitting the arm is what keeps such a pane from being
+		// called ready.
 		return strings.Contains(content, "❭")
 	case tmux.ProgramClaude:
 		if strings.Contains(content, "❯") ||

--- a/task/trust_readiness_parity_test.go
+++ b/task/trust_readiness_parity_test.go
@@ -1,0 +1,56 @@
+package task
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// docTrustDialogFixture is the generic documentation-trust dialog, at the full
+// length DocTrustPromptPresent requires. It is the one dialog shared across the
+// file-seam agents, which is what makes a single fixture enough below.
+const docTrustDialogFixture = `Add https://aider.chat/docs/faq.html to the chat?
+Open documentation url for more info
+(Y)es/(N)o/(D)on't ask again [Yes]:`
+
+// TestTrustDialogIsReadyOnlyForAgentsAFCanDismiss locks the #729 invariant
+// across the two enumerations that have to agree about it:
+//
+//   - isReadyContent decides whether a pane showing a trust dialog counts as
+//     READY, and
+//   - tmux.ProgramNeedsTrustDismissal decides whether AF will then clear it.
+//
+// If an agent is ready-on-dialog but not in the gate, AF declares the pane usable
+// and types the briefing into an undismissed modal. That is #729 exactly — codex
+// had a trust arm here and was missing from the gate — and #2416 put opencode in
+// the same state. The reverse desync is milder but still wrong: AF would run a
+// dismissal loop for a dialog it never treats as a reason to keep waiting.
+//
+// #2416 unified the two DISMISSAL sites, but this readiness arm is a third
+// enumeration of the same fact and nothing tied it to them. It is not circular:
+// the two sides are independent implementations, neither derived from the other,
+// so a desync in either direction fails here. Verified it bites by temporarily
+// adding devin to the gate — isReadyContent has no devin trust arm, and the case
+// failed on that mismatch.
+//
+// claude and codex are skipped deliberately: they carry agent-specific dialog
+// predicates (claude's trust/MCP screens, CodexTrustPromptPresent) rather than
+// the generic doc-trust one, so this fixture cannot speak for them. Their arms
+// are covered by their own cases in this package and in session/tmux.
+func TestTrustDialogIsReadyOnlyForAgentsAFCanDismiss(t *testing.T) {
+	covered := 0
+	for _, agent := range tmux.SupportedPrograms {
+		if agent == tmux.ProgramClaude || agent == tmux.ProgramCodex {
+			continue
+		}
+		covered++
+		want := tmux.ProgramNeedsTrustDismissal(agent)
+		if got := isReadyContent(docTrustDialogFixture, agent); got != want {
+			t.Errorf("isReadyContent(docTrustDialog, %q) = %t but ProgramNeedsTrustDismissal(%q) = %t; "+
+				"a dialog AF calls ready must be one AF dismisses (#729)", agent, got, agent, want)
+		}
+	}
+	if covered == 0 {
+		t.Fatal("only claude and codex are supported agents; this case asserts nothing")
+	}
+}


### PR DESCRIPTION
## Summary

`dismissConfigAgentTrustPrompt` decided which agents have a first-run trust dialog by enumerating them, under a comment claiming the list mirrored `LocalBackend.CheckAndHandleTrustPrompt`. The comment was not true when it was written: opencode was added to that gate in #1959 and never here. An opencode config-agent spawn therefore took the `default` branch, never ran the dismissal loop, and would hang on a dialog a normal session clears.

Adding opencode to the copy would have restored the mirror and left the next agent to drift the same way. This is the third time the class has shipped:

- #729 — codex missing from the enumeration, so its dialog was surfaced by `isReadyContent` but never dismissed
- #2097 — the same drift over the retry budget, under the same kind of "mirrors the other one" comment
- #2416 — this one

So the membership answer moves into one place, `tmux.ProgramHasTrustPrompt`, and both sites call it instead of each holding a list.

devin stays outside the gate deliberately, and that is now written down where the decision lives: af launches it with `--respect-workspace-trust false`, so its modal never renders (#2410). Running a dismissal loop for it would tap Enter into a live composer.

## Verification against current master

I re-verified the Detail report against `origin/master` before touching anything — `daemon/configagent.go:311` still listed five agents while `session/backend_local.go:813` listed six. The report is accurate and not stale.

One correction to it: it says the switch "should list 6 agents ... matching `LocalBackend.CheckAndHandleTrustPrompt`". Master now supports seven agents, and the seventh (devin, #2410) must **not** be listed. Copying the canonical list verbatim, as the report's recommended fix implies, would have been correct today only by luck. That is the argument for one gate rather than a corrected copy.

## Reproduction and regression coverage

Both regressions were watched failing first, against the real production paths.

**The reported defect.** `TestDismissConfigAgentTrustPrompt_ClearsEveryTrustPromptAgent` drives `dismissConfigAgentTrustPrompt` for every agent the shared gate classifies as prompting. With the old five-agent switch restored:

```
--- FAIL: TestDismissConfigAgentTrustPrompt_ClearsEveryTrustPromptAgent/opencode
    expected opencode's pane to be checked once for a trust dialog, got 0 checks
```

Only opencode failed — the defect signature exactly, no collateral. What it asserts is the *gate*, not the loop: each pane is given no dialog, so `DismissTrustPrompt` makes one check and returns without a readiness wait. One check means the agent reached the loop; zero is the bug. The loop's own behaviour (budget, re-wait, bound) stays with the two claude cases that already cover it, and per-agent ready glyphs stay in `task`'s tests instead of being restated in the daemon's — an earlier draft of this test did restate them and bought four 60s readiness timeouts for nothing.

Its counterpart, `TestDismissConfigAgentTrustPrompt_SkipsAgentsWithNoDialog`, holds the other side: closing the drift must not over-correct into dismissing for an agent whose modal af already suppresses. It feeds those panes `prompts: 1`, so a pane that *were* asked would answer "dialog present" and be counted — the check can fail.

**The recurrence.** One shared gate still lets a new agent default quietly to "no trust prompt", which is precisely how #729 and #2416 shipped. `TestProgramHasTrustPrompt_ClassifiesEverySupportedAgent` must name every entry of `SupportedPrograms`, so adding an agent fails until someone records which side it is on and why. Verified it has teeth by appending an unclassified agent:

```
--- FAIL: TestProgramHasTrustPrompt_ClassifiesEverySupportedAgent
    supported agent "newagent" is not classified for trust prompts;
    decide whether it raises a first-run dialog and add it to this table
```

## Gates

Exact head: `6c4e8713` (will update if I push again).

- `golangci-lint run --timeout=3m --fast` — clean
- `gofmt -l .` — no output
- `go build ./...` — clean
- `deadcode -test ./...` — no output
- `scripts/lint-file-length.sh` — passed, 985 files, 0 grandfathered
- `make test-container` — full suite, run on this pushed head

No user-visible TUI surface changes, so no play-test.

Closes #2416.

— Captain Claude
