### PR TITLE
fix(termpane): keep the newest size last on the wire (#2417)

### DIFF
--- a/ui/termpane/termpane.go
+++ b/ui/termpane/termpane.go
@@ -141,8 +141,10 @@ type Dialer func(ctx context.Context, since uint64) (Stream, error)
 // the bubbletea event loop; the run loop (inbound) and send pump (outbound) run on
 // their own goroutines. gridMu guards the emulator grid between the run loop's
 // writes and Render's reads; connMu guards the current stream + cursor + desired
-// size between the loops and the event-loop mutators. Close is safe to call more
-// than once.
+// size between the loops and the event-loop mutators; resizeMu serializes the two
+// RESIZE senders so the newest size is always the one written last (assertSize).
+// resizeMu is ordered before connMu, and no lock here is ever held across stream
+// I/O. Close is safe to call more than once.
 type TermPane struct {
 	gridMu sync.RWMutex
 	emu    *vt.Emulator
@@ -174,6 +176,13 @@ type TermPane struct {
 	stream             Stream // current live stream; nil while (re)connecting
 	wantRows, wantCols uint16 // desired size, (re)asserted on each connect
 	cursor             uint64 // absolute output cursor for ?since replay
+
+	// resizeMu serializes the two RESIZE senders — Resize() and the run loop's
+	// per-connect re-assert — so that reading the desired size and writing it is
+	// one indivisible step. It is what makes the server's last-resize-wins rule
+	// mean last-INTENT-wins; see assertSize. Ordered BEFORE connMu and never held
+	// the other way round.
+	resizeMu sync.Mutex
 
 	ctx       context.Context
 	cancel    context.CancelFunc
@@ -264,7 +273,6 @@ func (t *TermPane) run() {
 		// repaint re-synchronises.
 		t.cursor = stream.StartSeq()
 		t.stream = stream
-		rows, cols := t.wantRows, t.wantCols
 		t.connMu.Unlock()
 
 		t.gridMu.Lock()
@@ -275,9 +283,7 @@ func (t *TermPane) run() {
 
 		// (Re)assert our desired size so the server sizes this tab's window to us —
 		// the pane may have resized while we were disconnected (last-resize-wins).
-		wctx, cancelW := context.WithTimeout(t.ctx, writeTimeout)
-		_ = stream.SendResize(wctx, rows, cols)
-		cancelW()
+		t.assertSize(stream)
 
 		t.readStream(stream)
 
@@ -457,13 +463,41 @@ func (t *TermPane) Resize(width, height int) {
 	t.connMu.Lock()
 	t.wantRows, t.wantCols = uint16(height), uint16(width) //nolint:gosec // clampSize bounds to [1, 4096]
 	stream := t.stream
-	rows, cols := t.wantRows, t.wantCols
 	t.connMu.Unlock()
 	if stream != nil {
-		wctx, cancel := context.WithTimeout(t.ctx, writeTimeout)
-		_ = stream.SendResize(wctx, rows, cols)
-		cancel()
+		t.assertSize(stream)
 	}
+}
+
+// assertSize writes the pane's CURRENT desired size to stream as a RESIZE frame.
+//
+// The read and the write are one step, under resizeMu, because they have two
+// writers: Resize() when the geometry changes, and the run loop once per
+// (re)connect, to tell a brand-new stream a size the server has never heard. When
+// each merely captured the size and wrote it after unlocking, a Resize() landing
+// in the run loop's window updated the size and wrote it FIRST, leaving the run
+// loop's now-stale frame to arrive LAST. The server's rule is last-resize-wins, so
+// the stale value won and was echoed back, pinning the emulator grid to the old
+// geometry while the TUI frame stayed at the new one (#2417). Serializing makes
+// the last frame on the wire necessarily the newest intent: whichever sender
+// writes last reads the desired size only after acquiring resizeMu, and Resize()
+// always writes after committing its value.
+//
+// Deliberately NOT connMu, though connMu already guards these fields. connMu is
+// also taken per inbound data event to advance the replay cursor, and on the
+// bubbletea event loop by Resize/Close; holding it across a network write bounded
+// by writeTimeout would stall those behind a slow socket. This mirrors sendPump,
+// which likewise reads the stream under connMu and writes outside it — no lock in
+// this type is ever held across stream I/O.
+func (t *TermPane) assertSize(stream Stream) {
+	t.resizeMu.Lock()
+	defer t.resizeMu.Unlock()
+	t.connMu.Lock()
+	rows, cols := t.wantRows, t.wantCols
+	t.connMu.Unlock()
+	wctx, cancel := context.WithTimeout(t.ctx, writeTimeout)
+	_ = stream.SendResize(wctx, rows, cols)
+	cancel()
 }
 
 // Render returns the emulator's grid as exactly height ANSI-styled lines of

--- a/ui/termpane/termpane_test.go
+++ b/ui/termpane/termpane_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -29,6 +30,12 @@ type fakeStream struct {
 	mu      sync.Mutex
 	input   []byte
 	resizes [][2]uint16 // {rows, cols}
+	// resizeGate, when set, runs at the START of SendResize — after the caller has
+	// captured the size it is about to write, but before that frame is recorded. It
+	// is the seam a test needs to drive the reconnect/resize interleaving
+	// deterministically instead of racing it (#2417). Set before New; never held
+	// under s.mu, so a concurrent sender can still record while it runs.
+	resizeGate func()
 }
 
 func newFakeStream(startSeq uint64) *fakeStream {
@@ -56,6 +63,9 @@ func (s *fakeStream) SendInput(_ context.Context, b []byte) error {
 }
 
 func (s *fakeStream) SendResize(_ context.Context, rows, cols uint16) error {
+	if s.resizeGate != nil {
+		s.resizeGate()
+	}
 	s.mu.Lock()
 	s.resizes = append(s.resizes, [2]uint16{rows, cols})
 	s.mu.Unlock()
@@ -172,6 +182,98 @@ func TestResizeSendsResizeFrame(t *testing.T) {
 		r, ok := s.lastResize()
 		return ok && r == [2]uint16{30, 100} // rows, cols
 	}, 2*time.Second, 10*time.Millisecond, "Resize must send a RESIZE frame (rows,cols)=(30,100)")
+}
+
+// TestReconnectResizeKeepsTheNewestSize is the #2417 regression: last-resize-wins
+// has to mean last-INTENT-wins, not last-frame-to-win-the-write-lock.
+//
+// Both senders write RESIZE frames — Resize() when the pane geometry changes, and
+// run() once per (re)connect, to re-assert a size the server has never been told
+// (the pane may have resized while disconnected). run() captured the desired size
+// under connMu and then wrote it after unlocking, so a Resize() landing in that
+// window updated the size and sent it FIRST, leaving run()'s now-stale frame to
+// arrive LAST and win. The server sizes the PTY to the stale value and echoes it
+// back, so the emulator grid is forced to the old size while the TUI frame is at
+// the new one — mismatched wrapping until something resizes again.
+//
+// The interleaving is driven, not raced: the gate fires inside run()'s write, which
+// is exactly the window between its capture and its send, and the test waits for
+// the new geometry to be committed before letting that write proceed. Asserting on
+// the LAST frame rather than the frame count is deliberate — either sender may
+// legitimately write, and which of them writes last is the only thing the server's
+// last-resize-wins rule reads.
+func TestReconnectResizeKeepsTheNewestSize(t *testing.T) {
+	const (
+		oldWidth, oldHeight = 80, 24
+		newWidth, newHeight = 120, 40
+	)
+
+	s := newFakeStream(0)
+	d := &queueDialer{streams: []*fakeStream{s}}
+
+	// The gate runs on the run goroutine and needs the pane New() has not returned
+	// yet, so publish it through a channel rather than racing the assignment.
+	paneCh := make(chan *TermPane, 1)
+	resized := make(chan struct{})
+	// Deliberately NOT sync.Once: Do blocks its concurrent callers until the first
+	// call returns, which would park the very writer this gate is waiting for
+	// inside the gate itself. The guard has to let every later call straight
+	// through.
+	var gated atomic.Bool
+	s.resizeGate = func() {
+		if gated.CompareAndSwap(false, true) {
+			tp := <-paneCh
+			go func() {
+				defer close(resized)
+				tp.Resize(newWidth, newHeight)
+			}()
+			// Wait for the new geometry to reach the pane's desired size. That commit
+			// is the precise moment run()'s captured value goes stale, and it happens
+			// under connMu before Resize() writes anything — so this cannot deadlock
+			// against a fix that serializes the two writers.
+			require.Eventually(t, func() bool {
+				tp.connMu.Lock()
+				defer tp.connMu.Unlock()
+				return tp.wantRows == newHeight && tp.wantCols == newWidth
+			}, 5*time.Second, time.Millisecond, "Resize never committed the new desired size")
+
+			// Then hand the racing writer every chance to get its frame onto the wire
+			// FIRST, which is the losing interleaving being pinned: the stale frame
+			// this call is carrying would then land last and win. Waiting on the frame
+			// itself rather than on a bare sleep is what makes the reproduction
+			// deterministic instead of timing-dependent.
+			//
+			// A fix that serializes the two writers makes this wait run its full
+			// course by construction — the other sender cannot write while this one
+			// holds the serializer — so the bound is this test's fixed cost when
+			// green, never a flake. Timing out early could only ever cost a missed
+			// regression, not a false failure.
+			deadline := time.Now().Add(2 * time.Second)
+			for time.Now().Before(deadline) {
+				s.mu.Lock()
+				raced := len(s.resizes) > 0
+				s.mu.Unlock()
+				if raced {
+					return
+				}
+				time.Sleep(time.Millisecond)
+			}
+		}
+	}
+
+	tp := New(d.dial, oldWidth, oldHeight)
+	t.Cleanup(func() { _ = tp.Close() })
+	paneCh <- tp
+	<-resized
+
+	// The server's last word must be the size the user actually resized to.
+	require.Eventually(t, func() bool {
+		r, ok := s.lastResize()
+		return ok && r == [2]uint16{newHeight, newWidth}
+	}, 5*time.Second, 10*time.Millisecond,
+		"the LAST resize frame must carry the newest size (rows,cols)=(%d,%d); a stale "+
+			"re-assert landing last sizes the PTY to the old geometry and the server echoes it back",
+		newHeight, newWidth)
 }
 
 // TestResizeKeepsContentThenServerRepaints pins the PR6 resize behavior: unlike


### PR DESCRIPTION
Fixes #2417.

## The bug

A resize that landed while the pane was reconnecting could be undone by the reconnect itself. The PTY ended up at the **old** geometry, the server echoed that back, and the emulator grid was pinned to the old size while the TUI frame stayed at the new one — wrong wrapping and visual artifacts until something resized again.

Verified live on `master` (`6f90d5b1`) before fixing — this report is not stale.

`RESIZE` has two senders: `Resize()` when the pane geometry changes, and the run loop once per (re)connect, to tell a brand-new stream a size the server has never heard. Each captured the desired size under `connMu` and then wrote it *after* unlocking. A `Resize()` landing in the run loop's window updated the size and wrote it **first**, leaving the run loop's now-stale frame to arrive **last** — and the server's rule is last-resize-wins, so the stale value won. Which frame won was decided by who acquired the websocket write lock, not by who had the newer intent.

## The fix

Serialize the two senders on a `resizeMu`, so *reading* the desired size and *writing* it is one indivisible step (`assertSize`). The last frame on the wire is then necessarily the newest intent: whichever sender writes last reads the size only after acquiring the serializer, and `Resize()` always writes after committing its value. Both senders now share a single write site — after this change there is exactly one `SendResize` call in the package.

### Why not the fix suggested in the issue

The report recommends moving `SendResize` inside the existing `connMu` critical section. That does fix the ordering, but it holds `connMu` across a network write bounded by `writeTimeout` (5s). `connMu` is also taken **per inbound data event** to advance the replay cursor, and on the **bubbletea event loop** by `Resize`/`Close` — so a slow socket would stall the inbound pump and the TUI event loop behind it. This repo has been bitten by exactly that class before (work in front of the TUI turning a lock into a hang).

A separate serializer gets the same ordering guarantee while preserving the invariant `sendPump` already follows: read the stream under `connMu`, write outside it. **No lock in this type is held across stream I/O.** `resizeMu` is ordered before `connMu` and never taken the other way round, so there is no cycle.

**Tradeoff, stated plainly:** `Resize()` on the event loop can now wait for an in-flight re-assert, so its worst case goes from one `writeTimeout` to two. That contention only arises in the reconnect window this bug lives in — `resizeMu` is uncontended in the steady state — and the alternative was moving that same wait onto `connMu`, where it would block the inbound pump as well.

## Test

`TestReconnectResizeKeepsTheNewestSize` drives the interleaving deterministically rather than racing it: a gate fires inside the run loop's write — exactly the window between its capture and its send — and the test waits for the new geometry to be committed, then waits for the racing frame to actually land, before letting the stale write proceed.

It asserts on the **last** frame rather than the frame count, because either sender may legitimately write and last-resize-wins is the only thing the server reads.

Watched it fail first, on the reported symptom:

```
--- FAIL: TestReconnectResizeKeepsTheNewestSize (5.00s)
    Condition never satisfied
    the LAST resize frame must carry the newest size (rows,cols)=(40,120); a stale
    re-assert landing last sizes the PTY to the old geometry and the server echoes it back
```

Two notes on the test, both load-bearing:

- The guard is an `atomic.Bool`, **not** `sync.Once` — `Do` blocks its concurrent callers until the first call returns, which parked the very writer the gate was waiting on. My first version passed for that reason; the seam had to be fixed before the test could see the bug.
- The 2s bound in the gate is the test's fixed cost when green, not a flake: once the writers are serialized the racing frame *cannot* land while the gate is held, so the wait runs its full course by construction. Timing out early could only cost a missed regression, never a false failure.

## Gate

- `gofmt -l .` clean · `go build ./...` clean
- `golangci-lint run --timeout=3m --fast` clean
- `deadcode -test ./...` clean
- `scripts/lint-file-length.sh` passed (985 files)
- `./ui/termpane/...` green under **`-race`**
- Full suite via `make test-container` on the pushed head — SHA in a follow-up comment

## Review

The codex GitHub app is rate-limited until Jul 28. Requesting once; if it stays silent I'll say so explicitly rather than implying a clean review, and Captain Claude runs an independent review on this exact head before merge.

— Captain Claude
