### PR TITLE
fix(tui): keep interactive mode after a ctrl+] help dismiss (#2413)

### DIFF
--- a/app/home_update.go
+++ b/app/home_update.go
@@ -233,7 +233,20 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Deferred by the first-time interactive help screen's dismiss cmd
 		// (#1089 PR 2); the pane pointer is re-validated inside.
 		cmd := m.activateInteractive(msg.pane)
-		if msg.replay && m.interactive {
+		// The replay exists to forward the transition keystroke INTO the pane
+		// rather than swallow it (#1576). The host-reserved exit key is the one
+		// key that is not pane input, so replaying it here would run the mode we
+		// just entered straight back out.
+		//
+		// That is #2413, and the first-run help is what walks users into it: any
+		// key dismisses that overlay, and its last line reads "Press ctrl+] to
+		// return to navigation" — so the key the screen names is the key most
+		// likely to be pressed while reading it, and pressing it made interactive
+		// mode look broken on the very first try. Guarding at this sink rather
+		// than at either producer means no future replay source can reintroduce
+		// it. The key keeps working as the exit once the user is actually in the
+		// mode; only the synthetic replay of it is dropped.
+		if msg.replay && m.interactive && !isInteractiveExitKey(msg.replayKey) {
 			_, replayCmd := m.handleInteractiveKey(msg.replayKey)
 			cmd = tea.Batch(cmd, replayCmd)
 		}

--- a/app/interactive.go
+++ b/app/interactive.go
@@ -114,6 +114,19 @@ func (m *home) activateInteractive(p *store.OpenPane) tea.Cmd {
 	return nil
 }
 
+// isInteractiveExitKey reports whether msg is keys.KeyExitInteractive (Ctrl-]),
+// the ONE host-reserved key inside interactive mode. Everything else forwards to
+// the agent/shell.
+//
+// It is the single definition of that key for the app package, because two
+// places need to agree on it and they are not adjacent: handleInteractiveKey
+// acts on it, and the enterInteractiveMsg replay must refuse to feed it back in
+// (#2413). A second literal tea.KeyCtrlCloseBracket comparison drifting from
+// this one is exactly how that bug came back.
+func isInteractiveExitKey(msg tea.KeyMsg) bool {
+	return msg.Type == tea.KeyCtrlCloseBracket
+}
+
 // paneErrorLabel names pane p's session for a user-facing message, falling back
 // to a generic phrase when the title is unknown. A pane whose instance vanished
 // (or was never titled) used to render the name as an empty pair of quotes,
@@ -133,7 +146,7 @@ func paneErrorLabel(p *store.OpenPane) string {
 // sequence (the #1089 input contract; the honest not-forwarded list lives on
 // termpane.translateKey).
 func (m *home) handleInteractiveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if msg.Type == tea.KeyCtrlCloseBracket {
+	if isInteractiveExitKey(msg) {
 		m.setInteractive(false)
 		return m, nil
 	}

--- a/app/interactive_help_exit_key_test.go
+++ b/app/interactive_help_exit_key_test.go
@@ -1,0 +1,102 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/keys"
+)
+
+// TestFirstRunInteractiveHelpDismissedWithExitKeyStaysInteractive is #2413.
+//
+// The first-run interactive help is dismissed by ANY key, and the dismiss key is
+// then replayed into the pane so it is not swallowed (#1576). The overlay's last
+// line reads "Press ctrl+] to return to navigation." — so ctrl+] is the key the
+// screen puts in front of the user, and pressing it is the most natural thing to
+// do while reading.
+//
+// Replaying it ran it through handleInteractiveKey, where ctrl+] is the one
+// host-reserved key: it exits interactive mode. So a first-time user who
+// dismissed the help with the key the help named landed back in nav mode
+// instantly, having never typed a character — interactive mode looked simply
+// broken, on the one run where the user is least equipped to tell a bug from
+// their own mistake.
+//
+// The existing coverage (TestFirstRunInteractiveHelpForwardsDismissKey) dismisses
+// with `q`, which forwards harmlessly, so nothing caught this.
+func TestFirstRunInteractiveHelpDismissedWithExitKeyStaysInteractive(t *testing.T) {
+	h, _ := liveTestHome(t)
+	fakes, _ := stubLiveTermFactory(t)
+
+	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+	require.Nil(t, cmd, "first-time interactive entry waits on the help overlay")
+	require.Equal(t, stateHelp, h.state, "precondition: the first-run help is showing")
+
+	// The user presses the key the overlay just told them about.
+	_, cmd = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyCtrlCloseBracket})
+	runHermeticCmd(t, h, cmd, 0)
+
+	assert.True(t, h.interactive,
+		"dismissing the first-run help with ctrl+] — the key the overlay itself names — must "+
+			"leave the user IN interactive mode. Replaying it through handleInteractiveKey "+
+			"exits immediately, so the mode never starts (#2413).")
+
+	require.Len(t, *fakes, 1, "the pane's attachment must still be bound")
+	assert.Empty(t, (*fakes)[0].keys,
+		"ctrl+] is the host's mode-exit key, not pane input — it must be swallowed, not typed "+
+			"into the agent as a raw control byte")
+
+	// The mode is genuinely usable, not just flagged on: ordinary keys forward…
+	_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("z")})
+	assert.Equal(t, []string{"z"}, (*fakes)[0].keys,
+		"interactive mode must actually forward keystrokes after the help dismiss")
+
+	// …and the NEXT ctrl+] is the one that exits, exactly as the help promised.
+	_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyCtrlCloseBracket})
+	assert.False(t, h.interactive,
+		"ctrl+] pressed inside interactive mode must still return to navigation — the fix "+
+			"suppresses the REPLAY, never the key itself")
+	assert.Equal(t, []string{"z"}, (*fakes)[0].keys,
+		"the exit ctrl+] must not be forwarded to the pane either")
+}
+
+// TestFirstRunInteractiveHelpStillForwardsOrdinaryDismissKeys guards the
+// behavior #1576 added and #2413 must not cost: every dismiss key that is NOT
+// the host-reserved exit key still reaches the pane, so the keystroke the user
+// typed is not silently eaten.
+func TestFirstRunInteractiveHelpStillForwardsOrdinaryDismissKeys(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  tea.KeyMsg
+		want string
+	}{
+		{"letter", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")}, "q"},
+		{"enter", tea.KeyMsg{Type: tea.KeyEnter}, "enter"},
+		// ctrl+c is deliberately pane input inside interactive mode (it interrupts
+		// the agent, not af) — TestInteractiveForwardsAllKeysIncludingTab pins
+		// that, and the #2413 guard must not widen to it.
+		{"ctrl+c", tea.KeyMsg{Type: tea.KeyCtrlC}, "ctrl+c"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h, _ := liveTestHome(t)
+			fakes, _ := stubLiveTermFactory(t)
+
+			_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+			require.Nil(t, cmd)
+			require.Equal(t, stateHelp, h.state)
+
+			_, cmd = h.handleKeyPress(c.msg)
+			runHermeticCmd(t, h, cmd, 0)
+
+			require.True(t, h.interactive, "dismissing first-run help enters interactive mode")
+			require.Len(t, *fakes, 1)
+			assert.Equal(t, []string{c.want}, (*fakes)[0].keys,
+				"the key that dismisses the first-run interactive help must reach the pane (#1576)")
+		})
+	}
+}

--- a/docs/tui-manual-testing.md
+++ b/docs/tui-manual-testing.md
@@ -203,11 +203,35 @@ compose across `docker exec` invocations.
 `AGENT_FACTORY_AUTO_UPDATE` (driver sets to `false` to prevent mid-test
 self-updates that would timeout instance creation),
 `AF_DRIVER_TIMEOUT` (`25`s), `AF_DRIVER_POLL` (`0.25`s),
-`AF_DRIVER_DETACH_KEY` (`C-w`), `AF_DRIVER_BIN` (auto-resolved).
+`AF_DRIVER_DETACH_KEY` (`C-w`), `AF_DRIVER_BIN` (auto-resolved),
+`AF_DRIVER_HELP_SEEN` (`15`).
 
 Set `AF_DRIVER_COLS`/`ROWS` **before** `af_boot` to launch at a non-default
 size — `af_boot` pins it so it sticks (see the tiny-size gate below). Change
 the size mid-run with `af_resize <cols> <rows>`.
+
+### Driving a first-run overlay
+
+`af_boot` writes `help_screens_seen` before launching, and the default `15`
+marks **every** one-time overlay seen — that suppression is what makes ordinary
+scenarios deterministic, but it also means no scenario could reach a first-run
+screen at all. Clear the bit for the overlay you want:
+
+| bit | overlay |
+|-----|---------|
+| `1` | general help (`?`) |
+| `2` | instance-start help (`n`) |
+| `4` | instance-attach help (`o`) |
+| `8` | interactive-pane help (`enter` on a live pane) |
+
+```bash
+export AF_DRIVER_HELP_SEEN=7   # everything seen EXCEPT the interactive help
+```
+
+The bits are `app/help.go`'s `mask()` methods. Re-run `af_reset_sandbox` before
+a second boot in the same container — it wipes `state.json`, so the overlay is
+genuinely "first run" again; without it the first boot has already marked it
+seen. `scripts/tui-2413-scenario.sh` is a worked example.
 
 ---
 
@@ -229,6 +253,21 @@ scenario that failed in #1156, now deterministic:
 
 Green means the driver drives the TUI reliably. Any failure prints the step
 and the offending screen.
+
+### One scenario script (a per-fix real-TUI gate)
+
+```bash
+scripts/testbox.sh scenario scripts/tui-2413-scenario.sh
+```
+
+Runs a single scenario script in the same ephemeral, uniquely-named sandbox the
+self-test uses, then tears it down. The path is repo-relative (the repo is
+mounted read-only at `/src`); pin `AF_SELFTEST_NAME` to reuse a container
+instead.
+
+Use this for a regression scenario that belongs to one fix. Do **not** bolt such
+a case onto `tui-driver-selftest.sh`: that scenario is the shared acceptance
+proof, and destabilizing it costs more than the bug the new case guards.
 
 ### Driving by hand
 

--- a/scripts/testbox.sh
+++ b/scripts/testbox.sh
@@ -506,6 +506,36 @@ selftest)
     fi
     exit "$rc"
     ;;
+scenario)
+    # Run ONE driver scenario script in an ephemeral sandbox — the same fence
+    # `selftest` uses, but for a script the caller names instead of the fixed
+    # acceptance scenario.
+    #
+    # This exists because there was no way to run a one-off real-TUI gate: the
+    # only options were the shared selftest (which a per-bug case should not be
+    # bolted onto, since destabilizing the acceptance gate is worse than the bug
+    # it guards) or `drive`, which attaches a human. A regression scenario for a
+    # specific fix needs neither.
+    #
+    #   scripts/testbox.sh scenario scripts/tui-2413-scenario.sh
+    #
+    # The path is repo-relative; the repo is mounted read-only at /src.
+    scenario_rel="${1:-}"
+    [ -n "$scenario_rel" ] || { echo "testbox: scenario needs a script path (repo-relative)" >&2; exit 2; }
+    [ -f "$REPO_ROOT/$scenario_rel" ] || { echo "testbox: no such scenario script: $scenario_rel" >&2; exit 2; }
+    if [ -n "${AF_SELFTEST_NAME:-}" ]; then
+        PLAYTEST_NAME="$AF_SELFTEST_NAME"; teardown=no
+    else
+        PLAYTEST_NAME="af-driver-scenario-$(_uniq)"; teardown=yes
+    fi
+    ensure_playtest_up
+    rc=0
+    "$ENGINE" exec "$PLAYTEST_NAME" bash "/src/$scenario_rel" || rc=$?
+    if [ "$teardown" = yes ]; then
+        "$ENGINE" rm -f "$PLAYTEST_NAME" >/dev/null 2>&1 || true
+    fi
+    exit "$rc"
+    ;;
 drive)
     # Bring up a uniquely-named sandbox (#1171), boot af through the driver,
     # then attach you interactively to the live driver session so you can

--- a/scripts/tui-2413-scenario.sh
+++ b/scripts/tui-2413-scenario.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Real-TUI drive for #2413: dismissing the first-run interactive help with the
+# very key that help names (ctrl+]) must leave the user IN interactive mode.
+#
+# Runs inside the #1130 container sandbox:
+#   scripts/testbox.sh scenario scripts/tui-2413-scenario.sh
+#
+# AF_DRIVER_HELP_SEEN=7 clears the interactive bit (1<<3) so the first-run
+# overlay actually appears — every other one-time overlay stays suppressed, so
+# the scenario is still deterministic. af_reset_sandbox between geometries wipes
+# state.json, so the overlay is genuinely "first run" both times.
+set -euo pipefail
+
+export AF_DRIVER_HELP_SEEN=7
+
+# shellcheck source=/dev/null
+source /src/scripts/tui-driver.sh
+
+run_at() {
+    export AF_DRIVER_COLS="$1" AF_DRIVER_ROWS="$2"
+
+    af_reset_sandbox
+    af_boot
+    af_new_instance alpha
+    af_select alpha
+    af_open_pane
+
+    # Enter on the focused pane surfaces the first-run interactive help. Sync on
+    # the overlay's own title so we know we are looking at it, not a raced frame.
+    #
+    # Deliberately NOT synced on the nav menu's `↵ interact` hint first: that
+    # hint is optional and the menu's width clamp sheds it at 80 columns, so
+    # waiting on it would fail the narrow geometry for a reason that has nothing
+    # to do with this fix. af_open_pane already synced on `x hide pane`.
+    af_send Enter
+    af_wait_for 'Interactive pane' "$AF_DRIVER_TIMEOUT" 'first-run interactive help'
+    af_wait_for 'return to navigation' "$AF_DRIVER_TIMEOUT" 'the help line that names ctrl+]'
+
+    # The user does what the screen just told them to do.
+    af_send 'C-]'
+    af_wait_gone 'Interactive pane' "$AF_DRIVER_TIMEOUT" 'help overlay dismissed'
+
+    # THE ASSERTION. The interactive menu shows only `ctrl+] nav mode`, so its
+    # presence means the mode is live. Before #2413 the replayed ctrl+] exited
+    # immediately: the pane frame dropped back to a single border and the full
+    # nav menu returned, with the user never having typed anything.
+    af_wait_for 'nav mode' "$AF_DRIVER_TIMEOUT" 'STILL in interactive mode after the ctrl+] dismiss'
+
+    # The mode is genuinely usable, not merely flagged: type into the pane and
+    # see the shell answer.
+    af_send_to_pane 'echo af2413ok'
+    af_wait_for 'af2413ok' "$AF_DRIVER_TIMEOUT" 'the pane actually received input'
+
+    # And ctrl+] still exits, exactly as the help promised — the fix drops the
+    # synthetic replay, never the key.
+    af_exit_interactive
+
+    echo "PASS: #2413 scenario at ${AF_DRIVER_COLS}x${AF_DRIVER_ROWS}"
+}
+
+run_at 100 30
+run_at 80 24
+
+echo "PASS: #2413 real-TUI scenario at both geometries"

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -42,6 +42,21 @@
 : "${AF_DRIVER_DETACH_KEY:=C-w}"                 # tmux key that detaches attach
 : "${AF_DRIVER_STATE_DIR:=${TMPDIR:-/tmp}/af-driver}"  # cross-call scratch
 : "${AF_DRIVER_SEND_LINE_ATTEMPTS:=4}"           # af_send_line paste retries
+# help_screens_seen af_boot writes before launching. The default 15 marks every
+# one-time overlay seen, which is what makes ordinary scenarios deterministic.
+# Clear a bit to drive a FIRST-RUN overlay on purpose — e.g.
+# AF_DRIVER_HELP_SEEN=7 boots into the first-run interactive help, the only way
+# to reach that screen from a driver scenario (#2413).
+#
+# The bits are app/help.go's mask() methods, and they are NOT in the order this
+# file used to claim ("1 start | 2 attach | 4 interactive"): general is 1<<0,
+# instance-start 1<<1, instance-attach 1<<2, interactive 1<<3. Nothing depended
+# on the wrong list while the value was a hardcoded 15 — every bit was set
+# either way — but it is load-bearing the moment a caller clears one.
+#
+#   1  general help (?)          4  instance-attach help (o)
+#   2  instance-start help (n)   8  interactive-pane help (enter)
+: "${AF_DRIVER_HELP_SEEN:=15}"                   # one-time overlays pre-marked seen
 : "${AGENT_FACTORY_AUTO_UPDATE:=false}"          # disable startup auto-update: a
                                                  # branch binary built behind the
                                                  # latest release would try to
@@ -519,9 +534,9 @@ af_boot() {
         sleep 1
     done
 
-    # Suppress every first-time help overlay (bits: 1 start | 2 attach |
-    # 4 interactive, plus the general help bit) BEFORE the TUI reads state.
-    printf '{\n  "help_screens_seen": 15\n}\n' > "$AGENT_FACTORY_HOME/state.json"
+    # Suppress every first-time help overlay BEFORE the TUI reads state (see
+    # AF_DRIVER_HELP_SEEN above for the bits, and for clearing one on purpose).
+    printf '{\n  "help_screens_seen": %s\n}\n' "$AF_DRIVER_HELP_SEEN" > "$AGENT_FACTORY_HOME/state.json"
 
     # Fresh driver session. Kill ONLY our own named session — never the
     # server (the container hosts the daemon's sessions too).


### PR DESCRIPTION
## Summary

The first-run interactive help is dismissed by **any** key, and the dismiss key is then replayed into the pane so it is not swallowed (#1576). The overlay's last line reads:

> Press `ctrl+]` to return to navigation.

So `ctrl+]` is the key the screen puts in front of the user — and replaying it ran it through `handleInteractiveKey`, where `ctrl+]` is the one host-reserved key: it exits interactive mode.

A first-time user who dismissed the help with the key the help named landed straight back in nav mode having never typed a character. Interactive mode looked simply broken, on the one run where the user is least equipped to tell a bug from their own mistake.

## Report verification

Verified against `master` @ `6f90d5b1` before writing any code — the report is **accurate and current**. The whole chain is intact:

- `app/help.go:347-349` — `helpTypeInteractive` sets `replayHelpDismissKey = true`, and `:339` sets `textOverlayDismissAnyKey = true`, so *any* key both dismisses and gets replayed.
- `app/help.go:449-462` — `replayKeyAfterInteractiveHelpDismiss` stamps that key onto the `enterInteractiveMsg`.
- `app/home_update.go:236-239` — the handler feeds it to `handleInteractiveKey`.
- `app/interactive.go:136-138` — which treats `ctrl+]` as the exit.
- `app/help.go:255` — the copy that names `ctrl+]`, confirming the user is being walked into it.

The report's note that existing coverage misses it is also correct: `TestFirstRunInteractiveHelpForwardsDismissKey` dismisses with `q`, which forwards harmlessly.

## Fix

Guard the replay at its **sink** — the `enterInteractiveMsg` handler — rather than at the producer the report suggests. The replay's contract is "forward the transition keystroke *into the pane*"; the host-reserved key is the one key that is not pane input. Guarding where the replay is consumed means no future replay producer can reintroduce this, and it covers the second producer (`requestInteractive`'s #1576 entry key) for free.

Share one definition of that key — `isInteractiveExitKey` — between the guard and `handleInteractiveKey`. A second drifting `tea.KeyCtrlCloseBracket` literal is exactly how this comes back.

Only the **synthetic replay** is dropped. `ctrl+]` pressed inside interactive mode still returns to navigation, and every other dismiss key still reaches the pane.

I did not forward `ctrl+]` into the pane as raw input instead: the user pressed the key an overlay told them means "return to navigation", so delivering `0x1d` to the agent would be noise, not their intent.

## Fail-first

Watched fail on unmodified `master`:

```
--- FAIL: TestFirstRunInteractiveHelpDismissedWithExitKeyStaysInteractive
    Error:    Should be true
    Messages: dismissing the first-run help with ctrl+] — the key the overlay itself
              names — must leave the user IN interactive mode. Replaying it through
              handleInteractiveKey exits immediately, so the mode never starts (#2413).
    Error:    expected: []string{"z"}  actual: []string(nil)
    Messages: interactive mode must actually forward keystrokes after the help dismiss
```

The test asserts the mode is *usable*, not merely flagged on — a later `z` must reach the pane — so it cannot pass by flipping a boolean.

Regression guards that pin what the fix must not cost:

- `ctrl+]` pressed **inside** interactive mode still exits, and is not forwarded to the pane.
- Ordinary dismiss keys still forward (#1576): a letter, `enter`, and `ctrl+c`. `ctrl+c` is deliberately in that list — it is pane input inside interactive mode (it interrupts the agent, not af), so the guard must not widen to it.

## Real-TUI drive

This is user-visible behavior, so the model-level tests are not the whole gate. `scripts/tui-2413-scenario.sh` drives the actual rendered TUI: boot → instance → pane → `Enter` surfaces the real first-run overlay → `ctrl+]` → assert the interactive menu is still present → type into the pane and see the shell answer → `ctrl+]` exits. It runs at **100x30 and 80x24**, resetting the sandbox between so the overlay is genuinely first-run both times.

```
$ scripts/testbox.sh scenario scripts/tui-2413-scenario.sh
PASS: #2413 scenario at 100x30
PASS: #2413 scenario at 80x24
PASS: #2413 real-TUI scenario at both geometries
```

It **fails on `master`'s code** — reverting only `app/home_update.go` + `app/interactive.go` reproduces the bug on screen: single pane border and the full nav menu returned, i.e. the user dumped back to navigation having typed nothing. Full screens in the follow-up comment.

### Why this PR touches the harness

The driver could not reach that screen at all: `af_boot` hardcoded `help_screens_seen: 15`, which marks **every** one-time overlay seen. Three harness pieces, no product code:

- **`AF_DRIVER_HELP_SEEN`** (default unchanged at `15`) lets a scenario clear one bit. Its doc corrects the bit list `af_boot` carried, which was **off by one position** — it claimed "1 start | 2 attach | 4 interactive" where `app/help.go`'s `mask()` methods are general `1<<0`, start `1<<1`, attach `1<<2`, interactive `1<<3`. Nothing depended on the wrong list while the value was a hardcoded 15, but it is load-bearing the moment a caller clears one.
- **`testbox.sh scenario <script>`** runs one scenario in the same ephemeral sandbox `selftest` uses. Previously the only options were the shared acceptance selftest — which a single bug's case should not be bolted onto — or `drive`, which attaches a human.
- **`docs/tui-manual-testing.md`** documents both.

`make tui-driver-selftest` still passes **61/61**, so the shared gate is unaffected.

## Verification

Exact pushed head: `8bcc424d`

- `go build ./...`
- `gofmt -l .` (no output)
- `golangci-lint run --timeout=3m --fast`
- `deadcode -test ./...` (no output)
- `scripts/lint-file-length.sh` (986 files, 0 grandfathered)
- `make test-container`
- `make tui-driver-selftest` (61/61)
- `scripts/testbox.sh scenario scripts/tui-2413-scenario.sh` at 100x30 and 80x24, and confirmed failing without the fix

Closes #2413
