### PR TITLE
fix(daemon): refuse unclaimable titles before the archived rename (#2415)

### DIFF
--- a/daemon/create_reuse_archived_claimable_test.go
+++ b/daemon/create_reuse_archived_claimable_test.go
@@ -1,0 +1,183 @@
+package daemon
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #2415: reserveCreate ran the archived-name-reuse rename BEFORE
+// validateTitleAvailableLocked, so a create could be refused for a reason the
+// rename has no effect on — an orphan tmux session, the reserved "root" name, a
+// hook slug another project owns — after the archived session had already been
+// renamed to "<title> (archived)", its worktree physically relocated, its manager
+// key changed, and its durable record rewritten. There is no rollback on that
+// path, so the user was left with a permanently renamed archived session for a
+// create that never happened: precisely the state reserveCreate's own admission
+// comment promises it never produces, and the same invariant #2127 protects from
+// the branch side.
+
+// assertArchivedUntouched pins the invariant on every surface that could carry a
+// rename: the in-memory title, the manager key, the durable record (identity
+// included), and the archive directory on disk. A fix that reverted only some of
+// them would leave the session inconsistent rather than intact, so they are
+// checked together.
+func assertArchivedUntouched(t *testing.T, manager *Manager, archived *session.Instance, repoID, title, id string) {
+	t.Helper()
+	renamedTitle := title + " (archived)"
+
+	assert.Equal(t, title, archived.Title, "the archived session must keep its name after a refusal")
+
+	manager.mu.Lock()
+	_, origKeyed := manager.instances[daemonInstanceKey(repoID, title)]
+	_, renamedKeyed := manager.instances[daemonInstanceKey(repoID, renamedTitle)]
+	manager.mu.Unlock()
+	assert.True(t, origKeyed, "the archived row must stay keyed under its original name")
+	assert.False(t, renamedKeyed, "no row may be keyed under the disambiguated name")
+
+	rec := recordFor(t, repoID, title)
+	require.NotNil(t, rec, "the archived record must survive the refusal under its original name")
+	assert.Equal(t, id, rec.ID, "the archived session must be untouched, stable id and all")
+	assert.Nil(t, recordFor(t, repoID, renamedTitle), "no renamed record may be persisted for a refused create")
+
+	origDir, derr := archivedWorktreePath(repoID, title)
+	require.NoError(t, derr)
+	newDir, derr := archivedWorktreePath(repoID, renamedTitle)
+	require.NoError(t, derr)
+	assert.True(t, exists(origDir), "the archived worktree must stay at its original path")
+	assert.False(t, exists(newDir), "no relocation may have happened")
+
+	// And the archived session is still restorable — the refusal cost the user
+	// nothing, which is the difference between this and the pre-fix behavior.
+	_, _, rerr := manager.RestoreArchived(RestoreArchivedRequest{Title: title, RepoID: repoID})
+	require.NoError(t, rerr, "the untouched archived session must still restore under its own name")
+}
+
+// TestReserveCreate_OrphanTmuxRefusesBeforeArchivedRename is the #2415 headline
+// case, and the one the report names: a real orphan tmux session holding the name
+// the create wants.
+//
+// Freeing the TITLE does not kill that pane. validateTitleAvailableLocked probes
+// for it and refuses — but it ran after renameArchivedForReuseLocked had already
+// moved the archived session out of the way, so the user paid for a create that
+// could never have succeeded.
+//
+// Seeded with the branch FREED so #2127's guard cannot fire first: without that
+// this test would pass against the unfixed code for the wrong reason, proving
+// nothing about the check under test.
+func TestReserveCreate_OrphanTmuxRefusesBeforeArchivedRename(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	archived, id := seedArchivedSessionBranchFreed(t, manager, repoID, repoPath, "foo", "foo")
+
+	// The orphan: a tmux session under exactly the name this create would claim,
+	// owned by no af record. TestMain sandboxes the package onto a private tmux
+	// server, so this cannot touch a real one.
+	orphan := tmux.SanitizedNameForRepo("foo", repoPath)
+	out, err := exec.Command("tmux", "new-session", "-d", "-s", orphan, "sh").CombinedOutput()
+	require.NoError(t, err, string(out))
+	t.Cleanup(func() { _ = exec.Command("tmux", "kill-session", "-t", "="+orphan).Run() })
+
+	_, _, release, renamed, err := manager.reserveCreate(CreateSessionRequest{RepoPath: repoPath, Title: "foo", Program: "claude"})
+	if release != nil {
+		release()
+	}
+
+	require.Error(t, err, "the create must be refused: an orphan tmux session already holds the name")
+	assert.Contains(t, err.Error(), "conflicting tmux session",
+		"the refusal must be the orphan-tmux one, not some other failure")
+	assert.Nil(t, renamed, "no archived rename may happen for a create that cannot succeed")
+	assertArchivedUntouched(t, manager, archived, repoID, "foo", id)
+}
+
+// TestReserveCreate_ReservedHookNameRefusesBeforeArchivedRename covers a second,
+// entirely different reason the same way — which is the point. #2415 is not one
+// missing case but an ordering defect: EVERY check living after the rename
+// inherited it, which is why the fix is a split rather than a moved line.
+//
+// Here the blocker is a concurrent create holding the global hook slug. Hook names
+// are shared across projects (the scripts receive them verbatim as --name), and
+// findArchivedOnlyCollisionLocked — which decides whether to rename — consults
+// reservedTitles and reservedTmuxNames but never reservedRemoteNames. So the
+// rename went ahead and validateTitleAvailableLocked then refused, on a hold that
+// was already in place before the rename touched anything.
+//
+// Hermetic: no tmux involved, so it pins the ordering rather than the mechanics of
+// any one check.
+func TestReserveCreate_ReservedHookNameRefusesBeforeArchivedRename(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	archived, id := seedArchivedSessionBranchFreed(t, manager, repoID, repoPath, "foo", "foo")
+
+	// A concurrent hook create in flight under the slug this create would claim.
+	slug := session.Slugify("foo")
+	manager.mu.Lock()
+	manager.reservedRemoteNames[slug] = struct{}{}
+	manager.mu.Unlock()
+
+	_, _, release, renamed, err := manager.reserveCreate(CreateSessionRequest{
+		RepoPath: repoPath, Title: "foo", Program: "claude", ForceRemote: true,
+	})
+	if release != nil {
+		release()
+	}
+
+	require.Error(t, err, "the create must be refused: the hook name is reserved by a concurrent create")
+	assert.Contains(t, err.Error(), "is already reserved",
+		"the refusal must be the reserved-hook-name one, unchanged in wording by moving it earlier")
+	assert.Nil(t, renamed, "no archived rename may happen for a create that cannot succeed")
+	assertArchivedUntouched(t, manager, archived, repoID, "foo", id)
+}
+
+// TestReserveCreate_UnclaimableGuardStaysOutOfTheWay keeps the guard as narrow as
+// the invariant it protects, mirroring #2127's equivalent. With no archived
+// collision there is no rename to protect, so the refusal must land exactly where
+// it always did — same error, from validateTitleAvailableLocked — rather than
+// moving earlier and changing behavior for creates this issue is not about.
+func TestReserveCreate_UnclaimableGuardStaysOutOfTheWay(t *testing.T) {
+	manager, _, repoPath := newStatusTestManager(t)
+
+	orphan := tmux.SanitizedNameForRepo("solo", repoPath)
+	out, err := exec.Command("tmux", "new-session", "-d", "-s", orphan, "sh").CombinedOutput()
+	require.NoError(t, err, string(out))
+	t.Cleanup(func() { _ = exec.Command("tmux", "kill-session", "-t", "="+orphan).Run() })
+
+	_, _, release, renamed, err := manager.reserveCreate(CreateSessionRequest{RepoPath: repoPath, Title: "solo", Program: "claude"})
+	if release != nil {
+		release()
+	}
+	require.Error(t, err, "an orphan tmux session still blocks a create with no archived collision")
+	assert.Contains(t, err.Error(), "conflicting tmux session")
+	assert.Nil(t, renamed)
+}
+
+// TestValidateTitleClaimable_IgnoresTheRowBeingRenamed is the other direction of
+// the fix, and the regression it could most easily have introduced. The archived
+// row is the claim the rename is about to release, so counting it against the new
+// session would refuse a reuse that would have succeeded — turning a data-integrity
+// fix into a feature regression.
+//
+// Exercised on the hook-slug scans, which are the only ones in the claimable half
+// that read af's own records at all.
+func TestValidateTitleClaimable_IgnoresTheRowBeingRenamed(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	archived, err := session.NewInstance(session.InstanceOptions{Title: "MyApp", Path: repoPath, Program: "claude"})
+	require.NoError(t, err)
+	hookRow := []session.InstanceData{{Title: "MyApp", Path: repoPath, BackendType: "remote"}}
+	require.True(t, hookRow[0].IsRemoteHook(), "the fixture must actually be a hook row or this asserts nothing")
+
+	err = manager.validateTitleClaimableLocked(repoID, repoPath, "MyApp", "claude", runtimeNamespaceRemoteHook, false, hookRow, archived)
+	require.NoError(t, err,
+		"the archived row being renamed must not be counted as the collision that blocks its own reuse")
+
+	// Without the exclusion the very same row refuses — proof the scan really does
+	// see it, so the NoError above is the exclusion working rather than a scan that
+	// never fired.
+	err = manager.validateTitleClaimableLocked(repoID, repoPath, "MyApp", "claude", runtimeNamespaceRemoteHook, false, hookRow, nil)
+	require.Error(t, err, "an unignored hook row with the same slug must still refuse")
+	assert.Contains(t, err.Error(), "already maps to hook name")
+}

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -2,11 +2,8 @@ package daemon
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
-	"strings"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/agentproto"
@@ -302,6 +299,17 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 		if err := m.refuseHeldBranchReuseLocked(repo.ID, repo.Root, title, nameNamespace, req.InPlace, diskData); err != nil {
 			return nil, "", nil, nil, err
 		}
+		// And refuse for every other reason the rename cannot clear, still ahead
+		// of it (#2415). Freeing the title does not free an orphan tmux session of
+		// the same name, a hook slug another project owns, or the reserved "root"
+		// name — so validateTitleAvailableLocked below could refuse AFTER the
+		// rename had already relocated the archived worktree and rewritten its
+		// durable record, leaving exactly the state this function promises never to
+		// produce. Asking the record-independent half first turns those into
+		// side-effect-free refusals.
+		if err := m.refuseUnclaimableTitleReuseLocked(repo.ID, repo.Root, title, req.Program, nameNamespace, req.allowReserved, diskData); err != nil {
+			return nil, "", nil, nil, err
+		}
 		renamedArchived, err = m.renameArchivedForReuseLocked(repo.ID, repo.Root, title, req.Program, nameNamespace, &diskData)
 		if err != nil {
 			return nil, "", nil, nil, err
@@ -421,6 +429,44 @@ func (m *Manager) refuseHeldBranchReuseLocked(repoID, repoPath, title string, na
 	return fmt.Errorf("cannot create session %q: the archived session %q still has branch %q checked out at %s, and the new session would derive that same branch. Renaming the archived session aside frees its name but not its branch, so the create would fail at `git worktree add` — permanently delete the archived session to release both (%s), or create this session under a different name",
 		title, archived.Title, branch, config.ShellQuotePath(holder),
 		shellsuggest.Command("af", "sessions", "kill", archived.Title))
+}
+
+// refuseUnclaimableTitleReuseLocked refuses an explicit-title create BEFORE the
+// archived-name-reuse rename touches anything, when the title cannot be claimed
+// for a reason the rename has no effect on (#2415). Runs under m.mu.
+//
+// renameArchivedForReuseLocked clears exactly one thing: an af RECORD holding the
+// title. It does not free the "root" name, an orphan tmux session left by a crash,
+// or a hook slug another project owns — yet validateTitleAvailableLocked checks all
+// of those, and it ran AFTER the rename. So a create could fail on a condition that
+// was already true before anything happened, with the archived session left renamed
+// to "<title> (archived)", its worktree physically relocated, its manager key
+// changed, and its durable record rewritten — permanently, with no rollback, for a
+// create that never occurred. That is the same invariant #2127 protects from the
+// branch side, and the one reserveCreate's admission comment promises.
+//
+// The gap was structural rather than a missing case: the checks lived inline in a
+// function called after the mutation, so every check added there inherited the bug.
+// Splitting validateTitleAvailableLocked into a record-dependent half and a
+// record-independent half is what makes "ask everything answerable before mutating"
+// the default for future checks instead of a thing to remember.
+//
+// Two deliberate non-firings, mirroring refuseHeldBranchReuseLocked:
+//
+//   - No archived collision means no rename will happen, so there is no invariant
+//     to protect and this must stay out of the way. The create proceeds and
+//     validateTitleAvailableLocked reports the same refusal in the same words, at
+//     the same point it always did.
+//   - The archived row itself is excluded from the scans (the ignore argument).
+//     It is the claim the rename is about to release, so counting it would refuse
+//     a reuse that would have succeeded — turning a data-integrity fix into a
+//     feature regression.
+func (m *Manager) refuseUnclaimableTitleReuseLocked(repoID, repoPath, title, program string, namespace runtimeNameNamespace, allowReserved bool, diskData []session.InstanceData) error {
+	archived, _, err := m.findArchivedOnlyCollisionLocked(repoID, repoPath, title, namespace, diskData)
+	if err != nil || archived == nil {
+		return err
+	}
+	return m.validateTitleClaimableLocked(repoID, repoPath, title, program, namespace, allowReserved, diskData, archived)
 }
 
 // reuseArchivedRenamePersist is the durable title rewrite the archived-name-reuse
@@ -679,168 +725,6 @@ func (m *Manager) nextAvailableTitleLocked(repoID, repoPath, baseTitle, program 
 		}
 	}
 	return "", fmt.Errorf("could not find an available title for %q", baseTitle)
-}
-
-func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program string, namespace runtimeNameNamespace, allowReserved bool, diskData []session.InstanceData) error {
-	// Whitespace-only titles (e.g. "   ") are non-empty and so slip past a bare
-	// == "" check, creating sessions with effectively blank names (#973). Trim
-	// before the emptiness gate; the TUI naming flow applies the same check.
-	if strings.TrimSpace(title) == "" {
-		return fmt.Errorf("session title is required")
-	}
-	// The "root" title belongs to the daemon-managed root agent (#1106).
-	// Every creation path lands here — TUI, `af sessions create`, task
-	// spawns, DeliverPrompt auto-creates — so this single gate reserves the
-	// name everywhere. Only the daemon's own ensure loop passes
-	// allowReserved; title-base derivation (nextAvailableTitleLocked) never
-	// does, so a base of "root" skips to "root-2" instead of erroring.
-	if !allowReserved && session.IsReservedTitle(title) {
-		return fmt.Errorf("session title %q is reserved for the daemon-managed root agent; pick another name (to run a root agent on this repo, add it to root_agents in ~/.agent-factory/config.json)", title)
-	}
-	// Titles are sanitized into git branch names (git.SanitizeBranchName
-	// lowercases, turns spaces into dashes, strips unsafe chars, and collapses
-	// dashes), so distinct titles can map to the same branch: "MyApp"/"myapp"
-	// (#605) or "A B"/"a-b" (#741) both collide. The second worktree create
-	// would otherwise fail with a cryptic git error, so reject the conflict
-	// here, before any worktree or tmux setup runs.
-	if existing, kind, collisionNamespace := m.findTitleConflictLocked(repoID, repoPath, title, namespace == runtimeNamespaceLocalTmux, diskData); existing != "" {
-		switch {
-		case existing == title:
-			if kind == titleConflictReserved {
-				return fmt.Errorf("session with title %q is already reserved: %w", title, errConcurrentCreate)
-			}
-			return fmt.Errorf("session with title %q already exists: %w", title, errConcurrentCreate)
-		case collisionNamespace == titleNamespaceTmux:
-			return fmt.Errorf("session titled %q conflicts with existing session %q: both map to tmux session %q", title, existing, tmux.SanitizedNameForRepo(title, repoPath))
-		default:
-			return fmt.Errorf("session titled %q conflicts with existing session %q: both sanitize to the same git branch %q", title, existing, m.branchForTitle(title))
-		}
-	}
-	if namespace == runtimeNamespaceRemoteHook {
-		candidate := session.Slugify(title)
-		// Hook names are the ONE namespace that stays global while titles go
-		// per-repo: launch_cmd/delete_cmd receive `--name <slug>` verbatim, with
-		// no repo component, and external provisioners tag and reap real
-		// VMs/containers by it. Two repos handing scripts the same name would
-		// clobber one sandbox and let either delete reap the other's. So every
-		// check below spans ALL repos, unlike the per-repo title rules above.
-		if _, ok := m.reservedRemoteNames[candidate]; ok {
-			return fmt.Errorf("remote hook name %q is already reserved", candidate)
-		}
-		// Guard against in-memory remote sessions that are not (yet) on disk.
-		// refreshDaemonInstances preserves a running remote instance in
-		// m.instances even after its repo directory is deleted externally (a
-		// recoverable inconsistency), yet loadRepoInstanceData returns nothing
-		// for it — so a disk-only slug check would let a second title that
-		// slugifies to the same hook name through. The branch-collision check
-		// above misses this pair because Slugify drops underscores while branch
-		// sanitization keeps them as dashes ("My_App"->branch "my-app"/slug
-		// "myapp" vs "MyApp"->branch "myapp"/slug "myapp"). The TUI pre-check
-		// (FindSlugCollision over Snapshot()) catches it, but the HTTP
-		// CreateSession path bypasses that, so the daemon-side check must be
-		// complete (#1636).
-		for _, inst := range m.instances {
-			if inst == nil {
-				continue
-			}
-			data := inst.ToInstanceData()
-			if !data.IsRemoteHook() {
-				continue
-			}
-			if session.Slugify(data.Title) == candidate {
-				return fmt.Errorf("remote session titled %q already maps to hook name %q", data.Title, candidate)
-			}
-		}
-		for _, data := range diskData {
-			if !data.IsRemoteHook() {
-				continue
-			}
-			if session.Slugify(data.Title) == candidate {
-				return fmt.Errorf("remote session titled %q already maps to hook name %q", data.Title, candidate)
-			}
-		}
-		// diskData holds only THIS repo's rows, so a settled hook session in
-		// another repo would otherwise slip through — the hole that let two repos
-		// create the same hook name sequentially (they just could not race).
-		owner, ownerRepo, err := hookSlugOwnerInOtherRepos(candidate, repoID)
-		if err != nil {
-			return err
-		}
-		if owner != "" {
-			return fmt.Errorf("remote session titled %q in project %s already maps to hook name %q; remote hook names are shared across projects because the hook scripts receive them verbatim as --name — pick another title for this remote session", owner, ownerRepo, candidate)
-		}
-		return nil
-	}
-	if namespace != runtimeNamespaceLocalTmux {
-		return nil
-	}
-	tmuxSession := tmux.NewTmuxSessionForRepo(title, repoPath, program)
-	// Existence gates the create here, so read the tri-state, not the lossy bool
-	// (#1962): only a CONFIRMED existing session (known && exists) blocks. A
-	// wedged/timed-out has-session is NOT proof of a name collision — reporting
-	// "exists" through ExistsOrUnknown would refuse a legitimate create against a
-	// merely-wedged server. An unanswered probe (!known) falls through and lets the
-	// create proceed. That never silently clobbers a real orphan: the create's own
-	// `tmux new-session -s <name>` fails on a duplicate name, and Start's existence
-	// check (now ProbeSession too) surfaces it as "already exists" once the server
-	// answers, or as ErrTmuxTimeout while it stays wedged — either way non-
-	// destructive. Blocking here on a guess is the only unsafe option.
-	if exists, known := tmuxSession.ProbeSession(); known && exists {
-		// A tmux session exists with no daemon reservation, in-memory instance,
-		// or disk record — an orphan left by a crash or an external process.
-		// No creator will ever finish it, so this stays a plain error (not
-		// errConcurrentCreate): DeliverPrompt must fail fast with cleanup
-		// guidance rather than wait out waitForTargetSession's timeout (#916).
-		return fmt.Errorf("conflicting tmux session %q is already running; no agent-factory session owns it. Clean it up with: %s", title, shellsuggest.Command("tmux", "kill-session", "-t", tmuxSession.SanitizedName()))
-	}
-	return nil
-}
-
-// hookSlugOwnerInOtherRepos reports the title (and repo path) of a persisted
-// remote-hook session in ANY repo other than repoID whose slug equals candidate,
-// or "" when the hook name is free.
-//
-// The caller already scans this repo's rows and every in-memory instance; this
-// covers the remaining case — a settled hook session in a different repo, whose
-// rows loadRepoInstanceData(repoID) never returns. Without it the global
-// hook-name namespace is only enforced against concurrent creates (the in-flight
-// reservation), so two repos could take the same name sequentially and hand both
-// sandboxes the identical --name.
-//
-// Corrupted per-repo files are surfaced rather than skipped: a hidden hook
-// session would otherwise let a colliding name through, and the cost of a false
-// refusal here is a clear error, while the cost of a miss is two provisioned
-// sandboxes fighting over one name.
-func hookSlugOwnerInOtherRepos(candidate, repoID string) (string, string, error) {
-	allInstances, err := config.LoadAllRepoInstances()
-	if err != nil {
-		return "", "", fmt.Errorf("%w: %v", errTitleCheckFatal, err)
-	}
-	var corrupted []string
-	for rid, raw := range allInstances {
-		if rid == repoID {
-			continue
-		}
-		var rows []session.InstanceData
-		if err := json.Unmarshal(raw, &rows); err != nil {
-			corrupted = append(corrupted, rid)
-			continue
-		}
-		for i := range rows {
-			if !rows[i].IsRemoteHook() {
-				continue
-			}
-			if session.Slugify(rows[i].Title) == candidate {
-				return rows[i].Title, rows[i].Path, nil
-			}
-		}
-	}
-	if len(corrupted) > 0 {
-		sort.Strings(corrupted)
-		return "", "", fmt.Errorf("%w: cannot verify remote hook name %q is free: %d repo(s) have a corrupted instances.json that may be hiding a session using it: %s",
-			errTitleCheckFatal, candidate, len(corrupted), strings.Join(corrupted, ", "))
-	}
-	return "", "", nil
 }
 
 // errTitleCheckFatal marks a title-availability failure that is NOT "this

--- a/daemon/manager_create_names.go
+++ b/daemon/manager_create_names.go
@@ -1,6 +1,17 @@
+// Title admission for session creation: what names a create may claim, and the
+// refusals that decide it. Split out of manager_create.go, which holds the
+// creation FLOW; this file holds the naming RULES that flow consults.
+
 package daemon
 
 import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
@@ -113,4 +124,234 @@ func (m *Manager) findTitleConflictLocked(repoID, repoPath, title string, localT
 // TUI's naming pre-check stay in lockstep (#936).
 func (m *Manager) titlesCollide(a, b string) bool {
 	return git.TitlesCollide(a, b, m.cfg.BranchPrefix)
+}
+
+// validateTitleAvailableLocked refuses a title the create cannot have. It is
+// composed of three groups, kept in this order because their error precedence is
+// observable: the title's own SHAPE, then a collision with an af record, then the
+// EXTERNAL namespaces (hook slugs, a live tmux session) the title would claim.
+//
+// The shape and namespace halves are separately callable as
+// validateTitleClaimableLocked, which is what lets reserveCreate run every
+// record-independent refusal BEFORE the archived-name-reuse rename mutates
+// anything (#2415). Any new check belongs in one of the two halves rather than
+// inline here, so the pre-rename path picks it up automatically — a check added
+// only to this function is exactly how #2415 happened.
+func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program string, namespace runtimeNameNamespace, allowReserved bool, diskData []session.InstanceData) error {
+	if err := m.validateTitleShapeLocked(title, allowReserved); err != nil {
+		return err
+	}
+	if err := m.findTitleRecordConflictLocked(repoID, repoPath, title, namespace, diskData); err != nil {
+		return err
+	}
+	return m.validateTitleNamespacesLocked(repoID, repoPath, title, program, namespace, diskData, nil)
+}
+
+// validateTitleClaimableLocked is every refusal that does NOT depend on af's own
+// record for this title — the ones an archived-name-reuse rename cannot clear, so
+// a create that trips one is doomed no matter what the rename does.
+//
+// ignore is the archived instance the caller is about to rename out of the way.
+// It is excluded from the hook-slug scans, which would otherwise report the very
+// row being freed as the collision and refuse a reuse that would have succeeded.
+// It is not excluded from the tmux probe: archiving kills the session's pane, so
+// an archived row never owns a live tmux name, and anything the probe finds is a
+// genuine orphan the rename has no effect on.
+func (m *Manager) validateTitleClaimableLocked(repoID, repoPath, title, program string, namespace runtimeNameNamespace, allowReserved bool, diskData []session.InstanceData, ignore *session.Instance) error {
+	if err := m.validateTitleShapeLocked(title, allowReserved); err != nil {
+		return err
+	}
+	return m.validateTitleNamespacesLocked(repoID, repoPath, title, program, namespace, diskData, ignore)
+}
+
+// validateTitleShapeLocked rejects titles that are malformed or reserved,
+// independent of any existing session.
+func (m *Manager) validateTitleShapeLocked(title string, allowReserved bool) error {
+	// Whitespace-only titles (e.g. "   ") are non-empty and so slip past a bare
+	// == "" check, creating sessions with effectively blank names (#973). Trim
+	// before the emptiness gate; the TUI naming flow applies the same check.
+	if strings.TrimSpace(title) == "" {
+		return fmt.Errorf("session title is required")
+	}
+	// The "root" title belongs to the daemon-managed root agent (#1106).
+	// Every creation path lands here — TUI, `af sessions create`, task
+	// spawns, DeliverPrompt auto-creates — so this single gate reserves the
+	// name everywhere. Only the daemon's own ensure loop passes
+	// allowReserved; title-base derivation (nextAvailableTitleLocked) never
+	// does, so a base of "root" skips to "root-2" instead of erroring.
+	if !allowReserved && session.IsReservedTitle(title) {
+		return fmt.Errorf("session title %q is reserved for the daemon-managed root agent; pick another name (to run a root agent on this repo, add it to root_agents in ~/.agent-factory/config.json)", title)
+	}
+	return nil
+}
+
+// findTitleRecordConflictLocked reports a collision with an existing af record —
+// a reservation, a loaded instance, or a durable row. This is the ONE group the
+// archived-name-reuse rename clears, which is why it is not part of
+// validateTitleClaimableLocked.
+func (m *Manager) findTitleRecordConflictLocked(repoID, repoPath, title string, namespace runtimeNameNamespace, diskData []session.InstanceData) error {
+	// Titles are sanitized into git branch names (git.SanitizeBranchName
+	// lowercases, turns spaces into dashes, strips unsafe chars, and collapses
+	// dashes), so distinct titles can map to the same branch: "MyApp"/"myapp"
+	// (#605) or "A B"/"a-b" (#741) both collide. The second worktree create
+	// would otherwise fail with a cryptic git error, so reject the conflict
+	// here, before any worktree or tmux setup runs.
+	if existing, kind, collisionNamespace := m.findTitleConflictLocked(repoID, repoPath, title, namespace == runtimeNamespaceLocalTmux, diskData); existing != "" {
+		switch {
+		case existing == title:
+			if kind == titleConflictReserved {
+				return fmt.Errorf("session with title %q is already reserved: %w", title, errConcurrentCreate)
+			}
+			return fmt.Errorf("session with title %q already exists: %w", title, errConcurrentCreate)
+		case collisionNamespace == titleNamespaceTmux:
+			return fmt.Errorf("session titled %q conflicts with existing session %q: both map to tmux session %q", title, existing, tmux.SanitizedNameForRepo(title, repoPath))
+		default:
+			return fmt.Errorf("session titled %q conflicts with existing session %q: both sanitize to the same git branch %q", title, existing, m.branchForTitle(title))
+		}
+	}
+	return nil
+}
+
+// validateTitleNamespacesLocked refuses a title whose EXTERNAL name claims are
+// already taken: the global hook-slug namespace external provisioners key on, and
+// a live tmux session of the same name. See validateTitleClaimableLocked for what
+// ignore excludes and why.
+func (m *Manager) validateTitleNamespacesLocked(repoID, repoPath, title, program string, namespace runtimeNameNamespace, diskData []session.InstanceData, ignore *session.Instance) error {
+	if namespace == runtimeNamespaceRemoteHook {
+		candidate := session.Slugify(title)
+		var ignoreTitle string
+		if ignore != nil {
+			ignoreTitle = ignore.Title
+		}
+		// Hook names are the ONE namespace that stays global while titles go
+		// per-repo: launch_cmd/delete_cmd receive `--name <slug>` verbatim, with
+		// no repo component, and external provisioners tag and reap real
+		// VMs/containers by it. Two repos handing scripts the same name would
+		// clobber one sandbox and let either delete reap the other's. So every
+		// check below spans ALL repos, unlike the per-repo title rules above.
+		if _, ok := m.reservedRemoteNames[candidate]; ok {
+			return fmt.Errorf("remote hook name %q is already reserved", candidate)
+		}
+		// Guard against in-memory remote sessions that are not (yet) on disk.
+		// refreshDaemonInstances preserves a running remote instance in
+		// m.instances even after its repo directory is deleted externally (a
+		// recoverable inconsistency), yet loadRepoInstanceData returns nothing
+		// for it — so a disk-only slug check would let a second title that
+		// slugifies to the same hook name through. The branch-collision check
+		// above misses this pair because Slugify drops underscores while branch
+		// sanitization keeps them as dashes ("My_App"->branch "my-app"/slug
+		// "myapp" vs "MyApp"->branch "myapp"/slug "myapp"). The TUI pre-check
+		// (FindSlugCollision over Snapshot()) catches it, but the HTTP
+		// CreateSession path bypasses that, so the daemon-side check must be
+		// complete (#1636).
+		for _, inst := range m.instances {
+			// Pointer identity, not title: this scan spans every repo, and two
+			// repos may legitimately hold the same title. Ignoring by name would
+			// suppress a real cross-repo hook collision.
+			if inst == nil || inst == ignore {
+				continue
+			}
+			data := inst.ToInstanceData()
+			if !data.IsRemoteHook() {
+				continue
+			}
+			if session.Slugify(data.Title) == candidate {
+				return fmt.Errorf("remote session titled %q already maps to hook name %q", data.Title, candidate)
+			}
+		}
+		for _, data := range diskData {
+			// diskData is this repo's rows only, where a title is unique, so the
+			// name identifies the row being renamed unambiguously.
+			if ignoreTitle != "" && data.Title == ignoreTitle {
+				continue
+			}
+			if !data.IsRemoteHook() {
+				continue
+			}
+			if session.Slugify(data.Title) == candidate {
+				return fmt.Errorf("remote session titled %q already maps to hook name %q", data.Title, candidate)
+			}
+		}
+		// diskData holds only THIS repo's rows, so a settled hook session in
+		// another repo would otherwise slip through — the hole that let two repos
+		// create the same hook name sequentially (they just could not race).
+		owner, ownerRepo, err := hookSlugOwnerInOtherRepos(candidate, repoID)
+		if err != nil {
+			return err
+		}
+		if owner != "" {
+			return fmt.Errorf("remote session titled %q in project %s already maps to hook name %q; remote hook names are shared across projects because the hook scripts receive them verbatim as --name — pick another title for this remote session", owner, ownerRepo, candidate)
+		}
+		return nil
+	}
+	if namespace != runtimeNamespaceLocalTmux {
+		return nil
+	}
+	tmuxSession := tmux.NewTmuxSessionForRepo(title, repoPath, program)
+	// Existence gates the create here, so read the tri-state, not the lossy bool
+	// (#1962): only a CONFIRMED existing session (known && exists) blocks. A
+	// wedged/timed-out has-session is NOT proof of a name collision — reporting
+	// "exists" through ExistsOrUnknown would refuse a legitimate create against a
+	// merely-wedged server. An unanswered probe (!known) falls through and lets the
+	// create proceed. That never silently clobbers a real orphan: the create's own
+	// `tmux new-session -s <name>` fails on a duplicate name, and Start's existence
+	// check (now ProbeSession too) surfaces it as "already exists" once the server
+	// answers, or as ErrTmuxTimeout while it stays wedged — either way non-
+	// destructive. Blocking here on a guess is the only unsafe option.
+	if exists, known := tmuxSession.ProbeSession(); known && exists {
+		// A tmux session exists with no daemon reservation, in-memory instance,
+		// or disk record — an orphan left by a crash or an external process.
+		// No creator will ever finish it, so this stays a plain error (not
+		// errConcurrentCreate): DeliverPrompt must fail fast with cleanup
+		// guidance rather than wait out waitForTargetSession's timeout (#916).
+		return fmt.Errorf("conflicting tmux session %q is already running; no agent-factory session owns it. Clean it up with: %s", title, shellsuggest.Command("tmux", "kill-session", "-t", tmuxSession.SanitizedName()))
+	}
+	return nil
+}
+
+// hookSlugOwnerInOtherRepos reports the title (and repo path) of a persisted
+// remote-hook session in ANY repo other than repoID whose slug equals candidate,
+// or "" when the hook name is free.
+//
+// The caller already scans this repo's rows and every in-memory instance; this
+// covers the remaining case — a settled hook session in a different repo, whose
+// rows loadRepoInstanceData(repoID) never returns. Without it the global
+// hook-name namespace is only enforced against concurrent creates (the in-flight
+// reservation), so two repos could take the same name sequentially and hand both
+// sandboxes the identical --name.
+//
+// Corrupted per-repo files are surfaced rather than skipped: a hidden hook
+// session would otherwise let a colliding name through, and the cost of a false
+// refusal here is a clear error, while the cost of a miss is two provisioned
+// sandboxes fighting over one name.
+func hookSlugOwnerInOtherRepos(candidate, repoID string) (string, string, error) {
+	allInstances, err := config.LoadAllRepoInstances()
+	if err != nil {
+		return "", "", fmt.Errorf("%w: %v", errTitleCheckFatal, err)
+	}
+	var corrupted []string
+	for rid, raw := range allInstances {
+		if rid == repoID {
+			continue
+		}
+		var rows []session.InstanceData
+		if err := json.Unmarshal(raw, &rows); err != nil {
+			corrupted = append(corrupted, rid)
+			continue
+		}
+		for i := range rows {
+			if !rows[i].IsRemoteHook() {
+				continue
+			}
+			if session.Slugify(rows[i].Title) == candidate {
+				return rows[i].Title, rows[i].Path, nil
+			}
+		}
+	}
+	if len(corrupted) > 0 {
+		sort.Strings(corrupted)
+		return "", "", fmt.Errorf("%w: cannot verify remote hook name %q is free: %d repo(s) have a corrupted instances.json that may be hiding a session using it: %s",
+			errTitleCheckFatal, candidate, len(corrupted), strings.Join(corrupted, ", "))
+	}
+	return "", "", nil
 }


### PR DESCRIPTION
Fixes #2415.

## Verified against master first

The report reproduces on current `master`: `reserveCreate` still calls `renameArchivedForReuseLocked` at `daemon/manager_create.go:305` and `validateTitleAvailableLocked` at `:309`, with no rollback between them. Not stale.

## The bug

`renameArchivedForReuseLocked` frees a title by renaming the archived session that holds it — relocating its worktree, changing its manager key, and rewriting its durable record. `validateTitleAvailableLocked` then ran **after** that, and can refuse for reasons the rename has no effect on:

- an orphan tmux session already holding the name (`ProbeSession`),
- a hook slug another project owns, or one a concurrent create has reserved,
- the reserved `"root"` name.

There is no rollback on that path, so a refusal left the user with a permanently renamed archived session for a create that never happened — the exact state `reserveCreate`'s own admission comment promises it never produces, and the same invariant #2127 protects from the branch side.

## The fix

The gap was structural, not a missing case: the checks lived inline in a function called *after* the mutation, so every check added there inherited the bug. So this splits the function rather than moving a line.

`validateTitleAvailableLocked` is now composed of three groups:

1. the title's own **shape** (empty, reserved),
2. a collision with an af **record** — the one group the rename clears,
3. the **external namespaces** the title claims (hook slugs, a live tmux session), which no rename can free.

Groups 1 and 3 are separately callable as `validateTitleClaimableLocked`, and `reserveCreate` runs it ahead of the rename via `refuseUnclaimableTitleReuseLocked`. Any future check lands in one of the two halves and the pre-rename path picks it up automatically.

The three groups run in their original order, so **error precedence and wording are unchanged on every existing path** — the refusals just happen before the mutation instead of after.

### The regression this could have introduced

The archived row being renamed is excluded from the hook-slug scans. It is the claim the rename is about to release, so counting it would refuse a reuse that would have succeeded. The exclusion is by **pointer identity** for the in-memory scan (which spans every repo, where two repos may legitimately share a title) and by **name** for the disk scan (this repo's rows only, where titles are unique). The tmux probe takes no exclusion: archiving kills the pane, so an archived row never owns a live tmux name.

Like #2127's sibling guard, this stays out of the way when there is no archived collision.

## Tests (fail first)

Both regressions fail on the pre-fix code with the reported symptom — the archived session ends up renamed for a create that errored:

```
--- FAIL: TestReserveCreate_OrphanTmuxRefusesBeforeArchivedRename
    expected: "foo"
    actual  : "foo (archived)"
    Messages: the archived session must keep its name after a refusal
--- FAIL: TestReserveCreate_ReservedHookNameRefusesBeforeArchivedRename
    (same, via a concurrently reserved hook slug)
```

Two *different* refusals on purpose: the defect is the ordering, not either check. Each asserts the invariant on every surface that could carry a rename — in-memory title, manager key, durable record (stable id included), archive directory — plus that the session still restores.

- `TestReserveCreate_UnclaimableGuardStaysOutOfTheWay` — with no archived collision the refusal lands exactly where it always did.
- `TestValidateTitleClaimable_IgnoresTheRowBeingRenamed` — the `ignore` semantics in both directions: the archived row is not counted against its own reuse, and an *unignored* row with the same slug still refuses (so the pass is the exclusion working, not a scan that never fired).

A note on scope: I originally wrote the second regression against the reserved `"root"` title and discovered it is not reachable — `ArchiveSession` refuses to archive `"root"`, so an archived `"root"` row cannot exist. Swapped it for the reserved-hook-name path, which is reachable, and left the `"root"` check in the claimable half regardless since it costs nothing and is the same class.

## File split

The change pushed `manager_create.go` over the 1000-line limit, so the title-admission family moved to `manager_create_names.go` beside `findTitleConflictLocked`. That file already holds the naming **rules**; `manager_create.go` keeps the creation **flow**. No behavior change in the move — verified by the tests above plus the existing `create_tmux_name_collision`, `perrepo_title`, and `create_reuse_archived` suites.

## Gate

- `go build ./...`, `gofmt -l .`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean.
- `make test-container` on this head — result in a follow-up comment.

## Review

Requesting the codex GitHub app below. It is rate-limited until Jul 28 (it has already answered "you have reached your Codex usage limits" on sibling PRs); if it does not answer here I will say so explicitly and Captain Claude will run an independent review on this exact head before any merge. Not merging unreviewed.

— Captain Claude
