### PR TITLE
fix(session): adopt daemon tab id via copy-on-write (#2420)

### DIFF
--- a/session/tab_attach.go
+++ b/session/tab_attach.go
@@ -55,7 +55,7 @@ func (i *Instance) resolveAttachedTabLocked(name, tabID string) (*Tab, bool, err
 			}
 		}
 	}
-	for _, tab := range i.Tabs {
+	for idx, tab := range i.Tabs {
 		if tab.Name != name {
 			continue
 		}
@@ -63,8 +63,13 @@ func (i *Instance) resolveAttachedTabLocked(name, tabID string) (*Tab, bool, err
 			return tab, true, nil
 		}
 		if tab.ID == "" {
-			tab.ID = tabID
-			return tab, true, nil
+			// Adopt the daemon's id through copy-on-write, not an in-place
+			// tab.ID = tabID: this pointer may already be held by a GetTabs
+			// snapshot whose callers read ID off-lock, so writing the field in
+			// place races them (the instance.go copy-on-write invariant, #1930).
+			// ReconcileTabsFromData adopts an id the same way; #2420.
+			i.replaceTabFieldLocked(idx, func(c *Tab) { c.ID = tabID })
+			return i.Tabs[idx], true, nil
 		}
 		return nil, true, fmt.Errorf(
 			"cannot attach daemon tab %q (%s): that name now belongs to tab %s",

--- a/session/tab_attach_id_race_test.go
+++ b/session/tab_attach_id_race_test.go
@@ -1,0 +1,92 @@
+package session
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// TestAttachVSCodeTabIDAdoptDoesNotRaceSnapshot is the #2420 regression guard.
+//
+// resolveAttachedTabLocked adopts a daemon-minted id into an id-less local tab
+// projection. GetTabs hands out the LIVE *Tab pointers (it copies only the
+// slice), and callers — tree.TabLabels on the render path, the pane refresh —
+// read Name/Kind/ID off-lock. The instance.go copy-on-write invariant (the
+// GetTabs doc, established by #1930) therefore forbids assigning those fields in
+// place once a tab is observable via i.Tabs: a writer must swap in a COPY via
+// replaceTabFieldLocked so an existing snapshot keeps reading stable data.
+//
+// The prior `tab.ID = tabID` in resolveAttachedTabLocked violated that: it wrote
+// the id field of a pointer a GetTabs snapshot still held, off-lock readers and
+// the locked writer touching the same field with no happens-before edge — a data
+// race, not a stale read.
+//
+// Run under -race: each of the N id-less tabs takes exactly one adopt write
+// while a reader reads that tab's snapshot pointer's ID off-lock. The buggy
+// in-place write fails the detector on those N independent field races; the
+// copy-on-write fix leaves every snapshot pointer untouched and passes.
+func TestAttachVSCodeTabIDAdoptDoesNotRaceSnapshot(t *testing.T) {
+	const n = 256
+
+	i := &Instance{}
+	i.Tabs = make([]*Tab, n)
+	for k := range i.Tabs {
+		i.Tabs[k] = &Tab{Name: fmt.Sprintf("editor-%d", k)}
+	}
+
+	// A snapshot taken before the daemon ids arrive: live pointers whose ID a
+	// renderer reads without holding i.mu.
+	snapshot := i.GetTabs()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Reader: off-lock reads of every handed-out pointer's ID. The accumulator
+	// keeps the reads from being optimized away.
+	var observed int
+	go func() {
+		defer wg.Done()
+		for round := 0; round < 64; round++ {
+			for k := range snapshot {
+				observed += len(snapshot[k].ID)
+			}
+		}
+	}()
+
+	// Writer: adopt a distinct daemon id into each id-less tab through the real
+	// public attach path (which resolves via resolveAttachedTabLocked).
+	go func() {
+		defer wg.Done()
+		for k := 0; k < n; k++ {
+			tab, err := i.AttachVSCodeTab(fmt.Sprintf("editor-%d", k), fmt.Sprintf("daemon-%d", k))
+			if err != nil {
+				t.Errorf("AttachVSCodeTab adopt failed for editor-%d: %v", k, err)
+				return
+			}
+			if tab.ID != fmt.Sprintf("daemon-%d", k) {
+				t.Errorf("adopt returned id %q, want %q", tab.ID, fmt.Sprintf("daemon-%d", k))
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+	_ = observed
+
+	// Functional check: the adopt is observable on the authoritative list, so the
+	// copy-on-write path is not a silent no-op.
+	final := i.GetTabs()
+	for k := 0; k < n; k++ {
+		if got, want := final[k].ID, fmt.Sprintf("daemon-%d", k); got != want {
+			t.Fatalf("tab editor-%d id = %q, want %q", k, got, want)
+		}
+	}
+	// The pre-adopt snapshot pointers must still read their original id-less
+	// value: copy-on-write means the adopt swapped in new pointers rather than
+	// mutating the ones the snapshot handed out.
+	for k := 0; k < n; k++ {
+		if snapshot[k].ID != "" {
+			t.Fatalf("snapshot pointer for editor-%d was mutated in place: id = %q", k, snapshot[k].ID)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #2420.

`resolveAttachedTabLocked` adopted a daemon-minted tab id into an id-less local projection with an in-place `tab.ID = tabID`. `GetTabs` hands out the **live** `*Tab` pointers (it copies only the slice), and callers read `ID`/`Name`/`Kind` off-lock (`tree.TabLabels` on the render path, the pane refresh). Mutating the field in place on a pointer a snapshot still holds is a data race under the Go memory model — not a stale read — and violates the copy-on-write invariant documented on `GetTabs` (established by #1930).

Introduced by the id-based tab identity work in #2377.

## Fix

Adopt the id through `replaceTabFieldLocked` (copy-on-write) instead, exactly as `ReconcileTabsFromData` already does for the same "adopt daemon id" operation, and return the swapped-in copy so the caller's projection matches the authoritative tab list. The full-struct copy carries the tmux pointer along, so the tab's live session is preserved.

## Tests (fail first)

`session/tab_attach_id_race_test.go` adds `TestAttachVSCodeTabIDAdoptDoesNotRaceSnapshot`: it takes a `GetTabs` snapshot, then concurrently reads each snapshot pointer's `ID` off-lock while driving the real `AttachVSCodeTab` adopt path. On `master` it fails **two** ways —

- `go test -race` flags the write at `tab_attach.go:66` against the off-lock read, and
- a deterministic assertion catches the handed-out snapshot pointer being mutated in place (`id = "daemon-0"`).

With the fix it passes under `-race`.

## Verification

- Gate head: `d7be737f`
- `go build ./...`, `gofmt -l` (clean), `go vet`, `golangci-lint run --fast` (clean), `deadcode -test ./...` (clean), `scripts/lint-file-length.sh` (pass)
- `make test-container`: **full suite green** — every package, including `session` (36s, the new race test runs under the container's race config), `daemon`, `session/tmux`, `app`, `integration`, `ui`.
- Also adjacent-site audited: `resolveAttachedTabLocked` was the only in-place ID/Name/Kind mutation of a handed-out tab; every other `.Name`/`.ID` assignment is on a fresh pre-append tab.

## Base

Branched from `v1.0.208` (`6f90d5b1`); 9 commits behind current master, all in unrelated packages (upgrade/api/config/ui/docs) — disjoint from `session/`, so auto-mergeable. Bring current with `gh pr update-branch` at merge.

## Review

Codex GitHub-app review is rate-limited until Jul 28 — requested once. If it stays silent, Captain Claude runs the standby review (claude-subagent / codex-CLI) before merge. Held as draft; do not merge unreviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
