### PR TITLE
fix(bugreport): redact PendingHandoffMission in shared bundles (#2419)

### DIFF
--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -575,6 +575,11 @@ var sensitiveJSONKeys = map[string]bool{
 	// fields (agent, captured_at) are not worth reconstructing a shape
 	// contract for here (#1839).
 	"conversation": true, "agent_conversation": true,
+	// pending_handoff_mission mirrors the typed-path redaction (redactInstanceData
+	// blanks PendingHandoffMission): the rendered takeover brief embeds the user's
+	// free-text prompt/goal verbatim, the same sensitivity class as prompt. A
+	// record that fails the typed decode must still drop it (#2419).
+	"pending_handoff_mission": true,
 }
 
 // redactUnknownJSON recursively rebuilds a decoded JSON value, blanking any
@@ -618,6 +623,13 @@ func redactInstanceData(d *session.InstanceData) {
 	}
 	if d.Prompt != "" {
 		d.Prompt = redactedMarker
+	}
+	// PendingHandoffMission is a rendered takeover brief that embeds the user's
+	// free-text prompt/goal verbatim — the same sensitivity class as Prompt. It
+	// was added with transactional handoff (#2286) after this policy was written,
+	// so it passed through unredacted into publicly shared bundles (#2419).
+	if d.PendingHandoffMission != "" {
+		d.PendingHandoffMission = redactedMarker
 	}
 	if d.Worktree.SessionName != "" {
 		d.Worktree.SessionName = redactedMarker

--- a/bugreport/redact_handoff_mission_test.go
+++ b/bugreport/redact_handoff_mission_test.go
@@ -1,0 +1,57 @@
+package bugreport
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// TestRedactInstanceDataRedactsPendingHandoffMission is the #2419 regression
+// guard for the typed path. PendingHandoffMission holds a rendered takeover
+// brief that embeds the user's free-text prompt/goal verbatim — the same
+// sensitivity class as Prompt, which redactInstanceData already blanks. The
+// field was added with transactional handoff (#2286) after this redaction
+// policy was written, so it passed through unredacted into publicly shared bug
+// bundles.
+func TestRedactInstanceDataRedactsPendingHandoffMission(t *testing.T) {
+	d := session.InstanceData{
+		ID:                    "abc123",
+		Program:               "claude",
+		Status:                session.Status(1),
+		PendingHandoffMission: "continue the internal codename Kingfisher migration; secret runbook step 3",
+	}
+
+	redactInstanceData(&d)
+
+	if d.PendingHandoffMission != redactedMarker {
+		t.Errorf("pending handoff mission not redacted: %q", d.PendingHandoffMission)
+	}
+	// Structural fields still survive.
+	if d.ID != "abc123" || d.Program != "claude" || d.Status != session.Status(1) {
+		t.Errorf("structural fields mutated: %+v", d)
+	}
+}
+
+// TestRedactInstancesFallbackRedactsPendingHandoffMission is the #2419 fallback
+// guard. A legacy/corrupt record that fails the typed decode (here `status` is a
+// string) must still have pending_handoff_mission redacted on the generic path.
+// Before the fix the key was absent from sensitiveJSONKeys, so the handoff brief
+// — which is not a secret pattern, path, or known title the text scrub would
+// catch — leaked verbatim into the shared bundle.
+func TestRedactInstancesFallbackRedactsPendingHandoffMission(t *testing.T) {
+	r := &redactor{}
+	raw := json.RawMessage(`[{"id":"leg-1","status":"legacy-string-status","program":"claude","pending_handoff_mission":"internal codename Kingfisher handoff brief"}]`)
+	out := string(r.redactInstancesJSON(raw))
+	if strings.Contains(out, "Kingfisher") {
+		t.Errorf("fallback path leaked pending handoff mission:\n%s", out)
+	}
+	if !strings.Contains(out, redactedMarker) {
+		t.Errorf("expected redaction marker on the fallback path:\n%s", out)
+	}
+	// Safe structural fields still survive.
+	if !strings.Contains(out, "leg-1") || !strings.Contains(out, "legacy-string-status") {
+		t.Errorf("fallback dropped safe structural fields:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #2419.

`PendingHandoffMission` — the rendered takeover brief persisted on `InstanceData` — was not redacted from publicly-sharable bug report bundles. It embeds the user's free-text prompt/goal verbatim (the same sensitivity class as `Prompt`, which is redacted), so proprietary information, internal codenames, and non-standard secrets in a handoff brief could leak into a shared bundle.

The field was added with transactional handoff (#2286) after the bugreport redaction policy was written, so it was never wired into either redaction path.

## Fix

Both redaction paths now drop it:

- **Typed path** — `redactInstanceData` blanks `PendingHandoffMission` to `[redacted]` when non-empty, alongside `Prompt`.
- **Generic JSON fallback** — `"pending_handoff_mission"` is added to `sensitiveJSONKeys`, so a legacy/corrupt record that fails the typed decode still has it dropped (this path key-blanks; the text scrub would not catch an arbitrary codename).

## Tests (fail first)

A focused new file `bugreport/redact_handoff_mission_test.go` adds two regression guards, one per path:

- `TestRedactInstanceDataRedactsPendingHandoffMission`
- `TestRedactInstancesFallbackRedactsPendingHandoffMission`

Both fail on `master` (the brief leaks verbatim — confirmed by running them unpatched) and pass with the fix. The tests live in their own file rather than `bugreport_test.go`, which is already at the 1500-line test-file limit; extending it would have tripped the file-length lint, and grandfathering a fresh violation is not allowed.

## Verification

- Gate head: `80575aab`
- `go build ./...`, `gofmt -l` (clean), `go vet`, `golangci-lint run --fast` (clean), `deadcode -test ./...` (clean), `scripts/lint-file-length.sh` (pass)
- `make test-container`: **full suite green** — every package, `bugreport` included.

## Base

Branched from `v1.0.208` (`6f90d5b1`); 9 commits behind current master, all in unrelated packages (upgrade/api/config/ui/docs) — disjoint from `bugreport/`, so auto-mergeable. Bring current with `gh pr update-branch` at merge.

## Review

Codex GitHub-app review is rate-limited until Jul 28 — requested once. If it stays silent, Captain Claude runs the standby review (claude-subagent / codex-CLI) before merge. Held as draft; do not merge unreviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
