### PR TITLE
fix(hook): kill a failed launch_cmd's tree before delete_cmd reaps (#2440)

### DIFF
--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -128,15 +128,19 @@ A script that exceeds its budget is killed and the operation fails.
 
 **A timed-out `launch_cmd` is reaped, not left running.** When the budget expires af kills the script, so it will never return an endpoint and af will never dial whatever it was building. Any sandbox it did create is already orphaned at that moment — leaving it alone would not preserve a resource you could still use, only one you would still pay for. So a timeout is treated as a failure that reaps.
 
-**af kills only the script itself, not the processes it spawned.** If your `launch_cmd` shells out to a provisioner that keeps running after the script is killed, that provisioner may still create infrastructure *after* `delete_cmd` has already run. af cannot close that race from the outside — it is another reason to make `delete_cmd` idempotent and safe to re-run, and to prefer a `launch_cmd` that cleans up after itself on `EXIT`/`TERM`.
+**A reap stops the whole launch tree first, then runs `delete_cmd`.** If your `launch_cmd` shells out to a provisioner (`terraform`, `gcloud`, `kubectl`) and is killed at its budget while that provisioner is still working, af kills the entire process group it started *before* running `delete_cmd`. Without that, the surviving provisioner would finish creating infrastructure **after** `delete_cmd` had already reaped and reported success — a resource that bills with nothing pointing at it, since a failed provision leaves af no record of the session.
+
+This applies only when af is tearing the session down (a failed provision, a kill, or an archive), where everything the launch started is garbage by definition. It never applies to a `launch_cmd` that **succeeded** — see [Backgrounding a tunnel](#backgrounding-a-tunnel-is-supported--you-need-do-nothing). Making `delete_cmd` idempotent is still worthwhile, and a `launch_cmd` that cleans up after itself on `EXIT`/`TERM` is still good practice.
 
 ### Backgrounding a tunnel is supported — you need do nothing
 
 **Nothing to change in your `launch_cmd`.** This documents a behaviour change that only ever *removes* a restriction.
 
-Many `launch_cmd`s must leave a process running to make the agent-server reachable — an `ssh -L` forward, a `kubectl port-forward`, a tunnel client. That process is not a leak: it is the thing af then dials. af treats it as **yours** and never touches it.
+Many `launch_cmd`s must leave a process running to make the agent-server reachable — an `ssh -L` forward, a `kubectl port-forward`, a tunnel client. That process is not a leak: it is the thing af then dials. For as long as the session is alive, af treats it as **yours** and never touches it.
 
-- af bounds and kills **the script**, never anything the script left running.
+The one time af does stop it is when the session is being torn down — a failed provision, a kill, or an archive — because a tunnel to a sandbox that is being reaped has nothing left to reach. If you would rather manage that lifetime yourself, start the tunnel with `setsid` so it leaves the process group af tears down.
+
+- af bounds and kills **the script**, never anything a successful script left running.
 - The script's stdout/stderr go to a temporary **file**, not a pipe. A background process may inherit them and keep writing as long as it likes: af has already stopped reading, and there is no pipe whose closure could disturb it.
 - af stops reading when the **script** exits, and its **exit status** decides success.
 

--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -130,17 +130,15 @@ A script that exceeds its budget is killed and the operation fails.
 
 **A reap stops the whole launch tree first, then runs `delete_cmd`.** If your `launch_cmd` shells out to a provisioner (`terraform`, `gcloud`, `kubectl`) and is killed at its budget while that provisioner is still working, af kills the entire process group it started *before* running `delete_cmd`. Without that, the surviving provisioner would finish creating infrastructure **after** `delete_cmd` had already reaped and reported success — a resource that bills with nothing pointing at it, since a failed provision leaves af no record of the session.
 
-This applies only when af is tearing the session down (a failed provision, a kill, or an archive), where everything the launch started is garbage by definition. It never applies to a `launch_cmd` that **succeeded** — see [Backgrounding a tunnel](#backgrounding-a-tunnel-is-supported--you-need-do-nothing). Making `delete_cmd` idempotent is still worthwhile, and a `launch_cmd` that cleans up after itself on `EXIT`/`TERM` is still good practice.
+This applies only to a `launch_cmd` that **just failed**, where everything it started is garbage by definition. It never applies to one that succeeded — see [Backgrounding a tunnel](#backgrounding-a-tunnel-is-supported--you-need-do-nothing) — and it does not apply on kill or archive, where the launch ended long ago. Making `delete_cmd` idempotent is still worthwhile, and a `launch_cmd` that cleans up after itself on `EXIT`/`TERM` is still good practice.
 
 ### Backgrounding a tunnel is supported — you need do nothing
 
 **Nothing to change in your `launch_cmd`.** This documents a behaviour change that only ever *removes* a restriction.
 
-Many `launch_cmd`s must leave a process running to make the agent-server reachable — an `ssh -L` forward, a `kubectl port-forward`, a tunnel client. That process is not a leak: it is the thing af then dials. For as long as the session is alive, af treats it as **yours** and never touches it.
+Many `launch_cmd`s must leave a process running to make the agent-server reachable — an `ssh -L` forward, a `kubectl port-forward`, a tunnel client. That process is not a leak: it is the thing af then dials. af treats it as **yours** and never touches it.
 
-The one time af does stop it is when the session is being torn down — a failed provision, a kill, or an archive — because a tunnel to a sandbox that is being reaped has nothing left to reach. If you would rather manage that lifetime yourself, start the tunnel with `setsid` so it leaves the process group af tears down.
-
-- af bounds and kills **the script**, never anything a successful script left running.
+- af bounds and kills **the script**, never anything a script that **succeeded** left running. (A launch that *failed* is torn down as a tree — see [Script timeouts](#script-timeouts). If you want a process to survive even that, start it with `setsid`.)
 - The script's stdout/stderr go to a temporary **file**, not a pipe. A background process may inherit them and keep writing as long as it likes: af has already stopped reading, and there is no pipe whose closure could disturb it.
 - af stops reading when the **script** exits, and its **exit status** decides success.
 

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -338,6 +338,12 @@ func (p *hookProvisioner) launch() (*AgentServerEndpoint, error) {
 	// *exec.Error check would read "never ran" as "ran" and fire delete_cmd for a
 	// typo'd path.
 	p.launchStarted = cmd != nil && cmd.Process != nil
+	// Assigned unconditionally, INCLUDING the zero: launchPgid must describe the
+	// launch that just returned and nothing earlier. Leaving a previous attempt's
+	// value in place when this one never spawned would let quiesceLaunchGroup
+	// signal a group that is long gone — and whose id the kernel may since have
+	// handed to an unrelated process.
+	p.launchPgid = 0
 	if p.launchStarted {
 		// Setpgid made the child its own group leader, so the group id IS its pid.
 		p.launchPgid = cmd.Process.Pid
@@ -434,15 +440,28 @@ func (p *hookProvisioner) reap() error {
 //   - Those paths rebuild the provisioner from the stored cleanup handle
 //     (runtime_cleanup.go), which has no pgid to begin with — so the guard below
 //     already makes them no-ops. This comment records why that must stay true.
+//
+// Freshness is ENFORCED, not merely relied on, because "the caller builds a new
+// provisioner each time" is an invariant a future caller can silently break and
+// the failure mode is signalling a stranger's process group. Two mechanics hold
+// it: launch assigns launchPgid on every attempt including the zero, so it can
+// never describe an earlier launch; and this function consumes the value, so the
+// right to signal a given group is spent exactly once.
 func (p *hookProvisioner) quiesceLaunchGroup() {
 	if p.launchPgid == 0 {
 		return
 	}
+	// Consume it. A pgid is safe to signal only while the launch that led it has
+	// just returned, so the right to signal this one is spent here — a second
+	// call can never reach the syscall with a value that has since gone stale.
+	pgid := p.launchPgid
+	p.launchPgid = 0
+
 	// A negative pid targets the whole group led by launch_cmd. Any error means
 	// there is nothing left to wait for: ESRCH is the group already being empty,
 	// which is the common case (the script exited and spawned nothing that
 	// outlived it) and not a failure.
-	if err := syscall.Kill(-p.launchPgid, syscall.SIGKILL); err != nil {
+	if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil {
 		return
 	}
 	// SIGKILL cannot be caught, so this only covers the descheduling window
@@ -454,7 +473,7 @@ func (p *hookProvisioner) quiesceLaunchGroup() {
 	for time.Now().Before(deadline) {
 		// Signal 0 tests whether the group still has members without delivering
 		// anything; an error (ESRCH) means it has drained.
-		if err := syscall.Kill(-p.launchPgid, 0); err != nil {
+		if err := syscall.Kill(-pgid, 0); err != nil {
 			return
 		}
 		time.Sleep(hookQuiescePoll)

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -102,6 +102,14 @@ func (p *hookProvisioner) provisionOrReap() (ProvisionResult, error) {
 	if err == nil {
 		return res, nil
 	}
+	// Stop anything launch_cmd left mid-provision BEFORE delete_cmd runs, so the
+	// reap is authoritative rather than a snapshot something can outlive (#2440).
+	// This belongs here and not in reap: it is sound only while the launch we are
+	// cleaning up after has JUST returned. reap also backs Kill and archive,
+	// where the launch ended long ago and its group id may since have been
+	// recycled onto an unrelated process.
+	p.quiesceLaunchGroup()
+
 	// launch_cmd may have provisioned a sandbox before failing to hand back a
 	// usable endpoint: it can exit 0 having printed no/bad JSON, exit non-zero
 	// after creating a VM, or be killed at the timeout mid-provision. Reap via
@@ -381,10 +389,6 @@ func (p *hookProvisioner) reap() error {
 		if !p.launchStarted {
 			return
 		}
-		// Stop anything launch_cmd left provisioning BEFORE delete_cmd runs, so
-		// the reap is authoritative rather than a snapshot something can outlive.
-		p.quiesceLaunchGroup()
-
 		// runHookScript builds its timeout from context.Background(), NEVER a
 		// caller's context — and that is load-bearing here. reap's whole job is to
 		// run on the failure path, where the launch context is already cancelled or
@@ -417,10 +421,19 @@ func (p *hookProvisioner) reap() error {
 // orphanWarning never fires, because the reap did not fail. The resource bills
 // forever with nothing pointing at it, which is the exact harm #1955 was about.
 //
-// Only reap calls this, and reap runs only while a session is being torn down: a
-// failed provision, Kill, or archive. On those paths every descendant is garbage
-// by definition, so the "we stop listening; we kill nothing" rule that governs
-// the SUCCESS path does not apply here and must not be extended to it.
+// Only provisionOrReap calls this, and only on the failure of a launch that has
+// just returned. Every descendant of a launch being reaped seconds after it
+// failed is garbage by definition, so the "we stop listening; we kill nothing"
+// rule that governs the SUCCESS path does not apply — but it must not be
+// extended to the other reap paths, for two independent reasons:
+//
+//   - Kill and archive reap a launch that ended long ago. Its group is empty by
+//     then, so the group id may have been RECYCLED onto an unrelated process,
+//     and signalling it would kill a stranger's process tree. Freshness is what
+//     makes the pgid safe to signal, and only this call site has it.
+//   - Those paths rebuild the provisioner from the stored cleanup handle
+//     (runtime_cleanup.go), which has no pgid to begin with — so the guard below
+//     already makes them no-ops. This comment records why that must stay true.
 func (p *hookProvisioner) quiesceLaunchGroup() {
 	if p.launchPgid == 0 {
 		return

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
@@ -59,10 +60,21 @@ import (
 //     provisioner.
 //
 // These bound the SCRIPT, and only the script. Nothing here bounds — or touches
-// — a process the script deliberately leaves running: see runHookScript.
+// — a process the script deliberately leaves running on the SUCCESS path: see
+// runHookScript. On the REAP path that changes, and deliberately so:
+// quiesceLaunchGroup tears the whole launch tree down under hookQuiesceTimeout
+// before delete_cmd runs, because a session being torn down has no product left
+// to protect (#2440).
 var (
 	hookLaunchTimeout = 5 * time.Minute
 	hookDeleteTimeout = 60 * time.Second
+
+	// hookQuiesceTimeout bounds the wait for a SIGKILLed launch group to leave
+	// the process table before delete_cmd runs. Short by design: the signal
+	// cannot be refused, so this covers descheduling only.
+	hookQuiesceTimeout = 2 * time.Second
+	// hookQuiescePoll is how often that drain is re-checked.
+	hookQuiescePoll = 5 * time.Millisecond
 )
 
 // hookRuntime provisions a session on user-provided infrastructure via the
@@ -186,6 +198,11 @@ func runHookScript(timeout time.Duration, name string, args ...string) ([]byte, 
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Stdout = f
 	cmd.Stderr = f
+	// Lead a process group so that a FAILED launch's descendants can be torn down
+	// as a TREE before delete_cmd reaps — see quiesceLaunchGroup. Setting the
+	// group signals nothing by itself: a successful launch_cmd's tunnel is never
+	// killed, so the guarantee above is untouched.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	runErr := cmd.Run()
 
 	out, readErr := os.ReadFile(f.Name())
@@ -208,7 +225,15 @@ type hookProvisioner struct {
 	// two claims: a launch that started and then failed may have provisioned
 	// infrastructure, and only delete_cmd can reap it (#1955).
 	launchStarted bool
-	reapOnce      sync.Once
+
+	// launchPgid is the process group launch_cmd led, which is its own pid
+	// (runHookScript sets Setpgid). It is what lets the reap tear down a failed
+	// launch's still-running descendants BEFORE delete_cmd runs — see
+	// quiesceLaunchGroup. Zero when launch_cmd never ran, or when this
+	// provisioner was rebuilt for a Kill/archive rather than the launch itself.
+	launchPgid int
+
+	reapOnce sync.Once
 }
 
 // hookEndpointJSON is the object launch_cmd echoes: the authed `af agent-server`
@@ -305,6 +330,10 @@ func (p *hookProvisioner) launch() (*AgentServerEndpoint, error) {
 	// *exec.Error check would read "never ran" as "ran" and fire delete_cmd for a
 	// typo'd path.
 	p.launchStarted = cmd != nil && cmd.Process != nil
+	if p.launchStarted {
+		// Setpgid made the child its own group leader, so the group id IS its pid.
+		p.launchPgid = cmd.Process.Pid
+	}
 
 	if err != nil {
 		// "launch_cmd failed" stays a contiguous phrase: #1955's reap tests
@@ -352,6 +381,10 @@ func (p *hookProvisioner) reap() error {
 		if !p.launchStarted {
 			return
 		}
+		// Stop anything launch_cmd left provisioning BEFORE delete_cmd runs, so
+		// the reap is authoritative rather than a snapshot something can outlive.
+		p.quiesceLaunchGroup()
+
 		// runHookScript builds its timeout from context.Background(), NEVER a
 		// caller's context — and that is load-bearing here. reap's whole job is to
 		// run on the failure path, where the launch context is already cancelled or
@@ -367,6 +400,52 @@ func (p *hookProvisioner) reap() error {
 		log.InfoLog.Printf("hook runtime: reaped remote session %q via delete_cmd", p.slug)
 	})
 	return reapErr
+}
+
+// quiesceLaunchGroup SIGKILLs launch_cmd's process group and waits for it to
+// drain, so delete_cmd runs against a world in which nothing can still be
+// provisioning.
+//
+// This closes #1955's leak through the door the TIMEOUT path left open (#2440).
+// runHookScript kills only the SCRIPT — no WaitDelay, output to a file so Wait
+// returns the instant the script dies — which is deliberate and right for a
+// launch that SUCCEEDED: its tunnel is the product, not garbage. But a launch
+// killed mid-provision leaves its `terraform`/`gcloud` child running, and that
+// child is not killed with the script. delete_cmd then reaps only what exists at
+// that instant, reports SUCCESS, and the orphan finishes creating the VM
+// afterwards. Provisioning failed, so af keeps no record of the session — and
+// orphanWarning never fires, because the reap did not fail. The resource bills
+// forever with nothing pointing at it, which is the exact harm #1955 was about.
+//
+// Only reap calls this, and reap runs only while a session is being torn down: a
+// failed provision, Kill, or archive. On those paths every descendant is garbage
+// by definition, so the "we stop listening; we kill nothing" rule that governs
+// the SUCCESS path does not apply here and must not be extended to it.
+func (p *hookProvisioner) quiesceLaunchGroup() {
+	if p.launchPgid == 0 {
+		return
+	}
+	// A negative pid targets the whole group led by launch_cmd. Any error means
+	// there is nothing left to wait for: ESRCH is the group already being empty,
+	// which is the common case (the script exited and spawned nothing that
+	// outlived it) and not a failure.
+	if err := syscall.Kill(-p.launchPgid, syscall.SIGKILL); err != nil {
+		return
+	}
+	// SIGKILL cannot be caught, so this only covers the descheduling window
+	// between delivery and the last member leaving the process table. Bounded
+	// because a reap that hangs here would strand the caller it is cleaning up
+	// after — the leak this prevents is worse than a straggler, but not worse
+	// than a wedge.
+	deadline := time.Now().Add(hookQuiesceTimeout)
+	for time.Now().Before(deadline) {
+		// Signal 0 tests whether the group still has members without delivering
+		// anything; an error (ESRCH) means it has drained.
+		if err := syscall.Kill(-p.launchPgid, 0); err != nil {
+			return
+		}
+		time.Sleep(hookQuiescePoll)
+	}
 }
 
 // HookBackend is the in-process Backend for a remote-hook session (#1592 Phase 4

--- a/session/backend_hook_reap_test.go
+++ b/session/backend_hook_reap_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -397,6 +398,56 @@ echo "a VM that bills by the hour" > '%s'/sandboxes/"$name"/resource.txt
 				"delete_cmd reported success, so this sandbox now bills with nothing pointing at it", sandbox)
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestHookQuiesceNeverSignalsAStalePgid pins the other half of the process-group
+// kill: it may only ever target a group THIS attempt established.
+//
+// quiesceLaunchGroup runs on any provisioning failure, and its only guard is a
+// non-zero launchPgid. If a provisioner could carry a pgid from an earlier
+// launch into an attempt that never spawned, it would signal a group that is
+// long gone — and whose id the kernel may since have handed to an unrelated
+// process. Today no production path reuses a provisioner (hookRuntime.Provision
+// builds a fresh one per call), so this is a latent hazard rather than a live
+// bug; it is pinned because "the caller always builds a new one" is an invariant
+// a future caller can break silently, and the failure mode is SIGKILLing a
+// stranger's process tree.
+//
+// The sentinel below leads its OWN process group. That is not incidental: a kill
+// aimed at the test runner's group would take the test process with it.
+func TestHookQuiesceNeverSignalsAStalePgid(t *testing.T) {
+	shrinkHookTimeouts(t, 50*time.Millisecond, 5*time.Second)
+
+	// Stands in for whatever now owns a recycled pgid.
+	sentinel := exec.Command("sleep", "30")
+	sentinel.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	require.NoError(t, sentinel.Start())
+	stalePgid := sentinel.Process.Pid
+	exited := make(chan error, 1)
+	go func() { exited <- sentinel.Wait() }()
+	t.Cleanup(func() { _ = sentinel.Process.Kill() })
+
+	h := newHookState(t, "", "")
+	p := newHookProvisioner(h, "stale pgid")
+	// A pgid left behind by an earlier launch on this provisioner.
+	p.launchPgid = stalePgid
+	// …and an attempt that never spawns, so it establishes no group of its own
+	// and must not inherit the right to signal that one.
+	p.hooks.LaunchCmd = filepath.Join(h.dir, "does-not-exist.sh")
+
+	_, err := p.provisionOrReap()
+	require.Error(t, err, "a launch_cmd that cannot be executed must fail the provision")
+
+	assert.Zero(t, p.launchPgid,
+		"a launch that never spawned must clear launchPgid, not inherit the previous attempt's")
+
+	select {
+	case werr := <-exited:
+		t.Fatalf("quiesceLaunchGroup signalled a process group this attempt never established (%v); "+
+			"on a real box that pgid may belong to an unrelated process tree", werr)
+	case <-time.After(300 * time.Millisecond):
+		// Still running — the stale pgid was never signalled.
 	}
 }
 

--- a/session/backend_hook_reap_test.go
+++ b/session/backend_hook_reap_test.go
@@ -354,6 +354,52 @@ func TestHookReapUnaffectedByCancelledCaller(t *testing.T) {
 	assert.NoDirExists(t, h.sandbox(p.slug))
 }
 
+// TestHookReapKillsAnOrphanedLaunchChildBeforeDeleting locks the ordering that
+// makes the reap authoritative (#2440).
+//
+// runHookScript kills only the SCRIPT, so a launch_cmd killed at its bound
+// leaves whatever it had in flight — the `terraform`/`gcloud` doing the actual
+// provisioning — running. Before the fix, delete_cmd reaped only what existed at
+// that instant and reported SUCCESS, and the orphan then created the resource
+// AFTER the reap. Nothing surfaced it: provisioning failed so af keeps no record
+// of the session, and orphanWarning fires only when the reap FAILS.
+//
+// This is what TestHookReapUnaffectedByCancelledCaller was hitting intermittently
+// on CI, where the in-flight child was the fixture's own `mkdir` descheduled
+// under load. Here the window is explicit instead of a scheduling accident, so
+// the leak reproduces every run rather than one cell in four.
+func TestHookReapKillsAnOrphanedLaunchChildBeforeDeleting(t *testing.T) {
+	shrinkHookTimeouts(t, 50*time.Millisecond, 5*time.Second)
+	h := newHookState(t, "", "")
+
+	// The real shape of a launch_cmd: the provisioning is done by a CHILD, and
+	// the script is still waiting on it when the launch bound fires.
+	child := writeHookScript(t, filepath.Join(h.dir, "provision-child.sh"), fmt.Sprintf(`
+sleep 0.25
+mkdir -p '%s'/sandboxes/"$name"
+echo "a VM that bills by the hour" > '%s'/sandboxes/"$name"/resource.txt
+`, h.dir, h.dir))
+	writeHookScript(t, h.launch, fmt.Sprintf(`'%s' --name "$name"`, child))
+
+	p := newHookProvisioner(h, "orphaned child")
+	_, err := p.provisionOrReap()
+	require.Error(t, err, "launch_cmd is killed at its bound, so provisioning must fail")
+	require.True(t, h.deleteRan(t), "delete_cmd must run: launch_cmd started")
+
+	// Watch across the whole window in which the orphan would land its side
+	// effect. A resource that appears at ANY point after the reap is the leak —
+	// delete_cmd already reported success and will never run again.
+	sandbox := h.sandbox(p.slug)
+	deadline := time.Now().Add(1200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if _, statErr := os.Stat(sandbox); statErr == nil {
+			t.Fatalf("a launch_cmd child outlived the reap and re-created %s: "+
+				"delete_cmd reported success, so this sandbox now bills with nothing pointing at it", sandbox)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 // TestHookProvisionSucceedsWhenLaunchLeavesOutputPipeOpen guards the regression
 // the bound itself could cause. A launch_cmd that exits 0 and leaves a tunnel or
 // backgrounded daemon holding its stdout — a documented pattern, since the script


### PR DESCRIPTION
Fixes #2440.

## This was filed as a flake. It is a silent infrastructure leak.

Master Health Watch picked up the red master Build (run 30051286193). `TestHookReapUnaffectedByCancelledCaller` failed on one matrix cell and passed on the others, and the issue reasoned from that to "a timing flake — master's actual code is sound."

That argument establishes the failure is *non-deterministic*. It does not establish the code is sound. **A race is both at once.** The test is a faithful detector of a live bug, and deflaking it — the fix the issue originally proposed — would have made master green while disconnecting the only alarm on a real leak.

## The bug

`runHookScript` kills only the **script**: no `WaitDelay`, and output goes to a real file rather than a pipe, so `cmd.Run()` returns the instant the script process dies. That is deliberate and load-bearing for a launch that **succeeded** — the tunnel it leaves behind is the product, not garbage (#1943/#1966).

On the **timeout** path it means something else. A `launch_cmd` killed at `hookLaunchTimeout` leaves whatever it had in flight — the `terraform`/`gcloud` doing the actual provisioning — still running:

1. `launch_cmd` hits its bound → SIGKILL to the script only.
2. Its in-flight provisioning child is orphaned and survives.
3. `provisionOrReap` reaps; `delete_cmd` removes what exists *at that instant* and reports **success**.
4. The orphan finishes and creates the resource **after** the reap.

Nothing surfaces it. Provisioning failed, so af keeps no record of the session — and `orphanWarning` fires only when the reap **fails**, which here it did not. The user gets a plain provisioning error and a VM that bills forever with nothing pointing at it.

That is the exact harm #1955 was filed about, reintroduced through the timeout door, in the one code path whose doc comment says it prevents it. `docs/remote-hooks.md` had even written it off as unfixable — *"af cannot close that race from the outside."* It is closable from the inside.

## The fix

Give `launch_cmd` its own process group (`Setpgid`), and on a launch that just failed, SIGKILL that group and wait for it to drain **before** running `delete_cmd`. The reap becomes authoritative instead of a snapshot something can outlive.

This is the mechanism already in-tree for the same class: `session/tmux/bounded.go:89-93` names this defect precisely — `exec.CommandContext`'s default Cancel "kills just the direct process", orphaning children that outlive it.

**The success path is untouched.** Setting the group signals nothing by itself; a launch that returns an endpoint keeps its tunnel. `TestHookProvisionKeepsASuccessfulLaunchsTunnelAlive` and `TestHookLaunchDoesNotKillBackgroundedChildren` pin that, and both still pass.

The drain wait is bounded (`hookQuiesceTimeout`, 2s). SIGKILL cannot be refused, so it covers the descheduling window only — a reap that hung here would strand the caller it is cleaning up after.

## Second commit: scope, from my own review

The first commit called the quiesce from `reap`. That was too broad, and unsafe on one of `reap`'s three callers.

`reap` backs a failed provision, a **Kill**, and an **archive**. Only the first reaps a launch that has just returned. On Kill and archive the launch ended long ago, its group is empty, and the group id may since have been **recycled onto an unrelated process** — signalling it could SIGKILL a stranger's process tree. Freshness is what makes a pgid safe to signal, and only the provisioning-failure path has it.

So the call moved to `provisionOrReap`, immediately after the launch that failed. Both other paths were already no-ops in practice — they rebuild the provisioner from the stored cleanup handle (`runtime_cleanup.go:172`), which carries a slug and `delete_cmd` but no pgid — which made the hazard latent rather than live, and is exactly why it is worth pinning in a comment before someone later gives that struct a pgid.

Kill and archive therefore keep their existing behaviour exactly.

## Fail-first

`TestHookReapKillsAnOrphanedLaunchChildBeforeDeleting` makes the window **explicit** — a `launch_cmd` that delegates provisioning to a child, which is what a real one does — rather than waiting for the scheduler to produce it. Watched fail against unmodified master:

```
--- FAIL: TestHookReapKillsAnOrphanedLaunchChildBeforeDeleting (0.26s)
    a launch_cmd child outlived the reap and re-created
    /tmp/.../sandboxes/orphaned-child: delete_cmd reported success, so
    this sandbox now bills with nothing pointing at it
```

Green after the fix. It asserts across the whole window in which the orphan would land, so it cannot pass by checking too early.

The fix **also deflakes the original test** as a side effect — there the in-flight child was the fixture's own `mkdir`, descheduled under the loaded 4-way matrix. Both tests: 40 consecutive runs green.

## Docs

`docs/remote-hooks.md` claimed af "cannot close that race" and that af "never touches" what a script leaves running. The first is now false; the second is qualified to a script that **succeeded**, with the `setsid` escape hatch for a process the user wants to outlive a failed launch.

## Gate

Exact pushed head: `ef9a85f2`

- `gofmt -l .` (no output)
- `go build ./...`
- `golangci-lint run --timeout=3m --fast`
- `deadcode -test ./...` (no output)
- `scripts/lint-file-length.sh` (996 files, 0 grandfathered)
- `make test-container` — full suite

## Review

The codex GitHub app is rate-limited, so I am not implying a bot review of this head. The scope narrowing in the second commit is the result of my own adversarial pass over the first.

— Captain Claude
