### PR TITLE
test(tmux): fix the trust-gate guidance and widen the parity lock (#2416)

### DIFF
--- a/daemon/configagent.go
+++ b/daemon/configagent.go
@@ -304,10 +304,11 @@ func configAgentCodexReceiptHome(program, workingDir string) (string, error) {
 // The per-agent gate is tmux.ProgramNeedsTrustDismissal — the same call
 // LocalBackend.CheckAndHandleTrustPrompt makes, not a copy of its list. This
 // used to enumerate the agents here under a comment claiming it mirrored that
-// one, and it had already drifted: opencode was missing (#2416). The cost was
-// not a hang — isReadyContent's opencode arm treats the dialog as ready, so the
-// spawn proceeded and delivered the briefing INTO the undismissed dialog, which
-// is #729's signature.
+// one, and it had already drifted: opencode was missing (#2416). The exposure
+// was not a hang: isReadyContent's opencode arm calls a doc-trust dialog ready,
+// so had opencode ever raised one the spawn would have gone on to deliver the
+// briefing INTO it — #729's signature. opencode is not known to raise one, which
+// is why this stayed latent rather than being reported.
 func dismissConfigAgentTrustPrompt(ctx context.Context, target task.TrustPromptTarget) error {
 	if !tmux.ProgramNeedsTrustDismissal(target.ResolvedAgent()) {
 		return nil // AF has no dismissal to run for this program

--- a/daemon/configagent_trust_test.go
+++ b/daemon/configagent_trust_test.go
@@ -105,10 +105,11 @@ func TestDismissConfigAgentTrustPrompt_SkipsNonAgents(t *testing.T) {
 // This gate used to be its own hand-copied list of agents under a comment
 // claiming it mirrored LocalBackend.CheckAndHandleTrustPrompt. It had drifted:
 // opencode was added to that gate in #1959 and never here, so an opencode config
-// agent took the default branch and never ran the dismissal loop. It did not
-// hang — isReadyContent's opencode arm calls the dialog ready, so the spawn went
-// on to deliver the briefing into it. That is the #729 defect class the comment
-// was written to prevent.
+// agent took the default branch and never ran the dismissal loop. The exposure
+// was not a hang: isReadyContent's opencode arm calls a doc-trust dialog ready,
+// so had opencode ever raised one the spawn would have delivered the briefing
+// into it — the #729 defect class the comment was written to prevent. opencode
+// is not known to raise one, which is why this stayed latent.
 //
 // The case runs over the shared gate rather than a literal list, so it covers
 // whatever agents are in the gate today, and a future agent is covered the

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -54,11 +54,14 @@ func IsSupportedProgram(name string) bool {
 //
 // Both ways of being wrong cost something, and neither is free:
 //
-//   - Wrongly OUT: every agent in the set also has a trust arm in isReadyContent,
-//     so a pane showing the dialog reads as READY. Nothing then clears it and the
-//     briefing is typed into the modal. That is #729's actual signature, not a
-//     hang — codex was excluded here, its dialog was surfaced by isReadyContent,
-//     and the prompt went into it. #2416 put opencode in the same state.
+//   - Wrongly OUT: an agent that belongs in the set is one whose dialog
+//     isReadyContent also recognizes, so a pane showing that dialog reads as
+//     READY. Nothing then clears it and the briefing is typed into the modal.
+//     That is #729's actual signature, not a hang — codex was excluded here, its
+//     dialog was surfaced by isReadyContent, and the prompt went into it. #2416
+//     put opencode in the same state. task's
+//     TestTrustDialogIsReadyOnlyForAgentsAFCanDismiss is what keeps those two
+//     enumerations from drifting apart again.
 //   - Wrongly IN: membership subjects live panes to DocTrustPromptPresent on the
 //     daemon's one-second poll, and a false positive there types 'D'+Enter into a
 //     running agent that asked nothing — re-firing every tick the phrase stays on
@@ -67,7 +70,9 @@ func IsSupportedProgram(name string) bool {
 //
 // So a new agent belongs in the set once its first-run behaviour is characterized,
 // not by default in either direction. Guess IN and you may inject keystrokes into
-// live sessions; guess OUT and you may hand a briefing to a modal.
+// live sessions; guess OUT and you may hand a briefing to a modal. (amp is the one
+// member that predates this rule and was never characterized; it is grandfathered
+// in the classification table, not precedent for a new agent.)
 //
 // This is the ONE gate. Both dismissal sites call it instead of enumerating the
 // agents themselves: LocalBackend.CheckAndHandleTrustPrompt (a live session) and

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -52,27 +52,17 @@ func IsSupportedProgram(name string) bool {
 // set without a known dialog of their own. The question this answers is whether
 // AF looks.
 //
-// Both ways of being wrong cost something, and neither is free:
+// Neither answer is a safe default: wrongly out risks a briefing typed into an
+// undismissed modal (#729, #2416), wrongly in risks 'D'+Enter injected into a
+// live agent that asked nothing (#1952). The full argument, and the per-agent
+// decisions with their evidence, live in ONE place —
+// TestProgramNeedsTrustDismissal_ClassifiesEverySupportedAgent's table, which is
+// what goes red when a new agent is added and so is where the decision actually
+// gets made. Do not restate the argument here; two copies of it is what #2416
+// was, in prose.
 //
-//   - Wrongly OUT: an agent that belongs in the set is one whose dialog
-//     isReadyContent also recognizes, so a pane showing that dialog reads as
-//     READY. Nothing then clears it and the briefing is typed into the modal.
-//     That is #729's actual signature, not a hang — codex was excluded here, its
-//     dialog was surfaced by isReadyContent, and the prompt went into it. #2416
-//     put opencode in the same state. task's
-//     TestTrustDialogIsReadyOnlyForAgentsAFCanDismiss is what keeps those two
-//     enumerations from drifting apart again.
-//   - Wrongly IN: membership subjects live panes to DocTrustPromptPresent on the
-//     daemon's one-second poll, and a false positive there types 'D'+Enter into a
-//     running agent that asked nothing — re-firing every tick the phrase stays on
-//     screen (#1952). See that predicate's own doc in start.go; it is deliberately
-//     conservative for exactly this reason.
-//
-// So a new agent belongs in the set once its first-run behaviour is characterized,
-// not by default in either direction. Guess IN and you may inject keystrokes into
-// live sessions; guess OUT and you may hand a briefing to a modal. (amp is the one
-// member that predates this rule and was never characterized; it is grandfathered
-// in the classification table, not precedent for a new agent.)
+// task's TestTrustDialogIsReadyOnlyForAgentsAFCanDismiss holds this set against
+// isReadyContent's trust arms, so the two enumerations cannot drift apart.
 //
 // This is the ONE gate. Both dismissal sites call it instead of enumerating the
 // agents themselves: LocalBackend.CheckAndHandleTrustPrompt (a live session) and

--- a/session/tmux/trust_prompt_gate_test.go
+++ b/session/tmux/trust_prompt_gate_test.go
@@ -37,17 +37,20 @@ func TestProgramNeedsTrustDismissal_ClassifiesEverySupportedAgent(t *testing.T) 
 		ProgramCodex:  true,
 		ProgramAider:  true,
 		ProgramGemini: true,
-		// Verified to go straight to its composer in a fresh repo
-		// (0.0.0-main-202604230742), so no dialog of its own. In the set because
-		// the omission is exactly what #2416 was, and its generic-dialog behaviour
-		// is pinned by task's TestTrustDialogIsReadyOnlyForAgentsAFCanDismiss.
-		ProgramOpencode: true,
 		// Grandfathered — the one row that does not meet the "characterize first"
 		// rule above. amp's first run was never captured here; it has carried the
 		// dismissal check since before this gate was extracted, with no
 		// false-positive report against it. Left as it was rather than flipped on
-		// an untested guess. Not precedent for a NEW agent.
+		// an untested guess, and NOT precedent for a new agent. Flipping it is
+		// also no longer a free comment change: amp's isReadyContent arm carries
+		// isDocTrustPrompt, so task's parity test fails on the desync.
 		ProgramAmp: true,
+		// Verified to go straight to its composer in a fresh repo
+		// (0.0.0-main-202604230742), so no dialog of its own is known. In the set
+		// because the omission is exactly what #2416 was, and because its
+		// isReadyContent arm carries isDocTrustPrompt regardless — which is the
+		// desync task's parity test locks.
+		ProgramOpencode: true,
 		// Out because AF has no predicate identifying devin's workspace-trust
 		// modal: DocTrustPromptPresent cannot true-positive on that wording, so
 		// membership would buy no dismissal and leave only the false-positive

--- a/session/tmux/trust_prompt_gate_test.go
+++ b/session/tmux/trust_prompt_gate_test.go
@@ -10,12 +10,24 @@ import "testing"
 // forgetting the other was a silent, shippable mistake. It shipped twice: codex
 // (#729) and opencode (#1959 → #2416).
 //
-// The gate is one function now, but a new agent still defaults quietly to false,
-// and false is the expensive direction: the pane sits on an undismissed dialog
-// until readiness times out. This table is the forcing function — it must name
-// every entry of SupportedPrograms, so adding an agent fails here until someone
-// states which side it is on. Do not fix a failure by deleting the row; decide,
-// then record the decision with the reason.
+// The gate is one function now, but a new agent still defaults quietly to false.
+// This table is the forcing function: it must name every entry of
+// SupportedPrograms, so adding an agent fails here until someone states which
+// side it is on. Do not fix a failure by deleting the row; decide, then record
+// the decision with the reason.
+//
+// READ THIS BEFORE CHOOSING — both answers can cause harm, and the cheap one is
+// not obvious. ProgramNeedsTrustDismissal's doc carries the full argument:
+//
+//   - Wrongly false: an agent whose dialog isReadyContent recognizes reads as
+//     READY, nothing clears it, and the briefing is typed into the modal. That
+//     is #729, then #2416.
+//   - Wrongly true: the agent's live panes get DocTrustPromptPresent on the
+//     daemon's one-second poll, and a false positive there types 'D'+Enter into
+//     an agent that asked nothing, re-firing every tick (#1952).
+//
+// So neither answer is a safe default. Characterize the agent's first run, then
+// record what you saw.
 func TestProgramNeedsTrustDismissal_ClassifiesEverySupportedAgent(t *testing.T) {
 	classified := map[string]bool{
 		// Dialogs AF positively identifies and clears: claude's trust/MCP screens,
@@ -25,19 +37,22 @@ func TestProgramNeedsTrustDismissal_ClassifiesEverySupportedAgent(t *testing.T) 
 		ProgramCodex:  true,
 		ProgramAider:  true,
 		ProgramGemini: true,
-		// In the set without a known dialog of their own. opencode is verified to
-		// go straight to its composer in a fresh repo (0.0.0-main-202604230742);
-		// amp's first-run behaviour is not characterized here. Both are in anyway:
-		// the check injects nothing unless it identifies a dialog it can clear, so
-		// looking is close to free, while being wrongly OUT is how #729 and #2416
-		// both shipped.
-		ProgramAmp:      true,
+		// Verified to go straight to its composer in a fresh repo
+		// (0.0.0-main-202604230742), so no dialog of its own. In the set because
+		// the omission is exactly what #2416 was, and its generic-dialog behaviour
+		// is pinned by task's TestTrustDialogIsReadyOnlyForAgentsAFCanDismiss.
 		ProgramOpencode: true,
-		// Out because AF has no predicate that identifies devin's workspace-trust
-		// modal — the check could never match it, and treating an unclearable
-		// dialog as handled is the #729 trap (#2410 declined it for the same
-		// reason isReadyContent has no devin trust arm). This is NOT the claim
-		// that the modal never appears: see #2435.
+		// Grandfathered — the one row that does not meet the "characterize first"
+		// rule above. amp's first run was never captured here; it has carried the
+		// dismissal check since before this gate was extracted, with no
+		// false-positive report against it. Left as it was rather than flipped on
+		// an untested guess. Not precedent for a NEW agent.
+		ProgramAmp: true,
+		// Out because AF has no predicate identifying devin's workspace-trust
+		// modal: DocTrustPromptPresent cannot true-positive on that wording, so
+		// membership would buy no dismissal and leave only the false-positive
+		// exposure. Treating an unclearable dialog as handled is the #729 trap
+		// (#2410). NOT the claim that the modal never appears — see #2435.
 		ProgramDevin: false,
 	}
 
@@ -45,7 +60,7 @@ func TestProgramNeedsTrustDismissal_ClassifiesEverySupportedAgent(t *testing.T) 
 		want, named := classified[program]
 		if !named {
 			t.Errorf("supported agent %q is not classified for trust dismissal; "+
-				"decide whether AF should check its pane for a dialog and add it to this table", program)
+				"characterize its first run, then add it to this table with the reason", program)
 			continue
 		}
 		if got := ProgramNeedsTrustDismissal(program); got != want {

--- a/task/trust_readiness_parity_test.go
+++ b/task/trust_readiness_parity_test.go
@@ -13,37 +13,61 @@ const docTrustDialogFixture = `Add https://aider.chat/docs/faq.html to the chat?
 Open documentation url for more info
 (Y)es/(N)o/(D)on't ask again [Yes]:`
 
-// trustDialogKind records, per agent, WHICH first-run dialog it raises. Every
-// supported agent must appear; an unnamed one fails the test below.
+// Which predicate isReadyContent's arm for an agent uses to decide a trust
+// dialog means "ready". This is a fact about AF's code, greppable in runner.go —
+// NOT a claim about what the third-party agent displays.
 //
-// This map exists because the obvious version of this test — "skip claude and
-// codex, assert the biconditional for the rest" — is blind to the very incident
-// it cites. #729 was codex: an agent with its OWN dialog predicate that was
-// missing from the dismissal gate. Skipping the agent-specific cases skips that
-// shape entirely, and a hand-maintained skip list with no forcing function is
-// the same unforced hand-list #2416 was about, reintroduced inside its fix.
+// That distinction is the whole reason the gate is named
+// ProgramNeedsTrustDismissal rather than "has a trust prompt": amp and opencode
+// carry the isDocTrustPrompt arm without being known to raise the dialog at all
+// — opencode's arm says so itself, "kept for consistency with the other agents",
+// and amp's first run was never captured. Keying this map on agent behaviour
+// would assert things the repo has not measured, and in opencode's case the
+// opposite of what it did measure.
 const (
-	// dialogGeneric: raises the shared doc-trust dialog, which
-	// DocTrustPromptPresent identifies.
-	dialogGeneric = "generic"
-	// dialogAgentSpecific: raises its own dialog behind its own predicate
-	// (claude's trust/MCP screens, CodexTrustPromptPresent). The fixture below
-	// cannot speak for these, so they are asserted only for gate membership;
-	// their readiness arms are covered by their own cases in this package.
-	dialogAgentSpecific = "agent-specific"
-	// dialogNone: AF has no predicate that can identify a dialog for this agent,
-	// so it must stay OUT of the gate.
-	dialogNone = "none"
+	// armGeneric: the arm is isDocTrustPrompt, so docTrustDialogFixture exercises
+	// it and the full biconditional is checkable.
+	armGeneric = "generic"
+	// armAgentSpecific: the arm recognizes only the agent's OWN dialog and does
+	// not fall through to isDocTrustPrompt, so the shared fixture cannot exercise
+	// it and only gate membership is asserted. That arm is covered by the agent's
+	// own cases in runner_test.go. Note this is narrower than "has its own
+	// predicate" — claude has one and still falls through, so it is armGeneric.
+	armAgentSpecific = "agent-specific"
+	// armNone: no trust arm at all, so no dialog can ever read as ready, and the
+	// agent must stay out of the gate.
+	armNone = "none"
 )
 
-var trustDialogKind = map[string]string{
-	tmux.ProgramClaude:   dialogAgentSpecific,
-	tmux.ProgramCodex:    dialogAgentSpecific,
-	tmux.ProgramAider:    dialogGeneric,
-	tmux.ProgramGemini:   dialogGeneric,
-	tmux.ProgramAmp:      dialogGeneric,
-	tmux.ProgramOpencode: dialogGeneric,
-	tmux.ProgramDevin:    dialogNone,
+// trustReadinessArm must name every supported agent. It exists because the
+// obvious version of this test — "skip claude and codex, assert the
+// biconditional for the rest" — is blind to the very incident it cites. #729 was
+// codex: an agent with its OWN dialog predicate that was missing from the
+// dismissal gate. Skipping the agent-specific cases skips that shape entirely,
+// and a hand-maintained skip list with no forcing function is the same unforced
+// hand-list #2416 was about, reintroduced inside its own fix.
+//
+// Relabelling a row would DOWNGRADE what is asserted about that agent —
+// armGeneric is the only value carrying the full biconditional — so the label is
+// not taken on trust. Each value makes a checkable claim about whether the
+// generic doc-trust dialog reads as ready, and the test verifies that claim
+// against runner.go before using the label to pick an assertion. A row moved to
+// silence a failure fails on the label itself.
+var trustReadinessArm = map[string]string{
+	// claude's arm carries its own strings ("Do you trust", "new MCP server")
+	// AND falls through to isDocTrustPrompt, so the generic fixture does exercise
+	// it — armGeneric, not agent-specific. The label check below is what caught
+	// this; it was initially written as armAgentSpecific on the assumption that
+	// "has its own predicate" and "uses the generic one" were exclusive.
+	tmux.ProgramClaude: armGeneric,
+	// codex is the sole agent-specific member: CodexTrustPromptPresent plus the
+	// "›" composer glyph, with no isDocTrustPrompt fallback.
+	tmux.ProgramCodex:    armAgentSpecific,
+	tmux.ProgramAider:    armGeneric,
+	tmux.ProgramGemini:   armGeneric,
+	tmux.ProgramAmp:      armGeneric,
+	tmux.ProgramOpencode: armGeneric,
+	tmux.ProgramDevin:    armNone,
 }
 
 // TestTrustDialogIsReadyOnlyForAgentsAFCanDismiss locks the #729 invariant
@@ -60,52 +84,80 @@ var trustDialogKind = map[string]string{
 //
 // It is not circular: the two sides are independent implementations, neither
 // derived from the other, so a desync in either direction fails here. Verified by
-// experiment in both — forcing devin into the gate fails it, and removing
-// opencode fails it with #2416's own signature.
+// experiment in each — dropping codex from the gate, dropping opencode (#2416's
+// own state), and forcing devin in all fail, with distinct messages.
 //
-// What each kind can be asserted about differs, so the assertion is chosen per
-// kind rather than skipping the awkward agents:
-//
-//   - generic: the full biconditional against the shared fixture.
-//   - agent-specific: gate membership only. This fixture is not their dialog, so
-//     it cannot answer the readiness half; their own cases do.
-//   - none: must be out of the gate, since there is nothing AF could clear.
+// The assertion is chosen per arm rather than by skipping the awkward agents; see
+// trustReadinessArm.
 func TestTrustDialogIsReadyOnlyForAgentsAFCanDismiss(t *testing.T) {
+	fullyChecked := 0
 	for _, agent := range tmux.SupportedPrograms {
-		kind, named := trustDialogKind[agent]
+		arm, named := trustReadinessArm[agent]
 		if !named {
-			t.Errorf("supported agent %q has no entry in trustDialogKind; record which "+
-				"first-run dialog it raises so this invariant can be checked for it", agent)
+			t.Errorf("supported agent %q has no entry in trustReadinessArm; record which "+
+				"predicate its isReadyContent arm uses so this invariant can be checked for it", agent)
 			continue
 		}
 		inGate := tmux.ProgramNeedsTrustDismissal(agent)
 		ready := isReadyContent(docTrustDialogFixture, agent)
 
-		switch kind {
-		case dialogGeneric:
-			if ready != inGate {
-				t.Errorf("isReadyContent(docTrustDialog, %q) = %t but ProgramNeedsTrustDismissal(%q) = %t; "+
-					"a dialog AF calls ready must be one AF dismisses (#729)", agent, ready, agent, inGate)
+		// Verify the LABEL against runner.go first. Each arm value makes a
+		// checkable claim about whether the generic doc-trust dialog reads as
+		// ready, so a wrong or convenient label fails here rather than silently
+		// changing which assertion the agent gets. Without this the map is a
+		// strength dial: relabelling one row to armNone would turn a genuine #729
+		// desync green, which is exactly how a reviewer broke the previous version.
+		switch arm {
+		case armGeneric:
+			fullyChecked++
+			if !ready {
+				t.Errorf("%q is labelled armGeneric, but the generic doc-trust dialog does not make it "+
+					"ready — its isReadyContent arm no longer uses isDocTrustPrompt. Fix the row to "+
+					"match runner.go rather than leaving it stale", agent)
+				continue
 			}
-		case dialogAgentSpecific:
 			if !inGate {
-				t.Errorf("%q raises its own trust dialog and has a readiness predicate for it, "+
-					"but ProgramNeedsTrustDismissal(%q) = false; that is #729's shape — ready with "+
-					"nothing to clear it", agent, agent)
+				t.Errorf("isReadyContent(docTrustDialog, %q) = true but ProgramNeedsTrustDismissal(%q) = false; "+
+					"a dialog AF calls ready must be one AF dismisses (#729)", agent, agent)
 			}
-		case dialogNone:
+		case armAgentSpecific:
+			if ready {
+				t.Errorf("%q is labelled armAgentSpecific, but the generic doc-trust dialog makes it "+
+					"ready — its arm now includes isDocTrustPrompt, so it belongs in armGeneric where "+
+					"the full biconditional is checked", agent)
+			}
+			if !inGate {
+				t.Errorf("%q is labelled armAgentSpecific — it has its own readiness predicate for its "+
+					"own trust dialog — but ProgramNeedsTrustDismissal(%q) = false; that is #729's "+
+					"shape, ready with nothing to clear it", agent, agent)
+			}
+		case armNone:
+			if ready {
+				t.Errorf("%q is labelled armNone, but the generic doc-trust dialog makes it ready — it "+
+					"does have a doc-trust arm, so relabel it armGeneric. Do NOT leave this row as a "+
+					"way to skip the check", agent)
+			}
 			if inGate {
-				t.Errorf("%q has no dialog AF can identify, but ProgramNeedsTrustDismissal(%q) = true; "+
-					"the loop would buy no dismissal and leave only false-positive exposure (#1952)", agent, agent)
+				t.Errorf("%q has no trust arm, so no dialog of its can read as ready, but "+
+					"ProgramNeedsTrustDismissal(%q) = true; the loop would buy no dismissal and leave "+
+					"only false-positive exposure (#1952)", agent, agent)
 			}
 		default:
-			t.Errorf("agent %q has unknown trust-dialog kind %q", agent, kind)
+			t.Errorf("agent %q has unknown trust-readiness arm %q", agent, arm)
 		}
 	}
 
-	for agent := range trustDialogKind {
+	// armGeneric is the only value that checks the biconditional. Without this,
+	// relabelling every generic row leaves a green test asserting nothing —
+	// changing one word could turn a red test green with the defect intact.
+	if fullyChecked == 0 {
+		t.Fatal("no agent is classified armGeneric, so the biconditional is never checked — " +
+			"a row was probably relabelled to silence a failure")
+	}
+
+	for agent := range trustReadinessArm {
 		if !tmux.IsSupportedProgram(agent) {
-			t.Errorf("trustDialogKind names %q, which is no longer a supported agent; drop its row", agent)
+			t.Errorf("trustReadinessArm names %q, which is no longer a supported agent; drop its row", agent)
 		}
 	}
 }

--- a/task/trust_readiness_parity_test.go
+++ b/task/trust_readiness_parity_test.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/session/tmux"
@@ -9,6 +10,12 @@ import (
 // docTrustDialogFixture is the generic documentation-trust dialog, at the full
 // length DocTrustPromptPresent requires (it deliberately refuses to match a
 // shortened prefix — see its doc in session/tmux/start.go).
+//
+// It must contain NO agent composer glyph. Several arms are a disjunction of a
+// trust predicate and a composer glyph (codex is CodexTrustPromptPresent || "›"),
+// so a stray glyph would make those agents "ready" for a reason that has nothing
+// to do with a trust dialog, and the label checks below would blame runner.go for
+// a change in this string. TestTrustDialogFixtureHasNoComposerGlyph guards it.
 const docTrustDialogFixture = `Add https://aider.chat/docs/faq.html to the chat?
 Open documentation url for more info
 (Y)es/(N)o/(D)on't ask again [Yes]:`
@@ -21,53 +28,94 @@ Open documentation url for more info
 // ProgramNeedsTrustDismissal rather than "has a trust prompt": amp and opencode
 // carry the isDocTrustPrompt arm without being known to raise the dialog at all
 // — opencode's arm says so itself, "kept for consistency with the other agents",
-// and amp's first run was never captured. Keying this map on agent behaviour
-// would assert things the repo has not measured, and in opencode's case the
-// opposite of what it did measure.
+// and amp's first run was never captured. Keying this on agent behaviour would
+// assert things the repo has not measured, and in opencode's case the opposite
+// of what it did measure.
 const (
-	// armGeneric: the arm is isDocTrustPrompt, so docTrustDialogFixture exercises
-	// it and the full biconditional is checkable.
+	// armGeneric: the arm falls through to isDocTrustPrompt, so
+	// docTrustDialogFixture exercises it. claude qualifies despite also having its
+	// own strings — "has its own predicate" and "uses the generic one" are not
+	// exclusive.
 	armGeneric = "generic"
 	// armAgentSpecific: the arm recognizes only the agent's OWN dialog and does
 	// not fall through to isDocTrustPrompt, so the shared fixture cannot exercise
-	// it and only gate membership is asserted. That arm is covered by the agent's
-	// own cases in runner_test.go. Note this is narrower than "has its own
-	// predicate" — claude has one and still falls through, so it is armGeneric.
+	// it. codex is the sole member; its arm is covered by its own cases in
+	// runner_test.go.
 	armAgentSpecific = "agent-specific"
-	// armNone: no trust arm at all, so no dialog can ever read as ready, and the
-	// agent must stay out of the gate.
+	// armNone: no trust arm at all, so no dialog can ever read as ready.
 	armNone = "none"
 )
 
-// trustReadinessArm must name every supported agent. It exists because the
-// obvious version of this test — "skip claude and codex, assert the
-// biconditional for the rest" — is blind to the very incident it cites. #729 was
-// codex: an agent with its OWN dialog predicate that was missing from the
-// dismissal gate. Skipping the agent-specific cases skips that shape entirely,
+// trustArmSpec pairs the verifiable fact with the policy decision, deliberately
+// keeping them in separate fields.
+type trustArmSpec struct {
+	// arm is which predicate isReadyContent uses. It is VERIFIED against
+	// runner.go below, not taken on trust.
+	arm string
+	// inGate is what ProgramNeedsTrustDismissal must answer. It is STATED, never
+	// inferred from arm — and that is load-bearing.
+	//
+	// The label check can only ask runner.go one question: does the generic
+	// fixture make this agent ready? That splits three labels into two buckets —
+	// armGeneric (true) versus armAgentSpecific and armNone (both false). Those
+	// two are indistinguishable to the check while implying OPPOSITE gate
+	// answers, so inferring inGate from arm would let a relabel between them move
+	// the gate expectation silently. Both halves were demonstrated against the
+	// inferred version and both passed: relabel devin armNone→armAgentSpecific
+	// and add it to the gate (the #1952 exposure, waved through), or relabel
+	// codex armAgentSpecific→armNone and drop it from the gate (#729's literal
+	// shape). Stating inGate closes both, because no relabel can move it.
+	inGate bool
+}
+
+// trustReadinessArm must name every supported agent.
+//
+// It exists because the obvious version of this test — "skip claude and codex,
+// assert the biconditional for the rest" — is blind to the very incident it
+// cites. #729 was codex: an agent with its OWN dialog predicate that was missing
+// from the dismissal gate. Skipping the agent-specific cases skips that shape,
 // and a hand-maintained skip list with no forcing function is the same unforced
 // hand-list #2416 was about, reintroduced inside its own fix.
 //
-// Relabelling a row would DOWNGRADE what is asserted about that agent —
-// armGeneric is the only value carrying the full biconditional — so the label is
-// not taken on trust. Each value makes a checkable claim about whether the
-// generic doc-trust dialog reads as ready, and the test verifies that claim
-// against runner.go before using the label to pick an assertion. A row moved to
-// silence a failure fails on the label itself.
-var trustReadinessArm = map[string]string{
-	// claude's arm carries its own strings ("Do you trust", "new MCP server")
-	// AND falls through to isDocTrustPrompt, so the generic fixture does exercise
-	// it — armGeneric, not agent-specific. The label check below is what caught
-	// this; it was initially written as armAgentSpecific on the assumption that
-	// "has its own predicate" and "uses the generic one" were exclusive.
-	tmux.ProgramClaude: armGeneric,
-	// codex is the sole agent-specific member: CodexTrustPromptPresent plus the
-	// "›" composer glyph, with no isDocTrustPrompt fallback.
-	tmux.ProgramCodex:    armAgentSpecific,
-	tmux.ProgramAider:    armGeneric,
-	tmux.ProgramGemini:   armGeneric,
-	tmux.ProgramAmp:      armGeneric,
-	tmux.ProgramOpencode: armGeneric,
-	tmux.ProgramDevin:    armNone,
+// The inGate column deliberately restates what session/tmux's classification
+// table pins. That duplication is safe in a way #2416's was not: both are
+// compared against the same ProgramNeedsTrustDismissal, so if they ever disagree
+// one goes red immediately. Silent drift was the danger, not duplication.
+var trustReadinessArm = map[string]trustArmSpec{
+	// claude's arm carries its own strings ("Do you trust", "new MCP server") AND
+	// falls through to isDocTrustPrompt, so the generic fixture does exercise it.
+	// The label check is what caught this — it was first written armAgentSpecific
+	// on the assumption that the two were exclusive.
+	tmux.ProgramClaude: {arm: armGeneric, inGate: true},
+	// codex: CodexTrustPromptPresent plus the "›" composer glyph, with no
+	// isDocTrustPrompt fallthrough. The sole agent-specific member.
+	tmux.ProgramCodex:    {arm: armAgentSpecific, inGate: true},
+	tmux.ProgramAider:    {arm: armGeneric, inGate: true},
+	tmux.ProgramGemini:   {arm: armGeneric, inGate: true},
+	tmux.ProgramAmp:      {arm: armGeneric, inGate: true},
+	tmux.ProgramOpencode: {arm: armGeneric, inGate: true},
+	// devin has no trust arm and is out of the gate: AF has no predicate that
+	// identifies its modal, so membership would buy no dismissal and leave only
+	// false-positive exposure (#1952). If #2435 gives AF a devin predicate, the
+	// likely end state is {arm: armNone, inGate: true} — dismissed on the poll,
+	// never treated as ready. Separate fields make that representable; inferring
+	// inGate from arm did not.
+	tmux.ProgramDevin: {arm: armNone, inGate: false},
+}
+
+// TestTrustDialogFixtureHasNoComposerGlyph guards the precondition the label
+// checks depend on. Several readiness arms are (trust predicate || composer
+// glyph); a glyph in the fixture would make those agents ready for an unrelated
+// reason and produce a confident, wrong diagnosis pointing at runner.go.
+func TestTrustDialogFixtureHasNoComposerGlyph(t *testing.T) {
+	// claude ❯, codex ›, devin ❭, and frame glyphs the amp/opencode checks use.
+	for _, glyph := range []string{"❯", "›", "❭", "┃", "╹", "╰"} {
+		if strings.Contains(docTrustDialogFixture, glyph) {
+			t.Fatalf("docTrustDialogFixture contains the composer glyph %q; agents whose arm is "+
+				"(trust predicate || glyph) would read as ready for a reason unrelated to any trust "+
+				"dialog, and the parity checks would misattribute that to runner.go", glyph)
+		}
+	}
 }
 
 // TestTrustDialogIsReadyOnlyForAgentsAFCanDismiss locks the #729 invariant
@@ -79,80 +127,64 @@ var trustReadinessArm = map[string]string{
 //
 // If an agent is ready-on-dialog but not in the gate, AF calls the pane usable
 // and types the briefing into an undismissed modal. That is #729 exactly — codex
-// had a trust arm here and was missing from the gate — and #2416 put opencode in
-// the same state.
+// had a trust arm and was missing from the gate — and #2416 put opencode in the
+// same state.
 //
-// It is not circular: the two sides are independent implementations, neither
-// derived from the other, so a desync in either direction fails here. Verified by
-// experiment in each — dropping codex from the gate, dropping opencode (#2416's
-// own state), and forcing devin in all fail, with distinct messages.
-//
-// The assertion is chosen per arm rather than by skipping the awkward agents; see
-// trustReadinessArm.
+// It is not circular: isReadyContent and ProgramNeedsTrustDismissal are
+// independent implementations, neither derived from the other.
 func TestTrustDialogIsReadyOnlyForAgentsAFCanDismiss(t *testing.T) {
-	fullyChecked := 0
+	biconditionalsChecked := 0
 	for _, agent := range tmux.SupportedPrograms {
-		arm, named := trustReadinessArm[agent]
+		spec, named := trustReadinessArm[agent]
 		if !named {
-			t.Errorf("supported agent %q has no entry in trustReadinessArm; record which "+
-				"predicate its isReadyContent arm uses so this invariant can be checked for it", agent)
+			t.Errorf("supported agent %q has no entry in trustReadinessArm; record which predicate "+
+				"its isReadyContent arm uses, and whether it belongs in the dismissal gate", agent)
 			continue
 		}
 		inGate := tmux.ProgramNeedsTrustDismissal(agent)
 		ready := isReadyContent(docTrustDialogFixture, agent)
 
-		// Verify the LABEL against runner.go first. Each arm value makes a
-		// checkable claim about whether the generic doc-trust dialog reads as
-		// ready, so a wrong or convenient label fails here rather than silently
-		// changing which assertion the agent gets. Without this the map is a
-		// strength dial: relabelling one row to armNone would turn a genuine #729
-		// desync green, which is exactly how a reviewer broke the previous version.
-		switch arm {
+		// The gate answer is checked against the STATED expectation, so no arm
+		// relabel can move it. See trustArmSpec.inGate.
+		if inGate != spec.inGate {
+			t.Errorf("ProgramNeedsTrustDismissal(%q) = %t, want %t; if this is an intended change, "+
+				"update the row and say why — do not relabel its arm to make this pass",
+				agent, inGate, spec.inGate)
+		}
+
+		// Then verify the arm label itself against runner.go, so a stale or
+		// convenient label fails rather than silently changing what is asserted.
+		switch spec.arm {
 		case armGeneric:
-			fullyChecked++
 			if !ready {
 				t.Errorf("%q is labelled armGeneric, but the generic doc-trust dialog does not make it "+
-					"ready — its isReadyContent arm no longer uses isDocTrustPrompt. Fix the row to "+
-					"match runner.go rather than leaving it stale", agent)
+					"ready — its isReadyContent arm no longer falls through to isDocTrustPrompt. Fix "+
+					"the row to match runner.go rather than leaving it stale", agent)
 				continue
 			}
+			biconditionalsChecked++
+			// ready is true, so #729 says this agent must be dismissable.
 			if !inGate {
-				t.Errorf("isReadyContent(docTrustDialog, %q) = true but ProgramNeedsTrustDismissal(%q) = false; "+
-					"a dialog AF calls ready must be one AF dismisses (#729)", agent, agent)
+				t.Errorf("isReadyContent(docTrustDialog, %q) = true but ProgramNeedsTrustDismissal(%q) = "+
+					"false; a dialog AF calls ready must be one AF dismisses (#729)", agent, agent)
 			}
-		case armAgentSpecific:
+		case armAgentSpecific, armNone:
 			if ready {
-				t.Errorf("%q is labelled armAgentSpecific, but the generic doc-trust dialog makes it "+
-					"ready — its arm now includes isDocTrustPrompt, so it belongs in armGeneric where "+
-					"the full biconditional is checked", agent)
-			}
-			if !inGate {
-				t.Errorf("%q is labelled armAgentSpecific — it has its own readiness predicate for its "+
-					"own trust dialog — but ProgramNeedsTrustDismissal(%q) = false; that is #729's "+
-					"shape, ready with nothing to clear it", agent, agent)
-			}
-		case armNone:
-			if ready {
-				t.Errorf("%q is labelled armNone, but the generic doc-trust dialog makes it ready — it "+
-					"does have a doc-trust arm, so relabel it armGeneric. Do NOT leave this row as a "+
-					"way to skip the check", agent)
-			}
-			if inGate {
-				t.Errorf("%q has no trust arm, so no dialog of its can read as ready, but "+
-					"ProgramNeedsTrustDismissal(%q) = true; the loop would buy no dismissal and leave "+
-					"only false-positive exposure (#1952)", agent, agent)
+				t.Errorf("%q is labelled %s, but the generic doc-trust dialog makes it ready — its arm "+
+					"does fall through to isDocTrustPrompt, so it belongs in armGeneric where the "+
+					"biconditional is checked", agent, spec.arm)
 			}
 		default:
-			t.Errorf("agent %q has unknown trust-readiness arm %q", agent, arm)
+			t.Errorf("agent %q has unknown trust-readiness arm %q", agent, spec.arm)
 		}
 	}
 
-	// armGeneric is the only value that checks the biconditional. Without this,
-	// relabelling every generic row leaves a green test asserting nothing —
-	// changing one word could turn a red test green with the defect intact.
-	if fullyChecked == 0 {
-		t.Fatal("no agent is classified armGeneric, so the biconditional is never checked — " +
-			"a row was probably relabelled to silence a failure")
+	// Covers the wholesale case the per-row checks cannot: isDocTrustPrompt
+	// removed from every arm in runner.go with all labels updated to match. Every
+	// label check would pass and the #729 biconditional would never run.
+	if biconditionalsChecked == 0 {
+		t.Fatal("no agent exercised the ready-implies-dismissable check — the generic doc-trust " +
+			"readiness concept appears to be gone from runner.go entirely")
 	}
 
 	for agent := range trustReadinessArm {

--- a/task/trust_readiness_parity_test.go
+++ b/task/trust_readiness_parity_test.go
@@ -11,11 +11,10 @@ import (
 // length DocTrustPromptPresent requires (it deliberately refuses to match a
 // shortened prefix — see its doc in session/tmux/start.go).
 //
-// It must contain NO agent composer glyph. Several arms are a disjunction of a
-// trust predicate and a composer glyph (codex is CodexTrustPromptPresent || "›"),
-// so a stray glyph would make those agents "ready" for a reason that has nothing
-// to do with a trust dialog, and the label checks below would blame runner.go for
-// a change in this string. TestTrustDialogFixtureHasNoComposerGlyph guards it.
+// It must read as ready ONLY because it is a trust dialog: several arms are a
+// disjunction of a trust predicate and some other ready signal, so a second
+// signal hiding in here would satisfy a label check for the wrong reason.
+// TestTrustDialogFixtureCarriesOnlyATrustSignal guards that, via nonTrustTwin.
 const docTrustDialogFixture = `Add https://aider.chat/docs/faq.html to the chat?
 Open documentation url for more info
 (Y)es/(N)o/(D)on't ask again [Yes]:`
@@ -103,17 +102,41 @@ var trustReadinessArm = map[string]trustArmSpec{
 	tmux.ProgramDevin: {arm: armNone, inGate: false},
 }
 
-// TestTrustDialogFixtureHasNoComposerGlyph guards the precondition the label
-// checks depend on. Several readiness arms are (trust predicate || composer
-// glyph); a glyph in the fixture would make those agents ready for an unrelated
-// reason and produce a confident, wrong diagnosis pointing at runner.go.
-func TestTrustDialogFixtureHasNoComposerGlyph(t *testing.T) {
-	// claude ❯, codex ›, devin ❭, and frame glyphs the amp/opencode checks use.
-	for _, glyph := range []string{"❯", "›", "❭", "┃", "╹", "╰"} {
-		if strings.Contains(docTrustDialogFixture, glyph) {
-			t.Fatalf("docTrustDialogFixture contains the composer glyph %q; agents whose arm is "+
-				"(trust predicate || glyph) would read as ready for a reason unrelated to any trust "+
-				"dialog, and the parity checks would misattribute that to runner.go", glyph)
+// nonTrustTwin is docTrustDialogFixture with its doc-trust anchors removed, so
+// nothing about it should read as ready to any agent.
+//
+// DERIVED from the fixture rather than written alongside it. That is the
+// load-bearing part: a parallel constant would drift, while a replacement
+// carries any edit to the fixture into the twin automatically. If the fixture
+// ever gains a second ready signal, the twin gains it too and the check below
+// fails.
+var nonTrustTwin = strings.NewReplacer(
+	"Open documentation url for more info", "Some unrelated status line",
+	"(D)on't ask again", "",
+).Replace(docTrustDialogFixture)
+
+// TestTrustDialogFixtureCarriesOnlyATrustSignal guards the precondition every
+// label check depends on: that docTrustDialogFixture reads as ready ONLY because
+// it is a trust dialog.
+//
+// Several arms are (trust predicate || some other ready signal) — codex is
+// CodexTrustPromptPresent || "›", aider is isDocTrustPrompt || "\n> " || "Aider
+// v". A second signal hiding in the fixture would satisfy an armGeneric label
+// check for the wrong reason, making that row's verification vacuous while
+// staying green, and would fail armAgentSpecific rows with a confident diagnosis
+// blaming runner.go for a change in this string.
+//
+// Asserting on the derived twin rather than enumerating forbidden glyphs is
+// deliberate. An enumeration is a hand-maintained list that fails SILENTLY when
+// incomplete — the exact failure this whole change is about. A reviewer
+// demonstrated it: with a glyph list, adding "\n> " to the fixture left both
+// tests green while aider's arm had genuinely lost isDocTrustPrompt.
+func TestTrustDialogFixtureCarriesOnlyATrustSignal(t *testing.T) {
+	for _, agent := range tmux.SupportedPrograms {
+		if isReadyContent(nonTrustTwin, agent) {
+			t.Errorf("the doc-trust-stripped twin reads ready for %q: docTrustDialogFixture carries a "+
+				"ready signal that is not the trust dialog, so %q's label check is satisfied for the "+
+				"wrong reason and proves nothing", agent, agent)
 		}
 	}
 }
@@ -147,9 +170,18 @@ func TestTrustDialogIsReadyOnlyForAgentsAFCanDismiss(t *testing.T) {
 		// The gate answer is checked against the STATED expectation, so no arm
 		// relabel can move it. See trustArmSpec.inGate.
 		if inGate != spec.inGate {
-			t.Errorf("ProgramNeedsTrustDismissal(%q) = %t, want %t; if this is an intended change, "+
-				"update the row and say why — do not relabel its arm to make this pass",
-				agent, inGate, spec.inGate)
+			// Carry the reason into the message, not just the row comment: this is
+			// what someone reads in CI, and which direction they broke it in
+			// decides which harm they are about to ship.
+			why := "letting it into the gate buys no dismissal AF can perform and leaves only " +
+				"DocTrustPromptPresent's false-positive exposure on live panes (#1952)"
+			if spec.inGate {
+				why = "dropping it from the gate leaves a dialog AF calls ready with nothing to " +
+					"clear it, so the briefing is typed into the modal (#729)"
+			}
+			t.Errorf("ProgramNeedsTrustDismissal(%q) = %t, want %t: %s. If this is an intended "+
+				"change, update the row and say why — do not relabel its arm to make this pass",
+				agent, inGate, spec.inGate, why)
 		}
 
 		// Then verify the arm label itself against runner.go, so a stale or

--- a/task/trust_readiness_parity_test.go
+++ b/task/trust_readiness_parity_test.go
@@ -7,11 +7,44 @@ import (
 )
 
 // docTrustDialogFixture is the generic documentation-trust dialog, at the full
-// length DocTrustPromptPresent requires. It is the one dialog shared across the
-// file-seam agents, which is what makes a single fixture enough below.
+// length DocTrustPromptPresent requires (it deliberately refuses to match a
+// shortened prefix — see its doc in session/tmux/start.go).
 const docTrustDialogFixture = `Add https://aider.chat/docs/faq.html to the chat?
 Open documentation url for more info
 (Y)es/(N)o/(D)on't ask again [Yes]:`
+
+// trustDialogKind records, per agent, WHICH first-run dialog it raises. Every
+// supported agent must appear; an unnamed one fails the test below.
+//
+// This map exists because the obvious version of this test — "skip claude and
+// codex, assert the biconditional for the rest" — is blind to the very incident
+// it cites. #729 was codex: an agent with its OWN dialog predicate that was
+// missing from the dismissal gate. Skipping the agent-specific cases skips that
+// shape entirely, and a hand-maintained skip list with no forcing function is
+// the same unforced hand-list #2416 was about, reintroduced inside its fix.
+const (
+	// dialogGeneric: raises the shared doc-trust dialog, which
+	// DocTrustPromptPresent identifies.
+	dialogGeneric = "generic"
+	// dialogAgentSpecific: raises its own dialog behind its own predicate
+	// (claude's trust/MCP screens, CodexTrustPromptPresent). The fixture below
+	// cannot speak for these, so they are asserted only for gate membership;
+	// their readiness arms are covered by their own cases in this package.
+	dialogAgentSpecific = "agent-specific"
+	// dialogNone: AF has no predicate that can identify a dialog for this agent,
+	// so it must stay OUT of the gate.
+	dialogNone = "none"
+)
+
+var trustDialogKind = map[string]string{
+	tmux.ProgramClaude:   dialogAgentSpecific,
+	tmux.ProgramCodex:    dialogAgentSpecific,
+	tmux.ProgramAider:    dialogGeneric,
+	tmux.ProgramGemini:   dialogGeneric,
+	tmux.ProgramAmp:      dialogGeneric,
+	tmux.ProgramOpencode: dialogGeneric,
+	tmux.ProgramDevin:    dialogNone,
+}
 
 // TestTrustDialogIsReadyOnlyForAgentsAFCanDismiss locks the #729 invariant
 // across the two enumerations that have to agree about it:
@@ -20,37 +53,59 @@ Open documentation url for more info
 //     READY, and
 //   - tmux.ProgramNeedsTrustDismissal decides whether AF will then clear it.
 //
-// If an agent is ready-on-dialog but not in the gate, AF declares the pane usable
+// If an agent is ready-on-dialog but not in the gate, AF calls the pane usable
 // and types the briefing into an undismissed modal. That is #729 exactly — codex
 // had a trust arm here and was missing from the gate — and #2416 put opencode in
-// the same state. The reverse desync is milder but still wrong: AF would run a
-// dismissal loop for a dialog it never treats as a reason to keep waiting.
+// the same state.
 //
-// #2416 unified the two DISMISSAL sites, but this readiness arm is a third
-// enumeration of the same fact and nothing tied it to them. It is not circular:
-// the two sides are independent implementations, neither derived from the other,
-// so a desync in either direction fails here. Verified it bites by temporarily
-// adding devin to the gate — isReadyContent has no devin trust arm, and the case
-// failed on that mismatch.
+// It is not circular: the two sides are independent implementations, neither
+// derived from the other, so a desync in either direction fails here. Verified by
+// experiment in both — forcing devin into the gate fails it, and removing
+// opencode fails it with #2416's own signature.
 //
-// claude and codex are skipped deliberately: they carry agent-specific dialog
-// predicates (claude's trust/MCP screens, CodexTrustPromptPresent) rather than
-// the generic doc-trust one, so this fixture cannot speak for them. Their arms
-// are covered by their own cases in this package and in session/tmux.
+// What each kind can be asserted about differs, so the assertion is chosen per
+// kind rather than skipping the awkward agents:
+//
+//   - generic: the full biconditional against the shared fixture.
+//   - agent-specific: gate membership only. This fixture is not their dialog, so
+//     it cannot answer the readiness half; their own cases do.
+//   - none: must be out of the gate, since there is nothing AF could clear.
 func TestTrustDialogIsReadyOnlyForAgentsAFCanDismiss(t *testing.T) {
-	covered := 0
 	for _, agent := range tmux.SupportedPrograms {
-		if agent == tmux.ProgramClaude || agent == tmux.ProgramCodex {
+		kind, named := trustDialogKind[agent]
+		if !named {
+			t.Errorf("supported agent %q has no entry in trustDialogKind; record which "+
+				"first-run dialog it raises so this invariant can be checked for it", agent)
 			continue
 		}
-		covered++
-		want := tmux.ProgramNeedsTrustDismissal(agent)
-		if got := isReadyContent(docTrustDialogFixture, agent); got != want {
-			t.Errorf("isReadyContent(docTrustDialog, %q) = %t but ProgramNeedsTrustDismissal(%q) = %t; "+
-				"a dialog AF calls ready must be one AF dismisses (#729)", agent, got, agent, want)
+		inGate := tmux.ProgramNeedsTrustDismissal(agent)
+		ready := isReadyContent(docTrustDialogFixture, agent)
+
+		switch kind {
+		case dialogGeneric:
+			if ready != inGate {
+				t.Errorf("isReadyContent(docTrustDialog, %q) = %t but ProgramNeedsTrustDismissal(%q) = %t; "+
+					"a dialog AF calls ready must be one AF dismisses (#729)", agent, ready, agent, inGate)
+			}
+		case dialogAgentSpecific:
+			if !inGate {
+				t.Errorf("%q raises its own trust dialog and has a readiness predicate for it, "+
+					"but ProgramNeedsTrustDismissal(%q) = false; that is #729's shape — ready with "+
+					"nothing to clear it", agent, agent)
+			}
+		case dialogNone:
+			if inGate {
+				t.Errorf("%q has no dialog AF can identify, but ProgramNeedsTrustDismissal(%q) = true; "+
+					"the loop would buy no dismissal and leave only false-positive exposure (#1952)", agent, agent)
+			}
+		default:
+			t.Errorf("agent %q has unknown trust-dialog kind %q", agent, kind)
 		}
 	}
-	if covered == 0 {
-		t.Fatal("only claude and codex are supported agents; this case asserts nothing")
+
+	for agent := range trustDialogKind {
+		if !tmux.IsSupportedProgram(agent) {
+			t.Errorf("trustDialogKind names %q, which is no longer a supported agent; drop its row", agent)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #2428 (#2416). That PR auto-merged at `11706d63` while a third independent review pass was still running against it. The review came back with two P2s and three P3s, none of which are in master. This is those fixes.

The code behaviour of #2428 is unchanged and was correct. Everything here is guidance, comment accuracy, and one materially stronger test.

## The finding that matters — corrected guidance in only one of its two homes

#2428's second commit removed a false claim from `ProgramNeedsTrustDismissal`'s doc: that checking a pane for a trust dialog is "close to free" and that being wrongly OUT of the gate is "the expensive direction". Both halves are wrong — `DocTrustPromptPresent`'s own doc argues the opposite at length: a miss costs one keypress, a false positive types `'D'`+Enter into a running agent that asked nothing and re-fires every tick (#1952).

I stated in that commit that I had removed the claim entirely. I had removed it from one of its two homes. `session/tmux/trust_prompt_gate_test.go` still carried all three corrected claims verbatim, and that is the worse placement of the two:

> That table is the failure-output surface. It is what goes red when agent #8 is added, and its comments are what someone reads while deciding `true` or `false`.

So the corrected argument sat in a doc comment a maintainer had no reason to open, while the text at the actual decision point still told them to default to `true` — which would put an uncharacterized agent's live panes under `DocTrustPromptPresent` on the daemon's one-second poll. That is the #1952 exposure the rewrite existed to warn about.

Both homes now state both directions, and the classification table leads with them.

## The parity test skipped the incident it cites

`TestTrustDialogIsReadyOnlyForAgentsAFCanDismiss`, added in #2428, claimed to lock the #729 invariant but skipped claude and codex — **and codex is #729**: an agent with its own dialog predicate that was missing from the dismissal gate. Skipping the agent-specific cases skipped the incident's own shape. An agent could violate the real invariant and pass cleanly.

Worse, the skip was a two-name hand-maintained agent list with no forcing function — the exact unforced hand-list #2416 exists to eliminate, reintroduced inside its own fix.

Replaced with a `trustDialogKind` map that must name every supported agent, with the assertion chosen per kind instead of skipping the awkward ones:

- `generic` → the full biconditional against the shared doc-trust fixture
- `agent-specific` → gate membership only (this fixture is not their dialog, so it cannot answer the readiness half; their own cases do)
- `none` → must stay out of the gate

Verified all four ways, each producing a direction-appropriate message:

| Perturbation | Result |
|---|---|
| codex dropped from the gate | `"codex" raises its own trust dialog and has a readiness predicate for it … that is #729's shape` |
| opencode dropped from the gate | `isReadyContent(docTrustDialog, "opencode") = true but ProgramNeedsTrustDismissal("opencode") = false` — #2416's own signature |
| devin forced into the gate | `"devin" has no dialog AF can identify … only false-positive exposure (#1952)` |
| a new unclassified agent added | both forcing functions fire, in `task` and in `session/tmux` |

The first row is the one the old version could not see.

## Smaller corrections

- **Quantifier slip.** The wrongly-OUT bullet quantified over set *members* to explain a *non*-member's cost. It now states the premise it meant — an agent that belongs in the set is one whose dialog `isReadyContent` also recognizes — and names the parity test as what keeps that premise from decaying.
- **amp contradicted the new rule.** #2428 introduced "characterize the agent's first run, then decide", but amp is in the set and was never characterized. The deleted "looking is close to free" line had been what justified its row. Grandfathered explicitly, with the reason, and marked as not precedent for a new agent.
- **Indicative used for a counterfactual.** The corrected #2416 failure mode was written as though it had happened ("the spawn proceeded and delivered the briefing into the dialog"). opencode raises no known dialog, so the exposure was latent, not observed. Now conditional, in `daemon/configagent.go` and the daemon test.

## Review provenance

`@codex` is rate-limited until Jul 28 and answered #2428's single request with its usage-limit notice — a stated non-answer. The review of record is an independent Claude review, adversarially prompted, which ran three passes against #2428 and found real defects in each, including two I had introduced myself while fixing the previous round. This PR is pass three's output.

I will get this head reviewed too before merging rather than assuming a comment-only change is safe — the last two rounds both found that my corrections had introduced something.

## Gates

Exact head: `1b5a8064`.

- `golangci-lint run --timeout=3m --fast` · `gofmt -l .` · `go build ./...` · `deadcode -test ./...` · `scripts/lint-file-length.sh` — clean
- `make test-container` — full suite on this pushed head

No production-code behaviour change: `ProgramNeedsTrustDismissal` returns exactly what it returned in #2428, for every input.

Refs #2416.

— Captain Claude
