### PR TITLE
fix(session): refuse root handoff in the shared guard (#2436)

### DIFF
--- a/app/handoff_action_test.go
+++ b/app/handoff_action_test.go
@@ -73,6 +73,66 @@ func TestHandleHandoff_RefusesArchivedSessionBeforePicker(t *testing.T) {
 	require.Contains(t, strings.ToLower(h.errBox.FullError()), "archived")
 }
 
+// TestHandleHandoff_RefusesReservedRootBeforePicker is the #2436 regression. The
+// daemon has always refused to hand off the reserved root agent, but the TUI let
+// the user pick an agent and confirm the swap first, so the refusal arrived after
+// the interaction instead of instead of it — the exact shape this file's sibling
+// above exists to prevent, and which handleHandoff's own comment ("Guards run
+// BEFORE the picker, not after the choice") calls out as reading like a bug.
+//
+// Root is otherwise a perfectly healthy Ready session, so nothing else in the
+// guard chain rejects it: the row is live, started, and its backend advertises
+// Handoff. Only the reserved title makes it ineligible.
+func TestHandleHandoff_RefusesReservedRootBeforePicker(t *testing.T) {
+	h := newTestHome(t)
+	root := handoffActionInstance(t, session.RootSessionTitle, tmux.ProgramClaude)
+	h.store.AddInstance(root)
+	h.sidebar.SetSelectedInstance(0)
+
+	called := false
+	restore := SetHandoffRunnerForTest(func(daemon.HandoffSessionRequest) (string, error) {
+		called = true
+		return "", nil
+	})
+	defer restore()
+
+	_, _ = h.handleHandoff()
+
+	require.Equal(t, stateDefault, h.state, "the reserved root agent must not enter the handoff flow")
+	require.Nil(t, h.selectionOverlay, "the user must not be asked to pick a target for a handoff that cannot happen")
+	require.False(t, called, "no handoff may be dispatched for the reserved root agent")
+	// The refusal has to say WHY, or the user's next move is to try again.
+	require.Contains(t, strings.ToLower(h.errBox.FullError()), "root")
+}
+
+// A session merely NAMED like the reserved one in a different case is still the
+// reserved one — IsReservedTitle matches case-insensitively on the trimmed title
+// precisely so " ROOT " cannot masquerade as a separate session. The guard has to
+// use that predicate rather than comparing against the literal.
+func TestHandleHandoff_RefusesReservedRootRegardlessOfCase(t *testing.T) {
+	h := newTestHome(t)
+	h.store.AddInstance(handoffActionInstance(t, "Root", tmux.ProgramClaude))
+	h.sidebar.SetSelectedInstance(0)
+
+	_, _ = h.handleHandoff()
+
+	require.Equal(t, stateDefault, h.state, "a case-variant of the reserved title is still reserved")
+	require.Nil(t, h.selectionOverlay)
+}
+
+// An ordinary session must be unaffected: the guard rejects the reserved title,
+// not every session whose name happens to contain it.
+func TestHandleHandoff_AllowsSessionNamedLikeRoot(t *testing.T) {
+	h := newTestHome(t)
+	h.store.AddInstance(handoffActionInstance(t, "rootcause", tmux.ProgramClaude))
+	h.sidebar.SetSelectedInstance(0)
+
+	_, _ = h.handleHandoff()
+
+	require.Equal(t, stateSelectHandoffAgent, h.state, "only the reserved title is refused, not names containing it")
+	require.NotNil(t, h.selectionOverlay)
+}
+
 // The picker's selected index must be resolved against the FILTERED choice list
 // it was built from. Resolving it against tmux.SupportedPrograms instead would
 // hand off to the wrong agent — silently, and to a plausible-looking one.

--- a/daemon/handoff.go
+++ b/daemon/handoff.go
@@ -102,11 +102,14 @@ func (m *Manager) HandoffSession(req HandoffSessionRequest) (HandoffSessionRespo
 	// has a live runtime that may be replaced. Keeping state first prevents an
 	// Archived/Lost/Dead row from being reanimated through a capable backend
 	// instead of its restore path (#2231).
+	// The reserved-root refusal is part of that shared guard now, not a separate
+	// check here (#2436). It lived here alone, which meant the TUI — which asks
+	// ValidateRuntimeAction and nothing else before opening its picker — could not
+	// see it, and only discovered the refusal after the user chose an agent and
+	// confirmed. Moving it into the predicate both sides already call is what stops
+	// the two from disagreeing about the same session again.
 	if err := instance.ValidateRuntimeAction(session.RuntimeActionHandoff); err != nil {
 		return HandoffSessionResponse{}, err
-	}
-	if session.IsReservedTitle(instance.Title) {
-		return HandoffSessionResponse{}, fmt.Errorf("session %q cannot be handed off", req.Title)
 	}
 	target := strings.TrimSpace(req.To)
 	if err := instance.ValidateHandoffTarget(target); err != nil {

--- a/daemon/handoff_test.go
+++ b/daemon/handoff_test.go
@@ -401,6 +401,41 @@ func TestHandoffSession_RefusesArchivedSession(t *testing.T) {
 	}
 }
 
+// TestHandoffSession_RefusesTheReservedRootSession keeps the root refusal locked
+// at the daemon boundary (#2436).
+//
+// The rule now lives in the shared ValidateRuntimeAction guard rather than in a
+// standalone IsReservedTitle check here, because holding it here alone is what
+// let the TUI open its picker for root and only surface the refusal after the
+// user confirmed. This test asserts the daemon still refuses regardless of where
+// the rule is implemented, so the move cannot quietly become a removal — and
+// there was no daemon-level test covering it before, which is how a guard came
+// to be relied on without ever being exercised.
+func TestHandoffSession_RefusesTheReservedRootSession(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &handoffBackend{FakeBackend: session.NewFakeBackend()}
+	inst := registerHandoffSubject(t, manager, repoID, repoPath, session.RootSessionTitle, backend)
+
+	_, err := manager.HandoffSession(HandoffSessionRequest{
+		Title: session.RootSessionTitle, RepoID: repoID, To: tmux.ProgramGemini,
+	})
+	if err == nil {
+		t.Fatal("handoff accepted the daemon-managed root agent")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "root") {
+		t.Fatalf("error = %q, want a refusal that names the reserved root agent", err)
+	}
+	if swaps, prompts := backend.snapshot(); swaps != 0 || len(prompts) != 0 {
+		t.Fatalf("refused root handoff touched the runtime (swaps=%d prompts=%d), want neither", swaps, len(prompts))
+	}
+	if got := inst.AgentProgram(); got != tmux.ProgramClaude {
+		t.Fatalf("Program = %q after refused handoff, want %q", got, tmux.ProgramClaude)
+	}
+	if ledger := inst.Handoffs(); len(ledger) != 0 {
+		t.Fatalf("refused root handoff wrote %d ledger entries, want 0", len(ledger))
+	}
+}
+
 func TestHandoffSession_PreflightFailureLeavesOutgoingAgentUntouched(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	base := &handoffBackend{FakeBackend: session.NewFakeBackend()}

--- a/session/runtime_action.go
+++ b/session/runtime_action.go
@@ -78,6 +78,25 @@ func (v LifecycleView) ValidateRuntimeAction(action RuntimeAction) error {
 			return runtimeActionBusyError(v)
 		}
 	case RuntimeActionHandoff:
+		// The reserved root agent is the daemon's own singleton: it is re-ensured
+		// when it dies, so swapping its agent out from under the daemon is not a
+		// thing that can be committed to. This is checked FIRST, and here rather
+		// than at a caller, for two different reasons.
+		//
+		// First over the others because it is permanent. A busy row says "try again
+		// in a moment"; root will never become eligible, and sending the user back
+		// to retry a thing that cannot work is the worse of the two answers.
+		//
+		// Here rather than at a caller because the daemon used to hold this rule
+		// alone, next to its own call into this function. The TUI asks this
+		// predicate and nothing else before opening the handoff picker, so it
+		// believed root was eligible and only surfaced the refusal after the user
+		// had picked an agent and confirmed the swap (#2436). A rule each caller has
+		// to remember separately is one a caller will forget; this is the question
+		// they already share.
+		if IsReservedTitle(v.Title) {
+			return fmt.Errorf("session %q is the daemon-managed root agent and cannot be handed off", v.Title)
+		}
 		if v.InFlightOp != OpNone {
 			return runtimeActionBusyError(v)
 		}

--- a/session/runtime_action_test.go
+++ b/session/runtime_action_test.go
@@ -59,3 +59,41 @@ func TestRuntimeAction_HandoffRejectsTerminalStates(t *testing.T) {
 		}
 	}
 }
+
+// TestRuntimeAction_HandoffRejectsTheReservedTitle pins the reserved-root rule to
+// the SHARED predicate rather than to any one caller (#2436).
+//
+// The daemon has always refused this handoff, but it did so with its own
+// IsReservedTitle check after calling here — so the TUI, which asks this
+// predicate and nothing else, believed a root handoff was eligible and only
+// learned otherwise after making the user pick an agent and confirm. A rule that
+// two callers have to remember independently is a rule one of them will forget;
+// this is the question both of them already ask.
+//
+// Root is otherwise perfectly eligible — live, started, no in-flight op — so the
+// title is doing all the work here.
+func TestRuntimeAction_HandoffRejectsTheReservedTitle(t *testing.T) {
+	view := LifecycleView{Title: RootSessionTitle, Liveness: LiveRunning, Started: true}
+	err := view.ValidateRuntimeAction(RuntimeActionHandoff)
+	if err == nil {
+		t.Fatal("handoff accepted the reserved root title; the daemon would reject it after the user confirmed")
+	}
+	if !strings.Contains(err.Error(), RootSessionTitle) {
+		t.Fatalf("refusal must name the session; got %v", err)
+	}
+
+	// Case-insensitive on the trimmed title, matching IsReservedTitle — otherwise
+	// " ROOT " would route around the guard the daemon still enforces.
+	for _, title := range []string{"Root", " ROOT ", "rOoT"} {
+		variant := LifecycleView{Title: title, Liveness: LiveRunning, Started: true}
+		if err := variant.ValidateRuntimeAction(RuntimeActionHandoff); err == nil {
+			t.Fatalf("handoff accepted reserved-title variant %q", title)
+		}
+	}
+
+	// A name that merely CONTAINS the reserved word is an ordinary session.
+	ordinary := LifecycleView{Title: "rootcause", Liveness: LiveRunning, Started: true}
+	if err := ordinary.ValidateRuntimeAction(RuntimeActionHandoff); err != nil {
+		t.Fatalf("an ordinary session whose name contains the reserved word must still hand off: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #2436.

## The bug

The TUI let the user open the handoff picker for the daemon-managed root agent, choose a target, and confirm the swap — and only then surfaced the daemon's refusal. `handleHandoff`'s own comment says guards run BEFORE the picker "not after the choice", because making the user pick and confirm something that cannot happen reads as a bug.

Verified live on current `master` before fixing — this report is not stale.

## Why it happened, and where the fix goes

The report recommends adding an `IsReservedTitle` check to `handleHandoff`. That works, but it makes the rule a *third* thing each caller has to remember, and forgetting it is precisely how this bug arose.

The rule was implemented once, in `daemon/handoff.go` — sitting directly beneath that function's own call into `ValidateRuntimeAction`. The TUI asks `ValidateRuntimeAction` and nothing else before opening its picker, so it could not see the rule and concluded root was eligible.

So the refusal moves into `ValidateRuntimeAction`'s handoff case: the question both callers already ask, and the same place the archived/lost/dead refusals already live. The TUI gains the guard with no new client-side check to keep in sync, and the daemon keeps refusing through the same predicate. Its standalone `IsReservedTitle` check is **removed** rather than left as a second copy that can drift from the first.

It is checked **first** among the handoff conditions, ahead of the in-flight-op check, because it is permanent. A busy row says "try again in a moment"; root will never become eligible, and sending the user back to retry something that cannot work is the worse of the two answers.

## A gap this uncovered

The daemon-level refusal **had no test at all** — the guard being relied on was never exercised. Removing it on the strength of "the predicate covers it" would have been trading one untested assumption for another, so it now has a test at the daemon boundary (`TestHandoffSession_RefusesTheReservedRootSession`), asserting the refusal *and* that the runtime was never touched. The move cannot quietly become a removal.

## Tests

All watched failing first:

| test | package | locks |
| --- | --- | --- |
| `TestHandleHandoff_RefusesReservedRootBeforePicker` | `app` | no picker, no dispatch, and the error names root |
| `TestHandleHandoff_RefusesReservedRootRegardlessOfCase` | `app` | `"Root"` is still reserved |
| `TestHandleHandoff_AllowsSessionNamedLikeRoot` | `app` | control — `"rootcause"` still hands off |
| `TestRuntimeAction_HandoffRejectsTheReservedTitle` | `session` | the shared predicate, incl. `" ROOT "` variants |
| `TestHandoffSession_RefusesTheReservedRootSession` | `daemon` | end-to-end refusal, runtime untouched |

The root fixture is otherwise perfectly eligible — live, started, no in-flight op, backend advertises `Handoff` — so the title is doing all the work. Case variants are covered because `IsReservedTitle` matches case-insensitively on the trimmed title, and a guard comparing against the literal would route `" ROOT "` around a rule the daemon still enforces.

## Adjacent-call-site audit

Three other daemon sites pair `IsReservedTitle` with a lifecycle guard. Examined all three; folding them in was deliberately declined:

- **`daemon/restore.go:44`** — the closest structural match (same `ValidateRuntimeAction` + separate reserved check). Excluded because it has no equivalent symptom: `handleRestore` is a single keypress with **no confirmation step**, so there is no picker or confirm interaction to waste. Its refusal is also about the ensure loop owning root, not about the action being meaningless. Changing restore semantics with no reported symptom and no test proving a wasted interaction would widen this PR into a behavior change.
- **`daemon/archive.go:54`** — archive is not a `RuntimeAction`, so it does not route through this predicate at all; a different mechanism.
- **`daemon/manager_sessions.go:217`** — not a guard; it records kill intent for the self-heal delay (#1223).

## Gate

- `gofmt -l .` clean · `go build ./...` clean
- `golangci-lint run --timeout=3m --fast` clean
- `deadcode -test ./...` clean
- `scripts/lint-file-length.sh` passed (1001 files)
- `./session/... ./app/... ./daemon/...` green
- Full suite via `make test-container` on the pushed head — SHA in a follow-up comment

## Review

The codex GitHub app is rate-limited until Jul 28. Requesting once; if it stays silent I'll say so explicitly rather than letting green checks imply a review, and Captain Claude reviews this exact head before merge.

— Captain Claude
