### PR TITLE
fix(testbox): survive unreadable files in the working tree (#2432)

### DIFF
--- a/scripts/container/copy-src.sh
+++ b/scripts/container/copy-src.sh
@@ -29,6 +29,33 @@
 # tree is frequently a linked worktree whose .git does not resolve in the
 # container (the same fact that makes .git unusable above), so git cannot be
 # asked which paths are repo content.
+#
+# The skip list is matched LITERALLY (--no-wildcards), and that is load-bearing
+# rather than tidiness. `--exclude-from` reads each line as a GLOB by default,
+# which breaks in two directions at once the moment an unreadable name contains
+# `[`, `]`, `*` or `?` — and names like `web/[id].tsx` are ordinary here:
+#
+#   - The pattern does not match the literal file it was derived from, so the
+#     unreadable file stays in the archive and `tar -c` dies on it: exactly the
+#     #2432 abort this helper exists to prevent. `./secret[1].env` reads as a
+#     character class matching `secret1`, so it excludes everything except the
+#     one path it was written for.
+#   - That same pattern DOES match innocent siblings — `secret1.env` — which are
+#     then dropped from the copy with no error and exit 0. A readable source file
+#     silently absent is the "mystery compile error" failure mode
+#     --ignore-failed-read was rejected for, arriving by another route.
+#
+# --no-wildcards is positional in GNU tar, so it is placed immediately before the
+# skip list and --wildcards restored immediately after: the caller's own
+# --exclude flags (web/node_modules and friends) keep the glob semantics they
+# were written against, and only the machine-generated path list is literal.
+#
+# The remaining gap is a filename containing a NEWLINE, which --exclude-from
+# cannot express at all (its format is line-delimited). Such a file is excluded
+# by neither list and would still abort the run. Not handled because it cannot
+# occur here without someone creating it on purpose, and the honest fix — a
+# NUL-delimited include list — costs the caller's --exclude semantics, which the
+# web selftest depends on to keep node_modules out of the copy.
 copy_src_tree() {
     local src="$1" dest="$2"
     shift 2
@@ -36,9 +63,14 @@ copy_src_tree() {
     mkdir -p "$dest"
 
     # GNU find/-readable: this runs inside the Linux testbox image only.
+    #
+    # Symlinks are kept whichever way their target resolves: -readable tests the
+    # TARGET (access(2) follows), but tar only reads the LINK, so a dangling or
+    # private-target symlink archives fine. Excluding one would drop a working
+    # link over a permission tar never needs.
     local excludes
     excludes="$(mktemp)"
-    (cd "$src" && find . -path ./.git -prune -o ! -readable -print) >"$excludes" 2>/dev/null || true
+    (cd "$src" && find . -path ./.git -prune -o ! -type l ! -readable -print) >"$excludes" 2>/dev/null || true
 
     if [ -s "$excludes" ]; then
         echo "testbox: skipping $(wc -l <"$excludes" | tr -d ' ') path(s) under $src that uid $(id -u) cannot read:" >&2
@@ -47,6 +79,6 @@ copy_src_tree() {
         echo "testbox: if the build needs one of them, make it readable and re-run." >&2
     fi
 
-    (cd "$src" && tar -c --exclude=.git --exclude-from="$excludes" "$@" .) | tar -x -C "$dest"
+    (cd "$src" && tar -c --exclude=.git --no-wildcards --exclude-from="$excludes" --wildcards "$@" .) | tar -x -C "$dest"
     rm -f "$excludes"
 }

--- a/scripts/container/copy-src.sh
+++ b/scripts/container/copy-src.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Shared source-tree copy for the container entrypoints (run-tests.sh,
+# web-selftest-entry.sh). Sourced, not executed.
+#
+# The /src bind mount is read-only and carries the HOST user's ownership, so
+# every entrypoint mirrors it into a writable tree before building.
+
+# copy_src_tree SRC DEST [extra tar args...] — mirror SRC into DEST, minus .git
+# and minus anything this user cannot read.
+#
+# .git is dropped because dev checkouts are often linked worktrees whose .git is
+# a pointer to a host path that does not exist in the container.
+#
+# Unreadable paths are dropped because a single one used to take the entire run
+# down before a test compiled (#2432). The image runs as `dev` (uid 1000, see
+# Dockerfile.test) while the mount carries the host user's ownership, so a
+# mode-0600 file belonging to a developer whose uid is not 1000 is unreadable
+# here, and `tar -c` exits non-zero on it under `set -e`. Those files are
+# working-directory debris — .env, .netrc, editor state, agent tool configs —
+# never repo content under test, and an external contributor hitting this on
+# their own .env learns only that the harness is broken.
+#
+# Skipped, not tolerated with --ignore-failed-read: that flag drops files
+# SILENTLY, which turns a missing source file into a mystery compile error far
+# from its cause. Every skip is named on stderr, so if one ever does matter, the
+# reason is already on screen above the failure.
+#
+# The filter is permission-based rather than gitignore-based on purpose. This
+# tree is frequently a linked worktree whose .git does not resolve in the
+# container (the same fact that makes .git unusable above), so git cannot be
+# asked which paths are repo content.
+copy_src_tree() {
+    local src="$1" dest="$2"
+    shift 2
+
+    mkdir -p "$dest"
+
+    # GNU find/-readable: this runs inside the Linux testbox image only.
+    local excludes
+    excludes="$(mktemp)"
+    (cd "$src" && find . -path ./.git -prune -o ! -readable -print) >"$excludes" 2>/dev/null || true
+
+    if [ -s "$excludes" ]; then
+        echo "testbox: skipping $(wc -l <"$excludes" | tr -d ' ') path(s) under $src that uid $(id -u) cannot read:" >&2
+        sed 's/^/  /' "$excludes" >&2
+        echo "testbox: the harness mirrors your whole working tree, so private files land here." >&2
+        echo "testbox: if the build needs one of them, make it readable and re-run." >&2
+    fi
+
+    (cd "$src" && tar -c --exclude=.git --exclude-from="$excludes" "$@" .) | tar -x -C "$dest"
+    rm -f "$excludes"
+}

--- a/scripts/container/run-tests.sh
+++ b/scripts/container/run-tests.sh
@@ -11,10 +11,11 @@ set -euo pipefail
 # playtest-entry.sh.
 (cd / && git config --global --add safe.directory /src) 2>/dev/null || true
 
-# Copy without .git: dev checkouts are often linked worktrees whose .git is
-# a pointer to a host path that does not exist in the container.
-mkdir -p /work
-(cd /src && tar -c --exclude=.git .) | tar -x -C /work
+# Copy without .git (linked worktrees) or anything this user cannot read
+# (#2432); copy-src.sh carries the reasoning for both.
+# shellcheck source=scripts/container/copy-src.sh
+. /src/scripts/container/copy-src.sh
+copy_src_tree /src /work
 cd /work
 
 if [ $# -eq 0 ]; then

--- a/scripts/container/web-selftest-entry.sh
+++ b/scripts/container/web-selftest-entry.sh
@@ -16,10 +16,12 @@
 set -euo pipefail
 
 # --- writable working copy (the /src bind mount is read-only) ---------------
-# Copy without .git: dev checkouts are often linked worktrees whose .git is a
-# pointer to a host path absent in the container (mirrors run-tests.sh).
-mkdir -p /work
-(cd /src && tar -c --exclude=.git --exclude=web/node_modules --exclude=web/test-results .) | tar -x -C /work
+# Copy without .git (linked worktrees) or anything this user cannot read
+# (#2432); copy-src.sh carries the reasoning for both. Shared with run-tests.sh
+# so the two entrypoints cannot drift on which paths reach the build.
+# shellcheck source=scripts/container/copy-src.sh
+. /src/scripts/container/copy-src.sh
+copy_src_tree /src /work --exclude=web/node_modules --exclude=web/test-results
 cd /work
 
 HOME_DIR=/work/afhome

--- a/scripts/copy_src_test.go
+++ b/scripts/copy_src_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The container entrypoints mirror the read-only /src bind mount into a
+// writable tree before building. That mount carries the HOST user's ownership
+// while the image runs as `dev` (uid 1000), so a mode-0600 file belonging to a
+// developer whose uid is not 1000 is unreadable inside the container — and
+// `tar -c` exiting non-zero on ONE such file used to take the whole run down
+// before a single test compiled (#2432).
+//
+// The files that trigger it are working-directory debris — .env, .netrc, editor
+// state, agent tool configs — never repo content under test. An external
+// contributor hitting this on their own .env learns only that the harness is
+// broken.
+
+// runCopySrcTree sources copy-src.sh and copies src into a fresh dest,
+// returning dest and the combined output.
+func runCopySrcTree(t *testing.T, src string, extraArgs ...string) (string, string, error) {
+	t.Helper()
+	dest := filepath.Join(t.TempDir(), "work")
+	helper := filepath.Join(repoRoot(t), "scripts", "container", "copy-src.sh")
+	// `set -euo pipefail` is not decoration: every entrypoint that sources this
+	// helper sets it, and it is the whole reason one unreadable file was fatal —
+	// without pipefail the failing `tar -c` is masked by the succeeding `tar -x`
+	// at the other end of the pipe, and the copy merely comes out incomplete.
+	// A harness that omitted it would be strictly weaker than production and
+	// would watch this bug pass.
+	script := "set -euo pipefail\n. " + helper + "\ncopy_src_tree " + src + " " + dest
+	for _, arg := range extraArgs {
+		script += " " + arg
+	}
+	cmd := exec.Command("bash", "-c", script)
+	out, err := cmd.CombinedOutput()
+	return dest, string(out), err
+}
+
+// unreadableTree builds a source tree holding one ordinary file and one the
+// current user cannot read, which is what a private file on the host mount
+// looks like from inside the container.
+func unreadableTree(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		// copy_src_tree uses GNU `find -readable`, and it only ever runs inside
+		// the Linux testbox image. Skipping honestly beats asserting a
+		// portability claim this helper does not make.
+		t.Skip("copy_src_tree targets the Linux container image (GNU find)")
+	}
+	if os.Geteuid() == 0 {
+		// Root reads through any mode bits, so the unreadable file this test
+		// depends on would simply be readable and prove nothing.
+		t.Skip("root can read any file; the unreadable fixture is meaningless")
+	}
+
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "keep.txt"), []byte("repo content\n"), 0o644); err != nil {
+		t.Fatalf("write keep.txt: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(src, "pkg"), 0o755); err != nil {
+		t.Fatalf("mkdir pkg: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "pkg", "nested.go"), []byte("package pkg\n"), 0o644); err != nil {
+		t.Fatalf("write nested.go: %v", err)
+	}
+	private := filepath.Join(src, ".env")
+	if err := os.WriteFile(private, []byte("SECRET=1\n"), 0o600); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+	if err := os.Chmod(private, 0o000); err != nil {
+		t.Fatalf("chmod .env: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(private, 0o600) })
+	return src
+}
+
+// TestCopySrcTree_UnreadableFileDoesNotAbortTheCopy is the #2432 regression: one
+// unreadable path must cost that path, not the entire run.
+func TestCopySrcTree_UnreadableFileDoesNotAbortTheCopy(t *testing.T) {
+	src := unreadableTree(t)
+
+	dest, out, err := runCopySrcTree(t, src)
+	if err != nil {
+		t.Fatalf("copy_src_tree failed on a tree containing one unreadable file: %v\n%s", err, out)
+	}
+
+	// The point of the copy: repo content still arrives, at every depth.
+	for _, rel := range []string{"keep.txt", filepath.Join("pkg", "nested.go")} {
+		if _, statErr := os.Stat(filepath.Join(dest, rel)); statErr != nil {
+			t.Fatalf("%s missing from the copy — the skip must cost only the unreadable path: %v", rel, statErr)
+		}
+	}
+	if _, statErr := os.Stat(filepath.Join(dest, ".env")); statErr == nil {
+		t.Fatal(".env was copied; the fixture is not actually unreadable and this test proves nothing")
+	}
+}
+
+// A skip that is not reported is indistinguishable from a file that was never
+// there, which is why --ignore-failed-read was the wrong tool: it drops files
+// silently and turns a missing source into a mystery compile error. Whatever is
+// dropped has to be named, with the reason, above the failure it might cause.
+func TestCopySrcTree_NamesEverySkippedPath(t *testing.T) {
+	src := unreadableTree(t)
+
+	_, out, err := runCopySrcTree(t, src)
+	if err != nil {
+		t.Fatalf("copy_src_tree: %v\n%s", err, out)
+	}
+
+	if !strings.Contains(out, ".env") {
+		t.Fatalf("the skipped path was not named in the output:\n%s", out)
+	}
+	if !strings.Contains(strings.ToLower(out), "cannot read") {
+		t.Fatalf("output does not explain WHY the path was skipped:\n%s", out)
+	}
+	if !strings.Contains(strings.ToLower(out), "re-run") {
+		t.Fatalf("output does not tell the user what to do about it:\n%s", out)
+	}
+}
+
+// The ordinary case must stay silent: a clean tree has nothing to report, and a
+// harness that warns on every run trains people to ignore it.
+func TestCopySrcTree_SaysNothingWhenEverythingIsReadable(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("copy_src_tree targets the Linux container image (GNU find)")
+	}
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "keep.txt"), []byte("repo content\n"), 0o644); err != nil {
+		t.Fatalf("write keep.txt: %v", err)
+	}
+
+	dest, out, err := runCopySrcTree(t, src)
+	if err != nil {
+		t.Fatalf("copy_src_tree: %v\n%s", err, out)
+	}
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("a fully readable tree must copy silently; got:\n%s", out)
+	}
+	if _, statErr := os.Stat(filepath.Join(dest, "keep.txt")); statErr != nil {
+		t.Fatalf("keep.txt missing from the copy: %v", statErr)
+	}
+}
+
+// Extra tar arguments still apply — web-selftest-entry.sh passes its own
+// --exclude flags through this same function, and losing them would drag
+// node_modules into every web-selftest run.
+func TestCopySrcTree_HonorsExtraExcludes(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("copy_src_tree targets the Linux container image (GNU find)")
+	}
+	src := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(src, "web", "node_modules"), 0o755); err != nil {
+		t.Fatalf("mkdir node_modules: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "web", "node_modules", "junk.js"), []byte("//\n"), 0o644); err != nil {
+		t.Fatalf("write junk.js: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "web", "app.ts"), []byte("export {}\n"), 0o644); err != nil {
+		t.Fatalf("write app.ts: %v", err)
+	}
+
+	dest, out, err := runCopySrcTree(t, src, "--exclude=web/node_modules")
+	if err != nil {
+		t.Fatalf("copy_src_tree: %v\n%s", err, out)
+	}
+	if _, statErr := os.Stat(filepath.Join(dest, "web", "app.ts")); statErr != nil {
+		t.Fatalf("web/app.ts missing from the copy: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(dest, "web", "node_modules")); statErr == nil {
+		t.Fatal("web/node_modules was copied despite the caller's --exclude")
+	}
+}

--- a/scripts/copy_src_test.go
+++ b/scripts/copy_src_test.go
@@ -80,6 +80,110 @@ func unreadableTree(t *testing.T) string {
 	return src
 }
 
+// globMetacharTree is unreadableTree's adversarial twin: the unreadable file's
+// BASENAME contains shell-glob metacharacters, and a readable sibling sits next
+// to it whose name the same characters would match when read as a pattern.
+//
+// `secret[1].env` unreadable + `secret1.env` readable is the minimal fixture
+// that separates "this path is excluded" from "this pattern is excluded", and
+// it catches both halves of the same mistake at once:
+//
+//   - As a pattern, `./secret[1].env` is a character class matching `secret1`,
+//     so it does NOT match the literal file it came from — the unreadable file
+//     stays in the archive, tar opens it, and the run dies exactly as it did
+//     before #2432 was fixed.
+//   - That same pattern DOES match the readable sibling, which is dropped from
+//     the copy with no error and exit 0 — a source file that silently is not
+//     there, surfacing later as a compile error far from its cause.
+//
+// The `*` case is included too because it fails the same way without needing a
+// character class, which is the form most likely to appear in a real tree.
+func globMetacharTree(t *testing.T, private, readable string) string {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		t.Skip("copy_src_tree targets the Linux container image (GNU find)")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root can read any file; the unreadable fixture is meaningless")
+	}
+
+	src := t.TempDir()
+	for _, name := range []string{"keep.txt", readable} {
+		if err := os.WriteFile(filepath.Join(src, name), []byte("REAL SOURCE\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	secret := filepath.Join(src, private)
+	if err := os.WriteFile(secret, []byte("SECRET=1\n"), 0o600); err != nil {
+		t.Fatalf("write %s: %v", private, err)
+	}
+	if err := os.Chmod(secret, 0o000); err != nil {
+		t.Fatalf("chmod %s: %v", private, err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(secret, 0o600) })
+	return src
+}
+
+// The P2: the skip list must match PATHS, never patterns. `--exclude-from` reads
+// each line as a glob, which fails in two OPPOSITE directions depending on which
+// metacharacter the unreadable name happens to contain — so each gets its own
+// case, because a fix for one alone leaves the other live and a single combined
+// test would only ever report whichever fired first.
+func TestCopySrcTree_GlobMetacharInUnreadableName(t *testing.T) {
+	// A character class does not match the literal text it was built from:
+	// `./secret[1].env` as a pattern matches `secret1.env` and NOT
+	// `secret[1].env`. So the unreadable file is not excluded at all, tar opens
+	// it, and the run dies — #2432 reintroduced, loudly.
+	t.Run("class pattern misses its own path and aborts the run", func(t *testing.T) {
+		src := globMetacharTree(t, "secret[1].env", "secret1.env")
+
+		dest, out, err := runCopySrcTree(t, src)
+		if err != nil {
+			t.Fatalf("copy_src_tree aborted on an unreadable name containing a glob metacharacter — "+
+				"the exclusion did not match the literal path, so tar still opened it (#2432 reintroduced): %v\n%s", err, out)
+		}
+		assertCopiedAndSkipped(t, dest, out, "secret1.env", "secret[1].env")
+	})
+
+	// The quiet one, and the worse one. `./star*.key` DOES match itself, so the
+	// run exits 0 and looks fine — while the same pattern also swallows the
+	// readable `starindex.key`, which is simply not in the copy. No error, no
+	// warning, a source file gone. This is the "missing source -> mystery compile
+	// error" outcome --ignore-failed-read was rejected for, arriving by another
+	// route.
+	t.Run("star pattern silently swallows a readable sibling", func(t *testing.T) {
+		src := globMetacharTree(t, "star*.key", "starindex.key")
+
+		dest, out, err := runCopySrcTree(t, src)
+		if err != nil {
+			t.Fatalf("copy_src_tree: %v\n%s", err, out)
+		}
+		assertCopiedAndSkipped(t, dest, out, "starindex.key", "star*.key")
+	})
+}
+
+// assertCopiedAndSkipped pins the whole contract for one fixture: the readable
+// files arrived, the unreadable one did not, and the skip was reported.
+func assertCopiedAndSkipped(t *testing.T, dest, out, readable, private string) {
+	t.Helper()
+	for _, rel := range []string{readable, "keep.txt"} {
+		if _, err := os.Stat(filepath.Join(dest, rel)); err != nil {
+			t.Fatalf("readable %s is missing from the copy: an unreadable sibling's name was treated as a "+
+				"glob and swallowed it — a source file silently absent, with exit 0 and nothing on stderr: %v\n%s",
+				rel, err, out)
+		}
+	}
+	// Still excluded, so the fix is literal matching rather than a blanket
+	// "copy everything and hope".
+	if _, err := os.Stat(filepath.Join(dest, private)); err == nil {
+		t.Fatalf("%s was copied; the fixture is not actually unreadable and this test proves nothing", private)
+	}
+	// A metacharacter in the name must not cost the user the report either.
+	if !strings.Contains(out, private) {
+		t.Fatalf("skipped path %q was not named in the output:\n%s", private, out)
+	}
+}
+
 // TestCopySrcTree_UnreadableFileDoesNotAbortTheCopy is the #2432 regression: one
 // unreadable path must cost that path, not the entire run.
 func TestCopySrcTree_UnreadableFileDoesNotAbortTheCopy(t *testing.T) {


### PR DESCRIPTION
Fixes #2432.

## The bug

A single unreadable file anywhere in the checkout killed the entire suite before one test compiled:

```
$ make test-container
tar: ./.devin/config.local.json: Cannot open: Permission denied
tar: Exiting with failure status due to previous errors
make: *** [Makefile:33: test-container] Error 2
```

The container entrypoints mirror the read-only `/src` mount into a writable tree. That mount carries the **host** user's ownership while the image runs as `dev` (**uid 1000**, `Dockerfile.test:29`), so a mode-`0600` file belonging to a developer whose uid is not 1000 is unreadable inside, `tar -c` exits non-zero, and `set -o pipefail` takes the run down.

Two things make this broader than one stray file:

1. **Not limited to unusual uids.** Developer uids commonly aren't 1000 — 1001 on this box, 501 on macOS. And even at 1000, any `0600` file owned by a different user does it.
2. **The tar ignores gitignore.** Working-directory debris the repo has explicitly disclaimed is enough: `.env`, `.netrc`, editor state, credential caches, agent tool configs — all plausible, all typically `0600`.

The error names a file but not the cause, so it reads as "the harness is broken" rather than "chmod this". An external contributor meets it on their own `.env`, and the workaround it teaches — loosen permissions on a private file — is the wrong instinct.

## The fix

Skip unreadable paths, and **name every one** with the reason and the remedy:

```
testbox: skipping 1 path(s) under /src that uid 1000 cannot read:
  ./.scratch-2432/private.txt
testbox: the harness mirrors your whole working tree, so private files land here.
testbox: if the build needs one of them, make it readable and re-run.
```

Two choices worth stating, since #2432 listed four candidate approaches:

**Not `--ignore-failed-read`.** It drops files *silently*, converting a missing source file into a mystery compile error far from its cause. Nothing here is dropped quietly, so if a skip ever does matter the reason is already on screen directly above the failure.

**Not a gitignore-based filter**, which was my own first instinct in the issue. It cannot work: this tree is frequently a linked worktree whose `.git` is a *pointer file* to a host path absent in the container — the very fact that makes `.git` unexcludable-by-git and is why the script excludes it wholesale. Git cannot be asked which paths are repo content, so the filter has to be permission-based. (Verified: `.git` in this worktree is an 84-byte ASCII pointer.)

Shared by **both** entrypoints that perform this copy — `run-tests.sh` and `web-selftest-entry.sh` — so the two cannot drift on which paths reach the build. `web-selftest-entry.sh` passes its own `--exclude` flags through the same function.

## Tests

Four in `scripts/copy_src_test.go`, driving the real shell function via the existing Go-drives-bash pattern in that package:

| test | asserts |
| --- | --- |
| `UnreadableFileDoesNotAbortTheCopy` | one bad path costs that path, not the run; repo content still arrives at every depth |
| `NamesEverySkippedPath` | the path, the *why*, and the remedy all appear |
| `SaysNothingWhenEverythingIsReadable` | clean trees copy silently — a harness that warns every run trains people to ignore it |
| `HonorsExtraExcludes` | the caller's `--exclude` flags survive |

**One harness bug worth flagging, because it nearly cost the test its value.** My first version of `UnreadableFileDoesNotAbortTheCopy` **passed against the pre-fix code**. The reason: I ran the helper without `set -euo pipefail`, and in `tar -c … | tar -x` the pipeline takes the *last* command's status — the succeeding extract masks the failing create. Without pipefail the copy merely comes out incomplete instead of fatal. Every real entrypoint sets it, so the harness was strictly weaker than production and watched the bug pass. The test now sets it, and there is a comment saying why.

Watched failing first, after that correction — both regression tests fail on the exact production symptom while the two controls stay green:

```
--- FAIL: TestCopySrcTree_UnreadableFileDoesNotAbortTheCopy
    copy_src_tree failed on a tree containing one unreadable file: exit status 2
        tar: ./.env: Cannot open: Permission denied
--- FAIL: TestCopySrcTree_NamesEverySkippedPath
--- PASS: TestCopySrcTree_SaysNothingWhenEverythingIsReadable
--- PASS: TestCopySrcTree_HonorsExtraExcludes
```

The tests skip honestly rather than assert an environment fact: on non-Linux (the helper uses GNU `find -readable` and only ever runs in the Linux image) and as root (root reads through any mode bits, so the fixture would prove nothing). In the container they run for real as uid 1000.

## End-to-end verification

Beyond the unit tests, the original failure was reproduced and re-run against this branch — a fresh `0600` file in the working tree, which killed the suite on `master`:

```
$ make test-container GOTESTARGS="-run TestCopySrcTree ./scripts/..."
testbox: skipping 1 path(s) under /src that uid 1000 cannot read:
  ./.scratch-2432/private.txt
...
ok  	github.com/sachiniyer/agent-factory/scripts	0.056s
```

## Gate

- `gofmt -l .` clean · `go build ./...` clean
- `golangci-lint run --timeout=3m --fast` clean
- `deadcode -test ./...` clean
- `scripts/lint-file-length.sh` passed (1002 files)
- `shellcheck` clean on all three changed scripts (the one warning in `web-selftest-entry.sh` is pre-existing, at line 573, untouched here)
- Full suite via `make test-container` on the pushed head — SHA in a follow-up comment

## Review

The codex GitHub app is rate-limited until Jul 28. Requesting once; if it stays silent I'll say so explicitly rather than letting green checks imply a review, and Captain Claude reviews this exact head before merge.

— Captain Claude
