### PR TITLE
fix(session): re-dial a pty capture whose upstream died (#2438)

### DIFF
--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -140,8 +140,15 @@ type ptyBroker struct {
 	// EOF'd) rather than a teardown stopping it. `capturing` alone cannot express
 	// this: it stays true over the dead loop, so every later bring-up
 	// short-circuits and no new capture is ever dialled (#2438). Set by readLoop
-	// under mu BEFORE it closes `done`, so anything that joins the loop sees it;
-	// cleared by ensureCaptureStartedLocked when it reconciles.
+	// under mu BEFORE it closes `done`, so anything that joins the loop sees it.
+	//
+	// It is meaningful ONLY while `capturing` is true — the pair reads as "a
+	// capture is installed, and it is spent". Every site that clears `capturing`
+	// clears this too, in the same critical section, so the flag can never
+	// out-live the capture it describes and be read as a claim about the NEXT
+	// one. (Leaving it latched would be harmless today, since `capturing == false`
+	// already routes to the reconcile that clears it — but it would make the
+	// field a lie to anyone who reads it on its own.)
 	captureEnded bool
 	closed       bool
 	// tabClosed records that this broker was shut down because ITS TAB was closed
@@ -406,6 +413,7 @@ func (b *ptyBroker) maybeStopCapture() {
 	stop := b.stopCapture
 	b.capturing = false
 	b.stopCapture = nil
+	b.captureEnded = false
 	b.mu.Unlock()
 
 	if stop != nil {
@@ -464,6 +472,7 @@ func (b *ptyBroker) resetCapture() {
 		b.capturing = false
 		b.stopCapture = nil
 	}
+	b.captureEnded = false
 	b.mu.Unlock()
 
 	// The barrier MUST be lifted on EVERY path out — a failed restart, a Snapshot
@@ -735,6 +744,7 @@ func (b *ptyBroker) shutdown(tabClosed bool) {
 		b.capturing = false
 		b.stopCapture = nil
 	}
+	b.captureEnded = false
 	b.mu.Unlock()
 	if stop != nil {
 		stop()

--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -135,7 +135,15 @@ type ptyBroker struct {
 
 	capturing   bool
 	stopCapture func() // tears down the capture goroutine + clientless channel
-	closed      bool
+	// captureEnded records that the CURRENT capture's readLoop has exited on its
+	// own — its upstream ended (a remote WS dropped by a proxy, a local pipe that
+	// EOF'd) rather than a teardown stopping it. `capturing` alone cannot express
+	// this: it stays true over the dead loop, so every later bring-up
+	// short-circuits and no new capture is ever dialled (#2438). Set by readLoop
+	// under mu BEFORE it closes `done`, so anything that joins the loop sees it;
+	// cleared by ensureCaptureStartedLocked when it reconciles.
+	captureEnded bool
+	closed       bool
 	// tabClosed records that this broker was shut down because ITS TAB was closed
 	// (#2136) rather than because the whole session was torn down. It only selects
 	// which end-of-stream error NextEvent reports (ErrTabClosed vs bare io.EOF);
@@ -331,11 +339,33 @@ func (b *ptyBroker) ensureCaptureStartedLocked() error {
 		b.mu.Unlock()
 		return fmt.Errorf("pty broker closed")
 	}
-	if b.capturing {
+	if b.capturing && !b.captureEnded {
 		b.mu.Unlock()
 		return nil
 	}
+	// Either nothing is capturing (the lazy first bring-up) or the current
+	// capture's upstream died under us and its readLoop has exited (#2438). Both
+	// want the same thing: a fresh capture. The dead one must be RELEASED, not
+	// merely forgotten — the remote channel holds one socket at a time and its
+	// StartCapture refuses ("remote clientless capture already started") while it
+	// still holds the dropped one, so clearing the latch alone would leave the
+	// broker permanently un-restartable. Running the stored teardown also JOINS
+	// the finished readLoop, so no goroutine leaks across the re-dial.
+	//
+	// This is the only place the release may happen: it needs captureMu (held by
+	// every caller of this function) to stay ordered against a concurrent
+	// teardown (#1661), and readLoop itself must NOT take captureMu — a teardown
+	// parks on `<-done` while holding it, so a readLoop reaching for it would
+	// deadlock. Marking the latch there and reconciling here keeps readLoop free
+	// of both locks it cannot safely take.
+	stale := b.stopCapture
+	b.capturing = false
+	b.stopCapture = nil
+	b.captureEnded = false
 	b.mu.Unlock()
+	if stale != nil {
+		stale()
+	}
 
 	r, err := b.ch.StartCapture()
 	if err != nil {
@@ -551,8 +581,28 @@ func (b *ptyBroker) releaseRecoveryRepaint(armed []*ptySub, rp *repaintSnapshot)
 
 // readLoop copies the clientless capture reader into the ring until it errors or
 // the capture is stopped.
+//
+// On the way out it latches captureEnded so the next bring-up knows this capture
+// is spent and reconciles it (#2438). That matters for the case nothing else
+// observes: the upstream dying on its OWN. A remote session's data plane is a
+// long-lived WebSocket, independent of the REST control plane the daemon probes,
+// so a proxy or tunnel can drop it while the sandbox keeps answering Snapshot()
+// and Alive() perfectly — the session is never marked Lost, no recovery hook
+// runs (resetBrokerCaptures is localAgentServer's, the remote runtime has no
+// equivalent), and without this latch `capturing` stays true over a dead loop
+// and freezes the terminal for good.
+//
+// The latch is set BEFORE close(done) so a teardown joining on `done` cannot
+// observe the loop as finished while the latch still reads live. It deliberately
+// takes only mu — never captureMu, which a teardown holds while parked on
+// `<-done` (see ensureCaptureStartedLocked, where the reconcile happens).
 func (b *ptyBroker) readLoop(r io.Reader, done chan struct{}) {
-	defer close(done)
+	defer func() {
+		b.mu.Lock()
+		b.captureEnded = true
+		b.mu.Unlock()
+		close(done)
+	}()
 	buf := make([]byte, 32*1024)
 	for {
 		n, err := r.Read(buf)

--- a/session/ptybroker_upstream_death_test.go
+++ b/session/ptybroker_upstream_death_test.go
@@ -232,6 +232,10 @@ func TestPTYBrokerHealthyCaptureIsNotReDialled(t *testing.T) {
 // closed), a dead upstream must NOT be re-dialled. Otherwise the recovery path
 // would dial a fresh socket into a torn-down sandbox that nothing will ever
 // close — the #1632 resurrection this broker already refuses.
+//
+// This one is a LOCK, not a fail-first: the `b.closed` check short-circuits
+// before the reconcile is even reached, so it passes on master too. It is here
+// so a later change to the reconcile cannot quietly grow a resurrection path.
 func TestPTYBrokerUpstreamDeathDoesNotResurrectAClosedBroker(t *testing.T) {
 	ch := &singleSocketChannel{snapshot: []byte("SCREEN")}
 	br := newPTYBroker(ch)

--- a/session/ptybroker_upstream_death_test.go
+++ b/session/ptybroker_upstream_death_test.go
@@ -1,0 +1,255 @@
+package session
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+	"time"
+)
+
+// singleSocketChannel models the REMOTE clientlessChannel contract
+// (remoteClientlessChannel, agentserver_remote.go): ONE capture socket at a time.
+// StartCapture refuses while a socket is still held, and only StopCapture
+// releases it:
+//
+//	if c.conn != nil {
+//	    return nil, fmt.Errorf("remote clientless capture already started")
+//	}
+//
+// That refusal is load-bearing for #2438 and is exactly what fakeClientlessChannel
+// does NOT model — it re-starts happily, so a test written against it would pass
+// on a fix that merely clears the `capturing` latch while leaving the dead socket
+// held, and the remote session would still never recover in the field.
+type singleSocketChannel struct {
+	mu sync.Mutex
+	w  *io.PipeWriter
+	// held is true between a successful StartCapture and the StopCapture that
+	// releases it — the fake's stand-in for remoteClientlessChannel.conn != nil.
+	held     bool
+	starts   int
+	stops    int
+	snapshot []byte
+}
+
+func (c *singleSocketChannel) StartCapture() (io.ReadCloser, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.held {
+		return nil, fmt.Errorf("remote clientless capture already started")
+	}
+	c.held = true
+	c.starts++
+	r, w := io.Pipe()
+	c.w = w
+	return r, nil
+}
+
+func (c *singleSocketChannel) StopCapture() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.stops++
+	c.held = false
+	if c.w != nil {
+		_ = c.w.Close()
+		c.w = nil
+	}
+	return nil
+}
+
+// dropUpstream simulates the WebSocket dying under a live capture: the broker's
+// reader ends (so its readLoop returns) but NOTHING calls StopCapture, so the
+// channel still holds its socket. That is precisely remoteClientlessChannel's
+// state after a proxy/tunnel drops the long-lived connection — its own readLoop
+// returns on the read error and leaves c.conn set.
+func (c *singleSocketChannel) dropUpstream() {
+	c.mu.Lock()
+	w := c.w
+	c.w = nil
+	c.mu.Unlock()
+	if w != nil {
+		_ = w.Close()
+	}
+}
+
+func (c *singleSocketChannel) SendRaw([]byte) error        { return nil }
+func (c *singleSocketChannel) Resize(uint16, uint16) error { return nil }
+
+func (c *singleSocketChannel) Snapshot() (PaneSnapshot, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return PaneSnapshot{Screen: append([]byte(nil), c.snapshot...)}, nil
+}
+
+func (c *singleSocketChannel) counts() (starts, stops int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.starts, c.stops
+}
+
+func (c *singleSocketChannel) emit(t *testing.T, b []byte) {
+	t.Helper()
+	c.mu.Lock()
+	w := c.w
+	c.mu.Unlock()
+	if w == nil {
+		t.Fatal("emit with no live capture socket")
+	}
+	if _, err := w.Write(b); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+}
+
+// subscribeUntilReDial keeps subscribing until the broker has re-established
+// capture (a second StartCapture), or fails after a bounded wait. The retry is
+// not incidental: the readLoop notices the dead upstream ASYNCHRONOUSLY, so a
+// subscribe racing that exit legitimately rides the still-live capture. What
+// #2438 is about is the steady state — a broker that can NEVER re-dial no matter
+// how many subscribers arrive.
+func subscribeUntilReDial(t *testing.T, br *ptyBroker, ch *singleSocketChannel) *ptySub {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		sub, err := br.subscribe(0)
+		if err != nil {
+			t.Fatalf("subscribe after the upstream died: %v\n\n"+
+				"the broker refused a NEW subscriber outright. Clearing the capturing latch "+
+				"without releasing the dead socket leaves StartCapture returning "+
+				"\"already started\" forever (#2438)", err)
+		}
+		if starts, _ := ch.counts(); starts >= 2 {
+			return sub
+		}
+		_ = sub.Close()
+		if time.Now().After(deadline) {
+			starts, stops := ch.counts()
+			t.Fatalf("broker never re-dialled after its upstream died: StartCapture calls = %d, "+
+				"StopCapture calls = %d, want a second StartCapture.\n\n"+
+				"The capturing latch stays true over a dead readLoop, so every later subscribe "+
+				"short-circuits in ensureCaptureStartedLocked and the remote session is frozen "+
+				"permanently — REST probes keep answering, so nothing marks it Lost and nothing "+
+				"replaces the broker (#2438).", starts, stops)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestPTYBrokerReDialsAfterUpstreamDies is #2438.
+//
+// A remote session's data plane (the WS to the sandbox agent-server) and its
+// control plane (REST Snapshot/Alive probes) are independent transports. When a
+// proxy, tunnel, or load balancer drops the long-lived WebSocket while the
+// sandbox stays healthy over REST:
+//
+//   - the channel's reader ends, so the broker's readLoop returns;
+//   - `capturing` stays TRUE over that dead readLoop, because nothing clears it;
+//   - REST keeps answering, so the session is never marked Lost and no recovery
+//     hook replaces the broker (resetBrokerCaptures exists only on
+//     localAgentServer — the remote runtime has no equivalent);
+//   - so every later subscribe short-circuits on the latch and no new socket is
+//     ever dialled. The terminal is frozen permanently, and a browser refresh
+//     does not help because it reuses the same wedged broker.
+//
+// The broker must instead reconcile on the next bring-up: release the dead
+// capture (which JOINS the finished readLoop and lets the channel drop its
+// socket) and dial a fresh one.
+func TestPTYBrokerReDialsAfterUpstreamDies(t *testing.T) {
+	ch := &singleSocketChannel{snapshot: []byte("SCREEN")}
+	br := newPTYBroker(ch)
+
+	a, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+	mustRepaintContains(t, a, "SCREEN")
+	ch.emit(t, []byte("before-drop"))
+	mustData(t, a, "before-drop")
+	if starts, _ := ch.counts(); starts != 1 {
+		t.Fatalf("StartCapture calls = %d, want 1 before the drop", starts)
+	}
+
+	// The WebSocket dies. A stays attached (it is parked in NextEvent), and the
+	// sandbox is still perfectly healthy over REST.
+	ch.dropUpstream()
+
+	// The reconnecting client. It must get a working stream.
+	b := subscribeUntilReDial(t, br, ch)
+	defer func() { _ = b.Close() }()
+
+	starts, stops := ch.counts()
+	if stops < 1 {
+		t.Fatalf("StopCapture calls = %d, want at least 1: the dead socket must be RELEASED, "+
+			"not merely forgotten — remoteClientlessChannel.StartCapture refuses while it still "+
+			"holds one, so a latch-only fix leaves the broker permanently un-restartable (#2438)",
+			stops)
+	}
+	if starts != 2 {
+		t.Fatalf("StartCapture calls = %d, want exactly 2 (one re-dial, not a storm)", starts)
+	}
+
+	// The whole point: the reconnected subscriber actually receives live output.
+	mustRepaintContains(t, b, "SCREEN")
+	ch.emit(t, []byte("after-redial"))
+	mustData(t, b, "after-redial")
+}
+
+// TestPTYBrokerHealthyCaptureIsNotReDialled is the no-regression half: a live
+// capture must still be shared by every subscriber. A "fix" that tore the
+// capture down and re-dialled on every subscribe would satisfy the test above
+// while reintroducing the #1661 clobber and blipping every attached client.
+func TestPTYBrokerHealthyCaptureIsNotReDialled(t *testing.T) {
+	ch := &singleSocketChannel{snapshot: []byte("SCREEN")}
+	br := newPTYBroker(ch)
+
+	a, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+	mustRepaintContains(t, a, "SCREEN")
+
+	b, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe B: %v", err)
+	}
+	mustRepaintContains(t, b, "SCREEN")
+
+	starts, stops := ch.counts()
+	if starts != 1 {
+		t.Fatalf("StartCapture calls = %d, want 1 (a healthy capture is shared, never re-dialled)", starts)
+	}
+	if stops != 0 {
+		t.Fatalf("StopCapture calls = %d, want 0 (nothing died, so nothing may be torn down)", stops)
+	}
+
+	// Both subscribers ride the one capture.
+	ch.emit(t, []byte("shared"))
+	mustData(t, a, "shared")
+	mustData(t, b, "shared")
+}
+
+// TestPTYBrokerUpstreamDeathDoesNotResurrectAClosedBroker pins the guard the
+// reconcile must not lose: once the broker is closed (session killed, tab
+// closed), a dead upstream must NOT be re-dialled. Otherwise the recovery path
+// would dial a fresh socket into a torn-down sandbox that nothing will ever
+// close — the #1632 resurrection this broker already refuses.
+func TestPTYBrokerUpstreamDeathDoesNotResurrectAClosedBroker(t *testing.T) {
+	ch := &singleSocketChannel{snapshot: []byte("SCREEN")}
+	br := newPTYBroker(ch)
+
+	a, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+	mustRepaintContains(t, a, "SCREEN")
+
+	ch.dropUpstream()
+	br.close()
+
+	if _, err := br.subscribe(0); err == nil {
+		t.Fatal("subscribe on a CLOSED broker returned nil error: a dead upstream must never " +
+			"resurrect a broker whose session was torn down")
+	}
+	if starts, _ := ch.counts(); starts != 1 {
+		t.Fatalf("StartCapture calls = %d, want 1 (a closed broker must never re-dial)", starts)
+	}
+}


### PR DESCRIPTION
Fixes #2438.

## The bug

A remote session runs two **independent** transports: REST for control-plane probes (`Snapshot()`, `Alive()`) and a long-lived WebSocket for the PTY data plane. When a proxy, tunnel, or load balancer drops the WebSocket while the sandbox itself stays perfectly healthy:

1. the channel's reader ends, so the broker's `readLoop` returns;
2. `capturing` stays **true** over that dead `readLoop` — nothing cleared it;
3. REST keeps answering, so the session is never marked Lost and no recovery hook replaces the broker — `resetBrokerCaptures` is `localAgentServer`'s (`agentserver_local.go:282`), and the remote runtime has **no equivalent**;
4. every later `subscribe` short-circuits on the latch in `ensureCaptureStartedLocked`, so no new socket is ever dialled.

The terminal freezes permanently, and a browser refresh does not help because it reuses the same wedged broker.

## Why the report's suggested fix is not sufficient

The issue recommends clearing `capturing` in `readLoop`'s defer. That alone does **not** recover a remote session. `remoteClientlessChannel` holds one socket at a time:

```go
// agentserver_remote.go:380
if c.conn != nil {
    return nil, fmt.Errorf("remote clientless capture already started")
}
```

When the WS drops, the channel's own read loop returns but `StopCapture()` is never called, so `c.conn` stays set **forever**. Clearing the broker latch would just turn a silent freeze into every subsequent `subscribe` failing with "already started" — still unrecoverable, and now noisier.

So the dead capture has to be **released**, not merely forgotten.

## The fix

`readLoop` latches `captureEnded` on its way out; the next bring-up reconciles — runs the stored teardown (which calls `ch.StopCapture()`, letting the channel drop its socket, and **joins** the finished `readLoop` so nothing leaks) and then dials fresh.

The work splits across those two sites for a lock reason, not a stylistic one:

- The release needs `captureMu` to stay ordered against a concurrent teardown (#1661). `ensureCaptureStartedLocked`'s callers already hold it.
- `readLoop` must **not** take `captureMu`: a teardown parks on `<-done` while holding it, so a `readLoop` reaching for it would deadlock.

So `readLoop` only marks the latch under `mu`, **before** `close(done)` — a teardown joining the loop can never see it finished while the latch still reads live — and the reconcile happens where `captureMu` is already held.

No new capture can start between the latch and the reconcile, because a bring-up requires `capturing == false` and the latch keeps it true until the reconcile clears it. So a stale `readLoop` can never clobber a fresher capture's state.

## Deliberately not changed

The issue also flags `manager_status.go:404-424` and `remoteloss.go:166-171` for "ignoring" WebSocket state in recovery and Lost detection. I did not touch those, and I don't think they should change.

Making liveness sensitive to a data-plane drop would re-provision a sandbox that is **demonstrably still answering REST** — orphaning the live container and destroying every unpushed commit on it. That is #1794, which this repo has already been bitten by, and the reasoning is spelled out at `manager_status.go:210` and `limit.go:418`. A dropped WebSocket is a **reconnect** problem, not a liveness problem, and fixing it in the broker is what makes the session recover *without* betting a live sandbox on a transport blip.

Scope note: this restores service for reconnecting clients (a refresh now works, which is the reported symptom). A subscriber that stays attached across the drop is still parked until it reconnects — the client's own reconnect drives that, and proactively re-dialling underneath attached subscribers would want backoff to avoid a storm against a genuinely-down endpoint. Worth its own issue if it turns out to matter.

## Tests

The existing `fakeClientlessChannel` lets `StartCapture` succeed repeatedly, so a test built on it would **pass on a latch-only fix** and hide the field defect. These use `singleSocketChannel`, which models the real remote contract: `StartCapture` refuses while a socket is held, and only `StopCapture` releases it.

- `TestPTYBrokerReDialsAfterUpstreamDies` — the bug. Asserts the dead socket is released (`StopCapture` ≥ 1), exactly one re-dial (not a storm), and that the reconnected subscriber actually receives live output.
- `TestPTYBrokerHealthyCaptureIsNotReDialled` — a live capture is still shared by every subscriber. A fix that re-dialled on every subscribe would satisfy the test above while reintroducing the #1661 clobber and blipping every attached client.
- `TestPTYBrokerUpstreamDeathDoesNotResurrectAClosedBroker` — a dead upstream must never re-dial into a torn-down sandbox (#1632).

Verified failing before the fix:

```
--- FAIL: TestPTYBrokerReDialsAfterUpstreamDies
    broker never re-dialled after its upstream died: StartCapture calls = 1,
    StopCapture calls = 0, want a second StartCapture.
```

All 27 pre-existing `TestPTYBroker*` tests still pass, including the #1661 teardown-clobber test and the whole #1682/#1840/#1975 recovery suite. Also clean under `-race -count=3`.

## Gate

`golangci-lint --fast`, `gofmt -l .`, `go build ./...`, `deadcode -test ./...`, `scripts/lint-file-length.sh`, and `make test-container` — all clean on the pushed head.

## Review

The codex GitHub app is rate-limited until Jul 28, so its review is requested once and may not answer; I'll say so on the PR if it stays silent, and an independent review runs against this exact head before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
