### PR TITLE
fix(task): use amp's current (bottom-most) prompt frame (#2439)

### DIFF
--- a/task/amp_working_test.go
+++ b/task/amp_working_test.go
@@ -139,3 +139,28 @@ func TestIsWorkingContentAmpStaleScrollback(t *testing.T) {
 		t.Error("IsWorkingContent(stale working rule above a current idle frame, amp) = true, want false — a settled session would never go green again")
 	}
 }
+
+// TestIsWorkingContentAmpQuotedCompleteFrame is the #2439 regression. Unlike the
+// lone stale bottom rule TestIsWorkingContentAmpStaleScrollback covers, agent
+// output can quote a COMPLETE amp frame — labeled top rule, "│" interior, and a
+// working bottom rule — above the current idle frame (e.g. the agent pasting an
+// example of amp's UI, or an older turn's frame left in scrollback). Because
+// ampFrameBottomRule returned the FIRST complete frame, that quoted working rule
+// pinned a genuinely idle session at Running forever. The CURRENT frame is the
+// bottom-most complete pairing, never the first — the same reason
+// opencodeFrameLines tracks its LAST rule.
+func TestIsWorkingContentAmpQuotedCompleteFrame(t *testing.T) {
+	working, err := os.ReadFile("testdata/amp_working_streaming.ansi")
+	if err != nil {
+		t.Fatalf("read working fixture: %v", err)
+	}
+	idle, err := os.ReadFile("testdata/amp_idle_after_turn.ansi")
+	if err != nil {
+		t.Fatalf("read idle fixture: %v", err)
+	}
+	// A complete working frame sitting above the current idle frame.
+	quoted := string(working) + "\n" + string(idle)
+	if IsWorkingContent(quoted, tmux.ProgramAmp) {
+		t.Error("IsWorkingContent(complete working frame above the current idle frame, amp) = true, want false — the current frame is the bottom-most, so a settled session must go green")
+	}
+}

--- a/task/runner.go
+++ b/task/runner.go
@@ -315,24 +315,35 @@ func isOpencodePromptFrame(content string) bool {
 func ampFrameBottomRule(content string) (string, bool) {
 	plain := paneAnsiEscape.ReplaceAllString(content, "")
 	lines := strings.Split(plain, "\n")
+	var lastBottomRule string
+	found := false
 	for i, line := range lines {
 		if !ampPromptFrameTop.MatchString(line) {
 			continue
 		}
 		// Walk downward from the labeled top rule: box-interior rows begin with
-		// the "│" border; the first bottom rule closes a real, current frame.
-		// Any other line before the bottom rule means these borders are not one
-		// contiguous box, so this top rule is stale scrollback — keep scanning.
+		// the "│" border, and a bottom rule closes a contiguous box. Any other line
+		// before the bottom rule means these borders are not one box, so this top
+		// rule is stale scrollback — keep scanning.
+		//
+		// Keep the LAST such frame, not the first: agent output can quote a
+		// complete frame (labeled top rule, "│" interior, bottom rule) above the
+		// live one, so the CURRENT frame is the bottom-most complete pairing, never
+		// the first — returning the first pinned an idle session at Running when the
+		// quoted rule read as working (#2439). opencodeFrameLines tracks its last
+		// rule for the same reason.
 		for j := i + 1; j < len(lines); j++ {
 			if ampPromptFrameBottom.MatchString(lines[j]) {
-				return lines[j], true
+				lastBottomRule = lines[j]
+				found = true
+				break
 			}
 			if !strings.HasPrefix(strings.TrimSpace(lines[j]), "│") {
 				break
 			}
 		}
 	}
-	return "", false
+	return lastBottomRule, found
 }
 
 // IsWorkingContent reports whether the captured pane shows POSITIVE evidence


### PR DESCRIPTION
## Summary

Closes #2439.

`ampFrameBottomRule` (`task/runner.go`) located amp's current prompt frame by returning the **first** complete frame in the pane, not the last. Agent output can quote a complete amp frame — labeled top rule, `│` interior, and a bottom rule — above the live one (the agent pasting an example of amp's UI, or an older turn's frame in scrollback). When that quoted frame's bottom rule read as working, `IsWorkingContent` reported the session as working off the stale frame, so a genuinely idle amp session stayed stuck at **Running** forever: `af sessions watch` never unblocked and the status dot never turned green.

Introduced by #1756 (72b48ccc).

## Fix

The current frame is the **bottom-most** complete pairing, never the first. `ampFrameBottomRule` now keeps scanning and returns the last contiguous frame's bottom rule — exactly the fix already applied to the opencode sibling `opencodeFrameLines` (which tracks `lastRuleIdx` for the same quoted-frame reason, a150473c). The contiguity walk and `isAmpPromptFrame` readiness path are unchanged.

## Test (fail first)

`TestIsWorkingContentAmpQuotedCompleteFrame` quotes a real complete working-frame capture (`amp_working_streaming.ansi`) above a real idle-frame capture (`amp_idle_after_turn.ansi`) and asserts the session reads idle. It fails on `master` (reads the quoted working frame → Running) and passes with the fix. The distinct existing guards still pass: `TestIsWorkingContentAmpStaleScrollback` (a lone stale bottom rule, no top) and `TestIsWorkingContentAmpRealCapture` (working/idle/ready fixtures).

## Verification

- Gate head: `427e8ba2`
- `go build ./...`, `gofmt -l` (clean), `go vet`, `golangci-lint run --fast` (clean), `deadcode -test ./...` (clean), `scripts/lint-file-length.sh` (pass)
- `make test-container`: **full suite green** — every package, `task` included.

## Base

Branched from current master (`d54e143a`). Disjoint from other in-flight lanes (touches only `task/runner.go` + `task/amp_working_test.go`).

## Review

Codex GitHub-app review is rate-limited/frozen until Jul 28 — requested once. If it stays silent, Captain Claude runs the standby review (claude-subagent) before merge. Held as draft; do not merge unreviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
