### PR TITLE
fix(tui): accept enter on ordinary confirmation dialogs (#2405)

### DIFF
--- a/app/mouse_test.go
+++ b/app/mouse_test.go
@@ -826,7 +826,7 @@ func TestMouse_ConfirmOverlayClicks(t *testing.T) {
 	assert.Equal(t, stateDefault, h.state, "clicking n cancels the dialog")
 	assert.NotEqual(t, session.Deleting, alpha.GetStatus(), "cancel must not kill")
 
-	// Re-open and click "y to confirm".
+	// Re-open and click "y/enter to confirm".
 	clock.advance(time.Second)
 	_, _ = h.handleKill()
 	require.Equal(t, stateConfirm, h.state)

--- a/app/root_kill_guard_test.go
+++ b/app/root_kill_guard_test.go
@@ -111,3 +111,53 @@ func TestHandleKill_NonReservedKeepsOrdinaryConfirm(t *testing.T) {
 	require.NotNil(t, cmd)
 	assert.Equal(t, session.Deleting, inst.GetStatus())
 }
+
+// TestHandleKill_NonReservedEnterConfirms pins #2405 at the app level: on an
+// ordinary scratch kill, pressing Enter confirms exactly like 'y' — a reflexive
+// Enter no longer sits on an unmoving dialog.
+func TestHandleKill_NonReservedEnterConfirms(t *testing.T) {
+	h := newTestHome(t)
+	inst := newKillableInstance(t, "scratch-1")
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	model, _ := h.handleKill()
+	hm := model.(*home)
+	require.Equal(t, stateConfirm, hm.state)
+	require.Equal(t, "y", hm.confirmationOverlay.ConfirmKey,
+		"scratch kill must use the ordinary confirm key for enter to alias it")
+
+	model, cmd := hm.handleStateConfirm(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.Equal(t, stateDefault, model.(*home).state, "enter must confirm a scratch kill")
+	require.NotNil(t, cmd, "enter must forward the start-kill message like 'y'")
+	assert.Equal(t, session.Deleting, inst.GetStatus())
+}
+
+// TestHandleKill_RootIgnoresEnter is the #2405 safety guard: the escalated root
+// kill dialog must reject Enter just as it rejects a reflexive 'y' (#1238). If
+// Enter dispatched here, D+Enter would decapitate root's event pipeline — the
+// exact muscle-memory failure the distinct confirm key exists to stop.
+func TestHandleKill_RootIgnoresEnter(t *testing.T) {
+	h := newTestHome(t)
+	root := newKillableInstance(t, session.RootSessionTitle)
+	h.store.AddInstance(root)
+	h.sidebar.SetSelectedInstance(0)
+
+	model, _ := h.handleKill()
+	hm := model.(*home)
+	require.Equal(t, stateConfirm, hm.state)
+	require.Equal(t, rootKillConfirmKey, hm.confirmationOverlay.ConfirmKey)
+
+	model, cmd := hm.handleStateConfirm(tea.KeyMsg{Type: tea.KeyEnter})
+	hm = model.(*home)
+	assert.Equal(t, stateConfirm, hm.state, "enter must not confirm a root kill")
+	assert.NotNil(t, hm.confirmationOverlay, "dialog must stay open after a rejected enter")
+	assert.Nil(t, cmd, "no kill must be dispatched by enter")
+	assert.NotEqual(t, session.Deleting, root.GetStatus(), "root must not be marked Deleting")
+
+	// The named key still confirms, proving enter's rejection is targeted.
+	model, cmd = hm.handleStateConfirm(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(rootKillConfirmKey)})
+	assert.Equal(t, stateDefault, model.(*home).state, "the named key must still confirm")
+	require.NotNil(t, cmd)
+	assert.Equal(t, session.Deleting, root.GetStatus())
+}

--- a/ui/overlay/confirmationOverlay.go
+++ b/ui/overlay/confirmationOverlay.go
@@ -16,6 +16,13 @@ const (
 	confirmationOverlayVerticalPadding   = 1
 )
 
+// defaultConfirmKey is the confirm key an un-escalated confirmation uses. A
+// dialog that keeps it (ordinary kill, delete-project, handoff, …) also accepts
+// enter as an affirmative alias (#2405). A dialog that escalates to a distinct
+// key (root #1238, unmerged #2022) does so precisely to require a deliberate,
+// non-reflex keystroke, so enter is NOT aliased there.
+const defaultConfirmKey = "y"
+
 // ConfirmationOverlay represents a confirmation dialog overlay
 type ConfirmationOverlay struct {
 	// Whether the overlay has been dismissed
@@ -51,7 +58,7 @@ func NewConfirmationOverlay(message string) *ConfirmationOverlay {
 		Dismissed:   false,
 		message:     message,
 		width:       50, // Default width
-		ConfirmKey:  "y",
+		ConfirmKey:  defaultConfirmKey,
 		CancelKey:   "n",
 		borderColor: ui.CurrentTheme().Error,
 	}
@@ -72,10 +79,16 @@ func (c *ConfirmationOverlay) HandleKeyPress(msg tea.KeyMsg) bool {
 			c.OnCancel()
 		}
 		return true
-	case strings.ToLower(c.ConfirmKey):
+	}
+
+	// The named confirm key always confirms; enter is an affirmative alias only
+	// for an un-escalated dialog (see enterConfirms). An escalated dialog (root
+	// #1238, unmerged #2022) must not be dispatchable by the D+enter reflex — the
+	// same reason it already rejects a reflexive 'y' (#2405).
+	if key == strings.ToLower(c.ConfirmKey) || (key == "enter" && c.enterConfirms()) {
 		// A guarded overlay too small to show its consequences must not collect a
 		// confirm (#1973). Refusing here — not merely rendering a warning — is
-		// what makes the guarantee real: the render and the key agree, so a 'y'
+		// what makes the guarantee real: the render and the key agree, so a confirm
 		// typed blind against an unreadable dialog does nothing. The dialog stays
 		// open (esc still cancels) so the user can resize and read it.
 		rect := c.textRect()
@@ -87,10 +100,18 @@ func (c *ConfirmationOverlay) HandleKeyPress(msg tea.KeyMsg) bool {
 			c.OnConfirm()
 		}
 		return true
-	default:
-		// Ignore other keys in confirmation state
-		return false
 	}
+
+	// Ignore other keys in confirmation state
+	return false
+}
+
+// enterConfirms reports whether enter acts as an alias for the confirm key. It
+// does only while the confirm key is the un-escalated default: escalating to a
+// distinct key is the signal that easy affirmatives (a reflexive 'y', enter)
+// must not dispatch the action (#1238/#2022/#2405).
+func (c *ConfirmationOverlay) enterConfirms() bool {
+	return strings.EqualFold(strings.TrimSpace(c.ConfirmKey), defaultConfirmKey)
 }
 
 // frameStyle is the overlay's border+padding style, shared by every path that
@@ -341,7 +362,13 @@ func (c *ConfirmationOverlay) instruction(compact bool) string {
 		return bold(c.ConfirmKey) + " confirm • " +
 			bold(c.CancelKey) + "/" + bold("esc") + " cancel"
 	}
-	return "Press " + bold(c.ConfirmKey) + " to confirm, " +
+	confirmKeys := bold(c.ConfirmKey)
+	if c.enterConfirms() {
+		// "/enter" mirrors the compact "n/esc" idiom and keeps the full hint on one
+		// line at the confirmation's fixed width, so its click zone survives (#2405).
+		confirmKeys += "/" + bold("enter")
+	}
+	return "Press " + confirmKeys + " to confirm, " +
 		bold(c.CancelKey) + " or " + bold("esc") + " to cancel"
 }
 

--- a/ui/overlay/confirmationOverlay_test.go
+++ b/ui/overlay/confirmationOverlay_test.go
@@ -159,6 +159,74 @@ func TestConfirmationOverlay_HandleKeyPress_OtherKey(t *testing.T) {
 	assert.False(t, confirmCalled, "OnConfirm should not be called")
 }
 
+// TestConfirmationOverlay_HandleKeyPress_EnterConfirmsDefault pins #2405: on an
+// ordinary (un-escalated) confirmation, enter is an affirmative alias for the
+// confirm key. Before the fix enter fell through to the ignore branch, so a
+// user's reflexive Enter left the dialog sitting open with no visible effect.
+func TestConfirmationOverlay_HandleKeyPress_EnterConfirmsDefault(t *testing.T) {
+	overlay := NewConfirmationOverlay("Test confirmation")
+
+	confirmCalled := false
+	overlay.OnConfirm = func() { confirmCalled = true }
+	cancelCalled := false
+	overlay.OnCancel = func() { cancelCalled = true }
+
+	shouldClose := overlay.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.True(t, shouldClose, "enter should confirm an ordinary dialog")
+	assert.True(t, overlay.Dismissed, "overlay should be dismissed")
+	assert.True(t, confirmCalled, "OnConfirm should be called for enter")
+	assert.False(t, cancelCalled, "OnCancel should not be called for enter")
+}
+
+// TestConfirmationOverlay_HandleKeyPress_EnterIgnoredWhenEscalated pins the
+// safety half of #2405: a dialog that escalated to a distinct confirm key (root
+// #1238, unmerged #2022) must NOT accept enter, or the exact D+enter reflex the
+// escalation defends against would dispatch the irreversible action. The named
+// key must still confirm.
+func TestConfirmationOverlay_HandleKeyPress_EnterIgnoredWhenEscalated(t *testing.T) {
+	overlay := NewConfirmationOverlay("[!] Kill session 'root'?")
+	overlay.SetConfirmKey("k")
+
+	confirmCalled := false
+	overlay.OnConfirm = func() { confirmCalled = true }
+	cancelCalled := false
+	overlay.OnCancel = func() { cancelCalled = true }
+
+	shouldClose := overlay.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.False(t, shouldClose, "enter must be ignored on an escalated dialog")
+	assert.False(t, overlay.Dismissed, "overlay must stay open")
+	assert.False(t, confirmCalled, "OnConfirm must not be called by enter")
+	assert.False(t, cancelCalled, "OnCancel must not be called by enter")
+
+	shouldClose = overlay.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	assert.True(t, shouldClose, "the escalated key must still confirm")
+	assert.True(t, confirmCalled, "OnConfirm should be called for the named key")
+}
+
+// TestConfirmationOverlay_Instruction_AdvertisesEnterOnlyWhenAccepted pins the
+// prompt copy: an ordinary dialog advertises enter as a confirm alias, while an
+// escalated dialog names only its distinct key so the copy never promises an
+// enter it will refuse.
+func TestConfirmationOverlay_Instruction_AdvertisesEnterOnlyWhenAccepted(t *testing.T) {
+	def := NewConfirmationOverlay("[!] Kill session 'alpha'?")
+	def.SetWidth(50)
+	def.SetMaxSize(80, 24)
+	assert.Contains(t, overlayProse(def.Render()), "y/enter to confirm",
+		"an ordinary dialog must advertise enter as a confirm alias")
+
+	esc := NewConfirmationOverlay("[!] Kill session 'root'?")
+	esc.SetConfirmKey("k")
+	esc.SetWidth(50)
+	esc.SetMaxSize(80, 24)
+	rendered := overlayProse(esc.Render())
+	assert.Contains(t, rendered, "k to confirm",
+		"an escalated dialog still names its distinct key")
+	assert.NotContains(t, rendered, "enter",
+		"an escalated dialog must not offer enter")
+}
+
 // overlayProse reduces a rendered overlay to the prose inside it, so a multi-word
 // assertion matches content rather than failing on the wrap.
 //

--- a/ui/overlay/zones.go
+++ b/ui/overlay/zones.go
@@ -35,6 +35,11 @@ func (c *ConfirmationOverlay) RegisterZones(reg *zones.Registry, origin layout.P
 		return
 	}
 	yesNeedle := c.ConfirmKey + " to confirm"
+	if c.enterConfirms() {
+		// The full hint advertises enter as a confirm alias (#2405); the zone must
+		// cover the same words the renderer wrote, or the click target goes stale.
+		yesNeedle = c.ConfirmKey + "/enter to confirm"
+	}
 	noNeedle := c.CancelKey + " or esc to cancel"
 	compactYesNeedle := c.ConfirmKey + " confirm"
 	compactNoNeedle := c.CancelKey + "/esc cancel"

--- a/ui/overlay/zones_test.go
+++ b/ui/overlay/zones_test.go
@@ -59,8 +59,8 @@ func TestConfirmationOverlayRegistersYesNoZones(t *testing.T) {
 
 	assert.Equal(t, yes.Y, no.Y, "both buttons sit on the instruction line")
 	line := lines[yes.Y-origin.Y]
-	assert.Equal(t, "y to confirm", cellSliceAt(line, yes.X-origin.X, yes.W),
-		"the yes zone covers exactly its rendered words")
+	assert.Equal(t, "y/enter to confirm", cellSliceAt(line, yes.X-origin.X, yes.W),
+		"the yes zone covers exactly its rendered words, including the enter alias (#2405)")
 	assert.Equal(t, "n or esc to cancel", cellSliceAt(line, no.X-origin.X, no.W),
 		"the no zone covers exactly its rendered words")
 


### PR DESCRIPTION
## What

Fixes #2405. Confirmation overlays ignored **Enter** entirely — a user pressing Enter to confirm a kill (the common convention) saw the dialog sit open with no visible effect.

Enter now acts as an affirmative **alias for the confirm key**, but only on *un-escalated* dialogs:

| Dialog | Confirm key | Enter |
|---|---|---|
| Ordinary kill, delete-project, handoff, switch-project | `y` | **confirms** |
| Reserved **root** agent (#1238) | `k` | **no-op** — must press `k` |
| **Unmerged/unpushed** work (#2022) | `k` | **no-op** — must press `k` |

## Why the split (the load-bearing part)

The kill dialog deliberately uses a distinct key (`k`, not `y`) for the two irreversible cases so the muscle-memory `D`+`y` gesture — the one that decapitated root's event pipeline on 2026-07-05 — can't dispatch them. Mapping Enter to *confirm* uniformly would re-introduce exactly that regression via `D`+`Enter`. So **escalation (a non-default confirm key) is the single signal that gates both easy affirmatives** (`y` and `enter`); `enterConfirms()` is true only while the confirm key is the un-escalated default.

## Copy + mouse zone

The ordinary hint now reads `Press y/enter to confirm, n or esc to cancel`. `/enter` mirrors the file's existing compact `n/esc` idiom and keeps the hint on **one line** at the overlay's fixed width (44 ≤ 46 cols), so the mouse click zone still registers — `zones.go`'s needle tracks the same copy. Escalated dialogs still name only their distinct key.

## Tests (fail-first)

Added, and confirmed each fails against unmodified code first:
- `ui/overlay`: `…_EnterConfirmsDefault`, `…_EnterIgnoredWhenEscalated`, `…_Instruction_AdvertisesEnterOnlyWhenAccepted`
- `app`: `TestHandleKill_NonReservedEnterConfirms` (enter kills a scratch session), `TestHandleKill_RootIgnoresEnter` (enter is a no-op on root, `k` still confirms)
- Updated `TestConfirmationOverlayRegistersYesNoZones` to require the zone on the new one-line copy — which also locks the no-wrap property.

## Real rendered TUI @ 80×24

Driven through the container TUI driver:

**Ordinary kill** — dialog renders on one line, Enter confirms:
```
  [!] Kill session 'alpha'?
  Press y/enter to confirm, n or esc to cancel
```
→ `Enter` → `Instances (0)` / "No sessions yet" (killed).

**Unmerged kill (the reporter's exact `Press k to confirm` case)** — Enter is a no-op, `k` confirms:
```
  Branch "dev/beta" has 1 commit that isn't merged or pushed anywhere. Killing permanently deletes it · this cannot be undone.
  Press k to confirm, n or esc to cancel
```
→ `Enter` → dialog unchanged, beta not deleted → `k` → killed.

## Gate

`gofmt` · `go build ./...` · `golangci-lint --fast` · `deadcode -test ./...` · file-length · full suite via `make test-container` — all green on the pushed head.

## Review

Codex GitHub-app review is rate-limited until Jul 28; requested once. If it stays silent, Captain Claude runs the codex-CLI review before any merge — not merging unreviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
