### PR TITLE
fix(session): remove a captureEnded clear that never ran (#2438)

### DIFF
--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -142,13 +142,20 @@ type ptyBroker struct {
 	// short-circuits and no new capture is ever dialled (#2438). Set by readLoop
 	// under mu BEFORE it closes `done`, so anything that joins the loop sees it.
 	//
-	// It is meaningful ONLY while `capturing` is true — the pair reads as "a
-	// capture is installed, and it is spent". Every site that clears `capturing`
-	// clears this too, in the same critical section, so the flag can never
-	// out-live the capture it describes and be read as a claim about the NEXT
-	// one. (Leaving it latched would be harmless today, since `capturing == false`
-	// already routes to the reconcile that clears it — but it would make the
-	// field a lie to anyone who reads it on its own.)
+	// Read it ONLY together with `capturing`, never alone. The one read that
+	// exists — ensureCaptureStartedLocked's `capturing && !captureEnded` — is the
+	// contract: the pair means "a capture is installed, and it is spent". With
+	// `capturing` false this flag says NOTHING, and in particular does not mean a
+	// fresh capture; the reconcile clears it on the way to dialling one.
+	//
+	// It deliberately survives a teardown, because it CANNOT be cleared by one.
+	// Every teardown ends by joining the readLoop (`<-done` inside stopCapture),
+	// and the loop's last act before closing `done` is to latch this flag — so a
+	// teardown that clears it first has it set again by the join, every time. An
+	// attempt to clear it in those three sites shipped in #2438 and did exactly
+	// nothing; it was removed rather than moved after the join, because the state
+	// it was chasing is unobservable: the sole reader is guarded by `capturing`,
+	// which the same teardown already cleared.
 	captureEnded bool
 	closed       bool
 	// tabClosed records that this broker was shut down because ITS TAB was closed
@@ -413,7 +420,6 @@ func (b *ptyBroker) maybeStopCapture() {
 	stop := b.stopCapture
 	b.capturing = false
 	b.stopCapture = nil
-	b.captureEnded = false
 	b.mu.Unlock()
 
 	if stop != nil {
@@ -472,7 +478,6 @@ func (b *ptyBroker) resetCapture() {
 		b.capturing = false
 		b.stopCapture = nil
 	}
-	b.captureEnded = false
 	b.mu.Unlock()
 
 	// The barrier MUST be lifted on EVERY path out — a failed restart, a Snapshot
@@ -744,7 +749,6 @@ func (b *ptyBroker) shutdown(tabClosed bool) {
 		b.capturing = false
 		b.stopCapture = nil
 	}
-	b.captureEnded = false
 	b.mu.Unlock()
 	if stop != nil {
 		stop()

--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -148,14 +148,23 @@ type ptyBroker struct {
 	// `capturing` false this flag says NOTHING, and in particular does not mean a
 	// fresh capture; the reconcile clears it on the way to dialling one.
 	//
-	// It deliberately survives a teardown, because it CANNOT be cleared by one.
-	// Every teardown ends by joining the readLoop (`<-done` inside stopCapture),
-	// and the loop's last act before closing `done` is to latch this flag — so a
-	// teardown that clears it first has it set again by the join, every time. An
-	// attempt to clear it in those three sites shipped in #2438 and did exactly
-	// nothing; it was removed rather than moved after the join, because the state
-	// it was chasing is unobservable: the sole reader is guarded by `capturing`,
-	// which the same teardown already cleared.
+	// No teardown clears it, and the two cases are worth separating because they
+	// fail differently:
+	//
+	//   - A teardown that HAS a capture to release ends by joining the readLoop
+	//     (`<-done` inside stopCapture), and the loop's last act before closing
+	//     `done` is to latch this flag. So a clear placed before that join is
+	//     undone by it — #2438 shipped exactly that in three sites, and it did
+	//     nothing.
+	//   - A teardown that has NOTHING to release (it found `capturing` already
+	//     false, so stopCapture was nil and no join happened) could clear the flag
+	//     and make it stick. But there is nothing left to describe by then: the
+	//     capture it referred to is gone.
+	//
+	// Either way the residue is unobservable, because the sole reader is guarded
+	// by `capturing`, which every teardown has already cleared. So the clears were
+	// removed rather than moved after the join: moving them would add a second
+	// b.mu section on three teardown paths to change nothing.
 	captureEnded bool
 	closed       bool
 	// tabClosed records that this broker was shut down because ITS TAB was closed

--- a/session/ptybroker_upstream_death_test.go
+++ b/session/ptybroker_upstream_death_test.go
@@ -257,3 +257,69 @@ func TestPTYBrokerUpstreamDeathDoesNotResurrectAClosedBroker(t *testing.T) {
 		t.Fatalf("StartCapture calls = %d, want 1 (a closed broker must never re-dial)", starts)
 	}
 }
+
+// TestPTYBrokerCaptureEndedIsOnlyMeaningfulWithCapturing pins what captureEnded
+// actually promises, because #2438 shipped a change that assumed the opposite
+// and did nothing.
+//
+// A teardown CANNOT clear this flag. Every teardown ends by joining the readLoop
+// (`<-done` inside stopCapture), and the loop's last act before closing `done`
+// is to latch the flag — so a teardown that clears it first has it set again by
+// the join, every single time. Clearing it there was a no-op, and the field doc
+// that claimed the flag "can never out-live the capture it describes" was false.
+//
+// What is actually true, and what this locks: the flag is meaningless once
+// `capturing` is false, and the next bring-up dials a fresh capture regardless
+// of the residue. Asserting the residue directly is the point — it stops the
+// next reader from "fixing" a latch that cannot be fixed and is not a bug.
+func TestPTYBrokerCaptureEndedIsOnlyMeaningfulWithCapturing(t *testing.T) {
+	state := func(b *ptyBroker) (capturing, ended bool) {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		return b.capturing, b.captureEnded
+	}
+
+	ch := &singleSocketChannel{snapshot: []byte("SCREEN")}
+	br := newPTYBroker(ch)
+
+	a, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+	mustRepaintContains(t, a, "SCREEN")
+	if capturing, ended := state(br); !capturing || ended {
+		t.Fatalf("live capture = {capturing:%v ended:%v}, want {true false}", capturing, ended)
+	}
+
+	// The last subscriber leaves: maybeStopCapture tears the capture down and
+	// JOINS the readLoop, whose defer latches the flag on its way out.
+	if err := a.Close(); err != nil {
+		t.Fatalf("close A: %v", err)
+	}
+	capturing, ended := state(br)
+	if capturing {
+		t.Fatalf("capturing = true after the last subscriber left, want false")
+	}
+	if !ended {
+		t.Fatal("captureEnded = false after a teardown joined the readLoop.\n\n" +
+			"If this ever passes, the join stopped latching the flag — re-read the field doc, " +
+			"because it says a teardown CANNOT clear it and that is why no teardown tries.")
+	}
+
+	// And the residue is harmless: the next bring-up reconciles it away and dials
+	// a genuinely fresh capture. This is the only property any caller depends on.
+	b, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe after teardown: %v", err)
+	}
+	defer func() { _ = b.Close() }()
+	if capturing, ended := state(br); !capturing || ended {
+		t.Fatalf("re-armed capture = {capturing:%v ended:%v}, want {true false}", capturing, ended)
+	}
+	if starts, _ := ch.counts(); starts != 2 {
+		t.Fatalf("StartCapture calls = %d, want 2 (the teardown's residue must not block a fresh dial)", starts)
+	}
+	mustRepaintContains(t, b, "SCREEN")
+	ch.emit(t, []byte("after-teardown"))
+	mustData(t, b, "after-teardown")
+}

--- a/session/ptybroker_upstream_death_test.go
+++ b/session/ptybroker_upstream_death_test.go
@@ -262,16 +262,23 @@ func TestPTYBrokerUpstreamDeathDoesNotResurrectAClosedBroker(t *testing.T) {
 // actually promises, because #2438 shipped a change that assumed the opposite
 // and did nothing.
 //
-// A teardown CANNOT clear this flag. Every teardown ends by joining the readLoop
-// (`<-done` inside stopCapture), and the loop's last act before closing `done`
-// is to latch the flag — so a teardown that clears it first has it set again by
-// the join, every single time. Clearing it there was a no-op, and the field doc
-// that claimed the flag "can never out-live the capture it describes" was false.
+// This exercises the teardown that HAS a capture to release — the case #2438's
+// clears were written for, and the case they could not serve. Such a teardown
+// ends by joining the readLoop (`<-done` inside stopCapture), and the loop's
+// last act before closing `done` is to latch the flag, so a clear placed before
+// that join is simply undone by it. (A teardown that finds `capturing` already
+// false joins nothing and could clear it — but by then there is no capture left
+// to describe. See the field doc.)
 //
-// What is actually true, and what this locks: the flag is meaningless once
-// `capturing` is false, and the next bring-up dials a fresh capture regardless
-// of the residue. Asserting the residue directly is the point — it stops the
-// next reader from "fixing" a latch that cannot be fixed and is not a bug.
+// What this locks is the contract: the flag is meaningless once `capturing` is
+// false, and the next bring-up dials a fresh capture regardless of the residue.
+// Asserting the residue directly is the point — it stops the next reader from
+// "fixing" a latch that is not a bug.
+//
+// Note this test cannot fail-first on the code change it accompanies: removing
+// three writes that were already being undone has no observable effect, which is
+// the change's own thesis. It is a doc-lock, and the assertion it protects is
+// the one #2438's comment got wrong.
 func TestPTYBrokerCaptureEndedIsOnlyMeaningfulWithCapturing(t *testing.T) {
 	state := func(b *ptyBroker) (capturing, ended bool) {
 		b.mu.Lock()


### PR DESCRIPTION
Fixes a defect I shipped in #2447 (issue #2438). Part of #2450.

**Opened as draft deliberately.** #2447 auto-merged while a re-review of its head was still outstanding, which is how this got in. This one stays draft until it has a review verdict on its final head.

## What is wrong on master

#2447 added three `captureEnded = false` clears (`maybeStopCapture`, `resetCapture`, `shutdown`) and a field doc asserting the flag *"can never out-live the capture it describes"*. Both are wrong.

**A teardown cannot clear this flag.** Every teardown ends by joining the readLoop (`<-done` inside `stopCapture`), and the loop's last act before closing `done` is to latch the flag — so a teardown that clears it first has it set again by the join, every time.

Measured on the merged head with a throwaway probe:

```
after subscribe:        capturing=true  captureEnded=false
after maybeStopCapture: capturing=false captureEnded=true
after shutdown:         capturing=false captureEnded=true
```

So the clears are dead writes, and the invariant in the doc is false. Worse, that doc **deleted the one accurate line it replaced** — *"cleared by ensureCaptureStartedLocked when it reconciles"*, which is the only place the flag is genuinely reconciled — in favour of a claim a future reader could rely on. That is exactly the drifting-comment class the change was trying to clean up.

## Why remove rather than move after the join

Moving the clears after `stop()` would make the invariant true, but it would add a second `b.mu` section on three teardown paths to change nothing observable.

The state being chased is unreachable. The flag has exactly one reader — `ensureCaptureStartedLocked`'s `capturing && !captureEnded` — and every teardown has already cleared `capturing`, which fails the first conjunct on its own. So the residue cannot reach the only code that looks at it.

Removing the writes and describing the real contract is the smaller and more honest change.

## What the doc says now

Read the flag only together with `capturing`; with `capturing` false it says nothing. A teardown cannot clear it, which is why none tries. The reconcile is what clears it.

## Test

`TestPTYBrokerCaptureEndedIsOnlyMeaningfulWithCapturing` asserts the residue **directly** — `captureEnded == true` after a teardown — so the next reader cannot "fix" a latch that cannot be fixed and is not a bug. It then pins the property callers actually depend on: the next bring-up reconciles the residue away and dials a genuinely fresh capture (`StartCapture` count 2, repaint, live bytes).

Asserting internal state is the point here. The previous doc claim was unenforced, which is how it shipped false.

## Behaviour

Unchanged in both directions. This is the doc and the dead write only. The #2438 re-dial fix itself is untouched — its concurrency was attacked hard in review (lock-order audit plus directed and randomized `-race` harnesses) and held.

## Gate

`golangci-lint --fast`, `gofmt -l .`, `go build ./...`, `deadcode -test ./...`, `scripts/lint-file-length.sh`, `make test-container` (41 packages, zero failures), `go test -race ./session/`, and `-race -count=3` on the broker tests — all clean on this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
