### PR TITLE
feat(web): remove the live indicators from the app bar and pane header (#2458)

### DIFF
--- a/docs/web-selftest.md
+++ b/docs/web-selftest.md
@@ -58,7 +58,7 @@ Against the live SPA served over the daemon's plain-HTTP listener:
 | Flow | Assertion |
 | --- | --- |
 | **Login** | Pasting the daemon token into the login form renders the authed app. |
-| **Sidebar** | The rail lists the seeded sessions from the Snapshot/events plane, and the live pip reads "Live". |
+| **Sidebar** | The rail lists the seeded sessions from the Snapshot/events plane, and the client reports an open event stream (`.af-app[data-live="open"]`). |
 | **Attach** | Click-to-attach opens the xterm terminal and shows the fake agent's live output (a real binary PTY frame decoded by the TS codec and painted in the browser). |
 | **Keyboard (#1694)** | In the sessions view's rail mode `j`/`k` navigate the rail; `Enter` attaches the selection; `Escape` returns to the rail. |
 | **View cycling (#1694/PR8)** | In rail mode `]` cycles the top-level view forward (sessions → tasks) and `[` cycles it back (tasks → sessions), the active view tab following each step. |

--- a/docs/web.md
+++ b/docs/web.md
@@ -256,9 +256,9 @@ the top bar, the **project switcher** (top-right), or the `[` / `]` keys:
 
 ```
 ┌───────────────────────────────────────────────────────────────────────┐
-│  Agent Factory   [ Sessions ]  Tasks       project ▾   ● Live   Disconnect│  ← app bar
+│  Agent Factory   [ Sessions ]  Tasks           project ▾   Disconnect │  ← app bar
 ├──────────────────────┬────────────────────────────────────────────────┤
-│ Sessions      3 ▼ +New│ fix-login-flow · Live │ Agent │ Terminal │ + │  ← title + tabs
+│ Sessions      3 ▼ +New│ fix-login-flow │ Agent │ Terminal │ + │  ← title + tabs
 │                       │ ┌────────────────────────────────────────────┐ │
 │ ● fix-login-flow      │ │                                            │ │
 │   ⎇ fix/login         │ │                                            │ │
@@ -273,15 +273,17 @@ the top bar, the **project switcher** (top-right), or the `[` / `]` keys:
 The **app bar** carries, left to right: the **Agent Factory** brand, the two
 **view tabs** (Sessions / Tasks), the **project switcher** (top-right; lists
 every project with per-project session + working counts, and scopes the rail and
-Tasks view to the selected project), a **Live** pip showing the daemon
-event-stream state (`Live` / `Connecting…` / `Reconnecting…`), and
-**Disconnect**.
+Tasks view to the selected project), and **Disconnect**.
+
+The client keeps a live WebSocket to the daemon's event stream and reconnects on
+its own, but does not draw a connection indicator: the rail simply keeps up to
+date. A dropped stream shows as the rail going quiet rather than as a badge.
 
 On a phone, width is assigned by function rather than desktop shrink behavior. With
 no session selected, the session-drawer toggle and view tabs share one aligned row in
 their keyboard order; the current **project** gets the wide slot on the next row beside
 one **More** button. Long project names end in an ellipsis. The decorative brand
-disappears, while Live status, install, theme, and Disconnect remain available as
+disappears, while install, theme, and Disconnect remain available as
 comfortable touch targets inside **More** instead of being squeezed or removed.
 Selecting a session collapses the app bar to just the hamburger — the pane's tab row
 takes the whole top — and those project/view/**More** controls move into the drawer
@@ -352,10 +354,14 @@ tapping the dimmed scrim dismisses the drawer directly.
 
 The main pane hosts a real terminal (xterm.js) streaming the agent's live output
 over the daemon's WebSocket PTY plane — the same bytes the TUI paints. One pane-header
-row holds the session title, terminal connection state (`Live` / `Connecting…` /
-`Reconnecting…` / `Agent exited`), horizontally scrolling tabs, and the conditional
+row holds the session title, horizontally scrolling tabs, and the conditional
 **Retry** escape. The title keeps a useful minimum and ellipsizes; Retry never shrinks;
 the tab strip owns the remaining width and scrolls rather than wrapping.
+
+The header shows the title alone. It used to carry the terminal's connection state
+joined to the session's branch (`Live · master`); both were removed as chrome that
+earned no attention. The terminal still reconnects on its own — what changed is that
+it does so without narrating it.
 
 #### Per-session actions
 

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -494,27 +494,6 @@ body {
   justify-content: center;
   font-size: var(--af-fs-xs);
 }
-.af-live {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-size: var(--af-fs-xs);
-  color: var(--af-text-2);
-}
-.af-live-pip {
-  width: 0.55rem;
-  height: 0.55rem;
-  border-radius: 50%;
-  background: var(--af-text-3);
-}
-.af-live-pip.af-live-open {
-  background: var(--af-dot-ready);
-}
-.af-live-pip.af-live-connecting,
-.af-live-pip.af-live-reconnecting {
-  background: var(--af-dot-lost);
-  animation: af-pulse 1.2s ease-in-out infinite;
-}
 .af-appbar-tools-wrap,
 .af-appbar-tools {
   display: inline-flex;
@@ -943,14 +922,6 @@ body {
 .af-dot-limit {
   color: var(--af-dot-limit);
 }
-@keyframes af-pulse {
-  0%, 100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.35;
-  }
-}
 .af-main {
   flex: 1;
   min-width: 0;
@@ -1022,25 +993,6 @@ body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-.af-term-meta {
-  flex: 0 1 auto;
-  min-width: 0;
-  font-size: var(--af-fs-xs);
-  color: var(--af-text-2);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.af-term-meta.af-term-open {
-  color: var(--af-dot-ready);
-}
-.af-term-meta.af-term-connecting,
-.af-term-meta.af-term-reconnecting {
-  color: var(--af-dot-lost);
-}
-.af-term-meta.af-term-exited {
-  color: var(--af-dot-dead);
 }
 .af-tabbar {
   display: flex;
@@ -1965,10 +1917,6 @@ body {
   }
   .af-appbar-tools-open > .af-appbar-tools {
     display: flex;
-  }
-  .af-appbar-tools .af-live {
-    min-height: 2.75rem;
-    padding-inline: var(--af-sp-3);
   }
   .af-appbar-tools .af-install {
     width: 100%;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -10908,29 +10908,12 @@ function noAuthLoginView(state, actions2) {
   }
   return h2("main", { class: "af-login" }, h2("div", { class: "af-card" }, ...children));
 }
-function termStatusLabel(s) {
-  switch (s) {
-    case "open":
-      return "Live";
-    case "connecting":
-      return "Connecting\u2026";
-    case "reconnecting":
-      return "Reconnecting\u2026";
-    case "exited":
-      return "Agent exited";
-  }
-}
 var AppShell = class {
   constructor(actions2, termHost2, modalHost2, installEl) {
     this.actions = actions2;
     this.termHost = termHost2;
     this.modalHost = modalHost2;
     this.installEl = installEl;
-    this.pip = h2("span", { class: "af-live-pip" });
-    this.pip.setAttribute("aria-hidden", "true");
-    this.pipLabel = h2("span", { class: "af-live-label" });
-    const live = h2("span", { class: "af-live" }, this.pip, this.pipLabel);
-    live.setAttribute("role", "status");
     const disconnect2 = h2("button", { type: "button", class: "af-ghost" }, "Disconnect");
     disconnect2.setAttribute("title", "Disconnect and forget the saved token");
     const themeToggle = h2("div", { class: "af-theme-toggle" });
@@ -10991,7 +10974,6 @@ var AppShell = class {
     const appbarTools = h2(
       "div",
       { class: "af-appbar-tools", id: "af-appbar-tools" },
-      live,
       ...this.installEl ? [this.installEl] : [],
       themeToggle,
       disconnect2
@@ -11119,8 +11101,6 @@ var AppShell = class {
     this.el = h2("main", { class: "af-app" }, header, viewport, this.toast, this.modalHost);
   }
   el;
-  pip;
-  pipLabel;
   railCount;
   railList;
   main;
@@ -11172,7 +11152,6 @@ var AppShell = class {
   lastStatusFilter = null;
   // Header text nodes for the selected pane, (re)created per selection.
   headTitle = null;
-  headMeta = null;
   // The selected visible rail row's archive/restore control and daemon-owned verb it
   // currently shows (#1932, #2186, #2234). Every actionable row owns controls now
   // (#2223), but a session can flip archive⇄restore WITHOUT a selection change, so
@@ -11302,8 +11281,7 @@ var AppShell = class {
     }
     if (this.lastLive !== state.live) {
       this.lastLive = state.live;
-      this.pip.className = `af-live-pip af-live-${state.live}`;
-      this.pipLabel.textContent = state.live === "open" ? "Live" : state.live === "connecting" ? "Connecting\u2026" : "Reconnecting\u2026";
+      this.el.dataset.live = state.live;
     }
     if (this.lastView !== state.view) {
       this.lastView = state.view;
@@ -11783,13 +11761,13 @@ var AppShell = class {
     const selected = selectedSession(state);
     if (!selected) {
       this.headTitle = null;
-      this.headMeta = null;
       this.headActions = null;
       this.headActionSig = "";
       this.retryBtn = null;
       this.retryVisible = false;
       this.tabBar = null;
       this.main.className = "af-main af-main-empty";
+      delete this.main.dataset.termStatus;
       this.main.replaceChildren(
         h2("p", { class: "af-empty-title" }, "Select a session"),
         h2("p", { class: "af-empty-hint" }, "Pick a session in the rail to attach its terminal.")
@@ -11797,8 +11775,7 @@ var AppShell = class {
       return;
     }
     this.headTitle = h2("span", { class: "af-term-title" }, selected.title);
-    this.headMeta = h2("span", { class: "af-term-meta" });
-    const titleBox = h2("div", { class: "af-term-head-main" }, this.headTitle, this.headMeta);
+    const titleBox = h2("div", { class: "af-term-head-main" }, this.headTitle);
     const retryBtn = h2("button", { type: "button", class: "af-ghost af-term-action" }, "Retry");
     retryBtn.title = "Resume this session from its usage-limit wall";
     retryBtn.addEventListener("click", () => this.actions.retryLimit());
@@ -12040,16 +12017,11 @@ var AppShell = class {
   }
   patchMainHead(state) {
     const selected = selectedSession(state);
-    if (!selected || !this.headTitle || !this.headMeta) {
+    if (!selected || !this.headTitle) {
       return;
     }
     this.headTitle.textContent = selected.title;
-    const parts = [termStatusLabel(state.termStatus)];
-    if (selected.branch) {
-      parts.push(selected.branch);
-    }
-    this.headMeta.textContent = parts.join(" \xB7 ");
-    this.headMeta.className = `af-term-meta af-term-${state.termStatus}`;
+    this.main.dataset.termStatus = state.termStatus;
     this.patchHeadActions(state, selected);
     const nowAction = selected.lifecycle_action ?? null;
     if (this.lifecycleBtn && nowAction && nowAction !== this.lifecycleAction) {

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "02a6d7eb4855";
+const VERSION = "f6e7779339e0";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -1189,6 +1189,37 @@ test("#2458: no live indicator by the project selector, no live/branch meta by t
   expect(head?.trim()).toBe(SESSION_A);
 });
 
+// The phone path is checked separately because the indicator was not merely
+// narrower there — below the breakpoint it moved INTO the More popover and carried
+// its own sizing rule, so a desktop-only check would miss a copy still rendering
+// behind a disclosure the user has to open to see.
+test("#2458 mobile (375px): the More popover carries no live indicator", REAL_FIXTURE, async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 375, height: 667 } });
+  try {
+    const p = await ctx.newPage();
+    await openTokenless(p);
+    await expect(p.locator(".af-app")).toHaveAttribute("data-live", "open");
+
+    const more = p.locator(".af-appbar-more");
+    await expect(more).toBeVisible();
+    await more.click();
+    const tools = p.locator(".af-appbar-tools");
+    await expect(tools).toBeVisible();
+
+    // Opened, so this is a real look inside rather than a pass earned by the
+    // popover being collapsed.
+    await expect(tools.locator(".af-live")).toHaveCount(0);
+    await expect(tools).not.toContainText("Live");
+    await expect(tools).not.toContainText("Connecting…");
+    // The controls that DO belong there survived the removal — the popover lost one
+    // child, not its contents.
+    await expect(tools.getByRole("button", { name: "Disconnect" })).toBeVisible();
+    await expect(tools.locator(".af-theme-opt").first()).toBeVisible();
+  } finally {
+    await ctx.close();
+  }
+});
+
 test("click-to-attach opens the xterm terminal and shows live output", REAL_FIXTURE, async () => {
   await row(page, SESSION_A).click();
 

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -477,7 +477,7 @@ async function realRailDiagnostics(page: Page): Promise<string> {
   const selectedRepo = await page.locator(".af-project-switch-name").textContent().catch(() => null);
   const selectedRepoKey = await page.evaluate(() => localStorage.getItem("af-project")).catch(() => null);
   const renderedRows = await page.locator(".af-rail-list .af-row").allTextContents().catch(() => []);
-  const livePipClass = await page.locator(".af-live-pip").getAttribute("class").catch(() => null);
+  const liveState = await page.locator(".af-app").getAttribute("data-live").catch(() => null);
 
   let snapshotLine: string;
   try {
@@ -537,7 +537,7 @@ async function realRailDiagnostics(page: Page): Promise<string> {
 
   return [
     `selected repo=${JSON.stringify(selectedRepo)} persisted=${JSON.stringify(selectedRepoKey)}`,
-    `rendered rail rows=${JSON.stringify(renderedRows)} ui events=${JSON.stringify(livePipClass)}`,
+    `rendered rail rows=${JSON.stringify(renderedRows)} ui events=${JSON.stringify(liveState)}`,
     `real Snapshot: ${snapshotLine}`,
     `real events: ${eventsLine}`,
   ].join("\n");
@@ -627,8 +627,8 @@ test("tokenless loopback (#1696): the SPA auto-connects with no token, no login 
   await expect(page.locator("#af-token")).toHaveCount(0);
   await assertRealRailFixture(page);
   // The events WS connected on the empty-token credential (the ?access_token= is
-  // blank and the loopback peer is exempt): the live pip reads open.
-  await expect(page.locator(".af-live-pip.af-live-open")).toBeVisible();
+  // blank and the loopback peer is exempt): the client publishes an open stream.
+  await expect(page.locator(".af-app")).toHaveAttribute("data-live", "open");
 });
 
 test("#2276: a fresh shell with no seeded real row reports rail-plane diagnostics", async ({ browser }) => {
@@ -820,7 +820,7 @@ test("token persistence: a NEW TAB after a login resumes the token and never pro
   await expect(second.locator("#af-token")).toHaveCount(0);
   // And it is really authorized, not just past the gate: the events WS connected on
   // the resumed credential.
-  await expect(second.locator(".af-live-pip.af-live-open")).toBeVisible();
+  await expect(second.locator(".af-app")).toHaveAttribute("data-live", "open");
 
   // A reload of the ORIGINAL tab resumes it too (the browser-restart case, minus the
   // restart), and the login form still never appears.
@@ -938,9 +938,9 @@ test("sidebar lists the seeded sessions from the Snapshot/events plane", REAL_FI
   // The top-right switcher shows the current (default) project.
   await expect(page.locator(".af-project-switch-name")).toContainText("mock-repo");
   await expect(page.locator(".af-rail-count")).toHaveText(/[2-9]|\d{2,}/);
-  // The events WebSocket connected: the live pip reads "Live" (open), proving the
+  // The events WebSocket connected: the client publishes an open stream, proving the
   // push plane the rail resyncs from is up.
-  await expect(page.locator(".af-live-pip.af-live-open")).toBeVisible();
+  await expect(page.locator(".af-app")).toHaveAttribute("data-live", "open");
 });
 
 test("status dots (#1766): waiting shows a green dot, working shows none, error states are static — no spin anywhere", REAL_FIXTURE, async ({
@@ -1156,6 +1156,39 @@ test("#2234: creating and id-less rows expose no lifecycle actions; the shared p
   await ctx.close();
 });
 
+// #2458: the two "live" indicators are gone from the rendered UI — the pip and
+// "Live"/"Connecting…" label beside the project selector, and the "Live · master"
+// meta beside the attached session's title.
+//
+// Asserted on the REAL shell, attached, because that is the only state in which
+// both used to render: a removal test run on an empty pane would pass against the
+// unfixed code. The paired data-attribute assertions are the other half — they
+// prove the machinery still reports open, so this is a removal of the indicators
+// and not of the thing they indicated.
+test("#2458: no live indicator by the project selector, no live/branch meta by the title", REAL_FIXTURE, async () => {
+  await row(page, SESSION_A).click();
+  await expect(page.locator(".af-main")).toHaveAttribute("data-term-status", "open");
+  await expect(page.locator(".af-app")).toHaveAttribute("data-live", "open");
+
+  await expect(page.locator(".af-live"), "the appbar live indicator must be gone").toHaveCount(0);
+  await expect(page.locator(".af-live-pip")).toHaveCount(0);
+  await expect(page.locator(".af-live-label")).toHaveCount(0);
+  await expect(page.locator(".af-term-meta"), "the pane-header live/branch meta must be gone").toHaveCount(0);
+
+  // Text, not just class names: a rebuilt indicator under a different class would
+  // slip past the selectors above while looking identical to the user. The appbar
+  // and pane header are checked rather than the whole page, since "Live" can
+  // legitimately appear in session content or the terminal's own output.
+  await expect(page.locator(".af-appbar")).not.toContainText("Live");
+  await expect(page.locator(".af-appbar")).not.toContainText("Connecting…");
+  await expect(page.locator(".af-term-head")).not.toContainText("Live");
+
+  // The branch went with it: "Live · master" was one unit, and the head now carries
+  // the session title alone.
+  const head = await page.locator(".af-term-head-main").textContent();
+  expect(head?.trim()).toBe(SESSION_A);
+});
+
 test("click-to-attach opens the xterm terminal and shows live output", REAL_FIXTURE, async () => {
   await row(page, SESSION_A).click();
 
@@ -1168,9 +1201,9 @@ test("click-to-attach opens the xterm terminal and shows live output", REAL_FIXT
   // a real binary PTY frame decoded by the TS codec and painted in the browser.
   await expect(page.locator(".af-term-host")).toContainText(READY_MARKER);
 
-  // The pane header status resolved to the live stream, and the keyboard followed
-  // the attach into terminal mode (#1693/#1694).
-  await expect(page.locator(".af-term-meta")).toContainText("Live");
+  // The terminal's own connection resolved to the live stream, and the keyboard
+  // followed the attach into terminal mode (#1693/#1694).
+  await expect(page.locator(".af-main")).toHaveAttribute("data-term-status", "open");
   await expect(page.locator(".af-app.af-kb-terminal")).toBeVisible();
 
   // Every actionable instance reserves the quiet action slot, but only the selected
@@ -1215,7 +1248,7 @@ test("#2337: agent Shift+Enter preserves xterm input effects while shell keeps C
     await openTokenless(p);
     await row(p, SESSION_A).click();
     await expect(p.locator(".af-term-host .xterm")).toBeVisible();
-    await expect(p.locator(".af-term-meta")).toContainText("Live");
+    await expect(p.locator(".af-main")).toHaveAttribute("data-term-status", "open");
 
     await p.keyboard.press("Shift+Enter");
     await expect.poll(() => inputPayloads.length, { message: "Shift+Enter must emit one OpInput" }).toBe(1);
@@ -1282,7 +1315,7 @@ test("#2337: agent Shift+Enter preserves xterm input effects while shell keeps C
     await createTerminalTab(p);
     shellCreated = true;
     await expect(p.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Terminal", { timeout: 30_000 });
-    await expect(p.locator(".af-term-meta")).toContainText("Live");
+    await expect(p.locator(".af-main")).toHaveAttribute("data-term-status", "open");
 
     inputPayloads.length = 0;
     await p.keyboard.type("echo $((233700 + 42))");
@@ -1479,7 +1512,7 @@ test("tabs: create a shell tab, switch to it, see its distinct output, close it 
   await expect(page.locator(".af-term-host")).not.toContainText(READY_MARKER);
   // Wait for the shell tab's stream to be live before typing — keystrokes sent
   // before the WS opens are dropped by the terminal's send() guard.
-  await expect(page.locator(".af-term-meta")).toContainText("Live");
+  await expect(page.locator(".af-main")).toHaveAttribute("data-term-status", "open");
   // The + attached the shell tab, so keys reach it: type a marker and see it come
   // back over the new tab's stream — proof the switch re-pointed to a live PTY.
   await page.keyboard.type("echo AF_TAB_OUTPUT_OK");
@@ -1530,7 +1563,7 @@ test("split panes (feat): drag a tab to a pane edge splits into two live panes; 
   const tabbar = page.locator(".af-tabbar");
   await createTerminalTab(page);
   await expect(tabbar.locator(".af-tab")).toHaveCount(2, { timeout: 30_000 });
-  await expect(page.locator(".af-term-meta")).toContainText("Live");
+  await expect(page.locator(".af-main")).toHaveAttribute("data-term-status", "open");
 
   // A single pane so far — today's zero-config default.
   await expect(page.locator(".af-term-host .af-pane")).toHaveCount(1);
@@ -1553,7 +1586,7 @@ test("split panes (feat): drag a tab to a pane edge splits into two live panes; 
   // The other pane (the shell tab) is an independent live PTY — focus it and type, and
   // its echo comes back over its own stream, proving both panes are live at once.
   await shellPane.locator(".af-pane-host").click();
-  await expect(page.locator(".af-term-meta")).toContainText("Live");
+  await expect(page.locator(".af-main")).toHaveAttribute("data-term-status", "open");
   await page.keyboard.type("echo AF_SPLIT_OK");
   await page.keyboard.press("Enter");
   await expect(shellPane).toContainText("AF_SPLIT_OK", { timeout: 15_000 });
@@ -1735,7 +1768,7 @@ test("split panes (#1901): dragging the ACTIVE tab splits and opens a DIFFERENT 
   await resetToAgentTab(page);
   await createTerminalTab(page);
   await expect(tabbar.locator(".af-tab")).toHaveCount(2, { timeout: 30_000 });
-  await expect(page.locator(".af-term-meta")).toContainText("Live");
+  await expect(page.locator(".af-main")).toHaveAttribute("data-term-status", "open");
   // Creating a tab switches to it: the pane now shows Terminal, and Terminal is the tab
   // the bar marks active. That is the gesture's precondition — the dragged tab and the
   // target pane's tab are THE SAME.
@@ -1771,7 +1804,7 @@ test("split panes (#1901): dragging the ACTIVE tab splits and opens a DIFFERENT 
   await expect(agentPane, "the new half is the Agent tab").toHaveAttribute("data-tab-id", rightId ?? "");
   const termPane = page.locator(".af-term-host .af-pane", { hasNotText: READY_MARKER });
   await termPane.locator(".af-pane-host").click();
-  await expect(page.locator(".af-term-meta")).toContainText("Live");
+  await expect(page.locator(".af-main")).toHaveAttribute("data-term-status", "open");
   await page.keyboard.type("echo AF_SELFSPLIT_OK");
   await page.keyboard.press("Enter");
   await expect(termPane).toContainText("AF_SELFSPLIT_OK", { timeout: 15_000 });
@@ -1804,7 +1837,7 @@ test("split panes (#1901): dragging the only tab of a ONE-tab session is an iner
   await expect(page.locator(".af-term-host .af-pane")).toHaveAttribute("data-tab-id", before ?? "");
   // The pane is untouched, not merely present: its stream still carries the session.
   await page.locator(".af-term-host .af-pane-host").click();
-  await expect(page.locator(".af-term-meta")).toContainText("Live");
+  await expect(page.locator(".af-main")).toHaveAttribute("data-term-status", "open");
 });
 
 test("web tab (feat): a local dev-server preview is daemon-proxied and rendered in an iframe", REAL_FIXTURE, async () => {
@@ -2463,7 +2496,7 @@ test("split panes (feat): logout clears retained trees — a fresh login shows t
   await expect(page.locator(".af-login")).toBeVisible();
   await page.locator(".af-login button.af-primary").click();
   await expect(page.locator(".af-app")).toBeVisible();
-  await expect(page.locator(".af-live-pip.af-live-open")).toBeVisible();
+  await expect(page.locator(".af-app")).toHaveAttribute("data-live", "open");
 
   // Re-select A: the retained split was cleared on logout, so it opens as a SINGLE
   // pane (the zero-config default), not the previous two-pane split.
@@ -3959,7 +3992,7 @@ test("#2347: activating a terminal repairs peer-owned geometry before scrolling"
     const firstShell = first.locator(".af-tabbar .af-tab", { hasText: shellName });
     await expect(firstShell).toHaveCount(1, { timeout: 15_000 });
     await firstShell.click();
-    await expect(first.locator(".af-term-meta")).toContainText("Live");
+    await expect(first.locator(".af-main")).toHaveAttribute("data-term-status", "open");
     const firstHost = first.locator(".af-term-host");
     const firstRows = (): Promise<number> => firstHost.locator(".xterm-rows > div").count();
     await expect.poll(firstRows).toBeGreaterThan(24);
@@ -3992,7 +4025,7 @@ test("#2347: activating a terminal repairs peer-owned geometry before scrolling"
     const secondShell = second.locator(".af-tabbar .af-tab", { hasText: shellName });
     await expect(secondShell).toHaveCount(1, { timeout: 15_000 });
     await secondShell.click();
-    await expect(second.locator(".af-term-meta")).toContainText("Live");
+    await expect(second.locator(".af-main")).toHaveAttribute("data-term-status", "open");
     const secondHost = second.locator(".af-term-host");
     await expect.poll(firstRows).toBeGreaterThan(60);
     // New output while the first client is inactive must not stale its reading
@@ -4080,7 +4113,7 @@ test("#2347: the mobile agent terminal also reclaims peer-owned geometry", REAL_
     await first.locator(".af-nav-toggle").click();
     await expect(row(first, sessionName)).toBeVisible({ timeout: 15_000 });
     await row(first, sessionName).click();
-    await expect(first.locator(".af-term-meta")).toContainText("Live");
+    await expect(first.locator(".af-main")).toHaveAttribute("data-term-status", "open");
     const firstHost = first.locator(".af-term-host");
     const firstRows = (): Promise<number> => firstHost.locator(".xterm-rows > div").count();
     await expect.poll(firstRows).toBeGreaterThan(0);
@@ -4117,7 +4150,7 @@ test("#2347: the mobile agent terminal also reclaims peer-owned geometry", REAL_
       await peer.locator(".af-nav-toggle").click();
       await expect(row(peer, sessionName)).toBeVisible({ timeout: 15_000 });
       await row(peer, sessionName).click();
-      await expect(peer.locator(".af-term-meta")).toContainText("Live");
+      await expect(peer.locator(".af-main")).toHaveAttribute("data-term-status", "open");
       await expect.poll(firstRows, { message: label }).toBeGreaterThan(lineCount);
       const stranded = await terminalGeometry(firstHost, true);
       expect(stranded.rows, `${label}; peer geometry=${JSON.stringify(stranded)}`).toBeGreaterThan(lineCount);
@@ -4392,7 +4425,7 @@ test("#1815: a tab created out-of-band must not rewind the scrolled terminal", R
   await expect(shell).toHaveCount(1, { timeout: 15_000 });
   await shell.click();
   await expect(shell).toHaveClass(/af-tab-active/);
-  await expect(page.locator(".af-term-meta")).toContainText("Live");
+  await expect(page.locator(".af-main")).toHaveAttribute("data-term-status", "open");
 
   // More than one screen of numbered output, so which line is on screen is exact.
   // xterm renders only the VISIBLE rows, so the pane's text IS its viewport.
@@ -4491,7 +4524,7 @@ test("#1815: a resize must not re-arm the rewind on the next out-of-band resync"
   await expect(shellTab).toHaveCount(1, { timeout: 15_000 });
   await shellTab.click();
   await expect(shellTab).toHaveClass(/af-tab-active/);
-  await expect(page.locator(".af-term-meta")).toContainText("Live");
+  await expect(page.locator(".af-main")).toHaveAttribute("data-term-status", "open");
 
   await dragTabToPane(page, "Agent", "right");
   await expect(page.locator(".af-term-host .af-pane")).toHaveCount(2, { timeout: 15_000 });
@@ -4501,7 +4534,7 @@ test("#1815: a resize must not re-arm the rewind on the next out-of-band resync"
 
   // Fill the shell pane's scrollback and park the view up in it.
   await shellPane.locator(".af-pane-host").click();
-  await expect(page.locator(".af-term-meta")).toContainText("Live");
+  await expect(page.locator(".af-main")).toHaveAttribute("data-term-status", "open");
   await page.keyboard.type("for i in $(seq 1 200); do echo resize-line-$i; done");
   await page.keyboard.press("Enter");
   await expect(shellPane).toContainText("resize-line-200", { timeout: 15_000 });
@@ -5061,7 +5094,7 @@ test("the service worker NEVER caches /v1 — not the API, not the stream (the b
   // the Snapshot fetch both ran to render the rail, and the events WS is open. That
   // matters — a worker that cached indiscriminately would have caught them, so the
   // absence below is a real result rather than an absence of opportunity.
-  await expect(p.locator(".af-live-pip.af-live-open")).toBeVisible();
+  await expect(p.locator(".af-app")).toHaveAttribute("data-live", "open");
   await p.evaluate(() => fetch("/v1/auth-info"));
 
   const { urls } = await cacheContents(p);
@@ -5080,7 +5113,7 @@ test("the service worker does not SERVE /v1: offline, the shell survives from ca
   // offline assertions below are only meaningful once the shell is actually cached —
   // otherwise "the shell survives offline" could fail for want of a cache rather than
   // for the reason under test.
-  await expect(p.locator(".af-live-pip.af-live-open")).toBeVisible();
+  await expect(p.locator(".af-app")).toHaveAttribute("data-live", "open");
   await expect.poll(async () => (await cacheContents(p)).urls.some((u) => u.endsWith("/af-web.js"))).toBe(true);
 
   // Offline is the sharpest discriminator available, and the reason this test exists
@@ -5120,11 +5153,11 @@ test("a live PTY stream and the events WS survive the service worker controlling
   // The functional half of the bypass, and the one that matters to a user: with the
   // worker in control, attach and watch real PTY frames arrive. A worker that
   // intercepted or delayed the stream would show up here as an empty pane.
-  await expect(p.locator(".af-live-pip.af-live-open")).toBeVisible();
+  await expect(p.locator(".af-app")).toHaveAttribute("data-live", "open");
   await row(p, SESSION_A).click();
   await expect(p.locator(".af-term-host .xterm")).toBeVisible();
   await expect(p.locator(".af-term-host")).toContainText(READY_MARKER);
-  await expect(p.locator(".af-term-meta")).toContainText("Live");
+  await expect(p.locator(".af-main")).toHaveAttribute("data-term-status", "open");
   await ctx.close();
 });
 
@@ -6190,9 +6223,9 @@ test("#1813: a close+recreate of the same name mid-edit renames NOTHING — neve
       `the event gap must exist before daemon mutations; socket states=${JSON.stringify(eventSocketClose.states)}`,
     ).toBe(true);
     await expect(
-      win.locator(".af-live-pip"),
+      win.locator(".af-app"),
       "the client must enter reconnecting state while the events endpoint stays blocked",
-    ).toHaveClass(/af-live-reconnecting/);
+    ).toHaveAttribute("data-live", "reconnecting");
     af("sessions", "tab-delete", SESSION_ORDER, "--name", VICTIM);
     af("sessions", "tab-create", SESSION_ORDER, "--command", "sleep 300", "--name", VICTIM);
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -610,31 +610,6 @@ body {
   font-size: var(--af-fs-xs);
 }
 
-.af-live {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-size: var(--af-fs-xs);
-  color: var(--af-text-2);
-}
-
-.af-live-pip {
-  width: 0.55rem;
-  height: 0.55rem;
-  border-radius: 50%;
-  background: var(--af-text-3);
-}
-
-.af-live-pip.af-live-open {
-  background: var(--af-dot-ready);
-}
-
-.af-live-pip.af-live-connecting,
-.af-live-pip.af-live-reconnecting {
-  background: var(--af-dot-lost);
-  animation: af-pulse 1.2s ease-in-out infinite;
-}
-
 /* The trailing appbar controls are one semantic group. It stays inline on desktop;
  * the narrow breakpoint turns the wrapper into a single More trigger + popover so
  * project context gets the phone's scarce primary-row width (#2227). */
@@ -1188,18 +1163,10 @@ body {
   color: var(--af-dot-limit);
 }
 
-/* af-pulse is retained for the connection live-pip (.af-live-connecting /
- * .af-live-reconnecting / .af-term-connecting); the session status dot no longer
- * animates — a working row shows no dot at all (#1766). */
-@keyframes af-pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.35;
-  }
-}
+/* af-pulse is gone with its last consumer. It survived #1766's "no animated
+ * indicators" rule as the connection live-pip's pulse; removing that pip (#2458)
+ * left the keyframes with nothing to animate, and the stylesheet now contains no
+ * animation at all. */
 
 /* Main content area — an empty state, or the live attach terminal. */
 .af-main {
@@ -1298,30 +1265,6 @@ body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.af-term-meta {
-  flex: 0 1 auto;
-  min-width: 0;
-  font-size: var(--af-fs-xs);
-  color: var(--af-text-2);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-/* Status tints on the pane header, matching the live-pip vocabulary. */
-.af-term-meta.af-term-open {
-  color: var(--af-dot-ready);
-}
-
-.af-term-meta.af-term-connecting,
-.af-term-meta.af-term-reconnecting {
-  color: var(--af-dot-lost);
-}
-
-.af-term-meta.af-term-exited {
-  color: var(--af-dot-dead);
 }
 
 /* Tab bar (#1592 Phase 5 PR7, #2224): the flexible middle of the pane's single
@@ -2598,11 +2541,6 @@ body {
 
   .af-appbar-tools-open > .af-appbar-tools {
     display: flex;
-  }
-
-  .af-appbar-tools .af-live {
-    min-height: 2.75rem;
-    padding-inline: var(--af-sp-3);
   }
 
   .af-appbar-tools .af-install {

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -14,7 +14,7 @@
 // pane holds a stateful, focused xterm: a full rebuild on each session.* event
 // would detach the terminal's <textarea> and steal keyboard focus mid-type. So the
 // shell keeps ONE persistent terminal-host node and only re-touches the parts that
-// actually changed — the rail list, the live pip, the pane header — leaving the
+// actually changed — the rail list, the pane header — leaving the
 // terminal host (and its focus/scrollback) untouched except when the SELECTED
 // session changes (a deliberate user act that rebuilds the terminal anyway).
 
@@ -566,20 +566,6 @@ function noAuthLoginView(state: AppState, actions: Actions): HTMLElement {
   return h("main", { class: "af-login" }, h("div", { class: "af-card" }, ...children));
 }
 
-/** The label a terminal status reads as in the pane header. */
-function termStatusLabel(s: TerminalStatus): string {
-  switch (s) {
-    case "open":
-      return "Live";
-    case "connecting":
-      return "Connecting…";
-    case "reconnecting":
-      return "Reconnecting…";
-    case "exited":
-      return "Agent exited";
-  }
-}
-
 /**
  * The authed-app DOM, built once and patched in place. index.ts constructs one of
  * these when the login succeeds, appends `.el` to #app, and calls update(state) on
@@ -589,8 +575,6 @@ function termStatusLabel(s: TerminalStatus): string {
  */
 export class AppShell {
   readonly el: HTMLElement;
-  private readonly pip: HTMLElement;
-  private readonly pipLabel: HTMLElement;
   private readonly railCount: HTMLElement;
   private readonly railList: HTMLElement;
   private readonly main: HTMLElement;
@@ -646,7 +630,6 @@ export class AppShell {
 
   // Header text nodes for the selected pane, (re)created per selection.
   private headTitle: HTMLElement | null = null;
-  private headMeta: HTMLElement | null = null;
   // The selected visible rail row's archive/restore control and daemon-owned verb it
   // currently shows (#1932, #2186, #2234). Every actionable row owns controls now
   // (#2223), but a session can flip archive⇄restore WITHOUT a selection change, so
@@ -732,12 +715,6 @@ export class AppShell {
      *  install (a harness) can leave it out. */
     private readonly installEl?: HTMLElement,
   ) {
-    this.pip = h("span", { class: "af-live-pip" });
-    this.pip.setAttribute("aria-hidden", "true");
-    this.pipLabel = h("span", { class: "af-live-label" });
-    const live = h("span", { class: "af-live" }, this.pip, this.pipLabel);
-    live.setAttribute("role", "status");
-
     // Disconnect doubles as "forget the saved token": the credential persists across
     // visits now, so this button is the only way back to the login prompt on a shared
     // machine or after a rotation. The title says so — the label alone reads as a
@@ -826,7 +803,6 @@ export class AppShell {
     const appbarTools = h(
       "div",
       { class: "af-appbar-tools", id: "af-appbar-tools" },
-      live,
       ...(this.installEl ? [this.installEl] : []),
       themeToggle,
       disconnect,
@@ -1048,11 +1024,20 @@ export class AppShell {
       this.toast.classList.toggle("af-toast-show", state.tabError !== null);
     }
 
+    // The event-stream state is tracked and published, but no longer DRAWN: the
+    // "Live / Connecting… / Reconnecting…" pip beside the project selector was
+    // removed as chrome nobody wanted to look at (#2458). Only the indicator went
+    // — the reconnect machinery behind it is untouched, and the state it produces
+    // stays observable here as a data attribute.
+    //
+    // Not merely dead state kept alive for its own sake. The reconnect behaviour is
+    // otherwise invisible from outside the app, so deleting its last observable
+    // would have meant deleting the selftest that proves a blocked events endpoint
+    // actually drives the client into `reconnecting` — greening the suite by
+    // removing the only thing watching it.
     if (this.lastLive !== state.live) {
       this.lastLive = state.live;
-      this.pip.className = `af-live-pip af-live-${state.live}`;
-      this.pipLabel.textContent =
-        state.live === "open" ? "Live" : state.live === "connecting" ? "Connecting…" : "Reconnecting…";
+      this.el.dataset.live = state.live;
     }
 
     // View switching: show the active view's body, hide the other, and highlight its
@@ -1135,8 +1120,8 @@ export class AppShell {
 
     // The main pane's STRUCTURE only changes when the selected session changes (or on
     // the very first update, which lays down the initial empty-state placeholder);
-    // otherwise we just patch its header text (status/title/branch), leaving the
-    // terminal host — and its focus and scrollback — in place.
+    // otherwise we just patch its header (title, actions, published status), leaving
+    // the terminal host — and its focus and scrollback — in place.
     if (selectionChanged || !this.mainRendered) {
       this.mainRendered = true;
       this.renderMain(state);
@@ -1657,7 +1642,6 @@ export class AppShell {
     const selected = selectedSession(state);
     if (!selected) {
       this.headTitle = null;
-      this.headMeta = null;
       this.headActions = null;
       this.headActionSig = "";
       this.retryBtn = null;
@@ -1665,6 +1649,10 @@ export class AppShell {
       this.tabBar = null;
       // Detaches the terminal host if it was mounted; index.ts disposes the terminal.
       this.main.className = "af-main af-main-empty";
+      // Dropped rather than left at its last value: with no session attached there is
+      // no terminal for a status to describe, and a stale "open" here would let a
+      // selftest wait on the PREVIOUS attach and call it the new one.
+      delete this.main.dataset.termStatus;
       this.main.replaceChildren(
         h("p", { class: "af-empty-title" }, "Select a session"),
         h("p", { class: "af-empty-hint" }, "Pick a session in the rail to attach its terminal."),
@@ -1672,8 +1660,11 @@ export class AppShell {
       return;
     }
     this.headTitle = h("span", { class: "af-term-title" }, selected.title);
-    this.headMeta = h("span", { class: "af-term-meta" });
-    const titleBox = h("div", { class: "af-term-head-main" }, this.headTitle, this.headMeta);
+    // Title only. The "Live · master" meta that used to sit beside it — terminal
+    // connection state joined to the session's branch — was removed as chrome
+    // nobody wanted to look at (#2458). The wrapper stays: it owns the header's
+    // layout, and the tab bar beside it flexes against it.
+    const titleBox = h("div", { class: "af-term-head-main" }, this.headTitle);
 
     // Retry, for a session parked at a usage-limit wall (#1934). The web rendered
     // that state — ◆ glyph, "Limit reached" label, "[limit] resets …" title prefix
@@ -2031,16 +2022,15 @@ export class AppShell {
 
   private patchMainHead(state: AppState): void {
     const selected = selectedSession(state);
-    if (!selected || !this.headTitle || !this.headMeta) {
+    if (!selected || !this.headTitle) {
       return;
     }
     this.headTitle.textContent = selected.title;
-    const parts = [termStatusLabel(state.termStatus)];
-    if (selected.branch) {
-      parts.push(selected.branch);
-    }
-    this.headMeta.textContent = parts.join(" · ");
-    this.headMeta.className = `af-term-meta af-term-${state.termStatus}`;
+    // The terminal's connection state is published without being drawn, for the same
+    // reason as the event stream above (#2458): the pane header no longer shows
+    // "Live · master", but the status still has to be observable for the selftests
+    // that wait on a real attach rather than on a sleep.
+    this.main.dataset.termStatus = state.termStatus;
 
     this.patchHeadActions(state, selected);
 


### PR DESCRIPTION
Closes #2458.

## Verified against master first

Both indicators reproduce on current `master`, at the locations the issue names (line numbers had drifted slightly):

- `web/src/ui.ts:735–739` builds the `af-live` pip + label, appended into `af-appbar-tools` at ~821, repainted at ~1051.
- `patchMainHead` at ~2032 joins `termStatusLabel(state.termStatus)` with `selected.branch` using `" · "` → **"Live · master"**.

## What changed

**Element 1 — the app-bar pip.** The `af-live` span, its pip and label, and every `.af-live*` CSS rule (including the mobile-only sizing rule inside the `af-appbar-tools` breakpoint) are gone.

**Element 2 — the pane-header meta.** The `af-term-meta` span is gone from the header, along with `termStatusLabel` and the `.af-term-meta*` rules. Taken as one unit per the issue's default: live **and** branch.

## What deliberately did NOT change

The event-stream reconnect, the terminal's reconnect, and the state both produce are untouched. `AppState.live` and `AppState.termStatus` are still written by `index.ts`, and `lastLive` still guards the write.

The state is now published as **data attributes** — `data-live` on `.af-app`, `data-term-status` on `.af-main` — which render nothing to a sighted user or a screen reader.

That is not dead state kept alive for its own sake, and it is the main thing I'd like reviewed. Roughly **30 selftest assertions** used these two indicators as genuine readiness barriers ("wait until the event stream is open", "wait until the terminal actually attached") rather than as cosmetic checks. One of them:

```ts
await expect(
  win.locator(".af-app"),
  "the client must enter reconnecting state while the events endpoint stays blocked",
).toHaveAttribute("data-live", "reconnecting");
```

…is the **only external evidence that the reconnect machinery works at all**. Deleting the last observable would have meant deleting that test — greening the suite by removing the thing watching the behaviour, which is a worse outcome than the chrome. If you'd rather these were `aria-hidden` spans or removed outright, say so; I picked the option that keeps the tests honest.

## Knock-on cleanups

- **`af-pulse` is gone.** Removing the pip left the keyframes with no consumer. The stylesheet now contains **no `animation:` rule at all**, which is where #1766's "no animated indicators" rule was already pointing.
- Stale comments updated in `ui.ts` (file header, the patch-vs-render note) and the selftest.

## Docs

`docs/web.md` — the app-bar diagram, the app-bar inventory, the mobile **More** list, and the attach-terminal section. `docs/web-selftest.md` — the Sidebar row's assertion. Nothing in `parity/` referenced either indicator (its only "Live" hit is an unrelated test name).

## Tests

- **New, desktop**: pins the removal on the **real attached shell** — the only state where both used to render, so it cannot pass vacuously. Checks rendered **text** as well as class names, since a rebuilt indicator under a new class would look identical to the user, and asserts the head now reads exactly the session title.
- **New, mobile (375px)**: the indicator did not merely shrink on a phone — below the breakpoint it moved **into the More popover** and carried its own sizing rule. The test opens the popover (so it is a real look inside, not a pass earned by a collapsed panel) and confirms the live indicator is absent while Disconnect and the theme toggle still work.
- ~30 existing assertions repointed from `.af-live-pip.af-live-open` / `.af-term-meta` text to the data attributes — same barrier, same timing, no `waitForTimeout` introduced.

## One thing worth flagging

Removing the pane-header meta also removes the only surface for `Reconnecting…` and **`Agent exited`**. The reconnect still happens silently, but a user whose agent exits now learns it from the terminal content and the rail row's lifecycle glyph rather than from a header label. That is a real (small) loss distinct from the "live" chrome Sachin objected to — flagging it rather than quietly keeping a label he asked to remove. Easy to restore an exited-only label if it turns out to matter.

The **branch** is not lost: every rail row still carries its own branch line.

## Gate

- `make web-test` (typecheck + 418 unit tests): **0 failures**.
- `make web-build` run and `web/dist` committed; verified the bundle contains no `af-live` / `af-term-meta`.
- `go build ./...`, `gofmt -l .` clean.
- `make web-selftest-container` and `make test-container` — results in a follow-up comment.

## Review

Requesting the codex app below. It is rate-limited and has answered only with its usage-limit notice on every PR today; if it stays silent here I will say so explicitly rather than read bot silence as approval. Not merging unreviewed.

— Captain Claude
