### PR TITLE
fix(tui): shorten empty state and unify on "session" (#1993)

### DIFF
--- a/app/help.go
+++ b/app/help.go
@@ -165,9 +165,9 @@ func (h helpTypeGeneral) toContent() string {
 			{helpKey(keys.KeySplitPane), "Commit the current preview as another pane"},
 			{helpKey(keys.KeyHidePane), "Hide the focused pane (the tab keeps running)"},
 			{helpKey(keys.KeyPanePrev) + "/" + helpKey(keys.KeyPaneNext), "Move focus between open panes"},
-			{navKeys, "Navigate the tree (instances and their tabs)"},
-			{helpKey(keys.KeyLeft), "Collapse the selected instance's tabs"},
-			{helpKey(keys.KeyRight), "Expand the selected instance's tabs"},
+			{navKeys, "Navigate the tree (sessions and their tabs)"},
+			{helpKey(keys.KeyLeft), "Collapse the selected session's tabs"},
+			{helpKey(keys.KeyRight), "Expand the selected session's tabs"},
 		}},
 		{title: "Configuration:", rows: []helpRow{
 			{helpKey(keys.KeyConfigAgent), "Open the config agent to change your settings"},
@@ -206,7 +206,7 @@ func (h helpTypeInstanceStart) toContent() string {
 		tabHelp = keyStyle.Render("1-9 jump") + descStyle.Render(fmt.Sprintf(" - Select a tab (%s opens it; tabs live in the tree)", openPane))
 	}
 	content := lipgloss.JoinVertical(lipgloss.Left,
-		titleStyle.Render("Instance created"),
+		titleStyle.Render("Session created"),
 		"",
 		descStyle.Render("New session created:"),
 		descStyle.Render(fmt.Sprintf("• Git branch: %s (isolated worktree)",
@@ -228,7 +228,7 @@ func (h helpTypeInstanceStart) toContent() string {
 
 func (h helpTypeInstanceAttach) toContent() string {
 	lines := []string{
-		titleStyle.Render("Attaching to instance"),
+		titleStyle.Render("Attaching to session"),
 		"",
 		descStyle.Render("The attached program owns input and scrolling."),
 		descStyle.Render("AF's ") + keyStyle.Render(helpKey(keys.KeyShiftUp)+"/"+helpKey(keys.KeyShiftDown)) + descStyle.Render(" preview scrolling works only in navigation mode."),
@@ -250,7 +250,7 @@ func (h helpTypeInteractive) toContent() string {
 		"",
 		descStyle.Render("You are typing into this pane's terminal: every key — including tab —"),
 		descStyle.Render("goes to the agent/shell. The pane's frame turns green while it has the"),
-		descStyle.Render("keyboard, and the instances rail stays visible."),
+		descStyle.Render("keyboard, and the sessions rail stays visible."),
 		"",
 		descStyle.Render("Press ")+keyStyle.Render(helpKey(keys.KeyExitInteractive))+descStyle.Render(" to return to navigation."),
 		descStyle.Render("Full-screen attach is still available on ")+keyStyle.Render(helpKey(keys.KeyAttach))+descStyle.Render(" (from nav mode)."),

--- a/app/help_test.go
+++ b/app/help_test.go
@@ -92,8 +92,8 @@ func TestFirstRunHelpTitlesUseSentenceCase(t *testing.T) {
 		want    string
 		old     string
 	}{
-		{"instance created", helpStart(local).toContent(), "Instance created", "Instance Created"},
-		{"attach", helpTypeInstanceAttach{}.toContent(), "Attaching to instance", "Attaching to Instance"},
+		{"instance created", helpStart(local).toContent(), "Session created", "Session Created"},
+		{"attach", helpTypeInstanceAttach{}.toContent(), "Attaching to session", "Attaching to Session"},
 		{"interactive pane", helpTypeInteractive{}.toContent(), "Interactive pane", "Interactive Pane"},
 	}
 	for _, tc := range tests {

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -97,9 +97,11 @@ func TestFirstRunWorkspaceEmptyState(t *testing.T) {
 	view := h.View()
 
 	assert.Contains(t, view, "No sessions yet")
-	assert.Contains(t, view, "Press n to create a local session")
-	assert.Contains(t, view, "Press ? for all keys")
-	assert.Contains(t, view, "af doctor --setup")
+	assert.Contains(t, view, "press n to create one")
+	// The onboarding block is a single punchy line now (#1993 / empty-state
+	// polish): the help and setup lines that duplicated the footer are gone.
+	assert.NotContains(t, view, "Press ? for all keys")
+	assert.NotContains(t, view, "af doctor --setup")
 	assert.NotContains(t, view, "s opens the selected tab")
 }
 

--- a/app/tinyclip_overlay_test.go
+++ b/app/tinyclip_overlay_test.go
@@ -115,7 +115,7 @@ func TestTinyClipTasksOverlayFits(t *testing.T) {
 // section headers, and an instance row's title. None of them appear in the task
 // overlay's own chrome, so finding one in a full-screen frame means the rail
 // bled through.
-var railFragments = []string{"Agent Factory", "Instances", "Automations", "Projects", "rail-inst"}
+var railFragments = []string{"Agent Factory", "Sessions", "Automations", "Projects", "rail-inst"}
 
 // TestTasksOverlayNarrowIsFullScreenWithoutRailBleed is the #1821 regression.
 //

--- a/docs/tui-manual-testing.md
+++ b/docs/tui-manual-testing.md
@@ -166,7 +166,7 @@ compose across `docker exec` invocations.
 | Function | Keys | Completion marker |
 |----------|------|-------------------|
 | `af_reset_sandbox` | — | wipes instances/branches for a deterministic rerun (sandbox-scoped, fails closed) |
-| `af_boot` | launch `af` | `Agent Factory` frame + the instance rail painted — `Instances (` **or** the scrolled `▲ N more` the rail shows in its place (#2148) |
+| `af_boot` | launch `af` | `Agent Factory` frame + the session rail painted — `Sessions (` **or** the scrolled `▲ N more` the rail shows in its place (#2148) |
 | `af_new_instance <name>` | `n`,text,`Enter` | the row shows `<name> … ●` (ready) |
 | `af_select <name>` | `k`×,`j`× | `<name>`'s row shows `▾` |
 | `af_open_pane` | `s` | pane-focus menu (`x hide pane`) |
@@ -428,7 +428,7 @@ af_new_instance a
 af_select a; af_expect_selected a             # selection still works when narrow
 
 af_resize 40 10                               # squeeze to 40x10 mid-run
-af_assert_screen 'Instances'                  # header must survive the squeeze
+af_assert_screen 'Sessions'                   # header must survive the squeeze
 ```
 
 ---
@@ -472,5 +472,5 @@ teardown is `docker rm -f`. The driver reinforces this:
 - `af_reset_sandbox` **fails closed**: it refuses to wipe anything unless
   `AGENT_FACTORY_HOME` and the mock repo are sandbox paths, so it can never
   touch a real `~/.agent-factory`.
-- Instances run the cheap `bash` program (the sandbox's `config.toml`
+- Sessions run the cheap `bash` program (the sandbox's `config.toml`
   override), never a real agent or an unbounded generator.

--- a/scripts/tui-driver-selftest.sh
+++ b/scripts/tui-driver-selftest.sh
@@ -639,7 +639,7 @@ _expect_live_attach_send_line() {
 # stubbed captures (no live TUI) so all three polarities are deterministic.
 #
 # 1. POSITIVE: the exact first frame from the report — three sessions at 80x24
-#    with a lower one restored, so the rail has scrolled `Instances (N)` out of
+#    with a lower one restored, so the rail has scrolled `Sessions (N)` out of
 #    the window and drew `▲ 2 more` in its place. af_boot waited 35s for the
 #    header, never saw it, and reported a boot failure for a TUI that had booted
 #    fine with every session alive.
@@ -676,8 +676,8 @@ SCREEN
         }
         # Premise: the frame really is missing the header, or this is just
         # re-testing the case that always worked.
-        if af_capture | grep -qE -- 'Instances \('; then
-            _af_fail "#2148 stub is not reproducing the shape: the scrolled frame still shows the Instances header"
+        if af_capture | grep -qE -- 'Sessions \('; then
+            _af_fail "#2148 stub is not reproducing the shape: the scrolled frame still shows the Sessions header"
             return 1
         fi
         if ! af_wait_for "$_AF_RAIL_MARKER" 3 'scrolled rail reads as booted (#2148)' >/dev/null 2>&1; then
@@ -726,7 +726,7 @@ _expect_scrolled_rail_relaunch() {
             if ! af_capture | grep -qE -- '^[[:space:]]*▲ [0-9]+ more'; then
                 _af_log "#2148 premise not met: the 80x24 rail did NOT scroll, so this step proves nothing"
                 rc=1
-            elif af_capture | grep -qE -- 'Instances \('; then
+            elif af_capture | grep -qE -- 'Sessions \('; then
                 _af_log "#2148 premise not met: the header is still visible, so the old gate would have passed too"
                 rc=1
             fi
@@ -752,7 +752,7 @@ step "reset sandbox to a clean state"                       af_reset_sandbox
 step "boot af at ${AF_DRIVER_COLS}x${AF_DRIVER_ROWS}"        af_boot
 step "af_resize fails loudly on an impossible resize"       _expect_resize_rejected
 # --- #2148 regression: the boot gate must survive a scrolled rail ---
-# The `Instances (N)` header is the rail's first windowed ROW, not chrome, so a
+# The `Sessions (N)` header is the rail's first windowed ROW, not chrome, so a
 # scrolled rail hides it behind `▲ N more` and a header-only gate false-times-out
 # on a TUI that booted fine. Deterministic stub proof — both polarities.
 step "a scrolled rail still reads as booted (#2148)"        _expect_scrolled_rail_reads_as_booted

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -515,7 +515,7 @@ af_reset_sandbox() {
 # preceded on its row by the sidebar columns and the pane's own border. `▲` is
 # matched as a literal byte sequence rather than inside a bracket expression,
 # which the sandbox's C/POSIX locale would match byte-wise (#1994).
-: "${_AF_RAIL_MARKER:=Instances \(|^[[:space:]]*▲ [0-9]+ more}"
+: "${_AF_RAIL_MARKER:=Sessions \(|^[[:space:]]*▲ [0-9]+ more}"
 
 # af_boot — launch af at a fixed size in a fresh driver session and wait for
 # the first frame. Pre-seeds help_screens_seen so the one-time overlays

--- a/ui/layout_height_test.go
+++ b/ui/layout_height_test.go
@@ -100,7 +100,7 @@ func TestTerminalFallbackMatchesNormalModeHeight(t *testing.T) {
 	for _, h := range []int{20, 25, 30, 50} {
 		fb := NewTabPane(previewFromInstance)
 		fb.SetSize(80, h)
-		fb.setFallbackState("Select an instance to open a terminal")
+		fb.setFallbackState("Select a session to open a terminal")
 		require.Equal(t, h, renderedLineCount(fb.String()),
 			"height=%d: fallback must render exactly the allocated height", h)
 

--- a/ui/preview_scroll_fallback_test.go
+++ b/ui/preview_scroll_fallback_test.go
@@ -104,7 +104,7 @@ func TestPreviewScrollModeThenNilInstanceFallback(t *testing.T) {
 		"stale viewport content must be cleared on fallback")
 
 	rendered := p.String()
-	require.Contains(t, rendered, "No agents running yet",
+	require.Contains(t, rendered, "No sessions yet",
 		"rendered frame must show the welcome fallback, not stale scroll content")
 	require.NotContains(t, rendered, staleScrollMarker)
 }

--- a/ui/sidebar_archived_test.go
+++ b/ui/sidebar_archived_test.go
@@ -114,7 +114,7 @@ func TestSidebar_ArchivedPartitionedIntoFolder(t *testing.T) {
 
 	// Header labels carry the partitioned counts.
 	view := s.View()
-	assert.Contains(t, view, "Instances (1)", "Instances counts only live sessions")
+	assert.Contains(t, view, "Sessions (1)", "the header counts only live sessions")
 	assert.Contains(t, view, "Archived (1)")
 }
 
@@ -137,8 +137,8 @@ func TestSidebar_RestoringRowRehomedToInstances(t *testing.T) {
 	require.False(t, restoring.ShownArchived(), "a mid-restore row is not shown as archived")
 
 	view := s.View()
-	assert.Contains(t, view, "Instances (2)",
-		"a mid-restore row counts under Instances, not Archived (#1210)")
+	assert.Contains(t, view, "Sessions (2)",
+		"a mid-restore row counts under the live Sessions section, not Archived (#1210)")
 	assert.NotContains(t, view, "Archived (",
 		"the Archived folder is absent while the only archived-liveness row is restoring")
 }

--- a/ui/sidebar_model.go
+++ b/ui/sidebar_model.go
@@ -192,7 +192,7 @@ func NewSidebar(proj *store.Projection) *Sidebar {
 	s := &Sidebar{
 		proj: proj,
 		sections: []SidebarSection{
-			{Kind: SectionInstances, Title: "Instances", Expanded: true},
+			{Kind: SectionInstances, Title: "Sessions", Expanded: true},
 			// Archived (#1028): pinned last, collapsed by default. Rendered only
 			// when it holds archived sessions (rebuildVisibleItems skips the empty
 			// folder).

--- a/ui/sidebar_render.go
+++ b/ui/sidebar_render.go
@@ -286,8 +286,10 @@ func (s *Sidebar) renderHeader(kind SidebarSectionKind, selected bool) string {
 	live, archived := partitionByArchived(s.proj.GetInstances())
 	switch kind {
 	case SectionInstances:
-		// Count live sessions only — archived ones live under their own folder.
-		label = fmt.Sprintf("Instances (%d)", len(live))
+		// "Sessions" is the one user-facing noun (#1993) — the empty state, help,
+		// search, and actions all say session. Count live ones only; archived
+		// sessions live under their own folder.
+		label = fmt.Sprintf("Sessions (%d)", len(live))
 	case SectionArchived:
 		label = fmt.Sprintf("Archived (%d)", len(archived))
 	}

--- a/ui/sidebar_test.go
+++ b/ui/sidebar_test.go
@@ -281,7 +281,7 @@ func TestSidebarRender(t *testing.T) {
 	addTestInstance(s, inst)
 
 	rendered := s.String()
-	assert.Contains(t, rendered, "Instances (1)")
+	assert.Contains(t, rendered, "Sessions (1)")
 	assert.NotEmpty(t, rendered)
 }
 
@@ -335,7 +335,7 @@ func TestSidebarWindowsLongInstanceListToAllocation(t *testing.T) {
 		sel     func(s *Sidebar)
 		visible string
 	}{
-		{"top (Instances header)", func(s *Sidebar) {}, "Instances (25)"},
+		{"top (Sessions header)", func(s *Sidebar) {}, "Sessions (25)"},
 		{"middle instance", func(s *Sidebar) { s.SetSelectedInstance(12) }, "win-12"},
 		{"bottom instance", func(s *Sidebar) { s.SetSelectedInstance(24) }, "win-24"},
 		{"trailing tab row", func(s *Sidebar) {

--- a/ui/sidebar_zones_test.go
+++ b/ui/sidebar_zones_test.go
@@ -66,7 +66,7 @@ func TestSidebarRegistersRowZones(t *testing.T) {
 	// The section header row renders the section title on its zone's row.
 	header, ok := reg.Find(zones.TreeHeader)
 	require.True(t, ok, "header zone must be registered")
-	assert.Contains(t, lineAt(t, lines, rect, header.Y), "Instances",
+	assert.Contains(t, lineAt(t, lines, rect, header.Y), "Sessions",
 		"the header zone must sit on the rendered header row")
 
 	// Every instance row has a zone whose block contains its title.

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -489,7 +489,7 @@ func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) er
 	p.dropStaleView(instance, 0)
 	switch {
 	case instance == nil:
-		p.setFallbackState("No agents running yet. Spin up a new instance with 'n' to get started!")
+		p.setFallbackState("No sessions yet — press n to create one.")
 		p.mu.Unlock()
 		return nil
 	case instance.IsCreating():
@@ -557,7 +557,7 @@ func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) er
 	// Always update with content, even if empty, so a newly created instance
 	// displays immediately.
 	if len(snapshot.Content) == 0 && !instance.Started() {
-		p.setFallbackState("Please enter a name for the instance.")
+		p.setFallbackState("Please enter a name for the session.")
 	} else {
 		p.publishContent(tabContentState{fallback: false, text: snapshot.Content})
 	}
@@ -603,7 +603,7 @@ func (p *TabPane) updateShell(instance *session.Instance, activeTab int, guard c
 	}
 	p.dropStaleView(instance, activeTab)
 	if instance == nil {
-		p.setFallbackState("Select an instance to open a terminal")
+		p.setFallbackState("Select a session to open a terminal")
 		p.mu.Unlock()
 		return nil
 	}
@@ -616,7 +616,7 @@ func (p *TabPane) updateShell(instance *session.Instance, activeTab int, guard c
 		return nil
 	}
 	if !instance.Started() {
-		p.setFallbackState("Instance is not started yet.")
+		p.setFallbackState("Session is not started yet.")
 		p.mu.Unlock()
 		return nil
 	}

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -138,7 +138,7 @@ func TestTabPaneShellFallbackStates(t *testing.T) {
 		require.NoError(t, p.UpdateContent(nil, 1))
 		p.mu.Lock()
 		require.True(t, p.content.fallback)
-		require.Contains(t, p.content.text, "Select an instance")
+		require.Contains(t, p.content.text, "Select a session")
 		p.mu.Unlock()
 	})
 
@@ -234,7 +234,7 @@ func TestTabPaneShellFallbackResetsScrollMode(t *testing.T) {
 		p.mu.Unlock()
 
 		rendered := p.String()
-		require.Contains(t, rendered, "Select an instance")
+		require.Contains(t, rendered, "Select a session")
 		require.NotContains(t, rendered, priorContent)
 	})
 

--- a/ui/workspace.go
+++ b/ui/workspace.go
@@ -16,13 +16,12 @@ func EmptyWorkspace(r layout.Rect) string {
 
 // FirstRunWorkspace renders the zero-session onboarding state. It is distinct
 // from EmptyWorkspace because there is no selected tab yet, so the useful next
-// action is session creation, not opening a pane.
+// action is session creation, not opening a pane. One punchy line (#1993): the
+// footer already carries `? help` and `n new`, so the old four-line block only
+// repeated chrome and buried the one thing to do.
 func FirstRunWorkspace(r layout.Rect) string {
 	return emptyWorkspaceContent(r, []string{
-		"No sessions yet",
-		"Press n to create a local session",
-		"Press ? for all keys",
-		"Setup check: run af doctor --setup",
+		"No sessions yet — press n to create one.",
 	})
 }
 

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -11391,7 +11391,7 @@ var AppShell = class {
         h2(
           "li",
           { class: "af-rail-empty" },
-          "No sessions yet. Create one in the TUI or with ",
+          "No sessions yet \u2014 create one in the TUI or with ",
           h2("code", {}, "af sessions create"),
           "."
         )

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "f6e7779339e0";
+const VERSION = "d3754af6f1d7";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -1215,7 +1215,7 @@ export class AppShell {
         h(
           "li",
           { class: "af-rail-empty" },
-          "No sessions yet. Create one in the TUI or with ",
+          "No sessions yet — create one in the TUI or with ",
           h("code", {}, "af sessions create"),
           ".",
         ),


### PR DESCRIPTION
## What

Two small copy fixes, one theme (the empty-state/rail wording):

**1. Shorten the empty-state help.** The zero-session onboarding block was four lines that mostly repeated the footer (`n new`, `? help` are already down there) and buried the one thing to do:

```
No sessions yet
Press n to create a local session
Press ? for all keys
Setup check: run af doctor --setup
```

→ one punchy line:

```
No sessions yet — press n to create one.
```

The pane fallback for "no session selected" got the same treatment (`No agents running yet. Spin up a new instance with 'n' to get started!` → `No sessions yet — press n to create one.`). The web no-sessions rail is tightened to match (`No sessions yet — create one in the TUI or with af sessions create.`). The no-projects states (`No projects yet.`, `no other projects yet`) were already short and are left alone.

**2. Fix #1993 — one user-facing noun.** The rail said `Instances (N)` while the empty state, help, search, actions, and the whole web UI said *session*. `session` is the canonical term (even the CLI subcommand is `af sessions`), so the rail header, section title, pane fallbacks, and the tree/attach/interactive help copy now all say **session**:

- `Instances (N)` → `Sessions (N)`
- `Select an instance to open a terminal` → `Select a session…`, `Instance is not started yet.` → `Session…`, `Please enter a name for the instance.` → `…session.`
- help: `Navigate the tree (instances and their tabs)` → `sessions…`, `Instance created` → `Session created`, `Attaching to instance` → `Attaching to session`, `the instances rail` → `the sessions rail`

Internal identifiers (`SectionInstances`, `Instance` type, zone ids) and error-*log* strings are unchanged — this is a user-facing-copy change only. Closes #1993.

## Copy conventions

Sentence case, `—` for the clause, no exclamation/caps-shouting, no `...`. The em-dash one-liner matches the shape Sachin asked for.

## Tests (fail-first)

Updated every assertion that pinned the old copy (and confirmed they fail against the old strings before the production change): `TestFirstRunWorkspaceEmptyState`, `TestFirstRunHelpTitlesUseSentenceCase`, the sidebar header tests (`Sessions (N)`), the pane fallbacks, and the rail-fragment/zone tests.

## Real rendered TUI @ 80×24 and smaller

Driven with **zero sessions** through the container TUI driver — rail reads `Sessions (0)`, the empty state is the one-liner, the old four lines are gone, and it stays within the frame at 64×20 and 48×18. Web: `npm run typecheck` + 418 web tests green; `web/dist` rebuilt with `make web-build`.

## Gate

gofmt · `go build ./...` · golangci-lint `--fast` · `deadcode -test ./...` · file-length · web typecheck/tests · full `make test-container` — all green on the pushed head.

## Review

Codex GitHub-app review is rate-limited until Jul 28; requested once. If silent, Captain Claude runs the review before merge — not merging unreviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
