### PR TITLE
fix(session): re-dial a dead pty upstream without a new subscribe (#2450)

### DIFF
--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -620,6 +620,61 @@ func (c *remoteAgentClient) preview(tab int, full bool) (PreviewSnapshot, error)
 	}, nil
 }
 
+// accessTokenRedaction replaces the sandbox bearer token wherever a URL carrying
+// it would otherwise reach a log or an error surface.
+const accessTokenRedaction = "REDACTED"
+
+// redactAccessTokenInURL returns raw with the ?access_token= VALUE replaced.
+//
+// url.Redacted() is not a substitute and must not be reached for here: it
+// redacts USERINFO (the user:pass@ form) and leaves the query string untouched,
+// so an access_token query survives it completely.
+func redactAccessTokenInURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		// Unparseable: say nothing rather than risk echoing the credential.
+		return "[url redacted]"
+	}
+	q := parsed.Query()
+	if q.Get(agentproto.AccessTokenQueryParam) == "" {
+		return raw
+	}
+	q.Set(agentproto.AccessTokenQueryParam, accessTokenRedaction)
+	parsed.RawQuery = q.Encode()
+	return parsed.String()
+}
+
+// redactDialError strips the sandbox bearer token from a failed dial's error.
+//
+// The token rides the URL as ?access_token= (the browser-WS fallback the
+// agent-server also honours), and a failed dial surfaces as a *url.Error
+// carrying that whole URL — so wrapping the raw error puts the credential in
+// whatever renders it. That was survivable while the only failed-dial path was
+// subscribe(), whose error goes to an HTTP response; #2450 made the daemon retry
+// on a timer and LOG each failure, which would write the token to
+// agent-factory.log once per backoff for as long as a tab stays open.
+//
+// The *url.Error is mutated in place rather than replaced: it is freshly created
+// by this dial and unshared, and fixing it there cleans every wrapper that
+// renders it through %w, so errors.Is/As keep working on the chain.
+//
+// The substring check afterwards is a deliberate backstop, not redundancy: it
+// catches any failure shape that carried the credential somewhere other than a
+// *url.Error. If one ever does, the structure is dropped and the secret is not.
+func redactDialError(err error, token string) error {
+	if err == nil {
+		return nil
+	}
+	var uerr *url.Error
+	if errors.As(err, &uerr) {
+		uerr.URL = redactAccessTokenInURL(uerr.URL)
+	}
+	if token != "" && strings.Contains(err.Error(), token) {
+		return errors.New(strings.ReplaceAll(err.Error(), token, accessTokenRedaction))
+	}
+	return err
+}
+
 // dialStream opens the WS PTY subscription to tab `tab` (from the live tail). The
 // token rides both the Authorization header and the ?access_token= query — the
 // agent-server honors either, and the query mirrors the browser WS path Phase 5
@@ -645,7 +700,7 @@ func (c *remoteAgentClient) dialStream(ctx context.Context, tab int) (*websocket
 	defer cancel()
 	conn, _, err := websocket.Dial(dialCtx, u, opts)
 	if err != nil {
-		return nil, fmt.Errorf("remote agent-server: dial pty stream: %w", err)
+		return nil, fmt.Errorf("remote agent-server: dial pty stream: %w", redactDialError(err, c.token))
 	}
 	conn.SetReadLimit(4 << 20)
 	return conn, nil

--- a/session/agentserver_remote_token_redaction_test.go
+++ b/session/agentserver_remote_token_redaction_test.go
@@ -1,0 +1,139 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+)
+
+// TestRemoteAgentDialStream_ErrorCarriesNoToken is a credential-leak regression.
+//
+// dialStream puts the sandbox bearer token in the URL as ?access_token= (the
+// browser-WS fallback the agent-server also honours). coder/websocket's Dial
+// failure is a *url.Error carrying that whole URL, so wrapping it verbatim put
+// the token in the error text.
+//
+// That was survivable while the only failed-dial path was subscribe(), whose
+// error goes to an HTTP response. #2450 made the daemon retry dials on a timer
+// and LOG each failure, so on a remote session whose sandbox is down the token
+// would be written to agent-factory.log in cleartext, once per backoff, for as
+// long as a tab stays open. Persistent, on disk, and repeated.
+//
+// Note url.Redacted() is NOT a fix here: it redacts userinfo (user:pass@) only
+// and leaves query parameters untouched, so the access_token would survive it.
+// The value has to be removed from the query explicitly.
+func TestRemoteAgentDialStream_ErrorCarriesNoToken(t *testing.T) {
+	const token = "super-secret-sandbox-token-9f3a"
+
+	// A closed port: Dial fails fast, in the connect phase, which is exactly the
+	// shape of a down sandbox.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+
+	rc, err := newRemoteAgentClient(AgentServerEndpoint{
+		URL:   "http://" + addr,
+		Token: token,
+	}, "probe")
+	if err != nil {
+		t.Fatalf("newRemoteAgentClient: %v", err)
+	}
+
+	_, derr := rc.dialStream(context.Background(), 0)
+	if derr == nil {
+		t.Fatal("dial against a closed port returned nil error; this test needs a failed dial")
+	}
+
+	if strings.Contains(derr.Error(), token) {
+		t.Fatalf("the dial error contains the sandbox bearer token in cleartext.\n\n"+
+			"error: %s\n\n"+
+			"#2450 logs this error on every recovery backoff, so the token would be written to "+
+			"the persistent daemon log repeatedly. Strip the access_token query value before "+
+			"building the error — url.Redacted() does not do it, it only covers userinfo.",
+			derr.Error())
+	}
+
+	// The redaction must not gut the diagnostic: the host still has to be there,
+	// or a real outage becomes unreadable in the log.
+	if !strings.Contains(derr.Error(), addr) {
+		t.Fatalf("the dial error no longer names the endpoint it failed to reach: %s\n\n"+
+			"redaction must remove the credential, not the diagnosis", derr.Error())
+	}
+}
+
+// TestRedactAccessTokenInURL pins the redaction itself, including the two ways
+// it could quietly stop working: leaving the value in place, or destroying the
+// rest of the URL along with it.
+func TestRedactAccessTokenInURL(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		raw         string
+		wantAbsent  string
+		wantPresent []string
+	}{
+		{
+			name:        "token value replaced, everything else kept",
+			raw:         "http://box:8080/v1/sessions/s/stream?tab=2&access_token=sekrit",
+			wantAbsent:  "sekrit",
+			wantPresent: []string{"box:8080", "/v1/sessions/s/stream", "tab=2", accessTokenRedaction},
+		},
+		{
+			name:        "no token, untouched",
+			raw:         "http://box:8080/v1/sessions/s/stream?tab=2",
+			wantAbsent:  accessTokenRedaction,
+			wantPresent: []string{"box:8080", "tab=2"},
+		},
+		{
+			name: "unparseable url says nothing rather than risk echoing it",
+			// A control character makes url.Parse fail.
+			raw:         "http://box:8080/\x7f?access_token=sekrit",
+			wantAbsent:  "sekrit",
+			wantPresent: []string{"redacted"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redactAccessTokenInURL(tc.raw)
+			if tc.wantAbsent != "" && strings.Contains(got, tc.wantAbsent) {
+				t.Errorf("redactAccessTokenInURL(%q) = %q, must not contain %q", tc.raw, got, tc.wantAbsent)
+			}
+			for _, want := range tc.wantPresent {
+				if !strings.Contains(got, want) {
+					t.Errorf("redactAccessTokenInURL(%q) = %q, want it to contain %q", tc.raw, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestRedactDialErrorBackstop covers the defence that does not depend on the
+// error being a *url.Error: if some other failure shape ever carries the
+// credential, the structure is dropped rather than the secret.
+func TestRedactDialErrorBackstop(t *testing.T) {
+	const token = "tok-abc123"
+
+	plain := errors.New("some transport failure carrying access_token=" + token + " inline")
+	got := redactDialError(plain, token)
+	if strings.Contains(got.Error(), token) {
+		t.Fatalf("redactDialError left the token in a non-url.Error: %s", got.Error())
+	}
+	if !strings.Contains(got.Error(), accessTokenRedaction) {
+		t.Fatalf("redactDialError scrubbed the token but left no marker: %s", got.Error())
+	}
+
+	// An error with no credential in it must survive untouched, identity included,
+	// so ordinary failures keep their type for errors.Is/As.
+	clean := errors.New("connection refused")
+	if got := redactDialError(clean, token); got != clean {
+		t.Fatalf("redactDialError replaced a clean error (%v); it must pass it through unchanged", got)
+	}
+	if redactDialError(nil, token) != nil {
+		t.Fatal("redactDialError(nil) must stay nil")
+	}
+}

--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -625,7 +625,20 @@ func (b *ptyBroker) remove(id uint64) {
 		return
 	}
 	delete(b.subs, id)
-	lastLeft := len(b.subs) == 0 && b.capturing
+	// Deliberately NOT `&& b.capturing`. A capture being DIALLED right now has
+	// capturing=false until StartCapture returns, so gating on it made the last
+	// subscriber's departure skip the teardown entirely — and the dial then
+	// installed a capture with nobody attached and nothing that would ever stop
+	// it. That window was rare while recovery was user-driven and local; #2450
+	// made it routine, because a background timer now dials across a remote
+	// WebSocket handshake bounded at ten seconds, and a browser tab closed during
+	// a sandbox outage is an ordinary thing to do.
+	//
+	// Calling maybeStopCapture unconditionally is safe and is how it converges:
+	// it re-reads the subscriber count under captureMu, so it no-ops when there is
+	// genuinely nothing to stop, and when a dial is in flight it simply waits for
+	// captureMu and then tears down the capture that dial just installed.
+	lastLeft := len(b.subs) == 0
 	b.mu.Unlock()
 	if lastLeft {
 		b.maybeStopCapture()

--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/terminal"
@@ -166,7 +167,27 @@ type ptyBroker struct {
 	// removed rather than moved after the join: moving them would add a second
 	// b.mu section on three teardown paths to change nothing.
 	captureEnded bool
-	closed       bool
+	// captureStarted is when the CURRENT capture was installed. It exists only to
+	// decide whether a death is a fresh incident or a continuation of one: a
+	// capture that survived redialHealthySpan resets the backoff ladder, so an
+	// endpoint that drops once an hour does not inherit the delay earned by a
+	// flapping one. Set under mu by ensureCaptureStartedLocked.
+	captureStarted time.Time
+	// redialing marks that a recovery goroutine is already running for this
+	// broker, so N deaths cannot spawn N goroutines all dialling the same channel.
+	// Set under mu by the readLoop hand-off, cleared by redialLoop on its way out.
+	redialing bool
+	// redialAttempts is how many consecutive dials have been spent without a
+	// capture surviving redialHealthySpan. It is the ladder position, not a
+	// failure count — a dial that succeeds and then dies immediately consumes a
+	// rung, because that is the storm shape (#2450).
+	redialAttempts int
+	closed         bool
+	// closedCh is closed exactly once, by shutdown, so a recovery goroutine parked
+	// on its backoff wakes immediately instead of sleeping up to redialMaxBackoff
+	// past the teardown. Reading `closed` under mu answers the same question, but
+	// only when the goroutine is awake to ask.
+	closedCh chan struct{}
 	// tabClosed records that this broker was shut down because ITS TAB was closed
 	// (#2136) rather than because the whole session was torn down. It only selects
 	// which end-of-stream error NextEvent reports (ErrTabClosed vs bare io.EOF);
@@ -180,6 +201,7 @@ func newPTYBroker(ch clientlessChannel) *ptyBroker {
 		ch:       ch,
 		maxBytes: ptyRingMaxBytes,
 		subs:     make(map[uint64]*ptySub),
+		closedCh: make(chan struct{}),
 	}
 }
 
@@ -397,9 +419,29 @@ func (b *ptyBroker) ensureCaptureStartedLocked() error {
 	done := make(chan struct{})
 	b.mu.Lock()
 	b.capturing = true
+	b.captureStarted = time.Now()
 	b.stopCapture = func() {
 		if err := b.ch.StopCapture(); err != nil {
-			log.WarningLog.Printf("pty broker: stop clientless capture: %v", err)
+			// A stop that is RELEASING an already-dead capture is expected to fail
+			// to close cleanly: remoteClientlessChannel does
+			// conn.Close(StatusNormalClosure) on a socket whose read already
+			// errored, and coder/websocket reports that. Before #2450 this was rare
+			// — it took a user refresh to reach it — but the self-driven recovery
+			// runs it on every re-dial, which against a down endpoint means a
+			// WARNING every backoff interval, forever. The error is not news on
+			// that path, so it is logged as such.
+			//
+			// This is a log-level split only. Making the close itself clean
+			// (CloseNow) changes the graceful-close behaviour of ORDINARY teardowns
+			// too, so it stays its own change (#2450 item 3).
+			b.mu.Lock()
+			releasingDead := b.captureEnded
+			b.mu.Unlock()
+			if releasingDead {
+				log.InfoLog.Printf("pty broker: released a capture whose upstream had already ended: %v", err)
+			} else {
+				log.WarningLog.Printf("pty broker: stop clientless capture: %v", err)
+			}
 		}
 		_ = r.Close()
 		<-done
@@ -436,172 +478,6 @@ func (b *ptyBroker) maybeStopCapture() {
 	}
 }
 
-// resetCapture recovers the broker onto a re-spawned tmux pane WITHOUT closing it or
-// dropping its subscribers (#1682). On session recovery the previous tmux — and with
-// it the `pipe-pane` writer feeding this broker's FIFO — died, but the broker's
-// readLoop is parked on the O_RDWR FIFO (which never sees EOF) with `capturing` still
-// true, so the cached broker keeps short-circuiting ensureCaptureStarted and no bytes
-// ever flow again. resetCapture, holding captureMu across the whole transition so no
-// concurrent bring-up/teardown can interleave (#1661):
-//
-//  1. Stops the stale capture — unblocking and JOINING the parked readLoop (no
-//     goroutine leak) — and clears the capturing latch.
-//  2. Discards the dead pane's still-buffered ring bytes, so a subscriber that was
-//     lagging at recovery cannot be handed them after the repaint (#1840).
-//  3. If subscribers are STILL attached (a web/TUI client that stayed connected
-//     across the respawn — the common case), restarts the capture against the fresh
-//     pane and re-seeds each subscriber with a repaint of the recovered screen, so it
-//     resumes output on its OWN rather than hanging until some unrelated later
-//     Subscribe happens to bring the capture back up (the #1682 residual T-Rex hit).
-//     With no subscribers left, the lazy lifecycle is simply re-armed for the next
-//     Subscribe.
-//
-// Recovery is ATOMIC as each attached subscriber sees it (#1975): the barrier armed
-// below holds every subscriber's content stream from the moment recovery starts until
-// the repaint is installed, so the repaint is the FIRST thing a subscriber renders
-// after the respawn. Without it, steps 1-3 each leak a frame the repaint then wipes —
-// the dead pane's still-buffered bytes before the discard, and (the reported case) the
-// re-spawned pane's live bytes during step 3's snapshot, which runs without b.mu while
-// the freshly-started readLoop is already feeding and waking subscribers.
-//
-// The subscriber count is re-read AFTER the stop (still under captureMu) so a
-// subscriber that left during the blocking teardown is not resurrected onto a capture
-// nobody wants. A no-op when the broker is already closed.
-func (b *ptyBroker) resetCapture() {
-	b.captureMu.Lock()
-	defer b.captureMu.Unlock()
-
-	b.mu.Lock()
-	if b.closed {
-		b.mu.Unlock()
-		return
-	}
-	// Arm the barrier FIRST — before the teardown, the discard, and the restart — so no
-	// subscriber can emit a frame at any point inside the recovery. Armed subscribers
-	// are captured by identity, not re-read from b.subs at release time, so one that
-	// detaches mid-recovery is still released rather than left parked (#1975).
-	armed := b.armRecoveryRepaintLocked()
-	var stop func()
-	if b.capturing {
-		stop = b.stopCapture
-		b.capturing = false
-		b.stopCapture = nil
-	}
-	b.mu.Unlock()
-
-	// The barrier MUST be lifted on EVERY path out — a failed restart, a Snapshot
-	// error, nobody left attached — or an armed subscriber parks in NextEvent forever
-	// waiting for a repaint that never comes. rp is read when the deferred call runs,
-	// so this single exit point both installs whatever repaint the recovery managed to
-	// build and lifts the barrier, atomically under b.mu.
-	var rp *repaintSnapshot
-	defer func() { b.releaseRecoveryRepaint(armed, rp) }()
-
-	if stop != nil {
-		stop()
-	}
-
-	// Discard the dead pane's buffered output (#1840). This is the ONLY point where
-	// that is race-free: the old readLoop has been joined by the stop above and the
-	// fresh one is not started until below, so the ring provably holds dead-pane bytes
-	// and nothing else, and no feed can interleave. Dropping the bytes while KEEPING
-	// the seq monotonic (base jumps to head over an emptied ring) means a lagging
-	// subscriber — one whose WS write blocked while the dying pane kept producing —
-	// hits the existing `cursor < base` eviction clamp in NextEvent and fast-forwards
-	// to the live tail. Without this it would take the recovery repaint and THEN the
-	// pre-recovery bytes, overwriting the recovered screen with the dead pane's
-	// content. Nothing needs to touch subscriber cursors directly; the clamp is the
-	// same mechanism a ring overflow already uses.
-	//
-	// Unconditional, including when nobody is attached: a later Subscribe(since) would
-	// otherwise replay the dead pane's tail into a fresh client. That no-subscriber path
-	// is why subscribe() repaints a reconnect whose `since` lands below base — the
-	// discard leaves it a cursor that can never be replayed, and with nobody attached
-	// there is no re-seed here to cover it.
-	b.mu.Lock()
-	b.base = b.headLocked()
-	b.buf = nil
-	// Re-read the subscriber count AFTER the teardown drained: nobody left → just the
-	// lazy re-arm, the next Subscribe restarts a fresh capture.
-	resume := !b.closed && len(b.subs) != 0
-	b.mu.Unlock()
-	if !resume {
-		return
-	}
-
-	// A subscriber stayed attached across the respawn. Restart the capture against the
-	// re-spawned pane and re-seed every current subscriber so it repaints the recovered
-	// screen and resumes live output without a new Subscribe. The restarted capture's
-	// readLoop begins feeding and waking subscribers IMMEDIATELY — the barrier is what
-	// keeps those bytes behind the repaint built below (#1975).
-	if err := b.ensureCaptureStartedLocked(); err != nil {
-		log.WarningLog.Printf("pty broker: restart capture after recovery: %v", err)
-		return
-	}
-	rp = b.recoveryRepaint()
-}
-
-// armRecoveryRepaintLocked holds every currently-registered subscriber's content
-// stream (PTYCursor/PTYData) until the recovery repaint is installed, and returns the
-// subscribers it armed. Caller holds b.mu.
-//
-// The returned slice — NOT a later re-read of b.subs — is what releaseRecoveryRepaint
-// walks: a subscriber that detaches mid-recovery is gone from the map but may still be
-// parked in NextEvent, and it must be released too.
-func (b *ptyBroker) armRecoveryRepaintLocked() []*ptySub {
-	armed := make([]*ptySub, 0, len(b.subs))
-	for _, s := range b.subs {
-		s.repaintArmed = true
-		armed = append(armed, s)
-	}
-	return armed
-}
-
-// recoveryRepaint captures the recovered pane's screen and builds the repaint bytes
-// the re-seed installs, so a client that stayed attached across a tmux respawn
-// repaints the current screen and resumes live output on its own (#1682). It mirrors
-// subscribe()'s initial-repaint injection but builds ONE snapshot for all subscribers.
-// The Snapshot exec runs without b.mu held (matching subscribe) — which is precisely
-// the window the barrier exists to cover. Best-effort: a Snapshot error or an empty
-// screen yields nil, and the release degrades to just lifting the barrier and waking
-// the subscribers — the restarted capture's next live byte still reaches them — rather
-// than failing the recovery. Caller holds captureMu.
-func (b *ptyBroker) recoveryRepaint() *repaintSnapshot {
-	snap, err := b.ch.Snapshot()
-	if err != nil {
-		log.WarningLog.Printf("pty broker: snapshot for recovery re-seed: %v", err)
-		return nil
-	}
-	if !snapshotHasRepaintState(snap) {
-		return nil
-	}
-	rp := buildRepaintSnapshot(snap)
-	rp.provenance = PTYRepaintRecovery
-	return &rp
-}
-
-// releaseRecoveryRepaint installs rp on every armed subscriber and lifts the barrier —
-// both under ONE b.mu hold, so a subscriber can never observe the lifted barrier
-// without also seeing the repaint that was owed to it. Waking is what makes a parked
-// subscriber re-read that state.
-func (b *ptyBroker) releaseRecoveryRepaint(armed []*ptySub, rp *repaintSnapshot) {
-	b.mu.Lock()
-	for _, s := range armed {
-		if rp != nil && len(rp.data) > 0 {
-			s.pendingRepaint = rp
-		}
-		s.repaintArmed = false
-	}
-	b.wakeAllLocked()
-	b.mu.Unlock()
-	// wakeAllLocked only rings subscribers still in b.subs. An armed subscriber that
-	// detached mid-recovery is not in the map but can still be parked on the barrier,
-	// so ring its doorbell directly; wake() is a coalescing no-op when already signaled.
-	for _, s := range armed {
-		s.wake()
-	}
-}
-
 // readLoop copies the clientless capture reader into the ring until it errors or
 // the capture is stopped.
 //
@@ -619,12 +495,45 @@ func (b *ptyBroker) releaseRecoveryRepaint(armed []*ptySub, rp *repaintSnapshot)
 // observe the loop as finished while the latch still reads live. It deliberately
 // takes only mu — never captureMu, which a teardown holds while parked on
 // `<-done` (see ensureCaptureStartedLocked, where the reconcile happens).
+//
+// The latch alone only makes the dead capture RECOVERABLE — by the next
+// subscribe. With one client attached over a healthy daemon-browser WebSocket
+// there is no next subscribe, so this exit also HANDS OFF to redialLoop, which
+// is what actually brings the pane back (#2450). The hand-off is a goroutine for
+// the same reason the latch is not a teardown: stopCapture ends in `<-done`, so
+// this loop cannot run its own release inline. See ptybroker_recovery.go.
 func (b *ptyBroker) readLoop(r io.Reader, done chan struct{}) {
 	defer func() {
 		b.mu.Lock()
 		b.captureEnded = true
+		// Distinguish "the upstream died under us" from "a teardown stopped us".
+		// Every teardown — maybeStopCapture, recoverCapture, shutdown, and the
+		// reconcile in ensureCaptureStartedLocked — clears `capturing` under mu
+		// BEFORE it invokes stop(), and stop() is what ends this loop. So seeing
+		// `capturing` still true here means nothing asked us to stop: the socket
+		// dropped on its own, and this is the #2450 case where nobody else will
+		// ever notice.
+		spontaneous := b.capturing && !b.closed
+		var start bool
+		if spontaneous {
+			// A capture that ran a long time is a fresh incident, not a rung on the
+			// current ladder — reset before the hand-off reads the position.
+			if !b.captureStarted.IsZero() && time.Since(b.captureStarted) >= redialHealthySpan {
+				b.redialAttempts = 0
+			}
+			if !b.redialing {
+				b.redialing = true
+				start = true
+			}
+		}
 		b.mu.Unlock()
 		close(done)
+		// Started AFTER close(done): a teardown parked on `<-done` holds captureMu,
+		// which the recovery needs, so handing off first would just make the new
+		// goroutine wait — and then find `capturing` cleared and do nothing anyway.
+		if start {
+			go b.redialLoop()
+		}
 	}()
 	buf := make([]byte, 32*1024)
 	for {
@@ -751,6 +660,9 @@ func (b *ptyBroker) shutdown(tabClosed bool) {
 	}
 	b.closed = true
 	b.tabClosed = tabClosed
+	// Wake any recovery goroutine parked on its backoff. Closed exactly once —
+	// the `b.closed` guard above makes this section run once per broker.
+	close(b.closedCh)
 	b.wakeAllLocked()
 	var stop func()
 	if b.capturing {

--- a/session/ptybroker_recovery.go
+++ b/session/ptybroker_recovery.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"sync"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/log"
@@ -43,6 +44,44 @@ var (
 	redialMaxBackoff     = 30 * time.Second
 	redialHealthySpan    = 60 * time.Second
 )
+
+// redialLoopExitHook runs inside redialLoop immediately after it releases mu,
+// while it is on its way out. nil in production.
+//
+// It exists because the lost-wakeup this file guards against lives in a window a
+// few instructions wide, between the loop deciding to stop driving and the next
+// thing that touches `redialing`. A stress test would hit it only by luck; this
+// makes the interleaving exact. -race cannot substitute for it — every access to
+// `redialing` is already under mu, so that failure is a missed signal, not a
+// data race.
+//
+// Guarded by its own mutex rather than left a bare global: recovery goroutines
+// read it while a test writes it, which IS a data race, and -race duly caught
+// the first version of this seam. redialHookMu is a leaf — taken only here,
+// never while holding mu or captureMu.
+var (
+	redialHookMu       sync.Mutex
+	redialLoopExitHook func()
+)
+
+func redialExitHook() func() {
+	redialHookMu.Lock()
+	defer redialHookMu.Unlock()
+	return redialLoopExitHook
+}
+
+// setRedialLoopExitHookForTest installs fn and returns a restore func. Test-only.
+func setRedialLoopExitHookForTest(fn func()) func() {
+	redialHookMu.Lock()
+	prev := redialLoopExitHook
+	redialLoopExitHook = fn
+	redialHookMu.Unlock()
+	return func() {
+		redialHookMu.Lock()
+		redialLoopExitHook = prev
+		redialHookMu.Unlock()
+	}
+}
 
 // setRedialTimingForTest compresses the re-dial ladder so a test can exercise
 // several rungs without sleeping through the real one. Returns a restore func,
@@ -268,17 +307,41 @@ func redialDelay(attempt int) time.Duration {
 // lifecycle owns that case — the next subscribe brings the capture up), or a
 // healthy capture appearing (a subscribe beat us to it).
 func (b *ptyBroker) redialLoop() {
-	defer func() {
-		b.mu.Lock()
-		b.redialing = false
-		b.mu.Unlock()
-	}()
-
 	for {
 		b.mu.Lock()
 		healthy := b.capturing && !b.captureEnded
 		if b.closed || healthy || len(b.subs) == 0 {
+			// Clear `redialing` in the SAME critical section as the decision to stop
+			// driving. Splitting them — deciding here and clearing in a deferred
+			// section — opens a lost wakeup that reinstates the #2450 freeze:
+			//
+			//   1. this loop sees the capture it just re-dialled as healthy and
+			//      commits to returning, then releases mu;
+			//   2. that capture's upstream dies, and its readLoop hand-off takes mu,
+			//      finds `redialing` STILL true (this loop has not run its defer
+			//      yet), and therefore does NOT spawn a replacement;
+			//   3. the deferred clear then runs.
+			//
+			// The broker is left with capturing=true, captureEnded=true,
+			// redialing=false, a subscriber still attached, and NOBODY driving
+			// recovery — frozen until a new subscribe, which is the bug this file
+			// exists to fix. Clearing under the same lock makes the two outcomes the
+			// only ones reachable: the death lands BEFORE this section, so `healthy`
+			// is false and the loop keeps driving, or AFTER it, so the hand-off sees
+			// redialing=false and spawns a fresh loop.
+			//
+			// Note this is a missed-signal race, not a data race: every access is
+			// already under mu, so -race cannot see it. It is held by
+			// TestPTYBrokerReDialSurvivesAFlapWhileTheLoopIsExiting.
+			b.redialing = false
 			b.mu.Unlock()
+			// Test seam: lands an upstream death in the window described above,
+			// which is otherwise a few instructions wide. nil in production. With
+			// the clear above it is harmless — the hand-off sees redialing=false and
+			// spawns a replacement; with the clear deferred it reproduces the freeze.
+			if hook := redialExitHook(); hook != nil {
+				hook()
+			}
 			return
 		}
 		delay := redialDelay(b.redialAttempts)
@@ -287,6 +350,11 @@ func (b *ptyBroker) redialLoop() {
 
 		select {
 		case <-b.closedCh:
+			// The broker is closed, so no hand-off can be spontaneous (it requires
+			// !b.closed) and clearing here can strand nothing.
+			b.mu.Lock()
+			b.redialing = false
+			b.mu.Unlock()
 			return
 		case <-time.After(delay):
 		}

--- a/session/ptybroker_recovery.go
+++ b/session/ptybroker_recovery.go
@@ -225,7 +225,21 @@ func (b *ptyBroker) recoverCapture(onlyIfNoHealthyCapture bool) {
 	// readLoop begins feeding and waking subscribers IMMEDIATELY — the barrier is what
 	// keeps those bytes behind the repaint built below (#1975).
 	if err := b.ensureCaptureStartedLocked(); err != nil {
-		log.WarningLog.Printf("pty broker: restart capture after recovery: %v", err)
+		// Same reasoning as the stop-error split in ensureCaptureStartedLocked, and
+		// this is the site that fires MORE often: a failed dial is the unreachable
+		// -endpoint case, which the stop path never even reaches. redialLoop gives
+		// up only on closed / healthy / no-subscribers, so a tab left open against a
+		// down sandbox retries forever — at WARNING that is a failure line every 30s
+		// per tab, indefinitely, for a condition the user can see in the pane.
+		//
+		// The self-driven path (onlyIfNoHealthyCapture) logs it as routine; the
+		// externally-driven respawn hook keeps WARNING, because there a failure means
+		// a recovery someone asked for did not happen.
+		if onlyIfNoHealthyCapture {
+			log.InfoLog.Printf("pty broker: re-dial after upstream death failed, will retry: %v", err)
+		} else {
+			log.WarningLog.Printf("pty broker: restart capture after recovery: %v", err)
+		}
 		return
 	}
 	rp = b.recoveryRepaint()

--- a/session/ptybroker_recovery.go
+++ b/session/ptybroker_recovery.go
@@ -1,0 +1,319 @@
+package session
+
+import (
+	"time"
+
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// Capture recovery for the PTY broker: bringing a session's byte stream back
+// after the thing producing it went away.
+//
+// Two causes, one body. A LOCAL session's tmux pane can be re-spawned under a
+// live broker (#1682), and a REMOTE session's data-plane WebSocket can be
+// dropped by a proxy while the sandbox stays healthy over REST (#2438/#2450).
+// Both leave the broker holding a capture that will never produce another byte,
+// and both want the same repair: release the dead capture, discard what the dead
+// pane left in the ring, dial a fresh one, and re-seed every attached subscriber
+// with a repaint so its emulator is not silently desynced.
+//
+// They differ only in who notices. The local case is driven externally by the
+// respawn hook (resetCapture, from localAgentServer); the remote case has no
+// such hook, so it is driven by the readLoop's own exit through redialLoop.
+// Split out of ptybroker.go when that second driver pushed the file past the
+// 1000-line limit (#1145).
+
+// Bounds on the self-driven re-dial after an upstream death (#2450).
+//
+// The recovery is driven by the readLoop's own exit, which makes it a feedback
+// loop: an endpoint that accepts a socket and immediately drops it produces
+// death -> re-dial -> death as fast as the loop can turn. So each consecutive
+// attempt waits longer, doubling from redialInitialBackoff up to
+// redialMaxBackoff. The web client already backs off this way
+// (web/src/terminal.ts); this is the daemon-side equivalent, and without it the
+// daemon would hammer a down sandbox on the user's behalf with nobody watching.
+//
+// The ladder resets once a capture has survived redialHealthySpan, so an
+// endpoint that drops once an hour is treated as a fresh incident rather than
+// inheriting the previous one's delay.
+//
+// vars, not consts, so tests can compress them — see setRedialTimingForTest.
+var (
+	redialInitialBackoff = 500 * time.Millisecond
+	redialMaxBackoff     = 30 * time.Second
+	redialHealthySpan    = 60 * time.Second
+)
+
+// setRedialTimingForTest compresses the re-dial ladder so a test can exercise
+// several rungs without sleeping through the real one. Returns a restore func,
+// matching the SetTrustPromptTimingForTest seam in task. Test-only.
+func setRedialTimingForTest(unit time.Duration) func() {
+	prevInitial, prevMax, prevHealthy := redialInitialBackoff, redialMaxBackoff, redialHealthySpan
+	redialInitialBackoff, redialMaxBackoff, redialHealthySpan = unit, 4*unit, 50*unit
+	return func() {
+		redialInitialBackoff, redialMaxBackoff, redialHealthySpan = prevInitial, prevMax, prevHealthy
+	}
+}
+
+// resetCapture recovers the broker onto a re-spawned tmux pane WITHOUT closing it or
+// dropping its subscribers (#1682). On session recovery the previous tmux — and with
+// it the `pipe-pane` writer feeding this broker's FIFO — died, but the broker's
+// readLoop is parked on the O_RDWR FIFO (which never sees EOF) with `capturing` still
+// true, so the cached broker keeps short-circuiting ensureCaptureStarted and no bytes
+// ever flow again. resetCapture, holding captureMu across the whole transition so no
+// concurrent bring-up/teardown can interleave (#1661):
+//
+//  1. Stops the stale capture — unblocking and JOINING the parked readLoop (no
+//     goroutine leak) — and clears the capturing latch.
+//  2. Discards the dead pane's still-buffered ring bytes, so a subscriber that was
+//     lagging at recovery cannot be handed them after the repaint (#1840).
+//  3. If subscribers are STILL attached (a web/TUI client that stayed connected
+//     across the respawn — the common case), restarts the capture against the fresh
+//     pane and re-seeds each subscriber with a repaint of the recovered screen, so it
+//     resumes output on its OWN rather than hanging until some unrelated later
+//     Subscribe happens to bring the capture back up (the #1682 residual T-Rex hit).
+//     With no subscribers left, the lazy lifecycle is simply re-armed for the next
+//     Subscribe.
+//
+// Recovery is ATOMIC as each attached subscriber sees it (#1975): the barrier armed
+// below holds every subscriber's content stream from the moment recovery starts until
+// the repaint is installed, so the repaint is the FIRST thing a subscriber renders
+// after the respawn. Without it, steps 1-3 each leak a frame the repaint then wipes —
+// the dead pane's still-buffered bytes before the discard, and (the reported case) the
+// re-spawned pane's live bytes during step 3's snapshot, which runs without b.mu while
+// the freshly-started readLoop is already feeding and waking subscribers.
+//
+// The subscriber count is re-read AFTER the stop (still under captureMu) so a
+// subscriber that left during the blocking teardown is not resurrected onto a capture
+// nobody wants. A no-op when the broker is already closed.
+func (b *ptyBroker) resetCapture() { b.recoverCapture(false) }
+
+// recoverDeadUpstream is resetCapture's recovery, GUARDED: it runs only when
+// there is no healthy capture installed. That guard is what lets the readLoop's
+// own exit drive recovery (#2450).
+//
+// resetCapture cannot be called from there directly, for two independent
+// reasons. It unconditionally stops whatever capture is live, so a scheduled
+// recovery that raced a healthy re-dial (a subscribe got there first) would tear
+// down the good capture and blip every attached client. And it is asynchronous
+// by necessity: a readLoop cannot run the teardown inline, because stopCapture
+// ends in `<-done` — a wait on the very goroutine that would be calling it.
+//
+// Routing recovery through the SAME body as the local-respawn case is the point,
+// not an economy. A recovery that merely re-dialled would splice a silent gap
+// into an already-attached subscriber's stream: remoteClientlessChannel dials
+// from the LIVE TAIL, so every byte produced during the outage is gone, and the
+// ring seq stays contiguous across the hole so nothing tells the client anything
+// was lost. This body arms the #1975 barrier, performs the #1840 discard, and
+// re-seeds a repaint of the recovered screen — which is exactly what that
+// subscriber needs and what #2447's subscribe-only path did not do.
+func (b *ptyBroker) recoverDeadUpstream() { b.recoverCapture(true) }
+
+func (b *ptyBroker) recoverCapture(onlyIfNoHealthyCapture bool) {
+	b.captureMu.Lock()
+	defer b.captureMu.Unlock()
+
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return
+	}
+	// The guard, mirroring ensureCaptureStartedLocked's short-circuit: `capturing
+	// && !captureEnded` is the one expression in this file that means "a healthy
+	// capture is installed". A scheduled recovery whose death was already
+	// reconciled by a racing subscribe must do NOTHING rather than restart a
+	// capture that is working.
+	if onlyIfNoHealthyCapture && b.capturing && !b.captureEnded {
+		b.mu.Unlock()
+		return
+	}
+	// Arm the barrier FIRST — before the teardown, the discard, and the restart — so no
+	// subscriber can emit a frame at any point inside the recovery. Armed subscribers
+	// are captured by identity, not re-read from b.subs at release time, so one that
+	// detaches mid-recovery is still released rather than left parked (#1975).
+	armed := b.armRecoveryRepaintLocked()
+	var stop func()
+	if b.capturing {
+		stop = b.stopCapture
+		b.capturing = false
+		b.stopCapture = nil
+	}
+	b.mu.Unlock()
+
+	// The barrier MUST be lifted on EVERY path out — a failed restart, a Snapshot
+	// error, nobody left attached — or an armed subscriber parks in NextEvent forever
+	// waiting for a repaint that never comes. rp is read when the deferred call runs,
+	// so this single exit point both installs whatever repaint the recovery managed to
+	// build and lifts the barrier, atomically under b.mu.
+	var rp *repaintSnapshot
+	defer func() { b.releaseRecoveryRepaint(armed, rp) }()
+
+	if stop != nil {
+		stop()
+	}
+
+	// Discard the dead pane's buffered output (#1840). This is the ONLY point where
+	// that is race-free: the old readLoop has been joined by the stop above and the
+	// fresh one is not started until below, so the ring provably holds dead-pane bytes
+	// and nothing else, and no feed can interleave. Dropping the bytes while KEEPING
+	// the seq monotonic (base jumps to head over an emptied ring) means a lagging
+	// subscriber — one whose WS write blocked while the dying pane kept producing —
+	// hits the existing `cursor < base` eviction clamp in NextEvent and fast-forwards
+	// to the live tail. Without this it would take the recovery repaint and THEN the
+	// pre-recovery bytes, overwriting the recovered screen with the dead pane's
+	// content. Nothing needs to touch subscriber cursors directly; the clamp is the
+	// same mechanism a ring overflow already uses.
+	//
+	// Unconditional, including when nobody is attached: a later Subscribe(since) would
+	// otherwise replay the dead pane's tail into a fresh client. That no-subscriber path
+	// is why subscribe() repaints a reconnect whose `since` lands below base — the
+	// discard leaves it a cursor that can never be replayed, and with nobody attached
+	// there is no re-seed here to cover it.
+	b.mu.Lock()
+	b.base = b.headLocked()
+	b.buf = nil
+	// Re-read the subscriber count AFTER the teardown drained: nobody left → just the
+	// lazy re-arm, the next Subscribe restarts a fresh capture.
+	resume := !b.closed && len(b.subs) != 0
+	b.mu.Unlock()
+	if !resume {
+		return
+	}
+
+	// A subscriber stayed attached across the respawn. Restart the capture against the
+	// re-spawned pane and re-seed every current subscriber so it repaints the recovered
+	// screen and resumes live output without a new Subscribe. The restarted capture's
+	// readLoop begins feeding and waking subscribers IMMEDIATELY — the barrier is what
+	// keeps those bytes behind the repaint built below (#1975).
+	if err := b.ensureCaptureStartedLocked(); err != nil {
+		log.WarningLog.Printf("pty broker: restart capture after recovery: %v", err)
+		return
+	}
+	rp = b.recoveryRepaint()
+}
+
+// armRecoveryRepaintLocked holds every currently-registered subscriber's content
+// stream (PTYCursor/PTYData) until the recovery repaint is installed, and returns the
+// subscribers it armed. Caller holds b.mu.
+//
+// The returned slice — NOT a later re-read of b.subs — is what releaseRecoveryRepaint
+// walks: a subscriber that detaches mid-recovery is gone from the map but may still be
+// parked in NextEvent, and it must be released too.
+func (b *ptyBroker) armRecoveryRepaintLocked() []*ptySub {
+	armed := make([]*ptySub, 0, len(b.subs))
+	for _, s := range b.subs {
+		s.repaintArmed = true
+		armed = append(armed, s)
+	}
+	return armed
+}
+
+// recoveryRepaint captures the recovered pane's screen and builds the repaint bytes
+// the re-seed installs, so a client that stayed attached across a tmux respawn
+// repaints the current screen and resumes live output on its own (#1682). It mirrors
+// subscribe()'s initial-repaint injection but builds ONE snapshot for all subscribers.
+// The Snapshot exec runs without b.mu held (matching subscribe) — which is precisely
+// the window the barrier exists to cover. Best-effort: a Snapshot error or an empty
+// screen yields nil, and the release degrades to just lifting the barrier and waking
+// the subscribers — the restarted capture's next live byte still reaches them — rather
+// than failing the recovery. Caller holds captureMu.
+func (b *ptyBroker) recoveryRepaint() *repaintSnapshot {
+	snap, err := b.ch.Snapshot()
+	if err != nil {
+		log.WarningLog.Printf("pty broker: snapshot for recovery re-seed: %v", err)
+		return nil
+	}
+	if !snapshotHasRepaintState(snap) {
+		return nil
+	}
+	rp := buildRepaintSnapshot(snap)
+	rp.provenance = PTYRepaintRecovery
+	return &rp
+}
+
+// redialDelay is the backoff for the nth consecutive re-dial: initial, doubling,
+// capped. Attempt 0 still waits — an upstream that just dropped is rarely ready
+// the same millisecond, and the wait is also what keeps a racing subscribe (which
+// recovers synchronously and for free) from colliding with this path.
+func redialDelay(attempt int) time.Duration {
+	d := redialInitialBackoff
+	for i := 0; i < attempt && d < redialMaxBackoff; i++ {
+		d *= 2
+	}
+	if d > redialMaxBackoff {
+		d = redialMaxBackoff
+	}
+	return d
+}
+
+// redialLoop re-establishes a capture whose upstream died, without waiting for a
+// new subscribe (#2450).
+//
+// #2447 made a dead capture recoverable but reachable only from subscribe(), and
+// with one client attached over a healthy daemon-browser WebSocket nothing ever
+// re-subscribes — the daemon pings, the browser pongs, and the pane stays dead
+// until the user refreshes. This is the missing driver.
+//
+// It retries while there is no healthy capture and somebody is still attached,
+// climbing redialDelay's ladder. Two distinct storms are bounded by the same
+// counter, because to a down endpoint they look the same from here:
+//
+//   - the dial itself keeps failing (sandbox unreachable) — this loop retries;
+//   - the dial succeeds and the socket drops immediately (a flapping proxy) —
+//     this loop exits, the fresh readLoop dies, and its hand-off resumes the
+//     ladder WITHOUT resetting it, because the capture did not survive
+//     redialHealthySpan.
+//
+// It gives up on: the broker closing, the last subscriber leaving (the lazy
+// lifecycle owns that case — the next subscribe brings the capture up), or a
+// healthy capture appearing (a subscribe beat us to it).
+func (b *ptyBroker) redialLoop() {
+	defer func() {
+		b.mu.Lock()
+		b.redialing = false
+		b.mu.Unlock()
+	}()
+
+	for {
+		b.mu.Lock()
+		healthy := b.capturing && !b.captureEnded
+		if b.closed || healthy || len(b.subs) == 0 {
+			b.mu.Unlock()
+			return
+		}
+		delay := redialDelay(b.redialAttempts)
+		b.redialAttempts++
+		b.mu.Unlock()
+
+		select {
+		case <-b.closedCh:
+			return
+		case <-time.After(delay):
+		}
+
+		// Guarded: does nothing if a subscribe recovered the capture while we slept.
+		b.recoverDeadUpstream()
+	}
+}
+
+// releaseRecoveryRepaint installs rp on every armed subscriber and lifts the barrier —
+// both under ONE b.mu hold, so a subscriber can never observe the lifted barrier
+// without also seeing the repaint that was owed to it. Waking is what makes a parked
+// subscriber re-read that state.
+func (b *ptyBroker) releaseRecoveryRepaint(armed []*ptySub, rp *repaintSnapshot) {
+	b.mu.Lock()
+	for _, s := range armed {
+		if rp != nil && len(rp.data) > 0 {
+			s.pendingRepaint = rp
+		}
+		s.repaintArmed = false
+	}
+	b.wakeAllLocked()
+	b.mu.Unlock()
+	// wakeAllLocked only rings subscribers still in b.subs. An armed subscriber that
+	// detached mid-recovery is not in the map but can still be parked on the barrier,
+	// so ring its doorbell directly; wake() is a coalescing no-op when already signaled.
+	for _, s := range armed {
+		s.wake()
+	}
+}

--- a/session/ptybroker_redial_test.go
+++ b/session/ptybroker_redial_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
@@ -165,6 +166,74 @@ func TestPTYBrokerReDialKeepsTryingUntilTheEndpointComesBack(t *testing.T) {
 	mustRepaintContains(t, a, "RECOVERED")
 	ch.emit(t, []byte("back-online"))
 	mustData(t, a, "back-online")
+}
+
+// TestPTYBrokerReDialSurvivesAFlapWhileTheLoopIsExiting is the lost-wakeup
+// regression.
+//
+// redialLoop stops driving once it sees a healthy capture. If the flag that says
+// "a recovery goroutine exists" is cleared in a DEFERRED section rather than in
+// the same critical section as that decision, there is a window between the two
+// where the broker claims a driver it no longer has:
+//
+//  1. the loop sees the capture it just re-dialled as healthy, commits to
+//     returning, and releases mu;
+//  2. that capture's upstream dies. Its readLoop hand-off takes mu, finds
+//     `redialing` still true, and declines to spawn a replacement;
+//  3. the deferred clear runs.
+//
+// The broker is then capturing=true, captureEnded=true, redialing=false, with a
+// subscriber attached and NOBODY driving recovery — the #2450 freeze, restored
+// by the fix for #2450.
+//
+// The window is a few instructions wide, so this drives it exactly through
+// redialLoopExitHook rather than hoping a stress loop lands in it. -race is no
+// substitute: every access is already under mu, so this is a missed signal
+// rather than a data race, and the detector is silent either way.
+func TestPTYBrokerReDialSurvivesAFlapWhileTheLoopIsExiting(t *testing.T) {
+	defer setRedialTimingForTest(2 * time.Millisecond)()
+
+	ch := &singleSocketChannel{snapshot: []byte("SCREEN")}
+	br := newPTYBroker(ch)
+	defer br.close()
+
+	a, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+	mustRepaintContains(t, a, "SCREEN")
+
+	// Fire once, on the loop's way out, after it has decided the re-dialled
+	// capture is healthy. That is the window.
+	var once sync.Once
+	defer setRedialLoopExitHookForTest(func() {
+		once.Do(func() {
+			ch.dropUpstream()
+			// Give the dying readLoop's hand-off time to take mu and make its
+			// spawn decision while this loop is still returning.
+			time.Sleep(20 * time.Millisecond)
+		})
+	})()
+
+	// First death: spawns the loop, which re-dials, sees the new capture healthy,
+	// and exits — running the hook, which kills that capture inside the window.
+	ch.dropUpstream()
+
+	// 1 initial + 1 re-dial + 1 more after the flap. Reaching 3 is the whole
+	// assertion: it means SOMETHING was still driving recovery after the flap.
+	waitForStarts(t, ch, 3, 3*time.Second)
+
+	// And the attached subscriber is actually live again, not merely re-dialled.
+	ch.emit(t, []byte("after-flap"))
+	for {
+		ev, err := nextWithin(t, a, 2*time.Second)
+		if err != nil {
+			t.Fatalf("NextEvent after the flap: %v", err)
+		}
+		if ev.Kind == PTYData && string(ev.Data) == "after-flap" {
+			break
+		}
+	}
 }
 
 // TestPTYBrokerReDialStopsWhenTheLastSubscriberLeaves pins the lazy lifecycle

--- a/session/ptybroker_redial_test.go
+++ b/session/ptybroker_redial_test.go
@@ -1,0 +1,233 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+// waitForStarts blocks until the channel has been dialled `want` times, or fails.
+// It exists because the re-dial is driven by the readLoop's exit — asynchronous
+// with respect to the test — rather than by a call the test makes.
+func waitForStarts(t *testing.T, ch *singleSocketChannel, want int, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for {
+		starts, stops := ch.counts()
+		if starts >= want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("broker never re-dialled on its own: StartCapture calls = %d, StopCapture = %d, "+
+				"want %d starts within %s.\n\n"+
+				"With one subscriber attached and its daemon-browser WS healthy, NOTHING ever "+
+				"re-subscribes — the daemon pings and the browser pongs — so a recovery reachable "+
+				"only from subscribe() leaves the pane dead until the user refreshes. #2447 cured "+
+				"\"a refresh doesn't help\"; it did not cure \"it froze\" (#2450).",
+				starts, stops, want, within)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestPTYBrokerReDialsWithoutANewSubscribe is #2450 item 2.
+//
+// #2447 made a dead capture recoverable, but only from subscribe(): the recovery
+// is reached from ensureCaptureStarted, and ensureCaptureStarted is reached from
+// exactly two places — subscribe and resetCapture. resetCapture is the LOCAL
+// respawn hook (agentserver_local.go); the remote runtime has no equivalent. So
+// with a single client attached over a healthy daemon-browser WebSocket, nothing
+// ever re-subscribes and the capture stays dead indefinitely.
+//
+// The broker must recover from the readLoop's own exit instead, so the pane comes
+// back without the user refreshing.
+func TestPTYBrokerReDialsWithoutANewSubscribe(t *testing.T) {
+	defer setRedialTimingForTest(time.Millisecond)()
+
+	ch := &singleSocketChannel{snapshot: []byte("SCREEN")}
+	br := newPTYBroker(ch)
+	defer br.close()
+
+	a, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+	mustRepaintContains(t, a, "SCREEN")
+	ch.emit(t, []byte("before-drop"))
+	mustData(t, a, "before-drop")
+
+	// The WebSocket dies under the live capture. A stays attached and parked in
+	// NextEvent; the sandbox is still healthy over REST, so nothing marks the
+	// session Lost and no external hook fires.
+	ch.snapshot = []byte("RECOVERED")
+	ch.dropUpstream()
+
+	// No new subscribe anywhere in this test. That is the whole point.
+	waitForStarts(t, ch, 2, 3*time.Second)
+
+	if _, stops := ch.counts(); stops < 1 {
+		t.Fatalf("StopCapture calls = %d, want at least 1: the dead socket must be RELEASED, not "+
+			"merely forgotten — remoteClientlessChannel.StartCapture refuses while it still holds "+
+			"one", stops)
+	}
+
+	// The already-attached subscriber resumes on its own: a repaint of the
+	// recovered screen first (#2450 item 1 — without it A's emulator is silently
+	// desynced across the outage), then live bytes.
+	mustRepaintContains(t, a, "RECOVERED")
+	ch.emit(t, []byte("after-redial"))
+	mustData(t, a, "after-redial")
+}
+
+// TestPTYBrokerReDialIsBoundedWhenUpstreamKeepsDying is the storm guard.
+//
+// A re-dial driven by the readLoop's exit feeds back on itself: an endpoint that
+// accepts a socket and immediately drops it produces death -> re-dial -> death,
+// as fast as the loop can turn. The web client already backs off exponentially
+// (web/src/terminal.ts), but the daemon side had none, so this is the bound the
+// fix has to supply.
+//
+// The assertion is a RATE CEILING derived from the configured backoff, not a
+// hand-picked count: the loop sleeps at least redialInitialBackoff before every
+// dial, so over `span` it cannot exceed span/initial, plus slack for scheduling.
+// An earlier version of this test compared two windows for "acceleration" and
+// was vacuous — an unbounded retry spins at a constant, enormous rate rather
+// than an accelerating one, so it passed with the backoff deleted. Verified this
+// version fails with redialDelay stubbed to zero.
+func TestPTYBrokerReDialIsBoundedWhenUpstreamKeepsDying(t *testing.T) {
+	const unit = 20 * time.Millisecond
+	defer setRedialTimingForTest(unit)()
+
+	ch := &singleSocketChannel{snapshot: []byte("SCREEN"), dieOnStart: true}
+	br := newPTYBroker(ch)
+	defer br.close()
+
+	a, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+	defer func() { _ = a.Close() }()
+
+	const span = 600 * time.Millisecond
+	time.Sleep(span)
+	starts, _ := ch.counts()
+
+	// The floor: the recovery must actually be running, or the ceiling below is
+	// satisfied by doing nothing.
+	if starts < 2 {
+		t.Fatalf("StartCapture calls = %d after %s, want at least 2: the readLoop-driven recovery "+
+			"never ran, so this test's ceiling proves nothing", starts, span)
+	}
+	// The ceiling. Every dial is preceded by at least redialInitialBackoff, and
+	// most by more (the ladder doubles to 4*unit here), so this is generous.
+	ceiling := int(span/unit) + 4
+	if starts > ceiling {
+		t.Fatalf("StartCapture calls = %d in %s, want at most %d.\n\n"+
+			"Each re-dial must wait at least %s, doubling to %s. An unbounded retry dials as "+
+			"fast as the loop turns, which means the daemon hammers a down sandbox on the "+
+			"user's behalf with nobody watching (#2450).",
+			starts, span, ceiling, redialInitialBackoff, redialMaxBackoff)
+	}
+}
+
+// TestPTYBrokerReDialKeepsTryingUntilTheEndpointComesBack is the other half of
+// "recovers instead of staying dead": the interesting outage is not one where
+// the sandbox is ready the instant we notice, it is one where the dial keeps
+// failing for a while.
+//
+// A recovery that gave up after its first failed dial would leave the pane dead
+// exactly when the user is waiting — a sandbox restarting, a tunnel
+// re-establishing. The loop must keep climbing its ladder until the endpoint
+// answers, and then deliver a working stream to the subscriber that never left.
+func TestPTYBrokerReDialKeepsTryingUntilTheEndpointComesBack(t *testing.T) {
+	defer setRedialTimingForTest(2 * time.Millisecond)()
+
+	ch := &singleSocketChannel{snapshot: []byte("SCREEN")}
+	br := newPTYBroker(ch)
+	defer br.close()
+
+	a, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+	mustRepaintContains(t, a, "SCREEN")
+
+	// The endpoint goes away entirely: the socket drops AND the next three dials
+	// are refused.
+	ch.mu.Lock()
+	ch.failStarts = 3
+	ch.snapshot = []byte("RECOVERED")
+	ch.mu.Unlock()
+	ch.dropUpstream()
+
+	// 1 initial + 3 refused + 1 that succeeds.
+	waitForStarts(t, ch, 5, 3*time.Second)
+
+	mustRepaintContains(t, a, "RECOVERED")
+	ch.emit(t, []byte("back-online"))
+	mustData(t, a, "back-online")
+}
+
+// TestPTYBrokerReDialStopsWhenTheLastSubscriberLeaves pins the lazy lifecycle
+// against the new self-driving recovery: with nobody attached there is no pane to
+// keep alive, so the recovery must NOT hold a capture open. Otherwise a broker
+// whose last client detached would keep a socket dialled against the sandbox
+// forever, which is the resource leak the lazy start/stop exists to avoid.
+func TestPTYBrokerReDialStopsWhenTheLastSubscriberLeaves(t *testing.T) {
+	defer setRedialTimingForTest(time.Millisecond)()
+
+	ch := &singleSocketChannel{snapshot: []byte("SCREEN")}
+	br := newPTYBroker(ch)
+	defer br.close()
+
+	a, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+	mustRepaintContains(t, a, "SCREEN")
+
+	// Last subscriber leaves, THEN the upstream dies. maybeStopCapture has already
+	// torn the capture down, so there is nothing to recover and nobody to recover
+	// for.
+	if err := a.Close(); err != nil {
+		t.Fatalf("close A: %v", err)
+	}
+	ch.dropUpstream()
+
+	starts, _ := ch.counts()
+	time.Sleep(100 * time.Millisecond)
+	after, _ := ch.counts()
+	if after != starts {
+		t.Fatalf("StartCapture calls went %d -> %d with NO subscriber attached; the recovery must "+
+			"leave the lazy lifecycle alone and let the next subscribe bring the capture up",
+			starts, after)
+	}
+}
+
+// TestPTYBrokerReDialDoesNotResurrectAClosedBroker is the #1632 lock, applied to
+// the new entry point. A readLoop that exits BECAUSE the broker was shut down
+// must not hand off to a recovery that dials a fresh socket into a torn-down
+// sandbox — nothing would ever close it.
+func TestPTYBrokerReDialDoesNotResurrectAClosedBroker(t *testing.T) {
+	defer setRedialTimingForTest(time.Millisecond)()
+
+	ch := &singleSocketChannel{snapshot: []byte("SCREEN")}
+	br := newPTYBroker(ch)
+
+	a, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+	mustRepaintContains(t, a, "SCREEN")
+
+	// close() tears the capture down, which ends the readLoop. That exit must be
+	// recognised as a teardown, not an upstream death.
+	br.close()
+
+	starts, _ := ch.counts()
+	time.Sleep(100 * time.Millisecond)
+	after, _ := ch.counts()
+	if after != starts {
+		t.Fatalf("StartCapture calls went %d -> %d after the broker was closed; a closed broker "+
+			"must never re-dial (#1632)", starts, after)
+	}
+}

--- a/session/ptybroker_redial_test.go
+++ b/session/ptybroker_redial_test.go
@@ -59,7 +59,9 @@ func TestPTYBrokerReDialsWithoutANewSubscribe(t *testing.T) {
 	// The WebSocket dies under the live capture. A stays attached and parked in
 	// NextEvent; the sandbox is still healthy over REST, so nothing marks the
 	// session Lost and no external hook fires.
+	ch.mu.Lock()
 	ch.snapshot = []byte("RECOVERED")
+	ch.mu.Unlock()
 	ch.dropUpstream()
 
 	// No new subscribe anywhere in this test. That is the whole point.
@@ -238,9 +240,21 @@ func TestPTYBrokerReDialSurvivesAFlapWhileTheLoopIsExiting(t *testing.T) {
 
 // TestPTYBrokerReDialStopsWhenTheLastSubscriberLeaves pins the lazy lifecycle
 // against the new self-driving recovery: with nobody attached there is no pane to
-// keep alive, so the recovery must NOT hold a capture open. Otherwise a broker
-// whose last client detached would keep a socket dialled against the sandbox
-// forever, which is the resource leak the lazy start/stop exists to avoid.
+// keep alive, so the recovery must NOT leave a capture open. Otherwise a broker
+// whose last client detached keeps a socket dialled against the sandbox forever,
+// which is the resource leak the lazy start/stop exists to avoid.
+//
+// The subscriber detaches while the re-dial is IN FLIGHT, which is the window
+// that actually leaks. An earlier version of this test closed the subscriber
+// BEFORE the drop, so redialLoop never started — it passed with the entire
+// hand-off disabled and proved nothing. Reported in review; this is the rewrite.
+//
+// The leak it now covers: recoverCapture reads the subscriber count, then dials,
+// and only sets capturing=true once StartCapture returns. remove() used to gate
+// its teardown on `capturing`, so a departure during the dial saw capturing=false,
+// skipped maybeStopCapture, and let the completing dial install a capture with
+// zero subscribers and nothing to stop it. Rare while recovery was user-driven and
+// local; routine once a background timer dials across a remote WS handshake.
 func TestPTYBrokerReDialStopsWhenTheLastSubscriberLeaves(t *testing.T) {
 	defer setRedialTimingForTest(time.Millisecond)()
 
@@ -254,21 +268,88 @@ func TestPTYBrokerReDialStopsWhenTheLastSubscriberLeaves(t *testing.T) {
 	}
 	mustRepaintContains(t, a, "SCREEN")
 
-	// Last subscriber leaves, THEN the upstream dies. maybeStopCapture has already
-	// torn the capture down, so there is nothing to recover and nobody to recover
-	// for.
-	if err := a.Close(); err != nil {
-		t.Fatalf("close A: %v", err)
-	}
+	// Hold the NEXT dial open, so the detach below lands mid-handshake.
+	gate := make(chan struct{})
+	entered := make(chan struct{})
+	ch.mu.Lock()
+	ch.startGate, ch.gateEntered = gate, entered
+	ch.mu.Unlock()
+
+	// Release the gate on EVERY exit. Registered after the deferred br.close(), so
+	// it runs before it: a t.Fatal below would otherwise leave the dial parked
+	// holding captureMu, and close() would deadlock on it instead of reporting the
+	// real failure.
+	var gateOnce sync.Once
+	releaseGate := func() { gateOnce.Do(func() { close(gate) }) }
+	defer releaseGate()
+
 	ch.dropUpstream()
 
-	starts, _ := ch.counts()
-	time.Sleep(100 * time.Millisecond)
-	after, _ := ch.counts()
-	if after != starts {
-		t.Fatalf("StartCapture calls went %d -> %d with NO subscriber attached; the recovery must "+
-			"leave the lazy lifecycle alone and let the next subscribe bring the capture up",
-			starts, after)
+	// Wait for the dial to reach its gate. Not `starts >= 2`: that counter is
+	// incremented on the far side of the gate, so waiting on it would wait for the
+	// thing being held.
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the re-dial never reached StartCapture, so the in-flight window was never entered")
+	}
+
+	// Detach CONCURRENTLY. Close blocks: remove() hands off to maybeStopCapture,
+	// which waits for captureMu — held by the dial we are gating. That is the real
+	// shape (a detach during a slow handshake genuinely waits), so the test has to
+	// let it happen rather than serialise it and deadlock itself.
+	closed := make(chan error, 1)
+	go func() { closed <- a.Close() }()
+
+	// Give Close time to reach maybeStopCapture and park on captureMu, so the
+	// teardown is genuinely pending when the dial lands.
+	time.Sleep(50 * time.Millisecond)
+	releaseGate() // let the dial complete, with nobody attached
+
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("close A: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("closing the last subscriber never returned — the teardown is wedged behind the dial")
+	}
+
+	// The capture that dial installed must be released, not orphaned.
+	deadline := time.Now().Add(2 * time.Second)
+	for ch.isHeld() {
+		if time.Now().After(deadline) {
+			starts, stops := ch.counts()
+			t.Fatalf("a capture is still held with NO subscriber attached: starts=%d stops=%d.\n\n"+
+				"The last subscriber left while the re-dial was in flight, so the teardown was "+
+				"skipped and the completing dial installed a socket nothing will ever close — a "+
+				"leaked capture against the sandbox for the life of the broker.", starts, stops)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// TestRedialDelayClimbsAndCaps locks the ladder SHAPE, which the rate-ceiling
+// test above cannot: a flat backoff pinned at redialInitialBackoff yields 30
+// dials against its ceiling of 34, so that test passes with the doubling
+// removed. This one is pure arithmetic — no timing, no flakiness.
+func TestRedialDelayClimbsAndCaps(t *testing.T) {
+	defer setRedialTimingForTest(10 * time.Millisecond)()
+
+	if got, want := redialDelay(0), redialInitialBackoff; got != want {
+		t.Errorf("redialDelay(0) = %s, want %s (the first retry waits the initial rung)", got, want)
+	}
+	if got, want := redialDelay(1), 2*redialInitialBackoff; got != want {
+		t.Errorf("redialDelay(1) = %s, want %s — the ladder must DOUBLE, not stay flat", got, want)
+	}
+	if got, want := redialDelay(2), 4*redialInitialBackoff; got != want {
+		t.Errorf("redialDelay(2) = %s, want %s", got, want)
+	}
+	// And it must saturate rather than grow without bound.
+	for _, attempt := range []int{3, 10, 1000} {
+		if got := redialDelay(attempt); got != redialMaxBackoff {
+			t.Errorf("redialDelay(%d) = %s, want the cap %s", attempt, got, redialMaxBackoff)
+		}
 	}
 }
 

--- a/session/ptybroker_upstream_death_test.go
+++ b/session/ptybroker_upstream_death_test.go
@@ -30,6 +30,16 @@ type singleSocketChannel struct {
 	starts   int
 	stops    int
 	snapshot []byte
+	// dieOnStart makes every dialled socket drop immediately, modelling an
+	// endpoint that accepts the WebSocket and then loses it (a proxy flapping, a
+	// sandbox mid-restart). It is what turns a readLoop-driven re-dial into a
+	// feedback loop, so it is how the backoff bound is exercised.
+	dieOnStart bool
+	// failStarts is how many further StartCapture calls must fail outright,
+	// modelling an endpoint that is unreachable rather than flapping — the dial
+	// itself errors, so no socket is ever held and no readLoop is ever spawned.
+	// Each failure decrements it, so a test can have the endpoint come back.
+	failStarts int
 }
 
 func (c *singleSocketChannel) StartCapture() (io.ReadCloser, error) {
@@ -38,10 +48,21 @@ func (c *singleSocketChannel) StartCapture() (io.ReadCloser, error) {
 	if c.held {
 		return nil, fmt.Errorf("remote clientless capture already started")
 	}
+	if c.failStarts > 0 {
+		c.failStarts--
+		c.starts++
+		return nil, fmt.Errorf("dial sandbox agent-server: connection refused")
+	}
 	c.held = true
 	c.starts++
 	r, w := io.Pipe()
 	c.w = w
+	if c.dieOnStart {
+		// Close the write end straight away: the broker's readLoop gets EOF on its
+		// first Read, exactly as it would if the socket dropped mid-flight.
+		c.w = nil
+		_ = w.Close()
+	}
 	return r, nil
 }
 

--- a/session/ptybroker_upstream_death_test.go
+++ b/session/ptybroker_upstream_death_test.go
@@ -40,9 +40,39 @@ type singleSocketChannel struct {
 	// itself errors, so no socket is ever held and no readLoop is ever spawned.
 	// Each failure decrements it, so a test can have the endpoint come back.
 	failStarts int
+	// startGate, when non-nil, holds StartCapture until it is closed — standing in
+	// for the remote WebSocket handshake, which is bounded at ten seconds. It is
+	// what lets a test act (detach a subscriber, say) while a dial is genuinely
+	// in flight, which is a real and now-routine window rather than a contrived
+	// one. Read under mu; waited on WITHOUT mu so the gate cannot deadlock the fake.
+	startGate chan struct{}
+	// gateEntered is closed when a gated StartCapture reaches its gate. The dial's
+	// visible counter (starts) is incremented on the FAR side of the gate, so it
+	// cannot be used to detect that the dial is in flight — waiting on it would
+	// wait for the very thing the gate is holding.
+	gateEntered chan struct{}
+}
+
+// held reports whether the fake is still holding a capture socket. A capture
+// held with no subscriber attached is a leak: nothing will ever release it.
+func (c *singleSocketChannel) isHeld() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.held
 }
 
 func (c *singleSocketChannel) StartCapture() (io.ReadCloser, error) {
+	c.mu.Lock()
+	gate, entered := c.startGate, c.gateEntered
+	c.startGate, c.gateEntered = nil, nil
+	c.mu.Unlock()
+	if gate != nil {
+		if entered != nil {
+			close(entered)
+		}
+		<-gate
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.held {


### PR DESCRIPTION
## Verified against master first

Both #2447 (`c49653bc`) and its follow-up #2452 (`dc4a7a1b`) are in master, so the bug could plausibly have been closed already. It is not. Confirmed by reading, then by a failing test:

- `ensureCaptureStarted` is reached from exactly two places — `subscribe` (ptybroker.go) and `resetCapture`.
- `resetCapture` has exactly one caller: `agentserver_local.go:294`, the LOCAL respawn hook. The remote runtime has no equivalent.

So with one client attached over a healthy daemon↔browser WebSocket, nothing ever re-subscribes and nothing external fires. The capture stays dead. #2447 cured *"a refresh doesn't help"*; it did not cure *"it froze"*.

## What changed

**The readLoop's own exit now drives recovery.** Its defer already latched `captureEnded`; it now also decides whether the exit was *spontaneous* and hands off to `redialLoop`. The test is not a new flag — every teardown clears `capturing` under `mu` **before** invoking `stop()`, and `stop()` is what ends the loop, so `capturing` still true at loop exit means nothing asked it to stop. The hand-off is a goroutine by necessity: `stopCapture` ends in `<-done`, so the loop cannot run its own release inline.

**Recovery routes through `resetCapture`'s body, not a bare re-dial** — which closes item 1 of the issue too. `remoteClientlessChannel` dials from the **live tail**, so a plain re-dial splices a silent gap into an already-attached subscriber's stream: every byte produced during the outage is gone, and the ring seq stays contiguous across the hole, so nothing tells the client anything was lost. Sharing the body arms the #1975 barrier, performs the #1840 discard, and re-seeds a repaint of the recovered screen. `resetCapture` gained the guarded variant the issue asked for, since it unconditionally stops whatever capture is live.

**Bounded, because the driver is a feedback loop.** Delay doubles from 500ms to 30s. The ladder resets only once a capture has survived 60s, so a dial that *succeeds and dies instantly* still consumes a rung — that is the storm shape.

## Review found four more defects, all now fixed

This PR has been through several adversarial passes. Recording what they caught, because three of the four were introduced by this PR rather than pre-existing:

**P1 — credential leak (`694ac524`).** The new recovery path would write the sandbox bearer token to `agent-factory.log` in cleartext, once per backoff, for as long as a tab stayed open against a down sandbox. `dialStream` puts the token in the URL as `?access_token=`, a failed `websocket.Dial` surfaces as a `*url.Error` carrying that whole URL, and the error was wrapped verbatim. Master never logged it — the only failed-remote-dial path was `subscribe()`, whose error goes to an HTTP response. Fixed **at the source** so `subscribe`, recovery, and any future caller are covered by construction. Note `url.Redacted()` is not a fix: it covers userinfo only and leaves query params intact.

**P1 — lost wakeup (`3a6f9787`).** `redialLoop` decided to stop driving in one critical section and cleared `redialing` in a deferred one. A capture dying between them saw a stale `redialing == true`, declined to spawn a replacement, and then the flag was cleared — leaving nobody driving recovery. The #2450 freeze, reinstated by the fix for #2450. Now cleared inside the exit-decision section.

**P2 — orphaned capture (`938f1756`).** `remove()` gated its teardown on `capturing`, which is false while a dial is in flight, so a subscriber leaving mid-dial skipped the teardown and let the completing dial install a capture with zero subscribers and nothing to stop it. Pre-existing, but this PR changes its character: a background timer now dials across a remote WS handshake bounded at ten seconds, and closing a tab during an outage is ordinary.

**P2 — the log split covered one of two sibling sites (`938f1756`).** "restart capture after recovery" fires on every *failed* re-dial — the unreachable-endpoint case, strictly more common than the `StopCapture` path, which is only reached once a dial succeeds.

## Tests

| Case | Role |
|---|---|
| `ReDialsWithoutANewSubscribe` | the reported bug — **fails on master** (`StartCapture calls = 1`) |
| `ReDialSurvivesAFlapWhileTheLoopIsExiting` | the lost wakeup, driven deterministically through a hook seam |
| `ReDialStopsWhenTheLastSubscriberLeaves` | the orphaned capture, detaching mid-dial |
| `ReDialKeepsTryingUntilTheEndpointComesBack` | three refused dials, then success |
| `RedialDelayClimbsAndCaps` | the ladder shape, as arithmetic |
| `ReDialIsBoundedWhenUpstreamKeepsDying` | rate ceiling derived from the backoff |
| `RemoteAgentDialStream_ErrorCarriesNoToken` + redaction cases | the credential leak |
| `ReDialDoesNotResurrectAClosedBroker` | #1632 lock on the new entry point |

**Two of these were vacuous and were rewritten.** The storm guard originally compared windows for "acceleration" — an unbounded retry runs at a constant enormous rate, so it passed with the backoff deleted (now a rate ceiling; fails at 25,106 dials vs 34 with `redialDelay` stubbed to zero). And `StopsWhenTheLastSubscriberLeaves` closed the subscriber *before* the drop, so `redialLoop` never started — it passed with the entire hand-off disabled. Both were caught in review, not by me.

## Two things not asked for

**A file split.** `session/ptybroker.go` crossed the 1000-line limit; per CLAUDE.md I split rather than grandfathered. The recovery machinery is one coherent unit — local respawn and remote re-dial sharing a body, differing only in who notices.

**Log levels**, because this change causes the noise: automatic recovery turns two once-per-refresh WARNINGs into once-per-backoff-forever.

## Not addressed, deliberately

- Issue item 3's real fix (`CloseNow`) — it changes graceful-close for ordinary teardowns, so it wants its own change, exactly as the issue says.
- Teardown latency now includes waiting on `captureMu` held by a background re-dial across a handshake bounded at ten seconds. No deadlock — `Kill`/`closeTabStream` release `s.mu` first — but it is a real latency change and bounding it wants its own change.

## Gates

Exact head **`694ac524`**, clean tree. (An earlier revision of this body cited `4040f763`, which predated three of the fixes above — flagged in review and restated here.)

`golangci-lint --fast` · `gofmt -l .` · `go build ./...` · `deadcode -test ./...` · `scripts/lint-file-length.sh` · `make docs` (no drift) · `make test-container` on this head · `-race -count=3` across the broker, backoff and redaction tests · `-race` on the whole `session` package.

The concurrency here is the most delicate in the file, so the race runs are not decoration. Lock order (`captureMu` → `mu`) is unchanged, and `readLoop` still takes neither lock it cannot safely take.

Refs #2450.

— Captain Claude
