### PR TITLE
fix(tui): join status-menu hints with the middle dot (#2399)

### DIFF
--- a/docs/tui-manual-testing.md
+++ b/docs/tui-manual-testing.md
@@ -30,7 +30,7 @@ TUI was in*. Get this right and the rest follows.
 
 | Mode | What the keyboard does | Menu bar shows | How you got here |
 |------|------------------------|----------------|------------------|
-| **Nav** | Keys are TUI commands (`n` new, `s` open pane, `t` new tab, `j`/`k` move the tree cursor, …) | context hints (`n new • …`, `↵ interact • …`) | default; `Ctrl-]` from interactive |
+| **Nav** | Keys are TUI commands (`n` new, `s` open pane, `t` new tab, `j`/`k` move the tree cursor, …) | context hints (`n new · …`, `↵ interact · …`) | default; `Ctrl-]` from interactive |
 | **Interactive** | *Every* key — including Tab — forwards to the focused pane's shell/agent | only `ctrl+] nav mode` | `Enter` on a focused pane |
 | **Attached (full-screen)** | tmux owns the terminal; the TUI chrome is gone | the tmux status line (`[af_…`) | `o` on a selected instance |
 
@@ -45,9 +45,9 @@ In nav mode, `Tab`/`Shift-Tab` cycle **ring focus** across regions: the
 **instances tree** → each open **pane** → the **automations** strip → the **projects** section → back.
 The menu bar is context-sensitive and follows focus:
 
-- **tree** focused → `n new • …` (plus instance verbs when a row is selected)
-- **pane** focused → `↵ interact • o attach • ← prev pane • → next pane • … • s open pane • x hide pane`
-- **automations** focused → `enter manage • …`
+- **tree** focused → `n new · …` (plus instance verbs when a row is selected)
+- **pane** focused → `↵ interact · o attach · ← prev pane · → next pane · … · s open pane · x hide pane`
+- **automations** focused → `enter manage · …`
 - **projects** focused → `↵ switch · / search │ tab focus · ? help · q quit`
 
 `af_focus_tree` walks the ring (checking *before* it presses, so it never
@@ -67,7 +67,7 @@ text-greppable selection signal the driver asserts on:
 ```
 
 On a cold boot the cursor sits on the **section header** (no instance selected
-— menu shows the plain `n new • N new remote` set); the first `j` moves the
+— menu shows the plain `n new · N new remote` set); the first `j` moves the
 cursor down onto the first instance. `af_select` is robust to any starting
 position: it anchors at the top (`k` is idempotent there), then steps down
 with `j` until the target row shows `▾` **and** the tree cursor is actually on

--- a/scripts/tui-driver-selftest.sh
+++ b/scripts/tui-driver-selftest.sh
@@ -313,9 +313,9 @@ _expect_af_select_open_pane() {
             if [ "$_AF_OPENPANE_JCOUNT" -lt 5 ]; then
                 printf '%s\n' ' ▸ target                       │ menu: n new'
             elif [ "$_AF_OPENPANE_FOCUS" = pane ]; then
-                printf '%s\n' ' ▾ target                       │ ← prev pane • → next pane │ s open pane • x hide pane'
+                printf '%s\n' ' ▾ target                       │ ← prev pane · → next pane │ s open pane · x hide pane'
             else
-                printf '%s\n' ' ▾ target                       │ menu: n new • D kill'
+                printf '%s\n' ' ▾ target                       │ menu: n new · D kill'
             fi
         }
         af_select target
@@ -671,7 +671,7 @@ _expect_scrolled_rail_reads_as_booted() {
                       │                                        │
     └ 1 ◆ Agent *     │                                        │
                       ╰────────────────────────────────────────╯
-     n new • D kill │ t new tab • w close tab │ ? help • q quit
+     n new · D kill │ t new tab · w close tab │ ? help · q quit
 SCREEN
         }
         # Premise: the frame really is missing the header, or this is just

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -918,11 +918,19 @@ _af_tab_count() {
 #   * LEFT — `(^|[^[:alnum:]])`: the `r` must start a token (line start, or a
 #     non-alphanumeric like the frame padding / a `• ` separator before it), so
 #     the trailing `r` of a word does NOT count ("serve`r run` •", "you`r run`").
-#   * RIGHT — ` •` (U+2022): the run action is ALWAYS followed by the menu's
-#     space-and-bullet separator (`r run now • …` / `r run • …`), which no shell
-#     output line ("no longe`r run`ning.", "you`r run` finished") carries.
+#   * RIGHT — ` •` (U+2022): the run action is ALWAYS followed by the TASK
+#     OVERLAY's space-and-bullet separator (`r run now • …` / `r run • …`), which
+#     no shell output line ("no longe`r run`ning.", "you`r run` finished")
+#     carries.
 # The bullet is matched as a literal byte sequence, not a bracket expression, so
 # it works under the sandbox's C/POSIX locale (cf. _af_tab_count).
+#
+# This bullet is the TASK OVERLAY's (ui/task_pane.go), NOT the root status
+# menu's. Those are different rows built by different renderers, and the status
+# menu moved to the repo-standard ` · ` in #2399 while the overlay hints did not
+# — so do not "fix" this to a middle dot to match the status bar. If the overlay
+# hints are converted later, this anchor moves with them, and the tests in
+# ui/menu_test.go are what pin the status menu's own separator.
 : "${_AF_TASKS_RUN_HINT:=(^|[^[:alnum:]])r run( now)? •}"
 
 # af_open_tasks — open the task-manager overlay (`m`). Syncs on the overlay's

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -20,7 +20,20 @@ var sepStyle = lipgloss.NewStyle().Foreground(activeTheme.BackgroundSubtle)
 
 var actionGroupStyle = lipgloss.NewStyle().Foreground(AccentColor)
 
-var separator = " • "
+// separator joins hints WITHIN a group; verticalSeparator divides the groups.
+//
+// " · " is the repo-wide separator for fragments on one line (CLAUDE.md copy
+// conventions); this row rendered " • " instead (#2399). Because this is the
+// SHARED menu renderer rather than one overlay, the drift showed up throughout
+// ordinary navigation, which is why it was worth a change to a load-bearing
+// string.
+//
+// It is width-neutral, and that is not incidental — the hint row is clamped and
+// shed by width (hintDropOrder), so a separator one cell wider would silently
+// drop a hint at some terminal size. U+00B7 and U+2022 are both East Asian
+// Ambiguous, which lipgloss.Width counts as one cell each, so the row measures
+// identically. TestMenuSeparatorIsWidthNeutral pins that rather than trusting it.
+var separator = " · "
 var verticalSeparator = " │ "
 
 var menuStyle = lipgloss.NewStyle().

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -279,6 +279,66 @@ func TestMenuNewInstancePromptHintSwapsAndDoesNotAlias(t *testing.T) {
 // like a local one. The "remote omits unsupported tab keys" behavior it guarded
 // no longer exists.
 
+// #2399: the hint row joins fragments on one line, so it takes the repo-wide
+// " · " separator (CLAUDE.md copy conventions) rather than the " • " it used to
+// render. Asserted on the real rendered row, not on the package var, so a future
+// renderer that stops using `separator` cannot quietly reintroduce a bullet.
+//
+// The bullet check is scoped to what the menu itself emits: a hint's own DESC
+// could legitimately contain one, and this row is the only thing under test.
+func TestMenuJoinsHintsWithMiddleDot(t *testing.T) {
+	m := NewMenu()
+	m.SetInstance(readyUIInstance())
+	m.SetSize(100, 1)
+
+	out := m.String()
+	if !strings.Contains(out, " · ") {
+		t.Fatalf("hint row must join fragments with the middle dot separator:\n%s", out)
+	}
+	if strings.Contains(out, "•") {
+		t.Fatalf("hint row still renders a bullet separator (#2399):\n%s", out)
+	}
+}
+
+// The hint row is shed by WIDTH (hintDropOrder), so the separator's cell cost is
+// load-bearing: one cell wider and some terminal size silently loses a hint that
+// used to fit. U+00B7 and U+2022 are both East Asian Ambiguous and measure one
+// cell, so the swap is free — but "measures the same" is exactly the kind of
+// assumption that is true until a width table changes, so it is pinned here
+// rather than reasoned about in a comment alone.
+func TestMenuSeparatorIsWidthNeutral(t *testing.T) {
+	if got := lipgloss.Width(separator); got != 3 {
+		t.Fatalf("separator measures %d cells, want 3 — a wider separator sheds hints "+
+			"at widths that used to fit (#2399/#1083)", got)
+	}
+	if got, want := lipgloss.Width(separator), lipgloss.Width(" • "); got != want {
+		t.Fatalf("separator is %d cells but the bullet it replaced was %d; the drop order "+
+			"was tuned against the old width", got, want)
+	}
+}
+
+// The narrowest supported terminal is where a width regression would show first,
+// so the row is checked there too: it must still fit its bar, and must not have
+// been pushed onto the bullet-free path by simply dropping every hint.
+func TestMenuMiddleDotFitsAtEightyColumns(t *testing.T) {
+	m := NewMenu()
+	m.SetInstance(readyUIInstance())
+	m.SetSize(80, 1)
+
+	out := m.String()
+	if !strings.Contains(out, " · ") {
+		t.Fatalf("80-column hint row must still join fragments with the middle dot:\n%s", out)
+	}
+	if strings.Contains(out, "•") {
+		t.Fatalf("80-column hint row still renders a bullet separator (#2399):\n%s", out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if w := lipgloss.Width(line); w > 80 {
+			t.Fatalf("hint row overflows an 80-column bar at %d cells:\n%s", w, out)
+		}
+	}
+}
+
 func TestMenuNormalWidthSurfacesTabAndPaneManagement(t *testing.T) {
 	m := NewMenu()
 	m.SetInstance(readyUIInstance())


### PR DESCRIPTION
Closes #2399.

## Verified against master first

`ui/menu.go:23` is still `var separator = " • "` on current `master`, and the rendered row confirms it. Captured by running the new tests against the unmodified separator:

```
n new • D kill │ t new tab • w close tab • 1-9 jump │ s open pane │ tab focus • ? help • q quit
```

## The change

One string: `" • "` → `" · "`. The group divider `" │ "` is untouched — it separates **groups**, not fragments.

## Width was the real risk, and it is pinned

The hint row is shed by width (`hintDropOrder`), so a separator one cell wider would silently drop a hint at some terminal size — exactly the #1083 class this row already has a priority list to prevent.

`U+00B7` and `U+2022` are both East Asian Ambiguous, so `lipgloss.Width` counts each as one cell and the row measures identically. That is a fact about a width table, not about my change, so `TestMenuSeparatorIsWidthNeutral` asserts it (3 cells, and equal to the bullet it replaced) rather than leaving it in a comment. A second test renders at **80 columns** and asserts the row both still uses `·` and still fits the bar.

The rendered-row assertions read `m.String()`, not the package var — a renderer that stopped using `separator` could otherwise reintroduce a bullet with every test green.

**Fail-first** (both new rendered-row tests, against the old separator):

```
--- FAIL: TestMenuJoinsHintsWithMiddleDot
    hint row must join fragments with the middle dot separator
--- FAIL: TestMenuMiddleDotFitsAtEightyColumns
    80-column hint row must still join fragments with the middle dot
```

`TestMenuSeparatorIsWidthNeutral` is a forward guard, not a fail-first — it passed before the change too, which is the point of it.

## Scope

Scoped to the **status menu**, which is what the issue names. Deliberately **not** changed:

- **Legitimate list markers** — `app/help.go`'s first-run list, `commands/reset.go`'s plan summary. Those are bullets doing a bullet's job.
- **Other hint rows** that separate fragments with `" • "` and arguably share the same convention violation: `ui/task_pane.go`, `ui/task_pane_edit.go`, `ui/schedule_picker.go`, `ui/hooks_pane.go`, and the four overlays. Each is a different renderer with its own golden output, and converting them is a bigger change than this issue asked for. Flagging rather than silently leaving them — happy to open a follow-up if the convention should apply repo-wide.

## Fixtures and docs

The driver selftest's screen fixtures and `docs/tui-manual-testing.md` **depict this row**, so they were updated to match — nothing parses their bullet, so this is keeping them honest rather than repairing a break. Worth noting: `docs/tui-manual-testing.md` already documented the projects row as `↵ switch · / search │ …`, so the convention was written down before it was implemented.

One bullet was deliberately **kept**, with the reason written in place:

```sh
: "${_AF_TASKS_RUN_HINT:=(^|[^[:alnum:]])r run( now)? •}"
```

That anchor is the **task overlay's** separator (`ui/task_pane.go`), not the status menu's. Since the two rows now differ, the next reader would reasonably "fix" it to a middle dot and silently break `af_open_tasks` — so the comment now says which row it belongs to and not to.

## Gate

- `go test ./ui/` and `go test ./app/` (the package that renders this bar) — green.
- `go build ./...`, `gofmt -l .`, `golangci-lint --fast`, `shellcheck` on both driver scripts — clean.
- `make tui-driver-selftest` — the real TUI at 80×24 — and `make test-container`: results in a follow-up comment.

## Review

Requesting the codex app below. It is rate-limited and has answered only its usage-limit notice on every PR today; if it stays silent I will say so explicitly rather than treat silence as approval. **Not merging** — handing back for the claude-subagent gate.

— Captain Claude
