### PR TITLE
security(session): stop an agent swap granting cloud credentials (#2462)

### DIFF
--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -401,11 +401,17 @@ func LoadInRepoConfig(repoRoot string) (*InRepoConfig, []byte, error) {
 // conditional selector unlocks, so the rejection above can say what is actually
 // at stake instead of only quoting a variable name. An unknown selector falls
 // back to a truthful generic phrase rather than guessing.
+//
+// Every selector in sessionenv.GuardedSelectors belongs here.
+// TestInRepoCloudCredentialRefusalNamesEveryProvider enumerates that list rather
+// than a copy of it, because the copy is what went stale: #2462 put Gemini's two
+// selectors under guard and this switch kept answering "cloud provider" for
+// them, so the refusal named the variable without naming the stakes.
 func cloudProviderForSelector(selector string) string {
 	switch selector {
 	case "CLAUDE_CODE_USE_BEDROCK":
 		return "AWS"
-	case "CLAUDE_CODE_USE_VERTEX":
+	case "CLAUDE_CODE_USE_VERTEX", "GOOGLE_GENAI_USE_VERTEXAI", "GOOGLE_GENAI_USE_GCA":
 		return "Google Cloud"
 	case "CLAUDE_CODE_USE_FOUNDRY":
 		return "Azure"

--- a/config/inrepo_cloud_credentials_test.go
+++ b/config/inrepo_cloud_credentials_test.go
@@ -57,6 +57,16 @@ func TestInRepoProgramOverrideCannotEnableCloudCredentials(t *testing.T) {
 		// guard that keyed off the map key would miss this entirely.
 		{"cross-keyed under codex", `{"program_overrides": {"codex": "CLAUDE_CODE_USE_BEDROCK=1 claude"}}`,
 			"CLAUDE_CODE_USE_BEDROCK", "AWS"},
+		// Gemini's own cloud selectors, guarded since #2462. These are the cases
+		// that caught the follow-up: the rejection already fired, but the message
+		// named the variable and then fell through to the generic "cloud provider"
+		// because cloudProviderForSelector had not grown with the guarded set.
+		{"gemini vertex", `{"program_overrides": {"gemini": "GOOGLE_GENAI_USE_VERTEXAI=1 gemini"}}`,
+			"GOOGLE_GENAI_USE_VERTEXAI", "Google Cloud"},
+		{"gemini gca", `{"program_overrides": {"gemini": "GOOGLE_GENAI_USE_GCA=1 gemini"}}`,
+			"GOOGLE_GENAI_USE_GCA", "Google Cloud"},
+		{"gemini via env", `{"program_overrides": {"gemini": "env GOOGLE_GENAI_USE_VERTEXAI=true gemini"}}`,
+			"GOOGLE_GENAI_USE_VERTEXAI", "Google Cloud"},
 	}
 
 	for _, c := range cases {
@@ -158,16 +168,26 @@ func TestCommandEnablesCloudCredentialsAgreesWithSelectorResolution(t *testing.T
 }
 
 // TestInRepoCloudCredentialRefusalNamesEveryProvider keeps the operator-facing
-// message honest as the conditional set grows: a new provider added to
-// sessionenv without a name here would be reported as the generic fallback.
+// message honest as the conditional set grows: a selector put under guard in
+// sessionenv without a provider name here is reported as the generic fallback,
+// so the refusal quotes a variable without saying what is at stake.
+//
+// It enumerates sessionenv.GuardedSelectors rather than listing the selectors,
+// because a list is exactly what failed. This test previously hardcoded Claude's
+// three; #2462 then guarded Gemini's GOOGLE_GENAI_USE_VERTEXAI and
+// GOOGLE_GENAI_USE_GCA, and the test kept passing while their refusals said
+// "your cloud provider credentials" instead of "your Google Cloud credentials".
+// Deriving from the real set is what makes this a guard rather than a snapshot.
 func TestInRepoCloudCredentialRefusalNamesEveryProvider(t *testing.T) {
-	for _, selector := range []string{
-		"CLAUDE_CODE_USE_BEDROCK", "CLAUDE_CODE_USE_VERTEX", "CLAUDE_CODE_USE_FOUNDRY",
-	} {
+	guarded := sessionenv.GuardedSelectors()
+	require.NotEmpty(t, guarded, "no guarded selectors — this test would pass vacuously")
+
+	for _, selector := range guarded {
 		provider := cloudProviderForSelector(selector)
 		assert.NotEqual(t, "cloud provider", provider,
-			"%s fell through to the generic phrase — name its provider so the refusal says what is at stake",
-			selector)
+			"%s is guarded in sessionenv but has no provider name in cloudProviderForSelector, so its "+
+				"refusal falls through to the generic phrase — name its provider so the message says "+
+				"what is at stake", selector)
 		assert.False(t, strings.Contains(provider, "_"),
 			"%s should map to a human provider name, got %q", selector, provider)
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,11 +181,28 @@ The built-in allowlist keeps the pieces sessions need:
   dynamic words require exporting the selector before starting af, or explicitly
   listing the provider credential names. Codex gets
   `OPENAI_API_KEY`, `CODEX_API_KEY`, `CODEX_ACCESS_TOKEN`, `CODEX_HOME`,
-  `CODEX_SQLITE_HOME`, and its CA path; Gemini gets Gemini/Google API keys and
-  Google application-default/Vertex selectors; Amp gets `AMP_API_KEY` and
+  `CODEX_SQLITE_HOME`, and its CA path; Gemini gets Gemini/Google API keys, and
+  gets Google Cloud's credentials (`GOOGLE_APPLICATION_CREDENTIALS`,
+  `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`) only when one of its own cloud
+  modes is selected by `GOOGLE_GENAI_USE_VERTEXAI` or `GOOGLE_GENAI_USE_GCA`, on
+  the same exported-or-inline terms as Claude's; Amp gets `AMP_API_KEY` and
   `AMP_HOME`; Aider and OpenCode get their common model-provider API keys and
-  their own config locations. File- or keyring-backed logins remain preferred
-  because they do not put a credential in any environment at all.
+  their own config locations, and **no** cloud-infrastructure credentials.
+  File- or keyring-backed logins remain preferred because they do not put a
+  credential in any environment at all.
+
+  **OpenCode against Bedrock or Vertex** needs its cloud credentials listed
+  explicitly in `session_env_passthrough` (for example `AWS_PROFILE`,
+  `AWS_REGION`, and whichever of `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/
+  `AWS_SESSION_TOKEN` or `AWS_SHARED_CREDENTIALS_FILE` your setup uses). Unlike
+  Claude and Gemini, OpenCode has no environment variable that selects a cloud
+  provider — it chooses one inside its own config file or model id — so there is
+  no mode signal af could gate those credentials behind. Since the alternative is
+  handing them to every OpenCode session unconditionally, af requires the
+  operator to name them. That matters because the agent a session runs is
+  repo-settable through `default_program`/`program_overrides`: without this, a
+  cloned repository could swap the agent to OpenCode and inherit your cloud
+  credentials.
 
 Docker is a stricter trust boundary. A repository selects its container image,
 so af does not automatically send that image any built-in agent, GitHub,
@@ -211,6 +228,14 @@ otherwise cloning a repository and starting a session would hand that
 repository's agent your cloud credentials. A repo may still choose *which*
 program runs — a path, flags, a wrapper — because that grants nothing. Set the
 selector in your own global config or export it in your shell if you want it.
+
+Gemini's cloud modes work the same way, selected by `GOOGLE_GENAI_USE_VERTEXAI`
+or `GOOGLE_GENAI_USE_GCA`. Choosing *which* agent runs is also a repo's to make
+— `default_program` and `program_overrides` are both repo-settable, and swapping
+the program is a legitimate thing to do — so no agent's allowlist carries cloud
+credentials unconditionally. Whichever agent a session ends up running, reaching
+your AWS, Google Cloud, or Azure credentials takes a selector you set or a name
+you listed in `session_env_passthrough`.
 
 An agent wrapper that hides the real executable name, a custom Codex model
 provider whose `env_key` is user-defined, or a less-common Aider/OpenCode

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -45,6 +45,21 @@ written back.
   `CLAUDE_CODE_USE_*` assignment are admitted only for one literal Claude
   invocation. Compound commands, redirects, arbitrary wrappers, and dynamic
   words must use an exported selector or explicit pass-through names.
+- **No agent inherits cloud-infrastructure credentials by default.** Which agent
+  a session runs is repo-settable (`default_program`, `program_overrides`), and
+  swapping the program is legitimate — so a swap must not also be a credential
+  grant. Gemini's `GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_CLOUD_PROJECT`, and
+  `GOOGLE_CLOUD_LOCATION` now follow its own `GOOGLE_GENAI_USE_VERTEXAI` /
+  `GOOGLE_GENAI_USE_GCA` selectors, on the same terms as Claude's. OpenCode no
+  longer receives AWS credentials or Google application-default credentials at
+  all: it has no environment variable that selects a cloud provider, so there is
+  nothing to gate them behind.
+- **Action required if you run OpenCode against Bedrock or Vertex**: list the
+  exact credential names you need in the global `session_env_passthrough` (for
+  example `AWS_PROFILE`, `AWS_REGION`, and whichever of `AWS_ACCESS_KEY_ID` /
+  `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` or
+  `AWS_SHARED_CREDENTIALS_FILE` your setup uses). Aider is unaffected — its
+  Azure entries are Azure OpenAI service keys, not cloud credentials.
 
 ## Keymap Changes
 

--- a/internal/sessionenv/agent_swap_credentials_test.go
+++ b/internal/sessionenv/agent_swap_credentials_test.go
@@ -1,0 +1,214 @@
+package sessionenv
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// operatorCloudEnvironment is one operator's ambient environment holding cloud
+// credentials that have nothing to do with running a coding agent, alongside the
+// model-provider keys that do.
+func operatorCloudEnvironment() []string {
+	return []string{
+		"AWS_ACCESS_KEY_ID=fixture",
+		"AWS_SECRET_ACCESS_KEY=fixture",
+		"AWS_SESSION_TOKEN=fixture",
+		"AWS_PROFILE=fixture",
+		"AWS_CONFIG_FILE=/home/op/.aws/config",
+		"AWS_SHARED_CREDENTIALS_FILE=/home/op/.aws/credentials",
+		"AWS_WEB_IDENTITY_TOKEN_FILE=/home/op/.aws/token",
+		"AWS_ROLE_ARN=arn:aws:iam::1:role/fixture",
+		"GOOGLE_APPLICATION_CREDENTIALS=/home/op/gcp.json",
+		"GOOGLE_CLOUD_PROJECT=op-project",
+		"GOOGLE_CLOUD_LOCATION=us-central1",
+		"OPENAI_API_KEY=fixture",
+		"ANTHROPIC_API_KEY=fixture",
+		"GEMINI_API_KEY=fixture",
+	}
+}
+
+// namesOf reduces a filtered environment to its variable names, so an assertion
+// can name what crossed without a test ever handling a value.
+func namesOf(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, entry := range env {
+		if name, _, ok := strings.Cut(entry, "="); ok {
+			out = append(out, name)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+// TestAgentSwapCannotReachCloudCredentials is #2462.
+//
+// #2329 stopped a repository from turning ON a cloud-credential SELECTOR. It
+// does not stop — and must not stop — a repository from SWAPPING the agent:
+// `program_overrides` and `default_program` are both settable in a repo's
+// checked-in config, and choosing which program runs is what that key is for.
+//
+// The swap reached the same outcome by a different door. OpenCode's base
+// allowlist carried the operator's whole AWS credential set and Google
+// application-default credentials unconditionally, and Gemini's carried
+// GOOGLE_APPLICATION_CREDENTIALS, so `claude = "opencode"` or
+// `default_program = "gemini"` in a cloned repo moved the session onto an
+// allowlist holding secrets the operator never scoped to that repo — with no
+// selector anywhere for #2329 to reject.
+//
+// The fix is per-agent and stated in sessionenv.go: Gemini's group moved behind
+// its real selectors; OpenCode's was removed, because it has none.
+func TestAgentSwapCannotReachCloudCredentials(t *testing.T) {
+	// The names that must never cross on a swap alone. Deliberately the ones an
+	// attacker wants — a signing key, a session token, and the ADC file — not the
+	// whole group, so a failure names something that matters.
+	cloudSecrets := []string{
+		"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN",
+		"AWS_CONFIG_FILE", "AWS_SHARED_CREDENTIALS_FILE",
+		"AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_ROLE_ARN",
+		"GOOGLE_APPLICATION_CREDENTIALS",
+	}
+
+	// Every agent a repo can name, because the swap target is the repo's choice.
+	for _, agent := range []string{"claude", "codex", "gemini", "amp", "aider", "opencode"} {
+		t.Run(agent, func(t *testing.T) {
+			got := namesOf(FilterForCommand(operatorCloudEnvironment(), agent, agent, nil))
+			for _, secret := range cloudSecrets {
+				if slices.Contains(got, secret) {
+					t.Errorf("a repo that swaps the agent to %q reaches the operator's %s. "+
+						"Swapping the program is legitimate; inheriting cloud credentials because of "+
+						"it is not — the swapped agent's session runs the untrusted repo's worktree "+
+						"(#2462).\nadmitted: %v", agent, secret, got)
+				}
+			}
+		})
+	}
+}
+
+// TestOpenCodeKeepsItsModelProviderKeys pins what the removal must NOT cost.
+// OpenCode is a legitimate agent and swapping to it on purpose has to keep
+// working; only the cloud-infrastructure credentials left. If this fails, the
+// fix broke the feature it was supposed to preserve.
+func TestOpenCodeKeepsItsModelProviderKeys(t *testing.T) {
+	source := []string{
+		"OPENAI_API_KEY=fixture", "ANTHROPIC_API_KEY=fixture", "GEMINI_API_KEY=fixture",
+		"OPENROUTER_API_KEY=fixture", "GROQ_API_KEY=fixture", "MISTRAL_API_KEY=fixture",
+		"AZURE_OPENAI_API_KEY=fixture", "OPENCODE_CONFIG=/af/opencode.json",
+	}
+	got := namesOf(FilterForCommand(source, "opencode", "opencode", nil))
+	for _, want := range []string{
+		"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY",
+		"OPENROUTER_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY",
+		"AZURE_OPENAI_API_KEY", "OPENCODE_CONFIG",
+	} {
+		if !slices.Contains(got, want) {
+			t.Errorf("opencode lost %s — it is a model-provider key or its own config location, "+
+				"which is exactly what opencode is documented to receive", want)
+		}
+	}
+}
+
+// TestAiderKeepsItsModelProviderKeys is the same guard for aider, which #2462
+// deliberately did NOT change. Aider carries no AWS and no application-default
+// credentials; its Azure entries are Azure OpenAI SERVICE keys, the same class
+// as OPENAI_API_KEY and the ten other provider keys it needs to function.
+// Treating those as cloud credentials would disable aider by default.
+func TestAiderKeepsItsModelProviderKeys(t *testing.T) {
+	source := []string{
+		"OPENAI_API_KEY=fixture", "ANTHROPIC_API_KEY=fixture",
+		"AZURE_OPENAI_API_KEY=fixture", "AZURE_API_KEY=fixture",
+		"DEEPSEEK_API_KEY=fixture", "COHERE_API_KEY=fixture",
+	}
+	got := namesOf(FilterForCommand(source, "aider", "aider", nil))
+	for _, want := range []string{
+		"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "AZURE_OPENAI_API_KEY",
+		"AZURE_API_KEY", "DEEPSEEK_API_KEY", "COHERE_API_KEY",
+	} {
+		if !slices.Contains(got, want) {
+			t.Errorf("aider lost %s; #2462 changes nothing for aider", want)
+		}
+	}
+}
+
+// TestGeminiCloudCredentialsFollowItsSelectors is the operator-legitimate path:
+// the group Gemini lost by default must come back the moment the operator turns
+// on one of Gemini's own cloud modes. A fix that only removed access would break
+// every operator running Gemini against Vertex.
+func TestGeminiCloudCredentialsFollowItsSelectors(t *testing.T) {
+	cloud := []string{"GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION"}
+
+	t.Run("no selector admits none", func(t *testing.T) {
+		got := namesOf(FilterForCommand(operatorCloudEnvironment(), "gemini", "gemini", nil))
+		for _, name := range cloud {
+			if slices.Contains(got, name) {
+				t.Errorf("gemini admitted %s with no cloud mode selected", name)
+			}
+		}
+		// The default path still has to work.
+		if !slices.Contains(got, "GEMINI_API_KEY") {
+			t.Error("gemini lost GEMINI_API_KEY, its default authentication")
+		}
+	})
+
+	for _, selector := range []string{"GOOGLE_GENAI_USE_VERTEXAI", "GOOGLE_GENAI_USE_GCA"} {
+		t.Run("exported "+selector, func(t *testing.T) {
+			source := append(operatorCloudEnvironment(), selector+"=true")
+			got := namesOf(FilterForCommand(source, "gemini", "gemini", nil))
+			for _, name := range cloud {
+				if !slices.Contains(got, name) {
+					t.Errorf("operator exported %s, so gemini must receive %s — otherwise the fix "+
+						"breaks a legitimate Vertex/ADC setup", selector, name)
+				}
+			}
+		})
+
+		// Same selector, named inline on the operator's resolved command, which is
+		// the other channel ResolveAuthSelectors honors for Claude.
+		t.Run("inline "+selector, func(t *testing.T) {
+			command := selector + "=1 gemini"
+			got := namesOf(FilterForCommand(operatorCloudEnvironment(), "gemini", command, nil))
+			for _, name := range cloud {
+				if !slices.Contains(got, name) {
+					t.Errorf("an operator's global program_overrides of %q must select the cloud "+
+						"group, but %s did not cross", command, name)
+				}
+			}
+		})
+	}
+
+	t.Run("a disabled selector admits none", func(t *testing.T) {
+		source := append(operatorCloudEnvironment(), "GOOGLE_GENAI_USE_VERTEXAI=0")
+		got := namesOf(FilterForCommand(source, "gemini", "gemini", nil))
+		for _, name := range cloud {
+			if slices.Contains(got, name) {
+				t.Errorf("gemini admitted %s with its selector explicitly disabled", name)
+			}
+		}
+	})
+}
+
+// TestEveryConditionalAgentHasARealSelector states the rule that decides
+// membership in conditionalAgentNames, so a later agent cannot be added with an
+// af-invented flag. A selector must be a variable the AGENT itself reads, which
+// in practice means it also appears in that agent's base allowlist — af passes
+// the operator's setting through to the agent rather than consuming it.
+//
+// This is the lock on the #2462 judgment call: OpenCode's group was removed
+// instead of gated precisely because no such variable exists for it.
+func TestEveryConditionalAgentHasARealSelector(t *testing.T) {
+	for agent, groups := range conditionalAgentNames {
+		base, ok := agentNames[agent]
+		if !ok {
+			t.Errorf("conditional agent %q has no base allowlist", agent)
+			continue
+		}
+		for _, group := range groups {
+			if _, passed := base[group.selector]; !passed {
+				t.Errorf("agent %q gates credentials on %q, but that name is not in its base "+
+					"allowlist — so af would never pass the operator's setting to the agent, which "+
+					"means it is af policy rather than a mode the agent actually reads (#2462)",
+					agent, group.selector)
+			}
+		}
+	}
+}

--- a/internal/sessionenv/sessionenv.go
+++ b/internal/sessionenv/sessionenv.go
@@ -54,7 +54,9 @@ var agentNames = map[string]map[string]struct{}{
 	),
 	"gemini": nameSet(
 		"GEMINI_API_KEY", "GOOGLE_API_KEY", "GEMINI_CLI_HOME",
-		"GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION",
+		// The two selectors stay here, as Claude's do: they are the operator's
+		// mode signal, not a credential. Google Cloud's credentials are behind
+		// them in conditionalAgentNames (#2462).
 		"GOOGLE_GENAI_USE_VERTEXAI", "GOOGLE_GENAI_USE_GCA",
 	),
 	"amp": nameSet("AMP_API_KEY", "AMP_HOME"),
@@ -65,6 +67,26 @@ var agentNames = map[string]map[string]struct{}{
 		"OPENROUTER_API_KEY", "DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY",
 		"COHERE_API_KEY", "XAI_API_KEY", "AIDER_OPENAI_API_KEY", "AIDER_ANTHROPIC_API_KEY",
 	),
+	// OpenCode gets model-provider API keys and its own config locations, and
+	// deliberately NOT cloud-infrastructure credentials.
+	//
+	// It used to carry the operator's whole AWS credential set and Google
+	// application-default credentials unconditionally, for its Bedrock and Vertex
+	// providers. That made an agent SWAP a credential grant: `program_overrides`
+	// and `default_program` are both settable by a repository's checked-in
+	// config, so `claude = "opencode"` in a cloned repo moved the session onto an
+	// allowlist holding AWS_SECRET_ACCESS_KEY — the #2310 outcome through a door
+	// #2329 does not cover, because a swap carries no selector assignment to
+	// reject (#2462).
+	//
+	// Unlike Claude and Gemini there is no selector to gate them behind: OpenCode
+	// chooses a provider inside its config file or model id (`amazon-bedrock/…`)
+	// and reads the standard AWS variables directly, so OPENCODE_CONFIG* name
+	// config LOCATIONS and signal nothing about provider choice. Inventing an
+	// af-only flag would be new config surface that no agent reads, existing
+	// solely to re-permit what this removes. So these names take the escape hatch
+	// the docs already prescribe for an uncommon provider variable: the
+	// global-only, therefore operator-controlled, `session_env_passthrough`.
 	"opencode": nameSet(
 		"OPENCODE_CONFIG", "OPENCODE_CONFIG_DIR", "OPENCODE_CONFIG_CONTENT",
 		"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
@@ -72,11 +94,16 @@ var agentNames = map[string]map[string]struct{}{
 		"OPENAI_API_BASE", "OPENAI_BASE_URL",
 		"OPENROUTER_API_KEY", "DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY",
 		"COHERE_API_KEY", "XAI_API_KEY",
-		"AWS_PROFILE", "AWS_REGION", "AWS_DEFAULT_REGION", "AWS_ACCESS_KEY_ID",
-		"AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "GOOGLE_APPLICATION_CREDENTIALS",
-		"AWS_CONFIG_FILE", "AWS_SHARED_CREDENTIALS_FILE", "AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_ROLE_ARN",
 	),
 }
+
+// geminiCloudNames is Google Cloud's credential group for the Gemini CLI: the
+// application-default credential file and the project/location that scope it.
+// Shared by both selector entries below rather than written twice, so the two
+// modes can never drift into granting different things.
+var geminiCloudNames = nameSet(
+	"GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION",
+)
 
 type conditionalNames struct {
 	selector string
@@ -84,10 +111,16 @@ type conditionalNames struct {
 }
 
 // Cloud-provider credentials are narrower than the selected agent: Claude can
-// authenticate through Anthropic without needing the operator's unrelated AWS,
-// Google Cloud, or Azure production credentials. Admit each provider group only
-// when Claude's documented mode selector is enabled in the source environment
-// or as a literal assignment on the command that launches Claude.
+// authenticate through Anthropic, and Gemini through a Gemini API key, without
+// either needing the operator's unrelated AWS, Google Cloud, or Azure production
+// credentials. Admit each provider group only when that agent's own documented
+// mode selector is enabled in the source environment or as a literal assignment
+// on the command that launches it.
+//
+// An agent belongs here exactly when it HAS such a selector. That is the whole
+// test, and it is why OpenCode is absent rather than listed with an invented
+// flag: gating on a signal no agent reads would be af policy wearing the shape
+// of a mode switch (#2462).
 var conditionalAgentNames = map[string][]conditionalNames{
 	"claude": {
 		{
@@ -115,6 +148,20 @@ var conditionalAgentNames = map[string][]conditionalNames{
 				"AZURE_CLIENT_ID", "AZURE_TENANT_ID", "AZURE_CLIENT_SECRET", "AZURE_TOKEN_CREDENTIALS",
 			),
 		},
+	},
+	// Gemini authenticates with a Gemini/Google API key by default and needs
+	// Google Cloud's credentials only in its cloud modes, which it selects with
+	// these two documented variables — GOOGLE_GENAI_USE_VERTEXAI for Vertex AI,
+	// GOOGLE_GENAI_USE_GCA for Google Cloud application-default auth. Either mode
+	// unlocks the same group; both entries share geminiCloudNames so they cannot
+	// diverge.
+	//
+	// Before #2462 this group was unconditional, so `default_program = "gemini"`
+	// in a repository's checked-in config reached the operator's
+	// GOOGLE_APPLICATION_CREDENTIALS with no selector anywhere.
+	"gemini": {
+		{selector: "GOOGLE_GENAI_USE_VERTEXAI", names: geminiCloudNames},
+		{selector: "GOOGLE_GENAI_USE_GCA", names: geminiCloudNames},
 	},
 }
 

--- a/internal/sessionenv/sessionenv.go
+++ b/internal/sessionenv/sessionenv.go
@@ -428,6 +428,29 @@ func ResolveAuthSelectors(source []string, agent, command string) []string {
 	return selectors
 }
 
+// GuardedSelectors returns every conditional cloud-mode selector name across
+// all agents, sorted and deduplicated.
+//
+// It exists so a surface that must stay in step with the guarded set can
+// ENUMERATE it instead of keeping a copy. The copy is what rots: #2462 put
+// Gemini's two selectors under guard, and config's operator-facing refusal kept
+// answering with its generic fallback for them because its own list had not
+// grown. A caller that iterates this cannot drift the same way.
+func GuardedSelectors() []string {
+	set := make(map[string]struct{})
+	for _, groups := range conditionalAgentNames {
+		for _, group := range groups {
+			set[group.selector] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(set))
+	for selector := range set {
+		out = append(out, selector)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // NormalizeAuthSelectors validates a stored selector-name snapshot against the
 // selected agent's known conditional modes. Errors identify only the position,
 // never the untrusted stored text, so an accidental NAME=value record cannot


### PR DESCRIPTION
## Summary

#2329 stopped a repository turning **on** a cloud-credential *selector*. It does not stop a repository **swapping** the agent — and it must not: `default_program` and `program_overrides` are repo-settable, and choosing which program runs is what they are for.

The swap reached the same outcome through a different door. `opencode`'s base allowlist carried the operator's whole AWS credential set and Google application-default credentials **unconditionally**, and `gemini`'s carried `GOOGLE_APPLICATION_CREDENTIALS`/`GOOGLE_CLOUD_PROJECT`/`GOOGLE_CLOUD_LOCATION`. So a cloned repo's checked-in `claude = "opencode"` or `default_program = "gemini"` moved the session onto an allowlist holding secrets the operator never scoped to that repo — with no selector anywhere for #2329 to reject.

## Measured before changing anything

What each agent's base allowlist admitted from one operator environment holding AWS + GCP + Azure + OpenAI credentials, on `1aa106b1`:

```
claude   admits: []
codex    admits: []
gemini   admits: [GOOGLE_APPLICATION_CREDENTIALS]
amp      admits: []
aider    admits: [AZURE_OPENAI_API_KEY]
opencode admits: [AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
                  GOOGLE_APPLICATION_CREDENTIALS AZURE_OPENAI_API_KEY]
```

And all three swap inputs load clean, so nothing upstream stops them:

```
{"program_overrides": {"claude": "opencode"}}   loaded=true err=<nil>
{"program_overrides": {"claude": "aider"}}      loaded=true err=<nil>
{"default_program": "opencode"}                 loaded=true err=<nil>
```

That produced two corrections to the issue, both confirmed with the maintainer before implementing:

- **`aider` carries no AWS and no GCP credentials.** Its only hit is `AZURE_OPENAI_API_KEY`, an Azure **OpenAI service** key — the same class as `OPENAI_API_KEY`, `GROQ_API_KEY` and the ten other model-provider keys aider needs to function. Gating it would mean gating them all and disabling aider by default. **Unchanged.**
- **`gemini` is affected and was not in the issue.** Folded in here.

## The rule this lands on

A credential group may be gated behind a selector **only when the agent actually reads that selector**. That single test decides each agent:

- **`gemini` has real ones.** `GOOGLE_GENAI_USE_VERTEXAI` and `GOOGLE_GENAI_USE_GCA` are its documented cloud-mode switches and were already in its allowlist. Its Google Cloud group moves into `conditionalAgentNames` behind them — option 1 exactly as specified, working both exported and inline, same as Claude's.
- **`opencode` has none.** It selects a provider inside its own config file or model id (`amazon-bedrock/…`) and reads the AWS variables directly; `OPENCODE_CONFIG*` name config *locations* and signal nothing about provider choice. Inventing `AF_OPENCODE_USE_BEDROCK` would be new config surface no agent reads, existing solely to re-permit what this removes. So the group is **dropped**, and operators re-grant through the global-only, operator-controlled `session_env_passthrough` — the escape hatch the docs already prescribe for an uncommon provider variable.

This also makes the code match its own documentation, which already promised OpenCode *"their common model-provider API keys and their own config locations"* while the allowlist handed out AWS and GCP credentials.

`TestEveryConditionalAgentHasARealSelector` pins the rule itself: a gated selector must appear in that agent's base allowlist, so af passes the operator's setting *through* to the agent rather than consuming a flag of its own invention. That is the lock on why opencode was dropped rather than gated — a future agent cannot be added with an af-only flag.

## Fail-first

Watched fail against the pre-change allowlist, with the new tests unchanged:

```
--- FAIL: TestAgentSwapCannotReachCloudCredentials/opencode
    admitted: [... AWS_ACCESS_KEY_ID AWS_CONFIG_FILE AWS_PROFILE AWS_ROLE_ARN
     AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_SHARED_CREDENTIALS_FILE
     AWS_WEB_IDENTITY_TOKEN_FILE ... GOOGLE_APPLICATION_CREDENTIALS ...]
--- FAIL: TestAgentSwapCannotReachCloudCredentials/gemini
    admitted: [GEMINI_API_KEY GOOGLE_APPLICATION_CREDENTIALS
     GOOGLE_CLOUD_LOCATION GOOGLE_CLOUD_PROJECT]
--- FAIL: TestGeminiCloudCredentialsFollowItsSelectors/no_selector_admits_none
--- FAIL: TestGeminiCloudCredentialsFollowItsSelectors/a_disabled_selector_admits_none
```

`claude`, `codex`, `amp`, `aider` passed before and after — the swap test runs over **every** agent a repo can name, so it also proves the fix did not quietly widen anything else.

Guards on what the fix must not cost:

- **`TestGeminiCloudCredentialsFollowItsSelectors`** — the operator-legitimate path. With either selector exported **or** named inline on the operator's resolved command, gemini still gets its full GCP group; with the selector explicitly `=0`, it gets none; with no selector it still gets `GEMINI_API_KEY`, its default auth. A fix that only removed access would break every Vertex/ADC operator.
- **`TestOpenCodeKeepsItsModelProviderKeys`** — swapping to OpenCode on purpose still works; only the cloud-infrastructure credentials left.
- **`TestAiderKeepsItsModelProviderKeys`** — aider's provider keys, including the Azure OpenAI ones, are untouched.

## Docs

`docs/configuration.md` now states Gemini's selector gating, says Aider and OpenCode get **no** cloud-infrastructure credentials, and carries an OpenCode-on-Bedrock recipe explaining *why* it needs explicit names (no provider selector exists) rather than just that it does. `docs/release-notes.md` flags the behavior change and the action required.

## Verification

Exact pushed head: `bc2b00a6`

- `go build ./...`, `go vet ./...`
- `gofmt -l .` (no output) · `golangci-lint run --timeout=3m --fast` · `deadcode -test ./...` (no output)
- `scripts/lint-file-length.sh` (1022 files, 0 grandfathered)
- generated-artifact drift check — clean both directions
- `go test` green: `internal/sessionenv`, `config`, `session`
- `make test-container` — result posted below

Closes #2462
