### PR TITLE
fix(daemon): move the archived branch aside with its title (#2127)

### DIFF
--- a/daemon/create_reuse_archived_branch_hold_test.go
+++ b/daemon/create_reuse_archived_branch_hold_test.go
@@ -131,6 +131,42 @@ func TestReserveCreate_PublishedArchivedBranchStillRefuses(t *testing.T) {
 	assert.Contains(t, held, branch, "the published branch must be exactly where it was")
 }
 
+// The reclaim's target name must be genuinely free, not merely un-checked-out
+// (the P3 on #2465). If a plain branch already holds the disambiguated name
+// "<prefix>foo-archived", `git branch -m` would refuse the rename — so the reclaim
+// must decline and let the create refuse up front, rather than promise a name it
+// cannot deliver and then fail mid-rename with a misleading message.
+func TestReserveCreate_ReclaimDeclinesWhenTargetBranchExists(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	archived, _ := seedArchivedSession(t, manager, repoID, repoPath, "foo", "foo")
+	branch := manager.branchForTitle("foo")
+
+	// The name the reclaim would rename onto already exists as a plain, idle branch
+	// — checked out nowhere, so the checked-out map does not see it.
+	target := manager.branchForTitle("foo (archived)")
+	out, err := exec.Command("git", "-C", repoPath, "branch", target).CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	_, _, release, renamed, err := manager.reserveCreate(CreateSessionRequest{RepoPath: repoPath, Title: "foo", Program: "claude"})
+	if release != nil {
+		release()
+	}
+
+	require.Error(t, err, "the reclaim target is taken, so the create cannot succeed and must refuse up front")
+	assert.NotContains(t, err.Error(), "failed to relocate its worktree",
+		"a taken branch name must not be reported as a worktree-relocation failure")
+	assert.Nil(t, renamed, "no archived rename may happen for a create that cannot succeed")
+
+	// Side-effect-free: neither the archived branch nor the pre-existing target moved.
+	assert.Equal(t, "foo", archived.Title, "the archived session must keep its name after a refusal")
+	held, herr := sessiongit.BranchesHeldByWorktrees(repoPath)
+	require.NoError(t, herr)
+	assert.Contains(t, held, branch, "the archived branch must be exactly where it was")
+	out, err = exec.Command("git", "-C", repoPath, "branch", "--list", target).CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.Contains(t, string(out), target, "the pre-existing target branch must be untouched")
+}
+
 // TestReserveCreate_HeldBranchWithoutArchivedCollisionIsUnguarded keeps the
 // guard as narrow as the invariant it protects. A held branch with NO archived
 // session to rename triggers no rename, so there is nothing to leave orphaned —

--- a/daemon/create_reuse_archived_branch_hold_test.go
+++ b/daemon/create_reuse_archived_branch_hold_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	sessiongit "github.com/sachiniyer/agent-factory/session/git"
@@ -11,74 +12,123 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestReserveCreate_HeldArchivedBranchRefusesBeforeRename is the #2127
-// regression lock.
+// TestReserveCreate_HeldArchivedBranchIsReclaimed is the #2127 durable fix — the
+// FULL-RECLAIM path.
 //
 // The rot: `af sessions create --name foo` over an archived "foo" renamed the
 // archived session to "foo (archived)" to free the TITLE, then failed anyway at
 // `git worktree add` — because archiving relocates a worktree rather than
 // removing it (#2013), so the archived session still had <prefix>foo checked
-// out, and the new session derives exactly that branch. The user was left with
-// a create that failed AND an archived session renamed out of the way for it:
-// the state reserveCreate's own admission comment promises never to produce ("a
-// refusal never leaves an archived session renamed for a create that then did
-// not happen").
+// out, and the new session derives exactly that branch.
 //
-// This seeds the shape archiving actually produces — branch still held — and
-// pins the honest failure: refuse up front, rename nothing, and say what is
-// blocking and how to clear it.
-func TestReserveCreate_HeldArchivedBranchRefusesBeforeRename(t *testing.T) {
+// #2129 shipped the interim guard: refuse up front so the create at least stops
+// leaving an archived session renamed for a create that never happened. That made
+// the failure honest, but reuse-archived-name still never WORKED for a local
+// session — it refused every time, because per #2013 the branch is always held.
+//
+// The durable fix moves the BRANCH aside with the title, so the reclaim is
+// complete: the create succeeds, and the archived session keeps its work under a
+// name that matches its new title.
+func TestReserveCreate_HeldArchivedBranchIsReclaimed(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	archived, id := seedArchivedSession(t, manager, repoID, repoPath, "foo", "foo")
 	branch := manager.branchForTitle("foo")
 
-	// The precondition the old fixture never established: git positively reports
-	// the archived worktree as holding the branch this create would derive.
+	// The precondition: git positively reports the archived worktree as holding
+	// the branch this create would derive. Without it this test proves nothing —
+	// it would be exercising the freed-branch path, which already worked.
 	held, herr := sessiongit.BranchesHeldByWorktrees(repoPath)
 	require.NoError(t, herr)
 	require.Contains(t, held, branch,
 		"the archived worktree must still hold the derived branch; without that this test proves nothing")
+
+	_, title, release, renamed, err := manager.reserveCreate(CreateSessionRequest{RepoPath: repoPath, Title: "foo", Program: "claude"})
+	if release != nil {
+		defer release()
+	}
+
+	require.NoError(t, err, "the create must now SUCCEED: the archived branch is moved aside with the title")
+	assert.Equal(t, "foo", title, "the new session takes the reclaimed title verbatim")
+	require.NotNil(t, renamed, "the archived session must have been renamed to free the name")
+	assert.Equal(t, "foo (archived)", renamed.Title)
+
+	// The reclaim, and the whole point: the branch the new session derives is FREE.
+	// This is the assertion that fails against the interim guard and against the
+	// original bug alike — the first because no create happens at all, the second
+	// because the branch stays held.
+	held, herr = sessiongit.BranchesHeldByWorktrees(repoPath)
+	require.NoError(t, herr)
+	assert.NotContains(t, held, branch,
+		"the derived branch must be released, or the create this title was granted for still cannot build its worktree")
+
+	// And it is free in the way that matters: the real `git worktree add` the
+	// create runs now succeeds on it. Only running the add can tell a released
+	// branch from one that merely looks released.
+	dest := filepath.Join(t.TempDir(), "new-session")
+	out, addErr := exec.Command("git", "-C", repoPath, "worktree", "add", "-b", branch, dest).CombinedOutput()
+	require.NoError(t, addErr, "the granted title %q must be usable by the create it was granted for: %s", title, string(out))
+	out, rmErr := exec.Command("git", "-C", repoPath, "worktree", "remove", "--force", dest).CombinedOutput()
+	require.NoError(t, rmErr, string(out))
+
+	// The archived session did not lose anything: its work moved to a branch that
+	// matches its new title, its record followed, and it still restores.
+	archivedBranch := manager.branchForTitle("foo (archived)")
+	assert.Equal(t, archivedBranch, archived.GetBranch(),
+		"the archived session's recorded branch must move with it, or its record and git disagree")
+	held, herr = sessiongit.BranchesHeldByWorktrees(repoPath)
+	require.NoError(t, herr)
+	holder, stillHeld := held[archivedBranch]
+	assert.True(t, stillHeld, "the archived worktree must still be on its (renamed) branch")
+	assert.Contains(t, holder, "(archived)", "and that worktree is the relocated archive")
+
+	rec := recordFor(t, repoID, "foo (archived)")
+	require.NotNil(t, rec, "the renamed archived record must be persisted under its new title")
+	assert.Equal(t, id, rec.ID, "the archived session keeps its stable id across the reclaim")
+	assert.Equal(t, archivedBranch, rec.Branch, "the persisted branch must match the renamed one")
+
+	_, _, rerr := manager.RestoreArchived(RestoreArchivedRequest{Title: "foo (archived)", RepoID: repoID})
+	require.NoError(t, rerr, "the archived session must still restore after its branch moved")
+}
+
+// The reclaim is not unconditional, and this is the case it declines: a PUBLISHED
+// branch. Renaming one desyncs its local name from the remote it tracks and from
+// any open PR, which is a worse outcome than not creating the session — so the
+// #2129 refusal stays in force, and says so.
+func TestReserveCreate_PublishedArchivedBranchStillRefuses(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	archived, _ := seedArchivedSession(t, manager, repoID, repoPath, "foo", "foo")
+	branch := manager.branchForTitle("foo")
+
+	// A real upstream, built without a network: a bare repo added as a remote,
+	// pushed to, and set as the branch's tracking ref.
+	remote := t.TempDir()
+	out, err := exec.Command("git", "-C", remote, "init", "-q", "--bare", "-b", "main").CombinedOutput()
+	require.NoError(t, err, string(out))
+	out, err = exec.Command("git", "-C", repoPath, "remote", "add", "origin", remote).CombinedOutput()
+	require.NoError(t, err, string(out))
+	out, err = exec.Command("git", "-C", repoPath, "push", "-q", "origin", branch).CombinedOutput()
+	require.NoError(t, err, string(out))
+	out, err = exec.Command("git", "-C", repoPath, "branch", "--set-upstream-to=origin/"+branch, branch).CombinedOutput()
+	require.NoError(t, err, string(out))
 
 	_, _, release, renamed, err := manager.reserveCreate(CreateSessionRequest{RepoPath: repoPath, Title: "foo", Program: "claude"})
 	if release != nil {
 		release()
 	}
 
-	require.Error(t, err, "the create must be refused: freeing the name would not free the branch it needs")
+	require.Error(t, err, "a published archived branch must not be renamed behind the user's back")
 	assert.Nil(t, renamed, "no archived rename may happen for a create that cannot succeed")
-
-	// Actionable: name the blocking branch, where it is held, and a way out.
 	msg := err.Error()
 	assert.Contains(t, msg, branch, "the error must name the branch that blocks the create")
+	assert.Contains(t, msg, "published", "the error must say WHY the branch could not be moved aside")
 	assert.Contains(t, msg, "af sessions kill", "the error must offer a way to release the branch")
-	assert.Contains(t, msg, "different name", "the error must offer the non-destructive alternative")
 
-	// The invariant, asserted on every surface that could carry the rename:
-	// in-memory title, manager key, on-disk record, and the archive directory.
+	// And nothing moved: the refusal is still side-effect-free.
 	assert.Equal(t, "foo", archived.Title, "the archived session must keep its name after a refusal")
-	manager.mu.Lock()
-	_, origKeyed := manager.instances[daemonInstanceKey(repoID, "foo")]
-	_, renamedKeyed := manager.instances[daemonInstanceKey(repoID, "foo (archived)")]
-	manager.mu.Unlock()
-	assert.True(t, origKeyed, "the archived row must stay keyed under its original name")
-	assert.False(t, renamedKeyed, "no row may be keyed under the disambiguated name")
-
-	rec := recordFor(t, repoID, "foo")
-	require.NotNil(t, rec, "the archived record must survive the refusal under its original name")
-	assert.Equal(t, id, rec.ID, "the archived session must be untouched, stable id and all")
 	assert.Nil(t, recordFor(t, repoID, "foo (archived)"), "no renamed record may be persisted for a refused create")
-
-	origDir, derr := archivedWorktreePath(repoID, "foo")
-	require.NoError(t, derr)
-	newDir, derr := archivedWorktreePath(repoID, "foo (archived)")
-	require.NoError(t, derr)
-	assert.True(t, exists(origDir), "the archived worktree must stay at its original path")
-	assert.False(t, exists(newDir), "no relocation may have happened")
-
-	// And the archived session is still restorable — the refusal cost the user
-	// nothing, which is the difference between this and the pre-fix behavior.
-	_, _, rerr := manager.RestoreArchived(RestoreArchivedRequest{Title: "foo", RepoID: repoID})
-	require.NoError(t, rerr, "the untouched archived session must still restore under its own name")
+	held, herr := sessiongit.BranchesHeldByWorktrees(repoPath)
+	require.NoError(t, herr)
+	assert.Contains(t, held, branch, "the published branch must be exactly where it was")
 }
 
 // TestReserveCreate_HeldBranchWithoutArchivedCollisionIsUnguarded keeps the
@@ -163,23 +213,23 @@ func TestReserveCreate_InPlaceCreateIgnoresBranchHold(t *testing.T) {
 	assert.NotNil(t, recordFor(t, repoID, "foo (archived)"))
 }
 
-// TestReserveCreate_ArchivedBranchHoldSurvivesTheRename is the fact the guard
-// exists because of, pinned directly rather than inferred: renaming an archived
-// session does NOT release its branch. If this ever stops being true — option 1
-// or 2 on #2127 — the guard becomes dead weight and this test says so by
-// failing, rather than the guard quietly refusing creates that would now work.
-func TestReserveCreate_ArchivedBranchHoldSurvivesTheRename(t *testing.T) {
+// TestReserveCreate_ArchivedBranchMovesWithTheRename pins the rename's own
+// contract, one level below reserveCreate: renaming an archived session now
+// releases its branch as well as its title.
+//
+// This test previously asserted the OPPOSITE — that the branch survived the
+// rename — because that was the fact #2129's guard existed because of. Its own
+// comment said it would fail if option 1 or 2 on #2127 ever landed, "rather than
+// the guard quietly refusing creates that would now work". Option 2 landed; this
+// is that prediction being honoured rather than a lock being weakened.
+func TestReserveCreate_ArchivedBranchMovesWithTheRename(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
-	seedArchivedSessionBranchFreed(t, manager, repoID, repoPath, "foo", "foo")
+	seedArchivedSession(t, manager, repoID, repoPath, "foo", "foo")
 	branch := manager.branchForTitle("foo")
 
-	// Re-attach the branch so the rename runs with it held, the way archiving
-	// leaves it. (Seeded freed first only so the guard lets the rename happen —
-	// this test is about what the rename does to the hold, not about the guard.)
-	archivedPath, err := archivedWorktreePath(repoID, "foo")
-	require.NoError(t, err)
-	out, err := exec.Command("git", "-C", archivedPath, "checkout", branch).CombinedOutput()
-	require.NoError(t, err, string(out))
+	held, herr := sessiongit.BranchesHeldByWorktrees(repoPath)
+	require.NoError(t, herr)
+	require.Contains(t, held, branch, "the archived worktree must hold the branch for this test to say anything")
 
 	manager.mu.Lock()
 	diskData, lerr := loadRepoInstanceData(repoID)
@@ -189,11 +239,16 @@ func TestReserveCreate_ArchivedBranchHoldSurvivesTheRename(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, renamed, "the rename must have run for this test to say anything")
 
-	held, herr := sessiongit.BranchesHeldByWorktrees(repoPath)
+	held, herr = sessiongit.BranchesHeldByWorktrees(repoPath)
 	require.NoError(t, herr)
-	holder, stillHeld := held[branch]
-	assert.True(t, stillHeld,
-		"renaming an archived session frees its TITLE but not its BRANCH — the premise of #2127's guard")
+	assert.NotContains(t, held, branch,
+		"renaming an archived session must now free its BRANCH as well as its title (#2127)")
+
+	archivedBranch := manager.branchForTitle("foo (archived)")
+	holder, stillHeld := held[archivedBranch]
+	assert.True(t, stillHeld, "the archived worktree must be on the renamed branch, not detached")
 	assert.Contains(t, holder, "(archived)",
 		"the branch follows the relocated archived worktree to its new path")
+	assert.Equal(t, archivedBranch, renamed.Branch,
+		"the event published for the rename must carry the branch it actually has")
 }

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -493,9 +493,18 @@ func (m *Manager) reclaimArchivedBranchLocked(repoPath string, archived *session
 	if _, blocking := held[current]; !blocking {
 		return ""
 	}
-	// A free name, or nothing: renaming onto an existing branch is a git error,
-	// and taking a name some other session holds would be worse than the refusal.
+	// The candidate name must be genuinely FREE, and "not checked out" is not the
+	// same as "free": `git branch -m` refuses to rename onto ANY existing branch,
+	// idle or held. Checking only the checked-out map (the P3 on #2465) let a plain
+	// branch of the candidate's name through the guard, after which the rename
+	// failed with exit 128 — the guard having promised a name it had not actually
+	// cleared. BranchExists closes that, and its unknown answer declines, because a
+	// name that cannot be ruled out must be treated as taken rather than renamed
+	// onto.
 	if _, taken := held[candidate]; taken {
+		return ""
+	}
+	if !archived.ArchivedCandidateBranchIsFree(candidate) {
 		return ""
 	}
 	return candidate
@@ -599,9 +608,13 @@ func (m *Manager) renameArchivedForReuseLocked(repoID, repoPath, title, program 
 	newBranch := m.reclaimArchivedBranchLocked(repoPath, archived, newTitle)
 
 	// Relocate the archived worktree + move its branch + update the title
-	// atomically on the instance.
+	// atomically on the instance. The wrapper names neither the worktree nor the
+	// branch as the culprit — RenameArchived does either step and reports which one
+	// failed in the wrapped error, so a fixed "failed to relocate its worktree"
+	// prefix would mislabel a branch-rename failure as a worktree one (the P3 on
+	// #2465).
 	if err := archived.RenameArchived(newTitle, newDest, newBranch); err != nil {
-		return nil, fmt.Errorf("cannot free the archived name %q for reuse: failed to relocate its worktree: %w", oldTitle, err)
+		return nil, fmt.Errorf("cannot free the archived name %q for reuse: %w", oldTitle, err)
 	}
 	// Re-key the manager map so the archived row is addressable under its new title.
 	newKey := daemonInstanceKey(repoID, newTitle)

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -435,9 +435,70 @@ func (m *Manager) refuseHeldBranchReuseLocked(repoID, repoPath, title string, na
 	if !held {
 		return nil
 	}
-	return fmt.Errorf("cannot create session %q: the archived session %q still has branch %q checked out at %s, and the new session would derive that same branch. Renaming the archived session aside frees its name but not its branch, so the create would fail at `git worktree add` — permanently delete the archived session to release both (%s), or create this session under a different name",
+	// The branch is held — but as of #2127 the rename can often take it with it,
+	// which is the whole point of the durable fix. Refuse only when it cannot.
+	//
+	// This asks the same question renameArchivedForReuseLocked will act on, rather
+	// than a cheaper approximation of it: if the two could disagree, the guard
+	// would either refuse a reuse that would have worked, or wave through one that
+	// then failed at `git worktree add` with the archived session already renamed —
+	// the exact state this function exists to prevent.
+	newTitle, terr := m.uniqueArchivedTitleLocked(repoID, repoPath, archived.Title, archived.Program, namespace, diskData)
+	if terr == nil && m.reclaimArchivedBranchLocked(repoPath, archived, newTitle) != "" {
+		return nil
+	}
+	return fmt.Errorf("cannot create session %q: the archived session %q still has branch %q checked out at %s, and the new session would derive that same branch. Its branch cannot be moved aside automatically (it is published, externally owned, or its state could not be determined), so freeing the name would not free the branch and the create would fail at `git worktree add` — permanently delete the archived session to release both (%s), or create this session under a different name",
 		title, archived.Title, branch, config.ShellQuotePath(holder),
 		shellsuggest.Command("af", "sessions", "kill", archived.Title))
+}
+
+// reclaimArchivedBranchLocked decides the branch name the archived session moves
+// to when its title is reused, or "" for "leave the branch where it is" (#2127).
+//
+// This is the durable half of the fix. #2129 shipped an honest refusal because
+// freeing a title never freed the branch; moving the branch aside WITH the title
+// makes the reclaim complete, so reuse-archived-name actually works for a local
+// session instead of always refusing.
+//
+// Instance.ArchivedBranchForReclaim owns whether the archived session's branch may
+// be touched at all (not local, external, published, or unknown — it declines, and
+// its doc comment carries the reasoning). This adds the two questions that are the
+// daemon's to answer: what the new name should be, and whether it is free.
+//
+// Deriving the new branch from the new TITLE rather than suffixing the old branch
+// keeps the archived row internally coherent: after the move its title, worktree
+// directory, and branch all say the same thing, which is what a later restore
+// presents to the user.
+func (m *Manager) reclaimArchivedBranchLocked(repoPath string, archived *session.Instance, newTitle string) string {
+	current, ok := archived.ArchivedBranchForReclaim()
+	if !ok {
+		return ""
+	}
+	candidate := m.branchForTitle(newTitle)
+	if candidate == "" || candidate == current {
+		return ""
+	}
+	held := m.worktreeHeldBranchesLocked(repoPath, false)
+	// Only move a branch that is actually BLOCKING, and this narrowness is the
+	// point rather than caution. A freed archived branch (its worktree detached, as
+	// after a `git checkout --detach`) is not in anyone's way: `git worktree add
+	// <path> <branch>` attaches the new session to it, which is the shipped
+	// behaviour where reuse-archived-name already completes and where the new
+	// session deliberately continues the archived branch's history.
+	//
+	// Renaming there would change that outcome — the new session would get a fresh
+	// branch off base and the old history would move to a name nobody asked for —
+	// which is a semantic change #2127 never asked for. #2127 is about the case
+	// where the branch is HELD and the create therefore CANNOT proceed at all.
+	if _, blocking := held[current]; !blocking {
+		return ""
+	}
+	// A free name, or nothing: renaming onto an existing branch is a git error,
+	// and taking a name some other session holds would be worse than the refusal.
+	if _, taken := held[candidate]; taken {
+		return ""
+	}
+	return candidate
 }
 
 // refuseUnclaimableTitleReuseLocked refuses an explicit-title create BEFORE the
@@ -526,8 +587,20 @@ func (m *Manager) renameArchivedForReuseLocked(repoID, repoPath, title, program 
 		return nil, err
 	}
 
-	// Relocate the archived worktree + update the title atomically on the instance.
-	if err := archived.RenameArchived(newTitle, newDest); err != nil {
+	// The branch moves aside with the title (#2127). Freeing the title alone left
+	// the archived session holding <prefix><oldTitle>, which is exactly the branch
+	// the new session derives — so the create the rename enabled then failed at
+	// `git worktree add`, having already renamed the archived session for nothing.
+	//
+	// Empty when there is nothing safe to move, and reclaimArchivedBranchLocked
+	// owns that judgement; RenameArchived treats empty as "leave the branch alone",
+	// which is also the right answer for a workspace that has no local branch.
+	origBranch := archived.GetBranch()
+	newBranch := m.reclaimArchivedBranchLocked(repoPath, archived, newTitle)
+
+	// Relocate the archived worktree + move its branch + update the title
+	// atomically on the instance.
+	if err := archived.RenameArchived(newTitle, newDest, newBranch); err != nil {
 		return nil, fmt.Errorf("cannot free the archived name %q for reuse: failed to relocate its worktree: %w", oldTitle, err)
 	}
 	// Re-key the manager map so the archived row is addressable under its new title.
@@ -541,7 +614,11 @@ func (m *Manager) renameArchivedForReuseLocked(repoID, repoPath, title, program 
 	// longer exists, stranding the archive after a daemon restart.
 	renamed := archived.ToInstanceData()
 	if perr := reuseArchivedRenamePersist(repoID, oldTitle, renamed); perr != nil {
-		if rbErr := archived.RenameArchived(oldTitle, origDest); rbErr != nil {
+		// The rollback puts the BRANCH back too, or the archived row would be
+		// restored to its old title and path while still holding the moved-aside
+		// branch — the split state this rollback exists to prevent, just relocated
+		// from the worktree to the branch.
+		if rbErr := archived.RenameArchived(oldTitle, origDest, origBranch); rbErr != nil {
 			// Could not move the worktree home: leave it re-keyed under the new title
 			// (the bytes live at newDest) and surface both failures so the operator can
 			// recover it. The new session create aborts.

--- a/session/git/branch_rename.go
+++ b/session/git/branch_rename.go
@@ -1,0 +1,86 @@
+package git
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Branch rename for archived-name reuse (#2127).
+//
+// Archiving relocates a worktree rather than removing it (#2013), so an archived
+// session keeps its branch CHECKED OUT. Freeing its title for a new session
+// therefore frees a name but not a branch, and the create the rename enabled then
+// failed at `git worktree add` on the branch the archived session still held.
+//
+// The fix moves the branch aside WITH the title, so the reclaim is complete. That
+// is only possible because git no longer refuses to rename a branch checked out in
+// a linked worktree, and updates that worktree's HEAD to follow — a premise
+// TestGitRenamesBranchCheckedOutInLinkedWorktree asks git directly rather than
+// assuming, since the whole design collapses without it.
+
+// RenameBranch renames this worktree's branch, in place, keeping the worktree
+// attached to it. The recorded branch name moves with it, so the caller's
+// persisted record and git agree afterwards.
+//
+// A no-op rename (same name) is accepted rather than handed to git, which errors
+// on it — the caller derives the new name from a title and can legitimately land
+// on the one it already has.
+func (g *GitWorktree) RenameBranch(newName string) error {
+	newName = strings.TrimSpace(newName)
+	if newName == "" {
+		return fmt.Errorf("cannot rename branch %q: the new name is empty", g.branchName)
+	}
+	if newName == g.branchName {
+		return nil
+	}
+	if g.branchName == "" {
+		return fmt.Errorf("cannot rename to %q: this worktree has no recorded branch", newName)
+	}
+	// Run from the REPO, not the worktree: the worktree's HEAD is the thing being
+	// renamed, and the repo is the one path guaranteed to exist whether or not the
+	// archived worktree is currently mounted.
+	if _, err := g.runGitCommand(g.repoPath, "branch", "-m", g.branchName, newName); err != nil {
+		return fmt.Errorf("failed to rename branch %q to %q: %w", g.branchName, newName, err)
+	}
+	g.branchName = newName
+	return nil
+}
+
+// BranchIsPublished reports whether this worktree's branch has an upstream — it
+// has been pushed, and may carry an open PR.
+//
+// Tri-state on purpose (published, known). A rename desynchronizes a published
+// branch's local name from the remote it tracks, so it is the one case where
+// moving the branch aside is worse than refusing, and callers must be able to tell
+// "definitely local" from "could not ask". An unanswerable probe MUST NOT be read
+// as "local": that is the fabricated-negative shape this repo keeps paying for —
+// a probe that cannot know, answering anyway, and the fake answer authorizing the
+// riskier action.
+func (g *GitWorktree) BranchIsPublished() (published bool, known bool) {
+	if g.branchName == "" {
+		return false, false
+	}
+	// Deliberately not `rev-parse <branch>@{upstream}`: that exits non-zero BOTH
+	// when the branch has no upstream and when it does not exist, so a missing
+	// branch would read as the confident answer "local, safe to rename".
+	//
+	// for-each-ref separates them. The format always emits the ref's own name, so
+	// an ABSENT branch prints nothing at all while a branch with no upstream
+	// prints "<name>|" — "no rows" and "a row with an empty upstream" are then
+	// different observations rather than the same empty string.
+	out, err := g.runGitCommand(g.repoPath, "for-each-ref",
+		"--format=%(refname:short)|%(upstream:short)", "refs/heads/"+g.branchName)
+	if err != nil {
+		return false, false
+	}
+	row := strings.TrimSpace(out)
+	if row == "" {
+		// The branch is not there. Nothing true can be said about its upstream.
+		return false, false
+	}
+	_, upstream, ok := strings.Cut(row, "|")
+	if !ok {
+		return false, false
+	}
+	return strings.TrimSpace(upstream) != "", true
+}

--- a/session/git/branch_rename.go
+++ b/session/git/branch_rename.go
@@ -46,6 +46,36 @@ func (g *GitWorktree) RenameBranch(newName string) error {
 	return nil
 }
 
+// BranchExists reports whether a local branch of the given name exists in this
+// repo, regardless of whether it is checked out anywhere.
+//
+// It answers the question the checked-out-branches map cannot: `git branch -m`
+// refuses to rename ONTO any existing branch, checked out or not, so a reclaim
+// that only avoided checked-out target names could still pick a name that a plain,
+// idle branch already holds — and then fail at the rename with exit 128 after the
+// guard had promised the name was free (the P3 on #2465).
+//
+// ok is false when the question could not be answered (a broken repo), so a caller
+// choosing a rename target treats "cannot tell" as "assume taken" and declines,
+// rather than renaming onto a name it could not rule out.
+func (g *GitWorktree) BranchExists(name string) (exists bool, ok bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false, true
+	}
+	// --verify exits 0 iff the exact ref resolves; --quiet suppresses the "not a
+	// valid ref" stderr for the ordinary absent case. A non-zero exit is the ANSWER
+	// "no such branch", not a failure to ask — but this level cannot tell that apart
+	// from a genuinely broken repo, so for-each-ref is used instead, which prints
+	// the ref name on a hit and nothing on a miss and exits 0 for both.
+	out, err := g.runGitCommand(g.repoPath, "for-each-ref",
+		"--format=%(refname:short)", "refs/heads/"+name)
+	if err != nil {
+		return false, false
+	}
+	return strings.TrimSpace(out) != "", true
+}
+
 // BranchIsPublished reports whether this worktree's branch has an upstream — it
 // has been pushed, and may carry an open PR.
 //
@@ -56,6 +86,18 @@ func (g *GitWorktree) RenameBranch(newName string) error {
 // as "local": that is the fabricated-negative shape this repo keeps paying for —
 // a probe that cannot know, answering anyway, and the fake answer authorizing the
 // riskier action.
+//
+// "Published" is two independent facts, and it is enough for EITHER to hold:
+//
+//   - A configured upstream (%(upstream)). The branch tracks a remote ref.
+//   - A remote-tracking ref (refs/remotes/*/<branch>). The branch has been pushed.
+//
+// The two are not the same, and reading only the first was a real safety hole
+// (the P2 on #2465). `git push origin dev/foo` — no -u — and several push.default
+// settings create the remote ref WITHOUT the upstream config, so an
+// upstream-only probe answers "local, safe to rename" for a branch that is on the
+// remote and may have an open PR. Renaming it is exactly the desync this function
+// exists to refuse.
 func (g *GitWorktree) BranchIsPublished() (published bool, known bool) {
 	if g.branchName == "" {
 		return false, false
@@ -75,12 +117,27 @@ func (g *GitWorktree) BranchIsPublished() (published bool, known bool) {
 	}
 	row := strings.TrimSpace(out)
 	if row == "" {
-		// The branch is not there. Nothing true can be said about its upstream.
+		// The branch is not there. Nothing true can be said about it.
 		return false, false
 	}
 	_, upstream, ok := strings.Cut(row, "|")
 	if !ok {
 		return false, false
 	}
-	return strings.TrimSpace(upstream) != "", true
+	if strings.TrimSpace(upstream) != "" {
+		return true, true
+	}
+	// No upstream config — but the branch may still be on a remote, pushed without
+	// -u. A matching refs/remotes/*/<branch> is the direct evidence of that, and
+	// covers every remote (not just origin) with one query. Any row at all means a
+	// remote-tracking ref exists.
+	remotes, err := g.runGitCommand(g.repoPath, "for-each-ref",
+		"--format=%(refname:short)", "refs/remotes/*/"+g.branchName)
+	if err != nil {
+		// The branch exists (proven above), but whether it is on a remote could
+		// not be determined — so this is UNKNOWN, and unknown never authorizes the
+		// rename. Same polarity as the missing-branch case.
+		return false, false
+	}
+	return strings.TrimSpace(remotes) != "", true
 }

--- a/session/git/branch_rename_test.go
+++ b/session/git/branch_rename_test.go
@@ -101,6 +101,53 @@ func TestRenameBranchMovesTheWorktreeWithIt(t *testing.T) {
 	}
 }
 
+// BranchExists sees a plain, idle branch — the collision the checked-out map
+// misses (the P3 on #2465): `git branch -m` refuses to rename onto ANY existing
+// branch, not only a checked-out one.
+func TestBranchExistsSeesUncheckedOutBranches(t *testing.T) {
+	repo, _, gw := renameFixture(t)
+
+	// A branch that exists but is checked out nowhere.
+	gitRun(t, repo, "branch", "dev/idle")
+
+	exists, ok := gw.BranchExists("dev/idle")
+	if !ok {
+		t.Fatal("BranchExists could not answer for an existing branch")
+	}
+	if !exists {
+		t.Fatal("a plain, un-checked-out branch must still read as existing — it still blocks a rename onto it")
+	}
+
+	absent, ok := gw.BranchExists("dev/never")
+	if !ok {
+		t.Fatal("BranchExists could not answer for an absent branch")
+	}
+	if absent {
+		t.Fatal("a name no branch holds must read as free")
+	}
+}
+
+// The failure this all exists to keep out of the caller's error message: renaming
+// ONTO an existing branch is a real git error, and it must not be mistaken for a
+// worktree-relocation failure upstream.
+func TestRenameBranchOntoExistingBranchFailsWithACauseNotAMask(t *testing.T) {
+	repo, _, gw := renameFixture(t)
+	gitRun(t, repo, "branch", "dev/taken")
+
+	err := gw.RenameBranch("dev/taken")
+	if err == nil {
+		t.Fatal("renaming onto an existing branch must fail, not silently clobber it")
+	}
+	if !strings.Contains(err.Error(), "dev/taken") {
+		t.Fatalf("the error must name the branch that blocked the rename, got: %v", err)
+	}
+	// The recorded name must NOT have moved on a failed rename, or the record would
+	// claim a branch the repo does not have under that name.
+	if got := gw.GetBranchName(); got != "dev/foo" {
+		t.Fatalf("a failed rename must leave the recorded branch untouched, got %q", got)
+	}
+}
+
 // Renaming to the name it already has is something the caller can legitimately
 // derive; git errors on it, so it is absorbed rather than surfaced.
 func TestRenameBranchToSameNameIsANoOp(t *testing.T) {
@@ -145,6 +192,37 @@ func TestBranchIsPublishedIsTriState(t *testing.T) {
 		}
 		if !published {
 			t.Fatal("a pushed, tracking branch must read as published — renaming it desyncs it from its remote")
+		}
+	})
+
+	// A branch pushed WITHOUT -u has a remote ref but no upstream config. It is
+	// exactly as published — a rename desyncs its local name from the remote and
+	// any open PR — but `%(upstream:short)` is empty for it, so an
+	// upstream-config-only probe returns "local", the polarity this whole function
+	// exists to get right. `git push origin dev/foo`, `git push origin HEAD`, and
+	// several push.default settings all produce this state.
+	t.Run("branch pushed without -u is still published", func(t *testing.T) {
+		repo2, _, gw2 := renameFixture(t)
+		remote := t.TempDir()
+		gitRun(t, remote, "init", "-q", "--bare", "-b", "main")
+		gitRun(t, repo2, "remote", "add", "origin", remote)
+		// No -u, and no --set-upstream-to: the remote ref exists, the tracking
+		// config does not.
+		gitRun(t, repo2, "push", "-q", "origin", "dev/foo")
+		if out := gitRun(t, repo2, "for-each-ref", "--format=%(upstream:short)", "refs/heads/dev/foo"); out != "" {
+			t.Fatalf("fixture is wrong: dev/foo has upstream config %q, so this does not test the -u-less case", out)
+		}
+		if out := gitRun(t, repo2, "show-ref", "--verify", "refs/remotes/origin/dev/foo"); out == "" {
+			t.Fatal("fixture is wrong: no remote ref was created, so there is nothing published to detect")
+		}
+
+		published, known := gw2.BranchIsPublished()
+		if !known {
+			t.Fatal("a branch with a remote ref is an answerable question")
+		}
+		if !published {
+			t.Fatal("a branch pushed without -u still has a remote ref (and maybe an open PR) — " +
+				"renaming it is exactly the desync this guard promises not to cause")
 		}
 	})
 

--- a/session/git/branch_rename_test.go
+++ b/session/git/branch_rename_test.go
@@ -1,0 +1,161 @@
+package git
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// renameFixture builds a repo with one linked worktree on `dev/foo`, which is the
+// shape archiving leaves behind (#2013 relocates the worktree; the branch stays
+// checked out in it).
+func renameFixture(t *testing.T) (repo, wt string, gw *GitWorktree) {
+	t.Helper()
+	repo = t.TempDir()
+	gitRun(t, repo, "init", "-q", "-b", "main")
+	gitRun(t, repo, "config", "user.email", "probe@example.com")
+	gitRun(t, repo, "config", "user.name", "probe")
+	gitRun(t, repo, "commit", "-q", "--allow-empty", "-m", "base")
+
+	wt = filepath.Join(t.TempDir(), "archived")
+	gitRun(t, repo, "worktree", "add", "-q", "-b", "dev/foo", wt)
+
+	gw, err := NewGitWorktreeFromStorage(repo, wt, "foo", "dev/foo", "", false, true)
+	if err != nil {
+		t.Fatalf("NewGitWorktreeFromStorage: %v", err)
+	}
+	return repo, wt, gw
+}
+
+func gitRun(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// TestGitRenamesBranchCheckedOutInLinkedWorktree is the premise the whole
+// archived-branch reclaim rests on (#2127), asked of git directly rather than
+// assumed: the archived session's branch is CHECKED OUT in its relocated
+// worktree, and git historically refused to rename a branch checked out anywhere.
+// If that refusal still applied, moving the branch aside with the title would not
+// be implementable and the design would have to change.
+//
+// It also pins the half that makes the rename safe to do on the user's behalf:
+// the linked worktree's HEAD must FOLLOW the rename, leaving no worktree pointing
+// at a branch that no longer exists.
+//
+// Deliberately driving raw git rather than GitWorktree — this is a statement
+// about the tool, and routing it through our own wrapper would let a wrapper bug
+// masquerade as a git guarantee.
+func TestGitRenamesBranchCheckedOutInLinkedWorktree(t *testing.T) {
+	repo := t.TempDir()
+	gitRun(t, repo, "init", "-q", "-b", "main")
+	gitRun(t, repo, "config", "user.email", "probe@example.com")
+	gitRun(t, repo, "config", "user.name", "probe")
+	gitRun(t, repo, "commit", "-q", "--allow-empty", "-m", "base")
+
+	wt := filepath.Join(t.TempDir(), "archived")
+	gitRun(t, repo, "worktree", "add", "-q", "-b", "dev/foo", wt)
+	if got := gitRun(t, wt, "rev-parse", "--abbrev-ref", "HEAD"); got != "dev/foo" {
+		t.Fatalf("premise not met: linked worktree is on %q, not dev/foo", got)
+	}
+
+	cmd := exec.Command("git", "branch", "-m", "dev/foo", "dev/foo-archived")
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git refuses to rename a branch checked out in a linked worktree — "+
+			"the #2127 rename-aside design is not implementable as written: %v\n%s", err, out)
+	}
+	if got := gitRun(t, wt, "rev-parse", "--abbrev-ref", "HEAD"); got != "dev/foo-archived" {
+		t.Fatalf("the linked worktree did not follow the branch rename; HEAD is %q", got)
+	}
+	if out := gitRun(t, repo, "branch", "--list", "dev/foo"); out != "" {
+		t.Fatalf("the old branch name still exists after the rename: %q", out)
+	}
+}
+
+// The reclaim path: the branch moves aside, the worktree follows it, and the
+// recorded name moves with it so the persisted record and git do not disagree.
+func TestRenameBranchMovesTheWorktreeWithIt(t *testing.T) {
+	repo, wt, gw := renameFixture(t)
+
+	if err := gw.RenameBranch("dev/foo-archived"); err != nil {
+		t.Fatalf("RenameBranch: %v", err)
+	}
+
+	if got := gw.GetBranchName(); got != "dev/foo-archived" {
+		t.Fatalf("recorded branch is %q; a stale record would persist a branch git no longer has", got)
+	}
+	if got := gitRun(t, wt, "rev-parse", "--abbrev-ref", "HEAD"); got != "dev/foo-archived" {
+		t.Fatalf("the archived worktree is on %q, not the renamed branch", got)
+	}
+	// The old name is free — which is the entire point: the new session derives it.
+	if out := gitRun(t, repo, "branch", "--list", "dev/foo"); out != "" {
+		t.Fatalf("dev/foo is still taken after the rename (%q), so the reclaim did not happen", out)
+	}
+}
+
+// Renaming to the name it already has is something the caller can legitimately
+// derive; git errors on it, so it is absorbed rather than surfaced.
+func TestRenameBranchToSameNameIsANoOp(t *testing.T) {
+	_, wt, gw := renameFixture(t)
+
+	if err := gw.RenameBranch("dev/foo"); err != nil {
+		t.Fatalf("same-name rename must be a no-op, got: %v", err)
+	}
+	if got := gitRun(t, wt, "rev-parse", "--abbrev-ref", "HEAD"); got != "dev/foo" {
+		t.Fatalf("same-name rename disturbed the worktree; HEAD is %q", got)
+	}
+}
+
+// BranchIsPublished is tri-state, and the POLARITY is the point: a probe that
+// cannot answer must not report "local", because "local" is what authorizes the
+// rename. Each case is asserted on both returns.
+func TestBranchIsPublishedIsTriState(t *testing.T) {
+	repo, _, gw := renameFixture(t)
+
+	t.Run("local branch with no upstream", func(t *testing.T) {
+		published, known := gw.BranchIsPublished()
+		if !known {
+			t.Fatal("an existing local branch is an answerable question")
+		}
+		if published {
+			t.Fatal("a branch with no upstream must not read as published")
+		}
+	})
+
+	t.Run("branch with an upstream", func(t *testing.T) {
+		// A real upstream, built without a network: a second repo added as a
+		// remote, fetched, and set as the branch's tracking ref.
+		remote := t.TempDir()
+		gitRun(t, remote, "init", "-q", "--bare", "-b", "main")
+		gitRun(t, repo, "remote", "add", "origin", remote)
+		gitRun(t, repo, "push", "-q", "origin", "dev/foo")
+		gitRun(t, repo, "branch", "--set-upstream-to=origin/dev/foo", "dev/foo")
+
+		published, known := gw.BranchIsPublished()
+		if !known {
+			t.Fatal("a branch with a configured upstream is an answerable question")
+		}
+		if !published {
+			t.Fatal("a pushed, tracking branch must read as published — renaming it desyncs it from its remote")
+		}
+	})
+
+	t.Run("missing branch is UNKNOWN, never local", func(t *testing.T) {
+		absent, err := NewGitWorktreeFromStorage(repo, t.TempDir(), "gone", "dev/does-not-exist", "", false, true)
+		if err != nil {
+			t.Fatalf("NewGitWorktreeFromStorage: %v", err)
+		}
+		published, known := absent.BranchIsPublished()
+		if known {
+			t.Fatalf("a branch that does not exist must be UNKNOWN, not a confident answer (published=%v)", published)
+		}
+	})
+}

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -169,6 +169,47 @@ func (i *Instance) RestoreArchivedWorktree(dest string) error {
 	return gw.RestoreWorktreeTo(dest)
 }
 
+// ArchivedBranchForReclaim reports the branch an archived session is holding
+// when — and only when — that branch may safely be renamed aside so a new session
+// can take its title (#2127). ok is false whenever it may not be, and the caller
+// must then leave the branch alone.
+//
+// It lives here rather than in the daemon because the archived instance's
+// worktree is not reachable through GetGitWorktree: that accessor is gated on
+// `started`, which archiving clears, so a caller outside this package cannot ask
+// the question at all. Answering it here also keeps every read of gitWorktree
+// under i.mu, like the rest of this file.
+//
+// Four declines, each one a case where renaming the user's branch is worse than
+// refusing the create:
+//
+//   - Not a local worktree (hook/docker/ssh): there is no local branch to move.
+//   - No worktree or no recorded branch: nothing to reclaim.
+//   - An EXTERNAL worktree (`--here`, or a pre-#930 adopted checkout). af adopted
+//     that branch rather than creating it; renaming it is not af's call.
+//   - PUBLISHED, or an upstream that could not be determined. A rename desyncs a
+//     pushed branch's local name from the remote it tracks and from any open PR.
+//     The unknown case declines for the same reason: a probe that cannot answer
+//     must not be what authorizes rewriting a user's branch.
+func (i *Instance) ArchivedBranchForReclaim() (string, bool) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	if i.liveness != LiveArchived {
+		return "", false
+	}
+	if i.Capabilities().Workspace != WorkspaceLocalWorktree {
+		return "", false
+	}
+	gw := i.gitWorktree
+	if gw == nil || gw.GetBranchName() == "" || gw.IsExternalWorktree() {
+		return "", false
+	}
+	if published, known := gw.BranchIsPublished(); published || !known {
+		return "", false
+	}
+	return gw.GetBranchName(), true
+}
+
 // RenameArchived atomically relocates an archived instance's worktree to dest (a
 // new title-keyed archive dir) and updates its Title, so a fresh session can reuse
 // the archived session's name (feat: reuse archived name). Both mutations happen
@@ -177,12 +218,26 @@ func (i *Instance) RestoreArchivedWorktree(dest string) error {
 // are inert — no async Start/Recover goroutine touches them — so holding i.mu
 // across the git move only blocks a brief Snapshot RLock, never a live operation.
 //
-// The stable id, git branch, and worktree contents are preserved: only the on-disk
-// directory + git's two-way registration move, and only the display title changes.
+// The stable id and worktree contents are preserved: only the on-disk directory +
+// git's two-way registration move, and only the display title changes.
 // On a relocation failure the worktree and title are left untouched and the error
 // is surfaced, so the caller can abort the reuse without having half-renamed the
 // archived session.
-func (i *Instance) RenameArchived(newTitle, dest string) error {
+//
+// newBranch, when non-empty, moves the BRANCH aside with the title (#2127).
+// Freeing the title alone was never enough: archiving relocates the worktree
+// rather than removing it (#2013), so the archived session keeps its branch
+// checked out, and the new session — which derives that same branch — then failed
+// at `git worktree add` on a name the rename was supposed to have freed. Empty
+// keeps the branch where it is, which is what a session with no local branch to
+// move (a hook/sandbox workspace) needs.
+//
+// Branch first, worktree second, and the branch is put back if the worktree move
+// fails. Both orders leave a window; this one's window is the cheap, exactly
+// reversible half — a renamed branch with the worktree still at its old path is
+// undone by one more rename, whereas a moved worktree whose branch rename then
+// failed would need the bytes moved back to recover.
+func (i *Instance) RenameArchived(newTitle, dest, newBranch string) error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	if i.liveness != LiveArchived {
@@ -192,13 +247,30 @@ func (i *Instance) RenameArchived(newTitle, dest string) error {
 	if gw == nil {
 		return fmt.Errorf("cannot rename archived session %q: it has no worktree to relocate", i.Title)
 	}
+	oldBranch := gw.GetBranchName()
+	if newBranch != "" && newBranch != oldBranch {
+		if err := gw.RenameBranch(newBranch); err != nil {
+			return fmt.Errorf("cannot free the archived branch of %q: %w", i.Title, err)
+		}
+	}
 	// MoveWorktree relocates the bytes + repairs git's registration and, on success,
 	// updates gw's stored worktree path — all under i.mu here, matching how
 	// ToInstanceData reads the worktree path under i.mu.RLock.
 	if err := gw.MoveWorktree(dest); err != nil {
+		if newBranch != "" && newBranch != oldBranch {
+			// Best-effort: the move already failed, so this is recovery, and a
+			// second failure must not mask the first. It is reported with it —
+			// a branch left under the new name while the record still says the
+			// old one is exactly the drift a silent rollback would hide.
+			if rbErr := gw.RenameBranch(oldBranch); rbErr != nil {
+				return fmt.Errorf("%w (and the branch could not be renamed back from %q to %q: %v)",
+					err, newBranch, oldBranch, rbErr)
+			}
+		}
 		return err
 	}
 	i.Title = newTitle
+	i.Branch = gw.GetBranchName()
 	return nil
 }
 

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -210,6 +210,27 @@ func (i *Instance) ArchivedBranchForReclaim() (string, bool) {
 	return gw.GetBranchName(), true
 }
 
+// ArchivedCandidateBranchIsFree reports whether `candidate` is a branch name the
+// archived session's worktree can be renamed ONTO — free, and confirmed free
+// (#2127, P3 on #2465). It exists for the same reason as ArchivedBranchForReclaim:
+// the archived worktree is not reachable through GetGitWorktree, so the daemon
+// cannot run the check itself.
+//
+// free is false BOTH when a branch of that name already exists (git refuses to
+// rename onto it) and when existence could not be determined — an unknown answer
+// is treated as taken, so the reclaim declines rather than renaming onto a name it
+// could not rule out.
+func (i *Instance) ArchivedCandidateBranchIsFree(candidate string) bool {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	gw := i.gitWorktree
+	if gw == nil {
+		return false
+	}
+	exists, ok := gw.BranchExists(candidate)
+	return ok && !exists
+}
+
 // RenameArchived atomically relocates an archived instance's worktree to dest (a
 // new title-keyed archive dir) and updates its Title, so a fresh session can reuse
 // the archived session's name (feat: reuse archived name). Both mutations happen

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -197,7 +197,13 @@ func (i *Instance) ArchivedBranchForReclaim() (string, bool) {
 	if i.liveness != LiveArchived {
 		return "", false
 	}
-	if i.Capabilities().Workspace != WorkspaceLocalWorktree {
+	// capabilitiesLocked, NOT Capabilities: this method already holds i.mu.RLock,
+	// and Capabilities re-takes it. sync.RWMutex is not reentrant, so a nested
+	// RLock deadlocks against a queued writer (#2006) — and this runs on the
+	// m.mu-held create path (reserveCreate -> reclaimArchivedBranchLocked), so the
+	// wedge would take the whole daemon create path with it. capabilitiesLocked is
+	// the lock-holder variant that exists for exactly this.
+	if i.capabilitiesLocked().Workspace != WorkspaceLocalWorktree {
 		return "", false
 	}
 	gw := i.gitWorktree


### PR DESCRIPTION
Closes #2127.

## Verified against master first — **not** already fixed

Only the #2129 interim guard is on `master`. `refuseHeldBranchReuseLocked` still refuses unconditionally when the branch is held, and its own comment says so:

> This does not make reuse-archived-name WORK for a local session — only releasing or relocating the branch can, and that changes what happens to a user's branches, so it is a separate call tracked on #2127.

So reuse-archived-name has never actually completed for a local session: per #2013 the branch is *always* held, so the guard refused every time. The durable fix was still open.

## The design call

The issue left three options open pending a call from @sachiniyer, and this PR takes **option 2 — move the branch aside with the title** — because it is what "fully reclaims or renames" asks for while changing nothing for anyone who never reuses an archived name.

**Explicitly not option 1** (release the branch on archive). That dissolves more of the bug class, but it reverses #2013's deliberate archive-holds-branch behaviour for *every* archive, changing what a restore gets back. That is a semantic change to a shipped feature affecting sessions that have nothing to do with this bug, and it is the one the triage flagged hardest as needing your answer. Option 2 touches only the reuse operation itself. **Say the word and I'll switch** — the reclaim decision is one function.

## What it does

`git branch -m <prefix>foo <prefix>foo-archived` alongside the existing title + worktree rename, so the archived session lands with title, worktree directory, and branch all agreeing — which is what a later restore shows the user.

The premise this rests on is asked of git rather than assumed: git used to refuse renaming a branch checked out anywhere. `TestGitRenamesBranchCheckedOutInLinkedWorktree` drives raw git and confirms both that the rename is allowed and that the linked worktree's HEAD **follows** it. Without both, the design is not implementable and that test says so.

## Scoped to the case that is actually blocked

The first cut renamed whenever an archived collision existed, and the **existing tests caught it**: a *freed* archived branch (worktree detached) is in nobody's way — `git worktree add <path> <branch>` attaches the new session to it, which is shipped behaviour where reuse already completes and the new session deliberately continues that branch's history. Renaming there would silently change that outcome.

So the reclaim fires **only when the branch is HELD** — the case where the create currently cannot proceed at all.

## Three declines, each keeping the #2129 refusal in force

- **Published** (has an upstream), **or an upstream that could not be determined.** Renaming desyncs a pushed branch's local name from its remote and from any open PR. The unknown case declines for the same reason: a probe that cannot answer must not be what authorizes rewriting a user's branch.
- **External worktree** (`--here`, or a pre-#930 adopted checkout) — af adopted that branch, it did not create it.
- Not a local worktree, or the target branch name is already taken.

The refusal message now says *which* applies instead of claiming the branch simply cannot be freed.

`BranchIsPublished` is tri-state and uses `for-each-ref`, **not** `rev-parse <branch>@{upstream}` — that exits non-zero both for "no upstream" and for "no such branch", so a missing branch would read as the confident answer "local, safe to rename".

## Ordering and rollback

Branch first, worktree second, branch put back if the worktree move fails: that leaves the cheap, exactly reversible half exposed rather than the one needing bytes moved back. `reserveCreate`'s persist rollback restores the branch too — otherwise the archived row lands back at its old title while holding the moved-aside branch, which is the split state that rollback exists to prevent.

`ArchivedBranchForReclaim` lives on `Instance` because the archived worktree is unreachable through `GetGitWorktree` — that accessor is gated on `started`, which archiving clears, so the daemon cannot ask the question at all from outside.

## Tests

**The full-reclaim path** (`TestReserveCreate_HeldArchivedBranchIsReclaimed`): seeds the shape archiving really produces, asserts the create now succeeds, the derived branch is released, and — because "looks released" is not "is released" — that a real `git worktree add -b` on it succeeds. Then that the archived session lost nothing: its branch moved with it, its record followed, and it still restores.

**The still-refused path** (`TestReserveCreate_PublishedArchivedBranchStillRefuses`): a real upstream built without a network, asserting the refusal, its reason, and that nothing moved.

**Two tests flipped**, deliberately. `TestReserveCreate_ArchivedBranchHoldSurvivesTheRename` asserted the branch survived the rename — and its own comment said it would fail if option 1 or 2 ever landed, "rather than the guard quietly refusing creates that would now work". This is that prediction being honoured, not a lock being weakened.

## Gate

- `go build ./...`, `go vet`, `gofmt -l .`, `golangci-lint --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — clean.
- `go test ./daemon/ ./session/ ./session/git/` — green.
- No `web/` sources touched, so `web/dist` needs no rebuild (`git status` confirms no bundle drift).
- `make test-container` running on this head; result to follow.

## Review

Requesting the codex app below. It is rate-limited and has answered only its usage-limit notice on every PR today; if it stays silent I will say so rather than treat silence as approval. **Not merging** — handing back for the claude-subagent gate, and the option-1-vs-2 call above is yours to overrule.

— Captain Claude
