### PR TITLE
test(sessionenv): derive the agent-swap guard's agent list from the allowlist

### DIFF
--- a/internal/sessionenv/agent_swap_credentials_test.go
+++ b/internal/sessionenv/agent_swap_credentials_test.go
@@ -1,9 +1,12 @@
 package sessionenv
 
 import (
+	"maps"
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // operatorCloudEnvironment is one operator's ambient environment holding cloud
@@ -69,8 +72,22 @@ func TestAgentSwapCannotReachCloudCredentials(t *testing.T) {
 		"GOOGLE_APPLICATION_CREDENTIALS",
 	}
 
-	// Every agent a repo can name, because the swap target is the repo's choice.
-	for _, agent := range []string{"claude", "codex", "gemini", "amp", "aider", "opencode"} {
+	// Every agent that can receive per-agent credentials, DERIVED from the real
+	// allowlist rather than copied from it. The swap target is the repo's choice,
+	// so the guard has to cover whatever the map holds — and supportedAgent keys
+	// off exactly this map, so its key set IS the set of nameable swap targets.
+	//
+	// Deriving is the point. This PR's sibling test learned the same lesson one
+	// layer down: TestInRepoCloudCredentialRefusalNamesEveryProvider hardcoded
+	// Claude's three selectors, #2462 guarded Gemini's two, and the copy went
+	// stale silently — which is why that test now enumerates GuardedSelectors().
+	// A hardcoded agent list here fails the same way, and worse: a new agent
+	// added with a cloud group would not be uncovered loudly, it would simply
+	// never be tested.
+	agents := slices.Sorted(maps.Keys(agentNames))
+	require.NotEmpty(t, agents, "no agents in the allowlist — this test would pass vacuously")
+
+	for _, agent := range agents {
 		t.Run(agent, func(t *testing.T) {
 			got := namesOf(FilterForCommand(operatorCloudEnvironment(), agent, agent, nil))
 			for _, secret := range cloudSecrets {


### PR DESCRIPTION
Follow-up to #2464, found auditing it after it merged. **Test-only — no production code changes, no behaviour change.**

## Why I was looking

#2464 is a credential-leak fix that landed with **zero independent review**: Codex has been rate-limited all evening (it posted its usage-limit notice on that very PR at `02:28:56Z` and again at `02:45:26Z`), and sessions merge their own work. Auditing what ships unreviewed is what the master-health watch is for. The fix itself is sound — I checked its judgment calls and they hold.

## The finding

`TestAgentSwapCannotReachCloudCredentials` is the guard that stops a repo-settable agent swap from becoming a credential grant. It iterated a **hardcoded** list of six agents, under the comment *"Every agent a repo can name"*.

That list is a copy of `agentNames`' key set — and the copy is the part that rots. **#2464 fixed exactly this failure one layer down, and said so in its own diff:** its sibling test hardcoded Claude's three selectors, #2462 put Gemini's two under guard, the copy went stale silently, and the refusal said *"cloud provider"* instead of *"Google Cloud"*. The fix was to enumerate `GuardedSelectors()` instead of listing them. The identical shape was left in place for the agent list.

It matters more here, because the two failures are not equally loud:

| Stale list | Consequence |
|---|---|
| selectors (fixed in #2464) | guard fires, **message** is weak |
| agents (this PR) | guard **never runs** for the new agent |

A stale agent list does not report a gap. It just stops looking.

## This is not hypothetical

`devin` shipped as a first-class agent in #2410 and is a program a repo can name **today**. It is safe only because it has no `agentNames` entry at all, so it receives no per-agent credentials — `supportedAgent` (`internal/sessionenv/command_flags.go:55-61`) keys off that exact map. The moment anyone gives devin an entry, the hardcoded list silently stops covering the case the guard exists for.

So the guard's own comment was already inaccurate: a repo can name `devin`, and the test did not cover it.

## The change

Derive the loop from `agentNames`. `supportedAgent` keys off that map, so its key set **is** the set of nameable swap targets — the guard now covers the real population by construction instead of by someone remembering to update a list.

## Verification — I simulated the drift rather than asserting it would be caught

Temporarily added an agent carrying AWS credentials to `agentNames`, then ran the guard both ways against **identical production code**, changing only the loop's source:

```
derived list   -> FAIL
    a repo that swaps the agent to "tempagent" reaches the operator's
    AWS_ACCESS_KEY_ID ... admitted: [AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY]

hardcoded list -> ok      (silently uncovered)
```

The temporary agent was removed before committing; the diff is one file, and `git diff --stat` confirms `sessionenv.go` is untouched.

This cannot "fail first" in the usual sense — today the hardcoded six and the map's keys are the same set, so both pass. That is precisely why the gap was invisible, and why the demonstration above is the honest way to show the guard now guards.

## Gate

Exact pushed head: `8f978366`

- `gofmt -l .` (no output)
- `go build ./...`
- `golangci-lint run --timeout=3m --fast`
- `deadcode -test ./...` (no output)
- `scripts/lint-file-length.sh` (1023 files, 0 grandfathered)
- `make test-container` — full suite

Covers the same six agents today, so nothing changes now. The point is what happens on the seventh.

— Captain Claude
