### PR TITLE
fix(daemon): gate conversation capture on the session op-lock (#2451)

### DIFF
--- a/daemon/conversation_capture.go
+++ b/daemon/conversation_capture.go
@@ -34,10 +34,28 @@ func (m *Manager) captureAgentConversation(repoID, key string, inst *session.Ins
 		return
 	}
 
+	// Serialize the mutate+persist against this session's archive/kill/restore
+	// teardown, exactly as SetPRInfo (#2437) and the tab verbs do: take the
+	// per-session op-lock first, re-confirm the tracked session, and refuse an
+	// archived one. With no op-lock (the earlier behavior) this write could
+	// interleave INSIDE ArchiveSession — between its teardown and its persist — and
+	// write a conversation id (and whatever else ToInstanceData snapshots) over the
+	// record the archive just committed; archive is inert in BOTH directions
+	// (#1809, #2451). The runtime-generation token does not close this: archive
+	// never bumps agentRuntimeGeneration, so the token still matches post-archive.
+	//
+	// The op-lock is taken AFTER the capture subprocess, so a slow capture never
+	// blocks a kill or archive, and op-lock BEFORE the per-repo start lock matches
+	// the kill/archive ordering. The caller spawns this async and never waits on
+	// it, so parking behind an in-flight op cannot deadlock.
+	opLock := m.opLockFor(key)
+	opLock.Lock()
+	defer opLock.Unlock()
+
 	m.mu.Lock()
 	current := m.instances[key]
 	m.mu.Unlock()
-	if current != inst || inst.UserKilled() {
+	if current != inst || inst.UserKilled() || inst.IsArchived() {
 		return
 	}
 	if !inst.SetAgentConversationForRuntime(token, conv) {

--- a/daemon/conversation_capture_archived_test.go
+++ b/daemon/conversation_capture_archived_test.go
@@ -1,0 +1,122 @@
+package daemon
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// captureArchiveTestInstance stands up a tracked, running codex session whose
+// conversation id CaptureAgentConversation will resolve from a rollout file, and
+// persists its initial (id-less) record. It mirrors the setup in
+// TestCaptureAgentConversationPersistsCodexRolloutID so the only difference these
+// tests exercise is the archived gate.
+func captureArchiveTestInstance(t *testing.T) (*Manager, *session.Instance, string, string, session.ConversationCaptureSnapshot) {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	require.NoError(t, err)
+
+	manager, err := NewManager(config.DefaultConfig())
+	require.NoError(t, err)
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   "codex-worker",
+		Path:    repoPath,
+		Program: tmux.ProgramCodex,
+	})
+	require.NoError(t, err)
+	inst.SetTmuxSession(tmux.NewTmuxSession("codex-worker", tmux.ProgramCodex))
+	inst.SetStatusForTest(session.Running)
+	key := daemonInstanceKey(repo.ID, inst.Title)
+	manager.mu.Lock()
+	manager.instances[key] = inst
+	manager.mu.Unlock()
+	require.NoError(t, appendInstanceData(repo.ID, inst.ToInstanceData()))
+
+	snap := session.BeginConversationCapture()
+	writeDaemonCodexRolloutFile(t, codexHome, "rollout-2026-07-06T10-17-35-019f386f-7206-7fc2-803b-f7045e07a242.jsonl")
+	return manager, inst, repo.ID, key, snap
+}
+
+func persistedConversationID(t *testing.T, repoID string) string {
+	t.Helper()
+	raw, err := config.LoadRepoInstances(repoID)
+	require.NoError(t, err)
+	var stored []session.InstanceData
+	require.NoError(t, json.Unmarshal(raw, &stored))
+	require.Len(t, stored, 1)
+	if stored[0].AgentConversation == nil {
+		return ""
+	}
+	return stored[0].AgentConversation.ID
+}
+
+// TestCaptureAgentConversation_RejectsAlreadyArchivedSession is the #2451
+// front-door half: a session already archived when the async capture lands must
+// not have a conversation id (nor anything else ToInstanceData snapshots) written
+// over the record the archive committed. Archive is inert in BOTH directions
+// (#1809). Mirrors TestSetPRInfo_RejectsAlreadyArchivedSession.
+func TestCaptureAgentConversation_RejectsAlreadyArchivedSession(t *testing.T) {
+	manager, inst, repoID, key, snap := captureArchiveTestInstance(t)
+
+	inst.SetStatusForTest(session.Archived)
+
+	manager.captureAgentConversation(repoID, key, inst, snap, inst.AgentRuntimeToken(), time.Second)
+
+	if id := persistedConversationID(t, repoID); id != "" {
+		t.Fatalf("archived session gained a persisted conversation id %q; capture must refuse an archived record", id)
+	}
+}
+
+// TestCaptureAgentConversation_ArchiveWinningOpLockRaceKeepsCleanRecord is the
+// #2451 race half. captureAgentConversation resolved a LIVE session and did its
+// subprocess capture, then must serialize its mutate+persist behind this
+// session's op-lock — the lock ArchiveSession holds while it commits LiveArchived
+// and persists. With no op-lock (the pre-fix behavior) the capture would not park
+// at all: it would interleave INSIDE the archive and write a conversation id over
+// the record the archive just committed. Mirrors
+// TestSetPRInfo_ArchiveWinningOpLockRaceKeepsPRInfo.
+func TestCaptureAgentConversation_ArchiveWinningOpLockRaceKeepsCleanRecord(t *testing.T) {
+	manager, inst, repoID, key, snap := captureArchiveTestInstance(t)
+
+	opLock := manager.opLockFor(key)
+	opLock.Lock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		manager.captureAgentConversation(repoID, key, inst, snap, inst.AgentRuntimeToken(), time.Second)
+	}()
+
+	// The capture must PARK on the op-lock: it resolved a live session and finished
+	// its subprocess capture, so the only interleaving that reaches the post-lock
+	// archived gate is one that queues behind the operation holding the lock.
+	// Without the op-lock it returns immediately and the race is never exercised.
+	select {
+	case <-done:
+		opLock.Unlock()
+		t.Fatal("captureAgentConversation returned while the op-lock was held; it never took the op-lock and so cannot serialize against an archive")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	// The archive commits LiveArchived under the op-lock and leaves the same
+	// pointer tracked, exactly as ArchiveSession does before releasing the lock.
+	inst.SetStatusForTest(session.Archived)
+	opLock.Unlock()
+
+	<-done
+
+	if id := persistedConversationID(t, repoID); id != "" {
+		t.Fatalf("capture that queued behind an archive wrote conversation id %q over the archived record", id)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #2451.

`captureAgentConversation` (`daemon/conversation_capture.go`) mutated and persisted the instance record holding **only the per-repo start lock** — no per-session op-lock and no archived gate — unlike every sibling mutation of that record (CloseTab/RenameTab/SetPRInfo, #2437). With no op-lock it could interleave **inside** `ArchiveSession`, between the archive's teardown and its persist, and write a conversation id (and whatever else `ToInstanceData` snapshots) over the record the archive had just committed. Archive is inert in both directions (#1809).

## Verification of the bug (it was static analysis in the issue)

The issue flagged this as *"static analysis, not a reproduced failure,"* and asked whether the runtime-generation token in `SetAgentConversationForRuntime` closes the window by accident. **It does not** — archive never bumps `agentRuntimeGeneration`, so the token still matches post-archive. The new front-door test reproduces the persist: on unpatched master an already-archived session **gained** the captured conversation id on disk. Confirmed real.

## Fix direction (note)

The persist here is the function's **purpose** (#1311): it records the agent conversation id once (`HasID()`-guarded), and resume reads exactly that id back (`prepareExactResumeConversation` → `ResumeProgramWithConversationID`). The capture is triggered by session **create** and **handoff delivery** — lifecycle writes, not a read path. So the fix is *not* to remove the write (that would regress conversation resume); it is to give the write the same discipline as its siblings, per the issue's own suggested direction and confirmed with the maintainer.

## Fix

Take the per-session **op-lock** before the mutate+persist, re-confirm the tracked session, and **refuse an archived one** — mirroring `SetPRInfo` (#2437). The op-lock is taken *after* the capture subprocess (a slow capture never blocks a kill/archive) and *before* the per-repo start lock (matches the kill/archive ordering). The caller spawns this async and never waits on it, so parking behind an in-flight op cannot deadlock. The live-session capture path is unchanged, so resume keeps working.

## Tests (fail first)

`daemon/conversation_capture_archived_test.go`, mirroring the SetPRInfo #2437 pair:
- `TestCaptureAgentConversation_RejectsAlreadyArchivedSession` — front-door: an already-archived session must not gain a persisted conversation id. (Fails on master — the id is persisted.)
- `TestCaptureAgentConversation_ArchiveWinningOpLockRaceKeepsCleanRecord` — the capture must park on the op-lock and, after the archive commits under it, refuse. (Fails on master — the capture never takes the op-lock.)

The existing `TestCaptureAgentConversationPersistsCodexRolloutID` (live-session happy path) still persists.

## Verification

- Gate head: `1de7ce37`
- `go build ./...`, `gofmt -l` (clean), `go vet`, `golangci-lint run --fast` (clean), `deadcode -test ./...` (clean), `scripts/lint-file-length.sh` (pass)
- `make test-container`: **full suite green** — every package, `daemon` included at 186s (the two new tests + all handoff/archive/create tests).

## Base

Branched from current master (`dc4a7a1b`). Touches only `daemon/conversation_capture.go` + a new test file.

## Review

Codex GitHub-app review is frozen until Jul 28 — requested once. If silent, over to Captain Claude for the claude-subagent review. Held as **draft**; do not merge unreviewed (no self-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
