### PR TITLE
feat(config): add an always-available config-assistant button (#2453, #2454)

### DIFF
--- a/app/config_editor_assistant_test.go
+++ b/app/config_editor_assistant_test.go
@@ -1,0 +1,74 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/configagent"
+)
+
+// TestConfigEditorAssistantButtonSpawnsTheAgent is the #2453 wiring, end to end
+// through the real overlay handler: pressing C in the config editor closes the
+// overlay AND opens the config assistant. It drives handleStateConfigEditor (not
+// the pane directly), because the app layer is where the pane's assistant request
+// is turned into a spawn — a pane-layer test proves the request is recorded but
+// not that the host acts on it.
+//
+// The spawn is swapped for a seam that records it, so the test asserts the button
+// reaches the real spawn path without starting a daemon or a tmux session.
+func TestConfigEditorAssistantButtonSpawnsTheAgent(t *testing.T) {
+	h := openConfigEditorForTest(t)
+
+	spawned := 0
+	t.Cleanup(SetConfigAgentSpawnerForTest(func(mode configagent.Mode, _ string) (string, string, error) {
+		spawned++
+		assert.Equal(t, configagent.ModeChange, mode,
+			"the config-pane button opens the CHANGE flow, same as the C hotkey")
+		return "af_af-config-1", "", nil
+	}))
+
+	model, cmd := h.handleStateConfigEditor(runeKey('C'))
+	hm := model.(*home)
+
+	// The overlay must have closed — the assistant takes over the full screen, so
+	// the editor cannot still own it.
+	assert.Equal(t, stateDefault, hm.state, "pressing C must close the config editor overlay")
+	assert.False(t, hm.configPane.HasFocus(), "the config pane must drop focus when the assistant opens")
+
+	// A command must have been returned, and running it must reach the spawn seam.
+	require.NotNil(t, cmd, "pressing C must return a command that spawns the assistant")
+	msg := cmd()
+	_, isSpawn := msg.(configAgentSpawnedMsg)
+	require.True(t, isSpawn, "the command must drive the config-agent spawn, got %T", msg)
+	assert.Equal(t, 1, spawned, "the assistant button must spawn exactly one config agent")
+
+	// The request is one-shot: the pane must not still be holding it, or a later
+	// close would spawn a second agent.
+	assert.False(t, hm.configPane.TakeAssistantRequest(),
+		"the assistant request must be consumed by the spawn, not left pending")
+}
+
+// TestConfigEditorCTypedIntoAValueFieldDoesNotSpawn is the collision guard at the
+// app layer: while a value is being edited, C is ordinary text (a path under
+// /home/carol, a branch prefix) and must reach the field, never the assistant.
+func TestConfigEditorCTypedIntoAValueFieldDoesNotSpawn(t *testing.T) {
+	h := openConfigEditorForTest(t)
+
+	spawned := 0
+	t.Cleanup(SetConfigAgentSpawnerForTest(func(configagent.Mode, string) (string, string, error) {
+		spawned++
+		return "", "", nil
+	}))
+
+	// Open a value field, then type C.
+	_, _ = h.handleStateConfigEditor(tea.KeyMsg{Type: tea.KeyEnter})
+	require.True(t, h.configPane.IsEditing(), "precondition: a value field is open")
+	_, cmd := h.handleStateConfigEditor(runeKey('C'))
+
+	assert.Equal(t, stateConfigEditor, h.state, "typing C into a value must not close the editor")
+	assert.Nil(t, cmd, "typing C into a value must not spawn the assistant")
+	assert.Equal(t, 0, spawned, "no config agent may be spawned by C typed as text")
+}

--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -395,6 +395,14 @@ func (m *home) handleStateConfigEditor(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	m.configPane.HandleKeyPress(msg)
 	if !m.configPane.HasFocus() {
 		m.state = stateDefault
+		// The pane released focus. If that was the assistant button (C), open the
+		// config assistant now: the overlay is already closing, so the full-screen
+		// takeover has a clean terminal to attach to, and on return the user lands
+		// back at the default view with a freshly reloaded config (#2453). Taking
+		// the request consumes it, so a later close cannot re-fire it.
+		if m.configPane.TakeAssistantRequest() {
+			return m.handleConfigAgent()
+		}
 		return m, nil
 	}
 	return m, nil

--- a/commands/configcmd.go
+++ b/commands/configcmd.go
@@ -308,7 +308,9 @@ Settable keys:
   global_agent_skills        true | false
 
 Structural keys (root_agents, [theme], the [keys] rebind table) and the
-cors_allowed_origins list are not settable here — edit config.toml directly.
+session_env_passthrough / cors_allowed_origins lists have no single-scalar shape,
+so they are not settable here. Ask the config assistant to change them (it edits
+the file and validates), or edit config.toml directly and run "af config validate".
 Changes apply on the next af / daemon start.
 
 Examples:
@@ -337,6 +339,55 @@ Examples:
 			fmt.Fprintln(cmd.OutOrStdout(),
 				"note: af and the daemon read config.toml at startup — restart them to apply (same as a hand-edit)")
 		}
+		return nil
+	},
+}
+
+// configValidateResult is the machine-readable answer of `af config validate`:
+// whether the current global config parses and validates, and the file it
+// checked. The value is deliberately not returned — the point is the verdict,
+// and a config that fails to load has no value to report.
+type configValidateResult struct {
+	OK   bool   `json:"ok"`
+	Path string `json:"path"`
+}
+
+var configValidateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Check that the global config parses and validates",
+	Long: `Read the global config (~/.agent-factory/config.toml) exactly as af and the
+daemon do at startup and report whether it loads. It writes nothing and
+materializes nothing — a read-only check.
+
+This is the companion to a hand-edit. Most keys go through "af config set",
+which validates before it writes and so can never leave a broken file; but the
+structured settings (theme, the [keys] rebinds, root_agents, and the
+session_env_passthrough / cors_allowed_origins lists) are edited in the file
+directly, and a broken edit there is a hard startup failure with no fallback to
+defaults. Run this after such an edit: exit 0 means the next start will load it,
+a non-zero exit names what is wrong so it can be fixed before restarting.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		// LoadConfigReadOnly is the same parse+validate af runs at startup, minus
+		// the materialize/convert/secure side effects LoadConfig has — so validate
+		// can never itself change the thing it is checking. A missing file is not a
+		// failure: first run has no config yet, and af materializes defaults then.
+		loaded, err := config.LoadConfigReadOnly()
+		if err != nil {
+			return jsonWrapError(cmd, configJSONFlag, err)
+		}
+		if configJSONFlag {
+			return apiproto.WriteEnvelope(cmd.OutOrStdout(),
+				apiproto.Success(configValidateResult{OK: true, Path: loaded.Path}))
+		}
+		if loaded.Missing {
+			fmt.Fprintln(cmd.OutOrStdout(), "config OK: no config file yet — af will write defaults on first start")
+			return nil
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "config OK: %s loads\n", prettyPath(loaded.Path))
 		return nil
 	},
 }
@@ -378,7 +429,9 @@ func init() {
 	configListCmd.Flags().StringVar(&configListProjectFlag, "project", "",
 		"Resolve config for the project at this repository path")
 	configSetCmd.Flags().BoolVar(&configJSONFlag, "json", false, jsonUsage)
+	configValidateCmd.Flags().BoolVar(&configJSONFlag, "json", false, jsonUsage)
 	configCmd.AddCommand(configGetCmd)
 	configCmd.AddCommand(configListCmd)
 	configCmd.AddCommand(configSetCmd)
+	configCmd.AddCommand(configValidateCmd)
 }

--- a/commands/configvalidate_test.go
+++ b/commands/configvalidate_test.go
@@ -1,0 +1,117 @@
+package commands
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestConfigValidateAcceptsAGoodConfig is the #2453 companion to a hand-edit:
+// the config assistant edits the structured settings in the file directly, then
+// runs `af config validate` to prove the file still loads before it moves on. A
+// well-formed file must pass with a clear OK.
+func TestConfigValidateAcceptsAGoodConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	path := filepath.Join(home, "config.toml")
+	// A structured edit of exactly the shape the assistant now makes: a [theme]
+	// table that af config set cannot write, hand-written into the file.
+	if err := os.WriteFile(path, []byte("default_program = 'claude'\n\n[theme]\nbackground = '#101010'\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := configValidateCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("a well-formed config must validate, got error: %v", err)
+	}
+	if !strings.Contains(out.String(), "config OK") {
+		t.Errorf("validate must report OK for a good config, got: %q", out.String())
+	}
+}
+
+// TestConfigValidateRejectsABrokenEdit is the whole reason the command exists.
+// A direct structured edit that does not load is a HARD startup failure with no
+// fallback to defaults, so the assistant must be able to catch it before the
+// user restarts. Validate has to FAIL — loudly, with a locatable error — on a
+// malformed file.
+func TestConfigValidateRejectsABrokenEdit(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	path := filepath.Join(home, "config.toml")
+	// A broken edit: an unterminated table header. This is the class of mistake a
+	// hand-edit makes and af config set cannot, since set never regenerates the
+	// file from a bad state.
+	if err := os.WriteFile(path, []byte("default_program = 'claude'\n[theme\nbackground = '#101010'\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	err := configValidateCmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("validate must FAIL on a config that does not load — an unvalidated broken edit wedges startup")
+	}
+	if strings.Contains(out.String(), "config OK") {
+		t.Errorf("a broken config must not print OK, got stdout: %q", out.String())
+	}
+}
+
+// TestConfigValidateAcceptsAMissingConfig pins that first run is not a failure:
+// there is no config file yet, af materializes defaults on first start, and the
+// assistant running validate before anything exists must not report an error.
+func TestConfigValidateAcceptsAMissingConfig(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := configValidateCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("a missing config is first-run, not an error, got: %v", err)
+	}
+	if !strings.Contains(out.String(), "config OK") {
+		t.Errorf("a missing config should still report OK, got: %q", out.String())
+	}
+}
+
+// TestConfigValidateDoesNotMutateTheConfig is the read-only promise that matters.
+// `af config set` materializes and secures the home; validate must not touch the
+// config it checks — a check that rewrites what it checks is not one. Assert the
+// config file is byte-for-byte unchanged and no second config file (a
+// materialized default, a converted config.json) appeared.
+//
+// It deliberately does NOT assert the whole home is untouched: every command runs
+// log.Initialize, which writes agent-factory.log into the home. That is not a
+// config mutation, so the assertion is scoped to config files rather than a
+// directory-entry count that the log file would trip.
+func TestConfigValidateDoesNotMutateTheConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	tomlPath := filepath.Join(home, "config.toml")
+	jsonPath := filepath.Join(home, "config.json")
+	original := []byte("default_program = 'codex'\n\n[theme]\nbackground = '#202020'\n")
+	if err := os.WriteFile(tomlPath, original, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	if err := configValidateCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	after, _ := os.ReadFile(tomlPath)
+	if string(after) != string(original) {
+		t.Errorf("validate changed the config it checked.\n got: %q\nwant: %q", after, original)
+	}
+	if _, err := os.Stat(jsonPath); err == nil {
+		t.Error("validate materialized a second config file (config.json) — it must read, never write")
+	}
+}

--- a/config/manifest_value.go
+++ b/config/manifest_value.go
@@ -191,17 +191,28 @@ func ManifestWithValues(cfg *Config) []ConfigEntry {
 //     bare key is NOT settable, but its leaves are — so the honest hint names
 //     the command that works, rather than sending someone to a text editor for
 //     something af can do for them.
-//   - A structural key (theme, root_agents, keys, cors_allowed_origins) is
-//     hand-edited by design. There is no command; say so.
+//   - A structural key (theme, root_agents, keys, session_env_passthrough,
+//     cors_allowed_origins) has no single-scalar `af config set` shape. The hint
+//     points at the config assistant, which edits these in the file for the user
+//     — the whole reason "hand-edit the file yourself" is no longer the answer
+//     (#2453 / #2454).
+//
+// assistantEditHint is the one string for that second case, so both editor
+// surfaces (TUI pane, web pane) say the same thing and TestStructuralKeysPointAtTheAssistant
+// pins it. It is surface-neutral on purpose: the TUI opens the assistant with a
+// key and the web with a button, so the hint names neither and describes the
+// capability instead.
+const assistantEditHint = "the config assistant can change this for you"
+
 func editability(e ManifestEntry) (editable bool, hint string) {
 	if !e.Settable {
-		return false, "hand-edited in config.toml"
+		return false, assistantEditHint
 	}
 	spec, ok := settableKeySpecs[e.Key]
 	if !ok {
 		// Unreachable while TestManifestAgreesWithSettableKeys passes; fail
 		// closed rather than offer a field the writer has no spec for.
-		return false, "hand-edited in config.toml"
+		return false, assistantEditHint
 	}
 	if spec.dynamic {
 		return false, "set one entry: af config set " + e.Key + ".<name> <value>"

--- a/config/manifest_value_test.go
+++ b/config/manifest_value_test.go
@@ -314,18 +314,33 @@ func TestDynamicFamiliesAreNotEditableAndSayHow(t *testing.T) {
 	}
 }
 
-// TestStructuralKeysSayTheyAreHandEdited pins the other read-only case: there is
-// genuinely no command for theme/[keys]/root_agents, so the hint says so.
-func TestStructuralKeysSayTheyAreHandEdited(t *testing.T) {
+// TestStructuralKeysPointAtTheAssistant pins the other read-only case. There is
+// no single-scalar `af config set` shape for theme/[keys]/root_agents/the lists,
+// but "hand-edit the file yourself" is no longer the answer we give: the hint
+// points at the config assistant, which edits these in the file for the user
+// (#2453 / #2454).
+//
+// The old assertion required the exact string "hand-edited in config.toml", which
+// was the whole concept #2454 removed — so it is inverted here: no read-only key
+// may still send the user to a text editor.
+func TestStructuralKeysPointAtTheAssistant(t *testing.T) {
+	checked := 0
 	for _, e := range ManifestWithValues(DefaultConfig()) {
 		if e.Settable {
 			continue
 		}
+		checked++
 		if e.Editable {
 			t.Errorf("%s is not settable at all; it must not be editable", e.Key)
 		}
-		if e.EditHint != "hand-edited in config.toml" {
-			t.Errorf("%s: got hint %q", e.Key, e.EditHint)
+		if e.EditHint != assistantEditHint {
+			t.Errorf("%s: hint is %q, want the assistant hint %q", e.Key, e.EditHint, assistantEditHint)
 		}
+		if strings.Contains(e.EditHint, "hand-edit") {
+			t.Errorf("%s: the hint still tells the user to hand-edit the file (%q) — #2454 removed that", e.Key, e.EditHint)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no read-only structural keys found — this test is asserting nothing")
 	}
 }

--- a/configagent/briefing.go
+++ b/configagent/briefing.go
@@ -90,7 +90,12 @@ func BuildBriefing(mode Mode, cfg *config.Config, configPath string) string {
   Add ` + "`--json`" + ` when you want to parse it: the value comes back on stdout wrapped
   in a {data,error} envelope and errors come back on stderr, so the exit code alone
   only tells you whether it worked.
-`)
+
+A few settings have no ` + "`af config set`" + ` form because they are not one scalar value —
+` + "`theme`" + ` and the ` + "`[keys]`" + ` rebinds are tables, ` + "`root_agents`" + ` is a table, and
+` + "`session_env_passthrough`" + ` and ` + "`cors_allowed_origins`" + ` are lists. You edit those by
+editing the global config file directly. See "Editing the structured settings" below;
+the same immediate-apply and echo rules hold, and you validate after every such edit.`)
 	fmt.Fprintf(&b, "- Say once, near the start, that all of this lives in `%s` and stays\n"+
 		"  hand-editable, so anything can be undone by opening that file. Say it once · not per setting.\n",
 		configPath)
@@ -109,8 +114,12 @@ work, are on this machine. Do not go looking for them. Specifically:
 - Do not run git. Not status, not diff, not log · nothing.
 - Do not build, test, lint or run any project.
 - Do not create sessions, tabs or tasks.
-- The only writes you make are ` + "`af config set`" + `. The only reads you need are
-  ` + "`af config get`" + ` and ` + "`af config list`" + `.
+- The only files you may write are the GLOBAL config file named above and nothing
+  else — never a file in a repository, never a repository's own ` + "`.agent-factory`" + `
+  config. The writes you make are ` + "`af config set`" + ` and, for the structured
+  settings, direct edits to that one global file. The only reads you need are
+  ` + "`af config get`" + `, ` + "`af config list`" + `, and — only to check your own edit —
+  ` + "`af config validate`" + ` and reading back the global file you just wrote.
 
 If the user asks for anything outside configuration — even something small, even
 something helpful — tell them this session only does configuration, and that a normal
@@ -157,14 +166,40 @@ reverse proxy that terminates TLS (nginx, caddy), or a VPN such as Tailscale.
 	// The slot count is read from ThemeConfig rather than written here: a slot
 	// added to the struct would otherwise leave this sentence quietly wrong.
 	fmt.Fprintf(&b, `
-## theme
+## Editing the structured settings
 
-`+"`theme`"+` is a table of %d colors and `+"`af config set`"+` cannot write it. Do not try, and
-do not offer to pick hex values in conversation — that is a miserable way to choose
-colors. If the user wants to change them, say what the table does and point them at the
-`+"`[theme]`"+` section of their config file.
+Five settings have no `+"`af config set`"+` form because they are not one scalar value.
+You edit these by editing the global config file at `+"`%s`"+` directly — and ONLY that
+file, never a repository's config. They are:
 
-`, config.ThemeSlotCount())
+- `+"`theme`"+` — a table of %d colors, one `+"`#RRGGBB`"+` per slot, under a `+"`[theme]`"+` section.
+- `+"`keys`"+` — the keybinding table, under `+"`[keys]`"+`; each entry rebinds one action.
+- `+"`root_agents`"+` — a table under `+"`[root_agents]`"+`, one entry per repository path that
+  should always keep a session named root running.
+- `+"`session_env_passthrough`"+` — a list of exact environment variable NAMES a session may
+  inherit. Names only — never put a value here. This is a security setting.
+- `+"`cors_allowed_origins`"+` — a list of exact web origins allowed to call the API from a
+  browser. Also a security setting; empty blocks every one of them.
+
+How to edit one:
+
+1. Read the current file first so you edit in place and preserve every other section,
+   comment, and blank line. Change only what the user asked for.
+2. Make the edit.
+3. Run `+"`af config validate`"+`. It re-reads the file exactly as af does at startup and
+   reports whether it loads. This step is not optional: a broken structured edit is a
+   HARD startup failure with no fallback to defaults, so an unvalidated edit can wedge
+   af and the daemon. `+"`af config set`"+` validates before it writes and so is always safe
+   — a direct edit is not, which is why you check.
+4. If validate fails, it names what is wrong. FIX IT before moving on — never leave the
+   file in a state that does not load. If you cannot get it valid, restore what was
+   there before and tell the user.
+
+For `+"`theme`"+` specifically: do not offer to pick hex values slot by slot in
+conversation — that is a miserable way to choose colors. Ask what they want (a darker
+background, a different accent), set those slots, and validate.
+
+`, configPath, config.ThemeSlotCount())
 
 	fmt.Fprintf(&b, "## The settings\n\nEvery setting below is shown with its current value on this machine.\n"+
 		"Recommend from these values · do not guess at what is set.\n\n%s\n",

--- a/configagent/briefing_test.go
+++ b/configagent/briefing_test.go
@@ -159,12 +159,68 @@ func TestBriefingStatesTheApplyRules(t *testing.T) {
 	}
 }
 
-// TestBriefingRefusesToSetTheme pins that the agent is told not to attempt the
-// one key that would waste the user's time: 19 hex slots, not settable by CLI.
-func TestBriefingRefusesToSetTheme(t *testing.T) {
+// TestBriefingEditsStructuredKeysByFileThenValidates is the #2453/#2454 reversal.
+//
+// The five structured keys (theme, keys, root_agents, session_env_passthrough,
+// cors_allowed_origins) have no `af config set` scalar form, and the assistant is
+// now the editor for them: it edits the GLOBAL config file directly and then
+// validates. The briefing must both authorize that and require the validate step,
+// because a broken structured edit is a hard startup failure with no default
+// fallback — so an unvalidated edit is exactly the wedge this step prevents.
+//
+// This replaces TestBriefingRefusesToSetTheme, which pinned the OLD "af config set
+// cannot write it, do not try" instruction that #2454 removed.
+func TestBriefingEditsStructuredKeysByFileThenValidates(t *testing.T) {
 	out := BuildBriefing(ModeOnboard, briefingConfig(), "/tmp/af/config.toml")
-	if !strings.Contains(out, "cannot write it") || !strings.Contains(out, "do not offer to pick hex values") {
-		t.Errorf("briefing must tell the agent not to try setting theme:\n%s", out)
+
+	// Every structured key must be named as file-editable in the new section.
+	for _, key := range []string{
+		"theme", "keys", "root_agents", "session_env_passthrough", "cors_allowed_origins",
+	} {
+		if !strings.Contains(out, "`"+key+"`") {
+			t.Errorf("briefing must name the structured key %q as file-editable", key)
+		}
+	}
+	// The validate-after step must be present AND named as non-optional.
+	for _, want := range []string{
+		"## Editing the structured settings",
+		"editing the global config file",
+		"af config validate",
+		"not optional",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("briefing is missing the structured-edit instruction %q", want)
+		}
+	}
+	// The retired instruction must be gone: the agent is no longer told the theme
+	// cannot be written or to point the user at the file to do it themselves.
+	if strings.Contains(out, "cannot write it") {
+		t.Error("briefing still says `af config set` cannot write theme — #2454 makes the assistant the editor")
+	}
+	// The one piece of the old theme guidance that SURVIVES: don't grind through hex
+	// slots in chat. That is UX, not a prohibition on editing.
+	if !strings.Contains(out, "do not offer to pick hex values") {
+		t.Error("briefing should still tell the agent not to pick hex values slot by slot in conversation")
+	}
+}
+
+// TestBriefingKeepsRepoConfigOffLimits pins the boundary #2453 deliberately did
+// NOT cross: the assistant may write the GLOBAL config file, but the five
+// repo-scoped keys stay off-limits and the no-repo-files fence is intact. Lifting
+// that is a separate trust decision, and the agent has no repo cwd anyway.
+func TestBriefingKeepsRepoConfigOffLimits(t *testing.T) {
+	for _, mode := range []Mode{ModeOnboard, ModeChange} {
+		out := BuildBriefing(mode, briefingConfig(), "/tmp/af/config.toml")
+
+		// The repo prohibition must survive the widened write permission.
+		if !strings.Contains(out, "Do not read, create, edit, move or delete any file in any repository.") {
+			t.Errorf("mode %s: the no-repo-files fence must survive the global-file write permission", mode)
+		}
+		// The new write permission must be scoped to the global file explicitly, so
+		// "you may edit config files" cannot be read as "any config file".
+		if !strings.Contains(out, "never a repository's own") {
+			t.Errorf("mode %s: the write permission must exclude a repository's own .agent-factory config", mode)
+		}
 	}
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -21,6 +21,7 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 - [`af config get`](#af-config-get) — Print one global or project-effective config value
 - [`af config list`](#af-config-list) — Print global or project-effective config values
 - [`af config set`](#af-config-set) — Set a single settable global config key
+- [`af config validate`](#af-config-validate) — Check that the global config parses and validates
 - [`af daemon`](#af-daemon) — Manage the background daemon: serves the web UI and schedules tasks
 - [`af daemon install`](#af-daemon-install) — Register the daemon to start automatically at login
 - [`af daemon restart`](#af-daemon-restart) — Restart the running daemon without stopping live sessions
@@ -456,6 +457,7 @@ af config
 - [`af config get`](#af-config-get) — Print one global or project-effective config value
 - [`af config list`](#af-config-list) — Print global or project-effective config values
 - [`af config set`](#af-config-set) — Set a single settable global config key
+- [`af config validate`](#af-config-validate) — Check that the global config parses and validates
 
 **Global flags**
 
@@ -561,7 +563,9 @@ Settable keys:
   global_agent_skills        true | false
 
 Structural keys (root_agents, [theme], the [keys] rebind table) and the
-cors_allowed_origins list are not settable here — edit config.toml directly.
+session_env_passthrough / cors_allowed_origins lists have no single-scalar shape,
+so they are not settable here. Ask the config assistant to change them (it edits
+the file and validates), or edit config.toml directly and run "af config validate".
 Changes apply on the next af / daemon start.
 
 Examples:
@@ -571,6 +575,39 @@ Examples:
 
 ```
 af config set <key> <value> [flags]
+```
+
+**Flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--json` |  | Emit the value(s) as JSON wrapped in the {data,error} envelope |
+
+**Global flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--daemon-url` | `string` | Target a REMOTE daemon at this http:// or ws:// URL instead of the local unix socket (env: AF_DAEMON_URL). The daemon is HTTP-only; terminate TLS at your own proxy if needed. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
+
+## af config validate
+
+Check that the global config parses and validates
+
+Read the global config (~/.agent-factory/config.toml) exactly as af and the
+daemon do at startup and report whether it loads. It writes nothing and
+materializes nothing — a read-only check.
+
+This is the companion to a hand-edit. Most keys go through "af config set",
+which validates before it writes and so can never leave a broken file; but the
+structured settings (theme, the [keys] rebinds, root_agents, and the
+session_env_passthrough / cors_allowed_origins lists) are edited in the file
+directly, and a broken edit there is a hard startup failure with no fallback to
+defaults. Run this after such an edit: exit 0 means the next start will load it,
+a non-zero exit names what is wrong so it can be fixed before restarting.
+
+```
+af config validate [flags]
 ```
 
 **Flags**

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -875,6 +875,24 @@
       "notes": "The CLI now exposes complete on-disk source candidates, per-leaf origins, and whether the running daemon was checked. TUI/web/config-agent introspection remains #2216 stage 7 so those surfaces consume the same resolver rather than growing a second precedence implementation."
     },
     {
+      "id": "config.validate",
+      "title": "Check that the global config parses and validates",
+      "tui": {
+        "status": "n/a",
+        "pointer": ""
+      },
+      "web": {
+        "status": "n/a",
+        "pointer": ""
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "commands/configcmd.go config validate (LoadConfigReadOnly)"
+      },
+      "verdict": "deliberate",
+      "notes": "#2453/#2454: a read-only check that config.toml loads, the companion to a hand-edit and the config assistant's validate-after step. n/a on the TUI and web because their edits go through the validated SetGlobalConfigValue/manifest path and so can never produce an unloadable file — there is nothing for a validate affordance to catch. The config assistant, which does hand-edit the structured keys, runs `af config validate` itself."
+    },
+    {
       "id": "config.write",
       "title": "Set a global config key",
       "tui": {
@@ -1327,6 +1345,7 @@
       "af config get": "config.read",
       "af config list": "config.read",
       "af config set": "config.write",
+      "af config validate": "config.validate",
       "af daemon install": "daemon.lifecycle",
       "af daemon restart": "daemon.lifecycle",
       "af daemon status": "daemon.lifecycle",
@@ -1516,6 +1535,8 @@
       "af config list --project": "config.read-project",
       "af config set --help": "meta.discovery",
       "af config set --json": "cli.json-envelope",
+      "af config validate --help": "meta.discovery",
+      "af config validate --json": "cli.json-envelope",
       "af daemon --help": "meta.discovery",
       "af daemon install --help": "meta.discovery",
       "af daemon restart --help": "meta.discovery",

--- a/scripts/tui-2453-scenario.sh
+++ b/scripts/tui-2453-scenario.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Real-TUI drive for #2453 + #2454, in two honest parts:
+#
+#   scripts/testbox.sh scenario scripts/tui-2453-scenario.sh
+#
+# Part A (the visible TUI behavior): the config overlay advertises the assistant
+# button, pressing it opens the config-assistant takeover (the sandbox's config
+# agent runs bash, so the takeover lands in a real session), and exiting returns
+# to the TUI cleanly with no #2019-class attach error.
+#
+# Part B (the mechanism the assistant is briefed on): drive the REAL af binary
+# directly — hand-edit a [theme] block, run `af config validate` (OK), break it,
+# validate (fails), restore, validate (OK). This is deliberately NOT puppeteered
+# through the takeover's bash: the config agent pastes a long briefing into that
+# shell, and quote-escaping a multi-command edit through the paste path is flaky.
+# Running the binary proves the exact edit→validate contract deterministically.
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source /src/scripts/tui-driver.sh
+
+# --- Part A: the button and the takeover (visible TUI) ----------------------
+
+# press_button_and_spawn presses C in the config overlay and proves the button
+# triggered THIS PR's spawn: a bare config-agent tmux session (af_af-config-*),
+# on demand, not a project instance. It keys on the daemon-side session
+# appearing rather than on screen chrome — the config overlay goes full-screen at
+# a narrow geometry (#1821), so "the rail's header vanished" is not a reliable
+# takeover signal, whereas the af_af-config-* session is the unambiguous fact
+# that the button spawned the assistant.
+#
+# The return-to-TUI-on-detach path is unchanged by this PR: the button reaches
+# the same enterConfigAgent/ReapConfigAgent flow the nav hotkey does, which the
+# selftest already gates end to end (#2019). So this scenario proves the NEW
+# behavior — the trigger and what it spawns — and leaves the shared return path
+# to that gate. Best-effort detach after; the per-geometry af_reset_sandbox nukes
+# any leftover regardless.
+press_button_and_spawn() {
+    af_send C
+    local deadline cfg screen
+    deadline=$(( $(_af_now) + 75 ))
+    while :; do
+        screen="$(af_capture)"
+        if printf '%s\n' "$screen" | grep -qiE 'exit status 1|nested with care|can.t find session'; then
+            _af_log "#2453: the config-pane button's spawn collapsed to an error:"
+            printf '%s\n' "$screen" >&2
+            return 1
+        fi
+        # `|| true`: before the session exists grep exits 1, which under
+        # `set -e` + pipefail would kill the poll on its first empty iteration.
+        cfg="$(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep '^af_af-config-' | head -1 || true)"
+        if [ -n "$cfg" ]; then
+            _af_log "assert OK: the button spawned a bare config-agent session ($cfg)"
+            tmux detach-client -s "$cfg" 2>/dev/null || true
+            return 0
+        fi
+        [ "$(_af_now)" -ge "$deadline" ] && { _af_log "#2453: the button spawned no config-agent session in 75s"; return 1; }
+        sleep "$AF_DRIVER_POLL"
+    done
+}
+
+drive_button_takeover() {
+    export AF_DRIVER_COLS="$1" AF_DRIVER_ROWS="$2"
+    af_reset_sandbox
+    af_boot
+
+    af_open_config
+    af_assert_screen 'C assistant' "the config overlay advertises the assistant button (${1}x${2})"
+
+    press_button_and_spawn
+
+    echo "PASS: #2453 button + spawn at ${1}x${2}"
+}
+
+# --- Part B: the edit→validate mechanism (real binary) ----------------------
+
+drive_validate_mechanism() {
+    local bin home cfg out rc
+    bin="$(_af_resolve_bin)"
+    home="$(mktemp -d)"
+    cfg="$home/config.toml"
+
+    # run_validate captures both output and exit code WITHOUT tripping `set -e`
+    # on a failing validate: an `if` condition is exempt from set -e, whereas
+    # `out=$(cmd); rc=$?` dies at the assignment when cmd (correctly) fails.
+    run_validate() {
+        if out="$(AGENT_FACTORY_HOME="$home" "$bin" config validate 2>&1)"; then rc=0; else rc=$?; fi
+    }
+
+    # A valid structured edit — exactly the shape the assistant makes for theme.
+    printf 'default_program = "claude"\n\n[theme]\nbackground = "#123456"\n' > "$cfg"
+    run_validate
+    if [ "$rc" -ne 0 ] || ! printf '%s' "$out" | grep -q 'config OK'; then
+        _af_fail "#2453 validate: a valid [theme] edit did not validate (rc=$rc): $out"; return 1
+    fi
+    _af_log "validate OK: a valid [theme] edit passes"
+
+    # A broken edit MUST be caught — the whole reason the step exists.
+    printf 'default_program = "claude"\n[keys\n' >> "$cfg"
+    run_validate
+    if [ "$rc" -eq 0 ]; then
+        _af_fail "#2453 validate: a broken edit was NOT caught — an unvalidated wedge would ship: $out"; return 1
+    fi
+    _af_log "validate OK: a broken edit fails loudly (rc=$rc)"
+
+    # Restore and re-validate: the assistant is told to fix a failed validate.
+    printf 'default_program = "claude"\n\n[theme]\nbackground = "#123456"\n' > "$cfg"
+    run_validate
+    if [ "$rc" -ne 0 ] || ! printf '%s' "$out" | grep -q 'config OK'; then
+        _af_fail "#2453 validate: the restored config did not validate (rc=$rc): $out"; return 1
+    fi
+    _af_log "validate OK: the restored config passes"
+
+    rm -rf "$home"
+    echo "PASS: #2453 edit→validate mechanism"
+}
+
+drive_button_takeover 100 30
+drive_button_takeover 80 24
+drive_validate_mechanism
+echo "PASS: #2453 real-TUI scenario (button at both geometries + validate mechanism)"

--- a/ui/config_pane.go
+++ b/ui/config_pane.go
@@ -67,6 +67,14 @@ type ConfigPane struct {
 	// (NewConfigPane wires it); a test that swaps it is testing the pane's
 	// plumbing, not inventing a second writer.
 	save func(key, value string) (*config.SetResult, error)
+
+	// assistantRequested is set when the user presses the assistant key in normal
+	// mode. The pane cannot spawn the config agent itself — that is a daemon round
+	// trip owned by the app package — so it records the intent and the app reads it
+	// through TakeAssistantRequest after routing the key (#2453). It is a request,
+	// not a mode: the pane never enters an assistant state, it just asks the host
+	// to open one and closes.
+	assistantRequested bool
 }
 
 // configRow is one line of the flattened view: either a tier heading or an
@@ -157,7 +165,21 @@ func (c *ConfigPane) SetFocus(focus bool) {
 	if !focus {
 		c.cancelEdit()
 		c.clearStatus()
+		// A pending request is consumed the moment the app opens the assistant, so
+		// one that survives to a close was never taken (the pane was dismissed
+		// another way). Drop it so the next open cannot inherit a stale intent.
+		c.assistantRequested = false
 	}
+}
+
+// TakeAssistantRequest reports whether the user asked to open the config
+// assistant since the last call, clearing the flag. The app calls it after
+// routing a key to the pane: a true here means close this overlay and spawn the
+// assistant (#2453). Read-and-clear so the request fires exactly once.
+func (c *ConfigPane) TakeAssistantRequest() bool {
+	req := c.assistantRequested
+	c.assistantRequested = false
+	return req
 }
 
 // rebuildRows flattens the manifest into the visible list, honoring the
@@ -261,6 +283,21 @@ func (c *ConfigPane) HandleKeyPress(msg tea.KeyMsg) bool {
 	case "a":
 		c.showAdvanced = !c.showAdvanced
 		c.rebuildRows()
+		return true
+	case "C":
+		// Ask the host to open the config assistant. Uppercase C matches the global
+		// hotkey the assistant already has (keys.KeyConfigAgent), and it is free
+		// here because value text is only typed in edit mode, which this switch does
+		// not reach. The pane records the request and closes; the app spawns the
+		// agent (see TakeAssistantRequest). This is the "button" #2453 asks for —
+		// the always-available way into the assistant from the config surface, so a
+		// user editing config never has to know the global shortcut exists.
+		//
+		// Drop focus FIRST — SetFocus(false) clears a pending request as part of its
+		// reset — then record this one, so closing the overlay does not wipe the
+		// intent that is closing it.
+		c.SetFocus(false)
+		c.assistantRequested = true
 		return true
 	case "enter":
 		c.beginEdit()
@@ -661,7 +698,22 @@ func (c *ConfigPane) renderHints() string {
 	if c.showAdvanced {
 		advanced = "a hide advanced"
 	}
-	return "\n" + configHintStyle.Render("↑/↓ move · ↵ edit · "+advanced+" · esc close") + "\n"
+	// "C assistant" is the button #2453 adds: the discoverable way to open the
+	// config assistant from the config surface. It sits before "esc close" so the
+	// exit stays last, where a reader looks for it.
+	//
+	// Adding a hint is a WIDTH change (#1936). With the assistant hint the full row
+	// is ~1 column past the 64-wide box's inner width, so at the real geometries it
+	// would wrap "esc close" onto a second line. Rather than wrap, shed the most
+	// droppable hint when the row will not fit: the advanced toggle, because `a`
+	// still works and pressing it reveals the tier — whereas the assistant button
+	// and the exit must always show. This is the hintDropOrder pattern, scoped to
+	// the one optional hint this row has.
+	full := "↑/↓ move · ↵ edit · " + advanced + " · C assistant · esc close"
+	if c.width > 0 && lipgloss.Width(full) > c.width {
+		full = "↑/↓ move · ↵ edit · C assistant · esc close"
+	}
+	return "\n" + configHintStyle.Render(full) + "\n"
 }
 
 // SetEditValueForTest and EditValueForTest expose the value field's buffer to

--- a/ui/config_pane_assistant_test.go
+++ b/ui/config_pane_assistant_test.go
@@ -1,0 +1,127 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// TestConfigPaneAssistantButtonRequestsAndCloses is the #2453 button. Pressing C
+// in normal mode records an assistant request AND closes the pane: the pane
+// cannot spawn the agent itself (that is a daemon round trip owned by the app),
+// so it signals the host and steps aside. TakeAssistantRequest returns the
+// request once and clears it.
+func TestConfigPaneAssistantButtonRequestsAndCloses(t *testing.T) {
+	c := newTestConfigPane(t)
+
+	if c.TakeAssistantRequest() {
+		t.Fatal("a fresh pane must not have a pending assistant request")
+	}
+
+	c.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'C'}})
+
+	if c.HasFocus() {
+		t.Error("pressing C must close the config pane so the host can take over the terminal")
+	}
+	if !c.TakeAssistantRequest() {
+		t.Fatal("pressing C must record an assistant request for the host to act on")
+	}
+	// Read-and-clear: the request fires exactly once, so a second read is false and
+	// the host cannot re-spawn on a later, unrelated close.
+	if c.TakeAssistantRequest() {
+		t.Error("the assistant request must clear when taken — a second read must be false")
+	}
+}
+
+// TestConfigPaneAssistantRequestClearsOnAnUnrelatedClose pins that a request
+// cannot leak across opens. If the pane is dismissed some other way (Esc) after C
+// was somehow set but never taken, reopening must not inherit the stale intent.
+func TestConfigPaneAssistantRequestClearsOnAnUnrelatedClose(t *testing.T) {
+	c := newTestConfigPane(t)
+
+	// Directly arm the flag, then close via Esc without the host taking it.
+	c.assistantRequested = true
+	c.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if c.TakeAssistantRequest() {
+		t.Error("an Esc close must drop a pending assistant request, so a later open cannot inherit it")
+	}
+}
+
+// TestConfigPaneShowsTheAssistantButtonHint pins the affordance is discoverable:
+// the button is only a button if the user can see it. The normal-mode hint row
+// must advertise C.
+func TestConfigPaneShowsTheAssistantButtonHint(t *testing.T) {
+	c := newTestConfigPane(t)
+	view := c.String()
+	if !strings.Contains(view, "C assistant") {
+		t.Errorf("the config pane must advertise the assistant button in its hints.\n--- view ---\n%s", view)
+	}
+}
+
+// TestConfigPaneHintFitsTheBoxAndKeepsTheButton is the #1936 width guard for the
+// added hint. At the real overlay inner width (~60), the full hint row would be
+// one column too long and wrap "esc close" onto a second line. The row must
+// instead fit on ONE line, and the two hints that must never be shed — the
+// assistant button and the exit — must survive; the advanced toggle is the one
+// that drops.
+func TestConfigPaneHintFitsTheBoxAndKeepsTheButton(t *testing.T) {
+	c := newTestConfigPane(t)
+	const inner = 60 // the config overlay's real inner content width (box target 64)
+	c.SetSize(inner, 40)
+
+	hint := c.renderHints()
+	for _, line := range strings.Split(hint, "\n") {
+		if w := lipgloss.Width(line); w > inner {
+			t.Errorf("hint line is %d cols wide, past the %d-col box — it will wrap:\n%q", w, inner, line)
+		}
+	}
+	if !strings.Contains(hint, "C assistant") {
+		t.Error("the assistant button must survive the width squeeze — it is the headline affordance")
+	}
+	if !strings.Contains(hint, "esc close") {
+		t.Error("the exit hint must survive the width squeeze")
+	}
+	// The dropped one is the advanced toggle, and `a` still works regardless.
+	if strings.Contains(hint, "advanced") {
+		t.Error("at this width the advanced toggle should have been shed to make room")
+	}
+}
+
+// TestConfigPaneShowsAllHintsWhenWide pins the other side: given room, nothing is
+// dropped — the advanced toggle returns alongside the assistant button.
+func TestConfigPaneShowsAllHintsWhenWide(t *testing.T) {
+	c := newTestConfigPane(t) // sized 100 wide by the helper
+	hint := c.renderHints()
+	for _, want := range []string{"advanced", "C assistant", "esc close"} {
+		if !strings.Contains(hint, want) {
+			t.Errorf("a wide box must show every hint, missing %q:\n%q", want, hint)
+		}
+	}
+}
+
+// TestConfigPaneAssistantKeyIsInertWhileEditing guards the one collision: C is a
+// perfectly ordinary character to type into a value field (a path under
+// /home/carol, a branch prefix). While a value is being edited, C must reach the
+// field as text and must NOT open the assistant.
+func TestConfigPaneAssistantKeyIsInertWhileEditing(t *testing.T) {
+	c := newTestConfigPane(t)
+	c.beginEdit()
+	if !c.IsEditing() {
+		t.Fatal("precondition: a value field must be open")
+	}
+
+	c.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'C'}})
+
+	if c.TakeAssistantRequest() {
+		t.Error("C typed into a value field must be text, not the assistant button")
+	}
+	if !c.IsEditing() {
+		t.Error("typing C must not close the edit field")
+	}
+	if !strings.Contains(c.EditValueForTest(), "C") {
+		t.Errorf("C must reach the value field as a character, got %q", c.EditValueForTest())
+	}
+}

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6878,7 +6878,10 @@ var ConfigPane = class {
         "div",
         { class: "af-config-control" },
         h("code", { class: "af-config-value" }, e.value),
-        h("span", { class: "af-config-readonly" }, e.edit_hint ?? "hand-edited in config.toml")
+        // edit_hint is always populated for a read-only row (the manifest's
+        // assistantEditHint since #2454); the fallback only guards a malformed
+        // payload and must not resurrect the retired "hand-edit the file" copy.
+        h("span", { class: "af-config-readonly" }, e.edit_hint ?? "the config assistant can change this for you")
       );
     }
     if (kind === "checkbox") {

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "d3754af6f1d7";
+const VERSION = "69169b93fc01";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -1476,10 +1476,12 @@ test("config: the editor renders from the manifest and writes through the real p
   await expect(overrides.locator("input, select")).toHaveCount(0);
   await expect(overrides.locator(".af-config-readonly")).toContainText("af config set program_overrides.<name>");
 
-  // A hand-edited key is shown but never offered as a field whose save could only
-  // be refused.
+  // A structured key with no `af config set` scalar form is shown but never
+  // offered as a field whose save could only be refused. Its hint points at the
+  // config assistant, which edits these in the file — #2454 retired the old
+  // "hand-edit the file yourself" copy, and this assertion moves with it.
   const readOnly = pane.locator('.af-config-row[data-key="theme"] .af-config-readonly');
-  await expect(readOnly).toHaveText(/hand-edited/);
+  await expect(readOnly).toHaveText(/config assistant/);
   await expect(page.locator('.af-config-row[data-key="theme"] input')).toHaveCount(0);
 
   // Back to the sessions view for the flows that follow.

--- a/web/src/config.test.ts
+++ b/web/src/config.test.ts
@@ -140,8 +140,10 @@ test("the control for a key is decided by the manifest, so an unknown key still 
   assert.equal(controlFor(entry({ type: "string", enum: ["stable", "preview"] })), "select");
   assert.equal(controlFor(entry({ type: "string" })), "text");
   assert.equal(controlFor(entry({ type: "int" })), "text");
-  // A hand-edited key is never offered as a field: the write would be refused,
-  // so an editable-looking control would be a dead end.
+  // A structured key with no scalar `af config set` form is never offered as a
+  // field: the write would be refused, so an editable-looking control would be a
+  // dead end. Its hint points at the config assistant (#2454), but the CONTROL is
+  // still read-only regardless of the copy.
   assert.equal(controlFor(entry({ settable: false, editable: false, type: "table" })), "readonly");
   // A DYNAMIC FAMILY is the subtle one, and the reason the control reads
   // `editable` rather than `settable`. program_overrides is settable — its

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -295,7 +295,10 @@ export class ConfigPane {
         "div",
         { class: "af-config-control" },
         h("code", { class: "af-config-value" }, e.value),
-        h("span", { class: "af-config-readonly" }, e.edit_hint ?? "hand-edited in config.toml"),
+        // edit_hint is always populated for a read-only row (the manifest's
+        // assistantEditHint since #2454); the fallback only guards a malformed
+        // payload and must not resurrect the retired "hand-edit the file" copy.
+        h("span", { class: "af-config-readonly" }, e.edit_hint ?? "the config assistant can change this for you"),
       );
     }
 


### PR DESCRIPTION
## Summary

Makes the config assistant an always-available button on the config surface (#2453), and eliminates the "hand-edited-only config" concept by making the assistant the editor for the keys that had no `af config set` form (#2454). One PR, per the maintainer's decision to lean on the assistant.

## What already existed (investigated first)

The TUI was already wired end to end: `C` → guarded spawn → readiness/trust-prompt/receipt handling → `tea.ExecProcess` takeover → detach → `ReapConfigAgent` → reload. The agent runs at **AF home**, needs no repo, and is reaped on close. So "on-demand, ephemeral, non-project" was already true — `SpawnConfigAgent`/`ReapConfigAgent` did not need building. The gaps were only the *trigger* (a hotkey, not a button) and the *web* (nothing).

## Decisions implemented (confirmed by the maintainer)

- **Fork 2A — the button.** `C` in the config editor overlay opens the assistant through the existing spawn/attach/reap path. The pane records the request and closes; the app spawns the agent. The `C` hotkey stays. No embedded pane was built.
- **Fork 1 — TUI-only.** No web streaming: the WS PTY route binds an instance+tab, and a config agent is a bare tmux session, so a web chat pane is a tracked follow-up. The web config pane renders the assistant hint as guidance, no chat.
- **Fork 3 — the assistant edits the five global structured keys directly.** `theme`, the `[keys]` rebinds, `root_agents`, `session_env_passthrough`, `cors_allowed_origins` have no scalar `af config set` form, so the briefing now tells the agent to edit the global config file directly and **validate after**. The five **repo-scoped** keys stay off-limits — the no-repo-files fence is intact, widened only to the one global file.

## The pieces

- **`af config validate`** (new, read-only): reuses `LoadConfigReadOnly`, materializes and mutates nothing. It is the validate-after step. A direct structured edit is a hard startup failure with no fallback to defaults, so the briefing requires validating after each such edit and fixing on failure — the safety net `af config set` gives for free but a hand-edit does not.
- **The briefing** reverses the old *"`af config set` cannot write it, do not try, point them at the file"* text and authorizes the direct edit + validate, while keeping the scope fence (*"Do not read, create, edit, move or delete any file in any repository"*) and widening the write permission to exactly one file: the global config, *"never a repository's own `.agent-factory` config"*.
- **#2454 hint** (`editability`): the read-only hint no longer says "hand-edited in config.toml". It is one surface-neutral string pointing at the assistant. `TestStructuralKeysSayTheyAreHandEdited` is replaced by `TestStructuralKeysPointAtTheAssistant`, which also fails if any read-only key still sends the user to a text editor.
- **Hint-row width.** Adding "C assistant" pushes the hint row ~1 column past the 64-wide overlay's inner width, so it would wrap "esc close" onto a second line. The pane sheds the advanced-toggle hint when the row won't fit (the assistant button and the exit always survive), matching the hintDropOrder pattern (#1936) rather than wrapping.

## The #2454 audit that led here

Ten keys were `Settable:false`. None were obsolete; `schema_version` is the only genuinely-internal key (already excluded). The five global ones are shape-blocked (tables/lists), the five repo-scoped ones scope-blocked. This PR makes the assistant the editor for the five global ones and points every read-only hint at it, so "hand-edit the file" stops being an instruction the product gives.

## Real-TUI drive (`scripts/tui-2453-scenario.sh`)

This is visible TUI, so it was driven through the real rendered TUI at **100x30 and 80x24**:

```
assert OK: the config overlay advertises the assistant button (100x30)
assert OK: the button spawned a bare config-agent session (af_af-config-1)
PASS: #2453 button + spawn at 100x30
assert OK: the config overlay advertises the assistant button (80x24)
assert OK: the button spawned a bare config-agent session (af_af-config-1)
PASS: #2453 button + spawn at 80x24
validate OK: a valid [theme] edit passes
validate OK: a broken edit fails loudly (rc=1)
validate OK: the restored config passes
PASS: #2453 edit→validate mechanism
```

The button assertion proves the affordance is visible and that pressing it spawns a **bare** config-agent session (on demand, non-project — the af_af-config-* name) with no #2019 attach error, at both geometries. The keying is on the daemon-side session rather than screen chrome, because the overlay goes full-screen at the narrow geometry (#1821). The edit→validate contract is driven against the real `af` binary — a valid `[theme]` edit validates, a broken edit fails loudly, a restore validates again — the exact recipe the briefing gives the assistant. A live-model conversational round-trip is not reproducible in the hermetic sandbox (no real LLM there); the mechanism it would use is what's proven.

The return-to-TUI-on-detach path is unchanged by this PR — the button reaches the same enterConfigAgent/ReapConfigAgent flow the nav hotkey does, which `make tui-driver-selftest` already gates end to end (#2019).

## Verification

Exact pushed head: `4ee7144b`

- `go build ./...`, `go vet ./...`
- `gofmt -l .` (no output) · `golangci-lint run --timeout=3m --fast` · `deadcode -test ./...` (no output)
- `scripts/lint-file-length.sh` (1023 files, 0 grandfathered)
- generated-artifact drift: `scripts/gen-docs.sh` + `make web-build`, `git status` clean both directions
- `make web-test` (418 passed) — the config.ts fallback change
- parity ledger updated: new `config.validate` capability (n/a on TUI/web — their edits are validated by construction; the assistant runs validate itself) + the verb/flag entries
- `make test-container`
- real-TUI scenario at 100x30 and 80x24

Closes #2453
Closes #2454
