### PR TITLE
fix(configagent): suppress devin's workspace-trust modal on spawn (#2435)

### DIFF
--- a/configagent/agent.go
+++ b/configagent/agent.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/preflight"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 // The config agent (phase 2): the user's own default agent, spawned as an
@@ -161,7 +162,9 @@ func Spawn(opts Options) (string, string, error) {
 	command := config.ResolveProgram(agentCfg, agent)
 
 	// Check the binary before spending a daemon round trip, a tmux session and a
-	// readiness wait on a program that cannot start.
+	// readiness wait on a program that cannot start. Checked against the resolved
+	// command BEFORE the trust flag is appended below, so an unavailable-program
+	// error names the command the user configured, not one with an af flag on it.
 	if _, perr := preflight.CheckProgram(agentCfg, agent); perr != nil {
 		return "", "", &ProgramUnavailableError{
 			Agent:   agent,
@@ -169,6 +172,15 @@ func Spawn(opts Options) (string, string, error) {
 			Err:     preflight.ProgramError(agent, command, perr),
 		}
 	}
+
+	// Suppress devin's first-run workspace-trust modal the same way an ordinary
+	// session does. This path never runs injectSystemPrompt — a config agent edits
+	// config, has no worktree, and must not inherit skill/plugin injection — but
+	// without the trust flag a devin config agent launches bare, hangs on the modal
+	// for the full readiness timeout, and is reaped (#2435). Scoped to the trust
+	// flag only, via the shared helper both launch paths call; a non-devin command
+	// is returned unchanged.
+	command = tmux.EnsureDevinWorkspaceTrustSuppressed(command)
 
 	name, socketPath, err := spawnViaDaemon(daemon.SpawnConfigAgentRequest{
 		Program: command,

--- a/configagent/agent_test.go
+++ b/configagent/agent_test.go
@@ -2,6 +2,8 @@ package configagent
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -134,6 +136,43 @@ func TestSpawnMissingProgramReturnsTypedErrorAndCreatesNothing(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not installed or not on PATH") {
 		t.Errorf("error should be preflight's actionable message, got: %v", err)
+	}
+}
+
+// TestSpawnSuppressesDevinWorkspaceTrust is the #2435 regression at the client
+// seam. A user whose default_program is devin got a config agent that launched
+// bare and hung on devin's first-run workspace-trust modal for the full readiness
+// timeout, then was reaped. The config-agent path deliberately does not run
+// injectSystemPrompt — it edits config, has no worktree, and must not inherit
+// skill/plugin injection — so the trust flag has to be applied on this path or
+// nowhere.
+//
+// The fixture is a real executable named "devin" that the override points at, the
+// same shape as a user's installed devin: preflight checks the binary exists, and
+// DetectAgentFromCommand keys on the "devin" basename to recognize it.
+func TestSpawnSuppressesDevinWorkspaceTrust(t *testing.T) {
+	tempAFHome(t)
+	devinPath := filepath.Join(t.TempDir(), "devin")
+	if err := os.WriteFile(devinPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write devin fixture: %v", err)
+	}
+	stubResolve(t, config.Config{
+		DefaultProgram:   "devin",
+		ProgramOverrides: map[string]string{"devin": devinPath},
+	})
+
+	var got daemon.SpawnConfigAgentRequest
+	stubSpawn(t, func(req daemon.SpawnConfigAgentRequest) (string, string, error) {
+		got = req
+		return "af-config-1", "", nil
+	})
+
+	if _, _, err := Spawn(Options{Mode: ModeOnboard, RepoPath: "/tmp/some-repo"}); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	want := devinPath + " --respect-workspace-trust false"
+	if got.Program != want {
+		t.Errorf("config agent must launch devin with its workspace-trust modal suppressed, or it hangs on the modal and is reaped (#2435);\n got Program = %q\nwant Program = %q", got.Program, want)
 	}
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,12 +133,13 @@ it does not approve later tool calls or actions.
 
 **Devin** is the exception: af suppresses the dialog at launch instead of
 dismissing it, appending `--respect-workspace-trust false` — af created and owns
-the worktree, so it is already trusted. Your own value wins if you set one, so
-include the flag in a custom `program_overrides.devin` only when you want to
-choose it; af appends it when your override omits it. Two cases fall outside that
-suppression and will show devin's modal, which af has no dismissal for: setting
-`--respect-workspace-trust true` explicitly, and agent-assisted `af config` when
-`default_program` is devin ([#2435](https://github.com/sachiniyer/agent-factory/issues/2435)).
+the worktree, so it is already trusted. This applies to every launch path af
+controls, ordinary sessions and agent-assisted `af config` alike. Your own value
+wins if you set one, so include the flag in a custom `program_overrides.devin`
+only when you want to choose it; af appends it when your override omits it. The
+one way to still see the modal is to set `--respect-workspace-trust true`
+yourself: af leaves your explicit choice alone, and it has no dismissal for the
+dialog once it renders.
 
 Codex's **additional safety checks** model-routing picker is separate from
 approval and sandbox flags. The daemon recognizes the known

--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -234,37 +234,13 @@ func injectSystemPrompt(resolved string) string {
 		if _, err := ensureDevinSkillDir(); err != nil {
 			log.WarningLog.Printf("failed to set up devin af skill, af guidance unavailable to devin: %v", err)
 		}
-		// af created and owns this worktree, so it is trusted. Suppress devin's
-		// interactive workspace-trust modal ("Do you trust the authors of this
-		// directory?") so the session reaches ready WITHOUT a human answering it —
-		// there is no reliable, anchored dismissal for it and gating on it would
-		// race the modal (the #729 class). --respect-workspace-trust false disables
-		// the gate in interactive mode (verified against devin 3000.2.17).
-		//
-		// CONDITIONAL append, not unconditional: devin rejects a repeated
-		// --respect-workspace-trust ("cannot be used multiple times" — verified),
-		// so appending it when the resolved command already carries the flag would
-		// crash the launch. `resolved` has already folded in any
-		// program_overrides.devin, so skipping when the flag is present lets a user
-		// set --permission-mode via program_overrides without collision, and lets a
-		// user who set --respect-workspace-trust explicitly (either value) win.
-		//
-		// Unlike claude's --plugin-dir, this is NOT a repeatable flag and CAN be
-		// persisted into a user's program_overrides, so it needs the guard the
-		// unconditional appends above do not.
-		if devinCarriesWorkspaceTrustFlag(resolved) {
-			return resolved
-		}
-		return resolved + " --respect-workspace-trust false"
+		// af created and owns this worktree, so it is trusted: suppress devin's
+		// interactive workspace-trust modal so the session reaches ready without a
+		// human answering it. The suppression — and its guard against devin's
+		// rejection of a repeated flag — is shared with the config-agent launch path
+		// through tmux.EnsureDevinWorkspaceTrustSuppressed, one place so the two
+		// launch paths cannot drift (#2435; the #729/#2097/#2416 drift class).
+		return tmux.EnsureDevinWorkspaceTrustSuppressed(resolved)
 	}
 	return resolved
-}
-
-// devinCarriesWorkspaceTrustFlag reports whether a resolved devin command
-// already specifies --respect-workspace-trust (in any position or value form),
-// so injectSystemPrompt does not append a second one — devin rejects the flag
-// given twice. The name is distinctive enough that a substring check cannot
-// false-match another flag.
-func devinCarriesWorkspaceTrustFlag(resolved string) bool {
-	return strings.Contains(resolved, "--respect-workspace-trust")
 }

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -84,12 +84,14 @@ func IsSupportedProgram(name string) bool {
 // only the false-positive exposure above. #2410 declined to treat an unclearable
 // dialog as handled for the same reason, which is the #729 trap.
 //
-// This is NOT the claim that devin never shows the modal. Two paths arm it:
-// the config-agent spawn, which never calls injectSystemPrompt and so never gets
-// --respect-workspace-trust false (#2435); and any session whose
-// program_overrides.devin already carries the flag, since devinCarriesWorkspaceTrustFlag
-// deliberately lets a user's explicit value win. Closing those needs an anchored
-// devin predicate, not a change here.
+// This is NOT the claim that devin never shows the modal. af suppresses it on
+// every launch path it owns — ordinary sessions through injectSystemPrompt and the
+// config-agent spawn directly, both via EnsureDevinWorkspaceTrustSuppressed
+// (#2435). The one remaining way it renders is a program_overrides.devin that sets
+// --respect-workspace-trust true explicitly, which that helper deliberately leaves
+// alone so a user's own choice wins — opt-in, and not something af can silently
+// dismiss. Closing even that would need an anchored devin predicate, not a change
+// here.
 //
 // TestProgramNeedsTrustDismissal_ClassifiesEverySupportedAgent forces a new agent
 // to record which side it is on rather than defaulting quietly out of the set.
@@ -99,6 +101,44 @@ func ProgramNeedsTrustDismissal(program string) bool {
 		return true
 	}
 	return false
+}
+
+// devinWorkspaceTrustFlag is devin's interactive workspace-trust switch. af
+// created and owns the worktree it launches devin in, so devin is launched with
+// this flag set false — the trusted-workspace answer — rather than being asked.
+const devinWorkspaceTrustFlag = "--respect-workspace-trust"
+
+// EnsureDevinWorkspaceTrustSuppressed appends "--respect-workspace-trust false"
+// to a devin launch command so devin's first-run workspace-trust modal ("Do you
+// trust the authors of this directory?") never renders and the session reaches
+// ready with no human answering it (verified against devin 3000.2.17).
+//
+// This is the ONE place the suppression lives, and every path that launches devin
+// under af calls it. Ordinary worktree sessions reach it through
+// injectSystemPrompt; the config-agent spawn reaches it directly (#2435). That
+// path is deliberately OUTSIDE injectSystemPrompt's skill-injection seam — a
+// config agent edits config, it has no worktree and must not inherit plugin/skill
+// files — so before this it launched bare devin and hung on the modal for the full
+// readiness timeout before being reaped. Two launch paths each re-deriving the
+// flag is exactly the drift that produced #729/#2097/#2416; one function is how
+// they cannot disagree.
+//
+// Two conditions, both load-bearing:
+//   - A non-devin command is returned unchanged. A program_overrides entry can
+//     point "devin" at another binary (the #1116/#1131 class); appending a devin
+//     flag to it would make that binary exit on an unknown argument.
+//   - A command already carrying --respect-workspace-trust is left alone. devin
+//     rejects the flag given twice ("cannot be used multiple times", verified), so
+//     a second would crash the launch — and a user who set the flag explicitly
+//     (either value) must win.
+func EnsureDevinWorkspaceTrustSuppressed(command string) string {
+	if DetectAgentFromCommand(command) != ProgramDevin {
+		return command
+	}
+	if strings.Contains(command, devinWorkspaceTrustFlag) {
+		return command
+	}
+	return command + " " + devinWorkspaceTrustFlag + " false"
 }
 
 // TmuxSession represents a managed tmux session

--- a/session/tmux/trust_prompt_gate_test.go
+++ b/session/tmux/trust_prompt_gate_test.go
@@ -1,6 +1,9 @@
 package tmux
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestProgramNeedsTrustDismissal_ClassifiesEverySupportedAgent is the drift lock
 // for #2416.
@@ -86,5 +89,64 @@ func TestProgramNeedsTrustDismissal_RejectsNonAgents(t *testing.T) {
 		if ProgramNeedsTrustDismissal(program) {
 			t.Errorf("ProgramNeedsTrustDismissal(%q) = true, want false for a non-agent", program)
 		}
+	}
+}
+
+// TestEnsureDevinWorkspaceTrustSuppressed is the shared-helper contract both
+// launch paths depend on (#2435): injectSystemPrompt for ordinary sessions and
+// the config-agent spawn both route devin's launch command through here so its
+// first-run workspace-trust modal never renders — and so the two can never drift
+// on how it is suppressed (the #729/#2097/#2416 class).
+//
+// The cases mirror what TestInjectSystemPrompt_Devin already pins for the session
+// path, asserted here against the function itself so the config-agent path is
+// covered by the same contract rather than a copy of it.
+func TestEnsureDevinWorkspaceTrustSuppressed(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{"bare devin gets the flag", "devin", "devin --respect-workspace-trust false"},
+		{
+			"abs-path devin gets the flag",
+			"/home/u/.local/bin/devin",
+			"/home/u/.local/bin/devin --respect-workspace-trust false",
+		},
+		{
+			"a permission-mode override composes with the flag",
+			"devin --permission-mode accept-edits",
+			"devin --permission-mode accept-edits --respect-workspace-trust false",
+		},
+		// devin rejects a repeated --respect-workspace-trust ("cannot be used
+		// multiple times"), so an already-present flag must be left untouched — in
+		// either value form, so a user's explicit choice wins.
+		{
+			"already false is left alone",
+			"devin --respect-workspace-trust false",
+			"devin --respect-workspace-trust false",
+		},
+		{
+			"an explicit true wins",
+			"devin --respect-workspace-trust true",
+			"devin --respect-workspace-trust true",
+		},
+		// A program_overrides entry can point "devin" at another binary (#1116/#1131);
+		// appending a devin flag would make that binary exit on an unknown argument.
+		{"a non-devin command is unchanged", "bash", "bash"},
+		{"a claude command is unchanged", "claude --dangerously-skip-permissions", "claude --dangerously-skip-permissions"},
+		{"empty is unchanged", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EnsureDevinWorkspaceTrustSuppressed(tt.command); got != tt.want {
+				t.Errorf("EnsureDevinWorkspaceTrustSuppressed(%q) = %q, want %q", tt.command, got, tt.want)
+			}
+			// Whatever the path, the flag must never end up on the command twice —
+			// that is the launch crash the conditional exists to prevent.
+			if got := EnsureDevinWorkspaceTrustSuppressed(tt.command); strings.Count(got, devinWorkspaceTrustFlag) > 1 {
+				t.Errorf("EnsureDevinWorkspaceTrustSuppressed(%q) = %q carries %q more than once", tt.command, got, devinWorkspaceTrustFlag)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #2435.

## The bug

A user whose `default_program` is `devin` got a config agent (`C`) that launched bare `devin`, hung on its first-run workspace-trust modal ("Do you trust the authors of this directory?") for the full 60s readiness timeout, and was then reaped. Agent-assisted config was unusable for those users.

Verified live on current `master` before fixing — this report is not stale, and it is **not** covered by #2428 (which merged deliberately keeping devin out of the trust-*dismissal* gate).

## Why it happened

Ordinary sessions never hit this: `injectSystemPrompt` appends `--respect-workspace-trust false` for devin, so the modal never renders. The config-agent spawn is deliberately **outside** that seam — a config agent edits config, has no worktree, and must not inherit skill/plugin injection — so it never got the flag and launched bare.

The report offered three options and leaned toward #1 (inject the trust flag on the config-agent path too, scoped to the flag only). That's what this does, with one structural change to avoid the drift that keeps biting this area.

## The fix — one shared helper, not a second copy

The trust suppression was written inline in `injectSystemPrompt`'s devin case, which is precisely why only that one path had it. Copying the logic onto the config-agent path would restore the symptom's *cause*: two launch paths each re-deriving the same flag, exactly the "mirrors the other one" drift that produced #729, #2097, and #2416.

So the suppression moves into one function, `tmux.EnsureDevinWorkspaceTrustSuppressed`, and **both** launch paths call it:

- `injectSystemPrompt` (session package) — ordinary worktree sessions, unchanged behavior.
- `configagent.Spawn` (config-agent client) — the config agent, which now gets **only** the trust flag, not the full inject.

The helper keeps the two load-bearing conditions the inline code had:
- **Non-devin commands are returned unchanged** — a `program_overrides` entry can point `"devin"` at another binary (#1116/#1131), and a devin flag would make it exit on an unknown argument.
- **A command already carrying `--respect-workspace-trust` is left alone** — devin rejects the flag twice ("cannot be used multiple times", verified in #2410), and a user who set it explicitly (either value) must win.

### Why the client seam, not the daemon

The config-agent client already owns "what command to launch" — it does `ResolveProgram` and preflight. The daemon takes `req.Program` as authoritative and just spawns it. Applying the flag client-side keeps that split intact and makes the fix directly testable through the existing stub-spawn harness. The flag is appended **after** the preflight check, so an unavailable-program error still names the command the user configured, not one with an af flag on it.

### Not the dismissal gate

devin stays out of `ProgramNeedsTrustDismissal`. af has no anchored predicate for devin's modal, so the correct fix is to keep it from rendering (what this does), not to detect-and-clear it — the #729 trap #2410 declined. This closes the config-agent path that gate's own doc named as still arming the modal; that doc is updated to match (the only remaining arming path is a user explicitly setting `--respect-workspace-trust true`, which is opt-in and working-as-designed).

## Tests

Both watched failing first (the fix stashed):

- **`configagent.TestSpawnSuppressesDevinWorkspaceTrust`** — the seam. A real executable named `devin` (so preflight passes and `DetectAgentFromCommand` keys on it), `default_program = devin`, asserts the spawn request carries `… devin --respect-workspace-trust false`. Failed pre-fix with the bare command:
  ```
  got Program = "…/devin"
  want Program = "…/devin --respect-workspace-trust false"
  ```
- **`tmux.TestEnsureDevinWorkspaceTrustSuppressed`** — the helper contract: bare devin, abs path, permission-mode composition, already-false, explicit-true, non-devin passthrough, and never-twice. (New function, so pre-fix it fails to compile — its absence is the fail-first.)

Behaviour-preservation: the existing `TestInjectSystemPrompt_Devin` matrix still passes unchanged — the session path routes through the same helper and produces byte-identical commands.

## Adjacent-call-site audit

Every af-owned launch site that could run devin:

- `session/backend_local.go:186` (Provision) — placeholder program; the real launch command is set via `injectSystemPrompt` at `:272/:304/:517` → covered.
- `session/instance_data.go:387` (rehydrate) — sets the handle with the persisted command; Restore re-runs `injectSystemPrompt` → covered.
- `daemon/manager_create_names.go:290` — builds a session only to probe name existence; never launched → N/A.
- `daemon/configagent.go:222` — the config agent; fixed via the client seam.

Every path that actually *launches* devin now routes through the one helper.

## Gate

- `gofmt -l .` clean · `go build ./...` clean
- `golangci-lint run --timeout=3m --fast` clean
- `deadcode -test ./...` clean (confirms the removed `devinCarriesWorkspaceTrustFlag` left nothing dangling)
- `scripts/lint-file-length.sh` passed (1023 files)
- `./configagent/... ./session/... ./daemon/...` green
- Full suite via `make test-container` on the pushed head — SHA in a follow-up comment

## Review

Codex is rate-limited until Jul 28. Requesting once; if it stays silent I'll say so explicitly rather than letting green checks imply a review, and this goes to Captain Claude's claude-subagent gate on this exact head. Not self-merging.

— Captain Claude
