### PR TITLE
feat(daemon): add 'af daemon adopt' to reclaim a detached daemon (#2168)

### DIFF
--- a/commands/daemonadoptcmd.go
+++ b/commands/daemonadoptcmd.go
@@ -1,0 +1,180 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/log"
+
+	"github.com/spf13/cobra"
+)
+
+// `af daemon adopt` is #2168 Phase 5's missing recovery verb. The incident left
+// a detached, unsupervised daemon serving the control socket while the installed
+// systemd/launchd unit sat enabled-but-inactive, and no first-class af command
+// could hand supervision back: `systemctl --user restart` found the socket
+// already served, exited 0, and the unit stayed inactive. adopt performs the
+// one operation that reclaims it — stop the detached daemon, start the installed
+// unit in its place, and verify the unit now owns the process answering Ping.
+
+// adoptVerifyGrace bounds how long adopt waits for the freshly started unit to
+// answer Ping AND for the service manager to report it as the owner of that
+// responder. A unit started Type=simple is "active" as soon as it forks, before
+// the daemon binds its socket, so a single check races the bind and the
+// MainPID becoming queryable. Package vars so tests can shorten the failure
+// path; adoptVerifyPoll is the retry cadence, mirroring shutdownComplete* .
+var (
+	adoptVerifyGrace = 5 * time.Second
+	adoptVerifyPoll  = 50 * time.Millisecond
+)
+
+// Indirection points so the adopt orchestration can be tested without touching
+// the host's real service manager, config dir, or daemon. resolveSupervisionOwnerFn
+// derives the owner from the installed unit's baked home (#2168 Phase 3);
+// daemonStopFn SIGTERMs the detached daemon named in daemon.pid. The remaining
+// collaborators (daemonHealthFn, daemonStatusSupervisionFn, restartAutostartUnitFn,
+// waitForShutdownCompletionFn, configDirFn) are shared with the status and
+// restart paths.
+var (
+	resolveSupervisionOwnerFn = daemon.ResolveSupervisionOwner
+	daemonStopFn              = daemon.StopDaemon
+)
+
+var daemonAdoptCmd = &cobra.Command{
+	Use:   "adopt",
+	Short: "Hand a detached daemon back to the installed autostart unit",
+	Long: `Reclaim supervision of the background daemon for the installed autostart unit.
+
+When a daemon is running detached from its unit — an ad-hoc child a live af
+spawned, which the service manager can no longer restart — adopt stops that
+daemon and starts the installed unit in its place, then verifies the unit now
+owns the process answering the control socket. Live sessions keep running in
+tmux; the new supervised daemon re-adopts persisted session state on startup,
+exactly as 'af daemon restart' does.
+
+It needs an installed unit that serves this home ('af daemon install'); with no
+such unit there is nothing to adopt the daemon into. If the installed unit
+already owns the running daemon, adopt reports that and changes nothing.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+		return runDaemonAdopt(cmd.OutOrStdout())
+	},
+}
+
+func runDaemonAdopt(w io.Writer) error {
+	configDir, err := configDirFn()
+	if err != nil {
+		return fmt.Errorf("cannot resolve the config dir to find the daemon autostart unit: %w", err)
+	}
+	owner, err := resolveSupervisionOwnerFn(configDir)
+	if err != nil {
+		// Fail-closed. An unreadable or unparseable unit resolves to OwnerUnknown,
+		// and if the service manager cannot be consulted we could neither prove the
+		// running daemon unsupervised nor start the unit — so we do not touch a
+		// possibly-healthy daemon on missing evidence.
+		return fmt.Errorf("cannot determine the daemon supervision owner for this home, so refusing to adopt: %w", err)
+	}
+	if owner != daemon.OwnerUnit {
+		return fmt.Errorf("no installed autostart unit serves this home, so there is nothing to hand the daemon to — run `af daemon install` first")
+	}
+
+	// If a daemon is already serving and the installed unit already owns it,
+	// there is nothing to adopt: do not cycle a healthy supervised daemon.
+	h := daemonHealthFn()
+	stoppedDetached := false
+	if h.PingErr == nil {
+		var (
+			alreadyOwned bool
+			cannotTell   error
+		)
+		daemon.ServingDaemonSupervised(h, daemonStatusSupervisionFn()).Match(
+			func() { alreadyOwned = true },
+			func() {},
+			func() {},
+			func(cause error) { cannotTell = cause },
+		)
+		if alreadyOwned {
+			fmt.Fprintf(w, "daemon already adopted: the installed unit owns the responding daemon (pid %d)\n", h.ServingPID)
+			return nil
+		}
+		if cannotTell != nil {
+			// Fail-closed: we could not prove the running daemon is unsupervised.
+			// Displacing it on missing evidence risks killing a healthy supervised
+			// daemon, so refuse and point at the diagnostic instead.
+			return fmt.Errorf("cannot confirm whether the running daemon is already supervised, so refusing to displace it: %w — run `af doctor` for detail", cannotTell)
+		}
+		// A detached, unsupervised daemon is serving. Stop it and wait for its
+		// control socket to go quiet so the unit's fresh daemon acquires the freed
+		// singleton lock instead of exiting against a still-live socket (#854).
+		if _, err := daemonStopFn(); err != nil {
+			return fmt.Errorf("failed to stop the unsupervised daemon before adopting: %w", err)
+		}
+		if err := waitForShutdownCompletionFn(); err != nil {
+			return fmt.Errorf("the unsupervised daemon did not release the control socket, so the installed unit cannot take it over: %w", err)
+		}
+		stoppedDetached = true
+	}
+
+	// Start the daemon under the installed unit. RestartAutostartUnit clears
+	// Phase 1's crash-loop backstop (reset-failed) and starts a fresh supervised
+	// daemon — an explicit adopt is exactly the recovery path meant to clear it.
+	if err := restartAutostartUnitFn(); err != nil {
+		return fmt.Errorf("failed to start the installed autostart unit: %w", err)
+	}
+
+	answer, verified := verifyAdoption()
+	var adoptErr error
+	answer.Match(
+		func() {
+			if stoppedDetached {
+				fmt.Fprintf(w, "daemon adopted: stopped the unsupervised daemon and handed supervision to the installed unit (pid %d)\n", verified.ServingPID)
+			} else {
+				fmt.Fprintf(w, "daemon adopted: the installed unit now supervises the daemon (pid %d)\n", verified.ServingPID)
+			}
+		},
+		func() {
+			adoptErr = fmt.Errorf("started the installed unit, but pid %d is answering while the unit is not reported as its owner — run `af doctor` to inspect supervision", verified.ServingPID)
+		},
+		func() {
+			adoptErr = fmt.Errorf("started the installed unit, but the service manager has no record of it owning the responder — run `af doctor` to inspect supervision")
+		},
+		func(cause error) {
+			adoptErr = fmt.Errorf("started the installed unit, but could not confirm it owns the responding daemon: %w — run `af doctor`", cause)
+		},
+	)
+	return adoptErr
+}
+
+// verifyAdoption polls until the responding daemon is the installed unit's, or
+// the grace elapses. A negative answer (the responder is not the unit's) or an
+// undetermined one (the daemon has not answered Ping yet, or the manager has not
+// yet reported MainPID) is retried, because both settle in the seconds after a
+// unit start: only a persistent answer at the deadline is reported. It returns
+// the final supervision answer and the last health snapshot so the caller can
+// name the exact responding pid.
+func verifyAdoption() (daemon.ProbeAnswer, daemon.HealthStatus) {
+	deadline := time.Now().Add(adoptVerifyGrace)
+	for {
+		h := daemonHealthFn()
+		var answer daemon.ProbeAnswer
+		if h.PingErr != nil {
+			answer = daemon.Undetermined(fmt.Errorf("the installed unit's daemon did not answer Ping: %w", h.PingErr))
+		} else {
+			answer = daemon.ServingDaemonSupervised(h, daemonStatusSupervisionFn())
+		}
+		adopted := false
+		answer.Match(func() { adopted = true }, func() {}, func() {}, func(error) {})
+		if adopted || !time.Now().Before(deadline) {
+			return answer, h
+		}
+		time.Sleep(adoptVerifyPoll)
+	}
+}
+
+func init() {
+	daemonCmd.AddCommand(daemonAdoptCmd)
+}

--- a/commands/daemonadoptcmd_test.go
+++ b/commands/daemonadoptcmd_test.go
@@ -1,0 +1,204 @@
+package commands
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/stretchr/testify/require"
+)
+
+// The adopt orchestration is driven entirely through injected collaborators, so
+// none of these tests touches the host's real systemctl/launchctl, config dir,
+// or daemon — a real supervised daemon may be running on the box executing them.
+
+// stubAdoptVars snapshots and restores every collaborator runDaemonAdopt reaches,
+// then installs safe defaults: config resolves, the installed unit owns this home,
+// the verify budget is tiny so failure paths resolve fast, and the mutating
+// collaborators fail the test loudly if a case reaches them without opting in.
+func stubAdoptVars(t *testing.T) {
+	t.Helper()
+	prevConfigDir := configDirFn
+	prevResolve := resolveSupervisionOwnerFn
+	prevHealth := daemonHealthFn
+	prevSupervision := daemonStatusSupervisionFn
+	prevStop := daemonStopFn
+	prevWait := waitForShutdownCompletionFn
+	prevRestart := restartAutostartUnitFn
+	prevGrace := adoptVerifyGrace
+	prevPoll := adoptVerifyPoll
+	t.Cleanup(func() {
+		configDirFn = prevConfigDir
+		resolveSupervisionOwnerFn = prevResolve
+		daemonHealthFn = prevHealth
+		daemonStatusSupervisionFn = prevSupervision
+		daemonStopFn = prevStop
+		waitForShutdownCompletionFn = prevWait
+		restartAutostartUnitFn = prevRestart
+		adoptVerifyGrace = prevGrace
+		adoptVerifyPoll = prevPoll
+	})
+
+	configDirFn = func() (string, error) { return "/home/af", nil }
+	resolveSupervisionOwnerFn = func(string) (daemon.SupervisionOwner, error) { return daemon.OwnerUnit, nil }
+	adoptVerifyGrace = 20 * time.Millisecond
+	adoptVerifyPoll = time.Millisecond
+	daemonHealthFn = func() daemon.HealthStatus { return daemon.HealthStatus{PingErr: errors.New("no daemon")} }
+	daemonStatusSupervisionFn = func() daemon.SupervisionInfo {
+		return daemon.SupervisionInfo{Supported: true, UnitPresent: true}
+	}
+	daemonStopFn = func() (bool, error) { t.Fatal("StopDaemon must not be called on this path"); return false, nil }
+	waitForShutdownCompletionFn = func() error { t.Fatal("WaitForShutdownCompletion must not be called on this path"); return nil }
+	restartAutostartUnitFn = func() error { t.Fatal("RestartAutostartUnit must not be called on this path"); return nil }
+}
+
+func respondingHealth(pid int) daemon.HealthStatus { return daemon.HealthStatus{ServingPID: pid} }
+
+func supervisedInfo(mainPID int) daemon.SupervisionInfo {
+	return daemon.SupervisionInfo{
+		Supported: true, UnitPresent: true, Active: daemon.AnswerYes(),
+		MainPID: mainPID, MainPIDPresent: daemon.AnswerYes(),
+	}
+}
+
+func inactiveInfo() daemon.SupervisionInfo {
+	return daemon.SupervisionInfo{Supported: true, UnitPresent: true, Active: daemon.AnswerNo()}
+}
+
+func TestAdopt_NoUnitServingHome_RefusesWithInstallHint(t *testing.T) {
+	stubAdoptVars(t)
+	resolveSupervisionOwnerFn = func(string) (daemon.SupervisionOwner, error) { return daemon.OwnerAdHoc, nil }
+
+	var out bytes.Buffer
+	err := runDaemonAdopt(&out)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "af daemon install",
+		"with no installed unit there is nothing to adopt into; point the user at install")
+	require.Empty(t, out.String())
+}
+
+func TestAdopt_OwnerUnknown_FailsClosed(t *testing.T) {
+	stubAdoptVars(t)
+	resolveSupervisionOwnerFn = func(string) (daemon.SupervisionOwner, error) {
+		return daemon.OwnerUnknown, errors.New("unit file is unreadable")
+	}
+
+	var out bytes.Buffer
+	err := runDaemonAdopt(&out)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "refusing to adopt",
+		"an unresolvable owner must not authorize touching a possibly-healthy daemon")
+	require.Contains(t, err.Error(), "unit file is unreadable", "the cause must ride along")
+}
+
+func TestAdopt_AlreadyOwned_NoOp(t *testing.T) {
+	stubAdoptVars(t)
+	daemonHealthFn = func() daemon.HealthStatus { return respondingHealth(222) }
+	daemonStatusSupervisionFn = func() daemon.SupervisionInfo { return supervisedInfo(222) }
+	// daemonStopFn/restartAutostartUnitFn keep their t.Fatal guards: a healthy
+	// supervised daemon must never be cycled.
+
+	var out bytes.Buffer
+	err := runDaemonAdopt(&out)
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "already adopted")
+	require.Contains(t, out.String(), "pid 222")
+}
+
+func TestAdopt_UndeterminedSupervision_RefusesToDisplace(t *testing.T) {
+	stubAdoptVars(t)
+	daemonHealthFn = func() daemon.HealthStatus { return respondingHealth(222) }
+	daemonStatusSupervisionFn = func() daemon.SupervisionInfo {
+		return daemon.SupervisionInfo{Supported: true, UnitPresent: true, Active: daemon.Undetermined(errors.New("user bus is down"))}
+	}
+
+	var out bytes.Buffer
+	err := runDaemonAdopt(&out)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "refusing to displace",
+		"a fabricated negative here would send the user to kill a healthy supervised daemon")
+	require.Contains(t, err.Error(), "af doctor")
+}
+
+func TestAdopt_DetachedDaemon_StopsStartsVerifies(t *testing.T) {
+	stubAdoptVars(t)
+	started := false
+	stopCalls, waitCalls, restartCalls := 0, 0, 0
+	daemonStopFn = func() (bool, error) { stopCalls++; return true, nil }
+	waitForShutdownCompletionFn = func() error { waitCalls++; return nil }
+	restartAutostartUnitFn = func() error { started = true; restartCalls++; return nil }
+	daemonHealthFn = func() daemon.HealthStatus {
+		if started {
+			return respondingHealth(222)
+		}
+		return respondingHealth(111)
+	}
+	daemonStatusSupervisionFn = func() daemon.SupervisionInfo {
+		if started {
+			return supervisedInfo(222)
+		}
+		return inactiveInfo()
+	}
+
+	var out bytes.Buffer
+	err := runDaemonAdopt(&out)
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "stopped the unsupervised daemon")
+	require.Contains(t, out.String(), "pid 222")
+	require.Equal(t, 1, stopCalls, "the detached daemon must be stopped exactly once")
+	require.Equal(t, 1, waitCalls, "adopt must wait for the socket to go quiet before starting the unit")
+	require.Equal(t, 1, restartCalls, "the unit must be started once")
+}
+
+func TestAdopt_NothingRunning_StartsUnderUnit(t *testing.T) {
+	stubAdoptVars(t)
+	started := false
+	restartCalls := 0
+	restartAutostartUnitFn = func() error { started = true; restartCalls++; return nil }
+	daemonHealthFn = func() daemon.HealthStatus {
+		if started {
+			return respondingHealth(222)
+		}
+		return daemon.HealthStatus{PingErr: errors.New("no daemon")}
+	}
+	daemonStatusSupervisionFn = func() daemon.SupervisionInfo {
+		if started {
+			return supervisedInfo(222)
+		}
+		return inactiveInfo()
+	}
+	// daemonStopFn/waitForShutdownCompletionFn keep their guards: with nothing
+	// serving there is no detached daemon to stop.
+
+	var out bytes.Buffer
+	err := runDaemonAdopt(&out)
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "now supervises the daemon")
+	require.Contains(t, out.String(), "pid 222")
+	require.Equal(t, 1, restartCalls)
+}
+
+func TestAdopt_VerifyFails_ReportsDoctor(t *testing.T) {
+	stubAdoptVars(t)
+	started := false
+	daemonStopFn = func() (bool, error) { return true, nil }
+	waitForShutdownCompletionFn = func() error { return nil }
+	restartAutostartUnitFn = func() error { started = true; return nil }
+	daemonHealthFn = func() daemon.HealthStatus {
+		if started {
+			return respondingHealth(333)
+		}
+		return respondingHealth(111)
+	}
+	// The unit never takes ownership: a detached responder keeps answering.
+	daemonStatusSupervisionFn = func() daemon.SupervisionInfo { return inactiveInfo() }
+
+	var out bytes.Buffer
+	err := runDaemonAdopt(&out)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "pid 333")
+	require.Contains(t, err.Error(), "af doctor")
+	require.Empty(t, out.String(), "a failed adopt must not print a success line")
+}

--- a/commands/daemoncmd.go
+++ b/commands/daemoncmd.go
@@ -304,12 +304,12 @@ func printDaemonStatusHuman(cmd *cobra.Command, info daemonStatusInfo) {
 			case !info.AutostartUnit:
 				fmt.Fprintln(w, "  warning:        responding daemon is not supervised because no autostart unit serves this home")
 			case info.AutostartActive == "no" || info.AutostartActive == "not-found":
-				fmt.Fprintln(w, "  warning:        daemon is responding, but the installed unit is not running it — the responder is not supervised")
+				fmt.Fprintln(w, "  warning:        daemon is responding, but the installed unit is not running it — the responder is not supervised; run `af daemon adopt` to hand it back")
 			case info.UnitPID > 0:
-				fmt.Fprintf(w, "  warning:        responding daemon pid %d is not supervised by the installed unit, which owns pid %d\n",
+				fmt.Fprintf(w, "  warning:        responding daemon pid %d is not supervised by the installed unit, which owns pid %d; run `af daemon adopt` to hand it back\n",
 					info.ServingPID, info.UnitPID)
 			default:
-				fmt.Fprintln(w, "  warning:        responding daemon is not supervised by the installed unit")
+				fmt.Fprintln(w, "  warning:        responding daemon is not supervised by the installed unit; run `af daemon adopt` to hand it back")
 			}
 		default:
 			detail := info.SupervisionDetail

--- a/commands/daemonstatuscmd_test.go
+++ b/commands/daemonstatuscmd_test.go
@@ -262,6 +262,8 @@ func TestPrintDaemonStatusHumanNamesPIDMismatchAndStaleConfig(t *testing.T) {
 	got := out.String()
 	require.Contains(t, got, "responding daemon pid 42 is not supervised")
 	require.Contains(t, got, "installed unit, which owns pid 99")
+	require.Contains(t, got, "af daemon adopt",
+		"a responder the unit does not own is exactly what adopt fixes")
 	require.Contains(t, got, "config on disk differs from the running daemon")
 	require.Contains(t, got, "restart the daemon to apply it")
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -159,6 +159,7 @@ The background daemon hosts task cron schedules, watch-task scripts, session mon
 ```bash
 af daemon install      # register autostart at login
 af daemon restart      # restart a running daemon and re-adopt live sessions
+af daemon adopt        # hand a detached daemon back to the installed autostart unit
 af daemon uninstall    # remove the autostart unit (the daemon still starts on demand)
 af daemon status       # read-only health, supervision, and config freshness (+ --json)
 ```
@@ -169,6 +170,15 @@ af daemon status       # read-only health, supervision, and config freshness (+ 
 running daemon to shut down cleanly, restarts the autostart unit when one is
 installed, otherwise starts an ad-hoc daemon from the current binary. If no
 daemon is running, it exits successfully without starting one.
+
+`af daemon adopt` reclaims supervision when a daemon is running detached from
+its unit — an ad-hoc child a live `af` spawned, which the service manager can no
+longer restart. It stops that daemon, starts the installed unit in its place,
+and verifies the unit now owns the process answering the control socket. Live
+sessions keep running; the new supervised daemon re-adopts persisted state on
+startup, exactly as `af daemon restart` does. It needs an installed unit that
+serves this home; if that unit already owns the running daemon, adopt reports so
+and changes nothing.
 
 ## `af config`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -23,6 +23,7 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 - [`af config set`](#af-config-set) — Set a single settable global config key
 - [`af config validate`](#af-config-validate) — Check that the global config parses and validates
 - [`af daemon`](#af-daemon) — Manage the background daemon: serves the web UI and schedules tasks
+- [`af daemon adopt`](#af-daemon-adopt) — Hand a detached daemon back to the installed autostart unit
 - [`af daemon install`](#af-daemon-install) — Register the daemon to start automatically at login
 - [`af daemon restart`](#af-daemon-restart) — Restart the running daemon without stopping live sessions
 - [`af daemon status`](#af-daemon-status) — Report daemon liveness, config freshness, and supervision
@@ -672,10 +673,39 @@ af daemon
 
 **Subcommands**
 
+- [`af daemon adopt`](#af-daemon-adopt) — Hand a detached daemon back to the installed autostart unit
 - [`af daemon install`](#af-daemon-install) — Register the daemon to start automatically at login
 - [`af daemon restart`](#af-daemon-restart) — Restart the running daemon without stopping live sessions
 - [`af daemon status`](#af-daemon-status) — Report daemon liveness, config freshness, and supervision
 - [`af daemon uninstall`](#af-daemon-uninstall) — Remove the daemon autostart unit
+
+**Global flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--daemon-url` | `string` | Target a REMOTE daemon at this http:// or ws:// URL instead of the local unix socket (env: AF_DAEMON_URL). The daemon is HTTP-only; terminate TLS at your own proxy if needed. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
+
+## af daemon adopt
+
+Hand a detached daemon back to the installed autostart unit
+
+Reclaim supervision of the background daemon for the installed autostart unit.
+
+When a daemon is running detached from its unit — an ad-hoc child a live af
+spawned, which the service manager can no longer restart — adopt stops that
+daemon and starts the installed unit in its place, then verifies the unit now
+owns the process answering the control socket. Live sessions keep running in
+tmux; the new supervised daemon re-adopts persisted session state on startup,
+exactly as 'af daemon restart' does.
+
+It needs an installed unit that serves this home ('af daemon install'); with no
+such unit there is nothing to adopt the daemon into. If the installed unit
+already owns the running daemon, adopt reports that and changes nothing.
+
+```
+af daemon adopt
+```
 
 **Global flags**
 

--- a/doctor/skew.go
+++ b/doctor/skew.go
@@ -708,7 +708,7 @@ func supervisionActive(ctx *scanContext, report *Report, info daemon.Supervision
 					detail = "the installed unit is active but owns no daemon process; the responding daemon is not supervised by it"
 				}
 				report.Warn(sectionDaemon, "autostart supervision", detail+"; "+enablement,
-					"run `af daemon install` to hand the daemon back to the installed unit", true)
+					"run `af daemon adopt` to hand the daemon back to the installed unit", true)
 				handled = true
 			},
 			func() {
@@ -770,7 +770,7 @@ func supervisionNotRunning(report *Report, info daemon.SupervisionInfo, h daemon
 	if h.PingErr == nil {
 		report.Warn(sectionDaemon, "autostart supervision",
 			fmt.Sprintf("a daemon is responding, but the installed unit is not running it (%s); the responder is not supervised", info.Detail),
-			"run `af daemon install` to hand the daemon back to the installed unit", true)
+			"run `af daemon adopt` to hand the daemon back to the installed unit", true)
 		return
 	}
 	loadedButDead := false

--- a/doctor/skew_autostart_test.go
+++ b/doctor/skew_autostart_test.go
@@ -387,6 +387,8 @@ func TestAutostartSupervision_RespondingDaemonWithInactiveUnitNamesUnsupervised(
 	require.Equal(t, StatusWarn, c.Status)
 	require.Contains(t, c.Detail, "daemon is responding")
 	require.Contains(t, c.Detail, "not supervised")
+	require.Contains(t, c.Remediation, "af daemon adopt",
+		"the incident's fix is to hand the responder back to the unit, not to reinstall it")
 	require.True(t, c.Problem)
 }
 
@@ -422,12 +424,13 @@ func TestAutostartSupervision_OlderResponderWithoutPIDIsUnknown(t *testing.T) {
 // existing enablement warning must not hide that the responder is unsupervised.
 func TestAutostartSupervision_DisabledActiveUnitStillReportsOwnership(t *testing.T) {
 	for _, tc := range []struct {
-		name    string
-		unitPID int
-		want    string
+		name       string
+		unitPID    int
+		want       string
+		wantRemedy string
 	}{
-		{name: "different responder", unitPID: 99, want: "not supervised"},
-		{name: "same responder", unitPID: 42, want: "owns responding daemon pid 42"},
+		{name: "different responder", unitPID: 99, want: "not supervised", wantRemedy: "af daemon adopt"},
+		{name: "same responder", unitPID: 42, want: "owns responding daemon pid 42", wantRemedy: "af daemon install"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			testguard.IsolateTmux(t)
@@ -452,6 +455,7 @@ func TestAutostartSupervision_DisabledActiveUnitStillReportsOwnership(t *testing
 			require.Contains(t, c.Detail, "responding daemon pid 42")
 			require.Contains(t, c.Detail, tc.want)
 			require.Contains(t, c.Detail, "not enabled")
+			require.Contains(t, c.Remediation, tc.wantRemedy)
 			require.True(t, c.Problem)
 		})
 	}

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -930,7 +930,7 @@
     },
     {
       "id": "daemon.lifecycle",
-      "title": "Install / uninstall / restart / status the daemon",
+      "title": "Install / uninstall / restart / status / adopt the daemon",
       "tui": {
         "status": "n/a",
         "pointer": ""
@@ -941,7 +941,7 @@
       },
       "cli": {
         "status": "yes",
-        "pointer": "commands/daemoncmd.go:66,83,189,220"
+        "pointer": "commands/daemoncmd.go:66,83,189,220; commands/daemonadoptcmd.go:45"
       },
       "verdict": "deliberate",
       "notes": "Both UIs are clients OF the daemon: the web is served BY it (a web button to stop the daemon would kill the page), and the TUI needs it running to render. Host-lifecycle control belongs to the CLI."
@@ -1346,6 +1346,7 @@
       "af config list": "config.read",
       "af config set": "config.write",
       "af config validate": "config.validate",
+      "af daemon adopt": "daemon.lifecycle",
       "af daemon install": "daemon.lifecycle",
       "af daemon restart": "daemon.lifecycle",
       "af daemon status": "daemon.lifecycle",
@@ -1538,6 +1539,7 @@
       "af config validate --help": "meta.discovery",
       "af config validate --json": "cli.json-envelope",
       "af daemon --help": "meta.discovery",
+      "af daemon adopt --help": "meta.discovery",
       "af daemon install --help": "meta.discovery",
       "af daemon restart --help": "meta.discovery",
       "af daemon restart --quiet": "daemon.lifecycle",


### PR DESCRIPTION
## Summary

Phase 5a of the #2168 daemon-lifecycle epic — the incident's **third** failure, "no `af` verb did the safe thing." Adds `af daemon adopt` and wires the Phase-4 diagnostics that named the unsupervised state but offered no fix.

`af daemon adopt` reclaims supervision when a daemon is running detached from its unit (a live `af` spawned an ad-hoc child; the installed unit finds the socket already served, exits 0, and stays inactive). It:

1. derives the owner from the installed unit — `daemon.ResolveSupervisionOwner` (Phase 3);
2. if the unit already owns the responder, reports so and changes nothing;
3. otherwise stops the detached daemon and waits for its control socket to go quiet (the #854 respawn race) before starting the unit, so the unit's fresh daemon acquires the freed singleton lock instead of exiting against a live socket;
4. starts the daemon under the unit via `RestartAutostartUnit` (which `reset-failed`s Phase 1's crash-loop backstop — an explicit adopt is exactly the recovery path meant to clear it) — cross-platform: `systemctl --user restart` / `launchctl kickstart -k`;
5. **verifies** the unit's `MainPID` is the pid now answering `Ping` — `daemon.ServingDaemonSupervised` (Phase 4) — polling briefly to absorb the socket-bind and MainPID-population races after a `Type=simple` start.

**Fail-closed throughout** (the repo's recurring fabricated-negative discipline): an unresolvable owner or an *undetermined* supervision answer **refuses** rather than displacing a possibly-healthy supervised daemon; a verify that never confirms ownership exits non-zero pointing at `af doctor`. A no-unit home is told to `af daemon install` first.

### Diagnostics wiring
The Phase-4 rows that read "the responding daemon is not supervised by the installed unit" now recommend `af daemon adopt` (the precise fix) instead of a full `af daemon install`:
- `af daemon status` — the three warning branches where a unit exists but does not own the responder (`commands/daemoncmd.go`).
- `af doctor` — `supervisionActive`'s ownership-mismatch row and `supervisionNotRunning`'s responding-but-inactive row (the exact incident topology) in `doctor/skew.go`.

The "not-loaded" (`NotFound`) rows are deliberately left pointing at `systemctl --user daemon-reload` / `af daemon install`: adopt cannot start a unit the manager has no record of.

## Scope / sequencing
Deliberately narrow to `commands/` + `doctor/` (+ the `parity` inventory) — **no** `daemon`-package lifecycle changes — to stay clear of #2212 (auto-upgrade-in-daemon), which also touches daemon supervision. It reuses the Phase 3/4 primitives rather than adding new ones.

Deferred:
- **Phase 5b** — `af daemon start`/`stop` under the resolved owner, and `af daemon restart`-with-nothing-running starting the unit instead of no-op'ing — follow-up PR.
- **Phase 5c** — `restart --apply-config` — optional; not trivial (validate-before-stop plumbing), so not folded in.

## Test plan
New hermetic tests (all collaborators injected; nothing touches the host's real systemctl/launchctl/daemon):
- `commands/daemonadoptcmd_test.go` — no-unit refusal, unknown-owner fail-closed, already-owned no-op, undetermined-refuses-to-displace, detached→stop→start→verify happy path, nothing-running→start-under-unit, verify-fails→`af doctor`.
- `doctor/skew_autostart_test.go` — the incident topology and the ownership-mismatch row now assert the `af daemon adopt` remedy.
- `commands/daemonstatuscmd_test.go` — the status PID-mismatch line asserts the adopt remedy.
- `parity/inventory.json` — the surface-parity gate caught the new verb; added `af daemon adopt` / `--help` to the ledger under the existing `daemon.lifecycle` capability (TUI/web deliberately n/a — host-lifecycle control belongs to the CLI).

Rebased onto `master` (`77d3249e`) — head `8e2a38ab`. The only conflict was `parity/inventory.json` (master's `af config validate` ledger entry landed next to mine); resolved by keeping both, and `make docs` regenerated `docs/reference/cli.md` with no drift.

Gates:
- [x] `gofmt -l .` (clean) · `go build ./...` · `go vet ./commands/... ./doctor/...` — on `8e2a38ab`
- [x] `golangci-lint run --timeout=3m --fast` (full repo, clean) — on `8e2a38ab`
- [x] `deadcode -test ./...` (clean) · `scripts/lint-file-length.sh` (clean) — on `8e2a38ab`
- [x] `make docs` (regenerated; clean tree) — on `8e2a38ab`
- [x] `make test-container GOTESTARGS="./commands/... ./doctor/... ./parity/..."` — green on `8e2a38ab`
- [x] `make test-container` (full 46-package suite) — green on the pre-rebase head `e19eddf7` (identical adopt code; only the trivial parity merge differs). CI re-runs the full matrix on `8e2a38ab`.
- [x] smoke: built binary — `af daemon adopt --help` renders; `adopt` listed under `af daemon`

(Earlier PR Validation on the first head `15b0a207` failed only on the surface-parity inventory gap for the new verb — fixed here; the `Build` failure was its aggregate gate, not an independent build error.)

Part of #2168.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
