### PR TITLE
docs(session): correct residual captureEnded overstatements (#2438)

### DIFF
--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -143,32 +143,40 @@ type ptyBroker struct {
 	// short-circuits and no new capture is ever dialled (#2438). Set by readLoop
 	// under mu BEFORE it closes `done`, so anything that joins the loop sees it.
 	//
-	// Read it ONLY together with `capturing`, never alone. The one read that
-	// exists — ensureCaptureStartedLocked's `capturing && !captureEnded` — is the
-	// contract: the pair means "a capture is installed, and it is spent". With
-	// `capturing` false this flag says NOTHING, and in particular does not mean a
-	// fresh capture; the reconcile clears it on the way to dialling one.
+	// Read it ONLY together with `capturing`, never alone. The reads that decide
+	// whether to dial a fresh capture — ensureCaptureStartedLocked, recoverCapture,
+	// and redialLoop — all test `capturing && !captureEnded`: the pair means "a
+	// capture is installed, and it is spent". With `capturing` false the flag says
+	// NOTHING, and in particular does not mean a fresh capture; the reconcile
+	// clears it on the way to dialling one. (stopCapture also reads it alone, but
+	// only to pick a log level — #2450 item 3 — not to gate anything.)
 	//
-	// No teardown clears it, and the two cases are worth separating because they
-	// fail differently:
+	// No teardown clears it. Whether a clear WOULD be undone by the join or stick
+	// turns on whether the readLoop is still alive when the teardown runs — NOT on
+	// which teardown it is:
 	//
-	//   - A teardown that HAS a capture to release ends by joining the readLoop
-	//     (`<-done` inside stopCapture), and the loop's last act before closing
-	//     `done` is to latch this flag. So a clear placed before that join is
-	//     undone by it.
-	//   - A teardown that has NOTHING to release (it found `capturing` already
-	//     false, so stopCapture was nil and no join happened) can clear the flag
-	//     and make it stick. But there is nothing left to describe by then: the
-	//     capture it referred to is gone.
+	//   - Stopping a genuinely LIVE capture ends by joining the readLoop (`<-done`
+	//     inside stopCapture), and the loop's last act before closing `done` is to
+	//     latch this flag — so a clear placed before that join is undone by it.
+	//     The common case.
+	//   - When the readLoop has ALREADY exited, the join is a no-op (or never
+	//     happens) and a clear would instead STICK. Two ways in: a teardown that
+	//     found `capturing` already false (stopCapture was nil, no join at all);
+	//     and, since #2450, the spontaneous-death path, where the readLoop latched
+	//     this flag and closed `done` on its OWN while leaving `capturing` true. A
+	//     teardown guarded on `capturing` — maybeStopCapture included — still
+	//     admits that dead-but-not-yet-reconciled capture, calls stop(), and rides
+	//     its already-closed `<-done`, so its clear sticks too. maybeStopCapture is
+	//     NOT special here; harmless all the same, same as resetCapture/shutdown.
 	//
-	// #2438 shipped clears at all three teardowns and every one was unobservable,
-	// though not all for the same reason: maybeStopCapture only reaches its clear
-	// with a live capture, so its clear was always undone by the join;
-	// resetCapture and shutdown cleared unconditionally, so on the capturing-false
-	// path their clear actually stuck — harmlessly, because the sole reader is
-	// guarded by `capturing`, which every teardown has already cleared. So the
-	// clears were removed rather than moved after the join: moving them would add a
-	// second b.mu section on three teardown paths to change nothing observable.
+	// #2438 shipped clears at all three teardowns. Removing them is safe because
+	// the residue — undone or stuck — never reaches the reads that gate dialling:
+	// those all test `capturing && !captureEnded`, and every teardown clears
+	// `capturing` first, so the pair reads false regardless of the captureEnded
+	// bit. Moving the clears after the join instead would add a second b.mu section
+	// on three teardown paths for a residue those reads never see anyway. The
+	// dead-loop stick is pinned by
+	// TestPTYBrokerMaybeStopCaptureTearsDownADeadLoop.
 	captureEnded bool
 	// captureStarted is when the CURRENT capture was installed. It exists only to
 	// decide whether a death is a fresh incident or a continuation of one: a

--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -155,17 +155,20 @@ type ptyBroker struct {
 	//   - A teardown that HAS a capture to release ends by joining the readLoop
 	//     (`<-done` inside stopCapture), and the loop's last act before closing
 	//     `done` is to latch this flag. So a clear placed before that join is
-	//     undone by it — #2438 shipped exactly that in three sites, and it did
-	//     nothing.
+	//     undone by it.
 	//   - A teardown that has NOTHING to release (it found `capturing` already
-	//     false, so stopCapture was nil and no join happened) could clear the flag
+	//     false, so stopCapture was nil and no join happened) can clear the flag
 	//     and make it stick. But there is nothing left to describe by then: the
 	//     capture it referred to is gone.
 	//
-	// Either way the residue is unobservable, because the sole reader is guarded
-	// by `capturing`, which every teardown has already cleared. So the clears were
-	// removed rather than moved after the join: moving them would add a second
-	// b.mu section on three teardown paths to change nothing.
+	// #2438 shipped clears at all three teardowns and every one was unobservable,
+	// though not all for the same reason: maybeStopCapture only reaches its clear
+	// with a live capture, so its clear was always undone by the join;
+	// resetCapture and shutdown cleared unconditionally, so on the capturing-false
+	// path their clear actually stuck — harmlessly, because the sole reader is
+	// guarded by `capturing`, which every teardown has already cleared. So the
+	// clears were removed rather than moved after the join: moving them would add a
+	// second b.mu section on three teardown paths to change nothing observable.
 	captureEnded bool
 	// captureStarted is when the CURRENT capture was installed. It exists only to
 	// decide whether a death is a fresh incident or a continuation of one: a

--- a/session/ptybroker_redial_test.go
+++ b/session/ptybroker_redial_test.go
@@ -39,6 +39,103 @@ func waitForStarts(t *testing.T, ch *singleSocketChannel, want int, within time.
 // with a single client attached over a healthy daemon-browser WebSocket, nothing
 // ever re-subscribes and the capture stays dead indefinitely.
 //
+// TestPTYBrokerMaybeStopCaptureTearsDownADeadLoop pins the state the captureEnded
+// field doc describes, because the doc chain this belongs to (#2438 → #2452 →
+// #2481) exists precisely because unenforced claims about this flag keep shipping
+// false. A #2481 review pass caught the claim "maybeStopCapture only reaches its
+// clear with a live capture, so its clear was always undone by the join" — an
+// overstatement. This is the enforcement.
+//
+// The claim is false because of the #2450 spontaneous-death path: the readLoop
+// latches captureEnded and closes `done` on its OWN while leaving `capturing`
+// true, so `capturing` no longer implies a live loop. maybeStopCapture's guard is
+// `capturing`, so it admits that dead-but-not-reconciled capture and tears it
+// down; its stop() rides an already-closed `<-done` (a no-op join, not a
+// re-latch). So a clear placed there would STICK, not be undone — exactly like
+// resetCapture/shutdown on the capturing-false path.
+//
+// What is asserted is the reachable state: maybeStopCapture running its teardown
+// while captureEnded is already true. That directly refutes "only reaches its
+// clear with a live capture", and it cannot go stale the way the prose did.
+func TestPTYBrokerMaybeStopCaptureTearsDownADeadLoop(t *testing.T) {
+	// The re-dial backoff must exceed this test's own deadlines. redialLoop's
+	// recoverCapture would ALSO release the dead socket once its backoff fires, so
+	// a shorter backoff would let the test pass on that release and prove nothing
+	// about maybeStopCapture — it did, in an earlier draft, at exactly the 2s
+	// deadline. With the backoff parked far past the 2s deadlines below, the only
+	// thing that can release the socket in-window is maybeStopCapture, so the
+	// assertion isolates it. (The test does not wait the backoff out: br.close()
+	// wakes redialLoop off closedCh at the end.)
+	const isolatingBackoff = 30 * time.Second
+	defer setRedialTimingForTest(isolatingBackoff)()
+
+	state := func(b *ptyBroker) (capturing, ended bool) {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		return b.capturing, b.captureEnded
+	}
+
+	ch := &singleSocketChannel{snapshot: []byte("SCREEN")}
+	br := newPTYBroker(ch)
+	defer br.close()
+
+	a, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+	mustRepaintContains(t, a, "SCREEN")
+
+	// The upstream dies on its own. readLoop's defer latches captureEnded and
+	// closes `done`, but does NOT clear capturing — the #2450 spontaneous-death
+	// state. Wait until we actually observe it, so the assertion is about that
+	// state and not a race with it.
+	ch.dropUpstream()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		capturing, ended := state(br)
+		if capturing && ended {
+			break // dead loop, capturing still true — the state under test
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("never reached {capturing:true captureEnded:true}; got {%v %v}.\n\n"+
+				"The spontaneous-death path is supposed to latch captureEnded while leaving "+
+				"capturing true — without that state the doc's dead-loop case is unreachable.",
+				capturing, ended)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// Last subscriber leaves. remove() → maybeStopCapture, whose `capturing` guard
+	// passes over the ALREADY-DEAD loop. It must tear the capture down (release the
+	// socket, join the finished readLoop as a no-op) — the state the doc calls out.
+	if _, stops := ch.counts(); stops != 0 {
+		t.Fatalf("StopCapture already called %d times before the teardown under test", stops)
+	}
+	if err := a.Close(); err != nil {
+		t.Fatalf("close A: %v", err)
+	}
+
+	deadline = time.Now().Add(2 * time.Second)
+	for ch.isHeld() {
+		if time.Now().After(deadline) {
+			starts, stops := ch.counts()
+			t.Fatalf("maybeStopCapture did not release the dead capture: still held, starts=%d stops=%d.\n\n"+
+				"Its guard is `capturing`, which the spontaneous death left true, so it must admit "+
+				"and tear down the dead loop.", starts, stops)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// It ran exactly one teardown, and did not spuriously re-dial: the point is a
+	// no-op join over a finished loop, not a fresh capture.
+	if starts, stops := ch.counts(); starts != 1 || stops != 1 {
+		t.Fatalf("StartCapture=%d StopCapture=%d, want 1/1 (one dead-loop teardown, no re-dial)", starts, stops)
+	}
+	if capturing, _ := state(br); capturing {
+		t.Fatal("capturing is still true after the dead-loop teardown, want false")
+	}
+}
+
 // The broker must recover from the readLoop's own exit instead, so the pane comes
 // back without the user refreshing.
 func TestPTYBrokerReDialsWithoutANewSubscribe(t *testing.T) {

--- a/session/ptybroker_upstream_death_test.go
+++ b/session/ptybroker_upstream_death_test.go
@@ -326,10 +326,11 @@ func TestPTYBrokerUpstreamDeathDoesNotResurrectAClosedBroker(t *testing.T) {
 // Asserting the residue directly is the point — it stops the next reader from
 // "fixing" a latch that is not a bug.
 //
-// Note this test cannot fail-first on the code change it accompanies: removing
-// three writes that were already being undone has no observable effect, which is
-// the change's own thesis. It is a doc-lock, and the assertion it protects is
-// the one #2438's comment got wrong.
+// Note this test cannot fail-first on the code change it accompanies: the three
+// removed writes were unobservable — undone by the join where a capture was
+// joined, stuck-but-meaningless where none was (see the field doc) — so removing
+// them has no observable effect, which is the change's own thesis. It is a
+// doc-lock, and the assertion it protects is the one #2438's comment got wrong.
 func TestPTYBrokerCaptureEndedIsOnlyMeaningfulWithCapturing(t *testing.T) {
 	state := func(b *ptyBroker) (capturing, ended bool) {
 		b.mu.Lock()
@@ -360,8 +361,8 @@ func TestPTYBrokerCaptureEndedIsOnlyMeaningfulWithCapturing(t *testing.T) {
 	}
 	if !ended {
 		t.Fatal("captureEnded = false after a teardown joined the readLoop.\n\n" +
-			"If this ever passes, the join stopped latching the flag — re-read the field doc, " +
-			"because it says a teardown CANNOT clear it and that is why no teardown tries.")
+			"If this ever passes, the join stopped latching the flag — re-read the field doc: a " +
+			"teardown that joins the readLoop cannot clear this flag, because the join re-latches it.")
 	}
 
 	// And the residue is harmless: the next bring-up reconciles it away and dials


### PR DESCRIPTION
Follow-up to #2452 (which merged before a prose re-review completed). Comment-only; no code change.

A prose-accuracy review of #2452's merged head found two residual false absolutes plus one imprecise bullet — the same defect class #2452 itself was filed to fix, so they should not stay on master:

1. **The test's failure message still asserted the retracted absolute.** `ptybroker_upstream_death_test.go` told a future reader "the field doc says a teardown CANNOT clear it and that is why no teardown tries" — but the corrected field doc explicitly admits a teardown *can* clear it when it has no capture to join. Reworded to the true statement: a teardown that *joins the readLoop* cannot clear the flag, because the join re-latches it.

2. **The test-doc summary said all three removed writes "were already being undone."** Two of them (`resetCapture`, `shutdown`) cleared unconditionally, outside `if b.capturing`, so on the `capturing==false` path they *stuck* — harmlessly, but they were not "being undone." Reworded to "undone by the join where a capture was joined, stuck-but-meaningless where none was."

3. **The field-doc bullet said the #2438 clears "did nothing in three sites."** Precise now: only `maybeStopCapture`'s clear was always undone by the join (it only runs with a live capture); the other two stuck on the no-capture path. Unobservable either way — which is why removing them, not moving them, is correct — but for two different reasons.

All three were verified against the code (transition table, the three teardown bodies, and `maybeStopCapture`'s early-return on `!b.capturing`).

## Gate

`go test -race -run TestPTYBroker ./session/`, `gofmt -l .`, `go build ./...` clean; `make test-container` on the pushed head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
