### PR TITLE
docs(tui): fix the restore-window claim in the PR-info guard (#2437)

### DIFF
--- a/app/home_update.go
+++ b/app/home_update.go
@@ -126,20 +126,26 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// that (newLoadingInstance is OpCreating) and fails if the predicate is
 		// widened.
 		//
-		// Restore is NOT the counterexample it looks like, in either direction, and
-		// the two restore edges differ: MarkRestoring — the TUI's own optimistic
-		// restore — deliberately keeps liveness=Archived (see its doc), so IsArchived
-		// already catches it and the result is dropped. Only the daemon edge,
-		// BeginRestore, moves to LiveLost+OpRestoring, and a result landing in THAT
-		// window is still applied.
+		// Restore is deliberately NOT in the predicate, and it is worth being exact
+		// about why, because it is the residual below. MarkRestoring (the optimistic
+		// overlay) keeps whatever liveness it entered with — tkMarkRestoring's target
+		// is {s.liveness, OpRestoring}, not a fixed Archived. On an Archived row that
+		// is Archived, so IsArchived drops the result; but `r`/handleRestore is
+		// offered on Lost and Dead rows too (lifecycleActionFor), so the SAME edge
+		// routinely lands on {LiveLost, OpRestoring} — as does the daemon's
+		// BeginRestore, and as does adoptSnapshotOp reconciling a daemon-side
+		// restore. In those windows neither IsArchived nor IsTearingDown fires and
+		// the result is still applied. That is intended: a restoring session is
+		// coming back live and wants its badge.
 		//
-		// Which is where the honest residual sits: setPRInfoThroughDaemon below runs
-		// INLINE on the Update goroutine, and every long daemon op holds this
-		// session's op-lock — so a result arriving during a daemon-side restore still
-		// parks the TUI event loop until that restore finishes. This guard narrows
-		// the window to the ops whose results are worthless anyway; it does not close
-		// it. Closing it means not making a blocking RPC from the event loop at all,
-		// which is a different change.
+		// Which is the honest residual: setPRInfoThroughDaemon below runs INLINE on
+		// the Update goroutine, and every long daemon op holds this session's
+		// op-lock — so a result arriving during ANY restore (the TUI's own `r` on a
+		// Lost row included, not just a daemon-side one) still parks the event loop
+		// until that restore finishes. This guard narrows the freeze window to the
+		// ops whose results are worthless anyway; it does not close it. Closing it
+		// means not making a blocking RPC from the event loop at all, a different
+		// change.
 		//
 		// Dropping costs at most a stale badge: fetchPRInfoCmd already called
 		// MarkPRInfoFetched at kickoff, so nothing retries in a tight loop, and the

--- a/app/pr_info_test.go
+++ b/app/pr_info_test.go
@@ -630,15 +630,17 @@ func TestFetchPRInfoCmd_StampsRepoIDAtKickoff(t *testing.T) {
 // rare case. OpKilling is dropped for its own reason: a record about to be
 // deleted has no use for PR info.
 //
-// The companion TestPrInfoUpdatedMsg_SettledLiveTargetStillApplies, and the
-// pre-existing TestPrInfoUpdatedMsg_Success_AppliesInfoAndBumpsTimestamp (which
-// drives a LOADING instance, i.e. OpCreating), are what keep this from being
-// widened to HasInFlightOp — a session that is merely being created is coming
-// back live and still wants its badge.
+// The pre-existing TestPrInfoUpdatedMsg_Success_AppliesInfoAndBumpsTimestamp
+// (which drives a LOADING instance, i.e. OpCreating) is what keeps this from
+// being widened to HasInFlightOp — a session that is merely being created is
+// coming back live and still wants its badge, and that test fails if the
+// predicate is widened.
 //
-// Restore is not a counterexample either way: the TUI's own MarkRestoring keeps
-// liveness=Archived by design, so IsArchived already drops it; only the daemon's
-// BeginRestore (LiveLost+OpRestoring) is still applied.
+// Restore is deliberately outside the predicate: MarkRestoring keeps whatever
+// liveness it entered with (not a fixed Archived), and `r` is offered on Lost
+// and Dead rows too, so it routinely reaches {LiveLost, OpRestoring} — which is
+// still applied, on purpose, since a restoring session is coming back live. See
+// the handler comment for the freeze residual that follows from that.
 func TestPrInfoUpdatedMsg_TearingDownTargetDropsUpdate(t *testing.T) {
 	for _, tc := range []struct {
 		name  string

--- a/session/transition.go
+++ b/session/transition.go
@@ -173,10 +173,13 @@ func BeginRestore() TransitionEvent { return TransitionEvent{kind: tkBeginRestor
 func AbortRestoreToLost() TransitionEvent { return TransitionEvent{kind: tkAbortRestoreToLost} }
 
 // MarkRestoring overlays OpRestoring WITHOUT touching liveness — the TUI's
-// optimistic restore action. It deliberately keeps liveness=Archived (unlike
-// BeginRestore, the daemon edge, which flips to Lost) so the reconcile still
-// sees the Archived→live transition and rebuilds the row (#1203), while
-// ShownArchived re-homes it into the live section eagerly (#1210).
+// optimistic restore action. It keeps whatever liveness the row had (the target
+// is {s.liveness, OpRestoring}), unlike BeginRestore, the daemon edge, which
+// flips to Lost. For the common archived→restore that means liveness stays
+// Archived, so the reconcile still sees the Archived→live transition and rebuilds
+// the row (#1203) while ShownArchived re-homes it into the live section eagerly
+// (#1210). handleRestore also offers `r` on Lost/Dead rows, where this preserves
+// that liveness instead.
 func MarkRestoring() TransitionEvent { return TransitionEvent{kind: tkMarkRestoring} }
 
 // BeginHandoff raises the OpReplacing fence before the outgoing pane is touched.


### PR DESCRIPTION
Follow-up to #2445 (which merged before a prose re-review completed). Comment-only; no code change.

The merged #2445 guard comment claimed `MarkRestoring` "deliberately keeps liveness=Archived", so `IsArchived()` already drops a restore result and only the daemon's `BeginRestore` reaches the applied path. A prose-accuracy review found that false, and I verified it against the code:

- `tkMarkRestoring`'s target is `{s.liveness, OpRestoring}` (`session/transition.go`) — it keeps *whatever* liveness the row had, not a fixed Archived.
- `handleRestore` (`r`) is offered on `LiveArchived`, `LiveLost`, **and** `LiveDead` rows (`lifecycleActionFor`).

So the TUI's own `r` on a Lost row lands on `{LiveLost, OpRestoring}` — which neither `IsArchived()` nor `IsTearingDown()` catches, so the result *is* applied and, via the inline `setPRInfoThroughDaemon`, can park the Update goroutine on the op-lock a restore holds. That is the residual, and it is broader than "a daemon-side restore" — it is reachable from the TUI's own restore key.

This corrects three places that carried the false claim:
- the `prInfoUpdatedMsg` guard comment in `app/home_update.go`,
- the mirrored doc on `TestPrInfoUpdatedMsg_TearingDownTargetDropsUpdate`,
- the canonical `MarkRestoring` doc in `session/transition.go` (which was the source the claim leaned on).

The predicate itself (`IsArchived() || IsTearingDown()`) is unchanged and correct — a restoring session is coming back live and should get its badge. Only the explanation was wrong.

## Gate

`go test ./app/`, `gofmt -l .`, `go build ./...` clean; `make test-container` on the pushed head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
