### PR TITLE
feat(docker): ship a session runtime image + make session-image (#2194)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@
 	playtest-container playtest-container-detached tui-driver tui-driver-selftest \
 	lifecycle-container lifecycle-selftest \
 	testbox-image testbox-clean testbox-selftest \
+	session-image \
 	lint-file-length docs web-build web-test web-selftest-container
 
 # Structural-health lint (#1145): fail if any Go file exceeds its line limit
@@ -88,6 +89,19 @@ backend-docker-roundtrip:
 # where docker is unavailable. See docs/backends.md.
 backend-ssh-roundtrip:
 	go test ./integration -run 'TestSSHBackend(RoundTrip|ArchiveRestore)' -v -count=1 -timeout 20m
+
+# Session runtime image (#2194): the bring-your-own container image the docker
+# backend runs sessions in. There is NO af-published image (Sachin-locked
+# decision) — you build it locally and point a repo's .agent-factory/config
+# docker.image at the resulting tag. The `af` binary is docker-cp'd in at session
+# start, so this image carries only the workspace tooling: git, tmux, and the
+# agent CLIs (claude + codex; see scripts/container/Dockerfile.session for the
+# opt-in others). Built from stdin with no build context (the Dockerfile has no
+# COPY), matching the testbox images. Override the tag with SESSION_IMAGE=…; it
+# must be a glibc base >= the daemon's build glibc (see the Dockerfile header).
+SESSION_IMAGE ?= af-session:local
+session-image:
+	docker build -t $(SESSION_IMAGE) - < scripts/container/Dockerfile.session
 
 # Interactive TUI play-test sandbox: builds af inside, scaffolds a
 # throwaway AF home + mock project repo, drops you in a shell with a

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -96,19 +96,47 @@ only needs the workspace tooling:
   runs through `sh`.
 - **`dd`** — used to stream the live PTY (present in both busybox and coreutils).
 - The **agent CLIs** you intend to run (claude, codex, aider, gemini, …).
-- A libc/architecture compatible with the daemon's `af` binary. A **static**
-  `af` build (`CGO_ENABLED=0`) runs on any base (musl/alpine included); a
-  dynamically-linked `af` needs a matching glibc base (e.g. `debian:slim`).
+- A libc/architecture compatible with the daemon's `af` binary. The copied-in
+  binary is the **daemon's own executable**, and release builds are a plain
+  `go build` (cgo on) on `ubuntu-latest` — i.e. **dynamically linked against
+  glibc**. So your base must be **glibc, and its glibc must be ≥ the daemon
+  build's** (`ubuntu-latest` is glibc 2.39 today): `debian:trixie`/`ubuntu:24.04`
+  work, `debian:bookworm` (2.36) is too old, and a musl base (alpine) will not run
+  the binary at all. If you rebuild the daemon on a newer-glibc distro, rebuild the
+  image on a matching-or-newer base. (A **static** `af`, `CGO_ENABLED=0`, would run
+  on any base including alpine — but that is not how release builds are produced;
+  the integration test force-builds a static `af` precisely so it can use an alpine
+  test image.)
 
 The container's internal agent-server port is `8000`; avoid binding it in your
 image.
 
-A minimal example Dockerfile:
+#### The image this repo ships
+
+This repo carries a starting-point image so a docker-backed session works out of
+the box — build it with:
+
+```bash
+make session-image        # builds af-session:local from scripts/container/Dockerfile.session
+```
+
+It is based on `node:22-trixie-slim` (glibc 2.41; Node 22 for the codex CLI) and
+**includes `claude` and `codex`** — the two agents this repo's sessions use. The
+Dockerfile carries commented, one-uncomment install lines for the other agents
+(`gemini`, `amp`, `opencode`, `aider`); `devin` is not installed because af
+forwards it no per-agent credentials. Override the tag with
+`make session-image SESSION_IMAGE=my-org/af-runtime:latest`, then set that in the
+repo's `docker.image`. There is no registry step (bring-your-own, built locally).
+
+A minimal hand-rolled example, if you would rather not use the shipped one:
 
 ```dockerfile
-FROM alpine:3.20
-RUN apk add --no-cache git tmux bash
-# add the agent CLIs your sessions need, e.g. claude / codex / aider
+FROM node:22-trixie-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git tmux ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN npm install -g @anthropic-ai/claude-code @openai/codex
+# a musl base (alpine) works only if the daemon's af is a static (CGO_ENABLED=0) build
 ```
 
 ### Operations

--- a/scripts/container/Dockerfile.session
+++ b/scripts/container/Dockerfile.session
@@ -1,0 +1,66 @@
+# Session runtime image for agent-factory's docker backend (#2194).
+#
+# This is the image a session runs in when backend = "docker": the daemon
+# `docker run`s a container from it, clones the repo into /workspace, docker-cp's
+# the `af` binary in, and starts an in-container `af agent-server` that drives the
+# agent through tmux. There is NO af-published image — you bring your own
+# (Sachin-locked decision); this is the one this repo builds as a starting point.
+# Build it with `make session-image` (no build context is sent; there is no COPY).
+#
+# Base — glibc, deliberately. The `af` binary copied in at session start is the
+# daemon's OWN executable, and production/release builds are a plain `go build`
+# (cgo on) on ubuntu-latest, i.e. dynamically linked against glibc 2.39. Such a
+# binary will NOT run on a musl base (alpine) or an older glibc (debian bookworm =
+# 2.36). node:22-trixie-slim is Debian 13 (glibc 2.41 — >= 2.39, with headroom) and
+# carries Node 22, which the codex CLI requires. If you rebuild the daemon on a
+# newer-glibc distro, rebuild this image on a matching-or-newer base too. (A static
+# `af`, CGO_ENABLED=0, would run on any base — but that is not how release builds
+# are produced today; see the integration test, which force-builds a static `af`
+# precisely so it can use an alpine test image.)
+FROM node:22-trixie-slim
+
+# Workspace tooling: git clones /workspace, tmux drives the agent PTY, and
+# ca-certificates lets the HTTPS clone and the agent API calls verify TLS. sh,
+# sleep, and dd (used to stream the live PTY) already come from the base coreutils.
+# procps (ps/pgrep) is NOT needed by the in-container `af agent-server` — af's
+# only pgrep use is the host daemon's SIGTERM-fallback scan, which never runs
+# here — but it is kept so an operator can inspect a contained session's process
+# tree (`docker exec <c> ps -ef`), which is the point of running sessions boxed.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git tmux procps ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Stable in-container git identity so no clone or commit depends on host git config
+# leaking in (mirrors the testbox images), and mark /workspace safe so git never
+# refuses the daemon-owned clone as "dubious ownership" (#1167).
+RUN git config --system user.name "AF Session" \
+    && git config --system user.email "session@localhost" \
+    && git config --system init.defaultBranch master \
+    && git config --system --add safe.directory /workspace
+
+# Agent CLIs. This image ships claude + codex — the minimum #2194 asks for, and the
+# only agents this repo's sessions actually use (codex is the default here, claude
+# the other). Installed globally from npm; Node 22 satisfies both (claude needs
+# >= 18, codex needs >= 22). npm's global prefix (/usr/local) is on PATH, so the
+# binaries resolve regardless of the container's HOME.
+#
+# State plainly what is and is not in this image:
+#   INCLUDED:            claude, codex
+#   NOT included (opt in below): gemini, amp, opencode, aider
+#   devin:               not installed — af forwards it no per-agent credentials,
+#                        and there is no standard local-CLI credential model for it.
+RUN npm install -g @anthropic-ai/claude-code @openai/codex \
+    && npm cache clean --force
+
+# Opt-in agents — uncomment the line(s) your sessions use, then `make session-image`:
+#   gemini:   RUN npm install -g @google/gemini-cli && npm cache clean --force
+#   amp:      RUN npm install -g @ampcode/cli && npm cache clean --force   # renamed from @sourcegraph/amp (May 2026)
+#   opencode: RUN npm install -g opencode-ai && npm cache clean --force
+#   aider (needs a Python toolchain, so it is a heavier add):
+#     RUN apt-get update \
+#         && apt-get install -y --no-install-recommends python3 python3-pip pipx \
+#         && rm -rf /var/lib/apt/lists/* \
+#         && pipx install aider-chat
+
+# Do NOT EXPOSE or bind port 8000 — it is reserved for the in-container
+# `af agent-server` the daemon starts and dials over a published loopback port.


### PR DESCRIPTION
## What

Slice 1 of #2194 (run af's own sessions in a container): ship a **session
runtime image** and a `make session-image` target that builds it locally.

The docker backend is bring-your-own-image (there is no af-published image —
Sachin-locked decision), but this repo shipped no starting-point image, so a
docker-backed session had nothing to run in. This adds one.

- **`scripts/container/Dockerfile.session`** — based on `node:22-trixie-slim`,
  carrying `git`, `tmux`, `procps`, `ca-certificates`, and the agent CLIs.
- **`make session-image`** — builds it locally from stdin with no build context
  (matching the testbox images); tag overridable via `SESSION_IMAGE=…`.
- **`docs/backends.md`** — documents the shipped image, states the included
  agents, and corrects the base-image guidance (see glibc note below).

## Which agents are in the image

State it plainly:

| Agent | In the image? |
|-------|---------------|
| **claude** (`@anthropic-ai/claude-code`) | ✅ included |
| **codex** (`@openai/codex`) | ✅ included |
| gemini (`@google/gemini-cli`) | ⬜ commented opt-in line |
| amp (`@ampcode/cli`) | ⬜ commented opt-in line |
| opencode (`opencode-ai`) | ⬜ commented opt-in line |
| aider (pip; needs Python) | ⬜ commented opt-in line |
| devin | ❌ not installed — af forwards it no per-agent credentials |

claude + codex are the epic's mandated minimum and the only agents this repo's
sessions use (codex is the default here). The rest are one uncomment away in the
Dockerfile.

## Why a glibc base (not alpine)

The daemon copies its **own executable** into the container at session start, and
release builds are a plain `go build` (cgo on) on `ubuntu-latest` — i.e. a
**glibc-2.39 dynamically-linked** binary. So the image must be glibc, and its
glibc must be ≥ the daemon build's. `trixie` is glibc 2.41 (≥ 2.39, with
headroom); `bookworm` (2.36) is too old and alpine (musl) would not run the
binary at all. The integration test's `alpine:3.20` precedent only works because
it force-builds a *static* `af` (`CGO_ENABLED=0`), which is not how releases are
produced.

Node 22 (trixie) also satisfies the codex CLI's Node-22 floor and gives npm for
claude/codex.

## Verification

- `make session-image` builds green.
- Inside the image: `git 2.47.3`, `tmux 3.5a`, `claude 2.1.218`, `codex-cli
  0.145.0`, `dd (coreutils) 9.7`, glibc **2.41**.
- **Glibc-compat proof:** a freshly-built dynamic `af` (`ELF … dynamically
  linked, interpreter /lib64/ld-linux-x86-64.so.2`) runs `af version` →
  `agent-factory version 1.0.208` inside the image.
- No Go/web changes, so the Go and web gates are unaffected; docs build is a
  content-only append to an already-nav'd page (no new links).
- No `EXPOSE 8000` — that port is reserved for the in-container agent-server.

## Scope (what this slice deliberately does NOT do)

Image only. Later, separate PRs cover: (2) wiring the read-only agent-credential
mounts via `docker.run_args`, (3) flipping this repo's `.agent-factory/config`
to `backend=docker`, (4) orphan-container reaping.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
