### PR TITLE
fix(configagent): attach on an unconfirmed briefing receipt (#2483)

### DIFF
--- a/daemon/configagent.go
+++ b/daemon/configagent.go
@@ -44,11 +44,22 @@ const configAgentSessionPrefix = "af-config-"
 // user closes one and presses C again).
 var configAgentSeq atomic.Uint64
 
-// configAgentPromptReceiptTimeout bounds the receiver-side acknowledgement
-// after tmux submission. Codex writes its user turn locally before model work
-// begins, so this is startup I/O, not an API-response budget. A missing receipt
-// closes and fails the config agent instead of attaching the user to an empty
-// composer (#2220). A var keeps the deliberate-drop regression fast.
+// configAgentPromptReceiptTimeout bounds how long the spawn WAITS to CONFIRM
+// that Codex recorded the briefing as a user turn before it hands the terminal
+// over. Codex writes its user turn locally before model work begins, so on a
+// healthy box the confirmation lands in well under a second; this is startup
+// I/O, not an API-response budget.
+//
+// Its expiry is deliberately NOT fatal (#2483). The receipt is a POSITIVE
+// signal — its absence within the window does not prove the briefing failed to
+// land (the tmux paste+Enter already succeeded, and a slow or degraded Codex
+// simply records the turn after the window). Reaping the session on that
+// inferred negative left an operator on a degraded default agent unable to
+// configure af at all, which is strictly worse than the send-and-attach every
+// normal session does (task.WaitForReadyAndSendPrompt). So an unconfirmed
+// receipt attaches anyway and logs why; only a cancelled spawn tears down.
+//
+// A var keeps the receipt regressions fast.
 var configAgentPromptReceiptTimeout = 5 * time.Second
 
 // configAgentSupervisor owns every bare tmux session this daemon spawned for a
@@ -279,17 +290,29 @@ func (m *Manager) SpawnConfigAgent(ctx context.Context, req SpawnConfigAgentRequ
 		if err := ts.SendKeysCommand(req.Prompt); err != nil {
 			return fail(fmt.Errorf("config agent: failed to deliver the briefing: %w", err))
 		}
-		// A successful tmux send is not a delivery receipt. In the #2220
-		// reproduction every load/paste/Enter command succeeded against Codex's
-		// directory-trust modal; Enter merely selected "Yes", Codex opened a bare
-		// composer, and the briefing never became a user turn. Codex's rollout is
-		// the receiver-owned boundary: do not report "started" until that exact
-		// prompt is recorded there. Pane pixels cannot substitute — real Codex
-		// renders the same `› [Pasted Content …]` for both a pending paste and a
-		// submitted user message.
+		// A successful tmux send is not a delivery receipt, so we try to CONFIRM
+		// one. In the #2220 reproduction every load/paste/Enter command succeeded
+		// against Codex's directory-trust modal; Enter merely selected "Yes", Codex
+		// opened a bare composer, and the briefing never became a user turn. Codex's
+		// rollout is the receiver-owned boundary, and a confirmed turn there is the
+		// only thing that proves the briefing landed. Pane pixels cannot substitute
+		// — real Codex renders the same `› [Pasted Content …]` for both a pending
+		// paste and a submitted user message.
+		//
+		// But a confirmation we could not get within the window is not proof the
+		// briefing failed (#2483): the paste+Enter already succeeded, and a slow or
+		// degraded Codex records the turn just after our budget. Reaping on that
+		// inferred negative broke the assistant on a degraded default agent
+		// entirely. So an unconfirmed receipt attaches anyway and records why —
+		// matching the send-and-attach every normal session does — and only a
+		// cancelled spawn (the client/daemon is going away) tears the session down,
+		// as every other step on this context does.
 		if agent == tmux.ProgramCodex {
 			if err := session.WaitForPromptReceipt(ctx, agent, promptReceipt, req.Prompt, configAgentPromptReceiptTimeout); err != nil {
-				return fail(fmt.Errorf("config agent: could not verify that Codex accepted the briefing as a turn; the uncertain session was closed: %w", err))
+				if ctx.Err() != nil {
+					return fail(fmt.Errorf("config agent: spawn cancelled while awaiting the briefing receipt: %w", err))
+				}
+				log.WarningLog.Printf("config agent: %s started but the briefing receipt was not confirmed within %s (%v); attaching anyway — the briefing was delivered to Codex's composer and it may record the turn shortly", sessionName, configAgentPromptReceiptTimeout, err)
 			}
 		}
 	}

--- a/daemon/configagent_delivery_test.go
+++ b/daemon/configagent_delivery_test.go
@@ -77,28 +77,55 @@ func TestConfigAgentCodexTrustModalSubmitsBriefing(t *testing.T) {
 	}
 }
 
-func TestConfigAgentCodexMissingReceiptFailsSpawn(t *testing.T) {
+// TestConfigAgentUnconfirmedReceiptStillAttaches is #2483. A receiver that never
+// records the briefing turn within the confirmation window is exactly what a
+// slow or degraded Codex looks like — and it is what broke the assistant on
+// Sachin's box, where the 5s window hard-closed the session. The paste+Enter
+// already succeeded, so an unconfirmed receipt is not proof of a failed
+// delivery: the spawn must attach a live session anyway, matching the
+// send-and-attach every normal session does, rather than reaping the operator's
+// only path to configuring af.
+//
+// The "drop" fixture is the reproduction: it accepts trust and reveals the
+// composer but never writes a user turn to its rollout, so WaitForPromptReceipt
+// runs out its budget and returns ErrPromptReceiptNotObserved — the exact error
+// from the report.
+func TestConfigAgentUnconfirmedReceiptStillAttaches(t *testing.T) {
 	testguard.IsolateTmux(t)
-	manager, program, _ := newConfigAgentCodexFixture(t, "drop")
+	manager, program, rollout := newConfigAgentCodexFixture(t, "drop")
 
 	oldTimeout := configAgentPromptReceiptTimeout
 	configAgentPromptReceiptTimeout = 250 * time.Millisecond
 	t.Cleanup(func() { configAgentPromptReceiptTimeout = oldTimeout })
 
+	const prompt = "briefing the receiver never records as a turn"
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	sessionName, _, err := manager.SpawnConfigAgent(ctx, SpawnConfigAgentRequest{
 		Program: program,
-		Prompt:  "briefing deliberately dropped by receiver",
+		Prompt:  prompt,
 	})
-	if err == nil {
-		if sessionName != "" {
-			_ = manager.ReapConfigAgent(ReapConfigAgentRequest{SessionName: sessionName})
-		}
-		t.Fatal("a config agent whose receiver recorded no briefing turn reported success")
+	if err != nil {
+		t.Fatalf("an unconfirmed briefing receipt closed the config agent instead of attaching it (#2483): %v", err)
 	}
-	if !strings.Contains(err.Error(), "could not verify that Codex accepted the briefing") {
-		t.Fatalf("missing receiver receipt returned an unactionable error: %v", err)
+	if sessionName == "" {
+		t.Fatal("spawn returned no session name, so there is nothing to attach to")
+	}
+	t.Cleanup(func() {
+		if rerr := manager.ReapConfigAgent(ReapConfigAgentRequest{SessionName: sessionName}); rerr != nil {
+			t.Errorf("reap unconfirmed-receipt config agent: %v", rerr)
+		}
+	})
+
+	// Prove we attached WITHOUT a confirmed receipt: the receiver recorded only
+	// its session_meta, never the briefing turn. If this ever contains the prompt
+	// the fixture stopped modelling the degraded case and the test is vacuous.
+	data, err := os.ReadFile(rollout)
+	if err != nil {
+		t.Fatalf("read fake Codex rollout: %v", err)
+	}
+	if strings.Contains(string(data), prompt) {
+		t.Fatalf("the drop fixture unexpectedly recorded the briefing turn, so this no longer exercises an unconfirmed receipt:\n%s", data)
 	}
 }
 


### PR DESCRIPTION
Closes #2483.

## The break

The config assistant (shipped in #2453/#2454) fails to start on a box whose
`default_program` is Codex when Codex is slow/degraded:

```
config agent: could not verify that Codex accepted the briefing as a turn;
the uncertain session was closed: prompt receipt not observed in Codex
rollout within 5s
```

So the operator the assistant was built for cannot open it at all. This is
Sachin's box, right now.

## Root cause — destruction on an inferred negative

`SpawnConfigAgent` delivers the briefing over a tmux paste + Enter, then waits
up to 5s (`configAgentPromptReceiptTimeout`) for Codex to record the exact
briefing as a user turn in its rollout store (`WaitForPromptReceipt`, #2220).
If that turn is not observed in the window, the old code **reaped the session
and returned the error above.**

That receipt is a *positive* confirmation signal. Its absence within 5s does
not prove the briefing failed to land — the tmux paste+Enter already succeeded,
and a slow or degraded Codex simply writes the user turn to its rollout after
the window (large paste ingestion + first-turn startup I/O; the turn is written
locally before model work, so this is not an API-latency budget).

**Reference behavior confirmed across the codebase:** every *other*
prompt-delivery path treats a successful tmux send as delivery and attaches.
`task.WaitForReadyAndSendPrompt` (the normal create path) does readiness →
dismiss trust → `SendPrompt` → done, with no receipt gate. `manager_create`
uses conversation capture only opportunistically (for the resume id) and never
destroys a session over a missing one. The config agent was the sole path that
hard-closed over an unconfirmed receipt.

Net effect: a rare, recoverable, interactively-visible condition (briefing
maybe not yet submitted) was converted into a common, total, feature-breaking
one.

## Fix

Treat the window as a **confirmation budget whose expiry is non-fatal.** On
receipt-not-observed (or any non-cancellation receipt error) the spawn now
**attaches the session anyway** and logs why, matching the send-and-attach
reference behavior. The positive path is unchanged: a healthy Codex confirms in
well under a second and still logs cleanly. The spawn is still torn down when
its own context is cancelled (client/daemon going away), as every other step on
that context is.

The 5s window is deliberately **not** widened — that would only make a degraded
operator wait longer before the takeover, and make a genuinely-eaten briefing
hang longer before recovering. The lever that was wrong was "expiry ⇒ destroy,"
not the duration.

**Considered and rejected:** pinning the config agent to a fixed "reliable"
agent instead of `default_program`. Any agent can be slow, the operator may
only have their default authenticated, and every other surface runs the
operator's chosen program — so a special-cased program would surprise without
removing the race. The resilience fix helps regardless of which agent runs.

## Test

The existing `"drop"` Codex fixture in `configagent_delivery_test.go`
reproduces the report exactly: it accepts trust and reveals the composer but
never writes a user turn, so `WaitForPromptReceipt` runs out its budget and
returns `ErrPromptReceiptNotObserved`. The test that asserted the spawn *fails*
on a missing receipt is inverted (`TestConfigAgentUnconfirmedReceiptStillAttaches`)
to assert it now attaches a live, reapable session, and to prove it attached
*without* a confirmed receipt (the rollout still holds only `session_meta`).
Verified **fail-first** against the old behavior (fails with the exact reported
error) and green with the fix.

## Gate (head `75b633dd`)

- `go build ./...` — clean
- `gofmt -l .` — clean
- `golangci-lint run --timeout=3m --fast` (daemon, session) — clean
- `deadcode -test ./...` — clean
- `scripts/lint-file-length.sh` — clean (1032 files)
- `make test-container` — **all packages `ok`** (daemon 192s, parity, session/tmux, app)

Held as **draft** for the Captain-Claude (claude-subagent) review gate — not
self-merging. Codex GitHub-app review is rate-limited until Jul 28, so its pass
will be silent.
