### PR TITLE
fix(session): teach agents the af model in the system prompt (#2473)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "agent-factory",
       "source": "./plugins/claude/agent-factory",
       "description": "Run and schedule AI coding agents in isolated git worktrees with the Agent Factory (af) CLI",
-      "version": "3.2.3586076752+sha256.d5bf3050bea0bcdb"
+      "version": "3.3.4215606638+sha256.fb450d6ee2a3cf92"
     }
   ]
 }

--- a/commands/plugins_gen.go
+++ b/commands/plugins_gen.go
@@ -65,6 +65,7 @@ const (
 var pluginReleaseDigests = []string{
 	"951d1d7a412f6c4a28b9498c7b16bda79ff6fad12c5b40963b6cf68f637fcf91", // 3.1
 	"d5bf3050bea0bcdbcd41e436738b56d2dd4e25e82b508a751e3c2d1435473f09", // 3.2
+	"fb450d6ee2a3cf923ace4ef7dd693b5d9790bb52ec33328bc242fea910f0be95", // 3.3 — instance/session/tab/pane model + dispatched-parent escalation + tightened web-tab guidance (#2473)
 }
 
 // pluginGenBanner marks a generated Markdown/shell artifact. Like genBanner it

--- a/plugins/amp/agent-factory/SKILL.md
+++ b/plugins/amp/agent-factory/SKILL.md
@@ -21,11 +21,11 @@ Sessions (one agent per isolated worktree):
   af sessions handoff <title> --to <agent>             Continue a stuck session under a different agent (same worktree/branch)
   af sessions restore <title>                          Restore an archived, lost, or dead session
 
-Tabs (extra processes in a session's worktree; max 9 per session; not available for remote sessions):
-  af sessions tab-create <title> --command <cmd> [--name <tab>]   Prints the resolved tab name; tabs persist across restarts
-  af sessions tab-create <title> --kind web --port <n>|--url <u>  A browser pane (no PTY): shows a dev server/site to the user in the web UI
-  af sessions tab-create <title> --kind vscode                    A VS Code editor pane on this session's worktree (no --url/--port); needs code-server installed
-  af sessions tab-delete <title> --name <tab>                     The agent tab itself can't be deleted; kill the session instead
+Tabs (extra processes and views in your instance's worktree; max 9; not for remote sessions). The <title> is the target session — for your own, get it from "af sessions whoami". Tabs are how you put something in front of the user; use them instead of an external browser, editor, or global tool.
+  af sessions tab-create <title> --command <cmd> [--name <tab>]   Terminal tab running <cmd> in the worktree; prints the tab name; persists across restarts
+  af sessions tab-create <title> --kind web --url <u>|--port <n>  Web tab — a live browser view (no process) shown to the user in the web UI; this is how you show a URL, site, or dev server (--port n = http://localhost:n)
+  af sessions tab-create <title> --kind vscode                    VS Code editor tab on the worktree (no --url/--port); needs code-server installed
+  af sessions tab-delete <title> --name <tab>                     Delete a tab; the agent tab can't be deleted (kill the session instead)
 
 Tasks (deliver a prompt on a cron schedule, or whenever a long-running watch script prints a stdout line; exactly one of --cron/--watch-cmd per task):
   af tasks list [--all]                                List this project's tasks (--all spans every project)

--- a/plugins/claude/agent-factory/.claude-plugin/plugin.json
+++ b/plugins/claude/agent-factory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-factory",
   "description": "Run and schedule AI coding agents in isolated git worktrees with the Agent Factory (af) CLI",
-  "version": "3.2.3586076752+sha256.d5bf3050bea0bcdb",
+  "version": "3.3.4215606638+sha256.fb450d6ee2a3cf92",
   "author": {
     "name": "Agent Factory",
     "url": "https://github.com/sachiniyer/agent-factory"

--- a/plugins/claude/agent-factory/skills/agent-factory/SKILL.md
+++ b/plugins/claude/agent-factory/skills/agent-factory/SKILL.md
@@ -21,11 +21,11 @@ Sessions (one agent per isolated worktree):
   af sessions handoff <title> --to <agent>             Continue a stuck session under a different agent (same worktree/branch)
   af sessions restore <title>                          Restore an archived, lost, or dead session
 
-Tabs (extra processes in a session's worktree; max 9 per session; not available for remote sessions):
-  af sessions tab-create <title> --command <cmd> [--name <tab>]   Prints the resolved tab name; tabs persist across restarts
-  af sessions tab-create <title> --kind web --port <n>|--url <u>  A browser pane (no PTY): shows a dev server/site to the user in the web UI
-  af sessions tab-create <title> --kind vscode                    A VS Code editor pane on this session's worktree (no --url/--port); needs code-server installed
-  af sessions tab-delete <title> --name <tab>                     The agent tab itself can't be deleted; kill the session instead
+Tabs (extra processes and views in your instance's worktree; max 9; not for remote sessions). The <title> is the target session — for your own, get it from "af sessions whoami". Tabs are how you put something in front of the user; use them instead of an external browser, editor, or global tool.
+  af sessions tab-create <title> --command <cmd> [--name <tab>]   Terminal tab running <cmd> in the worktree; prints the tab name; persists across restarts
+  af sessions tab-create <title> --kind web --url <u>|--port <n>  Web tab — a live browser view (no process) shown to the user in the web UI; this is how you show a URL, site, or dev server (--port n = http://localhost:n)
+  af sessions tab-create <title> --kind vscode                    VS Code editor tab on the worktree (no --url/--port); needs code-server installed
+  af sessions tab-delete <title> --name <tab>                     Delete a tab; the agent tab can't be deleted (kill the session instead)
 
 Tasks (deliver a prompt on a cron schedule, or whenever a long-running watch script prints a stdout line; exactly one of --cron/--watch-cmd per task):
   af tasks list [--all]                                List this project's tasks (--all spans every project)

--- a/plugins/codex/agent-factory/.codex-plugin/plugin.json
+++ b/plugins/codex/agent-factory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-factory",
-  "version": "3.2.3586076752+sha256.d5bf3050bea0bcdb",
+  "version": "3.3.4215606638+sha256.fb450d6ee2a3cf92",
   "description": "Run and schedule AI coding agents in isolated git worktrees with the Agent Factory (af) CLI",
   "author": {
     "name": "Agent Factory",

--- a/plugins/codex/agent-factory/skills/agent-factory/SKILL.md
+++ b/plugins/codex/agent-factory/skills/agent-factory/SKILL.md
@@ -21,11 +21,11 @@ Sessions (one agent per isolated worktree):
   af sessions handoff <title> --to <agent>             Continue a stuck session under a different agent (same worktree/branch)
   af sessions restore <title>                          Restore an archived, lost, or dead session
 
-Tabs (extra processes in a session's worktree; max 9 per session; not available for remote sessions):
-  af sessions tab-create <title> --command <cmd> [--name <tab>]   Prints the resolved tab name; tabs persist across restarts
-  af sessions tab-create <title> --kind web --port <n>|--url <u>  A browser pane (no PTY): shows a dev server/site to the user in the web UI
-  af sessions tab-create <title> --kind vscode                    A VS Code editor pane on this session's worktree (no --url/--port); needs code-server installed
-  af sessions tab-delete <title> --name <tab>                     The agent tab itself can't be deleted; kill the session instead
+Tabs (extra processes and views in your instance's worktree; max 9; not for remote sessions). The <title> is the target session — for your own, get it from "af sessions whoami". Tabs are how you put something in front of the user; use them instead of an external browser, editor, or global tool.
+  af sessions tab-create <title> --command <cmd> [--name <tab>]   Terminal tab running <cmd> in the worktree; prints the tab name; persists across restarts
+  af sessions tab-create <title> --kind web --url <u>|--port <n>  Web tab — a live browser view (no process) shown to the user in the web UI; this is how you show a URL, site, or dev server (--port n = http://localhost:n)
+  af sessions tab-create <title> --kind vscode                    VS Code editor tab on the worktree (no --url/--port); needs code-server installed
+  af sessions tab-delete <title> --name <tab>                     Delete a tab; the agent tab can't be deleted (kill the session instead)
 
 Tasks (deliver a prompt on a cron schedule, or whenever a long-running watch script prints a stdout line; exactly one of --cron/--watch-cmd per task):
   af tasks list [--all]                                List this project's tasks (--all spans every project)

--- a/plugins/gemini/agent-factory/SKILL.md
+++ b/plugins/gemini/agent-factory/SKILL.md
@@ -21,11 +21,11 @@ Sessions (one agent per isolated worktree):
   af sessions handoff <title> --to <agent>             Continue a stuck session under a different agent (same worktree/branch)
   af sessions restore <title>                          Restore an archived, lost, or dead session
 
-Tabs (extra processes in a session's worktree; max 9 per session; not available for remote sessions):
-  af sessions tab-create <title> --command <cmd> [--name <tab>]   Prints the resolved tab name; tabs persist across restarts
-  af sessions tab-create <title> --kind web --port <n>|--url <u>  A browser pane (no PTY): shows a dev server/site to the user in the web UI
-  af sessions tab-create <title> --kind vscode                    A VS Code editor pane on this session's worktree (no --url/--port); needs code-server installed
-  af sessions tab-delete <title> --name <tab>                     The agent tab itself can't be deleted; kill the session instead
+Tabs (extra processes and views in your instance's worktree; max 9; not for remote sessions). The <title> is the target session — for your own, get it from "af sessions whoami". Tabs are how you put something in front of the user; use them instead of an external browser, editor, or global tool.
+  af sessions tab-create <title> --command <cmd> [--name <tab>]   Terminal tab running <cmd> in the worktree; prints the tab name; persists across restarts
+  af sessions tab-create <title> --kind web --url <u>|--port <n>  Web tab — a live browser view (no process) shown to the user in the web UI; this is how you show a URL, site, or dev server (--port n = http://localhost:n)
+  af sessions tab-create <title> --kind vscode                    VS Code editor tab on the worktree (no --url/--port); needs code-server installed
+  af sessions tab-delete <title> --name <tab>                     Delete a tab; the agent tab can't be deleted (kill the session instead)
 
 Tasks (deliver a prompt on a cron schedule, or whenever a long-running watch script prints a stdout line; exactly one of --cron/--watch-cmd per task):
   af tasks list [--all]                                List this project's tasks (--all spans every project)

--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -18,18 +18,22 @@ import (
 // text is delivered to TWO audiences whose framing differs (#2172):
 //
 //   - an agent af itself launched, which IS a session (afUsageIntroInside,
-//     afUsageOutroInside), and
+//     afUsageDispatched, afUsageOutroInside), and
 //   - an agent that installed the af plugin/skill on its own and is NOT running
 //     inside af (afUsageIntroPlugin, afUsageOutroPlugin) — see
 //     AfPluginUsageReference.
 //
 // Everything that is true for both — every command group, every scoping rule —
 // lives in the shared afUsageBody, so editing af's usage guidance changes both
-// audiences at once and neither can drift. Only the framing is swapped; the
+// audiences at once and neither can drift. The dispatched-parent escalation
+// guidance (afUsageDispatched) is inside-only: an agent that installed the plugin
+// is a CALLER of af, not a sub-instance a parent dispatched, so it appears in
+// afUsageReference but never in AfPluginUsageReference. Only the framing is
+// swapped otherwise; the
 // generated plugin artifacts must never carry a verbatim copy of the "you are
 // running inside af" opening, which is false for the audience that installed
 // them.
-const afUsageReference = afUsageIntroInside + " " + afUsageBody + "\n\n" + afUsageOutroInside + "\n\n" + afUsageOutro
+const afUsageReference = afUsageIntroInside + "\n\n" + afUsageDispatched + "\n\n" + afUsageBody + "\n\n" + afUsageOutroInside + "\n\n" + afUsageOutro
 
 // AfPluginUsageReference is afUsageReference reframed for an agent that is NOT
 // running inside af: the same body and the same command reference, but an
@@ -39,8 +43,27 @@ const afUsageReference = afUsageIntroInside + " " + afUsageBody + "\n\n" + afUsa
 // artifacts carry (see `af gen-docs --plugin-root`).
 const AfPluginUsageReference = afUsageIntroPlugin + " " + afUsageBody + "\n\n" + afUsageOutroPlugin + "\n\n" + afUsageOutro
 
-// afUsageIntroInside frames the body for an agent af launched: it IS a session.
-const afUsageIntroInside = `You are running inside Agent Factory (af), a terminal multiplexer that runs each AI coding agent in an isolated git worktree. Manage sessions, tasks, and the daemon with the "af" CLI.`
+// afUsageIntroInside frames the body for an agent af launched: it IS an instance.
+// It leads with the model and the terms (instance/session/tab/pane) because an
+// agent that does not know it is an af instance reaches for unrelated tools — the
+// #2473 case, where an agent asked to show a URL used a separate global browser
+// skill instead of an af web tab. "instance" leads; "session" is noted as the
+// CLI's word for the same thing.
+const afUsageIntroInside = `You are an AI coding agent running inside Agent Factory (af): a tool that runs many AI coding agents at once, each isolated in its own git worktree — you are one of them.
+
+- instance (the CLI calls it a session — same thing): one isolated git worktree and the agent in it. This worktree is yours, that agent is you; af runs many others alongside it.
+- tab: a process or view inside an instance. You run in its agent tab, and you can add terminal, web, and editor tabs next to it.
+- pane: what the user is looking at — an instance's currently-shown tab, in the terminal UI or the web UI.
+
+Drive af with the "af" CLI, and prefer its native mechanisms over unrelated or global tools. In particular, to put a web page, running dev server, or editor in front of the user, add a tab to your own session (see Tabs) — not a separate browser or editor tool, which opens somewhere the user cannot see.`
+
+// afUsageDispatched is the inside-only guidance for an agent another instance
+// dispatched: the parent watches the GitHub issue/PR, not this terminal, so a
+// blocker must be surfaced there — never in a local interactive prompt/picker the
+// parent cannot see, and never by guessing silently or idling. Several lanes got
+// stuck invisibly for exactly this reason (#2473). Not in the shared body: the
+// plugin audience installed af itself and is not a dispatched sub-instance.
+const afUsageDispatched = `When another instance dispatched you (your task came from a parent agent or lane, not a person at this terminal): the parent watches the relevant GitHub issue or PR, not your screen. If you hit a question or decision you cannot resolve, raise it there — post it plainly on that issue or PR. Never fall back on a local interactive prompt, picker, or menu: it renders only in your own terminal, so the parent never sees it and you block invisibly. Never guess silently, and never sit idle waiting — an unraised blocker is a stuck lane no one can help.`
 
 // afUsageIntroPlugin frames the body for an agent that is not an af session —
 // the plugin/skill audience. It states the two facts that framing changes:
@@ -75,11 +98,11 @@ Sessions (one agent per isolated worktree):
   af sessions handoff <title> --to <agent>             Continue a stuck session under a different agent (same worktree/branch)
   af sessions restore <title>                          Restore an archived, lost, or dead session
 
-Tabs (extra processes in a session's worktree; max 9 per session; not available for remote sessions):
-  af sessions tab-create <title> --command <cmd> [--name <tab>]   Prints the resolved tab name; tabs persist across restarts
-  af sessions tab-create <title> --kind web --port <n>|--url <u>  A browser pane (no PTY): shows a dev server/site to the user in the web UI
-  af sessions tab-create <title> --kind vscode                    A VS Code editor pane on this session's worktree (no --url/--port); needs code-server installed
-  af sessions tab-delete <title> --name <tab>                     The agent tab itself can't be deleted; kill the session instead
+Tabs (extra processes and views in your instance's worktree; max 9; not for remote sessions). The <title> is the target session — for your own, get it from "af sessions whoami". Tabs are how you put something in front of the user; use them instead of an external browser, editor, or global tool.
+  af sessions tab-create <title> --command <cmd> [--name <tab>]   Terminal tab running <cmd> in the worktree; prints the tab name; persists across restarts
+  af sessions tab-create <title> --kind web --url <u>|--port <n>  Web tab — a live browser view (no process) shown to the user in the web UI; this is how you show a URL, site, or dev server (--port n = http://localhost:n)
+  af sessions tab-create <title> --kind vscode                    VS Code editor tab on the worktree (no --url/--port); needs code-server installed
+  af sessions tab-delete <title> --name <tab>                     Delete a tab; the agent tab can't be deleted (kill the session instead)
 
 Tasks (deliver a prompt on a cron schedule, or whenever a long-running watch script prints a stdout line; exactly one of --cron/--watch-cmd per task):
   af tasks list [--all]                                List this project's tasks (--all spans every project)

--- a/session/systemprompt_golden_test.go
+++ b/session/systemprompt_golden_test.go
@@ -17,9 +17,9 @@ const goldenUsageReferencePath = "testdata/af_usage_reference.golden"
 // bytes.
 //
 // This is the load-bearing lock of the #2172 refactor. afUsageReference used to
-// be one literal; it is now a five-part concatenation
+// be one literal; it is now a six-part concatenation
 //
-//	afUsageIntroInside + " " + afUsageBody + "\n\n" + afUsageOutroInside + "\n\n" + afUsageOutro
+//	afUsageIntroInside + "\n\n" + afUsageDispatched + "\n\n" + afUsageBody + "\n\n" + afUsageOutroInside + "\n\n" + afUsageOutro
 //
 // and every joint is a place where a future edit — a trailing space, a "\n\n"
 // that becomes "\n" — silently changes the guidance text delivered to EVERY
@@ -135,9 +135,14 @@ func TestAfUsageReferenceJoints(t *testing.T) {
 		want string
 	}{
 		{
-			// intro + " " + body: one space, same paragraph.
-			name: "intro to body",
-			want: `with the "af" CLI. Commands print JSON on stdout;`,
+			// intro + "\n\n" + dispatched: a blank line, a new paragraph.
+			name: "intro to dispatched",
+			want: "the user cannot see.\n\nWhen another instance dispatched you",
+		},
+		{
+			// dispatched + "\n\n" + body: a blank line, a new paragraph.
+			name: "dispatched to body",
+			want: "no one can help.\n\nCommands print JSON on stdout;",
 		},
 		{
 			// body + "\n\n" + outro: a blank line, a new paragraph.
@@ -201,5 +206,8 @@ func TestUsageReferencesShareOneBody(t *testing.T) {
 	}
 	if strings.Contains(afUsageReference, afUsageIntroPlugin) {
 		t.Error("afUsageReference carries the plugin framing; af's own agents ARE running inside af")
+	}
+	if strings.Contains(AfPluginUsageReference, afUsageDispatched) {
+		t.Error("AfPluginUsageReference carries the dispatched-parent escalation guidance; a plugin installer is a caller of af, not a sub-instance a parent dispatched")
 	}
 }

--- a/session/testdata/af_usage_reference.golden
+++ b/session/testdata/af_usage_reference.golden
@@ -1,4 +1,14 @@
-You are running inside Agent Factory (af), a terminal multiplexer that runs each AI coding agent in an isolated git worktree. Manage sessions, tasks, and the daemon with the "af" CLI. Commands print JSON on stdout; run "af <command> --help" for full flag lists. Every session and task command is PROJECT-SCOPED: it acts on the current directory's project unless --repo <path> names another one, so "af tasks list" shows this project's tasks and "af tasks add" binds the new task here. Acting on another project always takes an explicit --repo; "af tasks list --all" is the one opt-in that spans every project. Session titles are unique WITHIN a project, not across projects, so the same name may exist in several repos: a <title> resolves inside --repo when given, else the current directory's repo. Task ids are globally unique but still project-scoped — "af tasks get/update/trigger/remove <id>" refuses an id owned by another project and names the --repo that would reach it. A task whose project changed underneath a command is refused rather than acted on; nothing is changed, so re-run it. With no repo context (outside a git repository) a title or id held by just one project still resolves, while a title held by several reports an error naming those projects — pass --repo to pick one. Remote hook sessions are the one exception: their names are shared across projects because the hook scripts receive them verbatim.
+You are an AI coding agent running inside Agent Factory (af): a tool that runs many AI coding agents at once, each isolated in its own git worktree — you are one of them.
+
+- instance (the CLI calls it a session — same thing): one isolated git worktree and the agent in it. This worktree is yours, that agent is you; af runs many others alongside it.
+- tab: a process or view inside an instance. You run in its agent tab, and you can add terminal, web, and editor tabs next to it.
+- pane: what the user is looking at — an instance's currently-shown tab, in the terminal UI or the web UI.
+
+Drive af with the "af" CLI, and prefer its native mechanisms over unrelated or global tools. In particular, to put a web page, running dev server, or editor in front of the user, add a tab to your own session (see Tabs) — not a separate browser or editor tool, which opens somewhere the user cannot see.
+
+When another instance dispatched you (your task came from a parent agent or lane, not a person at this terminal): the parent watches the relevant GitHub issue or PR, not your screen. If you hit a question or decision you cannot resolve, raise it there — post it plainly on that issue or PR. Never fall back on a local interactive prompt, picker, or menu: it renders only in your own terminal, so the parent never sees it and you block invisibly. Never guess silently, and never sit idle waiting — an unraised blocker is a stuck lane no one can help.
+
+Commands print JSON on stdout; run "af <command> --help" for full flag lists. Every session and task command is PROJECT-SCOPED: it acts on the current directory's project unless --repo <path> names another one, so "af tasks list" shows this project's tasks and "af tasks add" binds the new task here. Acting on another project always takes an explicit --repo; "af tasks list --all" is the one opt-in that spans every project. Session titles are unique WITHIN a project, not across projects, so the same name may exist in several repos: a <title> resolves inside --repo when given, else the current directory's repo. Task ids are globally unique but still project-scoped — "af tasks get/update/trigger/remove <id>" refuses an id owned by another project and names the --repo that would reach it. A task whose project changed underneath a command is refused rather than acted on; nothing is changed, so re-run it. With no repo context (outside a git repository) a title or id held by just one project still resolves, while a title held by several reports an error naming those projects — pass --repo to pick one. Remote hook sessions are the one exception: their names are shared across projects because the hook scripts receive them verbatim.
 
 Sessions (one agent per isolated worktree):
   af sessions whoami                                   Identify your own session
@@ -15,11 +25,11 @@ Sessions (one agent per isolated worktree):
   af sessions handoff <title> --to <agent>             Continue a stuck session under a different agent (same worktree/branch)
   af sessions restore <title>                          Restore an archived, lost, or dead session
 
-Tabs (extra processes in a session's worktree; max 9 per session; not available for remote sessions):
-  af sessions tab-create <title> --command <cmd> [--name <tab>]   Prints the resolved tab name; tabs persist across restarts
-  af sessions tab-create <title> --kind web --port <n>|--url <u>  A browser pane (no PTY): shows a dev server/site to the user in the web UI
-  af sessions tab-create <title> --kind vscode                    A VS Code editor pane on this session's worktree (no --url/--port); needs code-server installed
-  af sessions tab-delete <title> --name <tab>                     The agent tab itself can't be deleted; kill the session instead
+Tabs (extra processes and views in your instance's worktree; max 9; not for remote sessions). The <title> is the target session — for your own, get it from "af sessions whoami". Tabs are how you put something in front of the user; use them instead of an external browser, editor, or global tool.
+  af sessions tab-create <title> --command <cmd> [--name <tab>]   Terminal tab running <cmd> in the worktree; prints the tab name; persists across restarts
+  af sessions tab-create <title> --kind web --url <u>|--port <n>  Web tab — a live browser view (no process) shown to the user in the web UI; this is how you show a URL, site, or dev server (--port n = http://localhost:n)
+  af sessions tab-create <title> --kind vscode                    VS Code editor tab on the worktree (no --url/--port); needs code-server installed
+  af sessions tab-delete <title> --name <tab>                     Delete a tab; the agent tab can't be deleted (kill the session instead)
 
 Tasks (deliver a prompt on a cron schedule, or whenever a long-running watch script prints a stdout line; exactly one of --cron/--watch-cmd per task):
   af tasks list [--all]                                List this project's tasks (--all spans every project)


### PR DESCRIPTION
## Summary

Closes #2473.

An af-launched agent asked to show a URL reached for a separate global browser skill (`agent-browser`) and could not even name its own instance — the agent system prompt never taught it what af is. It opened with only "you are running inside af, a terminal multiplexer" and buried the web-tab capability mid-list.

This rewrites the inside-agent system prompt (`afUsageReference` in `session/systemprompt.go`) to make the model, terms, and capabilities obvious. Framing approved as-is by Sachin on #2473 (full draft posted [there](https://github.com/sachiniyer/agent-factory/issues/2473#issuecomment-5066721638)).

## What changed

- **New opening** that leads with the model and defines the terms plainly — instance (a.k.a. session), tab, pane — and says outright: to put a web page, dev server, or editor in front of the user, add a tab to your own session, not a separate browser/editor tool that opens where the user cannot see.
- **New inside-only section** (`afUsageDispatched`): when another instance dispatched you, escalate a blocker on the GitHub issue/PR the parent watches — never a local interactive prompt/picker the parent cannot see, never guess silently, never idle. This is the fix for lanes getting stuck invisibly. The plugin/installed-it-yourself audience never carries it (a caller of af is not a dispatched sub-instance) — guarded by a test.
- **Tightened Tabs block** so the web tab is the obvious answer for "show the user a URL/site/dev server", and notes the `whoami`-then-title flow for self-targeting.

## Generated artifacts

The shared body (Tabs block) changed, so the committed per-agent plugin `SKILL.md` files (claude/codex/gemini/amp), their `plugin.json`, and `marketplace.json` are regenerated via `scripts/gen-docs.sh`, and the append-only plugin content version is bumped (3.2 → 3.3). `docs/reference/{cli,api}.md` are unchanged (no CLI text touched).

## Tests

- `afUsageReference` golden regenerated and its joint tests updated to the new six-part assembly (`intro → dispatched → body → outro → tail`); added a guard that the plugin rendering never carries the inside-only dispatched section.
- `TestAfUsageReference_CoversFullSurface`, the plugin drift gate (`TestGeneratedPluginsAreCommitted`), and the plugin-version tests all pass.

## Follow-up (not in this PR)

`tab-create` takes a positional `<title>` (no `--self`), so the prompt uses the accurate `af sessions whoami` → `tab-create <title>` flow. The `--self` ergonomic parity is filed as #2487 — deliberately out of scope here.

## Verification

- Gate head: `eec66fb6`
- `go build ./...`, `gofmt -l` (clean), `go vet`, `golangci-lint run --fast` (clean), `deadcode -test ./...` (clean), `scripts/lint-file-length.sh` (pass), `make docs` (clean regenerated tree, committed)
- `make test-container`: **full suite green** — every package, `session` (37s, golden/joints/inject) and `commands` (drift + version gates) included.

## Base

Branched from current master (`77d3249e`).

## Review

Codex GitHub-app review is degraded/rate-limited — requested once. If it stays silent, over to Captain Claude for the claude-subagent review. Held as **draft**; do not merge unreviewed (no self-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
