### PR TITLE
fix(web): size the mobile shell to the visible viewport and contain overscroll (#2493)

### DIFF
--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -185,9 +185,11 @@
 body {
   margin: 0;
   min-height: 100vh;
+  min-height: 100dvh;
   background: var(--af-bg-canvas);
   color: var(--af-text);
   overflow-x: hidden;
+  overscroll-behavior: none;
 }
 * {
   scrollbar-width: thin;
@@ -227,6 +229,7 @@ body {
 }
 #app {
   min-height: 100vh;
+  min-height: 100dvh;
 }
 .af-icon {
   display: block;
@@ -237,6 +240,7 @@ body {
 }
 .af-login {
   min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -764,6 +768,7 @@ body {
   margin: 0;
   padding: 0.35rem;
   overflow-y: auto;
+  overscroll-behavior: contain;
   flex: 1;
 }
 .af-rail-empty {
@@ -1004,6 +1009,7 @@ body {
   background: transparent;
   border: 0;
   overflow-x: auto;
+  overscroll-behavior: contain;
   scrollbar-width: thin;
   position: relative;
 }
@@ -1193,6 +1199,9 @@ body {
   display: flex;
   background: var(--af-bg-term);
   overflow: hidden;
+}
+.af-term-host .xterm-viewport {
+  overscroll-behavior: contain;
 }
 .af-split {
   display: flex;
@@ -1481,6 +1490,7 @@ body {
   max-width: 30rem;
   max-height: 90vh;
   overflow-y: auto;
+  overscroll-behavior: contain;
   background: var(--af-bg-raised);
   border: 1px solid var(--af-border);
   border-radius: var(--af-r-lg);
@@ -1686,6 +1696,7 @@ body {
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  overscroll-behavior: contain;
 }
 .af-tasks-head {
   display: flex;
@@ -2044,6 +2055,7 @@ body {
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  overscroll-behavior: contain;
 }
 .af-config-head {
   display: flex;

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "69169b93fc01";
+const VERSION = "dc5307df59ac";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -210,7 +210,13 @@
 
 body {
   margin: 0;
+  /* Two-line fallback so the document height matches the VISIBLE viewport on mobile,
+   * exactly as .af-app does. Without the dvh line the body stays pinned to the
+   * tallest (URL-bar-hidden) viewport while .af-app sizes to the visible one, so the
+   * document is taller than the viewport, the page rubber-bands, and toggling the URL
+   * bar refits the terminal mid-gesture (#2493). dvh collapses to vh on desktop. */
   min-height: 100vh;
+  min-height: 100dvh;
   background: var(--af-bg-canvas);
   color: var(--af-text);
   /* The shell is a fixed-height flex layout whose inner regions own their own
@@ -218,6 +224,10 @@ body {
    * the PAGE itself sideways, so clamp horizontal overflow at the root. Vertical
    * scroll is unaffected, and fixed-position layers (the toast) are not clipped. */
   overflow-x: hidden;
+  /* A scroll that reaches the document edge must not rubber-band or trigger
+   * pull-to-refresh: both toggle the mobile URL bar, which resizes .af-app and refits
+   * the terminal mid-gesture. Collapses to the default (auto) on desktop (#2493). */
+  overscroll-behavior: none;
 }
 
 /* Themed scrollbars so the inner scroll regions match the active theme rather than
@@ -268,7 +278,10 @@ body {
 }
 
 #app {
+  /* Match .af-app / body: size to the VISIBLE viewport on mobile so the shell's
+   * ancestor can't be taller than the viewport (#2493). vh fallback for desktop. */
   min-height: 100vh;
+  min-height: 100dvh;
 }
 
 /* All interface icons are inline Lucide SVGs. One sizing primitive keeps their
@@ -283,7 +296,9 @@ body {
 
 /* Login view */
 .af-login {
+  /* Same visible-viewport fallback as .af-app / body / #app (#2493). */
   min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -960,6 +975,9 @@ body {
   margin: 0;
   padding: 0.35rem;
   overflow-y: auto;
+  /* Keep a scroll that reaches this list's edge from chaining into the document
+   * (rubber-band / pull-to-refresh) on mobile. Inert on desktop (#2493). */
+  overscroll-behavior: contain;
   flex: 1;
 }
 
@@ -1281,6 +1299,8 @@ body {
   background: transparent;
   border: 0;
   overflow-x: auto;
+  /* Don't chain a horizontal scroll past this tab strip into the page (#2493). */
+  overscroll-behavior: contain;
   scrollbar-width: thin;
   /* The containing block for the reorder insertion indicator (#1813), which is
    * absolutely positioned into the gap a drop would land in. */
@@ -1532,6 +1552,19 @@ body {
   display: flex;
   background: var(--af-bg-term);
   overflow: hidden;
+}
+
+/* The terminal's own scroll surface (xterm owns the element and its overflow). On
+ * mobile a touch drag inside the terminal must scroll the TERMINAL, not chain out
+ * into the document — a chained scroll toggles the URL bar, which resizes .af-app and
+ * refits the terminal mid-gesture so the scroll never sticks (#2493, Sachin's exact
+ * symptom). overscroll-behavior:contain keeps the scroll inside the viewport.
+ * touch-action is deliberately left at the default (auto) so xterm's native vertical
+ * AND horizontal touch-scroll both work; nothing in web/src sets it to none. Additive
+ * over xterm.css (which declares neither property) and inert on desktop. Scoped under
+ * .af-term-host so it wins regardless of the bundle's CSS order. */
+.af-term-host .xterm-viewport {
+  overscroll-behavior: contain;
 }
 
 /* A split node: two children laid out along its axis with a divider between them.
@@ -1954,6 +1987,8 @@ body {
   max-width: 30rem;
   max-height: 90vh;
   overflow-y: auto;
+  /* Keep a scroll inside the modal from chaining into the page behind it (#2493). */
+  overscroll-behavior: contain;
   background: var(--af-bg-raised);
   border: 1px solid var(--af-border);
   border-radius: var(--af-r-lg);
@@ -2223,6 +2258,8 @@ body {
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  /* Don't chain this view's scroll into the document (#2493). */
+  overscroll-behavior: contain;
 }
 
 .af-tasks-head {
@@ -2722,6 +2759,8 @@ body {
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  /* Don't chain this view's scroll into the document (#2493). */
+  overscroll-behavior: contain;
 }
 
 .af-config-head {


### PR DESCRIPTION
## What

Fixes #2493 — on mobile the terminal/pane wouldn't scroll (felt stuck).

## Root cause

`.af-app` was already `height: 100vh; height: 100dvh` (the *visible* viewport), but its ancestors `body` / `#app` / `.af-login` stayed `min-height: 100vh` — the *tallest* (URL-bar-hidden) viewport. So the document was taller than the visible viewport by the URL-bar height: the page rubber-banded, scrolling toggled the URL bar, `.af-app` resized, and the xterm FitAddon/ResizeObserver **refit the terminal mid-gesture** — so touch-scroll inside the terminal never stuck (Sachin's exact symptom). Residual from the #2037 mobile pass (moved `.af-app` to dvh but not its ancestors). And there was no `overscroll-behavior` anywhere, so the inner scrollers chained their scroll into the document.

## Fix (small, additive, desktop-inert)

1. `body` / `#app` / `.af-login` now use the same two-line fallback `.af-app` uses: `min-height: 100vh; min-height: 100dvh;` — the document height matches the visible viewport, so the page can't rubber-band.
2. `overscroll-behavior: none` on `body`, and `overscroll-behavior: contain` on the five inner scrollers (`.af-rail-list`, `.af-tabbar`, `.af-modal-card`, `.af-tasks`, `.af-config`) and the terminal's own `.af-term-host .xterm-viewport`. `touch-action` is left at the default so xterm's native vertical + horizontal touch-scroll both keep working.

dvh collapses to vh, and overscroll-behavior to its default, on desktop — so this is inert there.

## Verified at a mobile viewport

Headless Chromium at a Pixel 5 viewport (727px, touch) against the built CSS — all checks pass:
- `body` overscroll-behavior = `none`
- `#app` / `.af-login` `min-height` resolves to the visible viewport height (727px)
- all five scrollers + `.af-term-host .xterm-viewport` = `overscroll-behavior: contain`

Web typecheck + **418 web tests** green; `web/dist` rebuilt with `make web-build`; full `make test-container` on the pushed head. CI's **Web selftest** covers the end-to-end mobile flow. Sachin can confirm on his phone via the tailscale-serve HTTPS URL.

## Review

Codex GitHub-app review is rate-limited until Jul 28 and declines; requested once. Captain Claude runs the review before merge — not merging unreviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
