### PR TITLE
fix(tui): re-pin tab highlight across a legacy→new session swap (#2498)

### DIFF
--- a/app/tab_selection_reconcile_test.go
+++ b/app/tab_selection_reconcile_test.go
@@ -101,3 +101,69 @@ func TestTree_SnapshotTabReorderMovesCursorWithSelection(t *testing.T) {
 	assert.Equal(t, wantID, inst.GetTabs()[h.store.ActiveTab()].ID,
 		"pushSelection re-reads the cursor, so the active tab must survive the read")
 }
+
+// TestTree_SnapshotLegacyToNewSwapFollowsTabHighlight is the #2498 regression at
+// the daemon-reconcile entry point. A legacy pre-#1195 row carries no instance ID
+// (ID ""), while restoreLocalTabs backfills non-empty IDs onto its tabs. When a
+// same-title kill/recreate swaps it for a freshly built session (a real instance
+// ID, freshly minted tab IDs), BOTH tab bindings the reconcile carries — the
+// store's active tab AND the sidebar's tree cursor — must follow the equivalent
+// tab by name, the same replacedSessionTabs rule the panes use.
+//
+// Before the fix the tree cursor's own replacedSession predicate required both
+// instance IDs to be non-empty, so it missed the legacy "" → new-id swap, keyed
+// the re-pin on the stale backfilled tab id (which no fresh tab carries), and
+// dropped the cursor to the instance row. The active-tab remap — keyed
+// unconditionally on the name domain — was already correct, so the two disagreed.
+// Against master sel.IsTab is false.
+func TestTree_SnapshotLegacyToNewSwapFollowsTabHighlight(t *testing.T) {
+	h := newTestHome(t)
+
+	// A legacy record: no instance ID, tabs [agent, a, b] whose rows carry the
+	// non-empty IDs restoreLocalTabs backfills onto pre-#1738 tabs.
+	stale := instanceWithFakeBackend(t, "legacy-sess")
+	stale.ID = ""
+	for i, name := range []string{"agent", "a", "b"} {
+		kind := session.TabKindShell
+		if i == 0 {
+			kind = session.TabKindAgent
+		}
+		stale.AddTabForTest(name, kind)
+		stale.GetTabs()[i].ID = "backfilled-" + name
+	}
+	selectInstance(h, stale)
+	resizeHome(h, 200, 40)
+	h.sidebar.SelectTabRow(stale.Title, 1) // rest the cursor on tab "a"
+	require.Equal(t, "a", stale.GetTabs()[h.store.ActiveTab()].Name,
+		"precondition: the cursor and active tab rest on the legacy row's tab a")
+
+	// The recreated session: a real instance ID, freshly minted tab IDs, and a
+	// reordered roster so a slot-keyed re-pin would land on the wrong tab.
+	recreated := instanceWithFakeBackend(t, "legacy-sess")
+	recreated.ID = "new-session-id"
+	for i, name := range []string{"agent", "b", "a"} {
+		kind := session.TabKindShell
+		if i == 0 {
+			kind = session.TabKindAgent
+		}
+		recreated.AddTabForTest(name, kind)
+		recreated.GetTabs()[i].ID = "fresh-" + name
+	}
+	// swapInstanceFromSnapshot builds the live replacement through this seam.
+	t.Cleanup(SetInstanceBuilderForTest(func(session.InstanceData) (*session.Instance, error) {
+		return recreated, nil
+	}))
+
+	require.True(t, h.reconcileSnapshot([]session.InstanceData{recreated.ToInstanceData()}),
+		"a same-title kill/recreate is a visible change")
+
+	// The active tab (already correct on master) and the sidebar cursor (the fix)
+	// must agree: both land on the equivalent replacement tab a at its new slot.
+	assert.Equal(t, "a", recreated.GetTabs()[h.store.ActiveTab()].Name,
+		"the store's active tab follows the replacement tab by name")
+	sel := h.sidebar.GetSelection()
+	require.True(t, sel.IsTab,
+		"the sidebar cursor follows the legacy→new swap onto a tab row, not the instance row (#2498)")
+	assert.Equal(t, "a", recreated.GetTabs()[sel.TabIndex].Name,
+		"the cursor lands on tab a, matching the active-tab remap and the pane reconcile")
+}

--- a/ui/sidebar_nav.go
+++ b/ui/sidebar_nav.go
@@ -64,8 +64,18 @@ func (s *Sidebar) moveCursorToInstance(target *session.Instance) {
 	wantTab := -1
 	if s.lastCursorTitle == target.Title {
 		tabs := target.GetTabs()
-		replacedSession := s.lastCursorInstanceID != "" && target.ID != "" &&
-			s.lastCursorInstanceID != target.ID
+		// A replacement is any same-title swap to a different instance identity:
+		// a kill/recreate mints an entirely new session whose tab ids all differ
+		// by construction, so the cursor must follow the equivalent tab by NAME,
+		// exactly as the pane reconcile does for replacedSessionTabs (see
+		// app/handle_panes.go) — otherwise the tree selection and the panes
+		// disagree about which tab is "the same tab". The stable instance ID is
+		// that identity: a legacy pre-#1195 row carries ID "", so a legacy→new
+		// swap ("" → a real id) is a replacement too (#2498). The differing-ID
+		// test already excludes "both empty", so a re-selected legacy row
+		// (unchanged "" == "") is correctly NOT a replacement and keeps the
+		// same-session tab-ID rule below, where a vanished id means a vanished tab.
+		replacedSession := s.lastCursorInstanceID != target.ID
 		switch {
 		case replacedSession:
 			// A same-title kill/recreate mints fresh tab IDs. Preserve the

--- a/ui/sidebar_tab_identity_test.go
+++ b/ui/sidebar_tab_identity_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
 )
 
 // TestSidebarTreeRepinTracksTabIdentityAcrossReorder is the row-1 regression
@@ -94,4 +96,70 @@ func TestSidebarTreeRepinAgentUsesNameAcrossIDHealing(t *testing.T) {
 	sel := s.GetSelection()
 	require.True(t, sel.IsTab, "the re-pin keeps the agent tab across its ID heal")
 	assert.Equal(t, 0, sel.TabIndex)
+}
+
+// TestSidebarTreeRepinFollowsLegacyToNewSwap is the #2498 regression. A legacy
+// pre-#1195 row carries no stable instance ID (ID ""), while restoreLocalTabs
+// backfills non-empty IDs onto its tabs. When a kill/recreate swaps that row for
+// a freshly built session (a real instance ID, freshly minted tab IDs), the
+// sidebar cursor must follow its tab onto the equivalent slot of the
+// replacement — the same name-domain rebind the pane reconcile applies for
+// replacedSessionTabs (app/handle_panes.go), so the tree selection and the panes
+// never disagree about which tab is "the same tab".
+//
+// The bug: moveCursorToInstance's replacedSession predicate required BOTH the
+// stored and the target instance ID to be non-empty, so the legacy "" → new-id
+// swap read as a same-session tab change. It then keyed on the stale backfilled
+// tab ID, which no freshly minted tab carries, found nothing, and dropped the
+// cursor to the instance row — losing the tab highlight. Against master this
+// test lands on the instance row (sel.IsTab is false).
+func TestSidebarTreeRepinFollowsLegacyToNewSwap(t *testing.T) {
+	s := newTreeSidebar(t, 0)
+	dir := t.TempDir()
+
+	// A legacy record: no instance ID, tabs [agent, a, b] whose shell rows carry
+	// the non-empty IDs restoreLocalTabs backfills onto pre-#1738 tabs.
+	legacy, err := session.NewInstance(session.InstanceOptions{
+		Title: "t-00", Path: dir, Program: "test",
+	})
+	require.NoError(t, err)
+	legacy.ID = ""
+	legacy.AddTabForTest("agent", session.TabKindAgent)
+	legacy.AddTabForTest("a", session.TabKindShell)
+	legacy.AddTabForTest("b", session.TabKindShell)
+	legacy.GetTabs()[1].ID = "backfilled-a"
+	legacy.GetTabs()[2].ID = "backfilled-b"
+	addTestInstance(s, legacy)
+
+	s.SetSelectedInstance(0)
+	s.SelectTabRow(legacy.Title, 1) // rest the cursor on tab "a"
+	require.Equal(t, "a", legacy.GetTabs()[s.GetSelection().TabIndex].Name,
+		"precondition: the cursor rests on the legacy row's tab a")
+
+	// The recreated session: a real minted instance ID, freshly minted tab IDs,
+	// and a reordered roster so a slot-keyed re-pin would land on the wrong tab.
+	recreated, err := session.NewInstance(session.InstanceOptions{
+		Title: "t-00", Path: dir, Program: "test",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, recreated.ID, "precondition: a rebuilt session carries a stable ID")
+	recreated.AddTabForTest("agent", session.TabKindAgent)
+	recreated.AddTabForTest("b", session.TabKindShell)
+	recreated.AddTabForTest("a", session.TabKindShell)
+	recreated.GetTabs()[1].ID = "fresh-b"
+	recreated.GetTabs()[2].ID = "fresh-a"
+
+	// Swap the corpse for the live session, then fire the reconcile's #969 re-pin
+	// assertion — exactly what swapInstanceFromSnapshot + reconcileSnapshot do.
+	require.True(t, s.proj.ReplaceInstanceByTitle("t-00", recreated))
+	s.proj.SelectInstance(recreated)
+
+	sel := s.GetSelection()
+	require.True(t, sel.IsTab,
+		"the highlight follows the legacy→new swap onto a tab row, not the instance row (#2498)")
+	got := recreated.GetTabs()[sel.TabIndex]
+	assert.Equal(t, "a", got.Name,
+		"the cursor lands on the equivalent replacement tab by name, matching the pane reconcile")
+	assert.Equal(t, 2, sel.TabIndex,
+		"tab a moved to slot 2 in the recreated roster; the re-pin follows its identity, not the stale ordinal")
 }


### PR DESCRIPTION
## Summary

Fixes #2498. The TUI sidebar lost the tab highlight when a **legacy** session
(a pre-#1195 record with no stable instance ID, `ID == ""`) was replaced by a
kill/recreate that minted a **new** session (a real ID). The cursor dropped to
the instance row instead of following its tab onto the replacement.

## Root cause

`moveCursorToInstance` (`ui/sidebar_nav.go`) re-pins the tree cursor after a
same-title swap. It classifies the transition to pick a tab-identity strategy:

- **replaced session** → follow the equivalent tab by **name** (every tab ID is
  freshly minted, so name is the identity — the same rule the pane reconcile
  uses for `replacedSessionTabs`).
- **same session** → follow by stable **tab ID** (a vanished ID means a vanished
  tab; never hijack onto a different tab that reused the name).

The `replacedSession` predicate required **both** the stored and target instance
ID to be non-empty:

```go
replacedSession := s.lastCursorInstanceID != "" && target.ID != "" &&
    s.lastCursorInstanceID != target.ID
```

A legacy row carries `ID == ""`, so the legacy → new swap (`"" → real-id`) failed
that gate and was misread as a *same-session* tab change. It then keyed the
re-pin on the stale **backfilled** tab ID (`restoreLocalTabs` gives legacy tabs
non-empty IDs), which no freshly minted tab carries, matched nothing, and fell
through to the instance row — losing the highlight.

This is the same `replacedSessionTabs` transition that `swapInstanceFromSnapshot`
already treats correctly for the panes and the store's active tab; only the
sidebar cursor's own predicate was wrong, so the cursor and the panes disagreed
about which tab is "the same tab."

## Fix

```go
replacedSession := s.lastCursorInstanceID != target.ID
```

A replacement is any same-title swap to a **different instance identity**. The
differing-ID test already excludes "both empty" (equal empties can't differ), so
a re-selected legacy row (`"" == ""`) is correctly *not* a replacement and keeps
the same-session tab-ID rule.

> Note vs. the issue's suggested `… && (lastCursorInstanceID != "" || target.ID
> != "")`: the trailing clause is always true whenever the IDs differ, so it is
> redundant. This is the same predicate, simplified, with the identity semantics
> documented inline.

## Test

`TestSidebarTreeRepinFollowsLegacyToNewSwap` (in `ui/sidebar_tab_identity_test.go`,
beside the existing `TestSidebarTreeRepin*` family) drives the **real** swap +
#969 re-pin path — `ReplaceInstanceByTitle` → `SelectInstance` → `syncFromStore`
→ `moveCursorToInstance` — with the cursor resting on a legacy row's tab, a fresh
replacement carrying a real ID, and a **reordered** tab roster so a slot-keyed
re-pin would also land wrong. It asserts the cursor follows tab `a` onto its new
slot instead of the instance row.

- **Fails on master** (lands on the instance row, `sel.IsTab == false`).
- Passes with the fix; the sibling `TestSidebarTreeRepin*` guards
  (new→new swap, reused-name non-hijack, agent ID-heal) all still pass.

## Gate

`go build ./...`, `gofmt -l .`, `golangci-lint --fast`, `deadcode -test ./...`,
`scripts/lint-file-length.sh`, `make test-container`, and
`make tui-driver-selftest` (rendered-TUI regression baseline). Results in the
review thread.

## Review

Codex CLI review is rate-limited until Jul 28 and only returns usage-limit
notices — not requesting it on this PR. Greptile is the live AI reviewer.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
