### PR TITLE
refactor(session): drop vestigial agent param from post-worktree hook env API

### DIFF
--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -96,7 +96,7 @@ func refreshWorktreeEnvironment(i *Instance, worktree *git.GitWorktree) error {
 	if worktree == nil {
 		return nil
 	}
-	if err := worktree.SetHookEnvironment("", sessionEnvPassthroughForInstance(i)); err != nil {
+	if err := worktree.SetHookEnvironment(sessionEnvPassthroughForInstance(i)); err != nil {
 		return fmt.Errorf("invalid post-worktree environment pass-through: %w", err)
 	}
 	return nil

--- a/session/git/hooks.go
+++ b/session/git/hooks.go
@@ -41,15 +41,14 @@ const hookWaitDelay = 2 * time.Second
 // readiness wait uses it so a slow build hook running concurrently with the
 // agent is not charged against the agent's startup budget (see task.WaitForReady).
 func RunPostWorktreeHooksAsync(ctx context.Context, repoPath, worktreePath string) <-chan struct{} {
-	return RunPostWorktreeHooksAsyncWithEnvironment(ctx, repoPath, worktreePath, "", nil)
+	return RunPostWorktreeHooksAsyncWithEnvironment(ctx, repoPath, worktreePath, nil)
 }
 
 // RunPostWorktreeHooksAsyncWithEnvironment is the session-aware form used by
 // GitWorktree. Repository-provided commands receive common Git/runtime names
 // plus only the operator's explicit extensions. Selecting an agent for the
-// session does not grant that agent's provider credentials to repository code;
-// the agent parameter remains only for compatibility with existing callers.
-func RunPostWorktreeHooksAsyncWithEnvironment(ctx context.Context, repoPath, worktreePath, _ string, passthrough []string) <-chan struct{} {
+// session does not grant that agent's provider credentials to repository code.
+func RunPostWorktreeHooksAsyncWithEnvironment(ctx context.Context, repoPath, worktreePath string, passthrough []string) <-chan struct{} {
 	done := make(chan struct{})
 	repoCfg, err := config.ResolveConfig(repoPath)
 	if err != nil {

--- a/session/git/hooks_test.go
+++ b/session/git/hooks_test.go
@@ -30,7 +30,7 @@ func TestPostWorktreeHookEnvironmentRequiresExplicitCredentialNames(t *testing.T
 	repoPath := freshRepoConfig(t, []string{
 		fmt.Sprintf(`env | sed 's/=.*//' | sort > %q`, namesPath),
 	})
-	done := RunPostWorktreeHooksAsyncWithEnvironment(context.Background(), repoPath, t.TempDir(), "codex", []string{customName})
+	done := RunPostWorktreeHooksAsyncWithEnvironment(context.Background(), repoPath, t.TempDir(), []string{customName})
 	select {
 	case <-done:
 	case <-time.After(3 * time.Second):

--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -113,9 +113,9 @@ type GitWorktree struct {
 }
 
 // SetHookEnvironment sets exact operator-approved names used by post-worktree
-// commands. The agent parameter remains for compatibility but never grants
-// provider credentials to repository code. Call this before Setup or rebuild.
-func (g *GitWorktree) SetHookEnvironment(_ string, names []string) error {
+// commands. Post-worktree commands never receive an agent's provider
+// credentials. Call this before Setup or rebuild.
+func (g *GitWorktree) SetHookEnvironment(names []string) error {
 	normalized, err := sessionenv.NormalizeExtraNames(names)
 	if err != nil {
 		return err

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -49,8 +49,7 @@ func (g *GitWorktree) Setup() error {
 	}
 
 	// Fire-and-forget post-worktree hooks (cancellable via hooksCtx)
-	g.hooksDone = RunPostWorktreeHooksAsyncWithEnvironment(g.hooksCtx, g.repoPath, g.worktreePath,
-		"", g.hookEnvPassthrough)
+	g.hooksDone = RunPostWorktreeHooksAsyncWithEnvironment(g.hooksCtx, g.repoPath, g.worktreePath, g.hookEnvPassthrough)
 	return nil
 }
 
@@ -82,8 +81,7 @@ func (g *GitWorktree) RebuildFromExistingBranch() error {
 	}
 	g.branchCreatedByUs = branchCreatedByUs
 
-	g.hooksDone = RunPostWorktreeHooksAsyncWithEnvironment(g.hooksCtx, g.repoPath, g.worktreePath,
-		"", g.hookEnvPassthrough)
+	g.hooksDone = RunPostWorktreeHooksAsyncWithEnvironment(g.hooksCtx, g.repoPath, g.worktreePath, g.hookEnvPassthrough)
 	return nil
 }
 
@@ -123,8 +121,7 @@ func (g *GitWorktree) RebuildFreshFromRecordedBase() error {
 
 	g.baseCommitSHA = baseCommit
 	g.branchCreatedByUs = true
-	g.hooksDone = RunPostWorktreeHooksAsyncWithEnvironment(g.hooksCtx, g.repoPath, g.worktreePath,
-		"", g.hookEnvPassthrough)
+	g.hooksDone = RunPostWorktreeHooksAsyncWithEnvironment(g.hooksCtx, g.repoPath, g.worktreePath, g.hookEnvPassthrough)
 	return nil
 }
 


### PR DESCRIPTION
## What

Removes a vestigial `agent` parameter from the post-worktree hook environment API. A prior migration severed the feature where a session's selected agent granted its provider credentials to repository hook code. The `agent` string parameter was left behind as a discarded `_` in two signatures, and every caller threaded a throwaway value through it:

- `RunPostWorktreeHooksAsyncWithEnvironment(ctx, repoPath, worktreePath, _ string, passthrough)` → drops the `_ string`
- `(*GitWorktree).SetHookEnvironment(_ string, names)` → drops the `_ string`

Both carried a "remains for compatibility" comment sentence explaining the dead parameter; those sentences are gone too.

### Call sites updated (all six, grep-confirmed exhaustive)

| Site | Was |
| --- | --- |
| `session/git/worktree_ops.go` ×3 (`Setup`, `RebuildFromExistingBranch`, `RebuildFreshFromRecordedBase`) | passed `""` |
| `session/backend_local.go` (`refreshWorktreeEnvironment`) | passed `""` |
| `session/git/hooks.go` (`RunPostWorktreeHooksAsync` wrapper) | passed `""` |
| `session/git/hooks_test.go` | passed `"codex"` |

## Why it is behavior-preserving

The parameter was already `_` in **both** function bodies — it is never read at runtime. Removing it and dropping the argument at every call site produces byte-identical behavior, and Go's compiler enforces that all call sites are updated together, so nothing can silently break.

The one test that passed `"codex"` (`TestPostWorktreeHookEnvironmentRequiresExplicitCredentialNames`) still asserts that `OPENAI_API_KEY` is stripped from the hook environment — that guarantee is now structural (there is no agent-credential code path at all) rather than resting on the ignored argument.

As corroboration, the sibling env-passthrough setter on the tmux side — `TmuxSession.SetEnvPassthrough(names)` — already takes only the names. This change makes the two env-passthrough setters symmetric instead of one carrying a dead agent arg.

## Gate

- `go build ./...` — clean
- `gofmt -l .` — empty
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `scripts/lint-file-length.sh` — passes
- `make test-container` — full suite on the pushed head

## Scope

Daily abstraction-simplification sweep (#1241) — one small, safe, behavior-preserving cleanup. Relates to the #1195 structural audit (post-migration kludge removal).

Not self-merging — leaving for root review, since this is a behavior-sensitive area even though the change itself is a pure no-op parameter removal.

— Captain Claude
