### PR TITLE
docs: state the auto-update throttle window as 6h, not 24h (#2506)

### DIFF
--- a/commands/autoupdate_test.go
+++ b/commands/autoupdate_test.go
@@ -142,7 +142,7 @@ func withTestHome(t *testing.T) string {
 // TestAutoUpdateWindowsRecordsCheckWhenUpdateAvailable guards against the
 // regression tracked in issue #262: on Windows, when a newer release exists,
 // the early-return path must still record a successful platform decision so
-// the 24-hour throttle fires and the GitHub API is not hit on every launch.
+// the 6-hour throttle fires and the GitHub API is not hit on every launch.
 // It also guards #1002:
 // the Windows skip must precede any network call, so the fetch seam here is a
 // tripwire that fails the test if invoked.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -58,7 +58,7 @@ channel has been testing, and subsequent previews move to `1.0.139-preview-1`.
 ## How updates flow to users
 
 - **Auto-update follows the stable channel by default.** On launch
-  (throttled to once per 24h), `af` resolves the newest release on the
+  (throttled to once every 6h), `af` resolves the newest release on the
   configured channel and swaps the binary in place. With the default
   `update_channel: "stable"` it asks GitHub's `releases/latest` endpoint,
   which is pinned to the newest non-prerelease release — previews never


### PR DESCRIPTION
## Summary

Closes #2506.

The auto-update **check** window is 6h in code, but two stragglers from the 24h→6h change still stated 24h. This aligns the stale prose to the code — no constant, behavior, or the separate failure-throttle (#459/#1466) touched.

## Code proof (unchanged)

- `internal/autoupdate/cache.go:18` — `CheckInterval = 6 * time.Hour`, gated at `cache.go:106`.
- `commands/autoupdate.go:75-76` rationale already reads: *"the then-24-hour window … The window is now 6h."* Left as-is — its "then-24-hour" is a deliberate historical reference to the pre-change window, not a stale claim.

## Fix (prose only)

- `docs/release-process.md:61` — "throttled to once per 24h" → "throttled to once every 6h".
- `commands/autoupdate_test.go:145` — doc comment "the 24-hour throttle" → "the 6-hour throttle".

Every other surface (README, `docs/getting-started.md`, `docs/configuration.md`, generated `docs/reference/cli.md`) already says 6h; these were the two stragglers the #2506 audit found. The generated `cli.md` was not hand-edited.

## Verification

- Gate head: `11ef9398`
- `go build ./...`, `gofmt -l` (clean), `go vet ./commands/` (clean)
- `make test-container`: **full suite green** — every package, `commands` included.

## Base

Branched from current master (`8a990f9b`). Two-line diff.

## Review

Codex GitHub-app review is rate-limited until Jul 28 — requested once (expect a decline). Over to Captain Claude for the claude-subagent review. Held as **draft**; do not merge unreviewed (no self-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
