### PR TITLE
feat(web): hand a session off to a different agent (#2013)

### DIFF
--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -299,16 +299,16 @@
         "pointer": "keys/keys.go (F, handoff) -> app/handle_handoff.go -> app/session_control.go handoffSessionThroughDaemon"
       },
       "web": {
-        "status": "no",
-        "pointer": "no handoffSession() in web/src/api.ts (derived)"
+        "status": "yes",
+        "pointer": "web/src/api.ts handoffSession -> HandoffSession; web/src/ui.ts Handoff action (shown on a handoff-capable selection via canHandoff); picker web/src/modals.ts handoffModal"
       },
       "cli": {
         "status": "yes",
         "pointer": "api/sessions_handoff.go (af sessions handoff <title> --to <agent>)"
       },
-      "verdict": "real-gap",
+      "verdict": "parity",
       "issue": "#2013",
-      "notes": "Shipped TUI+CLI in the #2013 prompted-handoff PR; the web action is deferred to that issue's follow-up. Recorded as a real gap rather than a deliberate one, and #2084 is why: it just gave the web a way OUT of a limit-blocked session (closing #1934), so the web now surfaces the exact state that motivates a handoff and offers only one of the two answers to it - wait, but not switch. The agent picker the modal needs already exists (web/src/modals.ts programSelect), and HandoffSession is a public route, so this is a client-side addition rather than new plumbing."
+      "notes": "Closed across all three surfaces. Shipped TUI+CLI in the #2013 prompted-handoff PR; the web action was the deferred follow-up, and #2084 is why it stayed a real gap not a deliberate one — #2084 gave the web a way OUT of a limit-blocked session (closing #1934), so the web surfaced the exact state that motivates a handoff while offering only one of the two answers to it (wait, but not switch). The web now calls the existing HandoffSession public route through the same daemon path the TUI/CLI use — no parallel recovery logic — and renders the served ListPrograms enum (enum.agent-programs) in a picker, so a new agent is a handoff target with no web change. The gate is not re-derived client-side: the daemon projects InstanceData.CanHandoff from the SAME Capabilities().Handoff + ValidateRuntimeAction(RuntimeActionHandoff) predicates the TUI's handleHandoff reads, and CurrentAgent from the SAME session.CurrentAgentName the daemon's same-agent guard resolves through, so the picker's exclude-current and the button's show/hide cannot drift from the daemon. `brief` is deliberately not sent (see field_coverage HandoffSession.brief)."
     },
     {
       "id": "session.attach",
@@ -1501,6 +1501,7 @@
       "CreateTab": "session.tab.create",
       "DeleteProject": "project.delete",
       "GetConfig": "config.read",
+      "HandoffSession": "session.handoff",
       "KillSession": "session.kill",
       "ListBackends": "backend.list",
       "ListPrograms": "enum.agent-programs",
@@ -1978,6 +1979,11 @@
         },
         "port": {
           "gap": "session.tab.create.web"
+        }
+      },
+      "HandoffSession": {
+        "brief": {
+          "ok": "Deliberate, mirroring the TUI's brief=ok: the web handoff is pick-agent-then-confirm, and the incoming agent's mission defaults to the session's stored prompt (which the web can set at create time and change via the live terminal). Putting a free-text mission field inside a one-decision confirm is a different interaction; `af sessions handoff --brief` is the surface for overriding the mission inline. The web sends id (the all-project client's collision-proof key, resolved first so a duplicate title cannot misroute the swap), title, repo_id, and to."
         }
       },
       "UpdateTask": {

--- a/session/handoff.go
+++ b/session/handoff.go
@@ -173,6 +173,20 @@ func (i *Instance) CurrentAgentName() string {
 	return i.currentAgentNameLocked()
 }
 
+// canHandoffLocked reports whether this session's agent can be handed off in
+// place right now (#2013), reading the SAME two predicates the TUI's handoff gate
+// uses (app/handle_handoff.go handleHandoff): the backend's Handoff capability and
+// a runtime state that admits the swap. It is projected as InstanceData.CanHandoff
+// so browser clients — which cannot run these Go predicates — render the daemon's
+// decision rather than re-deriving the rule and drifting from it. Caller holds
+// i.mu (ToInstanceData reads it inside toInstanceDataLocked); the two predicates
+// resolve under that one hold, so the capability cannot disagree with the liveness
+// axes it was read beside.
+func (i *Instance) canHandoffLocked() bool {
+	return i.capabilitiesLocked().Handoff &&
+		i.lifecycleViewLocked().ValidateRuntimeAction(RuntimeActionHandoff) == nil
+}
+
 // currentAgentNameLocked is CurrentAgentName's already-locked half, for callers
 // holding i.mu (SwapAgentProgram builds the ledger entry inside its write lock,
 // and sync.RWMutex is not reentrant). TmuxSession.Program takes only the tmux

--- a/session/instance_data.go
+++ b/session/instance_data.go
@@ -44,6 +44,8 @@ func (i *Instance) toInstanceDataLocked() InstanceData {
 		InFlightOp:            i.inFlightOp,
 		LifecycleAction:       lifecycleActionFor(i.ID, i.liveness, i.inFlightOp, i.startupStateUnknown),
 		CanKill:               canKillFor(i.ID, i.inFlightOp),
+		CanHandoff:            i.canHandoffLocked(),
+		CurrentAgent:          i.currentAgentNameLocked(),
 		ModelChange:           agentModelChangeForLiveness(i.agentModelChange, i.liveness),
 		Height:                i.Height,
 		Width:                 i.Width,

--- a/session/storage.go
+++ b/session/storage.go
@@ -55,6 +55,21 @@ type InstanceData struct {
 	// vetoes runtime reuse but must remain explicitly removable. Like
 	// LifecycleAction, this is derived live and scrubbed before disk persistence.
 	CanKill bool `json:"can_kill,omitempty"`
+	// CanHandoff is the projection-only agent-swap capability shared by the TUI and
+	// web (#2013): true when this session's agent can be handed off in place — a
+	// local-worktree backend (Capabilities().Handoff) in a runtime state that admits
+	// the swap (ValidateRuntimeAction(RuntimeActionHandoff)). It is derived live by
+	// ToInstanceData from the SAME two predicates the TUI's handoff gate reads
+	// (app/handle_handoff.go), so a browser — which cannot run those Go predicates —
+	// renders the daemon's decision instead of re-deriving the rule. Scrubbed before
+	// disk persistence like LifecycleAction/CanKill.
+	CanHandoff bool `json:"can_handoff,omitempty"`
+	// CurrentAgent is the agent enum this session is treated AS
+	// (session.CurrentAgentName). Projection-only, carried so a client's handoff
+	// picker can exclude the running agent exactly as the daemon's same-agent guard
+	// does (session/handoff.go) — filtering on Program instead would drift from the
+	// guard on a wrapper-script session. Derived live and scrubbed before disk.
+	CurrentAgent string `json:"current_agent,omitempty"`
 	// ModelChange is the projection-only agent diagnostic carried to the CLI,
 	// TUI, and web row. It is derived from the live runtime's Observation and
 	// scrubbed by ForStorage so a resolved or replaced process cannot inherit a
@@ -155,6 +170,8 @@ func (d InstanceData) ForStorage() InstanceData {
 	d.InFlightOp = OpNone
 	d.LifecycleAction = LifecycleActionNone
 	d.CanKill = false
+	d.CanHandoff = false
+	d.CurrentAgent = ""
 	d.ModelChange = nil
 	switch {
 	case lv == LiveArchived:

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6292,6 +6292,9 @@ async function resumeFromLimit(id, title, token2) {
     throw new Error(result.reason || "resume was not performed");
   }
 }
+async function handoffSession(id, title, to, token2) {
+  return af("HandoffSession", { id, title, repo_id: "", to }, token2);
+}
 async function deleteProject(root2, token2) {
   return af("DeleteProject", { repo_path: root2, repo_id: "" }, token2);
 }
@@ -6449,6 +6452,17 @@ function programChoices(catalog, keep = "") {
   const extra = keep.trim();
   if (extra !== "" && !choices.some((c) => c.value === extra)) {
     choices.push({ value: extra, label: extra });
+  }
+  return choices;
+}
+function handoffAgentChoices(catalog, current) {
+  const cur = current.trim();
+  const choices = [];
+  for (const opt of catalog?.programs ?? []) {
+    if (opt.name === cur) {
+      continue;
+    }
+    choices.push({ value: opt.name, label: opt.name });
   }
   return choices;
 }
@@ -6652,6 +6666,54 @@ function newSessionModal(projects, defaultProject2, callbacks) {
     });
   });
   queueMicrotask(() => titleInput.focus());
+  return handle;
+}
+function handoffModal(sessionTitle, currentAgent, callbacks) {
+  const { handle, body, confirmBtn } = modalChrome({
+    title: `Hand off ${sessionTitle}`,
+    confirmLabel: "Hand off",
+    confirmClass: "af-primary",
+    onCancel: callbacks.onCancel
+  });
+  const agentSelect = h("select", { class: "af-input" });
+  agentSelect.setAttribute("aria-label", "New agent");
+  confirmBtn.disabled = true;
+  const renderChoices = (choices) => {
+    agentSelect.replaceChildren();
+    for (const choice of choices) {
+      agentSelect.append(h("option", { value: choice.value }, choice.label));
+    }
+    confirmBtn.disabled = choices.length === 0;
+  };
+  body.append(
+    field("New agent", agentSelect),
+    h(
+      "p",
+      { class: "af-modal-text" },
+      "The new agent starts fresh with a summary of the work so far. Same worktree and branch \u2014 nothing is discarded."
+    )
+  );
+  void callbacks.loadPrograms().then((catalog) => {
+    const choices = handoffAgentChoices(catalog, currentAgent);
+    renderChoices(choices);
+    if (choices.length === 0) {
+      handle.setError("No other agent is available to hand off to.");
+    }
+  }).catch(() => {
+    renderChoices([]);
+    handle.setError("Could not load the agent list. Try again.");
+  });
+  const card = handle.el.firstElementChild;
+  asForm(card, () => {
+    const target = agentSelect.value;
+    if (target === "") {
+      handle.setError("Pick an agent to hand off to.");
+      return;
+    }
+    handle.setError(null);
+    callbacks.onSubmit(target);
+  });
+  queueMicrotask(() => agentSelect.focus());
   return handle;
 }
 function confirmModal(opts) {
@@ -7519,6 +7581,9 @@ function isArchived(s) {
 }
 function isLimitReached(s) {
   return livenessOf(s) === Liveness.LimitReached;
+}
+function canHandoff(s) {
+  return s.can_handoff === true;
 }
 function compareSessionsForRail(a, b) {
   const aArchived = isArchived(a);
@@ -11174,6 +11239,12 @@ var AppShell = class {
   // only thing that rebuilds the header, so patchMainHead toggles it in place.
   retryBtn = null;
   retryVisible = false;
+  // The Handoff button and whether it is currently shown (#2013). Same in-place
+  // treatment as retryBtn: a session becomes (or stops being) handoff-capable —
+  // e.g. it goes Ready, or is archived from another client — WITHOUT a selection
+  // change, so patchMainHead toggles it rather than deciding once at build time.
+  handoffBtn = null;
+  handoffVisible = false;
   // The tab bar for the selected session, (re)created per selection and patched in
   // place when the tab list or active tab changes (#1592 Phase 5 PR7). null when
   // nothing is selected (the empty state has no tabs).
@@ -11785,6 +11856,12 @@ var AppShell = class {
     this.retryBtn = retryBtn;
     this.retryVisible = isLimitReached(selected);
     retryBtn.hidden = !this.retryVisible;
+    const handoffBtn = h2("button", { type: "button", class: "af-ghost af-term-action" }, "Handoff");
+    handoffBtn.title = "Continue this session under a different agent";
+    handoffBtn.addEventListener("click", () => this.actions.handoff());
+    this.handoffBtn = handoffBtn;
+    this.handoffVisible = canHandoff(selected);
+    handoffBtn.hidden = !this.handoffVisible;
     const headActions = h2("div", { class: "af-term-actions" });
     headActions.hidden = true;
     this.headActions = headActions;
@@ -11799,7 +11876,7 @@ var AppShell = class {
     this.tabInsert.setAttribute("aria-hidden", "true");
     this.attachTabReorder(tabBar);
     this.attachTabRename(tabBar);
-    const head = h2("div", { class: "af-term-head" }, titleBox, tabBar, headActions, retryBtn);
+    const head = h2("div", { class: "af-term-head" }, titleBox, tabBar, headActions, handoffBtn, retryBtn);
     this.main.className = "af-main af-main-term";
     this.main.replaceChildren(head, this.termHost);
     this.renderTabBar(state);
@@ -12035,6 +12112,11 @@ var AppShell = class {
     if (this.retryBtn && nowLimited !== this.retryVisible) {
       this.retryVisible = nowLimited;
       this.retryBtn.hidden = !nowLimited;
+    }
+    const nowHandoff = canHandoff(selected);
+    if (this.handoffBtn && nowHandoff !== this.handoffVisible) {
+      this.handoffVisible = nowHandoff;
+      this.handoffBtn.hidden = !nowHandoff;
     }
   }
   /** Keeps management reachable when the selected session's rail row is filtered
@@ -12842,6 +12924,32 @@ function doRetryLimit() {
   }
   void resumeFromLimit(sel.id, sel.title, tok).catch((e) => surfaceTabError(e));
 }
+function doHandoff() {
+  const sel = selectedSessionData();
+  if (!sel || !sel.id || !canHandoff(sel)) {
+    return;
+  }
+  const target = { id: sel.id, title: sel.title };
+  openModal(
+    handoffModal(sel.title, sel.current_agent ?? "", {
+      // The agent enum is global (#1970), so the picker asks with no repo scope.
+      loadPrograms: () => loadPrograms(""),
+      onSubmit: (to) => {
+        const tok = token;
+        if (tok === null || !modal) {
+          return;
+        }
+        const m = modal;
+        m.setBusy(true);
+        void handoffSession(target.id, target.title, to, tok).then(closeModal).catch((e) => {
+          m.setBusy(false);
+          m.setError(describeError(e));
+        });
+      },
+      onCancel: closeModal
+    })
+  );
+}
 function doRemoveTask(task) {
   const tok = token;
   if (tok === null) {
@@ -12885,6 +12993,7 @@ var actions = {
   archive: (session) => openConfirm("archive", session),
   restore: (session) => openConfirm("restore", session),
   retryLimit: doRetryLimit,
+  handoff: doHandoff,
   switchTab,
   layoutChanged: () => splitView.refit(),
   openTab,

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "dc5307df59ac";
+const VERSION = "382b8693b922";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -15,6 +15,7 @@ import {
   type CreateSessionInput,
   createTab,
   errorText,
+  handoffSession,
   isMutationCommittedError,
   killSession,
   listBackends,
@@ -133,6 +134,24 @@ test("resumeFromLimit rejects the daemon's no-op outcome", async () => {
     /another operation owns the retry/,
     "a successful HTTP envelope must not turn a daemon no-op into a successful web action",
   );
+});
+
+// #2013: a handoff STOPS a live agent and starts another, so it must key by stable
+// id like kill/archive — a title-resolved misroute would tear down an unrelated
+// repo's agent. `brief` is deliberately never sent from the web (the mission
+// defaults to the session's stored prompt; `af sessions handoff --brief` is the
+// inline-override surface), so this pins its ABSENCE as much as the id's presence.
+test("handoffSession posts the stable id and target agent, and never a brief", async () => {
+  const cap = stubFetch();
+  await handoffSession("id-repoB", "feature", "gemini", "tok");
+
+  assert.equal(cap.url, "/v1/HandoffSession");
+  assert.equal(cap.auth, "Bearer tok");
+  assert.equal(cap.body.id, "id-repoB", "the daemon resolves by id first, so a duplicate title cannot misroute the swap");
+  assert.equal(cap.body.title, "feature", "the title rides along for the event and the title-only fallback");
+  assert.equal(cap.body.to, "gemini", "the picked agent is the incoming program");
+  assert.equal(cap.body.repo_id, "", "an all-repos web client scopes by id, not repo");
+  assert.equal("brief" in cap.body, false, "the web never sends a brief — the mission defaults to the stored prompt");
 });
 
 test("listPrograms asks the daemon for the agent catalog (#1970)", async () => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -433,6 +433,34 @@ export async function resumeFromLimit(id: string, title: string, token: string):
   }
 }
 
+/** The daemon's HandoffSession response (daemon.HandoffSessionResponse): the
+ *  outgoing and incoming agents, echoed so the toast can name the swap without
+ *  re-reading the snapshot. */
+export interface HandoffResult {
+  from: string;
+  to: string;
+}
+
+/** Continues a session under a different agent, in place (#2013) — the web half of
+ *  the TUI's `F`. The daemon swaps the agent program, keeps the worktree and
+ *  branch, and delivers a mission brief to the incoming agent; the resulting
+ *  session.updated event repaints the rail. `to` is a supported agent enum name
+ *  from ListPrograms, never the current one (the daemon's same-agent guard rejects
+ *  that, and the picker already excludes it).
+ *
+ *  Sends `id` like kill/archive/resumeFromLimit, NOT title-only: a handoff STOPS a
+ *  live agent and starts another, so resolving a duplicate title across repos to
+ *  the wrong session would tear down an unrelated agent. `brief` is deliberately
+ *  not sent — the mission defaults to the session's stored prompt, and inline
+ *  override is `af sessions handoff --brief`'s surface (see docs/surface-parity.md,
+ *  field_coverage HandoffSession.brief).
+ *
+ *  A failed handoff (not found, busy, unsupported backend, same agent) comes back
+ *  as an envelope error and throws ApiError, so callers share one error path. */
+export async function handoffSession(id: string, title: string, to: string, token: string): Promise<HandoffResult> {
+  return af<HandoffResult>("HandoffSession", { id, title, repo_id: "", to }, token);
+}
+
 /** The daemon's DeleteProject response: how many sessions it archived vs tore
  *  down (in-place ones that can't be archived). */
 export interface DeleteProjectResult {

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -27,6 +27,7 @@ import {
   killSession,
   getConfig,
   isMutationCommittedError,
+  handoffSession,
   listBackends,
   listPrograms,
   listTasks,
@@ -46,7 +47,7 @@ import {
 } from "./api.js";
 import { createKeyedQueue } from "./config.js";
 import { EventStream, type EventStreamStatus } from "./events.js";
-import { confirmDeleteProjectModal, confirmModal, type ModalHandle, newSessionModal } from "./modals.js";
+import { confirmDeleteProjectModal, confirmModal, handoffModal, type ModalHandle, newSessionModal } from "./modals.js";
 import { InstallAffordance } from "./install.js";
 import { decideKey, type KeyboardFocus, type View } from "./nav.js";
 import { defaultFilter, filterSessions, loadFilter, persistFilter, withKind } from "./filter.js";
@@ -60,7 +61,7 @@ import {
   upsertSession,
 } from "./sessions.js";
 import { SplitView } from "./split.js";
-import { isArchived, type RowKind } from "./status.js";
+import { canHandoff, isArchived, type RowKind } from "./status.js";
 import { isRenameableTab } from "./tablabel.js";
 import { Store } from "./store.js";
 import { registerServiceWorker } from "./serviceworker.js";
@@ -1268,6 +1269,48 @@ function doRetryLimit(): void {
   void resumeFromLimit(sel.id, sel.title, tok).catch((e) => surfaceTabError(e));
 }
 
+/**
+ * Hands the selected session off to a different agent (#2013) — the web's analogue
+ * of the TUI's `F`. Opens the agent picker (excluding the running agent); on confirm
+ * it swaps the agent in place via HandoffSession, keeping the worktree and branch,
+ * and the resulting session.updated event repaints the rail.
+ *
+ * Gated on the daemon-projected `can_handoff` — the button that calls this only
+ * appears for a handoff-capable selection — and re-checked here, so a stale click
+ * still surfaces the daemon's error rather than acting. Unlike Retry this DOES
+ * confirm: the picker modal is the confirmation, matching the TUI, because a handoff
+ * stops a working agent and starts another. Uses the FULL projection (id + current
+ * agent), which the id/title-only selectedSession() omits. */
+function doHandoff(): void {
+  const sel = selectedSessionData();
+  if (!sel || !sel.id || !canHandoff(sel)) {
+    return;
+  }
+  const target = { id: sel.id, title: sel.title };
+  openModal(
+    handoffModal(sel.title, sel.current_agent ?? "", {
+      // The agent enum is global (#1970), so the picker asks with no repo scope.
+      loadPrograms: () => loadPrograms(""),
+      onSubmit: (to: string) => {
+        const tok = token;
+        // `=== null` not `!tok`: "" is the authorized-tokenless credential (#1696).
+        if (tok === null || !modal) {
+          return;
+        }
+        const m = modal;
+        m.setBusy(true);
+        void handoffSession(target.id, target.title, to, tok)
+          .then(closeModal)
+          .catch((e) => {
+            m.setBusy(false);
+            m.setError(describeError(e));
+          });
+      },
+      onCancel: closeModal,
+    }),
+  );
+}
+
 /** Removes a task (RemoveTask), then refetches. Keys off the stable id. */
 function doRemoveTask(task: TaskData): void {
   const tok = token;
@@ -1328,6 +1371,7 @@ const actions = {
   archive: (session: ActionableSession) => openConfirm("archive", session),
   restore: (session: ActionableSession) => openConfirm("restore", session),
   retryLimit: doRetryLimit,
+  handoff: doHandoff,
   switchTab,
   layoutChanged: () => splitView.refit(),
   openTab,

--- a/web/src/modals.ts
+++ b/web/src/modals.ts
@@ -18,7 +18,7 @@
 
 import type { CreateSessionInput } from "./api.js";
 import { type BackendCatalog, type BackendChoice, REPO_DEFAULT, backendChoices, backendNotice, backendSelectable } from "./backends.js";
-import { PROGRAM_REPO_DEFAULT, type ProgramCatalog, type ProgramChoice, programChoices } from "./programs.js";
+import { PROGRAM_REPO_DEFAULT, type ProgramCatalog, type ProgramChoice, handoffAgentChoices, programChoices } from "./programs.js";
 
 /** A live modal: its root element plus in-place patch controls index.ts drives
  *  around the async submit. close() removes it from the DOM. */
@@ -376,6 +376,86 @@ export function promptModal(
   });
 
   queueMicrotask(() => area.focus());
+  return handle;
+}
+
+/** The handoff modal (#2013): pick the agent to continue the session under — the
+ *  web half of the TUI's `F`. It collapses the TUI's pick-then-confirm into one
+ *  dialog: a web modal already gates the swap behind an explicit submit, and the
+ *  explanatory line IS the confirmation the TUI shows after the picker.
+ *
+ *  The agent list comes from the daemon (loadPrograms), never a list here, and
+ *  excludes the running agent — the daemon's same-agent guard would reject it. If
+ *  the catalog can't be reached or offers no other agent, Hand off stays disabled
+ *  with an explanation, so the modal degrades to "you can't from here" rather than
+ *  to a submit that always errors. */
+export function handoffModal(
+  sessionTitle: string,
+  currentAgent: string,
+  callbacks: {
+    onSubmit: (target: string) => void;
+    onCancel: () => void;
+    loadPrograms: () => Promise<ProgramCatalog>;
+  },
+): ModalHandle {
+  const { handle, body, confirmBtn } = modalChrome({
+    title: `Hand off ${sessionTitle}`,
+    confirmLabel: "Hand off",
+    confirmClass: "af-primary",
+    onCancel: callbacks.onCancel,
+  });
+
+  const agentSelect = h("select", { class: "af-input" });
+  agentSelect.setAttribute("aria-label", "New agent");
+  // Nothing to pick until the catalog lands; Hand off is disabled until it does.
+  confirmBtn.disabled = true;
+
+  const renderChoices = (choices: ProgramChoice[]): void => {
+    agentSelect.replaceChildren();
+    for (const choice of choices) {
+      agentSelect.append(h("option", { value: choice.value }, choice.label));
+    }
+    confirmBtn.disabled = choices.length === 0;
+  };
+
+  body.append(
+    field("New agent", agentSelect),
+    h(
+      "p",
+      { class: "af-modal-text" },
+      "The new agent starts fresh with a summary of the work so far. Same worktree and branch — nothing is discarded.",
+    ),
+  );
+
+  void callbacks
+    .loadPrograms()
+    .then((catalog) => {
+      const choices = handoffAgentChoices(catalog, currentAgent);
+      renderChoices(choices);
+      if (choices.length === 0) {
+        handle.setError("No other agent is available to hand off to.");
+      }
+    })
+    .catch(() => {
+      // A handoff needs a concrete target and the web cannot read the enum itself —
+      // that is the whole reason ListPrograms is served — so an unreachable catalog
+      // means the picker can't be offered. Say so rather than submit an empty `to`.
+      renderChoices([]);
+      handle.setError("Could not load the agent list. Try again.");
+    });
+
+  const card = handle.el.firstElementChild as HTMLElement;
+  asForm(card, () => {
+    const target = agentSelect.value;
+    if (target === "") {
+      handle.setError("Pick an agent to hand off to.");
+      return;
+    }
+    handle.setError(null);
+    callbacks.onSubmit(target);
+  });
+
+  queueMicrotask(() => agentSelect.focus());
   return handle;
 }
 

--- a/web/src/programs.test.ts
+++ b/web/src/programs.test.ts
@@ -10,7 +10,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { PROGRAM_REPO_DEFAULT, type ProgramCatalog, programChoices } from "./programs.js";
+import { PROGRAM_REPO_DEFAULT, type ProgramCatalog, handoffAgentChoices, programChoices } from "./programs.js";
 
 /** A catalog in the daemon's own shape: canonical (append-only) order, plus the
  *  program an unspecified create resolves to. */
@@ -125,4 +125,43 @@ test("a seeded program survives an unavailable catalog", () => {
   const choices = programChoices(null, "aider");
 
   assert.deepEqual(choices.map((c) => c.value), [PROGRAM_REPO_DEFAULT, "aider"]);
+});
+
+// The handoff picker (#2013) is the same served-enum design one screen over: it
+// lists the daemon's agents, so a new agent is offered with no web change — but it
+// has NO "repo default" row (a handoff must name a concrete target) and it drops
+// the running agent (the daemon's same-agent guard rejects a self-handoff).
+test("handoffAgentChoices offers the daemon's agents minus the current one, with no repo-default row", () => {
+  const choices = handoffAgentChoices(catalog(), "claude");
+
+  assert.deepEqual(
+    choices.map((c) => c.value),
+    ["codex", "aider", "gemini", "amp", "opencode"],
+    "the running agent is excluded and there is no repo-default sentinel",
+  );
+  assert.equal(
+    choices.some((c) => c.value === PROGRAM_REPO_DEFAULT),
+    false,
+    "a handoff must name a concrete target, so the empty repo-default value is never offered",
+  );
+});
+
+test("handoffAgentChoices offers a never-heard-of agent with no web change, like the create picker", () => {
+  const choices = handoffAgentChoices(catalog({ programs: [{ name: "claude" }, { name: "cursor" }] }), "claude");
+
+  assert.deepEqual(choices.map((c) => c.value), ["cursor"], "a newly supported agent is a valid handoff target with no web edit");
+});
+
+// If the daemon reports no agents, or an empty/unknown current agent leaves nothing
+// to exclude, the caller (the modal) sees an empty list and disables the action —
+// it must never fabricate a choice.
+test("handoffAgentChoices returns nothing to offer when the catalog is empty or null", () => {
+  assert.deepEqual(handoffAgentChoices(catalog({ programs: [] }), "claude"), []);
+  assert.deepEqual(handoffAgentChoices(null, "claude"), []);
+});
+
+test("handoffAgentChoices with an unknown current agent excludes nothing and keeps the full list", () => {
+  const choices = handoffAgentChoices(catalog({ programs: [{ name: "claude" }, { name: "codex" }] }), "");
+
+  assert.deepEqual(choices.map((c) => c.value), ["claude", "codex"], "an empty current agent drops nothing");
 });

--- a/web/src/programs.ts
+++ b/web/src/programs.ts
@@ -94,3 +94,29 @@ export function programChoices(catalog: ProgramCatalog | null, keep = ""): Progr
   }
   return choices;
 }
+
+/**
+ * The concrete agents a session can be handed off to (#2013): the catalog's
+ * programs minus the one already running (`current`).
+ *
+ * Unlike programChoices there is deliberately NO "repo default" row — a handoff
+ * must name a concrete target, which is exactly what the daemon's `to` requires.
+ * The current agent is dropped for the same reason the TUI's handoffAgentChoices
+ * drops it: the daemon's same-agent guard rejects a self-handoff, so offering it
+ * would only produce an error.
+ *
+ * Built entirely from the daemon's response — the same "THE WEB KNOWS NO AGENT
+ * NAMES" rule the rest of this file holds — so a new agent is offered here with no
+ * change to this file.
+ */
+export function handoffAgentChoices(catalog: ProgramCatalog | null, current: string): ProgramChoice[] {
+  const cur = current.trim();
+  const choices: ProgramChoice[] = [];
+  for (const opt of catalog?.programs ?? []) {
+    if (opt.name === cur) {
+      continue;
+    }
+    choices.push({ value: opt.name, label: opt.name });
+  }
+  return choices;
+}

--- a/web/src/status.test.ts
+++ b/web/src/status.test.ts
@@ -8,7 +8,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import type { IconName } from "./icon.js";
-import { type DotKind, isArchived, isCreating, isLimitReached, isWorking, rowStatus, rowTitle } from "./status.js";
+import { canHandoff, type DotKind, isArchived, isCreating, isLimitReached, isWorking, rowStatus, rowTitle } from "./status.js";
 import { InFlightOp, Liveness, Status, type SessionData } from "./types.js";
 
 function sess(over: Partial<SessionData> = {}): SessionData {
@@ -157,6 +157,27 @@ test("isLimitReached ignores limit_reset_at, which outlives the state it describ
     isLimitReached(sess({ liveness: Liveness.Ready, limit_reset_at: "2026-07-18T15:04:00Z" })),
     false,
     "a resumed session carrying a stale reset time must not offer Retry",
+  );
+});
+
+// canHandoff gates the web's Handoff action (#2013). It reads the daemon-projected
+// can_handoff decision rather than re-deriving the handoff rule from
+// backend_type/liveness — a second copy of that rule in the browser is how the
+// picker's "who can be replaced" would drift from the daemon's same-agent guard.
+test("canHandoff reads the daemon's projected decision, so the button appears exactly when the daemon allows it", () => {
+  assert.equal(canHandoff(sess({ can_handoff: true })), true);
+  assert.equal(canHandoff(sess({ can_handoff: false })), false);
+});
+
+// Fails CLOSED, like can_kill: an older daemon that omits the field, or any
+// projection without it, offers no Handoff — never a button that submits to a
+// daemon that cannot service it.
+test("canHandoff fails closed when the projection omits the field", () => {
+  assert.equal(canHandoff(sess()), false, "no can_handoff field must offer nothing, not everything");
+  assert.equal(
+    canHandoff(sess({ liveness: Liveness.Ready })),
+    false,
+    "the web must not INFER handoff-capability from liveness — that is the daemon's decision to project",
   );
 });
 

--- a/web/src/status.ts
+++ b/web/src/status.ts
@@ -170,6 +170,20 @@ export function isLimitReached(s: SessionData): boolean {
   return livenessOf(s) === Liveness.LimitReached;
 }
 
+/** True when this session's agent can be handed off to a different one in place
+ *  (#2013) — the state that gates the Handoff action, mirroring the TUI, which
+ *  advertises `F` only for a handoff-capable selection (app/handle_handoff.go) and
+ *  refuses it with an explanatory error otherwise.
+ *
+ *  Reads the daemon-projected `can_handoff` decision (a local-worktree session in a
+ *  runtime state that admits the swap) rather than re-deriving it from
+ *  backend_type/liveness here: a second copy of the handoff rule in the browser is
+ *  how the picker's "who can be replaced" drifts from the daemon's same-agent guard.
+ *  Fails closed — `=== true`, so an older daemon that omits the field offers nothing. */
+export function canHandoff(s: SessionData): boolean {
+  return s.can_handoff === true;
+}
+
 /**
  * The rail's session comparator, a line-for-line mirror of the TUI sidebar
  * (ui/sidebar_model.go partitionByArchived, #1605): live rows first, then the

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -101,6 +101,16 @@ export interface SessionData {
   /** Daemon-owned explicit teardown capability. True means the row has a stable
    *  non-creating target; absence/false fails closed. */
   can_kill?: boolean;
+  /** Daemon-owned agent-swap capability (#2013). True means this session can be
+   *  handed off to a different agent in place — a local-worktree session in a
+   *  runtime state that admits the swap. The web consumes this decision instead of
+   *  re-deriving the TUI's handoff policy from backend/liveness fields; absence/false
+   *  fails closed. */
+  can_handoff?: boolean;
+  /** The agent enum this session is treated AS (session.CurrentAgentName): the
+   *  handoff picker excludes it, matching the daemon's same-agent guard. Absent
+   *  when unknowable. */
+  current_agent?: string;
   /** Live, projection-only model diagnostic; never restored from instances.json. */
   model_change?: AgentModelChange;
   /** Usage-limit reset time (RFC3339), present only for a LimitReached row. */

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -34,6 +34,7 @@ import {
 } from "./filter.js";
 import { projectMeta, projectName, type ProjectSummary, projectSummaries, scopeToProject } from "./project.js";
 import {
+  canHandoff,
   compareSessionsForRail,
   isArchived,
   isCreating,
@@ -182,6 +183,12 @@ export interface Actions {
    *  TUI: it is not destructive (it re-delivers the prompt the session was already
    *  going to run) and it is the obvious next step for a session that is stuck. */
   retryLimit(): void;
+  /** Hands the current selection off to a different agent (#2013) — the web's
+   *  analogue of the TUI's `F`. Opens the agent picker; on confirm it swaps the
+   *  agent in place, keeping the worktree and branch. Offered only for a
+   *  handoff-capable selection (canHandoff), and DOES confirm (via the picker
+   *  modal) because it stops a working agent, unlike the no-confirm Retry. */
+  handoff(): void;
   /** Switches the selected session's active tab WITHOUT attaching — the keyboard
    *  stays in rail nav mode (the 1-9 keys, mirroring the TUI). */
   switchTab(index: number): void;
@@ -649,6 +656,12 @@ export class AppShell {
   // only thing that rebuilds the header, so patchMainHead toggles it in place.
   private retryBtn: HTMLElement | null = null;
   private retryVisible = false;
+  // The Handoff button and whether it is currently shown (#2013). Same in-place
+  // treatment as retryBtn: a session becomes (or stops being) handoff-capable —
+  // e.g. it goes Ready, or is archived from another client — WITHOUT a selection
+  // change, so patchMainHead toggles it rather than deciding once at build time.
+  private handoffBtn: HTMLElement | null = null;
+  private handoffVisible = false;
   // The tab bar for the selected session, (re)created per selection and patched in
   // place when the tab list or active tab changes (#1592 Phase 5 PR7). null when
   // nothing is selected (the empty state has no tabs).
@@ -1687,6 +1700,18 @@ export class AppShell {
     this.retryVisible = isLimitReached(selected);
     retryBtn.hidden = !this.retryVisible;
 
+    // Handoff, for continuing a session under a different agent (#2013) — the web
+    // half of the TUI's `F`. A limit-blocked session now shows BOTH exits the ledger
+    // called for: Retry (wait for the window) and Handoff (switch agents); a normal
+    // local session shows Handoff alone. Same build-once / patch-in-place treatment
+    // as Retry — gated by the daemon-projected can_handoff, toggled in patchMainHead.
+    const handoffBtn = h("button", { type: "button", class: "af-ghost af-term-action" }, "Handoff");
+    handoffBtn.title = "Continue this session under a different agent";
+    handoffBtn.addEventListener("click", () => this.actions.handoff());
+    this.handoffBtn = handoffBtn;
+    this.handoffVisible = canHandoff(selected);
+    handoffBtn.hidden = !this.handoffVisible;
+
     // Empty while the selected row is visible; patchMainHead fills it only when the
     // shared rail derivation says filtering/scoping removed that row. Keeping the
     // container stable avoids touching the terminal host as that condition flips.
@@ -1723,7 +1748,7 @@ export class AppShell {
     // Retry and the filtered-selection fallback are fixed pane-level actions. Their
     // hidden containers create no flex items on the common path, while visible
     // controls cannot shrink behind the tabs.
-    const head = h("div", { class: "af-term-head" }, titleBox, tabBar, headActions, retryBtn);
+    const head = h("div", { class: "af-term-head" }, titleBox, tabBar, headActions, handoffBtn, retryBtn);
 
     this.main.className = "af-main af-main-term";
     // The persistent terminal host is (re)mounted here; renderMain runs only on a
@@ -2054,6 +2079,16 @@ export class AppShell {
     if (this.retryBtn && nowLimited !== this.retryVisible) {
       this.retryVisible = nowLimited;
       this.retryBtn.hidden = !nowLimited;
+    }
+
+    // Show/hide Handoff as the selected session becomes (or stops being)
+    // handoff-capable without a selection change (#2013): a fresh session finishing
+    // startup, or one archived/killed from another client, flips can_handoff while it
+    // stays selected — the same in-place path Retry above uses, for the same reason.
+    const nowHandoff = canHandoff(selected);
+    if (this.handoffBtn && nowHandoff !== this.handoffVisible) {
+      this.handoffVisible = nowHandoff;
+      this.handoffBtn.hidden = !nowHandoff;
     }
   }
 


### PR DESCRIPTION
## Surface-parity gap closed: hand a session off from the web (#2013)

The TUI (`F`) and CLI (`af sessions handoff`) can continue a session under a
different agent **in place** — same worktree, same branch, new agent. The web
could not. The ledger scored this a `real-gap`, and #2084 is why it stayed one:
that PR gave the web an exit from a usage-limit wall (**Retry**) but not the
*other* answer — **switch agents** — so a limit-blocked session on the web
offered only "wait".

This PR closes `session.handoff`'s web cell.

### Reusing the same path, not a parallel one

The whole risk in a parity fix is shipping a second implementation that drifts.
This one doesn't:

- **The verb** is the existing `POST /v1/HandoffSession` public route the TUI/CLI
  already call — no new plumbing, no client-side recovery logic.
- **The agent list** is the served `ListPrograms` enum (#1970), so a new agent is
  a handoff target with no web change. The picker (`handoffAgentChoices`) drops
  the current agent and offers no "repo default" row — a handoff must name a
  concrete target, exactly what the daemon's `to` requires.
- **The gate is the daemon's, projected — not re-derived in the browser.** The
  daemon now projects `InstanceData.CanHandoff` from the *same*
  `Capabilities().Handoff` + `ValidateRuntimeAction(RuntimeActionHandoff)`
  predicates the TUI's `handleHandoff` reads, and `CurrentAgent` from the *same*
  `session.CurrentAgentName` the daemon's same-agent guard resolves through. So
  the button's show/hide and the picker's exclude-current cannot drift from the
  daemon — the exact "one concept, two representations" disease this package
  exists to kill. Both fields are projection-only, scrubbed by `ForStorage` like
  `LifecycleAction`/`CanKill`.

### What the user sees

A **Handoff** button beside **Retry** in the pane header, shown for a
handoff-capable selection (`canHandoff`). A limit-blocked local session now shows
*both* exits the ledger described — Retry (wait) and Handoff (switch); a normal
local session shows Handoff alone. Picking an agent and confirming (the picker
modal *is* the confirm, because a handoff stops a working agent) swaps it in
place; the resulting `session.updated` event repaints the rail.

`brief` is deliberately **not** sent from the web: the mission defaults to the
session's stored prompt, and `af sessions handoff --brief` is the inline-override
surface (recorded in `field_coverage` HandoffSession.brief, mirroring the TUI's
`brief=ok`).

### Ledger

- `session.handoff` web: `no` → `yes`; verdict `real-gap` → `parity`.
- `HandoffSession` mapped in `ledger.web_rpcs`.
- `field_coverage.web_rpcs.HandoffSession.brief` declared `ok`.

### Tests

- Go: `session` — `CanHandoff`/`CurrentAgent` projected and scrubbed (covered by
  the existing `ToInstanceData` suite; whole suite green).
- Web unit: `handoffSession` sends the stable id + target and never a brief;
  `canHandoff` reads the projected decision and fails closed; `handoffAgentChoices`
  excludes the current agent, has no repo-default row, and offers a never-heard-of
  agent with no web change.
- The Handoff button mirrors the proven Retry render path exactly (same classes,
  same `hidden`-toggle in `patchMainHead`, same `.af-term-action[hidden]` CSS —
  no new CSS), so no `web-selftest` change was needed.

### Gates (run after the final commit, on pushed head `ddfb24e0`)

- `go build ./...` — clean
- `gofmt -l .` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `scripts/lint-file-length.sh` — passed
- `make test-container` — all packages green
- `make web-test` — 425 pass, 0 fail (typecheck + unit)

Closes the web half of #2013.

— Captain Claude
