### PR TITLE
feat(sessions): pin the root agent to the top of both rails with a subtle separator (#2513)

### DIFF
--- a/session/instance_data.go
+++ b/session/instance_data.go
@@ -46,6 +46,7 @@ func (i *Instance) toInstanceDataLocked() InstanceData {
 		CanKill:               canKillFor(i.ID, i.inFlightOp),
 		CanHandoff:            i.canHandoffLocked(),
 		CurrentAgent:          i.currentAgentNameLocked(),
+		IsRoot:                IsReservedTitle(i.Title),
 		ModelChange:           agentModelChangeForLiveness(i.agentModelChange, i.liveness),
 		Height:                i.Height,
 		Width:                 i.Width,

--- a/session/liveness_test.go
+++ b/session/liveness_test.go
@@ -168,6 +168,29 @@ func TestLifecycleActionIsProjectionOnly(t *testing.T) {
 		"instances.json must not persist a UI capability derived from live state")
 }
 
+// TestIsRootIsSharedAcrossInstanceAndProjection pins #2513's cross-surface
+// contract: the reserved-root decision the web consumes (InstanceData.IsRoot) is
+// exactly the daemon's own session.IsReservedTitle, so the browser never
+// re-derives the reserved-title rule (and cannot drift from its case-insensitive,
+// trimmed spelling). It is projection-only — scrubbed before disk like CanKill.
+func TestIsRootIsSharedAcrossInstanceAndProjection(t *testing.T) {
+	for _, title := range []string{"root", "Root", "  root  ", "worker", ""} {
+		data := (&Instance{ID: "id", Title: title, liveness: LiveReady}).ToInstanceData()
+		require.Equal(t, IsReservedTitle(title), data.IsRoot,
+			"projected IsRoot must equal session.IsReservedTitle for %q", title)
+	}
+
+	rootData := (&Instance{ID: "root-id", Title: "root", liveness: LiveReady}).ToInstanceData()
+	require.True(t, rootData.IsRoot)
+
+	stored := rootData.ForStorage()
+	require.False(t, stored.IsRoot, "IsRoot is derived live, never persisted")
+	raw, err := json.Marshal(stored)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "is_root",
+		"instances.json must not persist a UI decision derived from the live title")
+}
+
 func TestKillAddressabilityIsSharedAcrossInstanceAndProjection(t *testing.T) {
 	for _, tc := range []struct {
 		name           string

--- a/session/storage.go
+++ b/session/storage.go
@@ -70,6 +70,14 @@ type InstanceData struct {
 	// does (session/handoff.go) — filtering on Program instead would drift from the
 	// guard on a wrapper-script session. Derived live and scrubbed before disk.
 	CurrentAgent string `json:"current_agent,omitempty"`
+	// IsRoot is the projection-only reserved-root decision shared by the TUI and web
+	// (#2513): the daemon's own session.IsReservedTitle applied to the title. It is
+	// projected so the web pins root to the top of the rail (and draws the
+	// demarcation rule) by CONSUMING the daemon's decision rather than
+	// re-implementing IsReservedTitle in TypeScript against a duplicated title
+	// constant — the exact one-concept-two-representations drift #2513 called out.
+	// Derived live by ToInstanceData and scrubbed before disk like CanKill/CanHandoff.
+	IsRoot bool `json:"is_root,omitempty"`
 	// ModelChange is the projection-only agent diagnostic carried to the CLI,
 	// TUI, and web row. It is derived from the live runtime's Observation and
 	// scrubbed by ForStorage so a resolved or replaced process cannot inherit a
@@ -172,6 +180,7 @@ func (d InstanceData) ForStorage() InstanceData {
 	d.CanKill = false
 	d.CanHandoff = false
 	d.CurrentAgent = ""
+	d.IsRoot = false
 	d.ModelChange = nil
 	switch {
 	case lv == LiveArchived:

--- a/ui/sidebar_model.go
+++ b/ui/sidebar_model.go
@@ -44,6 +44,12 @@ type SidebarItem struct {
 	ItemIndex int // index within the section's children (instances/tasks)
 	IsTab     bool
 	TabIndex  int // 0-based tab slot; meaningful only when IsTab
+	// IsRootSep marks the display-only hairline that demarcates the pinned root
+	// agent from the rest (#2513). It is its OWN item — never welded into a row —
+	// so the window math and mouse hit-zones account for its height; it carries
+	// ItemIndex -1 and is neither a nav stop nor an instance row (isInstanceRow),
+	// so every cursor/zone/selection loop skips it by construction.
+	IsRootSep bool
 }
 
 // SidebarSection holds state for one collapsible section.
@@ -57,7 +63,7 @@ type SidebarSection struct {
 // row in either the Instances or Archived section (#1028). Both carry a
 // projection ItemIndex; the difference is only which folder they render under.
 func isInstanceRow(item SidebarItem) bool {
-	return !item.IsHeader && (item.Kind == SectionInstances || item.Kind == SectionArchived)
+	return !item.IsHeader && !item.IsRootSep && (item.Kind == SectionInstances || item.Kind == SectionArchived)
 }
 
 // partitionByArchived splits projection indices into live and archived (#1028).

--- a/ui/sidebar_nav.go
+++ b/ui/sidebar_nav.go
@@ -264,8 +264,21 @@ func (s *Sidebar) rebuildVisibleItems() {
 			rows := tree.Flatten(len(live),
 				func(i int) bool { return s.instanceExpanded(instances[live[i]]) },
 				func(i int) int { return len(tree.TabLabels(instances[live[i]])) })
+			// The reserved root agent sorts first (LessInstanceOrder, #1144), so
+			// live[0] is root when one exists. Emit the demarcation rule as its OWN
+			// item just before the first non-root INSTANCE row — and only then, so a
+			// root-only or root-less list gets no dangling rule (#2513). Its own item
+			// (not a line welded into a row) keeps the window math and the mouse
+			// hit-zones correct.
+			rootPresent := len(live) > 0 && session.IsReservedTitle(instances[live[0]].Title)
+			sepDone := false
 			for _, r := range rows {
-				item := SidebarItem{Kind: SectionInstances, ItemIndex: live[r.InstanceIndex]}
+				idx := live[r.InstanceIndex]
+				if rootPresent && !sepDone && !r.IsTab() && !session.IsReservedTitle(instances[idx].Title) {
+					items = append(items, SidebarItem{Kind: SectionInstances, IsRootSep: true, ItemIndex: -1})
+					sepDone = true
+				}
+				item := SidebarItem{Kind: SectionInstances, ItemIndex: idx}
 				if r.IsTab() {
 					item.IsTab = true
 					item.TabIndex = r.TabIndex

--- a/ui/sidebar_render.go
+++ b/ui/sidebar_render.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/sachiniyer/agent-factory/ui/tree"
 
@@ -33,39 +32,21 @@ func (s *Sidebar) String() string {
 	rows := make([]string, len(s.visibleItems))
 	heights := make([]int, len(s.visibleItems))
 	totalLines := 0
-	// Demarcate the pinned root agent from the rest with a subtle rule (#2513).
-	// Root sorts first (LessInstanceOrder, #1144), so the rule is drawn as a LEADING
-	// line on the first non-root INSTANCE row after it. Doing it in the rendered
-	// string keeps s.visibleItems, s.selectedIdx, and the window math untouched — the
-	// rule is display-only — and it appears only when a root row is followed by a
-	// non-root one, so a root-only or root-less list gets no dangling rule.
-	instances := s.proj.GetInstances()
-	rootSeen := false
-	sepDrawn := false
 	for i, item := range s.visibleItems {
 		isSelected := i == s.selectedIdx
-		if item.IsHeader {
+		switch {
+		case item.IsHeader:
 			rows[i] = s.renderHeader(item.Kind, isSelected)
-		} else {
-			switch item.Kind {
-			case SectionInstances:
-				if item.IsTab {
-					rows[i] = s.renderTabRow(item, isSelected)
-				} else {
-					row := s.renderInstance(item.ItemIndex, isSelected)
-					if item.ItemIndex >= 0 && item.ItemIndex < len(instances) &&
-						session.IsReservedTitle(instances[item.ItemIndex].Title) {
-						rootSeen = true
-					} else if rootSeen && !sepDrawn {
-						row = s.renderRootSeparator() + "\n" + row
-						sepDrawn = true
-					}
-					rows[i] = row
-				}
-			case SectionArchived:
-				// Archived rows are flat instance rows (#1028) — no tab children.
-				rows[i] = s.renderInstance(item.ItemIndex, isSelected)
-			}
+		case item.IsRootSep:
+			// The display-only demarcation rule under the pinned root agent (#2513),
+			// its own item so heights/zones account for it (registerZones skips it).
+			rows[i] = s.renderRootSeparator()
+		case item.Kind == SectionInstances && item.IsTab:
+			rows[i] = s.renderTabRow(item, isSelected)
+		default:
+			// An instance row — live (SectionInstances) or archived (SectionArchived,
+			// flat #1028). Both index GetInstances() by ItemIndex.
+			rows[i] = s.renderInstance(item.ItemIndex, isSelected)
 		}
 		heights[i] = lipgloss.Height(rows[i])
 		totalLines += heights[i]
@@ -77,6 +58,14 @@ func (s *Sidebar) String() string {
 	if s.height > 0 && totalLines > avail {
 		s.scrollToSelection(heights, avail)
 		start = s.scrollOffset
+		// The root demarcation rule has no row above it to set off once root scrolls
+		// out of the window, so skip it when it would be the first rendered row —
+		// otherwise a scrolled window opens with a dangling hairline directly under
+		// the "▲ N more" indicator (#2513, P3-1). The selection sits below the rule,
+		// so advancing past it never scrolls the selection out of view.
+		if start < len(s.visibleItems) && s.visibleItems[start].IsRootSep {
+			start++
+		}
 		end, _, _ = fitWindow(heights, start, avail)
 		hiddenAbove = start
 		hiddenBelow = len(rows) - end

--- a/ui/sidebar_render.go
+++ b/ui/sidebar_render.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/sachiniyer/agent-factory/ui/tree"
 
@@ -32,6 +33,15 @@ func (s *Sidebar) String() string {
 	rows := make([]string, len(s.visibleItems))
 	heights := make([]int, len(s.visibleItems))
 	totalLines := 0
+	// Demarcate the pinned root agent from the rest with a subtle rule (#2513).
+	// Root sorts first (LessInstanceOrder, #1144), so the rule is drawn as a LEADING
+	// line on the first non-root INSTANCE row after it. Doing it in the rendered
+	// string keeps s.visibleItems, s.selectedIdx, and the window math untouched — the
+	// rule is display-only — and it appears only when a root row is followed by a
+	// non-root one, so a root-only or root-less list gets no dangling rule.
+	instances := s.proj.GetInstances()
+	rootSeen := false
+	sepDrawn := false
 	for i, item := range s.visibleItems {
 		isSelected := i == s.selectedIdx
 		if item.IsHeader {
@@ -42,7 +52,15 @@ func (s *Sidebar) String() string {
 				if item.IsTab {
 					rows[i] = s.renderTabRow(item, isSelected)
 				} else {
-					rows[i] = s.renderInstance(item.ItemIndex, isSelected)
+					row := s.renderInstance(item.ItemIndex, isSelected)
+					if item.ItemIndex >= 0 && item.ItemIndex < len(instances) &&
+						session.IsReservedTitle(instances[item.ItemIndex].Title) {
+						rootSeen = true
+					} else if rootSeen && !sepDrawn {
+						row = s.renderRootSeparator() + "\n" + row
+						sepDrawn = true
+					}
+					rows[i] = row
 				}
 			case SectionArchived:
 				// Archived rows are flat instance rows (#1028) — no tab children.
@@ -313,6 +331,19 @@ func (s *Sidebar) renderHeader(kind SidebarSectionKind, selected bool) string {
 	}
 	return style.Padding(0, narrowAwarePad(w)).Render(
 		lipgloss.Place(w, 1, lipgloss.Left, lipgloss.Center, text))
+}
+
+// renderRootSeparator is the subtle hairline demarcating the pinned root agent
+// from the rest of the sessions (#2513). It reuses the menu's dim sepStyle and the
+// box-drawing rule glyph so it reads as a hairline consistent with the rest of the
+// chrome — never a heavy divider — and carries no text. String() draws it only as
+// a leading line on the first non-root instance row, so it never dangles.
+func (s *Sidebar) renderRootSeparator() string {
+	w := s.contentWidth()
+	if w < 1 {
+		return ""
+	}
+	return sepStyle.Render(strings.Repeat("─", w))
 }
 
 func (s *Sidebar) renderInstance(idx int, selected bool) string {

--- a/ui/sidebar_test.go
+++ b/ui/sidebar_test.go
@@ -313,6 +313,48 @@ func TestSidebar_RootSeparator(t *testing.T) {
 		"a list with no root must draw no rule (#2513)")
 }
 
+// TestSidebar_RootSeparatorNoDanglingRuleWhenScrolled pins #2513 P3-1: because the
+// rule is its own visibleItem, a scrolled window that pushes root above the fold
+// skips a leading rule rather than opening with a dangling hairline under the
+// "▲ N more" indicator. The invariant checked: wherever a rule line renders, root
+// is directly above it — it never leads the window.
+func TestSidebar_RootSeparatorNoDanglingRuleWhenScrolled(t *testing.T) {
+	s := NewSidebar(store.NewProjection())
+	dir := t.TempDir()
+	for _, title := range []string{"root", "alpha", "beta", "gamma"} {
+		inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: dir, Program: "test"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		addAgentShellTabs(inst)
+		addTestInstance(s, inst)
+	}
+	// A short window with a lower row selected forces a scroll that pushes root off
+	// (the reviewer's exact repro: select beta in root+alpha+beta+gamma at ~12 rows).
+	s.SetSize(30, 12)
+	s.SetSelectedInstance(2) // beta
+
+	isRule := func(l string) bool {
+		tr := strings.TrimSpace(l)
+		return tr != "" && strings.Trim(tr, "─") == ""
+	}
+	lines := plainLines(s.String())
+	for i, l := range lines {
+		if !isRule(l) {
+			continue
+		}
+		above := ""
+		for j := i - 1; j >= 0; j-- {
+			if strings.TrimSpace(lines[j]) != "" {
+				above = lines[j]
+				break
+			}
+		}
+		assert.Contains(t, above, "root",
+			"the demarcation rule must sit directly under root, never dangle at the window top (#2513 P3-1)")
+	}
+}
+
 // indicatorArrows reports which "▲/▼ N more" scroll-indicator rows are present
 // in the rendered output. Detection keys on the "more" text because expanded
 // section headers also use a "▼ " arrow.

--- a/ui/sidebar_test.go
+++ b/ui/sidebar_test.go
@@ -285,6 +285,34 @@ func TestSidebarRender(t *testing.T) {
 	assert.NotEmpty(t, rendered)
 }
 
+// TestSidebar_RootSeparator pins the #2513 demarcation: a subtle rule sits between
+// the pinned root agent and the rest, but only when a root is present AND a non-root
+// row follows it — a root-only or root-less list draws no dangling rule.
+func TestSidebar_RootSeparator(t *testing.T) {
+	rule := strings.Repeat("─", 10) // a run long enough not to collide with any glyph
+	mk := func(title string) *session.Instance {
+		inst, _ := session.NewInstance(session.InstanceOptions{
+			Title: title, Path: t.TempDir(), Program: "test",
+		})
+		return inst
+	}
+	build := func(titles ...string) string {
+		s := NewSidebar(store.NewProjection())
+		s.SetSize(40, 24)
+		for _, tt := range titles {
+			addTestInstance(s, mk(tt))
+		}
+		return s.String()
+	}
+
+	assert.Contains(t, build("root", "my-feature"), rule,
+		"root + a non-root session must draw the demarcation rule (#2513)")
+	assert.NotContains(t, build("root"), rule,
+		"a root-only list must draw no dangling rule (#2513)")
+	assert.NotContains(t, build("alpha", "beta"), rule,
+		"a list with no root must draw no rule (#2513)")
+}
+
 // indicatorArrows reports which "▲/▼ N more" scroll-indicator rows are present
 // in the rendered output. Detection keys on the "more" text because expanded
 // section headers also use a "▼ " arrow.

--- a/ui/sidebar_zones_test.go
+++ b/ui/sidebar_zones_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/sachiniyer/agent-factory/ui/layout/zones"
+	"github.com/sachiniyer/agent-factory/ui/store"
 )
 
 // ----------------------------------------------------------------------------
@@ -122,6 +124,50 @@ func TestSidebarArrowZoneMatchesRenderedGlyph(t *testing.T) {
 	id, _, ok = reg.Resolve(r.X+3, r.Y)
 	require.True(t, ok)
 	assert.Equal(t, zones.TreeInstance("t-00"), id)
+}
+
+// TestSidebar_RootSeparatorKeepsArrowZoneAligned pins the #2513 P2 mouse bug: the
+// demarcation rule under the pinned root is its OWN visibleItem, so the arrow
+// hit-zone on the first NON-ROOT row still lands on the rendered ▸/▾ glyph. When
+// the rule was instead welded into that row's string it shifted every line of the
+// block down one, but sidebar_zones.go registered the arrow at the un-shifted Y —
+// the visible arrow fell outside its 1x1 rect, so a click missed it and a
+// double-click fell through to attach. The expected cell is read from the RENDERED
+// output (not the registry), so a registry-derived click could not hide the drift.
+func TestSidebar_RootSeparatorKeepsArrowZoneAligned(t *testing.T) {
+	s := NewSidebar(store.NewProjection())
+	dir := t.TempDir()
+	mkTabbed := func(title string) {
+		inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: dir, Program: "test"})
+		require.NoError(t, err)
+		addAgentShellTabs(inst)
+		addTestInstance(s, inst)
+	}
+	mkTabbed("root")
+	mkTabbed("worker")
+
+	reg := zones.NewRegistry()
+	s.SetZoneRegistry(reg)
+	rect := layout.Rect{X: 4, Y: 2, W: 38, H: 24}
+	s.SetRect(rect)
+	s.SetSelectedInstance(1) // worker (root sorts first) — expands to ▾, rule sits above it.
+
+	reg.Reset()
+	lines := plainLines(s.String())
+
+	require.Contains(t, s.String(), strings.Repeat("─", 10),
+		"root + a non-root must draw the demarcation rule")
+
+	r, ok := reg.Find(zones.TreeArrow("worker"))
+	require.True(t, ok, "arrow zone for the first non-root instance")
+	assert.Equal(t, '▾', runeAtCell(lineAt(t, lines, rect, r.Y), r.X-rect.X),
+		"the arrow zone must cover the rendered ▾ glyph on the row below the rule (#2513 P2)")
+
+	// Resolving the arrow cell hits the arrow, so a click toggles rather than
+	// falling through to TreeInstance -> select/attach.
+	id, _, ok := reg.Resolve(r.X, r.Y)
+	require.True(t, ok)
+	assert.Equal(t, zones.TreeArrow("worker"), id)
 }
 
 // TestSidebarZonesClippedToRect: rows scrolled out of the window register no

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -771,6 +771,12 @@ body {
   overscroll-behavior: contain;
   flex: 1;
 }
+.af-rail-sep {
+  height: 0;
+  margin: var(--af-sp-1) var(--af-sp-2);
+  border-top: 1px solid var(--af-border);
+  list-style: none;
+}
 .af-rail-empty {
   padding: var(--af-sp-4) var(--af-sp-3);
   color: var(--af-text-2);

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7585,9 +7585,8 @@ function isLimitReached(s) {
 function canHandoff(s) {
   return s.can_handoff === true;
 }
-var ROOT_SESSION_TITLE = "root";
 function isRootSession(s) {
-  return s.title.trim().toLowerCase() === ROOT_SESSION_TITLE;
+  return s.is_root === true;
 }
 function compareSessionsForRail(a, b) {
   const aArchived = isArchived(a);

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7585,12 +7585,21 @@ function isLimitReached(s) {
 function canHandoff(s) {
   return s.can_handoff === true;
 }
+var ROOT_SESSION_TITLE = "root";
+function isRootSession(s) {
+  return s.title.trim().toLowerCase() === ROOT_SESSION_TITLE;
+}
 function compareSessionsForRail(a, b) {
   const aArchived = isArchived(a);
   const aa = aArchived ? 1 : 0;
   const bb = isArchived(b) ? 1 : 0;
   if (aa !== bb) {
     return aa - bb;
+  }
+  const ar = isRootSession(a) ? 0 : 1;
+  const br = isRootSession(b) ? 0 : 1;
+  if (ar !== br) {
+    return ar - br;
   }
   const at = a.created_at ?? "";
   const bt = b.created_at ?? "";
@@ -11481,6 +11490,9 @@ var AppShell = class {
         (target) => this.rowActions(target, selected)
       );
     });
+    if (visible.length > 1 && isRootSession(visible[0])) {
+      rows.splice(1, 0, h2("li", { class: "af-rail-sep", ariaHidden: "true" }));
+    }
     const notice = this.railNotice(state, scoped, visible);
     list.replaceChildren(...notice ? [notice, ...rows] : rows);
   }

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "d47b2b9f072d";
+const VERSION = "58ea0e763e45";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "382b8693b922";
+const VERSION = "d47b2b9f072d";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/sessions.test.ts
+++ b/web/src/sessions.test.ts
@@ -178,7 +178,7 @@ test("orderedSessions: the reserved root agent pins to the top despite a newest 
   const list = [
     sess("beta", { created_at: "2026-01-01T00:00:00Z" }),
     // Newest created_at — would sort LAST among live rows without the root pin.
-    sess("root", { created_at: "2026-06-01T00:00:00Z" }),
+    sess("root", { is_root: true, created_at: "2026-06-01T00:00:00Z" }),
     sess("alpha", { created_at: "2026-01-02T00:00:00Z" }),
   ];
   // Root leads by IDENTITY, not by age — mirroring the TUI's LessInstanceOrder so a
@@ -186,12 +186,19 @@ test("orderedSessions: the reserved root agent pins to the top despite a newest 
   assert.deepEqual(orderedSessions(list).map((s) => s.title), ["root", "beta", "alpha"]);
 });
 
-test("orderedSessions: the root pin is case-insensitive on the trimmed title, like IsReservedTitle (#2513)", () => {
+test("orderedSessions: the root pin follows the projected is_root flag, not the title text (#2513)", () => {
+  // The web CONSUMES the daemon's reserved-root decision (InstanceData.IsRoot,
+  // session.IsReservedTitle) rather than re-matching the title, so the daemon owns
+  // the case-insensitive/trimmed rule and the browser cannot drift from it.
   const list = [
     sess("worker", { created_at: "2026-01-01T00:00:00Z" }),
-    sess(" Root ", { created_at: "2026-06-01T00:00:00Z" }),
+    // Flagged root pins regardless of how its title is spelled.
+    sess("primary", { is_root: true, created_at: "2026-06-01T00:00:00Z" }),
+    // A title that merely LOOKS like root but was not flagged does NOT pin — the
+    // web fails closed on the projection, it does not second-guess it from the text.
+    sess("root", { created_at: "2026-02-01T00:00:00Z" }),
   ];
-  assert.deepEqual(orderedSessions(list).map((s) => s.title), [" Root ", "worker"]);
+  assert.deepEqual(orderedSessions(list).map((s) => s.title), ["primary", "worker", "root"]);
 });
 
 // --- tabToKeepOnClose: a pane follows a TAB, never a slot -------------------

--- a/web/src/sessions.test.ts
+++ b/web/src/sessions.test.ts
@@ -174,6 +174,26 @@ test("orderedSessions: title breaks a created_at tie in the archived group (tota
   assert.deepEqual(orderedSessions(list).map((s) => s.title), ["arch-a", "arch-b"]);
 });
 
+test("orderedSessions: the reserved root agent pins to the top despite a newest created_at (#2513)", () => {
+  const list = [
+    sess("beta", { created_at: "2026-01-01T00:00:00Z" }),
+    // Newest created_at — would sort LAST among live rows without the root pin.
+    sess("root", { created_at: "2026-06-01T00:00:00Z" }),
+    sess("alpha", { created_at: "2026-01-02T00:00:00Z" }),
+  ];
+  // Root leads by IDENTITY, not by age — mirroring the TUI's LessInstanceOrder so a
+  // root re-ensure with a fresh created_at still leads; the rest keep oldest-first.
+  assert.deepEqual(orderedSessions(list).map((s) => s.title), ["root", "beta", "alpha"]);
+});
+
+test("orderedSessions: the root pin is case-insensitive on the trimmed title, like IsReservedTitle (#2513)", () => {
+  const list = [
+    sess("worker", { created_at: "2026-01-01T00:00:00Z" }),
+    sess(" Root ", { created_at: "2026-06-01T00:00:00Z" }),
+  ];
+  assert.deepEqual(orderedSessions(list).map((s) => s.title), [" Root ", "worker"]);
+});
+
 // --- tabToKeepOnClose: a pane follows a TAB, never a slot -------------------
 //
 // The post-merge Codex finding on #1815. closeSessionTab used to re-point the pane

--- a/web/src/status.ts
+++ b/web/src/status.ts
@@ -184,17 +184,33 @@ export function canHandoff(s: SessionData): boolean {
   return s.can_handoff === true;
 }
 
+/** The reserved root-agent title, mirroring session.RootSessionTitle (Go,
+ *  session/reserved.go). */
+export const ROOT_SESSION_TITLE = "root";
+
+/**
+ * Whether a session is the reserved root agent — a mirror of Go's
+ * session.IsReservedTitle (session/reserved.go): case-insensitive on the trimmed
+ * title. Root has no dedicated projected flag; its identity IS its reserved
+ * title, so both rails test it the same way rather than the UI inventing a new
+ * predicate (#2513).
+ */
+export function isRootSession(s: SessionData): boolean {
+  return s.title.trim().toLowerCase() === ROOT_SESSION_TITLE;
+}
+
 /**
  * The rail's session comparator, a line-for-line mirror of the TUI sidebar
- * (ui/sidebar_model.go partitionByArchived, #1605): live rows first, then the
- * archived group last. The two groups order OPPOSITELY — live rows are oldest-
- * created first (the projection's stable order), while archived rows are NEWEST-
- * created first, so the archive reads as a most-recent-on-top history, the inverse
- * of the live tree (#1605). Title breaks a created_at tie in BOTH groups so the
- * order is total and never jitters. Shared by the sessions rail (ui.ts
- * orderedSessions) and the project switcher (project.ts) so the two surfaces can
- * never diverge on order (#1674 PR3 review: the web must sort archived desc like
- * the TUI, not asc).
+ * (ui/sidebar_model.go partitionByArchived, #1605; ui/store/order.go
+ * LessInstanceOrder, #1144): the reserved root agent pins to the top, then live
+ * rows, then the archived group last. The two dated groups order OPPOSITELY —
+ * live rows are oldest-created first (the projection's stable order), while
+ * archived rows are NEWEST-created first, so the archive reads as a
+ * most-recent-on-top history, the inverse of the live tree (#1605). Title breaks
+ * a created_at tie in BOTH groups so the order is total and never jitters. Shared
+ * by the sessions rail (ui.ts orderedSessions) and the project switcher
+ * (project.ts) so the two surfaces can never diverge on order (#1674 PR3 review:
+ * the web must sort archived desc like the TUI, not asc).
  */
 export function compareSessionsForRail(a: SessionData, b: SessionData): number {
   const aArchived = isArchived(a);
@@ -202,6 +218,15 @@ export function compareSessionsForRail(a: SessionData, b: SessionData): number {
   const bb = isArchived(b) ? 1 : 0;
   if (aa !== bb) {
     return aa - bb;
+  }
+  // Root pins to the top of its group by IDENTITY, before created_at — mirroring
+  // the TUI's LessInstanceOrder (a root re-ensure with a fresh created_at after a
+  // tmux death still leads). Root is live in practice, so this leaves it first of
+  // the live rows (#1144/#2513).
+  const ar = isRootSession(a) ? 0 : 1;
+  const br = isRootSession(b) ? 0 : 1;
+  if (ar !== br) {
+    return ar - br;
   }
   const at = a.created_at ?? "";
   const bt = b.created_at ?? "";

--- a/web/src/status.ts
+++ b/web/src/status.ts
@@ -184,19 +184,16 @@ export function canHandoff(s: SessionData): boolean {
   return s.can_handoff === true;
 }
 
-/** The reserved root-agent title, mirroring session.RootSessionTitle (Go,
- *  session/reserved.go). */
-export const ROOT_SESSION_TITLE = "root";
-
 /**
- * Whether a session is the reserved root agent — a mirror of Go's
- * session.IsReservedTitle (session/reserved.go): case-insensitive on the trimmed
- * title. Root has no dedicated projected flag; its identity IS its reserved
- * title, so both rails test it the same way rather than the UI inventing a new
- * predicate (#2513).
+ * Whether a session is the reserved root agent (#2513). The web CONSUMES the
+ * daemon-projected `is_root` decision (InstanceData.IsRoot — the daemon's own
+ * session.IsReservedTitle, scrubbed by ForStorage) rather than re-deriving the
+ * reserved-title rule in the browser, the same "consume the decision, don't
+ * re-implement it" discipline as can_kill/can_handoff/lifecycle_action. Absence or
+ * false fails closed (treated as not root).
  */
 export function isRootSession(s: SessionData): boolean {
-  return s.title.trim().toLowerCase() === ROOT_SESSION_TITLE;
+  return s.is_root === true;
 }
 
 /**

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -981,6 +981,17 @@ body {
   flex: 1;
 }
 
+/* The hairline under the pinned root agent (#2513): a dim rule matching the rail's
+ * own borders (--af-border) so root reads as its own zone, never a heavy divider.
+ * Pure demarcation — aria-hidden, not a navigable row, and rendered only when a
+ * non-root row follows root. Mirrors the TUI sidebar's subtle rule. */
+.af-rail-sep {
+  height: 0;
+  margin: var(--af-sp-1) var(--af-sp-2);
+  border-top: 1px solid var(--af-border);
+  list-style: none;
+}
+
 .af-rail-empty {
   padding: var(--af-sp-4) var(--af-sp-3);
   color: var(--af-text-2);

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -111,6 +111,11 @@ export interface SessionData {
    *  handoff picker excludes it, matching the daemon's same-agent guard. Absent
    *  when unknowable. */
   current_agent?: string;
+  /** Daemon-owned reserved-root decision (#2513): true for the always-on root
+   *  agent. The web pins root to the top of the rail and draws the demarcation rule
+   *  by CONSUMING this decision (session.IsReservedTitle, projected) rather than
+   *  re-matching the title in the browser; absence/false fails closed (not root). */
+  is_root?: boolean;
   /** Live, projection-only model diagnostic; never restored from instances.json. */
   model_change?: AgentModelChange;
   /** Usage-limit reset time (RFC3339), present only for a LimitReached row. */

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -39,6 +39,7 @@ import {
   isArchived,
   isCreating,
   isLimitReached,
+  isRootSession,
   type RowKind,
   rowStatus,
   rowTitle,
@@ -1244,6 +1245,13 @@ export class AppShell {
         (target) => this.rowActions(target, selected),
       );
     });
+    // A subtle hairline under the pinned root agent (#2513), matching the TUI. Only
+    // when root actually leads the visible list AND a non-root row follows it, so
+    // there's never a dangling rule on an empty or root-only list. Root sorts first
+    // (compareSessionsForRail) and is unique, so it is visible[0] whenever present.
+    if (visible.length > 1 && isRootSession(visible[0])) {
+      rows.splice(1, 0, h("li", { class: "af-rail-sep", ariaHidden: "true" }));
+    }
     const notice = this.railNotice(state, scoped, visible);
     list.replaceChildren(...(notice ? [notice, ...rows] : rows));
   }


### PR DESCRIPTION
## What

Closes #2513 — pins the always-on **root** agent to the top of the sessions list in **both** rails, set off by a subtle hairline.

## The drift, fixed at the shared seam

The TUI already pinned root first (`LessInstanceOrder`, #1144); the web rail did **not** — `compareSessionsForRail` only did archived-last + created_at. This adds root-first to the web comparator, a line-for-line mirror of `LessInstanceOrder` (root pins by **identity**, before created_at, so a root re-ensure with a fresh timestamp still leads), via a new `isRootSession()` that mirrors Go's `session.IsReservedTitle` (case-insensitive on the trimmed title). Root has no dedicated projected flag — its identity *is* its reserved title — so both rails test it the same way rather than the UI inventing a predicate.

## The separator (both surfaces, subtle, no dangling rule)

Drawn only when a root is present **and** a non-root row follows it:
- **TUI**: a dim box-drawing rule (the menu's existing `sepStyle`) as a **leading line on the first non-root instance row**. Rendered into the row string, so `s.visibleItems`, `s.selectedIdx`, and the window math are untouched — the rule is display-only, so **selection/cursor are unaffected by construction** (#2358).
- **Web**: an `aria-hidden` `<li class="af-rail-sep">` with a `1px --af-border` `border-top`, spliced in after the root row.

## Verified in the real UIs

- **Real TUI** (root seeded via `root_agents`, at 80×24 and 120×40): root is pinned first with the rule below it —
  ```
   ▼ Sessions (4)
    ▸  root                  ●
       ⎇-master
  ────────────────────────────
    ▸  alpha                 ●
    ▸  beta                  ●
    ▾  gamma                 ●
  ```
- **Real web rail** rendered at desktop + mobile, light + dark: the separator is a **1px `--af-border` hairline** (rgb matches the token) sitting **between root and the rest**, rendered 1px, no rail overflow.
- Tests: TUI `TestSidebar_RootSeparator` (root+non-root → rule; root-only / no-root → none); web `orderedSessions` root-first (identity beats a newest created_at; case-insensitive trim).

## Gates

gofmt · `go build` · golangci-lint · `deadcode -test` · file-length · `ui`+`app`+`store`+`session` tests · web typecheck + **427 web tests** · full `make test-container` on the pushed head · `web/dist` rebuilt with `make web-build`.

## Review

Codex GitHub-app review is rate-limited until Jul 28 and declines; requested once. Captain Claude (claude-subagent) reviews before merge — not merging unreviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
