### PR TITLE
fix(config): warn once per source about a removed key, not per load (#2496)

### DIFF
--- a/config/removed.go
+++ b/config/removed.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/sachiniyer/agent-factory/log"
 )
@@ -25,8 +26,33 @@ func warnRemovedAutoYes(shape map[string]any, source string) {
 	}
 }
 
+// removedAutoYesWarned memoizes which sources have already received the
+// auto_yes-removal heads-up. A genuinely removed key deserves ONE migration
+// notice per source, not one per config load: the daemon loads config ~10x per
+// session-create, which turned this single notice into 1046 lines over two days
+// — the largest single source of WARNING noise in agent-factory.log (#2496).
+//
+// The key is the full source string, which already embeds the config kind and
+// its path, so two distinct offending files each still get their own notice
+// while a re-read of the same file stays silent. It is process-scoped: for the
+// long-lived daemon that is "once per daemon lifetime"; a short-lived CLI
+// invocation warns once and exits. sync.Map keeps the check-and-set atomic for
+// the concurrent loads a session-create issues.
+var removedAutoYesWarned sync.Map
+
 func warnRemovedAutoYesAt(source string) {
+	if _, seen := removedAutoYesWarned.LoadOrStore(source, struct{}{}); seen {
+		return
+	}
 	log.WarningLog.Printf("%s: %s; the stale setting is ignored during upgrade", source, RemovedAutoYesMessage)
+}
+
+// resetRemovedAutoYesWarnings clears the once-per-source memo. Tests that assert
+// the warning fires reset it first, so a source string already seen by an
+// earlier test in the same process does not suppress the notice under test; it
+// is wired into captureLog so every warning-observing test starts fresh.
+func resetRemovedAutoYesWarnings() {
+	removedAutoYesWarned.Clear()
 }
 
 func removedAutoYesInShape(shape map[string]any) bool {

--- a/config/removed_autoyes_test.go
+++ b/config/removed_autoyes_test.go
@@ -56,6 +56,53 @@ func TestRemovedAutoYesConfigLoadsForUpgradeAndWarns(t *testing.T) {
 	}
 }
 
+// TestRemovedAutoYesWarnsAtMostOncePerSource is #2496. The daemon loads config
+// ~10x per session-create, and the removed-key warning fired on every load —
+// 1046 log lines over two days from one migration notice. A genuinely removed
+// key deserves a single heads-up per source, not per-load spam.
+func TestRemovedAutoYesWarnsAtMostOncePerSource(t *testing.T) {
+	warnings := captureLog(t, &aflog.WarningLog)
+
+	// The same offending config, parsed as many times as a session-create loads
+	// it, warns exactly once.
+	const loads = 10
+	for range loads {
+		cfg, err := parseConfigTOML([]byte("auto_yes = true\n"), "config.toml")
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+	}
+	require.Equal(t, 1, strings.Count(warnings.String(), "auto_yes was removed"),
+		"%d loads of one config emitted more than one removed-key warning (#2496)", loads)
+
+	// A DIFFERENT offending file is a different migration story and still gets its
+	// own single notice — proving the memo is keyed per source, not a global
+	// once-and-done that would silence a second stale file.
+	cfg, err := parseConfigTOML([]byte("auto_yes = true\n"), "other.toml")
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Equal(t, 2, strings.Count(warnings.String(), "auto_yes was removed"),
+		"a distinct config path must still warn once of its own")
+}
+
+// TestRemovedAutoYesInRepoWarnsOnceAcrossManyLoads exercises the same guarantee
+// through the real LoadInRepoConfig path a create re-reads, not just the parser.
+func TestRemovedAutoYesInRepoWarnsOnceAcrossManyLoads(t *testing.T) {
+	repo := t.TempDir()
+	dir := filepath.Join(repo, InRepoConfigDirName)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, TomlConfigFileName), []byte("auto_yes = true\n"), 0o600))
+
+	warnings := captureLog(t, &aflog.WarningLog)
+	const loads = 10
+	for range loads {
+		cfg, _, err := LoadInRepoConfig(repo)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+	}
+	require.Equal(t, 1, strings.Count(warnings.String(), "auto_yes was removed"),
+		"%d in-repo loads emitted more than one removed-key warning (#2496)", loads)
+}
+
 func TestRemovedAutoYesInRepoConfigLoadsForUpgradeAndWarns(t *testing.T) {
 	repo := t.TempDir()
 	dir := filepath.Join(repo, InRepoConfigDirName)

--- a/config/resolve_test.go
+++ b/config/resolve_test.go
@@ -28,9 +28,13 @@ func setupResolveTest(t *testing.T, globalConfig string) string {
 	return t.TempDir()
 }
 
-// captureLog redirects the given project logger to a buffer for the test.
+// captureLog redirects the given project logger to a buffer for the test. It
+// also clears the once-per-source removed-key memo (#2496) so a test observing
+// the warning log sees the notice fire regardless of whether an earlier test in
+// the same process already warned for the same source string.
 func captureLog(t *testing.T, logger **stdlog.Logger) *bytes.Buffer {
 	t.Helper()
+	resetRemovedAutoYesWarnings()
 	var buf bytes.Buffer
 	old := *logger
 	*logger = stdlog.New(&buf, "", 0)


### PR DESCRIPTION
Closes #2496. (The perf facet #2497 is a separate follow-up — see below.)

## The noise

The removed-`auto_yes` migration warning fires on **every** config load, and the
daemon loads config ~10x per session-create. One migration notice became **1046
log lines over two days** — the single largest source of WARNING noise in
`agent-factory.log`, which the AF Usage Review and the log monitor watch.

## Fix — warn once per source

A genuinely removed key deserves one heads-up, not per-load spam. Memoize the
warning at `warnRemovedAutoYesAt` — the choke point all three call sites (global
config, in-repo config, personal-project config) funnel through — keyed by the
`source` string, which already embeds the config kind and its path:

- a **re-read of the same file** is now silent;
- a **distinct offending file** still gets its own single notice (so a second
  stale config is never hidden).

The memo is a `sync.Map`, so the check-and-set stays atomic under the concurrent
loads a session-create issues, and it is process-scoped: "once per daemon
lifetime" for the daemon, once-then-exit for a CLI invocation. This mirrors the
existing `projectRegistryWarnOnce` dedup already in `config/resolve.go`.

## Tests

- `TestRemovedAutoYesWarnsAtMostOncePerSource` — N=10 parses of one config warn
  exactly once, **and** a second distinct path still warns (proving the memo is
  per-source, not a global once-and-done that would silence a second stale file).
- `TestRemovedAutoYesInRepoWarnsOnceAcrossManyLoads` — same guarantee through the
  real `LoadInRepoConfig` path a create re-reads.
- Both **watched failing first** (10 loads → 10 warnings) against the un-memoized
  code, green with the fix.
- `captureLog` resets the memo, so every existing warning-observing test still
  sees its notice fire (no cross-test suppression).

## Secondary (#2497) — investigated, deferred by maintainer call

I confirmed the underlying inefficiency #2496 names: config is read from disk
~10x per create because `LoadConfig`/`ResolveConfig` have no cache and every
create-path layer loads independently (~13 sites across `daemon`, `session`,
`session/git`, `task`). A *safe* reduction is **not** a cache flag — the
per-create reload is deliberate and security-sensitive (`manager_create.go:112`:
env grants "are configurable while the daemon is running… reload for every new
create"), so only a **create-scoped snapshot threaded through the launch graph**
is safe, and several loaders are shared with non-create flows. That is a
cross-cutting refactor on a launch-critical path, so it is tracked as **#2497**
and will land as its own heavily-gated PR rather than riding this focused fix.
The observable harm — the log spam — is gone regardless, here.

## Gate (head `322f12e9`)

- `go build ./...` — clean
- `gofmt -l .` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `scripts/lint-file-length.sh` — clean (1039 files)
- `make test-container` — **all packages `ok`** (config, daemon 188s, session, app, parity)

Held as **draft** for the claude-subagent review gate — not self-merging. Codex
GitHub-app review is rate-limited until Jul 28, so its pass will be silent.
