### PR TITLE
feat(tui): Enter/attach restores a resting session in place (#2489)

### DIFF
--- a/app/dead_session_test.go
+++ b/app/dead_session_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,6 +20,15 @@ type deadBackend struct {
 }
 
 func (b *deadBackend) IsAlive(*session.Instance) (bool, error) { return false, nil }
+
+// reprovisioningBackend is a FakeBackend that reports a sandbox runtime type, so
+// Instance.RestoreWouldDiscardUnpushedWork() sees a Lost/Dead restore that would
+// re-provision a fresh sandbox — the case #2489 fences behind a confirmation.
+type reprovisioningBackend struct {
+	*session.FakeBackend
+}
+
+func (b *reprovisioningBackend) Type() string { return "docker" }
 
 // newDeadInstance returns a started instance backed by deadBackend with the
 // given starting status. It does not spin up tmux/git, so it is hermetic.
@@ -105,10 +115,11 @@ func TestHandleEnter_RestingRowRestores(t *testing.T) {
 			require.Equal(t, session.OpRestoring, inst.GetInFlightOp(),
 				"Enter restores the row (#2489), raising the optimistic restore op")
 
-			// No "press r" guard message: the gesture ACTS on the restore.
+			// No guard message: the gesture ACTS on the restore. This fails if the
+			// fix regresses to interactiveGuard, which emits "restore it first".
 			h.errBox.SetSize(200, 1)
-			require.NotContains(t, h.errBox.String(), "press",
-				"Enter must act on the restore, not name the restore key")
+			require.NotContains(t, h.errBox.String(), "restore it first",
+				"Enter must act on the restore, not surface the guard error")
 
 			require.NotNil(t, cmd, "the restore must dispatch its daemon command")
 			done, ok := cmd().(instanceRestoredMsg)
@@ -142,4 +153,101 @@ func TestHandleAttach_RestingRowRestores(t *testing.T) {
 	_, ok := cmd().(instanceRestoredMsg)
 	require.True(t, ok, "the command must emit instanceRestoredMsg")
 	require.True(t, called, "the restore RPC must fire")
+}
+
+// TestHandleEnter_RemoteLostRowConfirmsBeforeReprovision is the #2489 review's P2
+// data-loss guard: a Lost/Dead REMOTE session's restore re-provisions a fresh
+// sandbox when the old one can't be reached, discarding any unpushed work (#1794).
+// So Enter must CONFIRM before restoring it — never re-provision silently from a
+// keystroke (or a mouse double-click, which also routes through handleEnter).
+func TestHandleEnter_RemoteLostRowConfirmsBeforeReprovision(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status session.Status
+	}{
+		{"lost", session.Lost},
+		{"dead", session.Dead},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			inst := newDeadInstance(t, "remote-resting", tc.status)
+			inst.SetBackend(&reprovisioningBackend{FakeBackend: session.NewFakeBackend()})
+			h.store.AddInstance(inst)
+			h.sidebar.SetSelectedInstance(0)
+
+			called := false
+			prev := restoreSessionThroughDaemon
+			restoreSessionThroughDaemon = func(daemon.RestoreSessionRequest) (string, error) { called = true; return "/p", nil }
+			t.Cleanup(func() { restoreSessionThroughDaemon = prev })
+
+			model, _ := h.handleEnter()
+			h = model.(*home)
+
+			require.Equal(t, stateConfirm, h.state, "a remote Lost/Dead restore must confirm before re-provisioning")
+			require.NotNil(t, h.confirmationOverlay)
+			require.Equal(t, session.OpNone, inst.GetInFlightOp(), "no restore starts before the user confirms")
+			require.False(t, called, "the restore RPC must not fire before confirmation")
+
+			rendered := strings.Join(strings.Fields(h.confirmationOverlay.Render()), " ")
+			require.Contains(t, rendered, "never pushed", "the confirmation names the unpushed-work risk")
+
+			// Confirming raises the optimistic op and dispatches the restore off the
+			// event loop via startRestoreMsg (mirrors handleStateConfirm forwarding).
+			h.confirmationOverlay.OnConfirm()
+			require.Equal(t, session.OpRestoring, inst.GetInFlightOp(), "confirm raises the optimistic restore op")
+			start, ok := h.pendingConfirmMsg.(startRestoreMsg)
+			require.True(t, ok, "confirm emits startRestoreMsg")
+			_, cmd := h.Update(start)
+			require.NotNil(t, cmd, "the forwarded startRestoreMsg dispatches the restore")
+			_, ok = cmd().(instanceRestoredMsg)
+			require.True(t, ok)
+			require.True(t, called, "the confirmed restore fires the RPC")
+		})
+	}
+}
+
+// TestHandleEnter_RemoteArchivedRowRestoresImmediately is the safe-side companion:
+// an archived row restores from the branch the archive already pushed, so nothing
+// unpushed is at risk and it restores at once — even on a remote backend.
+func TestHandleEnter_RemoteArchivedRowRestoresImmediately(t *testing.T) {
+	h := newTestHome(t)
+	inst := newDeadInstance(t, "remote-archived", session.Archived)
+	inst.SetBackend(&reprovisioningBackend{FakeBackend: session.NewFakeBackend()})
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	prev := restoreSessionThroughDaemon
+	restoreSessionThroughDaemon = func(daemon.RestoreSessionRequest) (string, error) { return "/p", nil }
+	t.Cleanup(func() { restoreSessionThroughDaemon = prev })
+
+	model, cmd := h.handleEnter()
+	h = model.(*home)
+
+	require.Equal(t, stateDefault, h.state, "an archived restore needs no confirmation")
+	require.Equal(t, session.OpRestoring, inst.GetInFlightOp(), "the archived row restores immediately")
+	require.NotNil(t, cmd)
+}
+
+// TestInteractiveGuard_RestingRowsNameTheRestoreCommand keeps coverage for the
+// guard copy after #2489 moved the row verbs off it: the "restore it first"
+// message is still live for the paths that do NOT restore — an id-less row, an
+// OpReplacing row, and the focused-pane guards (interactive.go / handle_panes.go).
+func TestInteractiveGuard_RestingRowsNameTheRestoreCommand(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		status  session.Status
+		wantMsg string
+	}{
+		{"lost", session.Lost, "was lost"},
+		{"dead", session.Dead, "no longer running"},
+		{"archived", session.Archived, "is archived"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			inst := newDeadInstance(t, "guarded", tc.status)
+			err := interactiveGuard(inst)
+			require.Error(t, err, "a resting row still fences the non-restoring guard paths")
+			require.Contains(t, err.Error(), tc.wantMsg)
+			require.Contains(t, err.Error(), "restore it first", "the guard names the restore off-ramp")
+		})
+	}
 }

--- a/app/dead_session_test.go
+++ b/app/dead_session_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
 )
 
@@ -63,58 +64,82 @@ func TestHandleEnter_DeadSessionShowsError(t *testing.T) {
 		"the error must name the offending session")
 }
 
-// TestHandleEnter_LostSessionShowsError pins the #1108 × #1089-PR-2
-// interaction: Enter on a Lost session must take the explicit lost-error path
-// — never enter interactive mode on a dead binding, and never the generic
-// dead-tmux message (Lost is checked before TmuxAlive in interactiveGuard so
-// the specific "expected back" wording wins).
-func TestHandleEnter_LostSessionShowsError(t *testing.T) {
-	h := newTestHome(t)
+// TestHandleEnter_RestingRowRestores pins #2489: Enter on a resting
+// (Lost/Dead/archived) row restores it in place — the intuitive off-ramp — rather
+// than surfacing interactiveGuard's "press <key> to restore" message. It raises
+// the optimistic OpRestoring and dispatches the restore RPC, exactly as the `r`
+// verb does, with no confirmation and no interactive-mode entry on a dead binding.
+//
+// Distinct from the #935 case above: there the liveness is still live (Ready) and
+// only tmux vanished, so LifecycleAction()==Archive and Enter correctly errors;
+// here the daemon has settled the row into a resting liveness, which IS restorable.
+func TestHandleEnter_RestingRowRestores(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status session.Status
+	}{
+		{"lost", session.Lost},
+		{"dead", session.Dead},
+		{"archived", session.Archived},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			inst := newDeadInstance(t, "resting-session", tc.status)
+			h.store.AddInstance(inst)
+			h.sidebar.SetSelectedInstance(0)
 
-	inst := newDeadInstance(t, "lost-session", session.Lost)
-	h.store.AddInstance(inst)
-	h.sidebar.SetSelectedInstance(0)
+			var gotRequest daemon.RestoreSessionRequest
+			prev := restoreSessionThroughDaemon
+			restoreSessionThroughDaemon = func(request daemon.RestoreSessionRequest) (string, error) {
+				gotRequest = request
+				return "/worktree/path", nil
+			}
+			t.Cleanup(func() { restoreSessionThroughDaemon = prev })
 
-	model, cmd := h.handleEnter()
-	h = model.(*home)
+			model, cmd := h.handleEnter()
+			h = model.(*home)
 
-	require.Equal(t, stateDefault, h.state, "a lost session must not open any overlay")
-	require.Nil(t, h.textOverlay, "no help overlay should be installed for a lost session")
-	require.False(t, h.interactive, "Enter on a lost session must not enter interactive mode")
+			require.Equal(t, stateDefault, h.state, "restoring a resting row must not open any overlay")
+			require.Nil(t, h.textOverlay, "no help overlay should be installed")
+			require.False(t, h.interactive, "Enter on a resting row must restore, not enter interactive mode")
+			require.Equal(t, session.OpRestoring, inst.GetInFlightOp(),
+				"Enter restores the row (#2489), raising the optimistic restore op")
 
-	require.NotNil(t, cmd, "handleEnter must return the error-hide command, not a silent nil")
-	h.errBox.SetSize(200, 1)
-	require.Contains(t, h.errBox.String(), "was lost",
-		"the error must say the session was lost, not the generic dead message")
-	require.Contains(t, h.errBox.String(), "lost-session",
-		"the error must name the offending session")
+			// No "press r" guard message: the gesture ACTS on the restore.
+			h.errBox.SetSize(200, 1)
+			require.NotContains(t, h.errBox.String(), "press",
+				"Enter must act on the restore, not name the restore key")
+
+			require.NotNil(t, cmd, "the restore must dispatch its daemon command")
+			done, ok := cmd().(instanceRestoredMsg)
+			require.True(t, ok, "the command must emit instanceRestoredMsg")
+			require.NoError(t, done.err)
+			require.Equal(t, daemon.RestoreSessionRequest{ID: inst.ID, Title: "resting-session", RepoID: h.repoID}, gotRequest,
+				"the restore RPC carries the row's stable identity")
+		})
+	}
 }
 
-// TestHandleEnter_ArchivedSessionShowsError (#1028): Enter on an archived
-// session must take the explicit archived-error path — not interactive mode,
-// not the generic dead-tmux message — and must point the user at `restore` as
-// the off-ramp. Archived is checked before TmuxAlive in interactiveGuard so the
-// specific wording wins.
-func TestHandleEnter_ArchivedSessionShowsError(t *testing.T) {
+// TestHandleAttach_RestingRowRestores is the #2489 attach twin: `o` on a resting
+// row restores it too, not just Enter — the two verbs share restoreIfResting.
+func TestHandleAttach_RestingRowRestores(t *testing.T) {
 	h := newTestHome(t)
-
-	inst := newDeadInstance(t, "archived-session", session.Archived)
+	inst := newDeadInstance(t, "resting-session", session.Archived)
 	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
-	model, cmd := h.handleEnter()
+	called := false
+	prev := restoreSessionThroughDaemon
+	restoreSessionThroughDaemon = func(daemon.RestoreSessionRequest) (string, error) { called = true; return "/p", nil }
+	t.Cleanup(func() { restoreSessionThroughDaemon = prev })
+
+	model, cmd := h.handleAttach()
 	h = model.(*home)
 
-	require.Equal(t, stateDefault, h.state, "an archived session must not open any overlay")
-	require.Nil(t, h.textOverlay, "no help overlay should be installed for an archived session")
-	require.False(t, h.interactive, "Enter on an archived session must not enter interactive mode")
-
-	require.NotNil(t, cmd, "handleEnter must return the error-hide command, not a silent nil")
-	h.errBox.SetSize(200, 1)
-	require.Contains(t, h.errBox.String(), "is archived",
-		"the error must say the session is archived, not the generic dead message")
-	require.Contains(t, h.errBox.String(), "restore",
-		"the error must point at restore as the off-ramp")
-	require.Contains(t, h.errBox.String(), "archived-session",
-		"the error must name the offending session")
+	require.Equal(t, session.OpRestoring, inst.GetInFlightOp(), "`o` on a resting row restores it (#2489)")
+	require.False(t, h.attached.Load(), "`o` on a resting row must restore, not start an attach")
+	require.NotNil(t, cmd, "the restore must dispatch its daemon command")
+	_, ok := cmd().(instanceRestoredMsg)
+	require.True(t, ok, "the command must emit instanceRestoredMsg")
+	require.True(t, called, "the restore RPC must fire")
 }

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -413,32 +413,65 @@ func (m *home) handleRestore() (tea.Model, tea.Cmd) {
 	return m, m.restoreInstanceCmd(target)
 }
 
-// restoreIfResting turns an Enter/`o` on a resting (Lost/Dead/archived) row into
-// a restore instead of interactiveGuard's "press <key> to restore" error: the
-// gesture the user already made expresses the intent, so acting on it is more
-// intuitive than naming another key (#2489). It delegates to handleRestore — the
-// single owner of the restore transition and its own already-restoring guard — so
-// there is one restore code path, and reports whether it took the row.
-//
-// LifecycleActionRestore is true for EXACTLY the resting states interactiveGuard
+// restoreIfResting turns an Enter/`o` on a resting (Lost/Dead/archived) row into a
+// restore instead of interactiveGuard's "restore it first (af sessions restore …)"
+// error: the gesture the user already made expresses the intent, so acting on it
+// is more intuitive than naming a shell command (#2489). It reports whether it took
+// the row. LifecycleActionRestore is true for EXACTLY the resting states the guard
 // fences (LiveLost/LiveDead/LiveArchived, with a stable id and no teardown/replace
 // op), so a live, tearing-down, id-less, or startup-unknown row returns false and
-// falls through to the guard's own message unchanged. Restore is non-destructive
-// (worktree move + agent re-spawn), matching `r`, so — like `r` — it needs no
-// confirmation.
+// falls through to the guard's own message unchanged.
 //
-// Scope: the tree ROW verbs (handleEnter/handleAttach). The pane-entry guards
-// (activateInteractive, handleEnterPane) are a distinct, rarer interaction — a
-// focused pane whose session went Lost out from under it — on the delicate
-// deferred-activation path; they keep the guard message, and selecting a resting
-// session lands the cursor on its instance row, so the row verbs cover the case
-// the issue describes.
+// A restore is dispatched IMMEDIATELY (no confirmation) only where it is provably
+// safe: a local session re-spawns its tmux in place, and an archived session
+// restores from the branch the archive already pushed. But a Lost/Dead REMOTE
+// session's restore re-provisions a fresh sandbox when the old one can't be reached,
+// discarding any unpushed work on it (#1794) — so that one is gated behind a
+// confirmation that names the risk. Enter, `o`, and a mouse double-click all funnel
+// here, so none can silently discard work.
+//
+// Scope: the tree ROW verbs and the pane-preview commit reached from them. The
+// focused-pane guards (activateInteractive, handleEnterPane) are a distinct, rarer
+// interaction — a focused pane whose session went Lost out from under it — and keep
+// the guard message; `o` and Enter agree there too (both error).
 func (m *home) restoreIfResting(selected *session.Instance) (tea.Cmd, bool) {
 	if selected == nil || selected.LifecycleAction() != session.LifecycleActionRestore {
 		return nil, false
 	}
+	if selected.RestoreWouldDiscardUnpushedWork() {
+		return m.confirmReprovisioningRestore(selected), true
+	}
+	// Safe (local re-spawn, or archived restore from the pushed branch): act at
+	// once. handleRestore is the single owner of the restore transition and its
+	// own already-restoring guard.
 	_, cmd := m.handleRestore()
 	return cmd, true
+}
+
+// confirmReprovisioningRestore opens the confirmation that fences a remote
+// Lost/Dead restore behind an explicit yes, because it can re-provision a fresh
+// sandbox and discard unpushed work (#2489 review / #1794). On confirm it raises
+// the optimistic OpRestoring and dispatches the restore off the event loop via
+// startRestoreMsg, re-checking identity and state at that boundary in case a
+// snapshot healed or changed the row while the dialog was up.
+func (m *home) confirmReprovisioningRestore(selected *session.Instance) tea.Cmd {
+	title := selected.Title
+	target := captureSessionActionTarget(selected, m.repoID)
+	message := fmt.Sprintf("[!] Restore remote session '%s'?\n\nIf its sandbox can't be reached, restore provisions a fresh one from the last pushed commit and discards any changes on the old sandbox that were never pushed. A reachable sandbox just reconnects, losing nothing.", title)
+	return m.confirmAction(message, func() tea.Msg {
+		inst := m.resolveSessionActionTarget(target)
+		if inst == nil {
+			return nil
+		}
+		if inst.LifecycleAction() != session.LifecycleActionRestore {
+			return nil
+		}
+		if inst.GetInFlightOp() == session.OpRestoring {
+			return nil
+		}
+		_ = inst.Transition(session.MarkRestoring())
+		return startRestoreMsg{target: target}
+	})
 }
 
 // archiveInstanceCmd runs the daemon archive (tmux teardown + worktree move) off
@@ -614,6 +647,16 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if m.panePreviewTxn != nil {
+		// A resting (Lost/Dead) row's Enter must RESTORE it, even with a workspace
+		// pane open (#2489). selectionChanged builds a preview txn for the cursor's
+		// instance with no liveness gate, so this branch — not the row path below —
+		// is where Enter lands in the common pane-open steady state; without this the
+		// commit would only surface the guard error and the restore would never fire.
+		// Same restoreIfResting the tree-row and `o` paths use, so all three agree.
+		if cmd, handled := m.restoreIfResting(m.sidebar.GetSelectedInstance()); handled {
+			m.cancelPanePreview(false)
+			return m, cmd
+		}
 		// Committing a sidebar tab-row preview is a tree-navigation action (the
 		// preview only exists while the tree cursor sits on a tab row), so this
 		// Enter selects/commits — it must NOT type into the agent (nil replay),
@@ -658,8 +701,11 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 	}
 	// Instance selected — in either the Instances tree or the Archived folder
 	// (#1028). A resting (Lost/Dead/archived) row is not embeddable: rather than
-	// naming the restore key, Enter restores it in place (#2489). Any other
-	// non-embeddable state still surfaces interactiveGuard's error.
+	// surfacing the guard's "restore it first" error, Enter restores it — with a
+	// confirm first when that would re-provision a remote sandbox (#2489). Any other
+	// non-embeddable state still surfaces interactiveGuard's error. (This is the
+	// no-preview path — an archived row cancels its preview; the Lost/Dead pane-open
+	// case is handled by the preview branch above.)
 	selected := m.sidebar.GetSelectedInstance()
 	if selected == nil || selected.IsCreating() {
 		return m, nil
@@ -742,9 +788,10 @@ func (m *home) handleAttach() (tea.Model, tea.Cmd) {
 	}
 	sel := m.sidebar.GetSelection()
 	// Accept both the Instances tree and the Archived folder (#1028): a resting
-	// (Lost/Dead/archived) row is non-attachable, so `o` restores it in place
-	// rather than naming the restore key (#2489); any other non-attachable state
-	// surfaces interactiveGuard's error rather than a silent no-op.
+	// (Lost/Dead/archived) row is non-attachable, so `o` restores it — with a
+	// confirm first when that would re-provision a remote sandbox (#2489) — rather
+	// than surfacing the guard's "restore it first" error; any other non-attachable
+	// state surfaces interactiveGuard's error rather than a silent no-op.
 	if sel.IsHeader || (sel.Kind != ui.SectionInstances && sel.Kind != ui.SectionArchived) {
 		return m, nil
 	}

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -413,6 +413,34 @@ func (m *home) handleRestore() (tea.Model, tea.Cmd) {
 	return m, m.restoreInstanceCmd(target)
 }
 
+// restoreIfResting turns an Enter/`o` on a resting (Lost/Dead/archived) row into
+// a restore instead of interactiveGuard's "press <key> to restore" error: the
+// gesture the user already made expresses the intent, so acting on it is more
+// intuitive than naming another key (#2489). It delegates to handleRestore — the
+// single owner of the restore transition and its own already-restoring guard — so
+// there is one restore code path, and reports whether it took the row.
+//
+// LifecycleActionRestore is true for EXACTLY the resting states interactiveGuard
+// fences (LiveLost/LiveDead/LiveArchived, with a stable id and no teardown/replace
+// op), so a live, tearing-down, id-less, or startup-unknown row returns false and
+// falls through to the guard's own message unchanged. Restore is non-destructive
+// (worktree move + agent re-spawn), matching `r`, so — like `r` — it needs no
+// confirmation.
+//
+// Scope: the tree ROW verbs (handleEnter/handleAttach). The pane-entry guards
+// (activateInteractive, handleEnterPane) are a distinct, rarer interaction — a
+// focused pane whose session went Lost out from under it — on the delicate
+// deferred-activation path; they keep the guard message, and selecting a resting
+// session lands the cursor on its instance row, so the row verbs cover the case
+// the issue describes.
+func (m *home) restoreIfResting(selected *session.Instance) (tea.Cmd, bool) {
+	if selected == nil || selected.LifecycleAction() != session.LifecycleActionRestore {
+		return nil, false
+	}
+	_, cmd := m.handleRestore()
+	return cmd, true
+}
+
 // archiveInstanceCmd runs the daemon archive (tmux teardown + worktree move) off
 // the event loop (#1028), mirroring killInstanceCmd — the RPC blocks for the
 // whole operation, so it must not run on the Update goroutine.
@@ -629,11 +657,15 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	// Instance selected — in either the Instances tree or the Archived folder
-	// (#1028). An archived row is not embeddable: interactiveGuard surfaces the
-	// "restore it first" error before any pane/attach path is reached.
+	// (#1028). A resting (Lost/Dead/archived) row is not embeddable: rather than
+	// naming the restore key, Enter restores it in place (#2489). Any other
+	// non-embeddable state still surfaces interactiveGuard's error.
 	selected := m.sidebar.GetSelectedInstance()
 	if selected == nil || selected.IsCreating() {
 		return m, nil
+	}
+	if cmd, handled := m.restoreIfResting(selected); handled {
+		return m, cmd
 	}
 	if err := interactiveGuard(selected); err != nil {
 		return m, m.handleError(err)
@@ -709,15 +741,19 @@ func (m *home) handleAttach() (tea.Model, tea.Cmd) {
 		return m.handleEnterPane(p)
 	}
 	sel := m.sidebar.GetSelection()
-	// Accept both the Instances tree and the Archived folder (#1028): an
-	// archived row is non-attachable, and interactiveGuard surfaces the
-	// "restore it first" error rather than a silent no-op.
+	// Accept both the Instances tree and the Archived folder (#1028): a resting
+	// (Lost/Dead/archived) row is non-attachable, so `o` restores it in place
+	// rather than naming the restore key (#2489); any other non-attachable state
+	// surfaces interactiveGuard's error rather than a silent no-op.
 	if sel.IsHeader || (sel.Kind != ui.SectionInstances && sel.Kind != ui.SectionArchived) {
 		return m, nil
 	}
 	selected := m.sidebar.GetSelectedInstance()
 	if selected == nil || selected.IsCreating() {
 		return m, nil
+	}
+	if cmd, handled := m.restoreIfResting(selected); handled {
+		return m, cmd
 	}
 	if err := interactiveGuard(selected); err != nil {
 		return m, m.handleError(err)

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -304,6 +304,10 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Archive confirmed; run the daemon teardown+move off the event loop
 		// (#1028), mirroring the kill dispatch.
 		return m, m.archiveInstanceCmd(msg.target)
+	case startRestoreMsg:
+		// Reprovisioning restore confirmed (#2489); run the daemon restore off the
+		// event loop, mirroring the archive dispatch.
+		return m, m.restoreInstanceCmd(msg.target)
 	case instanceArchivedMsg:
 		return m.handleInstanceArchived(msg)
 	case startHandoffMsg:

--- a/app/messages.go
+++ b/app/messages.go
@@ -32,6 +32,15 @@ type startArchiveMsg struct {
 	target sessionActionTarget
 }
 
+// startRestoreMsg is emitted by the reprovisioning-restore confirmation (#2489);
+// its handler dispatches restoreInstanceCmd off the event loop, mirroring
+// startArchiveMsg → archiveInstanceCmd. Only the remote-sandbox restore that could
+// discard unpushed work is gated behind a confirm; a safe restore dispatches the
+// command immediately via handleRestore.
+type startRestoreMsg struct {
+	target sessionActionTarget
+}
+
 // startDeleteProjectMsg is emitted by the delete-project confirmation (#1735);
 // its handler dispatches deleteProjectCmd to run the daemon archive-then-remove
 // off the event loop, mirroring startArchiveMsg → archiveInstanceCmd.

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
@@ -739,45 +740,69 @@ func TestPanePreviewTabDismissesAndAdvances(t *testing.T) {
 	assert.NotContains(t, h.View(), "Preview")
 }
 
+// TestPanePreviewEnterBlocksUncommittableTargets: a row that is NOT restorable —
+// one mid-teardown (OpKilling), whose LifecycleAction is None — still blocks the
+// preview commit with its in-flight error. #2489's restore intercept fires only
+// for genuinely resting rows (Lost/Dead/archived); the Lost/Dead pane-open case is
+// covered by TestPanePreviewEnterRestoresRestingTarget below.
 func TestPanePreviewEnterBlocksUncommittableTargets(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+	beta := h.store.GetInstanceByTitle("beta")
+	beta.SetInFlightOpForTest(session.OpKilling)
+
+	pressKey(t, h, "s")
+	paneA := h.store.OpenPanes()[0]
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	require.NotNil(t, h.panePreviewTxn, "preview remains allowed for a blocked commit target")
+
+	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+
+	require.NotNil(t, h.panePreviewTxn, "a blocked commit keeps the preview active")
+	assert.Same(t, alpha, paneA.Instance())
+	assert.Contains(t, h.errBox.String(), "operation in flight")
+}
+
+// TestPanePreviewEnterRestoresRestingTarget is the #2489 review P1 regression:
+// with a workspace pane open (the steady state, since #1088 auto-opens one),
+// selectionChanged builds a preview txn for the cursor's instance with no liveness
+// gate, so Enter on a Lost/Dead row lands in the preview-commit branch — which must
+// RESTORE the row, not surface the guard error. This is exactly the case the
+// pane-less handler tests missed.
+func TestPanePreviewEnterRestoresRestingTarget(t *testing.T) {
 	for _, tc := range []struct {
-		name      string
-		configure func(*session.Instance)
-		wantErr   string
+		name     string
+		liveness session.Liveness
 	}{
-		{
-			name:      "dead",
-			configure: func(inst *session.Instance) { _ = inst.Transition(session.ObserveLiveness(session.LiveDead)) },
-			wantErr:   "no longer running",
-		},
-		{
-			name:      "lost",
-			configure: func(inst *session.Instance) { _ = inst.Transition(session.ObserveLiveness(session.LiveLost)) },
-			wantErr:   "was lost",
-		},
-		{
-			name:      "in-flight",
-			configure: func(inst *session.Instance) { inst.SetInFlightOpForTest(session.OpKilling) },
-			wantErr:   "operation in flight",
-		},
+		{"lost", session.LiveLost},
+		{"dead", session.LiveDead},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			h := paneTestHome(t)
-			alpha := h.store.GetInstanceByTitle("alpha")
 			beta := h.store.GetInstanceByTitle("beta")
-			tc.configure(beta)
+			_ = beta.Transition(session.ObserveLiveness(tc.liveness))
 
-			pressKey(t, h, "s")
-			paneA := h.store.OpenPanes()[0]
+			called := false
+			prev := restoreSessionThroughDaemon
+			restoreSessionThroughDaemon = func(daemon.RestoreSessionRequest) (string, error) { called = true; return "/p", nil }
+			t.Cleanup(func() { restoreSessionThroughDaemon = prev })
+
+			pressKey(t, h, "s") // open a workspace pane — the pane-open steady state
 			h.sidebar.SetSelectedInstance(1)
 			_ = h.selectionChanged()
-			require.NotNil(t, h.panePreviewTxn, "preview remains allowed for blocked commit targets")
+			require.NotNil(t, h.panePreviewTxn, "precondition: a preview txn is built for the resting row")
 
-			_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+			_, cmd := h.handleEnter()
 
-			require.NotNil(t, h.panePreviewTxn, "blocked commit should keep the preview active")
-			assert.Same(t, alpha, paneA.Instance())
-			assert.Contains(t, h.errBox.String(), tc.wantErr)
+			require.Equal(t, session.OpRestoring, beta.GetInFlightOp(),
+				"Enter on a resting row with a pane open must RESTORE it, not commit the preview (#2489 P1)")
+			require.Nil(t, h.panePreviewTxn, "the restore resolves the preview txn")
+			h.errBox.SetSize(200, 1)
+			require.NotContains(t, h.errBox.String(), "restore it first", "no guard error on the restore path")
+			require.NotNil(t, cmd)
+			_ = cmd()
+			require.True(t, called, "the restore RPC fires")
 		})
 	}
 }

--- a/session/archive_sandbox.go
+++ b/session/archive_sandbox.go
@@ -282,3 +282,36 @@ func backendKindForType(t string) (BackendKind, error) {
 		return "", fmt.Errorf("backend %q is not a re-provisionable sandbox runtime", t)
 	}
 }
+
+// RestoreReprovisionsSandbox reports whether a Lost/Dead restore of this session
+// re-provisions a FRESH off-box sandbox (cloning the last pushed commit) rather
+// than re-spawning it in place. Only the sandbox runtimes (docker/ssh/hook) route
+// their Recover through recoverSandbox → reprovisionRemote; a local session
+// re-spawns its tmux in the same worktree. A backend-less instance is treated as
+// local. This is the backend primitive — RestoreWouldDiscardUnpushedWork gates it
+// on the liveness that actually takes the re-provision path.
+func (i *Instance) RestoreReprovisionsSandbox() bool {
+	b := i.currentBackend()
+	if b == nil {
+		return false
+	}
+	_, err := backendKindForType(b.Type())
+	return err == nil
+}
+
+// RestoreWouldDiscardUnpushedWork reports whether restoring this row re-provisions
+// a fresh sandbox and thereby risks discarding work that was never pushed off the
+// old one (#1794). It is true only for a Lost/Dead REMOTE session: the daemon's
+// restore re-provisions a fresh sandbox when the old one can't be reached
+// (daemon/restore.go), losing anything unpushed. A local session re-spawns in
+// place, and an archived session (any backend) restores from the branch the
+// archive already pushed — neither loses anything. Interactive clients confirm a
+// restore for which this is true before triggering it.
+func (i *Instance) RestoreWouldDiscardUnpushedWork() bool {
+	switch i.GetLiveness() {
+	case LiveLost, LiveDead:
+		return i.RestoreReprovisionsSandbox()
+	default:
+		return false
+	}
+}

--- a/ui/sidebar_nav.go
+++ b/ui/sidebar_nav.go
@@ -698,8 +698,8 @@ func (s *Sidebar) GetSelectedInstance() *session.Instance {
 	s.syncFromStore()
 	sel := s.rawSelection()
 	// An archived row (#1028) is a real instance row too, so it resolves here —
-	// this is what lets the restore action and the Enter "restore it first"
-	// fence read the selected archived session.
+	// this is what lets the restore action, including the Enter/`o` restore of a
+	// resting row (#2489), read the selected archived session.
 	if !isInstanceRow(sel) {
 		return nil
 	}


### PR DESCRIPTION
## Summary

Fixes #2489. Pressing **Enter** or **`o`** (or double-clicking) a Lost/Dead/archived
row named a shell command in an error ("session '…' was lost — restore it first
(af sessions restore …)") instead of doing the obvious thing: restoring it. Per
Sachin's intuitiveness principle, the gesture the user already made *is* the
intent — act on it. Restore stays on `r` too.

## Change

`handleEnter` and `handleAttach` route a resting row to a restore before the
`interactiveGuard` error. The predicate is `LifecycleAction() == LifecycleActionRestore`
— true for **exactly** the resting states the guard fences (`LiveLost` / `LiveDead`
/ `LiveArchived`, with a stable id, not mid-teardown/replace). A live, id-less, or
tearing-down row still falls through to the guard.

### Safe-by-default, confirm only where work could be lost (review P2)

A restore fires **immediately, no confirmation** where it's provably safe:
- **local** sessions re-spawn tmux in the same worktree, and
- **archived** rows restore from the branch the archive already pushed.

But a **Lost/Dead remote** (docker/ssh/hook) restore re-provisions a *fresh*
sandbox when the old one can't be reached, discarding any unpushed work on it
(#1794). That one now shows a **confirmation naming the risk** before proceeding —
so Enter, `o`, and a mouse double-click (all funnelled through one
`restoreIfResting`) can never re-provision silently. New session predicate
`RestoreWouldDiscardUnpushedWork()` encapsulates the local-vs-sandbox +
liveness distinction.

### Fires in the common (pane-open) case (review P1)

`selectionChanged` builds a preview txn for the cursor's instance with no liveness
gate, and #1088 auto-opens a pane at launch — so with a pane open, Enter on a
Lost/Dead row lands in `handleEnter`'s preview-commit branch, not the row path.
That branch now defers to the same `restoreIfResting`, so Enter restores there too
and agrees with `o`. (Archived rows cancel their preview, so they take the row
path — which is why the first cut only appeared to work.)

### Scope

The tree-row verbs and the pane-preview commit reached from them. The focused-pane
guards (`activateInteractive`, `handleEnterPane`) — a focused pane whose session
went Lost out from under it — keep the guard message; `o` and Enter agree there
too (both error).

## Tests (each drives the real handler; the row-restore tests fail on master)

- `TestHandleEnter_RestingRowRestores` (Lost/Dead/archived) + `TestHandleAttach_RestingRowRestores` — immediate local restore.
- `TestPanePreviewEnterRestoresRestingTarget` — the P1 repro **with a pane open**; fails without the preview-branch intercept.
- `TestHandleEnter_RemoteLostRowConfirmsBeforeReprovision` — remote Lost/Dead confirms, does not restore until confirmed, and the confirmed path dispatches the RPC.
- `TestHandleEnter_RemoteArchivedRowRestoresImmediately` — archived-on-remote is safe, restores at once.
- `TestPanePreviewEnterBlocksUncommittableTargets` (in-flight still blocks) + `TestPanePreviewSplitBlocksUncommittableTargets` (unchanged).
- `TestInteractiveGuard_RestingRowsNameTheRestoreCommand` — keeps the guard-copy coverage for the paths that still fence.
- `TestHandleEnter_DeadSessionShowsError` kept: status `Ready` + tmux gone (#935) has a *live* liveness → `LifecycleAction()==Archive` → still errors, pinning the boundary.

## Gate

`go build`, `gofmt -l`, `golangci-lint --fast`, `deadcode -test ./...`,
`lint-file-length`, full `make test-container`, and `make tui-driver-selftest`.
Results in the review thread.

## Review

Codex CLI review is rate-limited until Jul 28 (usage-limit notices only). Greptile
is the live AI reviewer.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
