### PR TITLE
feat(daemon): wire the upgrade entrypoint gate + recovery launcher (#2212 R1)

### DIFF
--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -116,12 +116,16 @@ func ensureDaemonWithPolicy(launch func() error, preferUnit bool) error {
 		return nil
 	}
 	// #2212 R1: before spawning a daemon, defer to an in-progress upgrade rather
-	// than racing its recovery actor with a rival daemon. Fail-open — only a
-	// provably live upgrade stops the spawn, as a typed retryable error; a stale,
-	// corrupt, or absent journal proceeds. The gate is bounded, so a bad journal
-	// can never wedge this launch path (which fronts every af invocation).
+	// than racing its recovery actor with a rival daemon. A client defers to BOTH
+	// a forward upgrade and a rollback restoring the previous daemon — in the
+	// latter it must not stop and replace the very daemon the actor is validating.
+	// Fail-open — only a provably live upgrade stops the spawn, as a typed
+	// retryable error; a stale, corrupt, or absent journal proceeds. The gate is
+	// bounded, so a bad journal can never wedge this launch path (which fronts
+	// every af invocation).
 	if homeDir, ok := configHomeDir(); ok {
-		if decision, gateErr := checkUpgradeGate(homeDir); decision == upgradeGateInProgress {
+		switch decision, gateErr := checkUpgradeGate(homeDir, false); decision {
+		case upgradeGateInProgress, upgradeGateRestoringPrevious:
 			return gateErr
 		}
 	}

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -115,6 +115,16 @@ func ensureDaemonWithPolicy(launch func() error, preferUnit bool) error {
 	if err := pingDaemon(); err == nil {
 		return nil
 	}
+	// #2212 R1: before spawning a daemon, defer to an in-progress upgrade rather
+	// than racing its recovery actor with a rival daemon. Fail-open — only a
+	// provably live upgrade stops the spawn, as a typed retryable error; a stale,
+	// corrupt, or absent journal proceeds. The gate is bounded, so a bad journal
+	// can never wedge this launch path (which fronts every af invocation).
+	if homeDir, ok := configHomeDir(); ok {
+		if decision, gateErr := checkUpgradeGate(homeDir); decision == upgradeGateInProgress {
+			return gateErr
+		}
+	}
 	if preferUnit {
 		configDir, configErr := config.GetConfigDir()
 		if configErr != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -49,6 +49,21 @@ func RunDaemon(cfg *config.Config) error {
 func runDaemon(cfg *config.Config, upgradeTransactionID string) error {
 	log.InfoLog.Printf("starting daemon")
 
+	// #2212 R1: on an ordinary daemon start (not the transaction's own probation
+	// daemon, which carries a non-empty transaction id), defer to a genuinely
+	// in-progress upgrade instead of serving a rival, and exit cleanly so the
+	// autostart unit's Restart=on-failure does not loop against the recovery
+	// actor. Fail-open: a stale or corrupt journal proceeds to normal startup,
+	// so a bad journal can never wedge the daemon into the #2168 crash loop.
+	if upgradeTransactionID == "" {
+		if homeDir, ok := configHomeDir(); ok {
+			if decision, _ := checkUpgradeGate(homeDir); decision == upgradeGateInProgress {
+				log.InfoLog.Printf("a daemon upgrade is in progress; deferring to its recovery actor and exiting cleanly")
+				return nil
+			}
+		}
+	}
+
 	// No auth-posture gate here, deliberately (#2168 Phase 0). #2090 made a
 	// tokenless network listener a FATAL startup refusal at this exact spot; the
 	// owner reversed that: binding 0.0.0.0 with no token is allowed, and the

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -51,14 +51,19 @@ func runDaemon(cfg *config.Config, upgradeTransactionID string) error {
 
 	// #2212 R1: on an ordinary daemon start (not the transaction's own probation
 	// daemon, which carries a non-empty transaction id), defer to a genuinely
-	// in-progress upgrade instead of serving a rival, and exit cleanly so the
-	// autostart unit's Restart=on-failure does not loop against the recovery
-	// actor. Fail-open: a stale or corrupt journal proceeds to normal startup,
-	// so a bad journal can never wedge the daemon into the #2168 crash loop.
+	// in-progress FORWARD upgrade instead of serving a rival, and exit cleanly so
+	// the autostart unit's Restart=on-failure does not loop against the recovery
+	// actor. But a rollback restoring the previous daemon must PROCEED to bind:
+	// during that phase THIS daemon is the previous daemon the actor started and
+	// is waiting to validate — deferring would deadlock the rollback into
+	// rollback_failed with no daemon running. Uses the non-waking gate so it never
+	// re-runs the client's wake/wait and overruns the bind budget. Fail-open: a
+	// stale or corrupt journal proceeds, so a bad journal can never wedge the
+	// daemon into the #2168 crash loop.
 	if upgradeTransactionID == "" {
 		if homeDir, ok := configHomeDir(); ok {
-			if decision, _ := checkUpgradeGate(homeDir); decision == upgradeGateInProgress {
-				log.InfoLog.Printf("a daemon upgrade is in progress; deferring to its recovery actor and exiting cleanly")
+			if decision, _ := checkUpgradeGate(homeDir, true); decision == upgradeGateInProgress {
+				log.InfoLog.Printf("a forward daemon upgrade is in progress; deferring to its recovery actor and exiting cleanly")
 				return nil
 			}
 		}

--- a/daemon/upgrade_gate.go
+++ b/daemon/upgrade_gate.go
@@ -1,0 +1,103 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/upgradetxn"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// upgradeGateTimeout is the HARD ceiling on the entrypoint takeover gate —
+// covering both waking the recovery job (a bounded service-manager exec) and
+// waiting for that actor to take the recovery lock. It is passed as BOTH the
+// EntrypointGate.TakeoverTimeout and a context deadline, so no single gate path
+// — a live actor, a stale actor that never takes over, a half-written journal,
+// or a wedged systemctl — can exceed it.
+//
+// This bound is the whole point of the gate's placement (#2212 R1). The gate
+// sits on the daemon-spawn path, which is in front of every af launch. A daemon
+// that will not start is recoverable; an af binary that hangs on every command
+// is not. So the gate is fail-OPEN: only a provably live, in-progress upgrade
+// stops a launch, and it does so with an immediate typed error rather than a
+// wait. Every other outcome proceeds. Package var so tests can shorten it.
+var upgradeGateTimeout = 6 * time.Second
+
+// upgradeGateDecision is what checkUpgradeGate tells a daemon-spawn caller.
+type upgradeGateDecision int
+
+const (
+	// upgradeGateProceed means start/spawn the daemon normally. Returned for no
+	// journal, a corrupt or partial journal, a stale journal whose recovery
+	// actor never took over within the deadline, a rollback_failed circuit
+	// breaker, or any probe failure — anything but a provably live upgrade.
+	upgradeGateProceed upgradeGateDecision = iota
+	// upgradeGateInProgress means a live recovery actor provably owns an active
+	// upgrade transaction. The accompanying error is the typed, retryable
+	// "daemon is upgrading" message; the caller must NOT spawn a rival daemon.
+	upgradeGateInProgress
+)
+
+// checkUpgradeGate runs the transaction entrypoint gate fail-open. It returns
+// upgradeGateInProgress ONLY when a live recovery actor provably owns an active
+// transaction (an immediate, non-blocking result). Every other outcome returns
+// upgradeGateProceed:
+//
+//   - no journal on disk (the overwhelmingly common case) — a stat plus one
+//     ErrNoActiveTransaction load, so a healthy cold start is effectively free;
+//   - a corrupt, partial, or otherwise unparseable journal — treated as no
+//     transaction, never as a fatal error and never as an unbounded wait;
+//   - a stale/orphaned journal whose actor died and never re-took the lock
+//     within upgradeGateTimeout — the gate wakes the recovery job, waits at most
+//     the deadline, then proceeds;
+//   - the rollback_failed circuit breaker, or any service-manager/probe error.
+//
+// The context deadline is the hard bound over the ENTIRE call, including the
+// service-manager exec that Wake runs, so a wedged systemctl cannot hang the
+// launch. Nothing here blocks longer than upgradeGateTimeout.
+// runEntrypointGate is the actual gate probe, indirected so the fail-open
+// classification can be tested against every EntrypointGate.Check outcome
+// without constructing each on-disk journal state. Production wires the real
+// bounded gate.
+var runEntrypointGate = func(ctx context.Context, homeDir string) error {
+	gate := upgradetxn.EntrypointGate{TakeoverTimeout: upgradeGateTimeout}
+	return gate.Check(ctx, homeDir)
+}
+
+func checkUpgradeGate(homeDir string) (upgradeGateDecision, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), upgradeGateTimeout)
+	defer cancel()
+
+	err := runEntrypointGate(ctx, homeDir)
+	if err == nil {
+		return upgradeGateProceed, nil
+	}
+
+	var inProgress *upgradetxn.UpgradeInProgressError
+	if errors.As(err, &inProgress) {
+		// A live recovery actor owns the transaction. Report it so the caller
+		// surfaces "daemon is upgrading; retry shortly" instead of spawning a
+		// rival over the supervisor. Immediate — never a wait.
+		return upgradeGateInProgress, err
+	}
+
+	// Blocked recovery, a corrupt/partial journal, a timed-out takeover, the
+	// context deadline, or any other probe failure. Do NOT block the launch:
+	// log once and proceed with normal startup. Spawning a rival daemon is the
+	// accepted risk here; wedging every af invocation on a bad journal is not.
+	log.WarningLog.Printf("daemon upgrade entrypoint gate did not resolve (proceeding with normal startup): %v", err)
+	return upgradeGateProceed, nil
+}
+
+// configHomeDir resolves the AF home the entrypoint gate inspects. A resolution
+// failure is not fatal to the gate: with no resolvable home there is no journal
+// to honor, so the caller proceeds with normal startup.
+func configHomeDir() (string, bool) {
+	dir, err := config.GetConfigDir()
+	if err != nil || dir == "" {
+		return "", false
+	}
+	return dir, true
+}

--- a/daemon/upgrade_gate.go
+++ b/daemon/upgrade_gate.go
@@ -17,13 +17,19 @@ import (
 // — a live actor, a stale actor that never takes over, a half-written journal,
 // or a wedged systemctl — can exceed it.
 //
+// It is kept within the SMALLEST daemon-spawn caller budget
+// (ensureUnitStartTimeout, 2s) so the gate can never overrun a caller's
+// readiness window and churn a fallback spawn (#2212). Only the CLIENT entrypoint
+// (EnsureDaemon) ever spends this budget, and only on a stale journal: the
+// daemon-BIND path (RunDaemon) skips the wake/wait entirely, so it never waits.
+//
 // This bound is the whole point of the gate's placement (#2212 R1). The gate
 // sits on the daemon-spawn path, which is in front of every af launch. A daemon
 // that will not start is recoverable; an af binary that hangs on every command
 // is not. So the gate is fail-OPEN: only a provably live, in-progress upgrade
 // stops a launch, and it does so with an immediate typed error rather than a
 // wait. Every other outcome proceeds. Package var so tests can shorten it.
-var upgradeGateTimeout = 6 * time.Second
+var upgradeGateTimeout = 2 * time.Second
 
 // upgradeGateDecision is what checkUpgradeGate tells a daemon-spawn caller.
 type upgradeGateDecision int
@@ -35,51 +41,66 @@ const (
 	// breaker, or any probe failure — anything but a provably live upgrade.
 	upgradeGateProceed upgradeGateDecision = iota
 	// upgradeGateInProgress means a live recovery actor provably owns an active
-	// upgrade transaction. The accompanying error is the typed, retryable
-	// "daemon is upgrading" message; the caller must NOT spawn a rival daemon.
+	// FORWARD upgrade. The accompanying error is the typed, retryable "daemon is
+	// upgrading" message; NO caller may start a rival daemon over the supervisor.
 	upgradeGateInProgress
+	// upgradeGateRestoringPrevious means a live recovery actor is rolling back and
+	// restarting the PREVIOUS daemon right now (a rollback-restore phase). The
+	// daemon-BIND path (RunDaemon) must PROCEED — it IS that previous daemon, and
+	// deferring would deadlock the rollback (the actor is waiting for exactly this
+	// daemon to answer). A client must still DEFER: it must not stop and replace
+	// the daemon the actor is validating.
+	upgradeGateRestoringPrevious
 )
 
-// checkUpgradeGate runs the transaction entrypoint gate fail-open. It returns
-// upgradeGateInProgress ONLY when a live recovery actor provably owns an active
-// transaction (an immediate, non-blocking result). Every other outcome returns
-// upgradeGateProceed:
-//
-//   - no journal on disk (the overwhelmingly common case) — a stat plus one
-//     ErrNoActiveTransaction load, so a healthy cold start is effectively free;
-//   - a corrupt, partial, or otherwise unparseable journal — treated as no
-//     transaction, never as a fatal error and never as an unbounded wait;
-//   - a stale/orphaned journal whose actor died and never re-took the lock
-//     within upgradeGateTimeout — the gate wakes the recovery job, waits at most
-//     the deadline, then proceeds;
-//   - the rollback_failed circuit breaker, or any service-manager/probe error.
-//
-// The context deadline is the hard bound over the ENTIRE call, including the
-// service-manager exec that Wake runs, so a wedged systemctl cannot hang the
-// launch. Nothing here blocks longer than upgradeGateTimeout.
 // runEntrypointGate is the actual gate probe, indirected so the fail-open
 // classification can be tested against every EntrypointGate.Check outcome
-// without constructing each on-disk journal state. Production wires the real
-// bounded gate.
-var runEntrypointGate = func(ctx context.Context, homeDir string) error {
-	gate := upgradetxn.EntrypointGate{TakeoverTimeout: upgradeGateTimeout}
+// without constructing each on-disk journal state. skipWake selects the
+// non-waking daemon-bind variant. Production wires the real bounded gate.
+var runEntrypointGate = func(ctx context.Context, homeDir string, skipWake bool) error {
+	gate := upgradetxn.EntrypointGate{TakeoverTimeout: upgradeGateTimeout, SkipWake: skipWake}
 	return gate.Check(ctx, homeDir)
 }
 
-func checkUpgradeGate(homeDir string) (upgradeGateDecision, error) {
+// checkUpgradeGate runs the transaction entrypoint gate fail-open and classifies
+// the result for a daemon-spawn caller.
+//
+// skipWake=false is the CLIENT variant (EnsureDaemon): on a stale journal it may
+// wake the recovery job and wait for takeover, bounded by upgradeGateTimeout.
+// skipWake=true is the daemon-BIND variant (RunDaemon): non-waking and fast — it
+// only reports a live actor to defer to and never waits, so it cannot overrun the
+// caller's bind budget.
+//
+// It returns:
+//   - upgradeGateProceed for no journal (the common case — a stat plus one
+//     ErrNoActiveTransaction load), a corrupt/partial journal, a stale/dead-actor
+//     journal, the rollback_failed breaker, or any probe error. Fail-open: a bad
+//     journal never blocks a launch;
+//   - upgradeGateInProgress for a live FORWARD upgrade — every caller must defer;
+//   - upgradeGateRestoringPrevious for a live ROLLBACK restoring the previous
+//     daemon — the bind path proceeds, a client defers.
+//
+// The context deadline is the hard bound over the ENTIRE call, including the
+// service-manager exec that Wake runs, so a wedged systemctl cannot hang the
+// launch.
+func checkUpgradeGate(homeDir string, skipWake bool) (upgradeGateDecision, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), upgradeGateTimeout)
 	defer cancel()
 
-	err := runEntrypointGate(ctx, homeDir)
+	err := runEntrypointGate(ctx, homeDir, skipWake)
 	if err == nil {
 		return upgradeGateProceed, nil
 	}
 
 	var inProgress *upgradetxn.UpgradeInProgressError
 	if errors.As(err, &inProgress) {
-		// A live recovery actor owns the transaction. Report it so the caller
-		// surfaces "daemon is upgrading; retry shortly" instead of spawning a
-		// rival over the supervisor. Immediate — never a wait.
+		// A live recovery actor owns the transaction. During a rollback-restore
+		// phase it is starting the previous daemon, which the bind path must be
+		// allowed to become; otherwise defer so no rival is spawned over the
+		// supervisor. Immediate either way — never a wait.
+		if inProgress.Phase.IsRollbackRestore() {
+			return upgradeGateRestoringPrevious, err
+		}
 		return upgradeGateInProgress, err
 	}
 

--- a/daemon/upgrade_gate_test.go
+++ b/daemon/upgrade_gate_test.go
@@ -112,11 +112,13 @@ func TestUpgradeGate_ContextDeadline_Proceeds(t *testing.T) {
 	}
 }
 
-// The wrapper's context is the hard ceiling: a gate that honors its deadline
-// cannot make the launch wait past upgradeGateTimeout.
+// The wrapper's context is the hard ceiling tied to upgradeGateTimeout: a gate
+// that honors its deadline cannot make the launch wait past it. The bound is
+// asserted as a small multiple of the CONFIGURED value, so a regression that
+// hardcodes a larger ceiling (e.g. reverting to a fixed multi-second wait) fails.
 func TestUpgradeGate_IsBoundedByTimeout(t *testing.T) {
 	prevTimeout := upgradeGateTimeout
-	upgradeGateTimeout = 60 * time.Millisecond
+	upgradeGateTimeout = 100 * time.Millisecond
 	t.Cleanup(func() { upgradeGateTimeout = prevTimeout })
 
 	stubEntrypointGate(t, func(ctx context.Context, _ string, _ bool) error {
@@ -130,8 +132,8 @@ func TestUpgradeGate_IsBoundedByTimeout(t *testing.T) {
 	if decision != upgradeGateProceed || err != nil {
 		t.Fatalf("a timed-out gate must proceed; got decision=%v err=%v", decision, err)
 	}
-	if elapsed > 2*time.Second {
-		t.Fatalf("gate was not bounded by the timeout; took %s", elapsed)
+	if elapsed > 5*upgradeGateTimeout {
+		t.Fatalf("gate was not bounded by the configured %s ceiling; took %s", upgradeGateTimeout, elapsed)
 	}
 }
 
@@ -151,24 +153,37 @@ func TestUpgradeGate_PassesSkipWakeThrough(t *testing.T) {
 }
 
 // End-to-end against the REAL gate: no journal on disk is the overwhelmingly
-// common case and must proceed with no wait, on both variants.
+// common case and must proceed WITHOUT waiting. The fastness bound is a fraction
+// of upgradeGateTimeout, so a regression that started waiting the whole budget
+// (rather than returning immediately) fails.
 func TestUpgradeGate_NoJournalOnDisk_Proceeds(t *testing.T) {
+	prevTimeout := upgradeGateTimeout
+	upgradeGateTimeout = 500 * time.Millisecond
+	t.Cleanup(func() { upgradeGateTimeout = prevTimeout })
+
 	home := t.TempDir()
 	for _, skipWake := range []bool{false, true} {
 		start := time.Now()
 		decision, err := checkUpgradeGate(home, skipWake)
+		elapsed := time.Since(start)
 		if decision != upgradeGateProceed || err != nil {
 			t.Fatalf("empty home must proceed (skipWake=%v); got decision=%v err=%v", skipWake, decision, err)
 		}
-		if time.Since(start) > 2*time.Second {
-			t.Fatalf("no-journal gate was not fast (skipWake=%v); took %s", skipWake, time.Since(start))
+		if elapsed > upgradeGateTimeout/2 {
+			t.Fatalf("no-journal gate waited instead of proceeding (skipWake=%v, ceiling %s); took %s",
+				skipWake, upgradeGateTimeout, elapsed)
 		}
 	}
 }
 
 // End-to-end against the REAL gate: a corrupt on-disk journal must not block or
-// fatal an af launch (the exact hazard the fail-open gate exists for).
+// fatal an af launch (the exact hazard the fail-open gate exists for), and must
+// return WITHOUT waiting — asserted as a fraction of upgradeGateTimeout.
 func TestUpgradeGate_CorruptJournalOnDisk_Proceeds(t *testing.T) {
+	prevTimeout := upgradeGateTimeout
+	upgradeGateTimeout = 500 * time.Millisecond
+	t.Cleanup(func() { upgradeGateTimeout = prevTimeout })
+
 	home := t.TempDir()
 	upgradeDir := filepath.Join(home, "upgrade")
 	if err := os.MkdirAll(upgradeDir, 0o755); err != nil {
@@ -180,10 +195,11 @@ func TestUpgradeGate_CorruptJournalOnDisk_Proceeds(t *testing.T) {
 
 	start := time.Now()
 	decision, err := checkUpgradeGate(home, false)
+	elapsed := time.Since(start)
 	if decision != upgradeGateProceed || err != nil {
 		t.Fatalf("a corrupt on-disk journal must proceed, never wedge the launch; got decision=%v err=%v", decision, err)
 	}
-	if time.Since(start) > 2*time.Second {
-		t.Fatalf("corrupt-journal gate was not fast; took %s", time.Since(start))
+	if elapsed > upgradeGateTimeout/2 {
+		t.Fatalf("corrupt-journal gate waited instead of proceeding (ceiling %s); took %s", upgradeGateTimeout, elapsed)
 	}
 }

--- a/daemon/upgrade_gate_test.go
+++ b/daemon/upgrade_gate_test.go
@@ -14,7 +14,7 @@ import (
 // stubEntrypointGate replaces the gate probe with a fixed outcome and restores
 // it on cleanup. It lets the fail-open classification be tested against every
 // EntrypointGate.Check result without building each on-disk journal state.
-func stubEntrypointGate(t *testing.T, fn func(context.Context, string) error) {
+func stubEntrypointGate(t *testing.T, fn func(context.Context, string, bool) error) {
 	t.Helper()
 	prev := runEntrypointGate
 	t.Cleanup(func() { runEntrypointGate = prev })
@@ -26,27 +26,53 @@ func stubEntrypointGate(t *testing.T, fn func(context.Context, string) error) {
 // fronts every af invocation and a hang there is unrecoverable.
 
 func TestUpgradeGate_NoTransaction_Proceeds(t *testing.T) {
-	stubEntrypointGate(t, func(context.Context, string) error { return nil })
-	decision, err := checkUpgradeGate("/home/af")
+	stubEntrypointGate(t, func(context.Context, string, bool) error { return nil })
+	decision, err := checkUpgradeGate("/home/af", false)
 	if decision != upgradeGateProceed || err != nil {
 		t.Fatalf("no transaction must proceed with no error; got decision=%v err=%v", decision, err)
 	}
 }
 
-func TestUpgradeGate_LiveUpgrade_ReportsInProgress(t *testing.T) {
+func TestUpgradeGate_LiveForwardUpgrade_ReportsInProgress(t *testing.T) {
 	inProgress := &upgradetxn.UpgradeInProgressError{
-		TransactionID: "txn-1", ToVersion: "1.0.210", Phase: upgradetxn.PhaseSupervisorReady,
+		TransactionID: "txn-1", ToVersion: "1.0.210", Phase: upgradetxn.PhaseCandidateValidating,
 		Deadline: time.Now().Add(time.Minute),
 	}
-	stubEntrypointGate(t, func(context.Context, string) error { return inProgress })
+	stubEntrypointGate(t, func(context.Context, string, bool) error { return inProgress })
 
-	decision, err := checkUpgradeGate("/home/af")
+	decision, err := checkUpgradeGate("/home/af", false)
 	if decision != upgradeGateInProgress {
-		t.Fatalf("a live recovery actor must stop the launch; got decision=%v", decision)
+		t.Fatalf("a live forward upgrade must stop the launch; got decision=%v", decision)
 	}
 	var typed *upgradetxn.UpgradeInProgressError
 	if !errors.As(err, &typed) {
 		t.Fatalf("in-progress must return the typed retryable error; got %v", err)
+	}
+}
+
+// The P1 regression: a live actor restoring the previous daemon during a
+// rollback must classify as restoring-previous, so the daemon-BIND path binds
+// rather than deferring to the actor that is waiting for it. Every
+// rollback-restore phase must map this way.
+func TestUpgradeGate_LiveRollbackRestore_ReportsRestoringPrevious(t *testing.T) {
+	for _, phase := range []upgradetxn.Phase{
+		upgradetxn.PhaseRollbackRestored,
+		upgradetxn.PhasePreviousStarting,
+		upgradetxn.PhasePreviousValidating,
+		upgradetxn.PhaseRolledBack,
+	} {
+		t.Run(string(phase), func(t *testing.T) {
+			inProgress := &upgradetxn.UpgradeInProgressError{
+				TransactionID: "txn-2", ToVersion: "1.0.210", Phase: phase,
+				Deadline: time.Now().Add(time.Minute),
+			}
+			stubEntrypointGate(t, func(context.Context, string, bool) error { return inProgress })
+
+			decision, _ := checkUpgradeGate("/home/af", true)
+			if decision != upgradeGateRestoringPrevious {
+				t.Fatalf("phase %s must let the previous daemon bind; got decision=%v", phase, decision)
+			}
+		})
 	}
 }
 
@@ -55,12 +81,12 @@ func TestUpgradeGate_LiveUpgrade_ReportsInProgress(t *testing.T) {
 // dead actor.
 func TestUpgradeGate_StaleTakeoverBlocked_Proceeds(t *testing.T) {
 	blocked := &upgradetxn.UpgradeRecoveryBlockedError{
-		TransactionID: "txn-2", ToVersion: "1.0.210", Phase: upgradetxn.PhaseDaemonStopping,
+		TransactionID: "txn-3", ToVersion: "1.0.210", Phase: upgradetxn.PhaseDaemonStopping,
 		Reason: "the preserved previous binary did not acquire the recovery lock",
 	}
-	stubEntrypointGate(t, func(context.Context, string) error { return blocked })
+	stubEntrypointGate(t, func(context.Context, string, bool) error { return blocked })
 
-	decision, err := checkUpgradeGate("/home/af")
+	decision, err := checkUpgradeGate("/home/af", false)
 	if decision != upgradeGateProceed || err != nil {
 		t.Fatalf("a blocked/stale recovery must proceed, never wedge the launch; got decision=%v err=%v", decision, err)
 	}
@@ -69,18 +95,18 @@ func TestUpgradeGate_StaleTakeoverBlocked_Proceeds(t *testing.T) {
 // A corrupt or partial journal makes the gate return a generic error. It must be
 // treated as no-transaction and proceed, never as a fatal.
 func TestUpgradeGate_CorruptJournalError_Proceeds(t *testing.T) {
-	stubEntrypointGate(t, func(context.Context, string) error {
+	stubEntrypointGate(t, func(context.Context, string, bool) error {
 		return errors.New("inspect active daemon upgrade before entrypoint startup: unexpected end of JSON input")
 	})
-	decision, err := checkUpgradeGate("/home/af")
+	decision, err := checkUpgradeGate("/home/af", false)
 	if decision != upgradeGateProceed || err != nil {
 		t.Fatalf("a corrupt journal must proceed, never fatal; got decision=%v err=%v", decision, err)
 	}
 }
 
 func TestUpgradeGate_ContextDeadline_Proceeds(t *testing.T) {
-	stubEntrypointGate(t, func(context.Context, string) error { return context.DeadlineExceeded })
-	decision, err := checkUpgradeGate("/home/af")
+	stubEntrypointGate(t, func(context.Context, string, bool) error { return context.DeadlineExceeded })
+	decision, err := checkUpgradeGate("/home/af", false)
 	if decision != upgradeGateProceed || err != nil {
 		t.Fatalf("a deadline must proceed; got decision=%v err=%v", decision, err)
 	}
@@ -93,13 +119,13 @@ func TestUpgradeGate_IsBoundedByTimeout(t *testing.T) {
 	upgradeGateTimeout = 60 * time.Millisecond
 	t.Cleanup(func() { upgradeGateTimeout = prevTimeout })
 
-	stubEntrypointGate(t, func(ctx context.Context, _ string) error {
+	stubEntrypointGate(t, func(ctx context.Context, _ string, _ bool) error {
 		<-ctx.Done() // a wedged gate that respects its deadline
 		return ctx.Err()
 	})
 
 	start := time.Now()
-	decision, err := checkUpgradeGate("/home/af")
+	decision, err := checkUpgradeGate("/home/af", false)
 	elapsed := time.Since(start)
 	if decision != upgradeGateProceed || err != nil {
 		t.Fatalf("a timed-out gate must proceed; got decision=%v err=%v", decision, err)
@@ -109,17 +135,34 @@ func TestUpgradeGate_IsBoundedByTimeout(t *testing.T) {
 	}
 }
 
+// The daemon-bind path passes skipWake=true; the client path passes false. The
+// probe must receive exactly that so a bind never re-runs the client's wake.
+func TestUpgradeGate_PassesSkipWakeThrough(t *testing.T) {
+	var got []bool
+	stubEntrypointGate(t, func(_ context.Context, _ string, skipWake bool) error {
+		got = append(got, skipWake)
+		return nil
+	})
+	_, _ = checkUpgradeGate("/home/af", false)
+	_, _ = checkUpgradeGate("/home/af", true)
+	if len(got) != 2 || got[0] != false || got[1] != true {
+		t.Fatalf("skipWake was not forwarded to the probe; got %v", got)
+	}
+}
+
 // End-to-end against the REAL gate: no journal on disk is the overwhelmingly
-// common case and must proceed with no wait.
+// common case and must proceed with no wait, on both variants.
 func TestUpgradeGate_NoJournalOnDisk_Proceeds(t *testing.T) {
 	home := t.TempDir()
-	start := time.Now()
-	decision, err := checkUpgradeGate(home)
-	if decision != upgradeGateProceed || err != nil {
-		t.Fatalf("empty home must proceed; got decision=%v err=%v", decision, err)
-	}
-	if time.Since(start) > 2*time.Second {
-		t.Fatalf("no-journal gate was not fast; took %s", time.Since(start))
+	for _, skipWake := range []bool{false, true} {
+		start := time.Now()
+		decision, err := checkUpgradeGate(home, skipWake)
+		if decision != upgradeGateProceed || err != nil {
+			t.Fatalf("empty home must proceed (skipWake=%v); got decision=%v err=%v", skipWake, decision, err)
+		}
+		if time.Since(start) > 2*time.Second {
+			t.Fatalf("no-journal gate was not fast (skipWake=%v); took %s", skipWake, time.Since(start))
+		}
 	}
 }
 
@@ -136,7 +179,7 @@ func TestUpgradeGate_CorruptJournalOnDisk_Proceeds(t *testing.T) {
 	}
 
 	start := time.Now()
-	decision, err := checkUpgradeGate(home)
+	decision, err := checkUpgradeGate(home, false)
 	if decision != upgradeGateProceed || err != nil {
 		t.Fatalf("a corrupt on-disk journal must proceed, never wedge the launch; got decision=%v err=%v", decision, err)
 	}

--- a/daemon/upgrade_gate_test.go
+++ b/daemon/upgrade_gate_test.go
@@ -1,0 +1,146 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/internal/upgradetxn"
+)
+
+// stubEntrypointGate replaces the gate probe with a fixed outcome and restores
+// it on cleanup. It lets the fail-open classification be tested against every
+// EntrypointGate.Check result without building each on-disk journal state.
+func stubEntrypointGate(t *testing.T, fn func(context.Context, string) error) {
+	t.Helper()
+	prev := runEntrypointGate
+	t.Cleanup(func() { runEntrypointGate = prev })
+	runEntrypointGate = fn
+}
+
+// The classification is the whole safety contract (#2212 R1): only a provably
+// live upgrade stops a launch; every other outcome proceeds, because the gate
+// fronts every af invocation and a hang there is unrecoverable.
+
+func TestUpgradeGate_NoTransaction_Proceeds(t *testing.T) {
+	stubEntrypointGate(t, func(context.Context, string) error { return nil })
+	decision, err := checkUpgradeGate("/home/af")
+	if decision != upgradeGateProceed || err != nil {
+		t.Fatalf("no transaction must proceed with no error; got decision=%v err=%v", decision, err)
+	}
+}
+
+func TestUpgradeGate_LiveUpgrade_ReportsInProgress(t *testing.T) {
+	inProgress := &upgradetxn.UpgradeInProgressError{
+		TransactionID: "txn-1", ToVersion: "1.0.210", Phase: upgradetxn.PhaseSupervisorReady,
+		Deadline: time.Now().Add(time.Minute),
+	}
+	stubEntrypointGate(t, func(context.Context, string) error { return inProgress })
+
+	decision, err := checkUpgradeGate("/home/af")
+	if decision != upgradeGateInProgress {
+		t.Fatalf("a live recovery actor must stop the launch; got decision=%v", decision)
+	}
+	var typed *upgradetxn.UpgradeInProgressError
+	if !errors.As(err, &typed) {
+		t.Fatalf("in-progress must return the typed retryable error; got %v", err)
+	}
+}
+
+// A stale journal whose actor never re-takes the recovery lock surfaces as a
+// blocked-recovery result. It must PROCEED — the launch cannot wait forever on a
+// dead actor.
+func TestUpgradeGate_StaleTakeoverBlocked_Proceeds(t *testing.T) {
+	blocked := &upgradetxn.UpgradeRecoveryBlockedError{
+		TransactionID: "txn-2", ToVersion: "1.0.210", Phase: upgradetxn.PhaseDaemonStopping,
+		Reason: "the preserved previous binary did not acquire the recovery lock",
+	}
+	stubEntrypointGate(t, func(context.Context, string) error { return blocked })
+
+	decision, err := checkUpgradeGate("/home/af")
+	if decision != upgradeGateProceed || err != nil {
+		t.Fatalf("a blocked/stale recovery must proceed, never wedge the launch; got decision=%v err=%v", decision, err)
+	}
+}
+
+// A corrupt or partial journal makes the gate return a generic error. It must be
+// treated as no-transaction and proceed, never as a fatal.
+func TestUpgradeGate_CorruptJournalError_Proceeds(t *testing.T) {
+	stubEntrypointGate(t, func(context.Context, string) error {
+		return errors.New("inspect active daemon upgrade before entrypoint startup: unexpected end of JSON input")
+	})
+	decision, err := checkUpgradeGate("/home/af")
+	if decision != upgradeGateProceed || err != nil {
+		t.Fatalf("a corrupt journal must proceed, never fatal; got decision=%v err=%v", decision, err)
+	}
+}
+
+func TestUpgradeGate_ContextDeadline_Proceeds(t *testing.T) {
+	stubEntrypointGate(t, func(context.Context, string) error { return context.DeadlineExceeded })
+	decision, err := checkUpgradeGate("/home/af")
+	if decision != upgradeGateProceed || err != nil {
+		t.Fatalf("a deadline must proceed; got decision=%v err=%v", decision, err)
+	}
+}
+
+// The wrapper's context is the hard ceiling: a gate that honors its deadline
+// cannot make the launch wait past upgradeGateTimeout.
+func TestUpgradeGate_IsBoundedByTimeout(t *testing.T) {
+	prevTimeout := upgradeGateTimeout
+	upgradeGateTimeout = 60 * time.Millisecond
+	t.Cleanup(func() { upgradeGateTimeout = prevTimeout })
+
+	stubEntrypointGate(t, func(ctx context.Context, _ string) error {
+		<-ctx.Done() // a wedged gate that respects its deadline
+		return ctx.Err()
+	})
+
+	start := time.Now()
+	decision, err := checkUpgradeGate("/home/af")
+	elapsed := time.Since(start)
+	if decision != upgradeGateProceed || err != nil {
+		t.Fatalf("a timed-out gate must proceed; got decision=%v err=%v", decision, err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("gate was not bounded by the timeout; took %s", elapsed)
+	}
+}
+
+// End-to-end against the REAL gate: no journal on disk is the overwhelmingly
+// common case and must proceed with no wait.
+func TestUpgradeGate_NoJournalOnDisk_Proceeds(t *testing.T) {
+	home := t.TempDir()
+	start := time.Now()
+	decision, err := checkUpgradeGate(home)
+	if decision != upgradeGateProceed || err != nil {
+		t.Fatalf("empty home must proceed; got decision=%v err=%v", decision, err)
+	}
+	if time.Since(start) > 2*time.Second {
+		t.Fatalf("no-journal gate was not fast; took %s", time.Since(start))
+	}
+}
+
+// End-to-end against the REAL gate: a corrupt on-disk journal must not block or
+// fatal an af launch (the exact hazard the fail-open gate exists for).
+func TestUpgradeGate_CorruptJournalOnDisk_Proceeds(t *testing.T) {
+	home := t.TempDir()
+	upgradeDir := filepath.Join(home, "upgrade")
+	if err := os.MkdirAll(upgradeDir, 0o755); err != nil {
+		t.Fatalf("make upgrade dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(upgradeDir, "active.json"), []byte("{ this is not valid json"), 0o600); err != nil {
+		t.Fatalf("write corrupt journal: %v", err)
+	}
+
+	start := time.Now()
+	decision, err := checkUpgradeGate(home)
+	if decision != upgradeGateProceed || err != nil {
+		t.Fatalf("a corrupt on-disk journal must proceed, never wedge the launch; got decision=%v err=%v", decision, err)
+	}
+	if time.Since(start) > 2*time.Second {
+		t.Fatalf("corrupt-journal gate was not fast; took %s", time.Since(start))
+	}
+}

--- a/daemon/upgrade_recovery.go
+++ b/daemon/upgrade_recovery.go
@@ -1,0 +1,195 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/internal/upgradetxn"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// ErrUpgradeActivationNotEnabled is returned by every FORWARD-activation
+// SupervisorOperation in this slice (#2212 R1). R1 wires the entrypoint takeover
+// gate and the persistent recovery-job launcher, and implements the
+// recovery/rollback-side operations — but it deliberately does NOT implement the
+// operations that quiesce or replace a live daemon (StopPrevious, StartCandidate,
+// ValidateCandidate, ApproveCandidate, AwaitActivation). Those land with the
+// daemon quiesce/probation slice (R2). Binding them fail-closed makes "quiesce or
+// replace a live daemon" structurally impossible here: nothing in this build
+// creates a transaction, and even if one existed the supervisor could never drive
+// a forward activation.
+var ErrUpgradeActivationNotEnabled = errors.New("daemon upgrade activation is not enabled in this build")
+
+// upgradeValidateGrace bounds how long ValidatePrevious waits for the restored
+// previous daemon to answer Ping at the expected version with its recorded
+// listeners. Package vars so tests can shorten the path.
+var (
+	upgradeValidateGrace = 30 * time.Second
+	upgradeValidatePoll  = 100 * time.Millisecond
+)
+
+// upgradeRecoveryHealthFn is the no-spawn health probe validatePreviousDaemon
+// polls; indirected so tests can drive the readiness sequence without a real
+// daemon.
+var upgradeRecoveryHealthFn = Health
+
+// HandleUpgradeRecoveryExec consumes the internal __upgrade-recovery invocation
+// before normal Cobra startup, mirroring sessionenv.HandleInternalExec. On an
+// ordinary invocation it returns immediately. On the recovery invocation it runs
+// the previous-binary recovery actor and exits — a candidate can wake this exact
+// command but can never acquire the recovery lease (the flock capability is
+// granted only to the immutable previous binary).
+func HandleUpgradeRecoveryExec() {
+	invocation, matched, err := upgradetxn.ParseRecoveryInvocation(os.Args[1:])
+	if !matched {
+		return
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "af: invalid internal upgrade recovery invocation")
+		os.Exit(64) // EX_USAGE: the argv is malformed, not a recovery failure.
+	}
+	log.Initialize(false)
+	defer log.Close()
+	if runErr := RunUpgradeRecoveryActor(context.Background(), invocation); runErr != nil {
+		log.ErrorLog.Printf("daemon upgrade recovery actor failed: %v", runErr)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+// RunUpgradeRecoveryActor binds the production supervisor operations to the
+// upgradetxn recovery actor. The operations live here rather than in
+// internal/upgradetxn because they reach into daemon lifecycle primitives, which
+// upgradetxn cannot import without a cycle; SupervisorOperations is injectable
+// precisely to cross that boundary.
+func RunUpgradeRecoveryActor(ctx context.Context, invocation upgradetxn.RecoveryInvocation) error {
+	supervisor := upgradetxn.Supervisor{Operations: productionSupervisorOperations()}
+	return upgradetxn.RunRecoveryActor(ctx, invocation, supervisor)
+}
+
+// productionSupervisorOperations wires the recovery/rollback-side operations to
+// the daemon's real lifecycle primitives and binds the forward-activation
+// operations to ErrUpgradeActivationNotEnabled (R1; see that error's doc).
+func productionSupervisorOperations() upgradetxn.SupervisorOperations {
+	notEnabled := func(context.Context, upgradetxn.Journal) error {
+		return ErrUpgradeActivationNotEnabled
+	}
+	return upgradetxn.SupervisorOperations{
+		// Forward activation — not in this slice.
+		AwaitActivation: notEnabled,
+		StopPrevious: func(context.Context, upgradetxn.Journal) (upgradetxn.StopOutcome, error) {
+			return upgradetxn.StopUnknown, ErrUpgradeActivationNotEnabled
+		},
+		StartCandidate:    notEnabled,
+		ValidateCandidate: notEnabled,
+		ApproveCandidate:  notEnabled,
+		// Recovery / rollback — real, reusing the #2168 daemon lifecycle.
+		StopCandidate:      stopCandidateDaemon,
+		StartPrevious:      startPreviousDaemon,
+		ValidatePrevious:   validatePreviousDaemon,
+		DisableRecoveryJob: disableRecoveryJob,
+	}
+}
+
+// stopCandidateDaemon stops the candidate daemon so the previous binary and
+// metadata can be restored. The candidate serves this AF home's control socket
+// and pid file, so StopDaemon signals exactly it; WaitForShutdownCompletion then
+// upgrades a signalled stop into positive proof the socket is gone before the
+// caller restores anything (#854). Idempotent: with nothing running, StopDaemon
+// reports no daemon and the socket is already quiet — StopConfirmed.
+func stopCandidateDaemon(ctx context.Context, journal upgradetxn.Journal) (upgradetxn.StopOutcome, error) {
+	_ = ctx
+	_ = journal
+	if _, err := StopDaemon(); err != nil {
+		return upgradetxn.StopUnknown, fmt.Errorf("stop upgrade candidate daemon: %w", err)
+	}
+	if err := WaitForShutdownCompletion(); err != nil {
+		// The socket is still answering at the deadline. Report it as still
+		// running rather than confirming a stop we could not observe — restoring
+		// the previous binary under a live candidate would be destructive.
+		return upgradetxn.StopStillRunning, nil
+	}
+	return upgradetxn.StopConfirmed, nil
+}
+
+// startPreviousDaemon brings the restored previous daemon back under the
+// captured owner. The previous executable has already been restored to the
+// canonical path by the transaction, so a service-managed owner starts the unit
+// (reset-failed clears only the runtime failure counter, never the StartLimit*
+// directives #2168/#2212 preserve) and an ad-hoc owner spawns the canonical
+// binary directly. Idempotent: RestartAutostartUnit cycles a unit that is
+// already up, and the ad-hoc launcher is a no-op reclaim when a daemon answers.
+func startPreviousDaemon(ctx context.Context, journal upgradetxn.Journal) error {
+	_ = ctx
+	switch journal.Daemon.Owner.Kind {
+	case upgradetxn.SupervisionSystemd, upgradetxn.SupervisionLaunchd:
+		if err := RestartAutostartUnit(); err != nil {
+			return fmt.Errorf("restart previous daemon under its %s unit: %w", journal.Daemon.Owner.Kind, err)
+		}
+		return nil
+	default:
+		if err := launchDaemonProcessAt(journal.ExecutablePath); err != nil {
+			return fmt.Errorf("spawn previous ad-hoc daemon %s: %w", journal.ExecutablePath, err)
+		}
+		return nil
+	}
+}
+
+// validatePreviousDaemon confirms the restored previous daemon is genuinely the
+// FromVersion daemon and has rebound every listener that was healthy before the
+// upgrade — not merely that something answers the socket (#1947). It polls the
+// no-spawn health probe within a bounded grace; a wrong version, a missing
+// listener, or no answer by the deadline is a rollback validation failure.
+func validatePreviousDaemon(ctx context.Context, journal upgradetxn.Journal) error {
+	deadline := time.Now().Add(upgradeValidateGrace)
+	var lastErr error
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		h := upgradeRecoveryHealthFn()
+		lastErr = previousDaemonHealthy(h, journal)
+		if lastErr == nil {
+			return nil
+		}
+		if !time.Now().Before(deadline) {
+			return fmt.Errorf("restored previous daemon did not become healthy at version %s within %s: %w",
+				journal.FromVersion, upgradeValidateGrace, lastErr)
+		}
+		time.Sleep(upgradeValidatePoll)
+	}
+}
+
+// previousDaemonHealthy is the single readiness predicate for validatePreviousDaemon,
+// factored so it is testable without real time. It requires a live responder, the
+// exact FromVersion, and every listener the journal recorded as healthy.
+func previousDaemonHealthy(h HealthStatus, journal upgradetxn.Journal) error {
+	if h.PingErr != nil {
+		return fmt.Errorf("previous daemon is not answering: %w", h.PingErr)
+	}
+	if h.DaemonVersion == "" {
+		return errors.New("previous daemon answered but did not report its version")
+	}
+	if h.DaemonVersion != journal.FromVersion {
+		return fmt.Errorf("previous daemon reports version %s, want %s", h.DaemonVersion, journal.FromVersion)
+	}
+	want := journal.Daemon.Listeners
+	if want.HTTPUnixBound && !h.Listeners.HTTPUnixBound {
+		return errors.New("previous daemon has not rebound the HTTP control listener")
+	}
+	if want.TCPConfigured && want.TCPBound && !h.Listeners.TCPBound {
+		return errors.New("previous daemon has not rebound the configured TCP listener")
+	}
+	return nil
+}
+
+// disableRecoveryJob disarms the persistent recovery job's restart policy after
+// a terminal rollback or commit, without stopping the still-running actor (it
+// owns the flock and removes the active journal afterward). The controller
+// forbids --now/bootout by shape, so this cannot race the actor's own teardown.
+func disableRecoveryJob(ctx context.Context, journal upgradetxn.Journal) error {
+	return upgradetxn.RecoveryJobController{}.Disable(ctx, journal)
+}

--- a/daemon/upgrade_recovery.go
+++ b/daemon/upgrade_recovery.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/upgradetxn"
 	"github.com/sachiniyer/agent-factory/log"
 )
@@ -56,6 +57,17 @@ func HandleUpgradeRecoveryExec() {
 		fmt.Fprintln(os.Stderr, "af: invalid internal upgrade recovery invocation")
 		os.Exit(64) // EX_USAGE: the argv is malformed, not a recovery failure.
 	}
+	// Bind this process to the home the transaction is recovering BEFORE any
+	// home-derived path resolves — logging, the control socket, the pid file, and
+	// the autostart unit all go through config.GetConfigDir(), which reads
+	// AGENT_FACTORY_HOME. The recovery job execs us with --home only and supplies
+	// no environment (renderSystemd/LaunchdRecoveryUnit emit no Environment=), so
+	// without this every op would resolve the DEFAULT home and stop, validate, or
+	// restart a different daemon than the one being recovered (#782/#1916, #2212).
+	if setErr := os.Setenv("AGENT_FACTORY_HOME", invocation.HomeDir); setErr != nil {
+		fmt.Fprintln(os.Stderr, "af: cannot bind the upgrade recovery home")
+		os.Exit(1)
+	}
 	log.Initialize(false)
 	defer log.Close()
 	if runErr := RunUpgradeRecoveryActor(context.Background(), invocation); runErr != nil {
@@ -99,6 +111,26 @@ func productionSupervisorOperations() upgradetxn.SupervisorOperations {
 	}
 }
 
+// recoveryHomeGuard fails closed when this process is not resolved to the AF
+// home the transaction is recovering. HandleUpgradeRecoveryExec binds the home
+// from the invocation, so a mismatch means that binding did not take — and every
+// home-dependent op (StopDaemon, the health probe, the autostart unit) would then
+// act on a DIFFERENT daemon than the one under recovery. Refusing is the only safe
+// answer: proceeding on the wrong home is how a "stop" fabricates StopConfirmed
+// over a live candidate.
+func recoveryHomeGuard(journal upgradetxn.Journal) error {
+	dir, err := config.GetConfigDir()
+	if err != nil {
+		return fmt.Errorf("resolve AF home for upgrade recovery: %w", err)
+	}
+	if dir != journal.HomeDir {
+		return fmt.Errorf(
+			"upgrade recovery is bound to AF home %q but the transaction recovers %q; refusing to act on the wrong daemon",
+			dir, journal.HomeDir)
+	}
+	return nil
+}
+
 // stopCandidateDaemon stops the candidate daemon so the previous binary and
 // metadata can be restored. The candidate serves this AF home's control socket
 // and pid file, so StopDaemon signals exactly it; WaitForShutdownCompletion then
@@ -107,7 +139,15 @@ func productionSupervisorOperations() upgradetxn.SupervisorOperations {
 // reports no daemon and the socket is already quiet — StopConfirmed.
 func stopCandidateDaemon(ctx context.Context, journal upgradetxn.Journal) (upgradetxn.StopOutcome, error) {
 	_ = ctx
-	_ = journal
+	// Fail closed if this process is not resolved to the home being recovered:
+	// StopDaemon/WaitForShutdownCompletion act on config.GetConfigDir()'s home, so
+	// a mismatch would report StopConfirmed while the transaction's candidate is
+	// still alive — the destructive lie this op must never tell. StopUnknown, not
+	// StopConfirmed, so the supervisor never restores the previous binary under a
+	// live candidate.
+	if err := recoveryHomeGuard(journal); err != nil {
+		return upgradetxn.StopUnknown, err
+	}
 	if _, err := StopDaemon(); err != nil {
 		return upgradetxn.StopUnknown, fmt.Errorf("stop upgrade candidate daemon: %w", err)
 	}
@@ -129,6 +169,9 @@ func stopCandidateDaemon(ctx context.Context, journal upgradetxn.Journal) (upgra
 // already up, and the ad-hoc launcher is a no-op reclaim when a daemon answers.
 func startPreviousDaemon(ctx context.Context, journal upgradetxn.Journal) error {
 	_ = ctx
+	if err := recoveryHomeGuard(journal); err != nil {
+		return err
+	}
 	switch journal.Daemon.Owner.Kind {
 	case upgradetxn.SupervisionSystemd, upgradetxn.SupervisionLaunchd:
 		if err := startPreviousViaUnitFn(); err != nil {
@@ -149,6 +192,9 @@ func startPreviousDaemon(ctx context.Context, journal upgradetxn.Journal) error 
 // no-spawn health probe within a bounded grace; a wrong version, a missing
 // listener, or no answer by the deadline is a rollback validation failure.
 func validatePreviousDaemon(ctx context.Context, journal upgradetxn.Journal) error {
+	if err := recoveryHomeGuard(journal); err != nil {
+		return err
+	}
 	deadline := time.Now().Add(upgradeValidateGrace)
 	var lastErr error
 	for {
@@ -174,6 +220,17 @@ func validatePreviousDaemon(ctx context.Context, journal upgradetxn.Journal) err
 func previousDaemonHealthy(h HealthStatus, journal upgradetxn.Journal) error {
 	if h.PingErr != nil {
 		return fmt.Errorf("previous daemon is not answering: %w", h.PingErr)
+	}
+	// A non-empty transaction id is the tell of an upgrade CANDIDATE in probation
+	// (runDaemon carries it; an ordinary daemon reports empty). The restored
+	// previous daemon is an ordinary daemon, so a responder still carrying a
+	// transaction id is the candidate that never went away — not proof of a
+	// restart. Ping retains this field for the full candidate boot exactly so a
+	// supervisor can reject it (#1947). Without this check a rebuild/reinstall
+	// where from==to (dev-install, a re-published tag) would let a surviving
+	// candidate satisfy every version/listener test and pass off as rolled back.
+	if h.TransactionID != "" {
+		return fmt.Errorf("responder is an upgrade candidate (transaction %s), not the restored previous daemon", h.TransactionID)
 	}
 	if h.DaemonVersion == "" {
 		return errors.New("previous daemon answered but did not report its version")

--- a/daemon/upgrade_recovery.go
+++ b/daemon/upgrade_recovery.go
@@ -31,10 +31,15 @@ var (
 	upgradeValidatePoll  = 100 * time.Millisecond
 )
 
-// upgradeRecoveryHealthFn is the no-spawn health probe validatePreviousDaemon
-// polls; indirected so tests can drive the readiness sequence without a real
-// daemon.
-var upgradeRecoveryHealthFn = Health
+// Indirection points so the recovery/rollback operations can be exercised
+// without a real service manager, a spawned daemon, or a live control socket.
+// upgradeRecoveryHealthFn drives validatePreviousDaemon's readiness sequence;
+// the start hooks let startPreviousDaemon's owner dispatch be tested hermetically.
+var (
+	upgradeRecoveryHealthFn = Health
+	startPreviousViaUnitFn  = RestartAutostartUnit
+	startPreviousAdHocFn    = launchDaemonProcessAt
+)
 
 // HandleUpgradeRecoveryExec consumes the internal __upgrade-recovery invocation
 // before normal Cobra startup, mirroring sessionenv.HandleInternalExec. On an
@@ -126,12 +131,12 @@ func startPreviousDaemon(ctx context.Context, journal upgradetxn.Journal) error 
 	_ = ctx
 	switch journal.Daemon.Owner.Kind {
 	case upgradetxn.SupervisionSystemd, upgradetxn.SupervisionLaunchd:
-		if err := RestartAutostartUnit(); err != nil {
+		if err := startPreviousViaUnitFn(); err != nil {
 			return fmt.Errorf("restart previous daemon under its %s unit: %w", journal.Daemon.Owner.Kind, err)
 		}
 		return nil
 	default:
-		if err := launchDaemonProcessAt(journal.ExecutablePath); err != nil {
+		if err := startPreviousAdHocFn(journal.ExecutablePath); err != nil {
 			return fmt.Errorf("spawn previous ad-hoc daemon %s: %w", journal.ExecutablePath, err)
 		}
 		return nil

--- a/daemon/upgrade_recovery_test.go
+++ b/daemon/upgrade_recovery_test.go
@@ -4,9 +4,30 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/internal/upgradetxn"
 )
+
+// stubRecoveryOps replaces the recovery-op collaborators with hermetic fakes and
+// shortens validatePreviousDaemon's polling, restoring everything on cleanup.
+func stubRecoveryOps(t *testing.T) {
+	t.Helper()
+	prevHealth := upgradeRecoveryHealthFn
+	prevUnit := startPreviousViaUnitFn
+	prevAdHoc := startPreviousAdHocFn
+	prevGrace := upgradeValidateGrace
+	prevPoll := upgradeValidatePoll
+	t.Cleanup(func() {
+		upgradeRecoveryHealthFn = prevHealth
+		startPreviousViaUnitFn = prevUnit
+		startPreviousAdHocFn = prevAdHoc
+		upgradeValidateGrace = prevGrace
+		upgradeValidatePoll = prevPoll
+	})
+	upgradeValidateGrace = 500 * time.Millisecond
+	upgradeValidatePoll = time.Millisecond
+}
 
 func journalAt(fromVersion string, listeners upgradetxn.ListenerExpectation) upgradetxn.Journal {
 	return upgradetxn.Journal{
@@ -108,5 +129,100 @@ func TestForwardActivationOpsAreNotEnabled(t *testing.T) {
 	// the real path this slice delivers.
 	if ops.StopCandidate == nil || ops.StartPrevious == nil || ops.ValidatePrevious == nil || ops.DisableRecoveryJob == nil {
 		t.Fatal("recovery-side operations must be wired in R1")
+	}
+}
+
+func TestStartPreviousDaemon_DispatchesByOwner(t *testing.T) {
+	for _, tc := range []struct {
+		kind      upgradetxn.SupervisionKind
+		wantUnit  bool
+		wantAdHoc bool
+	}{
+		{upgradetxn.SupervisionSystemd, true, false},
+		{upgradetxn.SupervisionLaunchd, true, false},
+		{upgradetxn.SupervisionAdHoc, false, true},
+		{upgradetxn.SupervisionNone, false, true},
+	} {
+		t.Run(string(tc.kind)+"-owner", func(t *testing.T) {
+			stubRecoveryOps(t)
+			unitCalled, adHocCalled := false, false
+			startPreviousViaUnitFn = func() error { unitCalled = true; return nil }
+			startPreviousAdHocFn = func(string) error { adHocCalled = true; return nil }
+
+			j := upgradetxn.Journal{
+				ExecutablePath: "/opt/agent-factory/bin/af",
+				Daemon:         upgradetxn.DaemonSnapshot{Owner: upgradetxn.DaemonOwner{Kind: tc.kind}},
+			}
+			if err := startPreviousDaemon(context.Background(), j); err != nil {
+				t.Fatalf("startPreviousDaemon: %v", err)
+			}
+			if unitCalled != tc.wantUnit || adHocCalled != tc.wantAdHoc {
+				t.Fatalf("owner %s dispatched wrong: unit=%v adhoc=%v", tc.kind, unitCalled, adHocCalled)
+			}
+		})
+	}
+}
+
+func TestValidatePreviousDaemon_WaitsThenValidates(t *testing.T) {
+	stubRecoveryOps(t)
+	calls := 0
+	upgradeRecoveryHealthFn = func() HealthStatus {
+		calls++
+		if calls < 3 {
+			return HealthStatus{PingErr: errors.New("previous daemon not up yet")}
+		}
+		return HealthStatus{DaemonVersion: "1.0.100"}
+	}
+	if err := validatePreviousDaemon(context.Background(), journalAt("1.0.100", upgradetxn.ListenerExpectation{})); err != nil {
+		t.Fatalf("validate must succeed once the previous daemon answers at FromVersion: %v", err)
+	}
+}
+
+func TestValidatePreviousDaemon_WrongVersionFailsRollback(t *testing.T) {
+	stubRecoveryOps(t)
+	// The candidate never went away; a newer version keeps answering. Validation
+	// must fail so the supervisor rolls back rather than declaring success.
+	upgradeRecoveryHealthFn = func() HealthStatus { return HealthStatus{DaemonVersion: "1.0.210"} }
+	if err := validatePreviousDaemon(context.Background(), journalAt("1.0.100", upgradetxn.ListenerExpectation{})); err == nil {
+		t.Fatal("validate must fail when the responder is not the previous version")
+	}
+}
+
+// The P1 end-to-end at the ops layer the review flagged as missing: a live
+// recovery actor restarts the previous daemon and then validates it. The gate's
+// rollback-restore exemption (which lets that restarted daemon bind instead of
+// deferring to this very actor) is proven in upgrade_gate_test.go; here we prove
+// the operations the actor drives actually bring the previous daemon back.
+func TestRollbackRestore_RestartsThenValidatesPreviousDaemon(t *testing.T) {
+	stubRecoveryOps(t)
+	started := false
+	startPreviousViaUnitFn = func() error { started = true; return nil }
+	upgradeRecoveryHealthFn = func() HealthStatus {
+		if !started {
+			// Before StartPrevious the candidate is gone and nothing answers.
+			return HealthStatus{PingErr: errors.New("no daemon")}
+		}
+		return HealthStatus{DaemonVersion: "1.0.100", Listeners: DaemonListenerStatus{HTTPUnixBound: true}}
+	}
+
+	ops := productionSupervisorOperations()
+	journal := upgradetxn.Journal{
+		FromVersion:    "1.0.100",
+		ExecutablePath: "/opt/agent-factory/bin/af",
+		Daemon: upgradetxn.DaemonSnapshot{
+			Owner:     upgradetxn.DaemonOwner{Kind: upgradetxn.SupervisionSystemd, ServiceName: "agent-factory-daemon.service"},
+			Listeners: upgradetxn.ListenerExpectation{HTTPUnixBound: true},
+		},
+	}
+	ctx := context.Background()
+
+	if err := ops.StartPrevious(ctx, journal); err != nil {
+		t.Fatalf("StartPrevious: %v", err)
+	}
+	if !started {
+		t.Fatal("StartPrevious did not restart the previous daemon under its unit")
+	}
+	if err := ops.ValidatePrevious(ctx, journal); err != nil {
+		t.Fatalf("ValidatePrevious must confirm the restored previous daemon: %v", err)
 	}
 }

--- a/daemon/upgrade_recovery_test.go
+++ b/daemon/upgrade_recovery_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/sachiniyer/agent-factory/internal/upgradetxn"
 )
 
-// stubRecoveryOps replaces the recovery-op collaborators with hermetic fakes and
-// shortens validatePreviousDaemon's polling, restoring everything on cleanup.
-func stubRecoveryOps(t *testing.T) {
+// stubRecoveryOps replaces the recovery-op collaborators with hermetic fakes,
+// shortens validatePreviousDaemon's polling, and binds AGENT_FACTORY_HOME to a
+// throwaway home so the recovery-home guard passes. It returns that home so
+// tests build journals whose HomeDir matches. Everything is restored on cleanup.
+func stubRecoveryOps(t *testing.T) string {
 	t.Helper()
 	prevHealth := upgradeRecoveryHealthFn
 	prevUnit := startPreviousViaUnitFn
@@ -27,18 +29,23 @@ func stubRecoveryOps(t *testing.T) {
 	})
 	upgradeValidateGrace = 500 * time.Millisecond
 	upgradeValidatePoll = time.Millisecond
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	return home
 }
 
-func journalAt(fromVersion string, listeners upgradetxn.ListenerExpectation) upgradetxn.Journal {
+func journalAt(home, fromVersion string, listeners upgradetxn.ListenerExpectation) upgradetxn.Journal {
 	return upgradetxn.Journal{
+		HomeDir:     home,
 		FromVersion: fromVersion,
 		Daemon:      upgradetxn.DaemonSnapshot{Listeners: listeners},
 	}
 }
 
 // previousDaemonHealthy is the rollback readiness gate: "something answered" is
-// not health (#1947). It must require the exact FromVersion and every listener
-// that was healthy before the upgrade.
+// not health (#1947). It must require the exact FromVersion, every listener that
+// was healthy before the upgrade, and — critically — that the responder is NOT a
+// surviving upgrade candidate (which carries a transaction id).
 func TestPreviousDaemonHealthy(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
@@ -49,43 +56,52 @@ func TestPreviousDaemonHealthy(t *testing.T) {
 		{
 			name:    "healthy exact version, no listeners required",
 			health:  HealthStatus{DaemonVersion: "1.0.100"},
-			journal: journalAt("1.0.100", upgradetxn.ListenerExpectation{}),
+			journal: journalAt("", "1.0.100", upgradetxn.ListenerExpectation{}),
 			wantErr: false,
 		},
 		{
 			name:    "not answering",
 			health:  HealthStatus{PingErr: errors.New("connection refused")},
-			journal: journalAt("1.0.100", upgradetxn.ListenerExpectation{}),
+			journal: journalAt("", "1.0.100", upgradetxn.ListenerExpectation{}),
 			wantErr: true,
 		},
 		{
 			name:    "answered but no version reported (older responder)",
 			health:  HealthStatus{},
-			journal: journalAt("1.0.100", upgradetxn.ListenerExpectation{}),
+			journal: journalAt("", "1.0.100", upgradetxn.ListenerExpectation{}),
 			wantErr: true,
 		},
 		{
 			name:    "wrong version is not the previous daemon",
 			health:  HealthStatus{DaemonVersion: "1.0.210"},
-			journal: journalAt("1.0.100", upgradetxn.ListenerExpectation{}),
+			journal: journalAt("", "1.0.100", upgradetxn.ListenerExpectation{}),
+			wantErr: true,
+		},
+		{
+			// The from==to case (a rebuild/reinstall): a surviving candidate matches
+			// the version, but its non-empty transaction id gives it away. Without
+			// the transaction-id check this would falsely pass as rolled back.
+			name:    "surviving candidate at the same version is rejected by its transaction id",
+			health:  HealthStatus{DaemonVersion: "1.0.100", TransactionID: "txn-abc"},
+			journal: journalAt("", "1.0.100", upgradetxn.ListenerExpectation{}),
 			wantErr: true,
 		},
 		{
 			name:    "http listener not rebound",
 			health:  HealthStatus{DaemonVersion: "1.0.100", Listeners: DaemonListenerStatus{HTTPUnixBound: false}},
-			journal: journalAt("1.0.100", upgradetxn.ListenerExpectation{HTTPUnixBound: true}),
+			journal: journalAt("", "1.0.100", upgradetxn.ListenerExpectation{HTTPUnixBound: true}),
 			wantErr: true,
 		},
 		{
 			name:    "http listener rebound",
 			health:  HealthStatus{DaemonVersion: "1.0.100", Listeners: DaemonListenerStatus{HTTPUnixBound: true}},
-			journal: journalAt("1.0.100", upgradetxn.ListenerExpectation{HTTPUnixBound: true}),
+			journal: journalAt("", "1.0.100", upgradetxn.ListenerExpectation{HTTPUnixBound: true}),
 			wantErr: false,
 		},
 		{
 			name:    "tcp listener not rebound",
 			health:  HealthStatus{DaemonVersion: "1.0.100", Listeners: DaemonListenerStatus{TCPBound: false}},
-			journal: journalAt("1.0.100", upgradetxn.ListenerExpectation{TCPConfigured: true, TCPBound: true}),
+			journal: journalAt("", "1.0.100", upgradetxn.ListenerExpectation{TCPConfigured: true, TCPBound: true}),
 			wantErr: true,
 		},
 	} {
@@ -132,6 +148,42 @@ func TestForwardActivationOpsAreNotEnabled(t *testing.T) {
 	}
 }
 
+// P2: every home-dependent op acts on config.GetConfigDir()'s home, so if the
+// process is not bound to the transaction's home, a "stop" would report success
+// against a daemon it cannot even see — restoring the previous binary under a
+// live candidate. The op must fail closed (StopUnknown), never fabricate a stop.
+func TestStopCandidateDaemon_HomeMismatchFailsClosed(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	journal := upgradetxn.Journal{HomeDir: "/some/other/af/home"}
+
+	outcome, err := stopCandidateDaemon(context.Background(), journal)
+	if outcome != upgradetxn.StopUnknown {
+		t.Fatalf("a home mismatch must return StopUnknown, never a fabricated stop; got %v", outcome)
+	}
+	if err == nil {
+		t.Fatal("a home mismatch must return an error, not proceed on the wrong daemon")
+	}
+}
+
+func TestStartPreviousDaemon_HomeMismatchRefuses(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	prevUnit := startPreviousViaUnitFn
+	t.Cleanup(func() { startPreviousViaUnitFn = prevUnit })
+	called := false
+	startPreviousViaUnitFn = func() error { called = true; return nil }
+
+	journal := upgradetxn.Journal{
+		HomeDir: "/some/other/af/home",
+		Daemon:  upgradetxn.DaemonSnapshot{Owner: upgradetxn.DaemonOwner{Kind: upgradetxn.SupervisionSystemd}},
+	}
+	if err := startPreviousDaemon(context.Background(), journal); err == nil {
+		t.Fatal("a home mismatch must refuse to start a daemon for the wrong home")
+	}
+	if called {
+		t.Fatal("a home mismatch must not touch the local unit")
+	}
+}
+
 func TestStartPreviousDaemon_DispatchesByOwner(t *testing.T) {
 	for _, tc := range []struct {
 		kind      upgradetxn.SupervisionKind
@@ -144,12 +196,13 @@ func TestStartPreviousDaemon_DispatchesByOwner(t *testing.T) {
 		{upgradetxn.SupervisionNone, false, true},
 	} {
 		t.Run(string(tc.kind)+"-owner", func(t *testing.T) {
-			stubRecoveryOps(t)
+			home := stubRecoveryOps(t)
 			unitCalled, adHocCalled := false, false
 			startPreviousViaUnitFn = func() error { unitCalled = true; return nil }
 			startPreviousAdHocFn = func(string) error { adHocCalled = true; return nil }
 
 			j := upgradetxn.Journal{
+				HomeDir:        home,
 				ExecutablePath: "/opt/agent-factory/bin/af",
 				Daemon:         upgradetxn.DaemonSnapshot{Owner: upgradetxn.DaemonOwner{Kind: tc.kind}},
 			}
@@ -164,7 +217,7 @@ func TestStartPreviousDaemon_DispatchesByOwner(t *testing.T) {
 }
 
 func TestValidatePreviousDaemon_WaitsThenValidates(t *testing.T) {
-	stubRecoveryOps(t)
+	home := stubRecoveryOps(t)
 	calls := 0
 	upgradeRecoveryHealthFn = func() HealthStatus {
 		calls++
@@ -173,17 +226,17 @@ func TestValidatePreviousDaemon_WaitsThenValidates(t *testing.T) {
 		}
 		return HealthStatus{DaemonVersion: "1.0.100"}
 	}
-	if err := validatePreviousDaemon(context.Background(), journalAt("1.0.100", upgradetxn.ListenerExpectation{})); err != nil {
+	if err := validatePreviousDaemon(context.Background(), journalAt(home, "1.0.100", upgradetxn.ListenerExpectation{})); err != nil {
 		t.Fatalf("validate must succeed once the previous daemon answers at FromVersion: %v", err)
 	}
 }
 
 func TestValidatePreviousDaemon_WrongVersionFailsRollback(t *testing.T) {
-	stubRecoveryOps(t)
+	home := stubRecoveryOps(t)
 	// The candidate never went away; a newer version keeps answering. Validation
 	// must fail so the supervisor rolls back rather than declaring success.
 	upgradeRecoveryHealthFn = func() HealthStatus { return HealthStatus{DaemonVersion: "1.0.210"} }
-	if err := validatePreviousDaemon(context.Background(), journalAt("1.0.100", upgradetxn.ListenerExpectation{})); err == nil {
+	if err := validatePreviousDaemon(context.Background(), journalAt(home, "1.0.100", upgradetxn.ListenerExpectation{})); err == nil {
 		t.Fatal("validate must fail when the responder is not the previous version")
 	}
 }
@@ -194,7 +247,7 @@ func TestValidatePreviousDaemon_WrongVersionFailsRollback(t *testing.T) {
 // deferring to this very actor) is proven in upgrade_gate_test.go; here we prove
 // the operations the actor drives actually bring the previous daemon back.
 func TestRollbackRestore_RestartsThenValidatesPreviousDaemon(t *testing.T) {
-	stubRecoveryOps(t)
+	home := stubRecoveryOps(t)
 	started := false
 	startPreviousViaUnitFn = func() error { started = true; return nil }
 	upgradeRecoveryHealthFn = func() HealthStatus {
@@ -207,6 +260,7 @@ func TestRollbackRestore_RestartsThenValidatesPreviousDaemon(t *testing.T) {
 
 	ops := productionSupervisorOperations()
 	journal := upgradetxn.Journal{
+		HomeDir:        home,
 		FromVersion:    "1.0.100",
 		ExecutablePath: "/opt/agent-factory/bin/af",
 		Daemon: upgradetxn.DaemonSnapshot{

--- a/daemon/upgrade_recovery_test.go
+++ b/daemon/upgrade_recovery_test.go
@@ -1,0 +1,112 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/internal/upgradetxn"
+)
+
+func journalAt(fromVersion string, listeners upgradetxn.ListenerExpectation) upgradetxn.Journal {
+	return upgradetxn.Journal{
+		FromVersion: fromVersion,
+		Daemon:      upgradetxn.DaemonSnapshot{Listeners: listeners},
+	}
+}
+
+// previousDaemonHealthy is the rollback readiness gate: "something answered" is
+// not health (#1947). It must require the exact FromVersion and every listener
+// that was healthy before the upgrade.
+func TestPreviousDaemonHealthy(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		health  HealthStatus
+		journal upgradetxn.Journal
+		wantErr bool
+	}{
+		{
+			name:    "healthy exact version, no listeners required",
+			health:  HealthStatus{DaemonVersion: "1.0.100"},
+			journal: journalAt("1.0.100", upgradetxn.ListenerExpectation{}),
+			wantErr: false,
+		},
+		{
+			name:    "not answering",
+			health:  HealthStatus{PingErr: errors.New("connection refused")},
+			journal: journalAt("1.0.100", upgradetxn.ListenerExpectation{}),
+			wantErr: true,
+		},
+		{
+			name:    "answered but no version reported (older responder)",
+			health:  HealthStatus{},
+			journal: journalAt("1.0.100", upgradetxn.ListenerExpectation{}),
+			wantErr: true,
+		},
+		{
+			name:    "wrong version is not the previous daemon",
+			health:  HealthStatus{DaemonVersion: "1.0.210"},
+			journal: journalAt("1.0.100", upgradetxn.ListenerExpectation{}),
+			wantErr: true,
+		},
+		{
+			name:    "http listener not rebound",
+			health:  HealthStatus{DaemonVersion: "1.0.100", Listeners: DaemonListenerStatus{HTTPUnixBound: false}},
+			journal: journalAt("1.0.100", upgradetxn.ListenerExpectation{HTTPUnixBound: true}),
+			wantErr: true,
+		},
+		{
+			name:    "http listener rebound",
+			health:  HealthStatus{DaemonVersion: "1.0.100", Listeners: DaemonListenerStatus{HTTPUnixBound: true}},
+			journal: journalAt("1.0.100", upgradetxn.ListenerExpectation{HTTPUnixBound: true}),
+			wantErr: false,
+		},
+		{
+			name:    "tcp listener not rebound",
+			health:  HealthStatus{DaemonVersion: "1.0.100", Listeners: DaemonListenerStatus{TCPBound: false}},
+			journal: journalAt("1.0.100", upgradetxn.ListenerExpectation{TCPConfigured: true, TCPBound: true}),
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := previousDaemonHealthy(tc.health, tc.journal)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected an unhealthy verdict, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected healthy, got %v", err)
+			}
+		})
+	}
+}
+
+// The forward-activation operations are fail-closed in R1: this build can never
+// quiesce or replace a live daemon, so an interrupted transaction can only ever
+// resolve toward rollback, never forward.
+func TestForwardActivationOpsAreNotEnabled(t *testing.T) {
+	ops := productionSupervisorOperations()
+	journal := upgradetxn.Journal{}
+	ctx := context.Background()
+
+	forward := map[string]func() error{
+		"AwaitActivation":   func() error { return ops.AwaitActivation(ctx, journal) },
+		"StartCandidate":    func() error { return ops.StartCandidate(ctx, journal) },
+		"ValidateCandidate": func() error { return ops.ValidateCandidate(ctx, journal) },
+		"ApproveCandidate":  func() error { return ops.ApproveCandidate(ctx, journal) },
+		"StopPrevious": func() error {
+			_, err := ops.StopPrevious(ctx, journal)
+			return err
+		},
+	}
+	for name, call := range forward {
+		if err := call(); !errors.Is(err, ErrUpgradeActivationNotEnabled) {
+			t.Fatalf("%s must be fail-closed in R1; got %v", name, err)
+		}
+	}
+
+	// The recovery-side operations must NOT be the not-enabled sentinel — they are
+	// the real path this slice delivers.
+	if ops.StopCandidate == nil || ops.StartPrevious == nil || ops.ValidatePrevious == nil || ops.DisableRecoveryJob == nil {
+		t.Fatal("recovery-side operations must be wired in R1")
+	}
+}

--- a/internal/upgradetxn/entrypoint.go
+++ b/internal/upgradetxn/entrypoint.go
@@ -63,6 +63,15 @@ type EntrypointGate struct {
 	Sleep           func(context.Context, time.Duration) error
 	TakeoverTimeout time.Duration
 	PollInterval    time.Duration
+	// SkipWake makes a free recovery flock resolve immediately to "no live
+	// actor" (nil) instead of waking the recovery job and waiting for takeover.
+	// The daemon-BIND path (RunDaemon) sets it: that path only needs to know
+	// whether a live actor exists to defer to, and it runs inside a caller's
+	// bind budget — re-running the full wake/wait gate the client entrypoint
+	// already ran would blow that budget and churn a fallback spawn (#2212). A
+	// live actor is still reported (with its phase); only the wake/wait is
+	// skipped.
+	SkipWake bool
 }
 
 // Check returns nil only when no active transaction remains. Every other
@@ -92,6 +101,13 @@ func (g EntrypointGate) Check(ctx context.Context, homeDir string) error {
 	}
 	if live {
 		return g.liveRecoveryResult(journal)
+	}
+
+	if g.SkipWake {
+		// No live actor to defer to. The daemon-bind path proceeds rather than
+		// waking a dead recovery job — the client entrypoint owns that, and
+		// waking/waiting here would run twice and exceed the bind budget (#2212).
+		return nil
 	}
 
 	wake := g.WakeRecovery

--- a/internal/upgradetxn/entrypoint_test.go
+++ b/internal/upgradetxn/entrypoint_test.go
@@ -115,6 +115,21 @@ func TestEntrypointGateWakesPreviousBinaryAfterKernelProvesActorDeath(t *testing
 	require.Equal(t, txn.Journal().ID, inProgress.TransactionID)
 }
 
+// The daemon-BIND gate sets SkipWake: it only defers to a LIVE actor and must
+// never wake a dead recovery job or wait for takeover, because it runs inside a
+// caller's bind budget (#2212). A free flock therefore resolves immediately to
+// proceed, with no wake.
+func TestEntrypointGateSkipWakeProceedsWithoutWakingADeadActor(t *testing.T) {
+	_, home, _ := prepareFixture(t)
+	wakeCalls := 0
+	gate := EntrypointGate{
+		SkipWake:     true,
+		WakeRecovery: func(context.Context, *Transaction) error { wakeCalls++; return nil },
+	}
+	require.NoError(t, gate.Check(context.Background(), home))
+	require.Equal(t, 0, wakeCalls, "the daemon-bind gate must not wake a dead recovery job")
+}
+
 func TestEntrypointGateLosingTakeoverRaceObservesWinner(t *testing.T) {
 	_, home, _ := prepareFixture(t)
 	var winner *RecoveryLease

--- a/internal/upgradetxn/recovery_actor.go
+++ b/internal/upgradetxn/recovery_actor.go
@@ -36,10 +36,21 @@ func ParseRecoveryInvocation(args []string) (invocation RecoveryInvocation, matc
 	return RecoveryInvocation{HomeDir: home, TransactionID: args[4]}, true, nil
 }
 
-// runRecoveryActorWith is the runner core for the later production entrypoint
-// binding. The binding must supply TryAcquireRecovery (which derives identity
-// from os.Executable) and Supervisor.Run together; keeping that wrapper out of
-// this production-disabled slice avoids publishing an unreachable API.
+// RunRecoveryActor is the production entrypoint binding that runRecoveryActorWith
+// deferred: it supplies the real recovery-authority acquisition
+// ((*Transaction).TryAcquireRecovery, which derives identity from os.Executable)
+// together with the caller's supervisor. main.go routes the internal
+// __upgrade-recovery invocation here after ParseRecoveryInvocation, so the
+// preserved previous binary — never a candidate — runs the recovery/rollback
+// state machine. The supervisor's SupervisorOperations are injected by the
+// daemon package, which cannot be imported here without a cycle.
+func RunRecoveryActor(ctx context.Context, invocation RecoveryInvocation, supervisor Supervisor) error {
+	return runRecoveryActorWith(ctx, invocation, (*Transaction).TryAcquireRecovery, supervisor.Run)
+}
+
+// runRecoveryActorWith is the runner core for the production entrypoint binding
+// above. The binding supplies TryAcquireRecovery (which derives identity from
+// os.Executable) and Supervisor.Run together.
 func runRecoveryActorWith(
 	ctx context.Context,
 	invocation RecoveryInvocation,

--- a/internal/upgradetxn/transaction.go
+++ b/internal/upgradetxn/transaction.go
@@ -73,6 +73,28 @@ const (
 	PhaseRollbackFailed      Phase = "rollback_failed"
 )
 
+// IsRollbackRestore reports whether the previous daemon is being restored and
+// (re)started under this phase — the window in which the recovery actor calls
+// StartPrevious/ValidatePrevious (supervisor.go). A daemon starting during these
+// phases IS the previous daemon the actor is bringing back, so a daemon-bind
+// entrypoint gate must let it bind rather than defer to the very actor waiting
+// on it — otherwise automatic rollback deadlocks and dead-ends in rollback_failed
+// with no daemon running.
+//
+// The canonical executable has been restored to the previous binary by
+// rollback_restored, so a bind here is the correct previous version. The forward
+// candidate-start phases are deliberately excluded: an ordinary daemon must NOT
+// bind a rival over a live candidate — the candidate is started through the
+// transaction-id probation path, not this gate.
+func (p Phase) IsRollbackRestore() bool {
+	switch p {
+	case PhaseRollbackRestored, PhasePreviousStarting, PhasePreviousValidating, PhaseRolledBack:
+		return true
+	default:
+		return false
+	}
+}
+
 // RollbackProgress makes restoration resumable at file granularity. A
 // checkpoint is persisted only after its atomic write/removal completes, so a
 // crash before the checkpoint safely repeats that one idempotent operation.

--- a/internal/upgradetxn/transaction_test.go
+++ b/internal/upgradetxn/transaction_test.go
@@ -11,6 +11,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// IsRollbackRestore must be true for exactly the phases in which the recovery
+// actor restarts/validates the previous daemon, so the daemon-bind gate lets
+// that daemon bind. The forward candidate-start phases must be excluded — an
+// ordinary daemon must not bind a rival over a live candidate.
+func TestPhaseIsRollbackRestore(t *testing.T) {
+	for _, p := range []Phase{
+		PhaseRollbackRestored, PhasePreviousStarting, PhasePreviousValidating, PhaseRolledBack,
+	} {
+		require.Truef(t, p.IsRollbackRestore(), "%s should be a rollback-restore phase", p)
+	}
+	for _, p := range []Phase{
+		PhasePrepared, PhaseSupervisorReady, PhaseDaemonStopping, PhaseDaemonStopped,
+		PhaseCandidateInstalled, PhaseCandidateStarting, PhaseCandidateValidating,
+		PhaseCommitted, PhaseAborted, PhaseRollingBack, PhaseRollbackFailed,
+	} {
+		require.Falsef(t, p.IsRollbackRestore(), "%s must not be a rollback-restore phase", p)
+	}
+}
+
 func prepareFixture(t *testing.T) (*Transaction, string, string) {
 	t.Helper()
 	home := t.TempDir()

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/sachiniyer/agent-factory/commands"
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/internal/sessionenv"
 )
 
@@ -19,6 +20,10 @@ var (
 
 func main() {
 	sessionenv.HandleInternalExec()
+	// Consume the internal __upgrade-recovery invocation (the persistent recovery
+	// job execs the preserved previous binary this way) before Cobra, exactly as
+	// the session exec protocol above. An ordinary invocation returns immediately.
+	daemon.HandleUpgradeRecoveryExec()
 	rootCmd := rootCommand(commands.Options{Version: version})
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
## Summary

**#2212 R1** — wire the daemon-upgrade **entrypoint takeover gate + recovery-job launcher** into production. `internal/upgradetxn` shipped the whole engine (`#2338` transaction core, `#2362` previous-binary supervisor) with **zero production importers**; this is its first importer, and it makes the machinery reachable **without enabling any activation** (no daemon triggers or drives an upgrade — that's R2/R3).

Plan approved on the issue: https://github.com/sachiniyer/agent-factory/issues/2212#issuecomment-5074475810

### What lands
- **`upgradetxn.RunRecoveryActor`** — the production binding `recovery_actor.go:39` explicitly deferred: it hands `(*Transaction).TryAcquireRecovery` + `Supervisor.Run` to the existing runner core, so the preserved **previous binary** (never a candidate) runs the recovery/rollback state machine.
- **main.go interceptor** — routes the internal `__upgrade-recovery` invocation before Cobra, exactly like the session-exec interceptor. This is what the persistent recovery job execs.
- **`productionSupervisorOperations`** — the recovery/rollback-side ops (stop candidate, start+validate previous, disable job) reusing the **#2168** primitives (`StopDaemon`, `WaitForShutdownCompletion`, `RestartAutostartUnit`, `Health` version + listener verification). The **forward-activation** ops (`StopPrevious`/`StartCandidate`/`ValidateCandidate`/`ApproveCandidate`/`AwaitActivation`) are bound to `ErrUpgradeActivationNotEnabled`. Nothing here creates a transaction, and the supervisor cannot drive a forward activation, so **"quiesce or replace a live daemon" is structurally impossible in this slice** — the quiesce/probation wiring is R2.
- **`checkUpgradeGate`** wraps `EntrypointGate.Check` on the daemon-spawn path (`ensureDaemonWithPolicy`, after the liveness ping so healthy boxes never pay it) and the daemon's own startup (`runDaemon`).

### The gate is FAIL-OPEN (the hazard called out in review)
The gate fronts every `af` launch, so a hang there is unrecoverable. Therefore:
- the entire call is bounded by a **`context` deadline** covering *both* the recovery-job wake (a service-manager exec) and the takeover wait — no path exceeds `upgradeGateTimeout`;
- **only a provably live upgrade** stops a launch, and it does so with an **immediate typed error, never a wait**;
- a **stale / orphaned / corrupt / partial** journal, a **timed-out takeover**, the **`rollback_failed`** breaker, or **any probe error** logs once and **proceeds** with normal startup.

A daemon that will not start is recoverable; an `af` that hangs on every command is not — this is the #2168 crash-loop hazard one layer up, and the gate refuses to reintroduce it.

### Coordination
- Preserves #2168's `StartLimit*` / `RestartPreventExitStatus` byte-for-byte (`reset-failed` clears only the runtime counter). The recovery unit carries its own `StartLimitIntervalSec=300`/`Burst=3`.
- **No release-check loop** (that's R3); the #459→#1466→#1861 throttle is untouched.

## Review fixes (P1/P2/P3 — head `dd9e0bd9`)
- **P1 (blocker) — rollback deadlock.** The `runDaemon` gate had no exemption for the daemon the recovery actor *itself* restarts, so automatic rollback dead-ended in `rollback_failed` with no daemon. Fixed: `Phase.IsRollbackRestore()` (`rollback_restored`/`previous_starting`/`previous_validating`/`rolled_back`) + a 3rd decision `upgradeGateRestoringPrevious` — the **bind path proceeds** (it *is* the previous daemon), a **client still defers** (it must not replace the daemon the actor is validating). Forward candidate-start phases stay excluded (the candidate comes up via the transaction-id probation path, not this gate).
- **P2 — double-gate budget blowout.** Added `EntrypointGate.SkipWake`: the daemon-bind path resolves a free flock immediately (no wake, no wait), so the child never re-runs the client's wake/wait and can't overrun the parent's readiness budget and churn a fallback spawn. Ceiling shrunk to **2s** to fit the smallest caller budget.
- **P3** — restored the blank line so godoc attributes the fail-open contract to `checkUpgradeGate`.
- **Test gap closed** (the review's "nothing exercises a live actor restarts the previous daemon"): rollback-restore classification for every restore phase; `Phase.IsRollbackRestore()`; `SkipWake` proceeds without waking a dead actor; skipWake forwarded to the probe; and the end-to-end rollback ops — `startPreviousDaemon` owner dispatch, `validatePreviousDaemon` driven through the `upgradeRecoveryHealthFn` seam (waits-then-validates, wrong-version-fails), and `StartPrevious`→`ValidatePrevious` tied together.

Round-2 review (P2 home-binding + P3-a candidate-id + P3-b test thresholds) fixed at head `67fd7ec5` — see the PR comments.

## Test plan (all on `67fd7ec5`)
New daemon tests (container):
- **Fail-open classification matrix** — no-transaction→proceed, live-upgrade→typed in-progress, stale/blocked-takeover→proceed, corrupt-journal-error→proceed, context-deadline→proceed, and a **bounded-timeout proof** (a wedged gate cannot exceed the ceiling).
- **Real on-disk proofs** — an **empty** home and a **corrupt** `active.json` both proceed and return fast (the literal "a bad journal must never block a launch" hazard, on the real code path).
- **`previousDaemonHealthy`** — "something answered" is not health (#1947): requires the exact `FromVersion` and every listener healthy before the upgrade.
- **Forward ops fail-closed** — every forward-activation op returns `ErrUpgradeActivationNotEnabled`.

Gates:
- [x] `gofmt -l .` · `go build ./...` · `go vet ./daemon/... ./internal/upgradetxn/...`
- [x] `golangci-lint run --timeout=3m --fast` (full repo) · `deadcode -test ./...` · `scripts/lint-file-length.sh`
- [x] `make docs` — no drift (no Cobra command added; the recovery mode is an internal argv)
- [x] `make test-container GOTESTARGS="./daemon/... ./internal/upgradetxn/..."` — green (daemon 190s, upgradetxn 3.3s)
- [x] **`make test-container` (full suite) — green on `67fd7ec5`** (46 packages ok, incl. `daemon`, `internal/upgradetxn`, `parity`)

Part of #2212.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
