### PR TITLE
feat(daemon): preview-origin auth — a separate ephemeral credential (#1856 step 2)

### DIFF
--- a/daemon/agentserver_headless.go
+++ b/daemon/agentserver_headless.go
@@ -155,7 +155,7 @@ func RunAgentServer(opts AgentServerOptions, stdout io.Writer) error {
 	// The zero-value policy is exactly that strict posture; pass it explicitly so
 	// the intent is on the page and a future require_token=false in the host
 	// config can never weaken this listener.
-	closeTCP, tcpInfo, err := startTCPListener(hs.newMux(), cfg.ListenAddr, cfg, tokenGatePolicy{}, withoutWebShell)
+	closeTCP, tcpInfo, err := startTCPListener(hs.newMux(), cfg.ListenAddr, cfg, tokenGatePolicy{}, withoutWebShell, nil)
 	if err != nil {
 		return fmt.Errorf("failed to start agent-server listener on %q: %w", opts.ListenAddr, err)
 	}

--- a/daemon/agentserver_headless_test.go
+++ b/daemon/agentserver_headless_test.go
@@ -150,7 +150,7 @@ func TestHeadlessAgentServer_HTTPTokenRoundTrip(t *testing.T) {
 	// The agent-server uses the strict zero-value policy: token mandatory for
 	// every peer, loopback NOT exempt — so "missing token → 401" holds even over
 	// this loopback socket (#1696).
-	closeTCP, info, err := startTCPListener(hs.newMux(), cfg.ListenAddr, cfg, tokenGatePolicy{}, withoutWebShell)
+	closeTCP, info, err := startTCPListener(hs.newMux(), cfg.ListenAddr, cfg, tokenGatePolicy{}, withoutWebShell, nil)
 	require.NoError(t, err)
 	defer func() { _ = closeTCP() }()
 	require.NotEmpty(t, info.Token)
@@ -309,7 +309,7 @@ func TestAgentServerServesNoWebShell(t *testing.T) {
 	cfg.ListenAddr = "127.0.0.1:0"
 	hs := &headlessServer{}
 
-	closeTCP, info, err := startTCPListener(hs.newMux(), cfg.ListenAddr, cfg, tokenGatePolicy{}, withoutWebShell)
+	closeTCP, info, err := startTCPListener(hs.newMux(), cfg.ListenAddr, cfg, tokenGatePolicy{}, withoutWebShell, nil)
 	require.NoError(t, err)
 	defer func() { _ = closeTCP() }()
 

--- a/daemon/httpauth.go
+++ b/daemon/httpauth.go
@@ -61,6 +61,14 @@ type authGate struct {
 	// the token: the agent-server sets it false (mandatory token for every peer),
 	// the daemon's web listener sets it true.
 	loopbackExempt bool
+
+	// presentedToken extracts the credential a request presents. Nil ⇒
+	// webTabAwareToken, the daemon/agent-server default (Authorization header, then
+	// the ?access_token= / webtab query+cookie fallbacks). The PREVIEW listener
+	// (#1856) sets previewPresentedToken instead: it authenticates a SEPARATE
+	// ephemeral credential on a distinct query/cookie name, so the daemon bearer and
+	// the preview credential can never be read for one another.
+	presentedToken func(*http.Request) string
 }
 
 // authRequired reports whether THIS request must present a valid bearer token to
@@ -91,7 +99,11 @@ func (g *authGate) authorize(r *http.Request) bool {
 	if err != nil {
 		return false
 	}
-	return ConstantTimeEqual(webTabAwareToken(r), want)
+	extract := g.presentedToken
+	if extract == nil {
+		extract = webTabAwareToken
+	}
+	return ConstantTimeEqual(extract(r), want)
 }
 
 // webTabAwareToken returns the request's bearer token, resolved differently under

--- a/daemon/httpserver.go
+++ b/daemon/httpserver.go
@@ -207,7 +207,7 @@ func startHTTPServer(manager *Manager, scheduler *taskScheduler, watchers *watch
 		// DeliverPrompt warning, or its control-plane credential.
 		policy := previewListenerPolicy(manager.cfg)
 		notice := config.PreviewListenerExposureNotice(manager.cfg)
-		if closer, info, err := startTCPListener(newPreviewMux(), manager.cfg.PreviewListenAddr, manager.cfg, policy, withoutWebShell, previewListenerAuth(manager)); err != nil {
+		if closer, info, err := startTCPListener(newPreviewMux(), manager.cfg.PreviewListenAddr, manager.cfg, policy, previewShell, previewListenerAuth(manager)); err != nil {
 			log.WarningLog.Printf("failed to start web-tab preview listener on %q: %v", manager.cfg.PreviewListenAddr, err)
 		} else {
 			closePreview = closer

--- a/daemon/httpserver.go
+++ b/daemon/httpserver.go
@@ -154,7 +154,7 @@ func startHTTPServer(manager *Manager, scheduler *taskScheduler, watchers *watch
 		// opened, so the operator gets a single accurate line rather than a warning
 		// about a listener that was never served — and nothing on a per-request or
 		// per-connection path repeats it.
-		if closer, info, err := startTCPListener(mux, manager.cfg.ListenAddr, manager.cfg, policy, withWebShell); err != nil {
+		if closer, info, err := startTCPListener(mux, manager.cfg.ListenAddr, manager.cfg, policy, withWebShell, nil); err != nil {
 			log.WarningLog.Printf("failed to start daemon HTTP TCP listener on %q: %v", manager.cfg.ListenAddr, err)
 		} else {
 			closeTCP = closer
@@ -188,9 +188,10 @@ func startHTTPServer(manager *Manager, scheduler *taskScheduler, watchers *watch
 	// The web-tab PREVIEW listener (#1856), a SECOND TCP listener bound from
 	// preview_listen_addr. It exists so previews can eventually be served
 	// cross-origin to the SPA — a different origin the framed dev server cannot use
-	// to reach the SPA's token. This step only OPENS the port: it serves an empty
-	// mux (newPreviewMux) behind the strict preview policy, with the preview routes
-	// and the sandbox relax landing in a later step.
+	// to reach the SPA's token. Step 2 opens the AUTH handshake on it (its own
+	// ephemeral credential + the clean-before-render bootstrap, newPreviewMux) but
+	// still serves NO content; the preview proxy routes and the sandbox relax land
+	// in step 3.
 	//
 	// Same non-fatal discipline as the web listener above: a bind failure (a port
 	// conflict, an unbindable host) is logged and skipped, never fatal — the unix
@@ -199,13 +200,14 @@ func startHTTPServer(manager *Manager, scheduler *taskScheduler, watchers *watch
 	// entirely, so no second port opens until an operator opts in.
 	closePreview := func() error { return nil }
 	if manager.cfg.PreviewListenAddr != "" {
-		// Its OWN policy (previewListenerPolicy) and OWN exposure notice
-		// (PreviewListenerExposureNotice), never the control plane's: the preview
-		// origin does not serve the daemon API and must not borrow its posture or
-		// its DeliverPrompt warning.
+		// Its OWN policy (previewListenerPolicy), OWN exposure notice
+		// (PreviewListenerExposureNotice), and OWN credential (previewListenerAuth —
+		// the ephemeral preview token, never the daemon bearer). The preview origin
+		// does not serve the daemon API and must not borrow its posture, its
+		// DeliverPrompt warning, or its control-plane credential.
 		policy := previewListenerPolicy(manager.cfg)
 		notice := config.PreviewListenerExposureNotice(manager.cfg)
-		if closer, info, err := startTCPListener(newPreviewMux(), manager.cfg.PreviewListenAddr, manager.cfg, policy, withoutWebShell); err != nil {
+		if closer, info, err := startTCPListener(newPreviewMux(), manager.cfg.PreviewListenAddr, manager.cfg, policy, withoutWebShell, previewListenerAuth(manager)); err != nil {
 			log.WarningLog.Printf("failed to start web-tab preview listener on %q: %v", manager.cfg.PreviewListenAddr, err)
 		} else {
 			closePreview = closer
@@ -216,10 +218,9 @@ func startHTTPServer(manager *Manager, scheduler *taskScheduler, watchers *watch
 					manager.lifecycle.clearPreviewBound()
 				}()
 			}
-			// Deliberately no "bearer token:" line here: the preview origin's own
-			// credential is a later step, and this listener serves nothing yet, so
-			// printing the daemon token as if it were a login for this port would
-			// mislead.
+			// Deliberately no "bearer token:" line here: the preview credential is an
+			// in-memory ephemeral secret an authenticated client fetches over
+			// /v1/preview-auth, never something to print to the operator's log.
 			log.InfoLog.Printf("web-tab preview listener enabled on %s (serves no content yet — preview routing lands in a later step)", info.Addr)
 			if notice != "" {
 				log.WarningLog.Printf("%s", notice)
@@ -245,17 +246,6 @@ func startHTTPServer(manager *Manager, scheduler *taskScheduler, watchers *watch
 		}
 		return previewErr
 	}, nil
-}
-
-// newPreviewMux is the handler for the web-tab preview listener (#1856). It is
-// an EMPTY mux today: this step opens the preview port but serves no content, so
-// every path 404s. The preview routes (and the cross-origin sandbox relax) move
-// onto it in a later step. It is deliberately NOT the daemon control mux — the
-// whole point of the separate origin is that it must never serve the control
-// API — so a request for /v1/Snapshot on the preview port 404s rather than
-// dispatching.
-func newPreviewMux() http.Handler {
-	return http.NewServeMux()
 }
 
 // newHTTPMux builds the route table by iterating servedHTTPRoutes() — the public
@@ -284,6 +274,12 @@ func newHTTPMux(cs *controlServer) *http.ServeMux {
 	mux.HandleFunc("GET /v1/sessions/{id}/stream", cs.streamHandler)
 	mux.HandleFunc("GET /v1/sessions/{id}/stream-info", cs.streamInfoHandler)
 	mux.HandleFunc("GET /v1/events", cs.eventsHandler)
+
+	// The web-tab preview credential (#1856 step 2): an authenticated control-plane
+	// client fetches the preview origin's ephemeral token here, then delivers it to
+	// the preview iframe (step 3). Internal, not an `af api` RPC — like the stream
+	// routes it registers directly rather than through the httpRoutes catalog.
+	mux.HandleFunc("GET /v1/preview-auth", cs.previewAuthHandler)
 
 	// The web-tab reverse proxy: not a JSON-envelope RPC (it relays a dev
 	// server's raw HTTP/asset/WS traffic), so it is registered directly here like

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -15,6 +15,18 @@ import (
 type Manager struct {
 	cfg *config.Config
 
+	// previewToken is the ephemeral bearer credential for the web-tab PREVIEW
+	// listener (#1856 step 2). It is minted once, in memory, at daemon start
+	// (crypto/rand) and never written to disk — so it rotates on every restart and
+	// leaves no persistent secret. It is DELIBERATELY distinct from the daemon
+	// bearer token: the preview origin serves untrusted, repo/agent-controlled
+	// content, so a credential that leaked from there must authorize preview
+	// serving ONLY, never the control API (DeliverPrompt et al.). The preview
+	// listener's gate compares against this; an authenticated control-plane client
+	// learns it via GET /v1/preview-auth. Immutable after construction, read
+	// lock-free.
+	previewToken string
+
 	// limitDetector is the resolved usage-limit matcher set (#1146), built once
 	// from cfg.LimitPatterns at construction (it compiles the override regexes)
 	// and reused across poll ticks. Immutable; read lock-free by the poll loop.
@@ -234,6 +246,13 @@ func newManagerShellForDaemon(cfg *config.Config, transactionID string) (*Manage
 	if err != nil {
 		return nil, err
 	}
+	// Mint the ephemeral preview credential (#1856 step 2). In memory only, so it
+	// never touches disk and rotates on restart; generateToken is the same 256-bit
+	// crypto/rand source the daemon bearer uses.
+	previewToken, err := generateToken()
+	if err != nil {
+		return nil, fmt.Errorf("mint preview token: %w", err)
+	}
 	state := config.LoadState()
 	storage, err := session.NewStorage(state, "")
 	if err != nil {
@@ -251,6 +270,7 @@ func newManagerShellForDaemon(cfg *config.Config, transactionID string) (*Manage
 	}
 	return &Manager{
 		cfg:                 cfg,
+		previewToken:        previewToken,
 		limitDetector:       task.NewLimitDetector(cfg.LimitPatterns),
 		ready:               make(chan struct{}),
 		lifecycle:           lifecycle,

--- a/daemon/preview_auth.go
+++ b/daemon/preview_auth.go
@@ -1,0 +1,127 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/sachiniyer/agent-factory/agentproto"
+)
+
+// The web-tab PREVIEW origin's auth (#1856 step 2).
+//
+// The preview listener (preview_listen_addr) is a SEPARATE origin from the SPA,
+// so — once step 3 relaxes the sandbox — a framed dev server there cannot reach
+// the SPA's storage or the daemon bearer. This file gives that origin its own
+// credential: the daemon mints an ephemeral preview token (Manager.previewToken),
+// the listener's gate compares against it, and it is delivered to the browser
+// under the #2400 clean-before-render discipline exactly like the app-origin
+// web-tab flow — but on distinct query/cookie names holding the distinct
+// low-privilege credential, so the two can never be read for one another.
+//
+// This step opens the auth handshake only; the preview origin still serves NO
+// content (step 3 wires the proxy routes).
+
+// previewTokenCookie and previewTokenQueryParam carry the PREVIEW credential on
+// the preview origin. They are deliberately distinct from webtabTokenCookie /
+// webtabTokenQueryParam: the value is the preview token, never the daemon bearer,
+// and a distinct name keeps a request that somehow carried both from ever letting
+// one credential be read as the other. Same string for cookie and query because
+// it is the same credential on two transports (mirrors the webtab pair).
+const previewTokenCookie = "af_preview_token"     //nolint:gosec // cookie name, not a credential
+const previewTokenQueryParam = "af_preview_token" //nolint:gosec // query-param name, not a credential
+
+// previewPresentedToken extracts the credential a preview-origin request presents:
+// the Authorization header first (a direct client), then the private query param
+// (the iframe's top-level navigation, which cannot set a header), then the scoped
+// cookie (sub-resource requests, set by the clean-before-render bootstrap). It is
+// the preview listener's gate extractor (authGate.presentedToken), so the preview
+// origin authenticates ONLY the preview token and never ?access_token= or the
+// af_webtab_token transport.
+func previewPresentedToken(r *http.Request) string {
+	if tok := agentproto.BearerToken(r.Header.Get(agentproto.AuthHeader)); tok != "" {
+		return tok
+	}
+	if r.URL == nil {
+		return ""
+	}
+	if tok := r.URL.Query().Get(previewTokenQueryParam); tok != "" {
+		return tok
+	}
+	if c, err := r.Cookie(previewTokenCookie); err == nil {
+		return c.Value
+	}
+	return ""
+}
+
+// previewListenerAuth is the token wiring the preview listener's gate uses instead
+// of the daemon token file: the in-memory ephemeral preview token for both the
+// advertised value and the per-auth-event comparison, and previewPresentedToken
+// for the request side.
+func previewListenerAuth(m *Manager) *tcpListenerAuth {
+	return &tcpListenerAuth{
+		token:     func() (string, error) { return m.previewToken, nil },
+		presented: previewPresentedToken,
+	}
+}
+
+// newPreviewMux is the handler mounted on the preview listener (#1856). It runs
+// the clean-before-render bootstrap for a preview-origin navigation and otherwise
+// serves NOTHING yet — the preview proxy routes land in step 3.
+//
+// It is reached only AFTER withAuth's preview gate authorized the request against
+// the preview token, so the bootstrap here only moves that already-validated
+// credential from the URL into the scoped cookie and redirects to the clean URL.
+// The cookie is scoped to webtabPathPrefix: the preview origin serves its content
+// under the same /v1/webtab/<sid>/<tid>/ path the app origin mirrors, so the
+// browser sends the preview cookie on exactly those sub-resource requests.
+func newPreviewMux() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc(webtabPathPrefix+"{sessionId}/{tabId}/{rest...}", func(w http.ResponseWriter, r *http.Request) {
+		if cleanBootstrapToken(w, r, previewTokenQueryParam, previewTokenCookie, webtabPathPrefix) {
+			return
+		}
+		// Authenticated, credential parked in the cookie — but there is nothing to
+		// serve yet. Step 3 replaces this with the preview proxy.
+		writeHTTPError(w, r, http.StatusNotFound, errors.New("web-tab preview content is not wired yet (#1856 step 3)"))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		writeHTTPError(w, r, http.StatusNotFound, fmt.Errorf("unknown preview route %q", r.URL.Path))
+	})
+	return mux
+}
+
+// previewAuthResponse is the body of GET /v1/preview-auth: the preview origin's
+// ephemeral bearer token, which an authenticated control-plane client (the SPA)
+// then delivers to the preview iframe. Empty token ⇒ the preview listener is
+// disabled (preview_listen_addr unset), so there is nothing to authenticate.
+type previewAuthResponse struct {
+	Token string `json:"token"`
+}
+
+// previewAuthHandler answers GET /v1/preview-auth on the CONTROL listener with the
+// ephemeral preview token. It is behind the daemon's normal auth gate, so only a
+// client already authorized to the control plane can read it — which is fine, that
+// client can already do everything, and the preview token it learns is strictly
+// LESS privileged. It is the ONLY way to obtain the token: the token lives in
+// memory, is never written to disk, and is never logged.
+//
+// When preview_listen_addr is unset the token is withheld (empty): there is no
+// preview listener to present it to, so exposing an unusable credential would only
+// mislead.
+func (cs *controlServer) previewAuthHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeHTTPError(w, r, http.StatusMethodNotAllowed,
+			fmt.Errorf("method %s not allowed for /v1/preview-auth; use GET", r.Method))
+		return
+	}
+	if cs.manager == nil {
+		writeHTTPError(w, r, http.StatusServiceUnavailable, errors.New("daemon has no session manager"))
+		return
+	}
+	token := ""
+	if cs.manager.cfg != nil && cs.manager.cfg.PreviewListenAddr != "" {
+		token = cs.manager.previewToken
+	}
+	writeHTTPSuccess(w, r, previewAuthResponse{Token: token})
+}

--- a/daemon/preview_auth.go
+++ b/daemon/preview_auth.go
@@ -10,14 +10,24 @@ import (
 
 // The web-tab PREVIEW origin's auth (#1856 step 2).
 //
-// The preview listener (preview_listen_addr) is a SEPARATE origin from the SPA,
-// so — once step 3 relaxes the sandbox — a framed dev server there cannot reach
-// the SPA's storage or the daemon bearer. This file gives that origin its own
-// credential: the daemon mints an ephemeral preview token (Manager.previewToken),
-// the listener's gate compares against it, and it is delivered to the browser
-// under the #2400 clean-before-render discipline exactly like the app-origin
-// web-tab flow — but on distinct query/cookie names holding the distinct
-// low-privilege credential, so the two can never be read for one another.
+// The preview listener (preview_listen_addr) is a SEPARATE origin from the SPA
+// (different port), so DOM/storage IS isolated: a framed dev server on the preview
+// origin cannot read the SPA's window or localStorage. This file gives that origin
+// its own low-privilege credential: the daemon mints an ephemeral preview token
+// (Manager.previewToken), the listener's gate compares against it, and it is
+// delivered under the #2400 clean-before-render discipline like the app-origin
+// web-tab flow — on distinct query/cookie NAMES.
+//
+// What separation this actually buys, stated precisely because the naive framing
+// is wrong: cookies are scoped by (host, path) and NOT by port (RFC 6265 §8.5), so
+// the two origins share ONE cookie jar. Both credential cookies (af_webtab_token,
+// af_preview_token) are transmitted to BOTH ports on every /v1/webtab/ request.
+// The separation is enforced by the EXTRACTOR, not the browser: previewPresentedToken
+// reads only af_preview_token and webTabAwareToken reads only af_webtab_token, so
+// neither credential is HONORED on the other surface even though both are sent. The
+// consequence for the proxy is that forwardAppCookies / the upstream query strip
+// (webtab_proxy.go) MUST remove BOTH names, or the shared jar would leak the preview
+// token to the untrusted dev server — see those sites.
 //
 // This step opens the auth handshake only; the preview origin still serves NO
 // content (step 3 wires the proxy routes).
@@ -93,8 +103,8 @@ func newPreviewMux() http.Handler {
 
 // previewAuthResponse is the body of GET /v1/preview-auth: the preview origin's
 // ephemeral bearer token, which an authenticated control-plane client (the SPA)
-// then delivers to the preview iframe. Empty token ⇒ the preview listener is
-// disabled (preview_listen_addr unset), so there is nothing to authenticate.
+// then delivers to the preview iframe. Empty token ⇒ the preview listener is not
+// bound (disabled, or its bind failed), so there is nothing to authenticate.
 type previewAuthResponse struct {
 	Token string `json:"token"`
 }
@@ -106,9 +116,16 @@ type previewAuthResponse struct {
 // LESS privileged. It is the ONLY way to obtain the token: the token lives in
 // memory, is never written to disk, and is never logged.
 //
-// When preview_listen_addr is unset the token is withheld (empty): there is no
-// preview listener to present it to, so exposing an unusable credential would only
-// mislead.
+// The response is no-store: it carries a raw bearer, so it must never sit in a
+// shared/proxy cache (the recommended deployment fronts af with nginx/Caddy). This
+// mirrors the clean-before-render bootstrap, which sets the same on its
+// credential-bearing redirect.
+//
+// The token is withheld (empty) unless the preview listener is actually BOUND, not
+// merely configured. The bind is deliberately non-fatal (a port conflict leaves
+// PreviewConfigured=true, PreviewBound=false), and vending a live-looking token for
+// a dead port would only mislead the client into addressing an origin that will not
+// answer.
 func (cs *controlServer) previewAuthHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeHTTPError(w, r, http.StatusMethodNotAllowed,
@@ -120,8 +137,10 @@ func (cs *controlServer) previewAuthHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	token := ""
-	if cs.manager.cfg != nil && cs.manager.cfg.PreviewListenAddr != "" {
+	if cs.manager.lifecycle != nil && cs.manager.lifecycle.snapshot().listeners.PreviewBound {
 		token = cs.manager.previewToken
 	}
+	// A raw credential in the body: keep it out of any shared cache.
+	w.Header().Set("Cache-Control", "no-store")
 	writeHTTPSuccess(w, r, previewAuthResponse{Token: token})
 }

--- a/daemon/preview_auth.go
+++ b/daemon/preview_auth.go
@@ -29,6 +29,24 @@ import (
 // (webtab_proxy.go) MUST remove BOTH names, or the shared jar would leak the preview
 // token to the untrusted dev server — see those sites.
 //
+// WHAT THIS STEP DELIBERATELY DOES NOT BUY — session isolation. Manager.previewToken
+// is ONE process-global token, and the bootstrap parks it in a cookie scoped to the
+// WHOLE webtabPathPrefix. So the credential a preview page for session A would carry
+// is byte-identical to session B's, and is ambiently attached to a same-origin
+// fetch of ANY session's preview path. That is acceptable ONLY because this step
+// serves NO content: nothing sits behind the gate to read cross-session. It must NOT
+// survive into step 3. Before the preview proxy serves a single byte, the credential
+// has to become PER-TAB (an HMAC(secret, sid/tid)-derived token, gate validated
+// against the sid/tid in the request path) with the cookie scoped to
+// /v1/webtab/<sid>/<tid>/ — otherwise a global token turns the preview origin into a
+// cross-session read and makes #1856 WORSE than the status quo. Even per-tab tokens
+// only bound a page to ITS OWN credential; on this SHARED origin a concurrently-open
+// other tab's path-scoped cookie is still ambiently attached to a cross-tab
+// same-origin fetch, so FULL cross-tab isolation additionally needs per-tab ORIGINS
+// (a listener/port per tab) — the origin-model decision step 3 must make, tracked on
+// #1856. Do not read "separate origin" here as "sessions are isolated"; they are not
+// yet.
+//
 // This step opens the auth handshake only; the preview origin still serves NO
 // content (step 3 wires the proxy routes).
 
@@ -82,9 +100,10 @@ func previewListenerAuth(m *Manager) *tcpListenerAuth {
 // It is reached only AFTER withAuth's preview gate authorized the request against
 // the preview token, so the bootstrap here only moves that already-validated
 // credential from the URL into the scoped cookie and redirects to the clean URL.
-// The cookie is scoped to webtabPathPrefix: the preview origin serves its content
-// under the same /v1/webtab/<sid>/<tid>/ path the app origin mirrors, so the
-// browser sends the preview cookie on exactly those sub-resource requests.
+// The cookie is scoped to webtabPathPrefix — the WHOLE prefix, deliberately flagged:
+// that is the non-isolating scope the file header warns must narrow to
+// /v1/webtab/<sid>/<tid>/ before step 3 serves content. It is safe here only because
+// nothing is served yet.
 func newPreviewMux() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc(webtabPathPrefix+"{sessionId}/{tabId}/{rest...}", func(w http.ResponseWriter, r *http.Request) {
@@ -113,8 +132,12 @@ type previewAuthResponse struct {
 // ephemeral preview token. It is behind the daemon's normal auth gate, so only a
 // client already authorized to the control plane can read it — which is fine, that
 // client can already do everything, and the preview token it learns is strictly
-// LESS privileged. It is the ONLY way to obtain the token: the token lives in
-// memory, is never written to disk, and is never logged.
+// LESS privileged than the daemon bearer (it authenticates only the preview origin,
+// which serves nothing yet). It is NOT per-session: it is the one process-global
+// token, so it does not distinguish sessions — the endpoint gains a session/tab
+// selector when step 3 moves to per-tab tokens (see the file header). It is the ONLY
+// way to obtain the token: the token lives in memory, is never written to disk, and
+// is never logged.
 //
 // The response is no-store: it carries a raw bearer, so it must never sit in a
 // shared/proxy cache (the recommended deployment fronts af with nginx/Caddy). This

--- a/daemon/preview_auth_test.go
+++ b/daemon/preview_auth_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -164,18 +165,44 @@ func TestPreviewCredentialSeparation_BothDirections(t *testing.T) {
 		"the preview token must NOT authenticate the control plane")
 }
 
-// TestPreviewAuthEndpoint_ReturnsTokenToAuthenticatedClient pins the retrieval
-// endpoint: an authenticated control-plane client gets the ephemeral preview
-// token, and when the preview listener is disabled the token is withheld.
-func TestPreviewAuthEndpoint_ReturnsTokenToAuthenticatedClient(t *testing.T) {
-	m, _, controlAddr := startPreviewDaemon(t)
-	client := previewHTTPClient()
+// TestPreviewAuthEndpoint_RequiresAuthThenReturnsToken pins the retrieval endpoint
+// against a STRICT control listener (require_token + require_loopback_token), so
+// auth is actually exercised rather than short-circuited by the tokenless-loopback
+// default: no credential is 401, and the daemon token is 200 with the preview
+// token. The response is no-store — it carries a raw bearer.
+func TestPreviewAuthEndpoint_RequiresAuthThenReturnsToken(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	cfg := config.DefaultConfig()
+	cfg.ListenAddr = "127.0.0.1:0"
+	cfg.PreviewListenAddr = "127.0.0.1:0"
+	cfg.RequireToken = true
+	cfg.RequireLoopbackToken = true
+	m, err := NewManager(cfg)
+	require.NoError(t, err)
+	closeHTTP, err := startHTTPServer(m, newTaskScheduler(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, closeHTTP()) })
 
-	// Loopback + tokenless-default control listener authorizes without a token.
-	resp, err := client.Get("http://" + controlAddr + "/v1/preview-auth")
+	controlAddr := m.lifecycle.snapshot().listeners.TCPBoundAddr
+	client := previewHTTPClient()
+	url := "http://" + controlAddr + "/v1/preview-auth"
+
+	// No credential → 401 (the negative test the endpoint lacked).
+	require.Equal(t, http.StatusUnauthorized, previewGet(t, client, url, ""),
+		"the credential-vending endpoint must require control-plane auth")
+
+	// Daemon token → 200 with the preview token, and no-store.
+	daemonToken, err := LoadToken(mustTokenPath(t))
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+daemonToken)
+	resp, err := client.Do(req)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "no-store", resp.Header.Get("Cache-Control"),
+		"a raw-bearer response must not be cacheable")
 
 	var env struct {
 		Data previewAuthResponse `json:"data"`
@@ -183,18 +210,65 @@ func TestPreviewAuthEndpoint_ReturnsTokenToAuthenticatedClient(t *testing.T) {
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&env))
 	require.Equal(t, m.previewToken, env.Data.Token,
 		"an authenticated control-plane client must be able to fetch the preview token")
+}
 
-	// When preview is disabled, the endpoint withholds the (unusable) token.
-	off := controlServerForPreviewDisabled(t)
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/v1/preview-auth", nil)
-	off.previewAuthHandler(rec, req)
-	require.Equal(t, http.StatusOK, rec.Code)
-	var offEnv struct {
+// TestPreviewAuthEndpoint_WithholdsTokenUnlessBound pins that the token is vended
+// only when the preview listener actually BOUND, not merely configured — so a
+// bind conflict (non-fatal by design: PreviewConfigured=true, PreviewBound=false)
+// does not hand out a live-looking credential for a dead port.
+func TestPreviewAuthEndpoint_WithholdsTokenUnlessBound(t *testing.T) {
+	// Disabled: no preview listener at all.
+	t.Run("disabled", func(t *testing.T) {
+		t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+		cfg := config.DefaultConfig()
+		cfg.ListenAddr = "127.0.0.1:0"
+		cfg.PreviewListenAddr = ""
+		m, err := NewManager(cfg)
+		require.NoError(t, err)
+		closeHTTP, err := startHTTPServer(m, newTaskScheduler(), nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, closeHTTP()) })
+		require.Empty(t, fetchPreviewAuthToken(t, m), "a disabled preview listener must vend no token")
+	})
+
+	// Configured but bind FAILED: the port is already taken.
+	t.Run("configured but bind failed", func(t *testing.T) {
+		t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+		blocker, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer func() { _ = blocker.Close() }()
+
+		cfg := config.DefaultConfig()
+		cfg.ListenAddr = "127.0.0.1:0"
+		cfg.PreviewListenAddr = blocker.Addr().String() // guaranteed EADDRINUSE
+		m, err := NewManager(cfg)
+		require.NoError(t, err)
+		closeHTTP, err := startHTTPServer(m, newTaskScheduler(), nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, closeHTTP()) })
+
+		listeners := m.lifecycle.snapshot().listeners
+		require.True(t, listeners.PreviewConfigured, "the address was configured")
+		require.False(t, listeners.PreviewBound, "the bind failed")
+		require.Empty(t, fetchPreviewAuthToken(t, m),
+			"a configured-but-unbound preview listener must not vend a token for a dead port")
+	})
+}
+
+// fetchPreviewAuthToken calls GET /v1/preview-auth on m's control listener (over
+// its own unix-socket-trust loopback default) and returns the vended token.
+func fetchPreviewAuthToken(t *testing.T, m *Manager) string {
+	t.Helper()
+	controlAddr := m.lifecycle.snapshot().listeners.TCPBoundAddr
+	resp, err := previewHTTPClient().Get("http://" + controlAddr + "/v1/preview-auth")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var env struct {
 		Data previewAuthResponse `json:"data"`
 	}
-	require.NoError(t, json.NewDecoder(rec.Body).Decode(&offEnv))
-	require.Empty(t, offEnv.Data.Token, "a disabled preview listener must not hand out an unusable credential")
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&env))
+	return env.Data.Token
 }
 
 // TestPreviewToken_EphemeralAndNeverOnDisk pins the two properties of the
@@ -240,19 +314,6 @@ func previewGetWithCookie(t *testing.T, client *http.Client, url, cookieValue st
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
 	return resp.StatusCode
-}
-
-// controlServerForPreviewDisabled builds a controlServer whose manager has the
-// preview listener disabled, for the endpoint's withhold path.
-func controlServerForPreviewDisabled(t *testing.T) *controlServer {
-	t.Helper()
-	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
-	cfg := config.DefaultConfig()
-	cfg.PreviewListenAddr = "" // disabled
-	m, err := NewManager(cfg)
-	require.NoError(t, err)
-	require.NotEmpty(t, m.previewToken, "the token is still minted; it is only withheld from the endpoint")
-	return &controlServer{manager: m, scheduler: newTaskScheduler()}
 }
 
 // TestPreviewPresentedToken_IsolatedFromDaemonTransports pins the extractor

--- a/daemon/preview_auth_test.go
+++ b/daemon/preview_auth_test.go
@@ -1,0 +1,291 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+)
+
+// The web-tab preview origin's auth (#1856 step 2). The listener opens the auth
+// handshake — its own ephemeral credential plus the #2400 clean-before-render
+// bootstrap — but serves no content yet. These tests pin the credential SEPARATION
+// (the daemon bearer never authorizes the preview origin, and vice-versa), the
+// bootstrap's clean-before-render behavior, and the retrieval endpoint.
+
+// startPreviewDaemon brings up a daemon with the preview listener enabled on an
+// ephemeral port and returns the manager, the preview bound address, and the
+// control bound address. Both listeners are loopback.
+func startPreviewDaemon(t *testing.T) (m *Manager, previewAddr, controlAddr string) {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	cfg := config.DefaultConfig()
+	cfg.ListenAddr = "127.0.0.1:0"
+	cfg.PreviewListenAddr = "127.0.0.1:0"
+	m, err := NewManager(cfg)
+	require.NoError(t, err)
+
+	closeHTTP, err := startHTTPServer(m, newTaskScheduler(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, closeHTTP()) })
+
+	listeners := m.lifecycle.snapshot().listeners
+	require.True(t, listeners.PreviewBound)
+	return m, listeners.PreviewBoundAddr, listeners.TCPBoundAddr
+}
+
+// noRedirectClient inspects the bootstrap's 307 itself rather than following it.
+func noRedirectClient() *http.Client {
+	return &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+}
+
+// TestPreviewBootstrap_CleanBeforeRender pins the #2400 discipline on the preview
+// origin: a top-level navigation carrying the preview token on the private query
+// param is turned into an HttpOnly cookie and redirected to the same URL with the
+// token removed, so no framed app JS can read the credential from its own
+// window.location. The app's own query survives.
+func TestPreviewBootstrap_CleanBeforeRender(t *testing.T) {
+	m, previewAddr, _ := startPreviewDaemon(t)
+	client := noRedirectClient()
+
+	url := "http://" + previewAddr + "/v1/webtab/s1/t1/?doc=1&af_preview_token=" + m.previewToken
+	resp, err := client.Get(url)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode,
+		"a preview navigation carrying the token must redirect to a clean URL, not render")
+	require.Equal(t, "/v1/webtab/s1/t1/?doc=1", resp.Header.Get("Location"),
+		"the redirect must scrub the preview token and preserve the app's own query")
+	require.Equal(t, "no-store", resp.Header.Get("Cache-Control"))
+	require.Equal(t, "no-referrer", resp.Header.Get("Referrer-Policy"))
+
+	var cookie *http.Cookie
+	for _, c := range resp.Cookies() {
+		if c.Name == previewTokenCookie {
+			cookie = c
+		}
+	}
+	require.NotNil(t, cookie, "the bootstrap must set the preview-token cookie")
+	require.Equal(t, m.previewToken, cookie.Value)
+	require.True(t, cookie.HttpOnly, "the credential cookie must be HttpOnly so app JS cannot read it")
+	require.Equal(t, http.SameSiteStrictMode, cookie.SameSite)
+	require.Equal(t, webtabPathPrefix, cookie.Path,
+		"the cookie is scoped to the preview content path, not the whole origin's root")
+}
+
+// TestPreviewGate_CookieAuthenticatesFollowUpAndRejectsOthers pins the gate on the
+// preview listener: the cookie the bootstrap set authenticates a sub-resource
+// request (which carries neither header nor query), a wrong credential is 401, and
+// no credential is 401.
+func TestPreviewGate_CookieAuthenticatesFollowUpAndRejectsOthers(t *testing.T) {
+	m, previewAddr, _ := startPreviewDaemon(t)
+	client := previewHTTPClient()
+	assetURL := "http://" + previewAddr + "/v1/webtab/s1/t1/asset.js"
+
+	// A sub-resource GET carrying the preview cookie is authenticated — and only
+	// then finds no content (404), never a 401.
+	withCookie, err := http.NewRequest(http.MethodGet, assetURL, nil)
+	require.NoError(t, err)
+	withCookie.AddCookie(&http.Cookie{Name: previewTokenCookie, Value: m.previewToken})
+	resp, err := client.Do(withCookie)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode,
+		"the preview cookie must authenticate a sub-resource request (no content yet ⇒ 404, not 401)")
+
+	// A wrong cookie value is rejected.
+	require.Equal(t, http.StatusUnauthorized, previewGetWithCookie(t, client, assetURL, "not-the-token"),
+		"a wrong preview cookie must be rejected")
+
+	// No credential at all is rejected — the preview origin is not loopback-exempt.
+	require.Equal(t, http.StatusUnauthorized, previewGet(t, client, assetURL, ""),
+		"the preview origin requires its credential from every peer, loopback included")
+}
+
+// TestPreviewCredentialSeparation_BothDirections is the security core: the daemon
+// bearer cannot authorize the preview origin, and the preview token cannot
+// authorize the control plane. Neither credential is honored on the other surface.
+//
+// One daemon, made strict on the control side (require_token +
+// require_loopback_token) so a wrong credential there actually fails rather than
+// riding the tokenless-loopback default. The preview gate is always strict.
+func TestPreviewCredentialSeparation_BothDirections(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	cfg := config.DefaultConfig()
+	cfg.ListenAddr = "127.0.0.1:0"
+	cfg.PreviewListenAddr = "127.0.0.1:0"
+	cfg.RequireToken = true
+	cfg.RequireLoopbackToken = true
+	m, err := NewManager(cfg)
+	require.NoError(t, err)
+	closeHTTP, err := startHTTPServer(m, newTaskScheduler(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, closeHTTP()) })
+
+	listeners := m.lifecycle.snapshot().listeners
+	previewAddr := listeners.PreviewBoundAddr
+	controlAddr := listeners.TCPBoundAddr
+	client := previewHTTPClient()
+
+	daemonToken, err := LoadToken(mustTokenPath(t))
+	require.NoError(t, err)
+	require.NotEqual(t, daemonToken, m.previewToken, "the two credentials must differ")
+
+	// Sanity: each credential DOES authorize its own surface, so a 401 below is
+	// separation, not a broken listener.
+	require.Equal(t, http.StatusNotFound,
+		previewGet(t, client, "http://"+previewAddr+"/v1/webtab/s1/t1/asset.js", m.previewToken),
+		"the preview token authenticates the preview origin (no content ⇒ 404)")
+	require.Equal(t, http.StatusOK,
+		previewGet(t, client, "http://"+controlAddr+"/v1/health", daemonToken),
+		"the daemon token authenticates the control plane")
+
+	// Daemon token → preview origin: rejected (it is not the preview credential).
+	require.Equal(t, http.StatusUnauthorized,
+		previewGet(t, client, "http://"+previewAddr+"/v1/webtab/s1/t1/asset.js", daemonToken),
+		"the daemon bearer must NOT authenticate the preview origin")
+
+	// Preview token → control plane, presented on the daemon's own webtab query
+	// transport on the webtab path: the control gate wants the daemon token, so it
+	// 401s.
+	previewAsWebtab := "http://" + controlAddr + "/v1/webtab/s1/t1/?af_webtab_token=" + m.previewToken
+	require.Equal(t, http.StatusUnauthorized, previewGet(t, client, previewAsWebtab, ""),
+		"the preview token must NOT authenticate the control plane")
+}
+
+// TestPreviewAuthEndpoint_ReturnsTokenToAuthenticatedClient pins the retrieval
+// endpoint: an authenticated control-plane client gets the ephemeral preview
+// token, and when the preview listener is disabled the token is withheld.
+func TestPreviewAuthEndpoint_ReturnsTokenToAuthenticatedClient(t *testing.T) {
+	m, _, controlAddr := startPreviewDaemon(t)
+	client := previewHTTPClient()
+
+	// Loopback + tokenless-default control listener authorizes without a token.
+	resp, err := client.Get("http://" + controlAddr + "/v1/preview-auth")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var env struct {
+		Data previewAuthResponse `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&env))
+	require.Equal(t, m.previewToken, env.Data.Token,
+		"an authenticated control-plane client must be able to fetch the preview token")
+
+	// When preview is disabled, the endpoint withholds the (unusable) token.
+	off := controlServerForPreviewDisabled(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/preview-auth", nil)
+	off.previewAuthHandler(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var offEnv struct {
+		Data previewAuthResponse `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&offEnv))
+	require.Empty(t, offEnv.Data.Token, "a disabled preview listener must not hand out an unusable credential")
+}
+
+// TestPreviewToken_EphemeralAndNeverOnDisk pins the two properties of the
+// credential: it differs between daemon lifetimes (rotates on restart) and it is
+// never written to the AF home.
+func TestPreviewToken_EphemeralAndNeverOnDisk(t *testing.T) {
+	home := testguard.SocketTempDir(t)
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	cfg := config.DefaultConfig()
+
+	m1, err := NewManager(cfg)
+	require.NoError(t, err)
+	m2, err := NewManager(cfg)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, m1.previewToken)
+	require.NotEqual(t, m1.previewToken, m2.previewToken,
+		"the preview token must be freshly minted per daemon, not persisted and reused")
+
+	// The token value must appear in no file under the AF home.
+	require.NoError(t, filepath.WalkDir(home, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil // unreadable/special file — not where a secret would be
+		}
+		require.NotContains(t, string(data), m1.previewToken,
+			"the preview token must never be written to disk (found in %s)", path)
+		return nil
+	}))
+}
+
+// previewGetWithCookie issues a GET carrying the preview cookie and returns the
+// status code.
+func previewGetWithCookie(t *testing.T, client *http.Client, url, cookieValue string) int {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+	req.AddCookie(&http.Cookie{Name: previewTokenCookie, Value: cookieValue})
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode
+}
+
+// controlServerForPreviewDisabled builds a controlServer whose manager has the
+// preview listener disabled, for the endpoint's withhold path.
+func controlServerForPreviewDisabled(t *testing.T) *controlServer {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	cfg := config.DefaultConfig()
+	cfg.PreviewListenAddr = "" // disabled
+	m, err := NewManager(cfg)
+	require.NoError(t, err)
+	require.NotEmpty(t, m.previewToken, "the token is still minted; it is only withheld from the endpoint")
+	return &controlServer{manager: m, scheduler: newTaskScheduler()}
+}
+
+// TestPreviewPresentedToken_IsolatedFromDaemonTransports pins the extractor
+// separation at the unit level: previewPresentedToken reads ONLY the preview
+// transports (Authorization, af_preview_token query/cookie), never the daemon's
+// af_webtab_token or ?access_token=; and webTabAwareToken never reads the preview
+// param. So the two credentials cannot be read for one another even if a request
+// carried both.
+func TestPreviewPresentedToken_IsolatedFromDaemonTransports(t *testing.T) {
+	// A request carrying the daemon's transports but NOT the preview one: the
+	// preview extractor sees nothing.
+	r := httptest.NewRequest(http.MethodGet, "/v1/webtab/s/t/?af_webtab_token=DAEMON&access_token=DAEMON2", nil)
+	require.Empty(t, previewPresentedToken(r),
+		"previewPresentedToken must ignore the daemon's af_webtab_token / access_token transports")
+
+	// The preview param is read.
+	r2 := httptest.NewRequest(http.MethodGet, "/v1/webtab/s/t/?af_preview_token=PREVIEW", nil)
+	require.Equal(t, "PREVIEW", previewPresentedToken(r2))
+
+	// And the daemon's webtab extractor never reads the preview param.
+	r3 := httptest.NewRequest(http.MethodGet, "/v1/webtab/s/t/?af_preview_token=PREVIEW", nil)
+	require.Empty(t, webTabAwareToken(r3),
+		"webTabAwareToken must ignore the preview transport, so the preview credential can't authorize the daemon surface")
+
+	// The Authorization header is honored by both (a direct client), but that is the
+	// credential the caller chose to send, not a cross-transport leak.
+	r4 := httptest.NewRequest(http.MethodGet, "/v1/webtab/s/t/", nil)
+	r4.Header.Set("Authorization", "Bearer HDR")
+	require.Equal(t, "HDR", previewPresentedToken(r4))
+
+	// Sanity: an unrelated cookie is ignored; only af_preview_token is read.
+	r5 := httptest.NewRequest(http.MethodGet, "/v1/webtab/s/t/", nil)
+	r5.AddCookie(&http.Cookie{Name: webtabTokenCookie, Value: "DAEMONCOOKIE"})
+	require.Empty(t, previewPresentedToken(r5), "the preview extractor must not read the daemon's webtab cookie")
+	require.False(t, strings.Contains(previewPresentedToken(r5), "DAEMONCOOKIE"))
+}

--- a/daemon/preview_auth_test.go
+++ b/daemon/preview_auth_test.go
@@ -85,6 +85,42 @@ func TestPreviewBootstrap_CleanBeforeRender(t *testing.T) {
 		"the cookie is scoped to the preview content path, not the whole origin's root")
 }
 
+// TestPreviewBootstrap_ScrubsEveryAfCredential pins P2-a: the clean-before-render
+// sanitizer must strip the WHOLE set of af credential query params from the URL it
+// redirects to, not just the one this flow authorized on. A navigation that carries
+// both the preview token (which authorizes it here) AND the daemon bearer (which
+// rides along because the two origins share a query surface and cookie jar,
+// RFC 6265 §8.5) must land on a URL with NEITHER — otherwise the higher-value
+// daemon bearer is stranded in the document window.location the preview page renders
+// under. The cookie set is still only the preview one (this flow's own credential).
+func TestPreviewBootstrap_ScrubsEveryAfCredential(t *testing.T) {
+	m, previewAddr, _ := startPreviewDaemon(t)
+	client := noRedirectClient()
+
+	url := "http://" + previewAddr + "/v1/webtab/s1/t1/?doc=1&af_preview_token=" + m.previewToken + "&af_webtab_token=daemon-bearer-value"
+	resp, err := client.Get(url)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+	require.Equal(t, "/v1/webtab/s1/t1/?doc=1", resp.Header.Get("Location"),
+		"BOTH af credential params must be scrubbed; the daemon bearer must not survive in the redirect URL")
+
+	var previewCookie, webtabCookie *http.Cookie
+	for _, c := range resp.Cookies() {
+		switch c.Name {
+		case previewTokenCookie:
+			previewCookie = c
+		case webtabTokenCookie:
+			webtabCookie = c
+		}
+	}
+	require.NotNil(t, previewCookie, "the preview flow sets its own credential cookie")
+	require.Equal(t, m.previewToken, previewCookie.Value)
+	require.Nil(t, webtabCookie,
+		"the preview flow must NOT mint the daemon-bearer cookie — it strips that param, it does not adopt it")
+}
+
 // TestPreviewGate_CookieAuthenticatesFollowUpAndRejectsOthers pins the gate on the
 // preview listener: the cookie the bootstrap set authenticates a sub-resource
 // request (which carries neither header nor query), a wrong credential is 401, and

--- a/daemon/preview_listener_test.go
+++ b/daemon/preview_listener_test.go
@@ -51,12 +51,16 @@ func TestStartHTTPServer_NoPreviewWhenDisabled(t *testing.T) {
 	require.Empty(t, listeners.PreviewBoundAddr)
 }
 
-// TestStartHTTPServer_PreviewBindsButServesNothing is the core step-1 invariant.
-// A configured preview_listen_addr binds a second port, the lifecycle reports it
-// bound, and — critically — that port serves NEITHER the daemon control API NOR
-// any content. The whole reason for a separate origin is that it must never carry
-// the control plane, so a request for /v1/Snapshot on the preview port must not
-// dispatch.
+// TestStartHTTPServer_PreviewBindsButServesNothing is the core invariant, now
+// through the step-2 credential (#1856). A configured preview_listen_addr binds a
+// second port, the lifecycle reports it bound, and that port serves NEITHER the
+// daemon control API NOR any content — and it authenticates its OWN ephemeral
+// credential, not the daemon bearer.
+//
+// The separation is the headline: the daemon token is REJECTED on the preview port
+// (it is not the preview credential), while the preview token authenticates and
+// then still finds no content. Both prove the preview origin is a distinct,
+// non-control surface.
 func TestStartHTTPServer_PreviewBindsButServesNothing(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
 	cfg := config.DefaultConfig()
@@ -79,29 +83,28 @@ func TestStartHTTPServer_PreviewBindsButServesNothing(t *testing.T) {
 	previewAddr := listeners.PreviewBoundAddr
 	client := previewHTTPClient()
 
-	// Present a valid daemon token so the strict preview gate cannot be the reason
-	// a control route is unreachable — this proves the ROUTE is absent, not merely
-	// gated. With the token accepted, the empty preview mux 404s /v1/Snapshot.
-	tokenPath, err := TokenPath()
+	// The DAEMON token is the wrong credential for the preview origin: the gate
+	// rejects it. This is the separation — a control-plane credential cannot reach
+	// the preview surface at all.
+	daemonToken, err := LoadToken(mustTokenPath(t))
 	require.NoError(t, err)
-	token, err := LoadToken(tokenPath)
-	require.NoError(t, err)
+	require.NotEqual(t, daemonToken, m.previewToken, "the preview credential must be distinct from the daemon bearer")
 
-	req, err := http.NewRequest(http.MethodGet, "http://"+previewAddr+"/v1/Snapshot", nil)
-	require.NoError(t, err)
-	req.Header.Set("Authorization", "Bearer "+token)
-	resp, err := client.Do(req)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, http.StatusNotFound, resp.StatusCode,
-		"the preview origin must NOT serve the daemon control API — /v1/Snapshot must 404, not dispatch")
+	snapWithDaemon := previewGet(t, client, "http://"+previewAddr+"/v1/Snapshot", daemonToken)
+	require.Equal(t, http.StatusUnauthorized, snapWithDaemon,
+		"the daemon token must NOT authorize the preview origin — the credentials are separate")
 
-	// And it serves no browser shell either (withoutWebShell): a root request 404s
+	// The PREVIEW token authenticates, and only then do we learn there is no content
+	// and no control API: /v1/Snapshot resolves to the preview mux's 404, never a
+	// dispatch.
+	snapWithPreview := previewGet(t, client, "http://"+previewAddr+"/v1/Snapshot", m.previewToken)
+	require.Equal(t, http.StatusNotFound, snapWithPreview,
+		"authenticated, the preview origin still serves no control API — /v1/Snapshot must 404, not dispatch")
+
+	// No browser shell either (withoutWebShell): an authenticated root request 404s
 	// rather than returning the SPA.
-	rootResp, err := client.Get("http://" + previewAddr + "/")
-	require.NoError(t, err)
-	defer func() { _ = rootResp.Body.Close() }()
-	require.Equal(t, http.StatusNotFound, rootResp.StatusCode,
+	rootWithPreview := previewGet(t, client, "http://"+previewAddr+"/", m.previewToken)
+	require.Equal(t, http.StatusNotFound, rootWithPreview,
 		"the preview origin serves no content yet — root must 404, not return the SPA")
 
 	// The control listener, by contrast, DOES serve the API (tokenless loopback
@@ -111,6 +114,29 @@ func TestStartHTTPServer_PreviewBindsButServesNothing(t *testing.T) {
 	defer func() { _ = ctrlResp.Body.Close() }()
 	require.Equal(t, http.StatusOK, ctrlResp.StatusCode,
 		"the control listener still serves its API — the preview port is the odd one out, by design")
+}
+
+// mustTokenPath resolves the daemon token path or fails the test.
+func mustTokenPath(t *testing.T) string {
+	t.Helper()
+	p, err := TokenPath()
+	require.NoError(t, err)
+	return p
+}
+
+// previewGet issues a GET carrying token as a Bearer header and returns the status
+// code. A "" token sends no Authorization header.
+func previewGet(t *testing.T, client *http.Client, url, token string) int {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode
 }
 
 // TestStartHTTPServer_PreviewBindConflictNonFatal mirrors the control listener's

--- a/daemon/preview_listener_test.go
+++ b/daemon/preview_listener_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"io"
 	"net"
 	"net/http"
 	"testing"
@@ -101,11 +102,23 @@ func TestStartHTTPServer_PreviewBindsButServesNothing(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, snapWithPreview,
 		"authenticated, the preview origin still serves no control API — /v1/Snapshot must 404, not dispatch")
 
-	// No browser shell either (withoutWebShell): an authenticated root request 404s
-	// rather than returning the SPA.
-	rootWithPreview := previewGet(t, client, "http://"+previewAddr+"/", m.previewToken)
-	require.Equal(t, http.StatusNotFound, rootWithPreview,
-		"the preview origin serves no content yet — root must 404, not return the SPA")
+	// The non-/v1 404 sits OUTSIDE the gate (previewShell answers a root request
+	// UNAUTHENTICATED, before the token is consulted — so this deliberately sends no
+	// token). It must carry the PREVIEW origin's own message: not the SPA, and
+	// crucially NOT the agent-server's text, which names the control-plane address
+	// and would advertise it to an unauthenticated peer.
+	rootResp, err := client.Get("http://" + previewAddr + "/")
+	require.NoError(t, err)
+	rootBody, _ := io.ReadAll(rootResp.Body)
+	_ = rootResp.Body.Close()
+	require.Equal(t, http.StatusNotFound, rootResp.StatusCode,
+		"the preview origin serves no content — root must 404, not return the SPA")
+	require.Contains(t, string(rootBody), "preview origin",
+		"the preview port must answer with its own message")
+	require.NotContains(t, string(rootBody), "localhost:8443",
+		"the preview port must NOT advertise the control-plane address to an unauthenticated peer")
+	require.NotContains(t, string(rootBody), "agent-server",
+		"the preview port is not the agent-server; it must not borrow that message")
 
 	// The control listener, by contrast, DOES serve the API (tokenless loopback
 	// default), so the two ports are genuinely different surfaces.

--- a/daemon/tcpserver.go
+++ b/daemon/tcpserver.go
@@ -122,11 +122,15 @@ func previewListenerPolicy(_ *config.Config) tokenGatePolicy {
 type webShell int
 
 const (
+	// withoutWebShell answers every non-/v1 path with the agent-server's "no web UI
+	// here, the daemon serves it at http://localhost:8443" 404. It is FIRST so it is
+	// the zero value: like tokenGatePolicy and authGate's bool fields, an unset
+	// webShell must default to the fail-safe posture (serve NO frontend), never to
+	// mounting the SPA + its token-paste login on a listener that was never meant to
+	// carry it (#1696 fail-safe-zero-value convention).
+	withoutWebShell webShell = iota
 	// withWebShell serves the browser SPA on every non-/v1 path — the daemon.
-	withWebShell webShell = iota
-	// withoutWebShell answers every non-/v1 path with the agent-server's
-	// "no web UI here, the daemon serves it at http://localhost:8443" 404.
-	withoutWebShell
+	withWebShell
 	// previewShell answers every non-/v1 path with the preview origin's OWN 404.
 	// It must NOT reuse withoutWebShell's message: that text names the control-plane
 	// address, which the preview port must not advertise (least of all to an

--- a/daemon/tcpserver.go
+++ b/daemon/tcpserver.go
@@ -128,6 +128,23 @@ const (
 	withoutWebShell webShell = false
 )
 
+// tcpListenerAuth overrides the credential a listener's gate uses. Nil selects
+// the default: the file-backed daemon bearer token (EnsureToken/LoadToken), used
+// by the control-plane and agent-server listeners. The web-tab PREVIEW listener
+// (#1856) passes a non-nil value to authenticate its SEPARATE ephemeral credential
+// on a distinct query/cookie transport, so the daemon bearer never reaches the
+// preview origin.
+type tcpListenerAuth struct {
+	// token returns the credential to advertise AND to compare against, per auth
+	// event. For an in-memory preview token these are the same value; the daemon
+	// path keeps them separate (EnsureToken advertises, LoadToken compares) inside
+	// startTCPListener instead.
+	token func() (string, error)
+	// presented extracts the credential a request carries; it becomes
+	// authGate.presentedToken (nil there ⇒ the webTabAwareToken default).
+	presented func(*http.Request) string
+}
+
 // startTCPListener binds the plain-HTTP TCP listener on addr and serves mux
 // wrapped in a token-enforcing gate + the CORS allow-list. It returns a cleanup
 // function that shuts the server down and the banner payload the caller logs.
@@ -141,25 +158,42 @@ const (
 // supplies the shared token file and CORS allow-list; only the bind target
 // differs.
 //
-// It ensures the bearer token exists before opening the port (so an operator
-// enabling the listener always has a credential to present) and reads that
-// token FRESH per auth event through the gate so `af token rotate` takes effect
-// for new connections without a daemon restart.
-func startTCPListener(mux http.Handler, addr string, cfg *config.Config, policy tokenGatePolicy, shell webShell) (func() error, tcpListenerInfo, error) {
-	// Generate-if-absent so enabling the listener always yields a usable token;
-	// the gate below re-reads the file per auth event, so rotation stays live.
-	tokenPath, err := TokenPath()
-	if err != nil {
-		return nil, tcpListenerInfo{}, err
-	}
-	token, err := EnsureToken(tokenPath)
-	if err != nil {
-		return nil, tcpListenerInfo{}, fmt.Errorf("ensure daemon token: %w", err)
+// auth overrides the credential the gate enforces (see tcpListenerAuth); nil is
+// the file-backed daemon bearer token. It ensures the bearer token exists before
+// opening the port (so an operator enabling the listener always has a credential
+// to present) and reads that token FRESH per auth event through the gate so `af
+// token rotate` takes effect for new connections without a daemon restart. An
+// override supplies its own already-minted credential and is compared as-is.
+func startTCPListener(mux http.Handler, addr string, cfg *config.Config, policy tokenGatePolicy, shell webShell, auth *tcpListenerAuth) (func() error, tcpListenerInfo, error) {
+	var token string
+	var expectedToken func() (string, error)
+	var presentedToken func(*http.Request) string
+	if auth != nil {
+		t, err := auth.token()
+		if err != nil {
+			return nil, tcpListenerInfo{}, fmt.Errorf("resolve listener token: %w", err)
+		}
+		token = t
+		expectedToken = auth.token
+		presentedToken = auth.presented
+	} else {
+		// Generate-if-absent so enabling the listener always yields a usable token;
+		// the gate below re-reads the file per auth event, so rotation stays live.
+		tokenPath, err := TokenPath()
+		if err != nil {
+			return nil, tcpListenerInfo{}, err
+		}
+		token, err = EnsureToken(tokenPath)
+		if err != nil {
+			return nil, tcpListenerInfo{}, fmt.Errorf("ensure daemon token: %w", err)
+		}
+		expectedToken = func() (string, error) {
+			return LoadToken(tokenPath)
+		}
 	}
 	gate := &authGate{
-		expectedToken: func() (string, error) {
-			return LoadToken(tokenPath)
-		},
+		expectedToken:  expectedToken,
+		presentedToken: presentedToken,
 		tokenDisabled:  policy.tokenDisabled,
 		loopbackExempt: policy.loopbackExempt,
 	}

--- a/daemon/tcpserver.go
+++ b/daemon/tcpserver.go
@@ -119,13 +119,19 @@ func previewListenerPolicy(_ *config.Config) tokenGatePolicy {
 // pasted a token. Making this an explicit argument keeps "who serves the
 // frontend" a decision at the call site rather than an accident of sharing
 // startTCPListener.
-type webShell bool
+type webShell int
 
 const (
 	// withWebShell serves the browser SPA on every non-/v1 path — the daemon.
-	withWebShell webShell = true
-	// withoutWebShell leaves non-/v1 paths to the mux's own 404 — the agent-server.
-	withoutWebShell webShell = false
+	withWebShell webShell = iota
+	// withoutWebShell answers every non-/v1 path with the agent-server's
+	// "no web UI here, the daemon serves it at http://localhost:8443" 404.
+	withoutWebShell
+	// previewShell answers every non-/v1 path with the preview origin's OWN 404.
+	// It must NOT reuse withoutWebShell's message: that text names the control-plane
+	// address, which the preview port must not advertise (least of all to an
+	// unauthenticated peer), and "agent-server" is simply wrong here (#1856).
+	previewShell
 )
 
 // tcpListenerAuth overrides the credential a listener's gate uses. Nil selects
@@ -213,10 +219,13 @@ func startTCPListener(mux http.Handler, addr string, cfg *config.Config, policy 
 	// 404s), so the web assets never appear on the socket path. The agent-server
 	// passes withoutWebShell — it cannot back the SPA (see webShell).
 	handler := withAuth(mux, gate, cfg.CORSAllowedOrigins)
-	if shell == withWebShell {
+	switch shell {
+	case withWebShell:
 		handler = webShellHandler(handler)
-	} else {
-		handler = noWebShellHandler(handler)
+	case previewShell:
+		handler = noWebShellHandler(handler, noPreviewContentMessage)
+	default: // withoutWebShell — the agent-server
+		handler = noWebShellHandler(handler, noWebShellMessage)
 	}
 	srv := &http.Server{
 		Handler:           handler,

--- a/daemon/tcpserver_test.go
+++ b/daemon/tcpserver_test.go
@@ -40,7 +40,7 @@ func TestTCPListener_HTTP_TokenRoundTrip(t *testing.T) {
 	// the agent-server posture; it lets a real loopback socket still exercise the
 	// token-enforcement path (the daemon's loopback-exempt policy is covered by
 	// TestTCPListener_LoopbackExempt and the handler-level matrix in httpauth_test).
-	closeTCP, info, err := startTCPListener(newHTTPMux(cs), cfg.ListenAddr, cfg, tokenGatePolicy{}, withWebShell)
+	closeTCP, info, err := startTCPListener(newHTTPMux(cs), cfg.ListenAddr, cfg, tokenGatePolicy{}, withWebShell, nil)
 	require.NoError(t, err)
 	defer func() { _ = closeTCP() }()
 
@@ -144,7 +144,7 @@ func TestTCPListener_ServesWebShellUnauthed(t *testing.T) {
 	// Strict policy (loopback NOT exempt) so the "/v1 stays token-gated" assertions
 	// below still hold over a real loopback socket — this test's subject is the
 	// UNAUTHENTICATED static shell, which is policy-independent.
-	closeTCP, info, err := startTCPListener(newHTTPMux(cs), cfg.ListenAddr, cfg, tokenGatePolicy{}, withWebShell)
+	closeTCP, info, err := startTCPListener(newHTTPMux(cs), cfg.ListenAddr, cfg, tokenGatePolicy{}, withWebShell, nil)
 	require.NoError(t, err)
 	defer func() { _ = closeTCP() }()
 
@@ -197,7 +197,7 @@ func TestTCPListener_LoopbackExempt(t *testing.T) {
 	cs := &controlServer{manager: m, scheduler: newTaskScheduler()}
 	// The daemon's real posture: loopback exempt, token still required for the
 	// (here unreachable) network peers.
-	closeTCP, info, err := startTCPListener(newHTTPMux(cs), cfg.ListenAddr, cfg, tokenGatePolicy{loopbackExempt: true}, withWebShell)
+	closeTCP, info, err := startTCPListener(newHTTPMux(cs), cfg.ListenAddr, cfg, tokenGatePolicy{loopbackExempt: true}, withWebShell, nil)
 	require.NoError(t, err)
 	defer func() { _ = closeTCP() }()
 
@@ -243,7 +243,7 @@ func TestTCPListener_RequireLoopbackToken(t *testing.T) {
 	// require_loopback_token=true ⇒ loopbackExempt=false. Token still enforced
 	// for the (unreachable here) network peers too — this only removes the
 	// loopback shortcut.
-	closeTCP, info, err := startTCPListener(newHTTPMux(cs), cfg.ListenAddr, cfg, tokenGatePolicy{loopbackExempt: false}, withWebShell)
+	closeTCP, info, err := startTCPListener(newHTTPMux(cs), cfg.ListenAddr, cfg, tokenGatePolicy{loopbackExempt: false}, withWebShell, nil)
 	require.NoError(t, err)
 	defer func() { _ = closeTCP() }()
 	require.NotEmpty(t, info.Token)

--- a/daemon/web_listener_policy_test.go
+++ b/daemon/web_listener_policy_test.go
@@ -90,7 +90,7 @@ func TestTCPListener_NetworkBindDeniesLoopbackWithoutToken(t *testing.T) {
 	policy := webListenerPolicy(cfg)
 	require.False(t, policy.loopbackExempt, "a network bind must NOT exempt loopback (proxy-bypass fix)")
 
-	closeTCP, info, err := startTCPListener(newHTTPMux(cs), cfg.ListenAddr, cfg, policy, withWebShell)
+	closeTCP, info, err := startTCPListener(newHTTPMux(cs), cfg.ListenAddr, cfg, policy, withWebShell, nil)
 	require.NoError(t, err)
 	defer func() { _ = closeTCP() }()
 	require.NotEmpty(t, info.Token)
@@ -150,7 +150,7 @@ func TestTCPListener_LoopbackBindStillExemptViaPolicy(t *testing.T) {
 	require.True(t, policy.loopbackExempt, "a loopback bind must exempt loopback")
 	require.False(t, policy.tokenDisabled, "the gate must be live, so the exemption is what carries the request")
 
-	closeTCP, info, err := startTCPListener(newHTTPMux(cs), cfg.ListenAddr, cfg, policy, withWebShell)
+	closeTCP, info, err := startTCPListener(newHTTPMux(cs), cfg.ListenAddr, cfg, policy, withWebShell, nil)
 	require.NoError(t, err)
 	defer func() { _ = closeTCP() }()
 
@@ -181,7 +181,7 @@ func TestTCPListener_DefaultConfigIsTokenless(t *testing.T) {
 	policy := webListenerPolicy(cfg)
 	require.True(t, policy.tokenDisabled, "the default config must disable the token gate")
 
-	closeTCP, info, err := startTCPListener(newHTTPMux(cs), cfg.ListenAddr, cfg, policy, withWebShell)
+	closeTCP, info, err := startTCPListener(newHTTPMux(cs), cfg.ListenAddr, cfg, policy, withWebShell, nil)
 	require.NoError(t, err)
 	defer func() { _ = closeTCP() }()
 

--- a/daemon/webserve.go
+++ b/daemon/webserve.go
@@ -66,24 +66,33 @@ const noWebShellMessage = "this is an af agent-server (a headless single-workspa
 	"The web UI is served by the daemon: run 'af daemon' and open http://localhost:8443. " +
 	"This server speaks only the /v1/agent/* API that a daemon drives."
 
+// noPreviewContentMessage is the preview origin's non-/v1 404 (#1856). It is
+// deliberately NOT noWebShellMessage: that text names the control-plane address
+// (http://localhost:8443), and the preview port — which will host untrusted
+// repo/agent-controlled content and answers this branch UNAUTHENTICATED — must
+// never advertise the control plane, nor call itself an "agent-server". It
+// discloses only that this is the preview origin and where the UI lives, no
+// address and no state.
+const noPreviewContentMessage = "this is the af web-tab preview origin; it serves web-tab previews only, opened from the af web UI. " +
+	"There is nothing to browse here directly."
+
 // noWebShellHandler wraps the authed API handler for listeners that serve NO
-// frontend (the agent-server). It answers every non-/v1 path with a plain 404
-// explaining where the web UI actually lives, and routes /v1/... through the authed
-// handler untouched.
+// frontend (the agent-server, the preview origin). It answers every non-/v1 path
+// with a plain 404 carrying message, and routes /v1/... through the authed handler
+// untouched.
 //
 // The explanatory 404 sits OUTSIDE the gate, in the same place webShellHandler
 // serves the shell unauthenticated — a human who opened the wrong port has no token
-// to present, so gating the explanation would leave them staring at a bare 401. It
-// discloses only a fixed string (no state, no token, no workspace detail), and it is
-// strictly LESS exposure than what this listener served before: the entire SPA
-// bundle, unauthenticated, on the same paths.
-func noWebShellHandler(api http.Handler) http.Handler {
+// to present, so gating the explanation would leave them staring at a bare 401. So
+// message must disclose only a fixed, address-free string (no state, no token, no
+// workspace detail): it is shown to an UNAUTHENTICATED peer.
+func noWebShellHandler(api http.Handler, message string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/v1/") {
 			api.ServeHTTP(w, r)
 			return
 		}
-		writeHTTPError(w, r, http.StatusNotFound, errors.New(noWebShellMessage))
+		writeHTTPError(w, r, http.StatusNotFound, errors.New(message))
 	})
 }
 

--- a/daemon/webtab_proxy.go
+++ b/daemon/webtab_proxy.go
@@ -638,30 +638,46 @@ func (cs *controlServer) webTabProxyHandler(w http.ResponseWriter, r *http.Reque
 	proxy.ServeHTTP(w, r)
 }
 
-// cleanWebTabTokenBootstrap persists a credential presented directly by the
-// caller and, when the private query transport is present, redirects to the same
-// request URI without it. It reports whether it wrote that redirect.
+// cleanWebTabTokenBootstrap persists the daemon credential presented on the
+// app-origin web-tab navigation and, when the private query transport is present,
+// redirects to the same request URI without it. It reports whether it wrote that
+// redirect.
 //
 // The caller is behind withAuth, so a query value reaching this point has already
 // been compared with the daemon's token. Existing cookie-authorized requests do
 // not reissue the cookie: only a credential PRESENTED in the header or query does.
 func cleanWebTabTokenBootstrap(w http.ResponseWriter, r *http.Request) bool {
+	return cleanBootstrapToken(w, r, webtabTokenQueryParam, webtabTokenCookie, webtabPathPrefix)
+}
+
+// cleanBootstrapToken is the #2400 clean-before-render primitive, shared by the
+// app-origin web-tab flow and the preview-origin flow (#1856). It moves a
+// credential presented on the Authorization header or the private query param
+// into an HttpOnly cookie scoped to cookiePath, then — only when that query param
+// was present — redirects to the same request URI with it removed, so no app JS
+// ever sees the credential in its own window.location.
+//
+// The two callers pass DIFFERENT queryParam/cookieName so the daemon bearer and
+// the preview credential are never written to, or read from, each other's
+// transport. Keeping this one function is deliberate: two hand-copied
+// clean-before-render blocks are exactly the drift #2400's own class warns about.
+func cleanBootstrapToken(w http.ResponseWriter, r *http.Request, queryParam, cookieName, cookiePath string) bool {
 	presented := agentproto.BearerToken(r.Header.Get(agentproto.AuthHeader))
 	if presented == "" {
-		presented = r.URL.Query().Get(webtabTokenQueryParam)
+		presented = r.URL.Query().Get(queryParam)
 	}
 	if presented != "" {
 		http.SetCookie(w, &http.Cookie{
-			Name:     webtabTokenCookie,
+			Name:     cookieName,
 			Value:    presented,
-			Path:     webtabPathPrefix,
+			Path:     cookiePath,
 			HttpOnly: true,
 			Secure:   requestIsHTTPS(r),
 			SameSite: http.SameSiteStrictMode,
 		})
 	}
 
-	cleanRawQuery := stripRawQueryParam(r.URL.RawQuery, webtabTokenQueryParam)
+	cleanRawQuery := stripRawQueryParam(r.URL.RawQuery, queryParam)
 	if cleanRawQuery == r.URL.RawQuery {
 		return false
 	}

--- a/daemon/webtab_proxy.go
+++ b/daemon/webtab_proxy.go
@@ -658,16 +658,31 @@ func cleanWebTabTokenBootstrap(w http.ResponseWriter, r *http.Request) bool {
 	return cleanBootstrapToken(w, r, webtabTokenQueryParam, webtabTokenCookie, webtabPathPrefix)
 }
 
+// afCredentialQueryParams is the full set of private query params any af auth gate
+// will accept as a bearer: the daemon's (af_webtab_token) and the preview origin's
+// (af_preview_token). The clean-before-render sanitizer must scrub EVERY one of
+// them from the URL it redirects to, not just the one the current flow authorized
+// on — see cleanBootstrapToken. This is the webtab_url.go rule ("the STRIPPED set
+// must cover everything the AUTH GATE would ACCEPT") applied to the redirect URL,
+// which is the surface #2400 is actually about.
+var afCredentialQueryParams = []string{webtabTokenQueryParam, previewTokenQueryParam}
+
 // cleanBootstrapToken is the #2400 clean-before-render primitive, shared by the
-// app-origin web-tab flow and the preview-origin flow (#1856). It moves a
-// credential presented on the Authorization header or the private query param
-// into an HttpOnly cookie scoped to cookiePath, then — only when that query param
-// was present — redirects to the same request URI with it removed, so no app JS
-// ever sees the credential in its own window.location.
+// app-origin web-tab flow and the preview-origin flow (#1856). It moves the
+// credential presented on the Authorization header or this flow's private query
+// param into an HttpOnly cookie scoped to cookiePath, then redirects to the same
+// request URI with EVERY af credential param removed, so no app JS ever sees any
+// af bearer in its own window.location.
 //
-// The two callers pass DIFFERENT queryParam/cookieName so the daemon bearer and
-// the preview credential are never written to, or read from, each other's
-// transport. Keeping this one function is deliberate: two hand-copied
+// It SETS only cookieName (this flow's own credential), but STRIPS the whole
+// afCredentialQueryParams set. That asymmetry is the #2400 fix generalized to two
+// credentials: on the preview origin a navigation can legitimately carry both
+// (?af_preview_token authorizes it, ?af_webtab_token rides along because the two
+// origins share a cookie jar and query surface), and leaving the OTHER param in
+// the redirect URL would strand the daemon bearer — the higher-value credential —
+// in the document the preview page renders under. Both callers pass DIFFERENT
+// queryParam/cookieName so the two credentials are never written to, or read from,
+// each other's cookie; keeping this one function is deliberate — two hand-copied
 // clean-before-render blocks are exactly the drift #2400's own class warns about.
 func cleanBootstrapToken(w http.ResponseWriter, r *http.Request, queryParam, cookieName, cookiePath string) bool {
 	presented := agentproto.BearerToken(r.Header.Get(agentproto.AuthHeader))
@@ -685,7 +700,10 @@ func cleanBootstrapToken(w http.ResponseWriter, r *http.Request, queryParam, coo
 		})
 	}
 
-	cleanRawQuery := stripRawQueryParam(r.URL.RawQuery, queryParam)
+	cleanRawQuery := r.URL.RawQuery
+	for _, p := range afCredentialQueryParams {
+		cleanRawQuery = stripRawQueryParam(cleanRawQuery, p)
+	}
 	if cleanRawQuery == r.URL.RawQuery {
 		return false
 	}

--- a/daemon/webtab_proxy.go
+++ b/daemon/webtab_proxy.go
@@ -559,7 +559,15 @@ func (cs *controlServer) webTabProxyHandler(w http.ResponseWriter, r *http.Reque
 			// promises on the client. The app's own params, including its own
 			// ?access_token= (a DIFFERENT name from the daemon's), ride through
 			// untouched.
+			// Strip BOTH af credential query params before forwarding: af_webtab_token
+			// (this gate's) and af_preview_token (the preview origin's). They share a
+			// cookie jar and a path scope (RFC 6265 §8.5 — cookies are not port-scoped),
+			// so a crafted request to this origin can carry either, and the strip set
+			// must cover everything ANY af gate accepts, never just this one's (the
+			// webtab_url.go rule; the daemon-bearer half of it is why the first strip
+			// exists). Neither may reach the untrusted dev server.
 			pr.Out.URL.RawQuery = stripRawQueryParam(pr.Out.URL.RawQuery, webtabTokenQueryParam)
+			pr.Out.URL.RawQuery = stripRawQueryParam(pr.Out.URL.RawQuery, previewTokenQueryParam)
 			pr.SetXForwarded()
 			// SetXForwarded derives X-Forwarded-Proto from the DAEMON-facing hop,
 			// which OVERWRITES what the client's own hop reported (#1875). The
@@ -691,15 +699,27 @@ func cleanBootstrapToken(w http.ResponseWriter, r *http.Request, queryParam, coo
 	return true
 }
 
-// forwardAppCookies forwards the dev app's cookies upstream while stripping the
-// daemon's own token cookie, so a cookie-backed dev server sees its session/CSRF
-// cookies but never the daemon bearer token.
+// forwardAppCookies forwards the dev app's cookies upstream while stripping every
+// af credential cookie, so a cookie-backed dev server sees its session/CSRF
+// cookies but never a daemon or preview bearer.
+//
+// It strips BOTH af_webtab_token AND af_preview_token, and that second name is
+// load-bearing, not defensive tidiness. Cookies are scoped by (host, path), NOT
+// by port (RFC 6265 §8.5), so the app origin (127.0.0.1:8443) and the preview
+// origin (:8444) share ONE cookie jar: once the preview flow mints af_preview_token
+// (scoped to the same /v1/webtab/ path), the browser sends it here too, and
+// forwarding it upstream would hand a single GLOBAL preview credential to the
+// arbitrary repo/agent-controlled dev server — cross-session preview access, the
+// exact escalation the separate origin exists to prevent. The rule is the same one
+// webtab_url.go states for the strip set: it must cover everything ANY af gate
+// would accept (webTabAwareToken reads af_webtab_token; previewPresentedToken reads
+// af_preview_token), so both names are stripped here.
 func forwardAppCookies(r *http.Request) {
 	cookies := r.Cookies()
 	r.Header.Del("Cookie")
 	var b strings.Builder
 	for _, c := range cookies {
-		if c.Name == webtabTokenCookie {
+		if c.Name == webtabTokenCookie || c.Name == previewTokenCookie {
 			continue
 		}
 		if b.Len() > 0 {

--- a/daemon/webtab_proxy_test.go
+++ b/daemon/webtab_proxy_test.go
@@ -638,38 +638,86 @@ func TestWebTabProxy_QueryTokenIsOnlyABootstrapCredential(t *testing.T) {
 	}
 }
 
-// TestWebTabProxy_StripsPreviewTokenFromUpstreamQuery is the #1856 P1 query half.
-// af_preview_token shares the app origin's cookie jar and /v1/webtab/ path scope
-// (cookies are not port-scoped, RFC 6265 §8.5), so a request here can carry it —
-// and it must be stripped before the query is forwarded to the untrusted dev
-// server, exactly as af_webtab_token is. Otherwise a single GLOBAL preview
-// credential leaks upstream, handing one session's dev server access to every
-// other session's preview.
+// TestWebTabProxy_StripsPreviewTokenFromUpstreamQuery pins the #1856 invariant that no
+// af credential — the app's own af_webtab_token OR the foreign af_preview_token that
+// rides along via the shared cookie jar (cookies are not port-scoped, RFC 6265 §8.5) —
+// ever survives where an untrusted dev server could read it. It proves BOTH halves of
+// P2-a's interaction with the clean-before-render bootstrap:
+//
+//  1. Rendered URL: a request ARRIVING with both credential params is cleaned by a 307
+//     to a URL carrying NEITHER, before any upstream forward — strictly stronger than
+//     stripping on the way upstream, since the credential never enters window.location.
+//     The app origin adopts only its OWN credential as a cookie; it strips the foreign
+//     preview token, it does not adopt it.
+//  2. Proxied request: the post-bootstrap request (credentials in cookies) forwards the
+//     app's own query with NO af param, and forwardAppCookies strips BOTH af cookies so
+//     neither reaches the dev server.
 func TestWebTabProxy_StripsPreviewTokenFromUpstreamQuery(t *testing.T) {
+	var upstreamCalls atomic.Int32
 	seenQuery := make(chan string, 1)
+	seenCookie := make(chan string, 1)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls.Add(1)
 		seenQuery <- r.URL.RawQuery
+		seenCookie <- r.Header.Get("Cookie")
 		fmt.Fprint(w, "ok")
 	}))
 	defer upstream.Close()
 	mux, id, tabID := newWebTabProxyFixture(t, upstream.URL)
 
-	// A clean sub-resource request: it carries NO af_webtab_token (so no bootstrap
-	// redirect fires) but DOES carry af_preview_token in the query.
+	// Arrives with BOTH credentials: af_webtab_token (its own, authorizes) and
+	// af_preview_token (foreign, rides along). The bootstrap strips every af param.
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet,
-		fmt.Sprintf("/v1/webtab/%s/%s/asset.js?real=1&af_preview_token=leak", id, tabID), nil)
+		fmt.Sprintf("/v1/webtab/%s/%s/asset.js?real=1&af_webtab_token=fixture-token&af_preview_token=leak", id, tabID), nil)
 	mux.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("status = %d, want 307 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := upstreamCalls.Load(); got != 0 {
+		t.Fatalf("the credential-bearing request reached the dev server %d time(s), want 0", got)
+	}
+	location := rec.Header().Get("Location")
+	if !strings.Contains(location, "real=1") {
+		t.Fatalf("redirect Location = %q, want the app's own param preserved", location)
+	}
+	for _, leak := range []string{"af_preview_token", "leak", "af_webtab_token", "fixture-token"} {
+		if strings.Contains(location, leak) {
+			t.Fatalf("redirect Location = %q must carry NO af credential (%q survived) — none may enter window.location", location, leak)
+		}
+	}
+	if c := cookieNamed(rec, previewTokenCookie); c != nil {
+		t.Fatalf("app origin set the preview cookie %+v; it must strip the foreign preview token, not adopt it", c)
+	}
+	ownCookie := cookieNamed(rec, webtabTokenCookie)
+	if ownCookie == nil || !ownCookie.HttpOnly {
+		t.Fatalf("app origin cookie = %+v, want its own HttpOnly af_webtab_token", ownCookie)
 	}
 
+	// The proxied follow-up: credentials now in cookies (the preview one riding along via
+	// the shared jar). The upstream sees the app's own query and NO af cookie.
+	clean := httptest.NewRecorder()
+	cleanReq := httptest.NewRequest(http.MethodGet, location, nil)
+	cleanReq.AddCookie(ownCookie)
+	cleanReq.AddCookie(&http.Cookie{Name: previewTokenCookie, Value: "leak"})
+	mux.ServeHTTP(clean, cleanReq)
+	if clean.Code != http.StatusOK {
+		t.Fatalf("clean follow-up status = %d, want 200 (body: %s)", clean.Code, clean.Body.String())
+	}
 	got := <-seenQuery
 	if !strings.Contains(got, "real=1") {
 		t.Fatalf("upstream RawQuery = %q, want the app's own param preserved", got)
 	}
-	if strings.Contains(got, "af_preview_token") || strings.Contains(got, "leak") {
-		t.Fatalf("upstream RawQuery = %q must not carry af_preview_token — a global preview credential must never reach the dev server", got)
+	for _, leak := range []string{"af_preview_token", "leak", "af_webtab_token", "fixture-token"} {
+		if strings.Contains(got, leak) {
+			t.Fatalf("upstream RawQuery = %q must carry NO af credential (%q reached the dev server)", got, leak)
+		}
+	}
+	gotCookie := <-seenCookie
+	for _, leak := range []string{"af_preview_token", "leak", "af_webtab_token", "fixture-token"} {
+		if strings.Contains(gotCookie, leak) {
+			t.Fatalf("upstream Cookie = %q must carry NO af credential (%q survived) — forwardAppCookies must strip both", gotCookie, leak)
+		}
 	}
 }
 

--- a/daemon/webtab_proxy_test.go
+++ b/daemon/webtab_proxy_test.go
@@ -638,6 +638,41 @@ func TestWebTabProxy_QueryTokenIsOnlyABootstrapCredential(t *testing.T) {
 	}
 }
 
+// TestWebTabProxy_StripsPreviewTokenFromUpstreamQuery is the #1856 P1 query half.
+// af_preview_token shares the app origin's cookie jar and /v1/webtab/ path scope
+// (cookies are not port-scoped, RFC 6265 §8.5), so a request here can carry it —
+// and it must be stripped before the query is forwarded to the untrusted dev
+// server, exactly as af_webtab_token is. Otherwise a single GLOBAL preview
+// credential leaks upstream, handing one session's dev server access to every
+// other session's preview.
+func TestWebTabProxy_StripsPreviewTokenFromUpstreamQuery(t *testing.T) {
+	seenQuery := make(chan string, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenQuery <- r.URL.RawQuery
+		fmt.Fprint(w, "ok")
+	}))
+	defer upstream.Close()
+	mux, id, tabID := newWebTabProxyFixture(t, upstream.URL)
+
+	// A clean sub-resource request: it carries NO af_webtab_token (so no bootstrap
+	// redirect fires) but DOES carry af_preview_token in the query.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v1/webtab/%s/%s/asset.js?real=1&af_preview_token=leak", id, tabID), nil)
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	got := <-seenQuery
+	if !strings.Contains(got, "real=1") {
+		t.Fatalf("upstream RawQuery = %q, want the app's own param preserved", got)
+	}
+	if strings.Contains(got, "af_preview_token") || strings.Contains(got, "leak") {
+		t.Fatalf("upstream RawQuery = %q must not carry af_preview_token — a global preview credential must never reach the dev server", got)
+	}
+}
+
 // TestWebTabProxy_QueryTokenCleanupKeepsMirroredPath ensures a non-root target
 // cannot bypass the bootstrap boundary. The redirect stays on the exact mirrored
 // path and preserves the app's raw query bytes and order; it does not bounce via
@@ -827,20 +862,29 @@ func TestWebTabProxy_ForwardsCookiesBothDirections(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/v1/webtab/%s/%s/", id, tabID), nil)
-	// The browser sends both the daemon token cookie and the app's own cookie.
-	req.Header.Set("Cookie", webtabTokenCookie+"=daemon-tok; appsess=xyz")
+	// The browser sends the daemon token cookie, the PREVIEW token cookie (the two
+	// origins share a cookie jar — cookies are not port-scoped, RFC 6265 §8.5 — and
+	// both are minted at Path=/v1/webtab/, so both arrive here), and the app's own
+	// cookie.
+	req.Header.Set("Cookie", webtabTokenCookie+"=daemon-tok; "+previewTokenCookie+"=preview-tok; appsess=xyz")
 	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
 
-	// Upstream must have seen the app cookie but NOT the daemon token cookie.
+	// Upstream must have seen the app cookie but NEITHER af credential cookie.
 	echoed := rec.Header().Get("X-Echo-Cookie")
 	if !contains(echoed, "appsess=xyz") {
 		t.Fatalf("upstream Cookie %q missing app cookie appsess=xyz", echoed)
 	}
 	if contains(echoed, webtabTokenCookie) {
 		t.Fatalf("upstream Cookie %q must not carry the daemon token cookie", echoed)
+	}
+	// #1856 P1: the preview token shares this jar; forwarding it upstream would hand
+	// a global preview credential to the untrusted dev server (cross-session preview
+	// access). It must be stripped just like the daemon token.
+	if contains(echoed, previewTokenCookie) {
+		t.Fatalf("upstream Cookie %q must not carry the preview token cookie — it would leak a global preview credential to the dev server", echoed)
 	}
 
 	// The upstream Set-Cookie must be relayed back, re-scoped under this tab's proxy


### PR DESCRIPTION
Step 2 of #1856 (dedicated web-tab preview origin, option A). Follows the merged step 1 (#2495). **The security-sensitive slice — please review this one hardest.**

**Draft**, second of four sequential PRs. It establishes the preview origin's auth but lands no browser-observable behavior (the client re-address is step 3).

## The load-bearing decision (maintainer-approved)

The preview origin will host untrusted, repo/agent-controlled content (the #2455 driver), so its credential must authorize preview serving **only** — never the control API. Given three options (reuse the daemon bearer / a persisted separate token / an **ephemeral** separate token), the maintainer picked the ephemeral separate token — least-privilege, no persistent secret, rotates on restart. That is what this implements: the daemon bearer never reaches the preview origin at all.

## What it builds

- **`Manager.previewToken`** — minted in `newManagerShellForDaemon` via the same `crypto/rand` source as the daemon bearer, **in memory, never on disk**, immutable. A leaked preview credential grants preview serving, nothing else.
- **`authGate.presentedToken`** — the gate's credential extractor is now pluggable. Default stays `webTabAwareToken`; the preview listener uses **`previewPresentedToken`** (`af_preview_token` header/query/cookie — **distinct transports** from the daemon's `af_webtab_token`/`access_token`, so neither credential can be read for the other, even on a request carrying both).
- **`startTCPListener`** takes an optional `tcpListenerAuth` override; `nil` keeps the file-backed daemon token (control + agent-server unchanged). The preview caller passes the in-memory token.
- **`newPreviewMux`** runs the **clean-before-render bootstrap** and otherwise 404s (no content yet). The bootstrap is `cleanBootstrapToken` — extracted from the existing app-origin `cleanWebTabTokenBootstrap` and **shared** by both, so the two #2400 flows can't drift (the exact class #2400 warns about). It sets an HttpOnly `af_preview_token` cookie scoped to `/v1/webtab/`, scrubs the token from the URL, and 307s with `no-store` + `no-referrer` — before any resolution.
- **`GET /v1/preview-auth`** (internal, control-plane, authenticated) hands the ephemeral token to a client already authorized to the control plane — the **only** way to obtain it (it's in-memory, never logged); withheld when the preview listener is disabled.

## Security properties, each pinned by a test

| property | test |
| --- | --- |
| daemon bearer does **not** authenticate the preview origin | `TestPreviewCredentialSeparation_BothDirections`, `TestStartHTTPServer_PreviewBindsButServesNothing` |
| preview token does **not** authenticate the control plane | `TestPreviewCredentialSeparation_BothDirections` |
| clean-before-render: scoped HttpOnly cookie + scrubbed 307 + no-store/no-referrer | `TestPreviewBootstrap_CleanBeforeRender` |
| the cookie authenticates a sub-resource; wrong/absent credential → 401 | `TestPreviewGate_CookieAuthenticatesFollowUpAndRejectsOthers` |
| the two credentials ride **disjoint** transports (extractor isolation) | `TestPreviewPresentedToken_IsolatedFromDaemonTransports` |
| token is ephemeral (per-daemon) and **never on disk** | `TestPreviewToken_EphemeralAndNeverOnDisk` |
| retrieval endpoint returns it to an authed client, withholds when disabled | `TestPreviewAuthEndpoint_ReturnsTokenToAuthenticatedClient` |

The existing web-tab bootstrap tests prove the `cleanBootstrapToken` extraction is behavior-preserving.

## Scope notes

- **No user-facing surface yet** — the credential is invisible and the SPA doesn't use the preview origin until step 3, so no docs (they land with the browser-observable steps 3/4) and no meaningful `web-selftest` exercise here. Said plainly rather than implied.
- `/v1/preview-auth` is an **internal** route (not the `af api` catalog), like the stream routes — so no `api.md` drift (confirmed: `gen-docs` produced none).

## Gate — head `7ca514e8126d67eb369130f0f308c484cabbea3b`

- `gofmt -l .` clean · `go build ./...` clean
- `golangci-lint run --timeout=3m --fast` clean
- `deadcode -test ./...` clean
- `scripts/lint-file-length.sh` passed (1039 files)
- `gen-docs` produced no drift
- full `make test-container` suite green on the pushed head

## Review

Codex is degraded/rate-limited. Requesting once; if it stays silent I'll say so explicitly rather than letting green checks imply a review, and this goes to Captain Claude's review gate on this exact head. Not self-merging (and it stays draft as step 2 of the sequence regardless).

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
