### PR TITLE
feat(sessions): autocreate a readable session name from a shadow placeholder (#2470)

### DIFF
--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sachiniyer/agent-factory/internal/namegen"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
@@ -27,6 +28,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.state = stateDefault
 		m.namingInstance = nil
+		m.clearNamingPlaceholder()
 		m.pendingPrompt = ""
 		// Menu.SetState rebuilds the options slice; call it synchronously
 		// on the event-loop goroutine rather than from a tea.Cmd closure
@@ -45,7 +47,18 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// through to session creation, producing an invisible name in the
 		// sidebar (#973). TrimSpace mirrors the daemon's validateTitleAvailableLocked.
 		if strings.TrimSpace(instance.Title) == "" {
-			return m, m.handleError(fmt.Errorf("title cannot be empty"))
+			// #2470: an untouched (or whitespace-only) field adopts the shadow
+			// placeholder shown in its row, so pressing enter autocreates the
+			// suggested name. It was generated collision-free in startNewInstance;
+			// the reserved/collision/preflight checks below still run on it. Fall back
+			// to the old error only if no placeholder was generated (never, in
+			// practice — startNewInstance always sets one).
+			if m.namingPlaceholder == "" {
+				return m, m.handleError(fmt.Errorf("title cannot be empty"))
+			}
+			if err := instance.SetTitle(m.namingPlaceholder); err != nil {
+				return m, m.handleError(err)
+			}
 		}
 		// "root" is reserved for the daemon-managed root agent (#1106). The
 		// daemon's reserveCreate is the authoritative gate; rejecting here
@@ -99,6 +112,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		prompt := strings.TrimSpace(m.pendingPrompt)
 		m.pendingPrompt = ""
 		m.namingInstance = nil
+		m.clearNamingPlaceholder()
 		m.state = stateDefault
 		m.menu.SetState(ui.StateDefault)
 
@@ -183,6 +197,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			log.ErrorLog.Printf("failed to clean up instance on cancel: %v", err)
 		}
 		m.namingInstance = nil
+		m.clearNamingPlaceholder()
 		m.pendingPrompt = ""
 		m.state = stateDefault
 		cmd := m.selectionChanged()
@@ -253,8 +268,47 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 	m.store.AddInstance(instance)
 	m.sidebar.SelectInstance(instance)
 	m.namingInstance = instance
+	// #2470: generate the autocreate-name suggestion and show it as shadow text on
+	// the naming row. Pressing enter on the untouched field adopts it.
+	m.namingPlaceholder = m.suggestSessionName(instance)
+	m.sidebar.SetNamingPlaceholder(instance, m.namingPlaceholder)
 	m.state = stateNew
 	m.menu.SetNamingHasPrompt(false)
 	m.menu.SetState(ui.StateNewInstance)
 	return m, nil
+}
+
+// suggestSessionName picks a readable random "adjective-noun" name for the
+// naming placeholder (#2470) that the naming flow would not itself reject: it
+// avoids the reserved root title and any existing title git.TitlesCollide flags
+// — the exact rule the enter handler enforces — so accepting the placeholder on
+// an empty submit passes those same checks. A residual collision (a session
+// created during naming) is still caught at submit and, authoritatively, by the
+// daemon.
+func (m *home) suggestSessionName(naming *session.Instance) string {
+	prefix := ""
+	if m.appConfig != nil {
+		prefix = m.appConfig.BranchPrefix
+	}
+	return namegen.Suggest(func(name string) bool {
+		if session.IsReservedTitle(name) {
+			return true
+		}
+		for _, other := range m.store.GetInstances() {
+			if other == naming {
+				continue
+			}
+			if git.TitlesCollide(other.Title, name, prefix) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// clearNamingPlaceholder drops the autocreate-name shadow text (#2470) from both
+// the model and the sidebar renderer when a naming session ends by any route.
+func (m *home) clearNamingPlaceholder() {
+	m.namingPlaceholder = ""
+	m.sidebar.SetNamingPlaceholder(nil, "")
 }

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -43,29 +43,37 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	switch msg.Type {
 	case tea.KeyEnter:
-		// Reject whitespace-only titles too: len()/== "" pass a "   " title
-		// through to session creation, producing an invisible name in the
-		// sidebar (#973). TrimSpace mirrors the daemon's validateTitleAvailableLocked.
-		if strings.TrimSpace(instance.Title) == "" {
-			// #2470: an untouched (or whitespace-only) field adopts the shadow
-			// placeholder shown in its row, so pressing enter autocreates the
-			// suggested name. It was generated collision-free in startNewInstance;
-			// the reserved/collision/preflight checks below still run on it. Fall back
-			// to the old error only if no placeholder was generated (never, in
-			// practice — startNewInstance always sets one).
-			if m.namingPlaceholder == "" {
-				return m, m.handleError(fmt.Errorf("title cannot be empty"))
-			}
-			if err := instance.SetTitle(m.namingPlaceholder); err != nil {
-				return m, m.handleError(err)
-			}
+		// Resolve the effective title into a LOCAL and run every naming gate against
+		// it, committing it to the instance only AFTER they all pass (#2470 review).
+		//
+		// An EXACT-empty field (nothing typed) adopts the shadow placeholder shown in
+		// its row — the "autocreate". The match with the renderer is deliberate: the
+		// row paints the placeholder only when the title is exactly empty
+		// (ui/tree/render.go), so adopting on exact-empty too means enter creates
+		// precisely the name the user could see. A whitespace-only field is NOT that —
+		// its shadow text is already gone — so it stays the #973 error, not a silent
+		// adopt of an off-screen name. TrimSpace mirrors the daemon's
+		// validateTitleAvailableLocked.
+		//
+		// Writing the title before the gates (the first cut of this feature) left a
+		// FAILED gate — a reserved/colliding name, or a missing agent binary at
+		// preflight — with the suggestion permanently stamped as a real, full-contrast
+		// title the user never chose and had to backspace out by hand. Keeping it a
+		// local until every gate passes leaves the row showing the shadow placeholder,
+		// retryable, on any failure.
+		title := instance.Title
+		if title == "" {
+			title = m.namingPlaceholder
+		}
+		if strings.TrimSpace(title) == "" {
+			return m, m.handleError(fmt.Errorf("title cannot be empty"))
 		}
 		// "root" is reserved for the daemon-managed root agent (#1106). The
 		// daemon's reserveCreate is the authoritative gate; rejecting here
 		// keeps the user in the naming overlay instead of surfacing the
 		// error after submit, mirroring the #936 collision pre-check below.
-		if session.IsReservedTitle(instance.Title) {
-			return m, m.handleError(fmt.Errorf("title %q is reserved for the daemon-managed root agent; pick another name", instance.Title))
+		if session.IsReservedTitle(title) {
+			return m, m.handleError(fmt.Errorf("title %q is reserved for the daemon-managed root agent; pick another name", title))
 		}
 		for _, other := range m.store.GetInstances() {
 			if other == instance {
@@ -76,8 +84,8 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			// flow rejects what the daemon would reject after submit, instead of
 			// only catching exact duplicates and deferring case/branch variants
 			// to a post-Start error (#936).
-			if git.TitlesCollide(other.Title, instance.Title, m.appConfig.BranchPrefix) {
-				return m, m.handleError(fmt.Errorf("a session titled %q conflicts with existing session %q", instance.Title, other.Title))
+			if git.TitlesCollide(other.Title, title, m.appConfig.BranchPrefix) {
+				return m, m.handleError(fmt.Errorf("a session titled %q conflicts with existing session %q", title, other.Title))
 			}
 		}
 		if instance.Capabilities().Workspace == session.WorkspaceRemote {
@@ -88,14 +96,20 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				}
 				existing = append(existing, other)
 			}
-			if dup := session.FindSlugCollision(instance.Title, existing); dup != "" {
+			if dup := session.FindSlugCollision(title, existing); dup != "" {
 				return m, m.handleError(fmt.Errorf(
 					"a remote session titled %q already maps to hook name %q",
-					dup, session.Slugify(instance.Title),
+					dup, session.Slugify(title),
 				))
 			}
 		}
+		// preflightSessionCreate reads only the backend/program, not the title, so it
+		// runs before the title is committed.
 		if err := m.preflightSessionCreate(instance); err != nil {
+			return m, m.handleError(err)
+		}
+		// Every gate passed — commit the resolved title exactly once.
+		if err := instance.SetTitle(title); err != nil {
 			return m, m.handleError(err)
 		}
 

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -389,18 +389,19 @@ func TestHandleStateNewPreflightErrorKeepsNamingFlow(t *testing.T) {
 // len()==0 check let it through to session creation, producing an invisible name
 // in the sidebar. Typing spaces and then Enter must leave the naming overlay open
 // and the namingInstance pointer intact (i.e. not submitted).
+//
+// It drives the REAL startNewInstance flow so a #2470 placeholder IS present (as it
+// always is in production), which is what makes the guard cover shipped behavior: a
+// whitespace-only title must be rejected even with a placeholder available, and must
+// NOT be silently replaced by it — the shadow name is gone the moment a space is
+// typed, so adopting it would create a name that was never on screen.
 func TestHandleStateNewWhitespaceViaRealInput(t *testing.T) {
 	h := newTestHome(t)
-	h.state = stateNew
 	h.errBox.SetSize(120, 1)
 
-	naming, err := session.NewInstance(session.InstanceOptions{
-		Title:   "",
-		Path:    t.TempDir(),
-		Program: "claude",
-	})
-	require.NoError(t, err)
-	h.namingInstance = naming
+	_, _ = h.startNewInstance(false)
+	require.NotNil(t, h.namingInstance)
+	require.NotEmpty(t, h.namingPlaceholder, "startNewInstance always generates a placeholder")
 
 	// Simulate the user typing three spaces in the naming flow: each KeySpace
 	// appends " " to instance.Title (the KeySpace branch in handle_input.go).
@@ -409,11 +410,13 @@ func TestHandleStateNewWhitespaceViaRealInput(t *testing.T) {
 	}
 	require.Equal(t, "   ", h.namingInstance.Title, "precondition: title is whitespace-only")
 
-	// Submit with Enter — must be rejected, keeping the flow open.
+	// Submit with Enter — must be rejected, keeping the flow open, and the whitespace
+	// must NOT have been adopted into the placeholder name.
 	_, _ = h.handleStateNew(tea.KeyMsg{Type: tea.KeyEnter})
 
 	assert.Equal(t, stateNew, h.state, "naming flow must stay open for whitespace-only title")
 	require.NotNil(t, h.namingInstance, "naming instance must not be submitted")
+	assert.Equal(t, "   ", h.namingInstance.Title, "whitespace-only must NOT adopt the placeholder")
 	assert.Contains(t, h.errBox.String(), "title cannot be empty")
 }
 
@@ -558,6 +561,35 @@ func TestHandleStateNewEmptySubmitAdoptsPlaceholder(t *testing.T) {
 	assert.Equal(t, placeholder, inst.Title, "the empty submit adopted the shadow placeholder as the title")
 	assert.Empty(t, h.namingPlaceholder, "the placeholder is cleared once naming ends")
 	assert.Equal(t, stateDefault, h.state)
+}
+
+// TestHandleStateNewEmptySubmitFailedGateKeepsPlaceholder is the #2470 review P2-a
+// guard: an empty submit resolves the placeholder into a LOCAL and commits it to the
+// instance only after every gate passes. So a FAILED gate — here a preflight error,
+// e.g. the agent binary missing — must leave the naming flow open with the title
+// still EMPTY, so the row keeps showing the shadow placeholder rather than a real,
+// full-contrast name the user never chose and would have to backspace out.
+func TestHandleStateNewEmptySubmitFailedGateKeepsPlaceholder(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+	t.Cleanup(SetLocalSessionPreflightForTest(func(*config.Config, string) error {
+		return errors.New("Claude Code is not installed or not on PATH")
+	}))
+
+	_, _ = h.startNewInstance(false)
+	inst := h.namingInstance
+	require.NotNil(t, inst)
+	require.Equal(t, "", inst.Title, "precondition: the field starts empty")
+	require.NotEmpty(t, h.namingPlaceholder)
+
+	// Enter on the untouched field: the placeholder resolves, but preflight FAILS.
+	_, _ = h.handleStateNew(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Equal(t, stateNew, h.state, "a failed gate keeps the naming flow open")
+	require.Same(t, inst, h.namingInstance, "the naming instance is not submitted")
+	assert.Equal(t, "", inst.Title, "a failed gate must NOT stamp the placeholder as a real title")
+	assert.NotEmpty(t, h.namingPlaceholder, "the placeholder is still available to retry or edit")
+	assert.Contains(t, h.errBox.String(), "not installed")
 }
 
 // TestCancelNamingClearsPlaceholder guards that both cancel paths drop the #2470

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -536,3 +536,51 @@ func TestNamingCreateFlow_NoDoubleTransition(t *testing.T) {
 	// returned async cmd, which this test does not run).
 	assert.Equal(t, session.OpCreating, inst.GetInFlightOp())
 }
+
+// TestHandleStateNewEmptySubmitAdoptsPlaceholder pins the #2470 autocreate: with
+// the name field left untouched, pressing enter adopts the generated shadow
+// placeholder as the session title instead of erroring "title cannot be empty".
+func TestHandleStateNewEmptySubmitAdoptsPlaceholder(t *testing.T) {
+	h := newTestHome(t)
+	t.Cleanup(SetLocalSessionPreflightForTest(func(*config.Config, string) error { return nil }))
+
+	_, _ = h.startNewInstance(false)
+	inst := h.namingInstance
+	require.NotNil(t, inst)
+	require.Equal(t, "", inst.Title, "precondition: the name field starts empty")
+	require.NotEmpty(t, h.namingPlaceholder, "startNewInstance must generate a suggested name")
+	placeholder := h.namingPlaceholder
+
+	// Enter on the untouched field.
+	_, _ = h.handleStateNew(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Nil(t, h.namingInstance, "an empty submit with a placeholder submits, it does not error")
+	assert.Equal(t, placeholder, inst.Title, "the empty submit adopted the shadow placeholder as the title")
+	assert.Empty(t, h.namingPlaceholder, "the placeholder is cleared once naming ends")
+	assert.Equal(t, stateDefault, h.state)
+}
+
+// TestCancelNamingClearsPlaceholder guards that both cancel paths drop the #2470
+// placeholder alongside the naming pointer, so a later frame cannot paint a stale
+// suggestion on some other row.
+func TestCancelNamingClearsPlaceholder(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{"escape", tea.KeyMsg{Type: tea.KeyEsc}},
+		{"ctrl+c", tea.KeyMsg{Type: tea.KeyCtrlC}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			_, _ = h.startNewInstance(false)
+			require.NotNil(t, h.namingInstance)
+			require.NotEmpty(t, h.namingPlaceholder, "precondition: a placeholder was generated")
+
+			_, _ = h.handleStateNew(tc.key)
+
+			assert.Nil(t, h.namingInstance, "cancel clears the naming pointer")
+			assert.Empty(t, h.namingPlaceholder, "cancel clears the placeholder")
+		})
+	}
+}

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -148,6 +148,11 @@ type home struct {
 	// Stored as a direct pointer so background sync cannot change which
 	// instance the naming keystrokes target.
 	namingInstance *session.Instance
+	// namingPlaceholder is the random "adjective-noun" name shown as shadow text
+	// while namingInstance has an empty title (#2470). Pressing enter on the
+	// untouched field adopts it as the session name (the "autocreate"); it is
+	// generated once per naming in startNewInstance and cleared with namingInstance.
+	namingPlaceholder string
 
 	// keySent is used to manage underlining menu items
 	keySent bool

--- a/daemon/httproutes.go
+++ b/daemon/httproutes.go
@@ -74,6 +74,13 @@ var httpRoutes = []HTTPRoute{
 	},
 	{
 		Method:        http.MethodPost,
+		Path:          "/v1/SuggestSessionName",
+		Description:   "Suggest a random, readable session name (adjective-noun) not used by any live session, for the create form's autocreate placeholder.",
+		RequestFields: jsonFields(reflect.TypeOf(SuggestSessionNameRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.SuggestSessionName) },
+	},
+	{
+		Method:        http.MethodPost,
 		Path:          "/v1/Snapshot",
 		Description:   "List sessions from the daemon's authoritative in-memory state (empty repo_id = all repos).",
 		RequestFields: jsonFields(reflect.TypeOf(SnapshotRequest{})),

--- a/daemon/lifecycle_test.go
+++ b/daemon/lifecycle_test.go
@@ -262,6 +262,9 @@ var controlMethodPolicies = map[string]probationPolicy{
 	"ReleaseUpgradeProbation": allowedDuringProbation,
 	"Shutdown":                allowedDuringProbation,
 	"Snapshot":                allowedDuringProbation,
+	// A name suggestion is a best-effort read (no readiness gate), so it answers
+	// during probation like the other read-only lookups (#2470).
+	"SuggestSessionName": allowedDuringProbation,
 }
 
 func TestControlServerProbationAdmissionLedger(t *testing.T) {

--- a/daemon/suggest_name.go
+++ b/daemon/suggest_name.go
@@ -1,0 +1,64 @@
+package daemon
+
+import (
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/internal/namegen"
+)
+
+// The suggested-session-name RPC (#2470). The web New Session modal shows a
+// random "adjective-noun" name as shadow text in the title field, and creating
+// with the field left empty adopts that name. The web cannot generate the name
+// itself: the wordlist is Go-only by the #1970 ruling ("serve the list from the
+// daemon; do not duplicate it in the client"), which parity/enum_coverage_test.go
+// enforces. So the daemon owns the wordlist (internal/namegen) and serves one
+// collision-avoiding name here; the web displays it and echoes it back as
+// title_base on an empty submit. The TUI needs no RPC — it calls namegen in
+// process — but shares the exact same wordlist, so the two surfaces cannot drift.
+//
+// It is read-only: it provisions nothing and reserves nothing. The name it
+// returns is only a SUGGESTION — the authoritative per-repo uniqueness still runs
+// at create time (the title_base auto-suffix walk in manager_create.go), so this
+// avoids live titles as a courtesy (a placeholder that already names a session
+// reads as a mistake) without needing to be a reservation.
+
+// SuggestSessionNameRequest has no fields: the suggestion avoids every live
+// session title the daemon knows, across all repos, so it is collision-free
+// whichever project the modal is pointed at. A no-argument POST (jsonFields
+// returns nil for it, like ListTasks).
+type SuggestSessionNameRequest struct{}
+
+// SuggestSessionNameResponse carries the suggested name.
+type SuggestSessionNameResponse struct {
+	// Name is a readable "adjective-noun" title (e.g. "brave-otter"), avoiding
+	// every live session's title. Always set (the wordlist is non-empty).
+	Name string `json:"name"`
+}
+
+// SuggestSessionName returns a random, readable session name that avoids every
+// live session's title. It draws from the daemon-owned wordlist so every client
+// renders names from the same list.
+//
+// It deliberately does NOT gate on requireManagerReady: unlike Snapshot as a
+// state projection, a name suggestion is best-effort — a placeholder — so serving
+// one during the restore window (avoiding whatever titles are already back) is
+// strictly better than failing the modal's fetch, and the authoritative per-repo
+// uniqueness still runs at create time. Snapshot takes m.mu, so the read is safe
+// even mid-restore.
+func (s *controlServer) SuggestSessionName(req SuggestSessionNameRequest, resp *SuggestSessionNameResponse) error {
+	// Avoid every live title across all repos (empty repo_id = all): titles are
+	// per-repo unique, so avoiding them everywhere makes the suggestion safe for
+	// whichever project the user ends up picking in the modal.
+	taken := make(map[string]bool)
+	if s.manager != nil {
+		for _, d := range s.manager.Snapshot("") {
+			if t := strings.ToLower(strings.TrimSpace(d.Title)); t != "" {
+				taken[t] = true
+			}
+		}
+	}
+	resp.Name = namegen.Suggest(func(name string) bool {
+		return taken[strings.ToLower(name)]
+	})
+	return nil
+}

--- a/daemon/suggest_name.go
+++ b/daemon/suggest_name.go
@@ -35,6 +35,12 @@ type SuggestSessionNameResponse struct {
 	Name string `json:"name"`
 }
 
+// suggestName is the wordlist generator the RPC calls. It is a package var (not a
+// direct namegen.Suggest call) purely so a test can capture the collision predicate
+// the handler builds from live titles and assert it deterministically — the random
+// generator cannot be forced into an observable collision otherwise.
+var suggestName = namegen.Suggest
+
 // SuggestSessionName returns a random, readable session name that avoids every
 // live session's title. It draws from the daemon-owned wordlist so every client
 // renders names from the same list.
@@ -57,7 +63,7 @@ func (s *controlServer) SuggestSessionName(req SuggestSessionNameRequest, resp *
 			}
 		}
 	}
-	resp.Name = namegen.Suggest(func(name string) bool {
+	resp.Name = suggestName(func(name string) bool {
 		return taken[strings.ToLower(name)]
 	})
 	return nil

--- a/daemon/suggest_name_test.go
+++ b/daemon/suggest_name_test.go
@@ -1,0 +1,76 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+)
+
+// isAdjectiveNoun reports whether name looks like a namegen suggestion: two
+// non-empty lowercase [a-z] words joined by a single hyphen.
+func isAdjectiveNoun(name string) bool {
+	parts := strings.Split(name, "-")
+	if len(parts) != 2 {
+		return false
+	}
+	for _, p := range parts {
+		if p == "" {
+			return false
+		}
+		if strings.ToLower(p) != p {
+			return false
+		}
+	}
+	return true
+}
+
+// TestSuggestSessionName_ReturnsReadableName pins that the RPC serves a readable
+// adjective-noun name end-to-end (#2470): the daemon owns the wordlist and the
+// handler always answers, even with no sessions and no readiness gate.
+func TestSuggestSessionName_ReturnsReadableName(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	m, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	var resp SuggestSessionNameResponse
+	if err := (&controlServer{manager: m}).SuggestSessionName(SuggestSessionNameRequest{}, &resp); err != nil {
+		t.Fatalf("SuggestSessionName: %v", err)
+	}
+	if !isAdjectiveNoun(resp.Name) {
+		t.Fatalf("SuggestSessionName = %q, want an adjective-noun name", resp.Name)
+	}
+}
+
+// TestSuggestSessionName_ExercisesLiveTitles runs the suggestion with a live
+// session present, so the Snapshot→taken-set→namegen path is walked with a
+// non-empty title set. The name stays well-formed and never echoes the live
+// title (the collision-avoidance itself is pinned deterministically in
+// internal/namegen; here it is the daemon wiring that is under test).
+func TestSuggestSessionName_ExercisesLiveTitles(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	m, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	const repo = "/tmp/suggest-name-repo"
+	rid := config.RepoIDFromRoot(repo)
+	startedLocalTabInstance(t, m, rid, repo, "brave-otter", "af_brave_otter_agent")
+
+	cs := &controlServer{manager: m}
+	for i := 0; i < 50; i++ {
+		var resp SuggestSessionNameResponse
+		if err := cs.SuggestSessionName(SuggestSessionNameRequest{}, &resp); err != nil {
+			t.Fatalf("SuggestSessionName: %v", err)
+		}
+		if !isAdjectiveNoun(resp.Name) {
+			t.Fatalf("SuggestSessionName = %q, want an adjective-noun name", resp.Name)
+		}
+		if strings.EqualFold(resp.Name, "brave-otter") {
+			t.Fatalf("SuggestSessionName returned the live title %q", resp.Name)
+		}
+	}
+}

--- a/daemon/suggest_name_test.go
+++ b/daemon/suggest_name_test.go
@@ -45,12 +45,14 @@ func TestSuggestSessionName_ReturnsReadableName(t *testing.T) {
 	}
 }
 
-// TestSuggestSessionName_ExercisesLiveTitles runs the suggestion with a live
-// session present, so the Snapshot→taken-set→namegen path is walked with a
-// non-empty title set. The name stays well-formed and never echoes the live
-// title (the collision-avoidance itself is pinned deterministically in
-// internal/namegen; here it is the daemon wiring that is under test).
-func TestSuggestSessionName_ExercisesLiveTitles(t *testing.T) {
+// TestSuggestSessionName_BuildsTakenFromLiveTitles pins the daemon wiring
+// DETERMINISTICALLY (the random generator cannot be forced into an observable
+// collision, so a "call it 50 times and hope" test passes even with the avoidance
+// deleted). It captures the collision predicate the handler hands the generator and
+// asserts it: a live session's title (any case) reads as taken, a name no session
+// holds reads as free. If the Snapshot projection stopped carrying Title, or the
+// ToLower/TrimSpace key stopped matching, this fails instead of flaking.
+func TestSuggestSessionName_BuildsTakenFromLiveTitles(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
 	m, err := NewManager(config.DefaultConfig())
 	if err != nil {
@@ -58,19 +60,34 @@ func TestSuggestSessionName_ExercisesLiveTitles(t *testing.T) {
 	}
 	const repo = "/tmp/suggest-name-repo"
 	rid := config.RepoIDFromRoot(repo)
-	startedLocalTabInstance(t, m, rid, repo, "brave-otter", "af_brave_otter_agent")
+	// A mixed-case title so the case-insensitive match is actually exercised.
+	startedLocalTabInstance(t, m, rid, repo, "Brave-Otter", "af_brave_otter_agent")
 
-	cs := &controlServer{manager: m}
-	for i := 0; i < 50; i++ {
-		var resp SuggestSessionNameResponse
-		if err := cs.SuggestSessionName(SuggestSessionNameRequest{}, &resp); err != nil {
-			t.Fatalf("SuggestSessionName: %v", err)
-		}
-		if !isAdjectiveNoun(resp.Name) {
-			t.Fatalf("SuggestSessionName = %q, want an adjective-noun name", resp.Name)
-		}
-		if strings.EqualFold(resp.Name, "brave-otter") {
-			t.Fatalf("SuggestSessionName returned the live title %q", resp.Name)
-		}
+	var captured func(string) bool
+	orig := suggestName
+	suggestName = func(taken func(string) bool) string {
+		captured = taken
+		return "captured-stub"
+	}
+	t.Cleanup(func() { suggestName = orig })
+
+	var resp SuggestSessionNameResponse
+	if err := (&controlServer{manager: m}).SuggestSessionName(SuggestSessionNameRequest{}, &resp); err != nil {
+		t.Fatalf("SuggestSessionName: %v", err)
+	}
+	if resp.Name != "captured-stub" {
+		t.Fatalf("handler did not return the generator's output: %q", resp.Name)
+	}
+	if captured == nil {
+		t.Fatal("handler never called the generator")
+	}
+	if !captured("brave-otter") {
+		t.Error("a live session's title must read as taken (the collision set is empty or unwired)")
+	}
+	if !captured("BRAVE-OTTER") {
+		t.Error("the collision check must be case-insensitive")
+	}
+	if captured("some-unused-name") {
+		t.Error("a name no live session holds must read as free")
 	}
 }

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -16,6 +16,7 @@ Request fields are the JSON keys of each route's request body; a `—` means the
 | `POST` | `/v1/CreateSession` | `title`, `title_base`, `repo_path`, `program`, `prompt`, `in_place`, `force_remote`, `backend` | Create a new session (git worktree + agent) in a repo. |
 | `POST` | `/v1/ListBackends` | `repo_path` | List the runtimes a session in this repo can be created on, whether the repo's config supports each, and the backend an unspecified create defaults to. |
 | `POST` | `/v1/ListPrograms` | `repo_path` | List the agent programs a session can be created with, and the program an unspecified create defaults to. |
+| `POST` | `/v1/SuggestSessionName` | — | Suggest a random, readable session name (adjective-noun) not used by any live session, for the create form's autocreate placeholder. |
 | `POST` | `/v1/Snapshot` | `repo_id` | List sessions from the daemon's authoritative in-memory state (empty repo_id = all repos). |
 | `POST` | `/v1/KillSession` | `title`, `repo_id`, `id` | Tear down a session: kill its tmux/agent and remove its worktree and record. |
 | `POST` | `/v1/ArchiveSession` | `title`, `repo_id`, `id` | Archive a session: tear down tmux and relocate its worktree to the archive dir, keeping the record. |

--- a/internal/namegen/namegen.go
+++ b/internal/namegen/namegen.go
@@ -1,0 +1,83 @@
+// Package namegen produces short, readable "adjective-noun" session names
+// (e.g. "brave-otter") for the autocreate-name placeholder (#2470).
+//
+// The wordlist lives HERE, in Go, and only here. It is the single source of
+// truth the daemon serves to the web (the SuggestSessionName RPC) and the TUI
+// calls in-process, so the two surfaces cannot drift and no copy of the list
+// ever reaches TypeScript — the #1970 ruling ("serve the list from the daemon;
+// do not duplicate it in the client"), which parity/enum_coverage_test.go
+// actively enforces by failing on a hardcoded array reappearing in web/src.
+package namegen
+
+import "math/rand/v2"
+
+// maxAttempts bounds the collision-avoidance retries. After it, Suggest returns
+// its last candidate regardless: the name is only a PLACEHOLDER, and every real
+// create still runs through the daemon's authoritative per-repo uniqueness
+// (the title_base auto-suffix walk, daemon/manager_create.go), so a rare
+// residual collision is resolved there rather than papered over with an endless
+// loop here.
+const maxAttempts = 20
+
+// adjectives and nouns are curated to be readable and inoffensive: friendly
+// adjectives and common colours paired with recognizable animals. Every entry
+// is a single lowercase [a-z]+ word, so a joined "adjective-noun" is already a
+// clean git-branch/tmux-safe slug that needs no sanitizing and can never equal
+// the reserved "root" title. namegen_test.go pins those invariants.
+var adjectives = []string{
+	"amber", "azure", "bold", "brave", "bright", "calm", "cheerful", "clever",
+	"cobalt", "coral", "cozy", "crimson", "curious", "daring", "eager", "emerald",
+	"gentle", "golden", "happy", "hazel", "jade", "jolly", "keen", "kind",
+	"lively", "lucky", "mellow", "merry", "nimble", "olive", "plucky", "proud",
+	"quick", "quiet", "rapid", "ruby", "sapphire", "scarlet", "silver", "snappy",
+	"spry", "sunny", "swift", "teal", "tidy", "violet", "vivid", "witty",
+}
+
+var nouns = []string{
+	"badger", "beaver", "bison", "cougar", "dolphin", "egret", "falcon", "ferret",
+	"finch", "fox", "gecko", "gopher", "hare", "heron", "ibis", "iguana",
+	"jackal", "jaguar", "kestrel", "koala", "lemur", "lynx", "magpie", "marmot",
+	"marten", "narwhal", "newt", "ocelot", "osprey", "otter", "panda", "puffin",
+	"quail", "rabbit", "raccoon", "robin", "salmon", "sparrow", "tapir", "urchin",
+	"vole", "walrus", "weasel", "wombat", "yak", "zebra",
+}
+
+// Generator draws names from the wordlists. The rand source is injectable so a
+// test can assert the format and the collision-retry behavior deterministically
+// without reaching into a global — a package-global rand written by a test would
+// race every other test in the package under -race.
+type Generator struct {
+	intn func(n int) int
+}
+
+// NewGenerator returns a Generator backed by the concurrency-safe global rand
+// (math/rand/v2 needs no seeding and is safe for use from multiple goroutines).
+func NewGenerator() *Generator {
+	return &Generator{intn: rand.IntN}
+}
+
+// Random returns one "adjective-noun" name.
+func (g *Generator) Random() string {
+	return adjectives[g.intn(len(adjectives))] + "-" + nouns[g.intn(len(nouns))]
+}
+
+// Suggest returns a name for which taken reports false, regenerating on a
+// collision up to maxAttempts times before giving up and returning the last
+// candidate anyway (see maxAttempts). taken may be nil, meaning "nothing is
+// taken". Callers pass whatever collision rule they enforce downstream — the TUI
+// mirrors the daemon's git.TitlesCollide, the daemon checks its live titles — so
+// the placeholder it shows is one the same surface would not immediately reject.
+func (g *Generator) Suggest(taken func(name string) bool) string {
+	name := g.Random()
+	for i := 0; i < maxAttempts && taken != nil && taken(name); i++ {
+		name = g.Random()
+	}
+	return name
+}
+
+// def is the shared generator behind the package-level helpers.
+var def = NewGenerator()
+
+// Suggest returns a collision-avoiding name from the shared generator; see
+// (*Generator).Suggest.
+func Suggest(taken func(name string) bool) string { return def.Suggest(taken) }

--- a/internal/namegen/namegen_test.go
+++ b/internal/namegen/namegen_test.go
@@ -1,0 +1,131 @@
+package namegen
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// wordRe pins every wordlist entry to a single lowercase [a-z] word. This is the
+// property that lets a joined "adjective-noun" be used verbatim as a session
+// title: it sanitizes to itself as a git branch and a tmux name, and can never
+// equal the reserved "root" title or need trimming.
+var wordRe = regexp.MustCompile(`^[a-z]+$`)
+
+func TestWordlistsAreCleanSlugs(t *testing.T) {
+	for _, group := range []struct {
+		name  string
+		words []string
+	}{
+		{"adjective", adjectives},
+		{"noun", nouns},
+	} {
+		seen := map[string]bool{}
+		for _, w := range group.words {
+			if !wordRe.MatchString(w) {
+				t.Errorf("%s %q is not a single lowercase [a-z] word", group.name, w)
+			}
+			if session.IsReservedTitle(w) {
+				t.Errorf("%s %q collides with the reserved root title", group.name, w)
+			}
+			if seen[w] {
+				t.Errorf("%s %q is duplicated in its list", group.name, w)
+			}
+			seen[w] = true
+		}
+		if len(group.words) < 2 {
+			t.Errorf("%s list is too small (%d) to vary names", group.name, len(group.words))
+		}
+	}
+}
+
+// TestGeneratedNameIsNeverReserved is the belt-and-suspenders check that no
+// adjective-noun pair (not just the individual words) reads as the root title.
+func TestGeneratedNameIsNeverReserved(t *testing.T) {
+	for _, a := range adjectives {
+		for _, n := range nouns {
+			name := a + "-" + n
+			if session.IsReservedTitle(name) {
+				t.Fatalf("generated name %q is reserved", name)
+			}
+			if !wordRe.MatchString(strings.ReplaceAll(name, "-", "")) {
+				t.Fatalf("generated name %q is not a clean slug", name)
+			}
+		}
+	}
+}
+
+// seqGen returns a Generator whose index picks walk a fixed sequence, so the
+// exact names it produces are deterministic.
+func seqGen(seq ...int) *Generator {
+	i := 0
+	return &Generator{intn: func(n int) int {
+		v := seq[i%len(seq)] % n
+		i++
+		return v
+	}}
+}
+
+func TestRandomFormat(t *testing.T) {
+	// First pick indexes adjectives[0], second indexes nouns[0].
+	got := seqGen(0, 0).Random()
+	want := adjectives[0] + "-" + nouns[0]
+	if got != want {
+		t.Fatalf("Random() = %q, want %q", got, want)
+	}
+	if len(strings.Split(got, "-")) != 2 {
+		t.Fatalf("Random() = %q, want exactly one hyphen", got)
+	}
+}
+
+func TestSuggestSkipsTakenNames(t *testing.T) {
+	// Sequence yields adjectives[0]-nouns[0], then adjectives[1]-nouns[1], …
+	g := seqGen(0, 0, 1, 1, 2, 2)
+	first := adjectives[0] + "-" + nouns[0]
+	second := adjectives[1] + "-" + nouns[1]
+	taken := map[string]bool{first: true}
+	got := g.Suggest(func(name string) bool { return taken[name] })
+	if got != second {
+		t.Fatalf("Suggest skipped to %q, want %q (the first free name)", got, second)
+	}
+}
+
+func TestSuggestNilTakenReturnsFirst(t *testing.T) {
+	got := seqGen(3, 4).Suggest(nil)
+	want := adjectives[3] + "-" + nouns[4]
+	if got != want {
+		t.Fatalf("Suggest(nil) = %q, want %q", got, want)
+	}
+}
+
+func TestSuggestGivesUpButStaysValid(t *testing.T) {
+	// taken is always true: Suggest exhausts maxAttempts and returns its last
+	// candidate anyway — still a well-formed name (the daemon's create-time
+	// auto-suffix, not this loop, guarantees final uniqueness).
+	got := seqGen(0, 0).Suggest(func(string) bool { return true })
+	if !wordRe.MatchString(strings.ReplaceAll(got, "-", "")) || len(strings.Split(got, "-")) != 2 {
+		t.Fatalf("Suggest gave up with a malformed name %q", got)
+	}
+}
+
+func TestPackageSuggestUsesSharedGenerator(t *testing.T) {
+	// The exported helpers must actually draw from the wordlists.
+	name := Suggest(nil)
+	parts := strings.Split(name, "-")
+	if len(parts) != 2 {
+		t.Fatalf("Suggest(nil) = %q, want adjective-noun", name)
+	}
+	adj := map[string]bool{}
+	for _, a := range adjectives {
+		adj[a] = true
+	}
+	noun := map[string]bool{}
+	for _, n := range nouns {
+		noun[n] = true
+	}
+	if !adj[parts[0]] || !noun[parts[1]] {
+		t.Fatalf("Suggest(nil) = %q, not drawn from the wordlists", name)
+	}
+}

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -1443,6 +1443,7 @@
       "POST /v1/SetConfigValue": "config.write",
       "POST /v1/SetPRInfo": "session.pr.set",
       "POST /v1/Snapshot": "session.list",
+      "POST /v1/SuggestSessionName": "-",
       "POST /v1/TriggerTask": "task.trigger",
       "POST /v1/UpdateTask": "task.edit"
     },
@@ -1517,6 +1518,7 @@
       "ResumeFromLimit": "session.limit-retry",
       "SetConfigValue": "config.write",
       "Snapshot": "session.list",
+      "SuggestSessionName": "-",
       "TriggerTask": "task.trigger",
       "UpdateTask": "task.edit"
     },

--- a/ui/sidebar_model.go
+++ b/ui/sidebar_model.go
@@ -219,6 +219,13 @@ func (s *Sidebar) SetSize(width, height int) {
 	s.renderer.SetWidth(s.contentWidth())
 }
 
+// SetNamingPlaceholder threads the autocreate-name shadow text (#2470) from the
+// app's naming state down to the row renderer: while inst is being named with an
+// empty title, its row shows text as muted placeholder. (nil, "") clears it.
+func (s *Sidebar) SetNamingPlaceholder(inst *session.Instance, text string) {
+	s.renderer.SetNamePlaceholder(inst, text)
+}
+
 // contentWidth is the effective row width inside the sidebar allocation: the
 // full width minus the 2-cell row padding the row styles add. This replaces
 // the pre-cutover AdjustPreviewWidth 0.9 buffer (#1024 PR 4) — the tree gets

--- a/ui/tree/render.go
+++ b/ui/tree/render.go
@@ -170,6 +170,11 @@ var tabRowSelectedStyle = lipgloss.NewStyle().
 // the background (#844, #853).
 var deletingTitleColor lipgloss.TerminalColor = lipgloss.Color("#989890")
 
+// placeholderTitleColor renders the autocreate-name shadow text (#2470) in the
+// muted foreground so it reads as a suggestion, not a real name — the same
+// treatment the task/prompt forms give their placeholders.
+var placeholderTitleColor lipgloss.TerminalColor = lipgloss.Color("#989890")
+
 // ApplyTheme rebuilds package-level tree styles after the TUI palette changes.
 func ApplyTheme(t Theme) {
 	readyStyle = lipgloss.NewStyle().Foreground(t.Success)
@@ -201,6 +206,7 @@ func ApplyTheme(t Theme) {
 		Background(t.SelectionBackground).
 		Foreground(t.SelectionForeground)
 	deletingTitleColor = t.ForegroundMuted
+	placeholderTitleColor = t.ForegroundMuted
 }
 
 // InstanceRenderer renders the tree's rows: session.Instance rows (absorbed
@@ -210,6 +216,15 @@ type InstanceRenderer struct {
 	// usable column (its rect minus row padding), keeping the layout math in
 	// one place outside this package.
 	width int
+	// namingInstance and namePlaceholder drive the autocreate-name shadow text
+	// (#2470): while an instance with an EMPTY title is being named, its row shows
+	// namePlaceholder in muted foreground instead of a blank name. Keyed by pointer
+	// identity so only the one row being named shows it, and it vanishes the instant
+	// the title is non-empty (the user typed a character). Set by the sidebar from
+	// the app's naming state; the zero value means "not naming", so every other
+	// caller (and every existing test) renders exactly as before.
+	namingInstance  *session.Instance
+	namePlaceholder string
 }
 
 // NewInstanceRenderer creates a renderer.
@@ -220,6 +235,14 @@ func NewInstanceRenderer() *InstanceRenderer {
 // SetWidth sets the effective content width rows render into.
 func (r *InstanceRenderer) SetWidth(width int) {
 	r.width = width
+}
+
+// SetNamePlaceholder sets the instance whose empty-title row shows shadow text,
+// and that text (#2470). Passing (nil, "") clears it — the state the renderer
+// carries between naming sessions.
+func (r *InstanceRenderer) SetNamePlaceholder(inst *session.Instance, text string) {
+	r.namingInstance = inst
+	r.namePlaceholder = text
 }
 
 // branchIcon is the real terminal branch glyph ⎇ (U+2387), matching the web
@@ -320,6 +343,16 @@ func (r *InstanceRenderer) Render(i *session.Instance, _ int, selected bool, has
 
 	// Cut the title if it's too long
 	titleText := i.Title
+	// Autocreate-name shadow text (#2470): a row being named with an empty title
+	// shows the suggested name in muted foreground. The check is exact-empty, not
+	// trimmed, so typing any character (a space included) reveals the real title and
+	// hides the placeholder — flowing the suggestion through the same truncation and
+	// prefix logic below, just recoloured.
+	placeholder := i == r.namingInstance && i.Title == "" && r.namePlaceholder != ""
+	if placeholder {
+		titleText = r.namePlaceholder
+		titleS = titleS.Foreground(placeholderTitleColor)
+	}
 	if i.Capabilities().Workspace == session.WorkspaceRemote {
 		titleText = "[remote] " + titleText
 	}

--- a/ui/tree/render_test.go
+++ b/ui/tree/render_test.go
@@ -51,6 +51,52 @@ func TestInstanceRendererRemoteBadge(t *testing.T) {
 		"a local instance must not carry the [remote] badge")
 }
 
+// TestInstanceRendererNamePlaceholder pins the autocreate-name shadow text
+// (#2470): the row of the instance being named shows the suggested name while its
+// title is empty, and only that row, and only while empty.
+func TestInstanceRendererNamePlaceholder(t *testing.T) {
+	mk := func(title string) *session.Instance {
+		inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: t.TempDir(), Program: "test"})
+		require.NoError(t, err)
+		return inst
+	}
+	naming := mk("")
+	other := mk("beta")
+
+	r := NewInstanceRenderer()
+	r.SetWidth(60)
+	r.SetNamePlaceholder(naming, "brave-otter")
+
+	plain := func(inst *session.Instance) string {
+		return ansiEscape.ReplaceAllString(r.Render(inst, 1, true, false, false), "")
+	}
+
+	// The empty-title naming row shows the placeholder.
+	assert.Contains(t, plain(naming), "brave-otter",
+		"the named row must show the suggested name as shadow text")
+
+	// A different instance never borrows the placeholder.
+	assert.NotContains(t, plain(other), "brave-otter",
+		"only the named instance's row shows the placeholder")
+	assert.Contains(t, plain(other), "beta")
+
+	// The instant the title is non-empty the placeholder is gone — even a single
+	// space counts as "the user typed".
+	require.NoError(t, naming.SetTitle(" "))
+	assert.NotContains(t, plain(naming), "brave-otter",
+		"typing any character hides the placeholder")
+
+	require.NoError(t, naming.SetTitle("typed"))
+	out := plain(naming)
+	assert.Contains(t, out, "typed")
+	assert.NotContains(t, out, "brave-otter")
+
+	// Cleared placeholder shows nothing special on the (re-emptied) row.
+	require.NoError(t, naming.SetTitle(""))
+	r.SetNamePlaceholder(nil, "")
+	assert.NotContains(t, plain(naming), "brave-otter", "a cleared placeholder is not rendered")
+}
+
 // effectiveWidth models a sidebar-style content buffer (narrower than the
 // allocation) so the renderer tests exercise an effective content width the
 // way the sidebar passes one to SetWidth in production. Inlined rather than

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6263,6 +6263,10 @@ async function listBackends(repoPath, token2) {
 async function listPrograms(repoPath, token2) {
   return af("ListPrograms", { repo_path: repoPath }, token2);
 }
+async function suggestSessionName(token2) {
+  const resp = await af("SuggestSessionName", {}, token2);
+  return resp?.name ?? "";
+}
 async function createSession(input, token2) {
   const body = {
     title_base: input.title,
@@ -6553,6 +6557,7 @@ function newSessionModal(projects, defaultProject2, callbacks) {
   });
   const titleInput = h("input", { type: "text", class: "af-input", placeholder: "Session title", autocomplete: "off" });
   titleInput.setAttribute("aria-label", "Session title");
+  let suggestedName = "";
   const projectSelect = h("select", { class: "af-input" });
   projectSelect.setAttribute("aria-label", "Project");
   if (projects.length === 0) {
@@ -6655,11 +6660,23 @@ function newSessionModal(projects, defaultProject2, callbacks) {
   renderPrograms();
   renderChoices();
   loadCatalogsFor(projectSelect.value);
+  void callbacks.suggestName().then((name) => {
+    if (name !== "") {
+      suggestedName = name;
+      titleInput.placeholder = name;
+    }
+  }).catch(() => {
+  });
   const card = handle.el.firstElementChild;
   asForm(card, () => {
-    const title = titleInput.value.trim();
-    if (title === "" || projectSelect.value === "") {
-      handle.setError("A title and a project are required.");
+    const typed = titleInput.value.trim();
+    const title = typed !== "" ? typed : suggestedName;
+    if (projectSelect.value === "") {
+      handle.setError("A project is required.");
+      return;
+    }
+    if (title === "") {
+      handle.setError("A title is required.");
       return;
     }
     handle.setError(null);
@@ -12652,6 +12669,9 @@ function newSession() {
       loadBackends: (repoPath) => token === null ? Promise.reject(new Error("not authorized")) : listBackends(repoPath, token),
       // The agent catalog, same contract (#1970): the daemon owns the enum.
       loadPrograms,
+      // The autocreate-name suggestion (#2470): the daemon owns the wordlist, so
+      // the web asks rather than generating a name of its own.
+      suggestName: () => token === null ? Promise.reject(new Error("not authorized")) : suggestSessionName(token),
       onSubmit: (values) => {
         const tok = token;
         if (tok === null || !modal) {

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "85a605d16a8b";
+const VERSION = "4274b237d63f";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "14b7b5c1b45f";
+const VERSION = "85a605d16a8b";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -28,6 +28,7 @@ import {
   reorderTab,
   restoreSession,
   resumeFromLimit,
+  suggestSessionName,
   triggerTask,
   updateTask,
 } from "./api.js";
@@ -175,6 +176,19 @@ test("listPrograms works with no repo picked", async () => {
 
   assert.equal(cap.url, "/v1/ListPrograms");
   assert.equal(cap.body.repo_path, "");
+});
+
+// The autocreate-name suggestion (#2470). The daemon owns the wordlist, so the web
+// asks for one name and renders it; it sends no arguments (the suggestion is
+// repo-agnostic) and reads `name` out of the envelope.
+test("suggestSessionName asks the daemon and returns the name", async () => {
+  const cap = stubFetch(); // envelope data carries name: "shell"
+  const name = await suggestSessionName("tok");
+
+  assert.equal(cap.url, "/v1/SuggestSessionName");
+  assert.equal(cap.auth, "Bearer tok");
+  assert.deepEqual(cap.body, {}, "the suggestion takes no arguments");
+  assert.equal(name, "shell", "the resolved name is read from the envelope");
 });
 
 test("killSession posts the stable id as the primary key alongside the title", async () => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -354,6 +354,16 @@ export async function listPrograms(repoPath: string, token: string): Promise<Pro
   return af<ProgramCatalog>("ListPrograms", { repo_path: repoPath }, token);
 }
 
+/** Asks the daemon for a random, readable "adjective-noun" session name not used
+ *  by any live session (#2470), for the create form's autocreate placeholder. The
+ *  wordlist is Go-only (the #1970 "serve the list, don't duplicate it" ruling), so
+ *  the web never generates names itself — it shows this and, on an empty submit,
+ *  sends it back as the title. Returns "" if the daemon has no suggestion. */
+export async function suggestSessionName(token: string): Promise<string> {
+  const resp = await af<{ name: string }>("SuggestSessionName", {}, token);
+  return resp?.name ?? "";
+}
+
 /** Creates a session and returns the daemon's authoritative projection of it (the
  *  resolved title + stable id). The created row also arrives via /v1/events. */
 export async function createSession(input: CreateSessionInput, token: string): Promise<SessionData> {

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -32,6 +32,7 @@ import {
   listBackends,
   listProjects,
   listPrograms,
+  suggestSessionName,
   listTasks,
   setConfigValue,
   loadToken,
@@ -611,6 +612,9 @@ function newSession(): void {
       loadBackends: (repoPath: string) => (token === null ? Promise.reject(new Error("not authorized")) : listBackends(repoPath, token)),
       // The agent catalog, same contract (#1970): the daemon owns the enum.
       loadPrograms,
+      // The autocreate-name suggestion (#2470): the daemon owns the wordlist, so
+      // the web asks rather than generating a name of its own.
+      suggestName: () => (token === null ? Promise.reject(new Error("not authorized")) : suggestSessionName(token)),
       onSubmit: (values: CreateSessionInput) => {
         const tok = token;
         // `=== null` not `!tok`: "" is the authorized-tokenless credential (#1696).

--- a/web/src/modals.ts
+++ b/web/src/modals.ts
@@ -152,6 +152,9 @@ export function newSessionModal(
     onCancel: () => void;
     loadBackends: (repoPath: string) => Promise<BackendCatalog>;
     loadPrograms: (repoPath: string) => Promise<ProgramCatalog>;
+    // #2470: fetch a random, readable session name from the daemon (the wordlist
+    // is Go-only) to show as shadow text; an empty submit adopts it.
+    suggestName: () => Promise<string>;
   },
 ): ModalHandle {
   const { handle, body, confirmBtn } = modalChrome({
@@ -163,6 +166,11 @@ export function newSessionModal(
 
   const titleInput = h("input", { type: "text", class: "af-input", placeholder: "Session title", autocomplete: "off" });
   titleInput.setAttribute("aria-label", "Session title");
+  // #2470: the daemon-suggested autocreate name. Shown as the title placeholder
+  // (shadow text that clears the instant the user types) and, when the field is
+  // submitted empty, used as the session name. "" until the fetch lands or if it
+  // fails — in which case the field falls back to requiring a typed title.
+  let suggestedName = "";
 
   const projectSelect = h("select", { class: "af-input" });
   projectSelect.setAttribute("aria-label", "Project");
@@ -328,11 +336,35 @@ export function newSessionModal(
   renderChoices();
   loadCatalogsFor(projectSelect.value);
 
+  // Ask for the autocreate name once, on open. Repo-agnostic (the daemon avoids
+  // every live title), so it needs no re-fetch on a project change. A failure is
+  // silent: the field keeps its static placeholder and simply requires a typed
+  // title, exactly as before this feature.
+  void callbacks
+    .suggestName()
+    .then((name) => {
+      if (name !== "") {
+        suggestedName = name;
+        titleInput.placeholder = name;
+      }
+    })
+    .catch(() => {
+      /* no suggestion — leave the static placeholder and the typed-title requirement */
+    });
+
   const card = handle.el.firstElementChild as HTMLElement;
   asForm(card, () => {
-    const title = titleInput.value.trim();
-    if (title === "" || projectSelect.value === "") {
-      handle.setError("A title and a project are required.");
+    // #2470: an empty field adopts the suggested name (the shadow text). The
+    // placeholder already equals suggestedName, so submitting untouched creates
+    // exactly the name the user saw.
+    const typed = titleInput.value.trim();
+    const title = typed !== "" ? typed : suggestedName;
+    if (projectSelect.value === "") {
+      handle.setError("A project is required.");
+      return;
+    }
+    if (title === "") {
+      handle.setError("A title is required.");
       return;
     }
     handle.setError(null);


### PR DESCRIPTION
Closes #2470.

Both the web New Session modal and the TUI create input now show a random,
readable **adjective-noun** name (e.g. `brave-otter`) as shadow/placeholder text.
It clears the instant the user types, and **submitting the field empty adopts it
as the session name** — the "autocreate".

## Design — one wordlist, no client copy

The wordlist lives in a new **`internal/namegen`** package, in Go, and is never
duplicated into TypeScript — the #1970 ruling ("serve the list from the daemon,
don't re-implement it in the client"), which `parity/enum_coverage_test.go`
actively enforces. So the two surfaces share one source of truth:

- **TUI** calls `namegen` in-process. `startNewInstance` generates a name that
  avoids the reserved `root` title and any `git.TitlesCollide` conflict — the
  same rule the enter handler enforces — stores it, and renders it as muted
  shadow text on the naming row (keyed by pointer identity, exact-empty-title so
  one typed character hides it). Enter on the untouched field adopts it.
- **Web** asks the daemon via a new read-only `SuggestSessionName` RPC that
  serves one name avoiding every live title. The modal shows it as the title
  placeholder and, on an empty submit, echoes it as `title_base` (the daemon
  still auto-suffixes any create-time collision). A fetch failure degrades to the
  old typed-title requirement.

The suggestion RPC is best-effort and deliberately **not** gated on manager
readiness — it answers during the restore window like the other read-only lookups
(`Snapshot`/`ListBackends`), so it is classified `allowedDuringProbation`. The
authoritative per-repo uniqueness still runs at create time.

## Tests

- `internal/namegen`: format, collision-retry, and reserved-title avoidance,
  driven by a deterministic rand source.
- `ui/tree`: the renderer shows the placeholder on the empty naming row, hides it
  the moment the title is non-empty, and shows it for that row only — asserted on
  real rendered output.
- `app`: an empty submit adopts the placeholder as the title; both cancel paths
  (Esc / ctrl+c) clear it.
- `daemon`: `SuggestSessionName` returns a well-formed name and never echoes a
  live session's title.
- `web`: `suggestSessionName` posts `SuggestSessionName` and reads the name.
- Route **and** web RPC added to `parity/inventory.json` (`"-"`, create-form
  plumbing like `DeliverPrompt`); `docs/reference/api.md` regenerated.

## Gate

`gofmt`, `go build ./...`, `golangci-lint --fast`, `deadcode -test ./...`,
`scripts/lint-file-length.sh`, **`make test-container`** (all packages incl.
`daemon`, `app`, `ui`, `parity`), web `typecheck` + 428 tests, `make web-build`
(committed dist regenerated) — all green.

**Verification note:** the TUI behavior is pinned on real rendered output
(`InstanceRenderer.Render`) plus the model-level submit/cancel flow; the web
behavior is covered by the wire test + the daemon handler test + `tsc`. I did not
drive a live browser here — relying on CI's web-selftest for the live-web smoke.
Happy to do a live drive if you'd like before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
