### PR TITLE
fix(web): forward Escape to the agent as its interrupt; ctrl+] detaches (#2517)

### DIFF
--- a/docs/web-selftest.md
+++ b/docs/web-selftest.md
@@ -60,7 +60,7 @@ Against the live SPA served over the daemon's plain-HTTP listener:
 | **Login** | Pasting the daemon token into the login form renders the authed app. |
 | **Sidebar** | The rail lists the seeded sessions from the Snapshot/events plane, and the client reports an open event stream (`.af-app[data-live="open"]`). |
 | **Attach** | Click-to-attach opens the xterm terminal and shows the fake agent's live output (a real binary PTY frame decoded by the TS codec and painted in the browser). |
-| **Keyboard (#1694)** | In the sessions view's rail mode `j`/`k` navigate the rail; `Enter` attaches the selection; `Escape` returns to the rail. |
+| **Keyboard (#1694/#2517)** | In the sessions view's rail mode `j`/`k` navigate the rail; `Enter` attaches the selection; `ctrl+]` returns to the rail; `Escape` forwards to the agent as its interrupt (the ESC byte reaches the PTY and focus stays in the terminal). |
 | **View cycling (#1694/PR8)** | In rail mode `]` cycles the top-level view forward (sessions → tasks) and `[` cycles it back (tasks → sessions), the active view tab following each step. |
 | **Tabs (#1592 PR7)** | The tab bar creates a shell tab (`+` / `t`), switches to it (click / `1`-`9`) and shows its distinct PTY output, and closes it (`×` / `w`) — the agent tab stays unclosable. |
 | **Create** | The **+ New** modal creates a session and its row appears in the rail. |

--- a/docs/web.md
+++ b/docs/web.md
@@ -335,12 +335,14 @@ keyboard never surprises you:
   attach — it just highlights a row. j/k always navigate, even after you've been
   typing to an agent.
 - **`Enter` attaches** the selected session: the main pane's terminal takes the
-  keyboard, and keystrokes now flow to the agent.
-- **`Escape` detaches**, handing the keyboard back to the rail. (The Escape is
-  swallowed — it never leaks a stray byte to the agent.)
+  keyboard, and keystrokes now flow to the agent — **including `Escape`**, which is
+  the agents' interrupt key (it cancels the current turn), exactly as in the TUI.
+- **`ctrl+]` detaches**, handing the keyboard back to the rail — the same detach
+  chord the TUI uses. (`Escape` is *not* a detach: it goes to the agent.)
 - **Clicking a row** does both at once: it selects *and* attaches, the same as
   `Enter` on that row. Clicking directly into the terminal also attaches; clicking
-  or tabbing away returns to rail navigation.
+  or tabbing away (or, on mobile, opening the rail drawer) returns to rail
+  navigation — so you are never trapped even without `ctrl+]`.
 
 The pane you're driving is highlighted with an accent border, so the active mode is
 always legible.
@@ -624,14 +626,18 @@ editor. Tab navigation (`1`–`9`, the sidebar tree) treats it like any other ta
 | --- | --- |
 | `j` / `k`, `↓` / `↑` | Move the rail selection (never attaches) |
 | `Enter` | Attach the selected session's terminal |
-| `Escape` | Detach — return the keyboard to the rail (or close a modal) |
+| `ctrl+]` | Detach — return the keyboard to the rail |
+| `Escape` | Interrupt the agent (forwarded to the terminal); closes an open modal/menu first |
 | `1`–`9` | Switch to that tab of the selected session |
 | `t` | New shell tab in the worktree |
 | `w` | Close the active shell tab (tab 0, the agent, is unclosable) |
 | `[` / `]` | Cycle the top-level view (Sessions → Tasks) |
 
 `[` / `]` work in every view; the rest are the Sessions view's session/tab keys.
-While a terminal is attached, all keys except `Escape` flow to the agent.
+While a terminal is attached, **every** key flows to the agent — `Escape` included,
+as the interrupt — and only `ctrl+]` detaches. An open modal or menu still takes
+`Escape` to close itself. (No keyboard? Click the rail, or open the mobile rail
+drawer, to detach.)
 
 ---
 

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7423,7 +7423,7 @@ function decideKey(key, ctx, mods = {}) {
     return { kind: "closePane" };
   }
   if (ctx.focus === "terminal") {
-    return key === "Escape" ? { kind: "toRail" } : { kind: "none" };
+    return mods.ctrl === true && key === "]" ? { kind: "toRail" } : { kind: "none" };
   }
   if (key === "[") {
     return { kind: "switchView", view: cycleView(ctx.view, -1) };
@@ -13169,7 +13169,7 @@ function onKeydown(e) {
       activeTab: state.activeTab,
       tabManagement: actionableSelected ? canManageTabs(actionableSelected) : false
     },
-    { alt: e.altKey }
+    { alt: e.altKey, ctrl: e.ctrlKey }
   );
   if (action.kind === "none") {
     return;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7422,8 +7422,11 @@ function decideKey(key, ctx, mods = {}) {
     }
     return { kind: "closePane" };
   }
+  if (key === "]" && mods.ctrl === true && mods.alt !== true && mods.altGraph !== true) {
+    return ctx.focus === "terminal" ? { kind: "toRail" } : { kind: "none" };
+  }
   if (ctx.focus === "terminal") {
-    return mods.ctrl === true && key === "]" ? { kind: "toRail" } : { kind: "none" };
+    return { kind: "none" };
   }
   if (key === "[") {
     return { kind: "switchView", view: cycleView(ctx.view, -1) };
@@ -13169,7 +13172,7 @@ function onKeydown(e) {
       activeTab: state.activeTab,
       tabManagement: actionableSelected ? canManageTabs(actionableSelected) : false
     },
-    { alt: e.altKey, ctrl: e.ctrlKey }
+    { alt: e.altKey, ctrl: e.ctrlKey, altGraph: e.getModifierState("AltGraph") }
   );
   if (action.kind === "none") {
     return;

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "bceb4a9916ae";
+const VERSION = "59e584708334";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "58ea0e763e45";
+const VERSION = "bceb4a9916ae";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -13,7 +13,8 @@
 //                      literal "[object Object]" the string/object envelope fork gave
 //   2. sidebar         the rail lists the sessions from the Snapshot/events plane
 //   3. attach          click-to-attach opens the xterm terminal + shows live output
-//   4. keyboard (#1694) j/k navigate the rail, Enter attaches, Escape returns to rail
+//   4. keyboard (#1694/#2517) j/k navigate the rail, Enter attaches, ctrl+] returns to
+//      rail, and Escape forwards to the agent as its interrupt
 //   5. create          the + New modal creates a session; its row appears
 //   6. kill            the kill confirm removes the session's row
 //   7. archive         the archive confirm moves a session to the archived group
@@ -1366,10 +1367,12 @@ test("#2337: agent Shift+Enter preserves xterm input effects while shell keeps C
   }
 });
 
-test("the #1694 keyboard model: j/k navigate, Enter attaches, Escape returns to rail", REAL_FIXTURE, async () => {
-  // We are attached to A (terminal mode from the previous flow). Escape is the one
-  // hatch back to the rail — no stray ESC byte leaks to the PTY.
-  await page.keyboard.press("Escape");
+test("the #1694 keyboard model: j/k navigate, Enter attaches, ctrl+] returns to rail", REAL_FIXTURE, async () => {
+  // We are attached to A (terminal mode from the previous flow). ctrl+] is the one
+  // KEYBOARD hatch back to the rail (#2517, mirroring the TUI's tea.KeyCtrlCloseBracket)
+  // — no stray byte leaks to the PTY. Escape is no longer a detach (it interrupts the
+  // agent); the dedicated interrupt-forwarding test below proves that on the PTY.
+  await page.keyboard.press("Control+]");
   await expect(page.locator(".af-app.af-kb-rail")).toBeVisible();
   await expect(row(page, SESSION_A)).toHaveClass(/af-row-selected/);
 
@@ -1393,17 +1396,73 @@ test("the #1694 keyboard model: j/k navigate, Enter attaches, Escape returns to 
   await page.keyboard.press("Enter");
   await expect(page.locator(".af-app.af-kb-terminal")).toBeVisible();
 
-  // Escape detaches back to the rail, completing the round trip.
-  await page.keyboard.press("Escape");
+  // ctrl+] detaches back to the rail, completing the round trip.
+  await page.keyboard.press("Control+]");
   await expect(page.locator(".af-app.af-kb-rail")).toBeVisible();
 });
 
+test("#2517: Escape interrupts the agent (forwards down the PTY) and never detaches; ctrl+] detaches without leaking", REAL_FIXTURE, async ({
+  browser,
+}) => {
+  // The bug: Escape is the agents' interrupt key (#2070), but the web consumed it as a
+  // detach so a running agent could never be interrupted. Proof on the REAL browser +
+  // PTY: with the terminal focused, Escape emits exactly one OpInput carrying the ESC
+  // byte (0x1b) and the keyboard STAYS in terminal mode; ctrl+] is the detach and never
+  // reaches the PTY.
+  const ctx = await browser.newContext();
+  const p = await ctx.newPage();
+  const inputPayloads: number[][] = [];
+  p.on("websocket", (ws) => {
+    if (!ws.url().includes("/v1/sessions/") || !ws.url().includes("/stream")) {
+      return;
+    }
+    ws.on("framesent", ({ payload }) => {
+      const raw = typeof payload === "string" ? new TextEncoder().encode(payload) : new Uint8Array(payload);
+      const frame = decode(raw);
+      if (frame.op === Op.Input) {
+        inputPayloads.push(Array.from(frame.data));
+      }
+    });
+  });
+
+  try {
+    await openTokenless(p);
+    await row(p, SESSION_A).click();
+    await expect(p.locator(".af-term-host .xterm")).toBeVisible();
+    await expect(p.locator(".af-main")).toHaveAttribute("data-term-status", "open");
+    await expect(p.locator(".af-app.af-kb-terminal")).toBeVisible();
+
+    // Escape FORWARDS to the agent as its interrupt, exactly like every other key.
+    inputPayloads.length = 0;
+    await p.keyboard.press("Escape");
+    await expect
+      .poll(() => inputPayloads.length, { message: "Escape must reach the agent — it is the interrupt key" })
+      .toBe(1);
+    expect(inputPayloads[0], "Escape forwards the ESC byte (0x1b) down the PTY").toEqual([0x1b]);
+    await expect(
+      p.locator(".af-app.af-kb-terminal"),
+      "Escape must NOT detach — focus stays in the terminal so the user can keep driving the agent",
+    ).toBeVisible();
+
+    // ctrl+] is the sole keyboard detach; it is consumed by the app and never leaks a
+    // byte into the PTY.
+    inputPayloads.length = 0;
+    await p.keyboard.press("Control+]");
+    await expect(p.locator(".af-app.af-kb-rail"), "ctrl+] detaches back to the rail").toBeVisible();
+    await expect(row(p, SESSION_A)).toHaveClass(/af-row-selected/);
+    expect(inputPayloads, "the ctrl+] detach chord must not reach the agent").toEqual([]);
+  } finally {
+    await ctx.close();
+  }
+});
+
 test("the #1694 keyboard model: [ / ] cycle the top-level view (sessions → tasks → config)", REAL_FIXTURE, async () => {
-  // Rail mode from the previous flow. [ / ] cycle the top-level view; they fire in
-  // rail mode only (a modal or focused terminal would swallow them). After Escape
-  // the active element is document.body, so the document-level capture-phase keydown
-  // listener (index.ts) handles the press. The Projects view is gone (redesign PR2);
-  // the config view joins the cycle with the config editor.
+  // Rail mode from the previous flow (the prior test ended by detaching with ctrl+]).
+  // [ / ] cycle the top-level view; they fire in rail mode only (a modal or focused
+  // terminal would swallow them). In rail mode the active element is document.body, so
+  // the document-level capture-phase keydown listener (index.ts) handles the press. The
+  // Projects view is gone (redesign PR2); the config view joins the cycle with the
+  // config editor.
   const active = (view: string) =>
     expect(page.locator(`.af-viewtab[data-view="${view}"]`)).toHaveClass(/af-viewtab-active/);
   await active("sessions");
@@ -1552,9 +1611,9 @@ test("tabs: create a shell tab, switch to it, see its distinct output, close it 
   await page.keyboard.press("Enter");
   await expect(page.locator(".af-term-host")).toContainText("AF_TAB_OUTPUT_OK", { timeout: 15_000 });
 
-  // 1-9 switch tabs in rail nav mode: Escape back to the rail, then 1 selects the
-  // agent tab and 2 the shell tab — the active highlight follows the digit.
-  await page.keyboard.press("Escape");
+  // 1-9 switch tabs in rail nav mode: ctrl+] back to the rail (#2517), then 1 selects
+  // the agent tab and 2 the shell tab — the active highlight follows the digit.
+  await page.keyboard.press("Control+]");
   await expect(page.locator(".af-app.af-kb-rail")).toBeVisible();
   await page.keyboard.press("1");
   await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Agent");
@@ -3568,7 +3627,7 @@ test("filter (feat): keyboard nav walks the VISIBLE rows — j never lands on a 
   // session the user cannot see in the rail, with no row highlighted.
   await setFilter(page, "archived", false);
   await row(page, SESSION_A).click();
-  await page.keyboard.press("Escape"); // hand the keyboard back to the rail
+  await page.keyboard.press("Control+]"); // hand the keyboard back to the rail (#2517)
 
   const visited: string[] = [];
   const rows = await page.locator(".af-rail-list .af-row").count();
@@ -5694,10 +5753,10 @@ test("vscode tab (#2077): the labelled New tab menu creates a VS Code tab and se
   // is an iframe with no xterm, so there is nothing to attach to. Before the
   // SplitView.focus() boolean contract, focusTerminal() committed the app to
   // focus:"terminal" anyway and the xterm focus silently no-opped, leaving nav.ts
-  // resolving every non-Escape key to {kind:"none"}: j/k/digits/t/w reached neither a
-  // terminal nor the rail handler, so the user was stuck until they pressed Escape.
-  // (The same trap predates VS Code — it applies to any web tab opened from the tab
-  // bar — which is why the fallback lives in focusTerminal rather than this path.)
+  // resolving every key but the ctrl+] detach to {kind:"none"}: j/k/digits/t/w reached
+  // neither a terminal nor the rail handler, so the user was stuck until they pressed
+  // ctrl+] (#2517). (The same trap predates VS Code — it applies to any web tab opened
+  // from the tab bar — which is why the fallback lives in focusTerminal rather than here.)
   await expect(
     page.locator(".af-app.af-kb-rail"),
     "creating a tab with no terminal must fall back to rail mode, not claim terminal mode",

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -1658,7 +1658,7 @@ function onKeydown(e: KeyboardEvent): void {
       activeTab: state.activeTab,
       tabManagement: actionableSelected ? canManageTabs(actionableSelected) : false,
     },
-    { alt: e.altKey, ctrl: e.ctrlKey },
+    { alt: e.altKey, ctrl: e.ctrlKey, altGraph: e.getModifierState("AltGraph") },
   );
   if (action.kind === "none") {
     // Not ours — including Escape while a terminal is focused, which now FORWARDS to

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -219,9 +219,9 @@ function mount(): void {
 
   // The keyboard/focus state machine (#1693), wired once at the document level in
   // the CAPTURE phase so it decides BEFORE xterm's textarea handler: in rail mode
-  // j/k always navigate; in terminal mode keys fall through to the agent except
-  // Escape, which we swallow here (stopPropagation) so detaching never leaks a
-  // stray ESC byte into the PTY.
+  // j/k always navigate; in terminal mode keys fall through to the agent — Escape
+  // included, so it can interrupt the agent (#2517) — and only the ctrl+] detach
+  // chord is swallowed here (stopPropagation) so it never leaks into the PTY.
   document.addEventListener("keydown", onKeydown, true);
 
   // Follow the OS theme while the choice is Auto (redesign PR1).
@@ -421,9 +421,9 @@ function openFromRail(id: string): void {
  *  When the focused pane has NO terminal — a web or VS Code tab, which renders an
  *  iframe — there is nothing to attach to, so we fall back to the rail instead of
  *  claiming "terminal" mode over a terminal that does not exist. That state strands
- *  the user: nav.ts resolves every non-Escape key to {kind:"none"} while focus is
- *  "terminal", so j/k/digits/t/w reach neither an xterm nor the rail handler and are
- *  silently swallowed until Escape.
+ *  the user: nav.ts resolves every key but the ctrl+] detach to {kind:"none"} while
+ *  focus is "terminal", so j/k/digits/t/w reach neither an xterm nor the rail handler
+ *  and are silently swallowed until ctrl+] (or a non-keyboard rail exit).
  *
  *  The decision lives HERE, behind SplitView.focus()'s boolean, rather than at each
  *  call site: openTab, createSessionTab and openFromRail all route through this
@@ -448,8 +448,8 @@ function focusTerminal(): void {
   store.set({ focus: "terminal" });
 }
 
-/** Returns the keyboard to the rail (Escape / detach): blurs every pane so
- *  document-level j/k navigate again. */
+/** Returns the keyboard to the rail (ctrl+] / detach, or a non-keyboard rail exit):
+ *  blurs every pane so document-level j/k navigate again. */
 function focusRail(): void {
   store.set({ focus: "rail" });
   splitView.blur();
@@ -1613,9 +1613,9 @@ function onKeydown(e: KeyboardEvent): void {
   }
   // Let native controls handle their own keys, EXCEPT the terminal (whose textarea
   // lives in termHost and is driven by the nav state machine) and Escape (which must
-  // still close a modal / detach the terminal even from a focused field). Without
-  // this a focused + New / Disconnect / pane-action button would have its Enter
-  // hijacked as an attach, and modal typing would move the rail.
+  // still close a modal even from a focused field). Without this a focused + New /
+  // Disconnect / pane-action button would have its Enter hijacked as an attach, and
+  // modal typing would move the rail.
   const target = e.target as HTMLElement | null;
   const inTerminal = target ? termHost.contains(target) : false;
   if (!inTerminal && e.key !== "Escape" && isNativeControl(target)) {
@@ -1658,14 +1658,20 @@ function onKeydown(e: KeyboardEvent): void {
       activeTab: state.activeTab,
       tabManagement: actionableSelected ? canManageTabs(actionableSelected) : false,
     },
-    { alt: e.altKey },
+    { alt: e.altKey, ctrl: e.ctrlKey },
   );
   if (action.kind === "none") {
+    // Not ours — including Escape while a terminal is focused, which now FORWARDS to
+    // the agent as its interrupt (#2517). Returning without preventDefault lets the
+    // capture-phase event continue to xterm's textarea, so the ESC goes down the PTY
+    // like every other key. (An open menu's own capture listener still stops Escape
+    // and closes itself before xterm sees it — see ui.ts.)
     return;
   }
   // A handled key is ours: preventDefault AND stopPropagation so it never also
-  // reaches xterm's textarea (capture phase) — this is what suppresses the stray
-  // ESC byte when Escape detaches the terminal.
+  // reaches xterm's textarea (capture phase). This is what keeps the ctrl+] detach
+  // chord from leaking into the PTY; a plain "]" is not handled here, so it still
+  // reaches the agent.
   e.preventDefault();
   e.stopPropagation();
   switch (action.kind) {

--- a/web/src/nav.test.ts
+++ b/web/src/nav.test.ts
@@ -69,6 +69,26 @@ test("terminal mode: every key reaches the agent, Escape included; only ctrl+] r
   assert.deepEqual(decideKey("]", t, { ctrl: true }), { kind: "toRail" }, "ctrl+] detaches back to the rail");
   // A BARE "]" still forwards — the agent needs it; only the ctrl chord detaches.
   assert.deepEqual(decideKey("]", t), { kind: "none" }, "a bare ] reaches the agent");
+  // AltGr guard (#2517 review P2): on Windows AltGr is delivered as ctrl+alt, and "]"
+  // is an AltGr key on many EU layouts (German AltGr+9, Spanish, French, …). An
+  // AltGr-typed "]" must FORWARD to the agent, never be mistaken for the detach chord.
+  assert.deepEqual(
+    decideKey("]", t, { ctrl: true, alt: true }),
+    { kind: "none" },
+    "ctrl+alt (AltGr on Windows) ] forwards to the agent, it is not the detach chord",
+  );
+  assert.deepEqual(
+    decideKey("]", t, { ctrl: true, altGraph: true }),
+    { kind: "none" },
+    "an AltGraph-signalled ] (Chromium/Linux) forwards too",
+  );
+});
+
+test("rail mode: ctrl+] is inert, never a view cycle (#2517 review P3)", () => {
+  // After detaching with ctrl+], a habitual second press in rail mode must NOT fall
+  // through to the [ / ] view cycle and lose the rail. A bare ] still cycles.
+  assert.deepEqual(decideKey("]", ctx(), { ctrl: true }), { kind: "none" }, "ctrl+] in rail is inert");
+  assert.deepEqual(decideKey("]", ctx()), { kind: "switchView", view: "tasks" }, "a bare ] still cycles the view");
 });
 
 test("modal mode: the modal owns the keyboard — only Escape (to cancel) is ours", () => {

--- a/web/src/nav.test.ts
+++ b/web/src/nav.test.ts
@@ -1,8 +1,9 @@
 // Tests for the keyboard/focus state machine (#1693): the TUI-style nav-vs-attach
 // model that makes j/k ALWAYS navigate the rail. These pin the exact transitions
 // the play-test exercises — nav mode moves the selection, Enter attaches, a focused
-// terminal sends to the agent, Escape returns to nav, and a modal owns the keyboard
-// — with no DOM and no daemon, exactly as sessions.test.ts pins the list reducer.
+// terminal sends every key to the agent (Escape included, as its interrupt) with
+// ctrl+] the sole keyboard detach, and a modal owns the keyboard — with no DOM and
+// no daemon, exactly as sessions.test.ts pins the list reducer.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -55,13 +56,19 @@ test("nav mode: Enter on a selection attaches; Enter with none selected is a no-
   assert.deepEqual(decideKey("Enter", ctx({ selectedId: null })), { kind: "none" });
 });
 
-test("terminal mode: keys go to the agent; only Escape returns to the rail", () => {
+test("terminal mode: every key reaches the agent, Escape included; only ctrl+] returns to the rail", () => {
   const t = ctx({ focus: "terminal" });
   assert.deepEqual(decideKey("j", t), { kind: "none" }, "j reaches the agent, does NOT navigate");
   assert.deepEqual(decideKey("ArrowDown", t), { kind: "none" });
   assert.deepEqual(decideKey("Enter", t), { kind: "none" }, "Enter reaches the agent");
   assert.deepEqual(decideKey("x", t), { kind: "none" });
-  assert.deepEqual(decideKey("Escape", t), { kind: "toRail" }, "Escape is the escape hatch back to nav");
+  // #2517: Escape is the agent's INTERRUPT key, so it forwards like any other key
+  // rather than detaching — the whole point of the fix.
+  assert.deepEqual(decideKey("Escape", t), { kind: "none" }, "Escape forwards to the agent as its interrupt");
+  // ctrl+] is the sole keyboard detach, mirroring the TUI's tea.KeyCtrlCloseBracket.
+  assert.deepEqual(decideKey("]", t, { ctrl: true }), { kind: "toRail" }, "ctrl+] detaches back to the rail");
+  // A BARE "]" still forwards — the agent needs it; only the ctrl chord detaches.
+  assert.deepEqual(decideKey("]", t), { kind: "none" }, "a bare ] reaches the agent");
 });
 
 test("modal mode: the modal owns the keyboard — only Escape (to cancel) is ours", () => {
@@ -157,8 +164,8 @@ test("view switch: ] / [ cycle the top-level view in rail mode of any view", () 
 });
 
 test("view switch: a focused terminal / an open modal own the keyboard — [ and ] fall through", () => {
-  // Terminal mode forwards everything but Escape to the agent, so [ / ] reach the
-  // shell (a shell needs brackets) rather than switching views.
+  // Terminal mode forwards everything but the ctrl+] detach to the agent, so a bare
+  // [ / ] reach the shell (a shell needs brackets) rather than switching views.
   assert.deepEqual(decideKey("]", ctx({ focus: "terminal" })), { kind: "none" });
   assert.deepEqual(decideKey("[", ctx({ focus: "terminal" })), { kind: "none" });
   // A modal owns the keyboard: brackets type into the form, they don't switch views.

--- a/web/src/nav.ts
+++ b/web/src/nav.ts
@@ -7,8 +7,9 @@
 // The model is two keyboard modes plus the modal overlay:
 //   - "rail" (the default): j/k / arrows move the selection; Enter attaches the
 //     selected session and hands the keyboard to its terminal.
-//   - "terminal": keys flow to the agent; Escape is the ONE hatch back to rail
-//     navigation (blur the terminal), matching the TUI's detach/back-to-nav.
+//   - "terminal": keys flow to the agent — Escape included, since it is the agents'
+//     interrupt key (#2517). ctrl+] is the ONE keyboard hatch back to rail navigation
+//     (blur the terminal), matching the TUI's tea.KeyCtrlCloseBracket detach.
 //   - a modal, when open, owns the keyboard: only Escape (to cancel) is meaningful.
 //
 // This is kept pure — a (key, context) → action decision with no DOM and no I/O —
@@ -16,7 +17,9 @@
 // event wiring in index.ts, exactly as the session-list reducer (sessions.ts) is.
 
 /** Which pane owns the keyboard. The rail is the default; the terminal takes over
- *  on attach (Enter / click) and hands back on Escape. */
+ *  on attach (Enter / click) and hands back on ctrl+] (or any non-keyboard exit —
+ *  clicking the rail, the mobile drawer). Escape is NOT a detach: it forwards to the
+ *  agent as its interrupt (#2517). */
 export type KeyboardFocus = "rail" | "terminal";
 
 /** The app's top-level view: the live sessions rail+terminal, or the tasks
@@ -79,10 +82,12 @@ export type NavAction =
   | { kind: "cyclePane"; delta: 1 | -1 }
   | { kind: "closePane" };
 
-/** Modifier flags the split keybinds read. Only Alt is consulted; the rest are
- *  ignored so the split chords never shadow a browser/OS shortcut. */
+/** Modifier flags the keybinds read. Alt gates the split-pane chords; Ctrl gates
+ *  the ctrl+] detach. Shift and Meta are ignored so the chords never shadow a
+ *  browser/OS shortcut. */
 export interface KeyMods {
   alt?: boolean;
+  ctrl?: boolean;
 }
 
 /** The next selected id after moving `delta` rows, clamped to the ends. From no
@@ -134,10 +139,15 @@ export function decideKey(key: string, ctx: NavContext, mods: KeyMods = {}): Nav
     }
     return { kind: "closePane" };
   }
-  // The terminal owns the keyboard: keys go to the agent. Escape is the escape
-  // hatch back to rail navigation (mirrors the TUI detach); nothing else is ours.
+  // The terminal owns the keyboard: EVERY key goes to the agent, Escape included.
+  // Escape is the agents' INTERRUPT key (#2070) — swallowing it here (as a detach)
+  // meant a running agent could never be interrupted from the web at all (#2517). The
+  // one hatch back to the rail is ctrl+], mirroring the TUI's tea.KeyCtrlCloseBracket
+  // (app/interactive.go), a chord the agent never needs. A bare "]" still forwards —
+  // only the ctrl chord detaches. (An open menu/modal still owns Escape: the modal
+  // branch above, and each menu's own capture listener in ui.ts, run first.)
   if (ctx.focus === "terminal") {
-    return key === "Escape" ? { kind: "toRail" } : { kind: "none" };
+    return mods.ctrl === true && key === "]" ? { kind: "toRail" } : { kind: "none" };
   }
   // View switching: [ / ] cycle the top-level view (sessions ⇄ tasks). Rail-mode
   // ONLY — a modal owns the keyboard (handled above) and a focused terminal forwards

--- a/web/src/nav.ts
+++ b/web/src/nav.ts
@@ -83,11 +83,14 @@ export type NavAction =
   | { kind: "closePane" };
 
 /** Modifier flags the keybinds read. Alt gates the split-pane chords; Ctrl gates
- *  the ctrl+] detach. Shift and Meta are ignored so the chords never shadow a
- *  browser/OS shortcut. */
+ *  the ctrl+] detach. altGraph is `getModifierState("AltGraph")`: it excludes an
+ *  AltGr-produced "]" (an AltGr key on many EU layouts) from the detach chord, since
+ *  Chromium on Linux signals AltGr this way rather than via ctrlKey. Shift and Meta
+ *  are ignored so the chords never shadow a browser/OS shortcut. */
 export interface KeyMods {
   alt?: boolean;
   ctrl?: boolean;
+  altGraph?: boolean;
 }
 
 /** The next selected id after moving `delta` rows, clamped to the ends. From no
@@ -139,15 +142,27 @@ export function decideKey(key: string, ctx: NavContext, mods: KeyMods = {}): Nav
     }
     return { kind: "closePane" };
   }
-  // The terminal owns the keyboard: EVERY key goes to the agent, Escape included.
-  // Escape is the agents' INTERRUPT key (#2070) — swallowing it here (as a detach)
-  // meant a running agent could never be interrupted from the web at all (#2517). The
-  // one hatch back to the rail is ctrl+], mirroring the TUI's tea.KeyCtrlCloseBracket
-  // (app/interactive.go), a chord the agent never needs. A bare "]" still forwards —
-  // only the ctrl chord detaches. (An open menu/modal still owns Escape: the modal
-  // branch above, and each menu's own capture listener in ui.ts, run first.)
+  // ctrl+] is the terminal-detach chord (#2517), mirroring the TUI's
+  // tea.KeyCtrlCloseBracket (app/interactive.go). It is guarded against Alt/AltGr: on
+  // Windows AltGr arrives as ctrl+alt, and "]" is an AltGr key on many EU layouts
+  // (German AltGr+9, Spanish, French, Italian, …), so a "]" typed via AltGr must NOT
+  // be read as the chord — it has to reach the agent. Both altKey and the AltGraph
+  // modifier are excluded (Chromium on Linux signals AltGr through the latter, not
+  // ctrlKey), matching clipboard.ts's Ctrl-chord guard. Handled before BOTH the
+  // terminal branch (so it detaches) and the rail-mode [ / ] view cycle below (so a
+  // habitual repeat after detaching is inert, not a view switch); its toRail is a
+  // no-op when already on the rail.
+  if (key === "]" && mods.ctrl === true && mods.alt !== true && mods.altGraph !== true) {
+    return ctx.focus === "terminal" ? { kind: "toRail" } : { kind: "none" };
+  }
+  // The terminal owns the keyboard: EVERY OTHER key goes to the agent, Escape
+  // included. Escape is the agents' INTERRUPT key (#2070) — swallowing it here (as a
+  // detach) meant a running agent could never be interrupted from the web at all
+  // (#2517). Only the ctrl+] chord above is ours; everything else forwards. (An open
+  // menu/modal still owns Escape: the modal branch above, and each menu's own capture
+  // listener in ui.ts, run first.)
   if (ctx.focus === "terminal") {
-    return mods.ctrl === true && key === "]" ? { kind: "toRail" } : { kind: "none" };
+    return { kind: "none" };
   }
   // View switching: [ / ] cycle the top-level view (sessions ⇄ tasks). Rail-mode
   // ONLY — a modal owns the keyboard (handled above) and a focused terminal forwards

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -119,8 +119,9 @@ export interface AppState {
   /** the attach terminal's connection state, shown in the pane header. */
   termStatus: TerminalStatus;
   /** which pane owns the keyboard (#1693): "rail" is the default nav mode (j/k move
-   *  the selection); "terminal" means keys go to the agent until Escape. Drives the
-   *  visible focus indicator so the active mode is legible, mirroring the TUI. */
+   *  the selection); "terminal" means keys go to the agent — Escape included, as its
+   *  interrupt (#2517) — until ctrl+] hands the keyboard back. Drives the visible
+   *  focus indicator so the active mode is legible, mirroring the TUI. */
   focus: KeyboardFocus;
   /** the selected session's active tab index (#1592 Phase 5 PR7): 0 is the agent
    *  tab, 1-8 the user-created shell/process tabs. The attach terminal streams
@@ -1570,8 +1571,9 @@ export class AppShell {
       if (e.key !== "Escape") {
         return;
       }
-      // Swallow it: an open menu owns Escape, so closing it must not ALSO detach
-      // the terminal / drop rail focus the way a bare Escape does.
+      // Swallow it: an open menu owns Escape, so closing it must NOT also let the ESC
+      // reach the agent (a bare Escape now forwards to the PTY as the agent's
+      // interrupt, #2517 — an open menu is the exception).
       e.stopPropagation();
       close();
       trigger.focus();
@@ -1584,13 +1586,14 @@ export class AppShell {
       scrollParent?.addEventListener("scroll", positionMenu, { passive: true });
       window.addEventListener("resize", positionMenu);
       document.addEventListener("mousedown", onDocMouseDown);
-      // CAPTURE phase, deliberately. The app's own keydown handler is a
-      // capture-phase listener on document that stopPropagation()s Escape (so
-      // detaching can't leak a stray ESC into the PTY), which stops the event
-      // before it can bubble back here — a bubble-phase listener would simply never
-      // see it, and Escape would not close this menu. Same-node listeners are
-      // unaffected by stopPropagation, so registering in capture puts this beside
-      // the app's handler rather than downstream of it.
+      // CAPTURE phase, deliberately, so this runs BEFORE xterm's textarea handler:
+      // when the menu is open, Escape must close it here and this listener's own
+      // stopPropagation must keep the ESC from also reaching the agent (#2517: a bare
+      // Escape now forwards to the PTY as the agent's interrupt — an open menu is the
+      // exception that still owns it). It sits beside the app's own capture-phase
+      // document handler (index.ts onKeydown), which no longer stopPropagations
+      // Escape; same-node capture listeners both fire, so this one does the closing
+      // and the stopping.
       document.addEventListener("keydown", onKeyDown, true);
     };
 


### PR DESCRIPTION
Closes #2517.

Escape is the agents' **interrupt** key (#2070 — it cancels the current turn), but
on the web it resolved to a `toRail` detach and the key handler swallowed the byte,
so **a running agent could not be interrupted from the browser at all**.

## Fix — match the TUI

The TUI forwards every key to the pane and detaches on **`ctrl+]` only**
(`app/interactive.go`'s `tea.KeyCtrlCloseBracket`; `ui/termpane/keymap.go` maps
`Escape` straight through). The web now does the same:

- In terminal focus, `decideKey` returns `none` for **Escape** → `onKeydown` returns
  without `preventDefault`, so the capture-phase event reaches xterm and the ESC
  (`0x1b`) goes down the PTY like any other key.
- It returns `toRail` only for **`ctrl+]`** (the agent never needs that chord). A bare
  `]` still forwards.

## What still owns Escape (unchanged)

- An **open modal** — the `decideKey` `modalOpen` branch closes it first.
- The **tab / appbar menus** — each has its own capture-phase document listener that
  closes on Escape and `stopPropagation`s before xterm sees it (`ui.ts`).

And every **non-keyboard exit** stays — clicking the rail, the mobile rail drawer —
so a user who doesn't know `ctrl+]` (or has no such key, e.g. on mobile) is never
trapped.

## Verification

- **Real browser** (`web-driver.spec.ts`, run by the CI **Web selftest** job): with
  the terminal focused, Escape emits exactly one `OpInput` carrying `0x1b` and the
  keyboard **stays** in terminal mode; `ctrl+]` detaches to the rail and leaks no byte
  to the PTY. The `#1694` keyboard-model selftest and its downstream detach steps now
  use `ctrl+]`. Desktop + mobile drawer detach paths are untouched.
- **Unit** (`nav.test.ts`): Escape → `none`, `ctrl+]` → `toRail`, bare `]` → `none`,
  modal-over-terminal Escape → `closeModal`.
- `docs/web.md` keyboard reference updated. `make web-build` (committed dist).

Web-only — **zero Go changes**, so the Go suite is unaffected; CI runs the full
matrix (Web, Web selftest, Lint, Test) regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
