### PR TITLE
fix(sessions): classify hook delete_cmd timeout as unknown-state (#2529)

### DIFF
--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -247,6 +248,15 @@ func runHookScriptWithResolvedEnvironment(timeout time.Duration, name, agent str
 	// killed, so the guarantee above is untouched.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	runErr := cmd.Run()
+	if runErr != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		// The context deadline killed the script mid-run, so whatever it was doing
+		// to the remote workspace is UNKNOWN. exec surfaces this as a bare
+		// "signal: killed" that does NOT wrap context.DeadlineExceeded, so wrap it
+		// here — that is the only place the ctx is in scope — letting callers (reap
+		// in particular) tell a timeout from a script that answered, and retain the
+		// record instead of trusting a success that never happened (#2529).
+		runErr = fmt.Errorf("%w: %w", context.DeadlineExceeded, runErr)
+	}
 
 	out, readErr := os.ReadFile(f.Name())
 	if readErr != nil && runErr == nil {
@@ -464,6 +474,15 @@ func (p *hookProvisioner) reap() error {
 			p.environmentAgent(), p.authSelectors, p.spec.SessionEnvPassthrough, "--name", p.slug)
 		if err != nil {
 			reapErr = fmt.Errorf("backend=hook: delete_cmd failed for %q: %s: %w", p.slug, strings.TrimSpace(string(out)), err)
+			if errors.Is(err, context.DeadlineExceeded) {
+				// A timeout is proof of NOTHING: delete_cmd was killed mid-reap, so
+				// the remote workspace may still be running. Mark it unknown-state so
+				// deleteSessionRecord RETAINS the record for retry rather than deleting
+				// it and leaking the workspace with no handle — the same classification
+				// the docker backend applies (#2529). A delete_cmd that ANSWERS with an
+				// error stays known-state (it told us something), so the record may go.
+				reapErr = fmt.Errorf("%w: %w", ErrWorkspaceStateUnknown, reapErr)
+			}
 			log.ErrorLog.Printf("%s", p.orphanWarning(reapErr))
 			return
 		}

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -139,8 +139,12 @@ func (p *hookProvisioner) provisionOrReap() (ProvisionResult, error) {
 	if reapErr := p.reap(); reapErr != nil {
 		// The reap failed too, so something on the user's account may still be
 		// running and billing with no record of it on our side. That has to reach
-		// the person creating the session, not just the log.
-		return ProvisionResult{}, fmt.Errorf("%w\n\n%s", err, p.orphanWarning(reapErr))
+		// the person creating the session, not just the log. errors.Join keeps
+		// reapErr's ErrWorkspaceStateUnknown sentinel classifiable rather than
+		// flattening it into %s text — the hook/docker/ssh unknown-state parity this
+		// path is about (ssh does the same in reapProvisionFailure); orphanWarning
+		// carries the human-actionable detail.
+		return ProvisionResult{}, fmt.Errorf("%w\n\n%s", errors.Join(err, reapErr), p.orphanWarning(reapErr))
 	}
 	return ProvisionResult{}, err
 }
@@ -294,7 +298,17 @@ type hookProvisioner struct {
 	// provisioner was rebuilt for a Kill/archive rather than the launch itself.
 	launchPgid int
 
-	reapOnce sync.Once
+	// Reap memoizes only an attempt that COMPLETED — a success or a delete_cmd that
+	// ANSWERED with an error. A TIMEOUT deliberately does NOT latch: it leaves the
+	// remote workspace state unknown, so the daemon must retain the record and
+	// actually re-run delete_cmd on its next poll. sync.Once cannot express that
+	// conditional latch — it latched the timeout too, so the second reap skipped the
+	// closure and returned nil (reapErr was a per-call local), the record was
+	// deleted, and the sandbox leaked exactly one poll later (#2529), the same
+	// #2063-review defect docker and ssh already fixed this way.
+	reapMu  sync.Mutex
+	reaped  bool
+	reapErr error
 }
 
 // hookEndpointJSON is the object launch_cmd echoes: the authed `af agent-server`
@@ -450,44 +464,63 @@ func (p *hookProvisioner) launch() (*AgentServerEndpoint, error) {
 // and only if launch_cmd actually STARTED — if it never ran, nothing was
 // provisioned and there is nothing to delete. It backs the session's Kill (after
 // the in-sandbox workspace is torn down over REST), a provisioning failure, and a
-// bad-endpoint NewInstance failure — so a provisioned sandbox is never leaked. The
-// sync.Once collapses the repeated Kill retries and the Kill-vs-provision-failure
-// races to one delete_cmd.
+// bad-endpoint NewInstance failure — so a provisioned sandbox is never leaked.
+//
+// It memoizes CONDITIONALLY (reapMu + reaped, not sync.Once): a success or a
+// delete_cmd that ANSWERED with an error latches, collapsing repeated Kill retries
+// to one delete_cmd. A TIMEOUT does NOT latch — the reap did not complete, so the
+// daemon must re-run delete_cmd on its next poll rather than see a cached nil and
+// delete the record (#2529, the #2063-review defect docker/ssh fixed the same way).
 //
 // This is best-effort by contract: it may be called for a sandbox that was never
 // fully built, so delete_cmd must tolerate a slug it cannot find (documented in
 // docs/remote-hooks.md).
 func (p *hookProvisioner) reap() error {
-	var reapErr error
-	p.reapOnce.Do(func() {
-		if !p.launchStarted {
-			return
-		}
-		p.resolveAuthSelectors()
-		// runHookScript builds its timeout from context.Background(), NEVER a
-		// caller's context — and that is load-bearing here. reap's whole job is to
-		// run on the failure path, where the launch context is already cancelled or
-		// expired, and a WithTimeout derived from a dead parent is born expired:
-		// delete_cmd would never spawn and the sandbox would leak in silence. That
-		// is the exact failure #1955 is about, reintroduced by the cleanup.
-		out, _, err := runHookScriptWithResolvedEnvironment(hookDeleteTimeout, p.hooks.DeleteCmd,
-			p.environmentAgent(), p.authSelectors, p.spec.SessionEnvPassthrough, "--name", p.slug)
-		if err != nil {
-			reapErr = fmt.Errorf("backend=hook: delete_cmd failed for %q: %s: %w", p.slug, strings.TrimSpace(string(out)), err)
-			if errors.Is(err, context.DeadlineExceeded) {
-				// A timeout is proof of NOTHING: delete_cmd was killed mid-reap, so
-				// the remote workspace may still be running. Mark it unknown-state so
-				// deleteSessionRecord RETAINS the record for retry rather than deleting
-				// it and leaking the workspace with no handle — the same classification
-				// the docker backend applies (#2529). A delete_cmd that ANSWERS with an
-				// error stays known-state (it told us something), so the record may go.
-				reapErr = fmt.Errorf("%w: %w", ErrWorkspaceStateUnknown, reapErr)
-			}
-			log.ErrorLog.Printf("%s", p.orphanWarning(reapErr))
-			return
-		}
+	// Held across delete_cmd so concurrent reaps serialize and the latch is written
+	// race-free — the mutual exclusion sync.Once gave, minus its permanent latch.
+	p.reapMu.Lock()
+	defer p.reapMu.Unlock()
+	if p.reaped {
+		return p.reapErr
+	}
+	if !p.launchStarted {
+		// launch_cmd never ran, so nothing was provisioned: a completed no-op reap.
+		p.reaped = true
+		return nil
+	}
+	p.resolveAuthSelectors()
+	// runHookScript builds its timeout from context.Background(), NEVER a caller's
+	// context — and that is load-bearing here. reap's whole job is to run on the
+	// failure path, where the launch context is already cancelled or expired, and a
+	// WithTimeout derived from a dead parent is born expired: delete_cmd would never
+	// spawn and the sandbox would leak in silence. That is the exact failure #1955 is
+	// about, reintroduced by the cleanup.
+	out, _, err := runHookScriptWithResolvedEnvironment(hookDeleteTimeout, p.hooks.DeleteCmd,
+		p.environmentAgent(), p.authSelectors, p.spec.SessionEnvPassthrough, "--name", p.slug)
+	if err == nil {
+		p.reaped = true
+		p.reapErr = nil
 		log.InfoLog.Printf("hook runtime: reaped remote session %q via delete_cmd", p.slug)
-	})
+		return nil
+	}
+	reapErr := fmt.Errorf("backend=hook: delete_cmd failed for %q: %s: %w", p.slug, strings.TrimSpace(string(out)), err)
+	if errors.Is(err, context.DeadlineExceeded) {
+		// A timeout is proof of NOTHING: delete_cmd was SIGKILLed mid-reap, so the
+		// remote workspace may still be running. Mark it unknown-state so
+		// deleteSessionRecord RETAINS the record, and do NOT latch (reaped stays
+		// false) so the next poll actually RE-RUNS delete_cmd — a latch here would
+		// buy one poll of retention and then return nil, deleting the record and
+		// leaking the workspace one poll later (#2529). Same as docker/ssh.
+		reapErr = fmt.Errorf("%w: %w", ErrWorkspaceStateUnknown, reapErr)
+		log.ErrorLog.Printf("%s", p.orphanWarning(reapErr))
+		return reapErr
+	}
+	// delete_cmd ANSWERED with an error: the reap completed and TOLD us something, so
+	// it latches as a KNOWN-state error and the record may be deleted — retrying
+	// would just re-run a delete that already reported.
+	p.reaped = true
+	p.reapErr = reapErr
+	log.ErrorLog.Printf("%s", p.orphanWarning(reapErr))
 	return reapErr
 }
 

--- a/session/backend_hook_reap_test.go
+++ b/session/backend_hook_reap_test.go
@@ -336,6 +336,42 @@ func TestHookReapIsBounded(t *testing.T) {
 	}
 }
 
+// TestHookReapTimeoutIsUnknownState is the #2529 regression: a delete_cmd killed
+// at its timeout is proof of NOTHING — the remote workspace may still be running.
+// So the reap error must be classified as unknown-state (wrap ErrWorkspaceStateUnknown)
+// exactly as the docker backend does, so deleteSessionRecord RETAINS the record and
+// the workspace stays reap-able. A plain error lets the record be deleted, leaking
+// the workspace with nothing pointing at it — the #2440/#1955 false-success disease.
+//
+// Against master this FAILS: the timeout surfaces as "signal: killed", which reap
+// wraps as a plain error, so TeardownStateUnknown is false and the record is deleted.
+func TestHookReapTimeoutIsUnknownState(t *testing.T) {
+	// delete_cmd wedges past its own short bound, so the reap is killed by the
+	// timeout rather than answering.
+	shrinkHookTimeouts(t, 300*time.Millisecond, 300*time.Millisecond)
+	h := newHookState(t, "exit 0\n", "sleep 5\n")
+	p := newHookProvisioner(h, "wedged delete unknown state")
+	p.launchStarted = true
+
+	err := p.reap()
+	require.Error(t, err, "a delete_cmd killed at its timeout is a failed reap")
+	assert.True(t, TeardownStateUnknown(err),
+		"a timed-out delete_cmd leaves the workspace state UNKNOWN — the record must be retained, not deleted")
+	assert.True(t, errors.Is(err, ErrWorkspaceStateUnknown),
+		"the reap error must wrap ErrWorkspaceStateUnknown so deleteSessionRecord refuses to delete the record")
+	// The orphan the user needs to know about is still named.
+	assert.Contains(t, err.Error(), p.slug, "the failure must still name the orphaned sandbox")
+	// And a delete_cmd that ANSWERS with an error stays known-state (record may go),
+	// mirroring docker — only the timeout is unknown-state.
+	h2 := newHookState(t, "exit 0\n", "echo 'nope' >&2\nexit 9\n")
+	p2 := newHookProvisioner(h2, "answered failure known state")
+	p2.launchStarted = true
+	err2 := p2.reap()
+	require.Error(t, err2)
+	assert.False(t, TeardownStateUnknown(err2),
+		"a delete_cmd that answered with an error TOLD us something — it is known-state, not unknown")
+}
+
 // TestHookReapUnaffectedByCancelledCaller locks the one subtlety that would
 // silently un-fix #1955: reap runs on the failure path, where the launch context
 // is ALREADY expired. If reap's context were ever derived from that dead parent

--- a/session/backend_hook_reap_test.go
+++ b/session/backend_hook_reap_test.go
@@ -50,6 +50,18 @@ func (h hookState) deleteRan(t *testing.T) bool {
 	return err == nil
 }
 
+// deleteRunCount is how many times delete_cmd actually ran: it appends one line
+// per invocation BEFORE any wedge/sleep, so a growing count proves a reap
+// re-invoked delete_cmd rather than short-circuiting on a latch.
+func (h hookState) deleteRunCount(t *testing.T) int {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(h.dir, "delete-ran.log"))
+	if err != nil {
+		return 0
+	}
+	return strings.Count(string(data), "\n")
+}
+
 // writeHookScript writes an executable bash script and returns its path. Paths
 // are interpolated single-quoted, so the script never depends on cwd or $HOME.
 func writeHookScript(t *testing.T, path, body string) string {
@@ -361,15 +373,75 @@ func TestHookReapTimeoutIsUnknownState(t *testing.T) {
 		"the reap error must wrap ErrWorkspaceStateUnknown so deleteSessionRecord refuses to delete the record")
 	// The orphan the user needs to know about is still named.
 	assert.Contains(t, err.Error(), p.slug, "the failure must still name the orphaned sandbox")
-	// And a delete_cmd that ANSWERS with an error stays known-state (record may go),
-	// mirroring docker — only the timeout is unknown-state.
-	h2 := newHookState(t, "exit 0\n", "echo 'nope' >&2\nexit 9\n")
-	p2 := newHookProvisioner(h2, "answered failure known state")
-	p2.launchStarted = true
-	err2 := p2.reap()
-	require.Error(t, err2)
-	assert.False(t, TeardownStateUnknown(err2),
+}
+
+// TestHookReapTimeoutIsReRunnable is the #2529-review guard: a timed-out reap must
+// NOT latch. The daemon's finishUserKill re-invokes reap() on the SAME provisioner
+// every poll for a retained (unknown-state) record. sync.Once latched the timeout
+// too, so the second reap skipped the closure and returned nil — deleteSessionRecord
+// then deleted the record and the workspace leaked exactly one poll later, the same
+// leak as master, one tick delayed. A second reap while delete_cmd is still wedged
+// must (i) ACTUALLY re-run delete_cmd and (ii) keep returning the unknown sentinel.
+func TestHookReapTimeoutIsReRunnable(t *testing.T) {
+	shrinkHookTimeouts(t, 300*time.Millisecond, 300*time.Millisecond)
+	h := newHookState(t, "exit 0\n", "sleep 5\n") // logs one line, then wedges
+	p := newHookProvisioner(h, "re-runnable wedged reap")
+	p.launchStarted = true
+
+	first := p.reap()
+	require.True(t, errors.Is(first, ErrWorkspaceStateUnknown), "first timed-out reap must be unknown-state")
+	require.Equal(t, 1, h.deleteRunCount(t), "delete_cmd ran once")
+
+	second := p.reap()
+	require.Error(t, second,
+		"a second reap while delete_cmd is still wedged must not return nil — a nil would let deleteSessionRecord delete the record and orphan the workspace one poll later")
+	require.True(t, errors.Is(second, ErrWorkspaceStateUnknown),
+		"a re-run timed-out reap must keep returning ErrWorkspaceStateUnknown")
+	require.Equal(t, 2, h.deleteRunCount(t),
+		"the second reap must ACTUALLY re-invoke delete_cmd (the log line count grows), not skip it via a latch")
+}
+
+// TestHookReapAnsweredErrorIsKnownStateAndLatches is the other half: a delete_cmd
+// that ANSWERS with a non-zero exit told us something, so it is known-state (the
+// record may go) AND it latches — a second reap returns the cached error without
+// re-running a delete that already reported. A GENEROUS delete timeout keeps a slow
+// script spawn under load from being misread as a timeout (which would be
+// unknown-state) — only the wedged tests above need the short bound (#2529 review).
+func TestHookReapAnsweredErrorIsKnownStateAndLatches(t *testing.T) {
+	shrinkHookTimeouts(t, 5*time.Second, 5*time.Second)
+	h := newHookState(t, "exit 0\n", "echo 'nope' >&2\nexit 9\n")
+	p := newHookProvisioner(h, "answered failure known state")
+	p.launchStarted = true
+
+	err := p.reap()
+	require.Error(t, err)
+	assert.False(t, TeardownStateUnknown(err),
 		"a delete_cmd that answered with an error TOLD us something — it is known-state, not unknown")
+	require.Equal(t, 1, h.deleteRunCount(t), "delete_cmd ran once")
+
+	err2 := p.reap()
+	require.Error(t, err2, "the latched known-state error is returned again")
+	assert.Equal(t, 1, h.deleteRunCount(t),
+		"an answered-error reap latches — delete_cmd is not re-run")
+}
+
+// TestHookProvisionFailureWithReapTimeoutPreservesUnknownSentinel locks #2529
+// review P3-a: when provisioning fails AND the reap then times out, the provision
+// error must keep reapErr's ErrWorkspaceStateUnknown sentinel classifiable
+// (errors.Join, not flattened into %s text) — the hook/docker/ssh unknown-state
+// parity this fix is about, matching ssh's reapProvisionFailure.
+func TestHookProvisionFailureWithReapTimeoutPreservesUnknownSentinel(t *testing.T) {
+	shrinkHookTimeouts(t, 300*time.Millisecond, 300*time.Millisecond)
+	h := newHookState(t, "echo 'provisioned then died' >&2\nexit 4\n", "sleep 5\n")
+	p := newHookProvisioner(h, "create then wedged reap")
+
+	_, err := p.provisionOrReap()
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrWorkspaceStateUnknown),
+		"the provision error must keep the reap's unknown-state sentinel classifiable (#2529 review P3-a)")
+	// The original launch failure and the human-actionable orphan warning survive too.
+	assert.Contains(t, err.Error(), "launch_cmd failed", "the provisioning error is not swallowed")
+	assert.Contains(t, err.Error(), "may still be running on your infrastructure")
 }
 
 // TestHookReapUnaffectedByCancelledCaller locks the one subtlety that would


### PR DESCRIPTION
Fixes #2529. A timed-out `delete_cmd` is proof of nothing — the remote workspace may still be running — but the hook backend wrapped every reap error (timeout included) as a plain error, so `deleteSessionRecord` deleted the record and leaked the workspace with no handle. Same false-success-hides-a-leak class as #2440/#1955, in the one path docker already guards (backend_docker.go:574).

**Fix:** `runHookScriptWithResolvedEnvironment` (which owns the timeout ctx) now wraps a tripped deadline into the returned error — exec only surfaces a bare `signal: killed` that doesn't wrap `context.DeadlineExceeded`. `reap()` then wraps `ErrWorkspaceStateUnknown` on a deadline, exactly as docker does → `TeardownStateUnknown` true → record retained for retry, orphan warning still fires. A `delete_cmd` that *answers* with an error stays known-state (record may go), matching docker. The runtime-cleanup path uses the same `reap()`, so it inherits the fix.

**Test:** `TestHookReapTimeoutIsUnknownState` drives a wedged `delete_cmd`, asserts the reap error is `TeardownStateUnknown`/wraps `ErrWorkspaceStateUnknown`, and that an answered-error reap stays known-state. **Fails on master** (timeout → plain error → record deleted).

Gate: build, gofmt, golangci-lint, deadcode, `make test-container`. Codex is rate-limited (usage-limit notices only); Greptile is the live reviewer.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)