### PR TITLE
fix(sessions): replace every dead shell tab on restore, not just one (#2527)

### DIFF
--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -693,12 +693,22 @@ func (b *LocalBackend) setupTabs(i *Instance) {
 	// create path hermetic. Reuse the dead tab's OWN persisted tmux name rather than
 	// re-deriving from its display name (#1957): the session it names is dead, so
 	// retaking it is free, and it cannot collide with a renamed tab's live session.
-	// Persisted shells always carry a distinct TmuxName (#955), so per-shell reuse
-	// never collides; uniqueTabTmuxName covers only a legacy single-shell row whose
-	// TmuxName predates that field (a multi-shell record cannot have an empty one).
+	// uniqueTabTmuxName covers only a legacy single-shell row whose TmuxName predates
+	// that field. Names derived this pass are RESERVED as they are chosen — not
+	// recomputed against the stale snapshot, which never learns them — so two
+	// nil-TmuxName dead shells cannot resolve to the same token and collide on the
+	// second Start (#2527 review).
+	prefix := agentTmux.SanitizedName() + tmuxTabSeparator
+	reserved := make(map[string]bool, len(tabs))
+	for _, t := range tabs {
+		if token := tabTmuxToken(prefix, t); token != "" {
+			reserved[token] = true
+		}
+	}
 	type shellBinding struct {
-		tab  *Tab
-		tmux *tmux.TmuxSession
+		id    string
+		tmux  *tmux.TmuxSession
+		bound bool
 	}
 	var bindings []shellBinding
 	for _, tab := range deadShells {
@@ -708,35 +718,58 @@ func (b *LocalBackend) setupTabs(i *Instance) {
 		}
 		tmuxName := ""
 		if tab.tmux != nil {
+			// The dead shell's own token is already in reserved (seeded from tabs).
 			tmuxName = tab.tmux.SanitizedName()
 		}
 		if tmuxName == "" {
-			tmuxName = uniqueTabTmuxName(tabs, agentTmux.SanitizedName(), name)
+			token := firstFreeName(reserved, name)
+			reserved[token] = true
+			tmuxName = prefix + token
 		}
 		shellTmux := agentTmux.NewSiblingSession(tmuxName, defaultShell())
 		if err := shellTmux.Start(worktreePath); err != nil {
 			log.WarningLog.Printf("start shell tab %q for %q failed: %v", name, i.Title, err)
 			continue
 		}
-		bindings = append(bindings, shellBinding{tab: tab, tmux: shellTmux})
+		bindings = append(bindings, shellBinding{id: tab.ID, tmux: shellTmux})
 	}
 	if len(bindings) == 0 {
 		return
 	}
 
-	// Bind the fresh sessions under one lock, re-finding each tab by pointer so a
-	// tab removed out from under us (a concurrent close) is skipped rather than
-	// resurrected.
+	// Bind the fresh sessions under one lock, re-finding each tab by its STABLE ID,
+	// never its pointer: replaceTabFieldLocked copy-on-writes a tab to a NEW *Tab for
+	// the same logical tab, so a pointer captured before the unlock window (N Restores
+	// + probes + spawns ago) can be stale — the #1987 resolution keys on the live
+	// roster, not a captured pointer. restoreLocalTabs backfills a non-empty ID on
+	// every restored tab, so the id is a reliable key.
 	i.mu.Lock()
-	for _, bnd := range bindings {
+	for k := range bindings {
 		for _, t := range i.Tabs {
-			if t == bnd.tab {
-				t.tmux = bnd.tmux
+			if t.ID == bindings[k].id {
+				t.tmux = bindings[k].tmux
+				bindings[k].bound = true
 				break
 			}
 		}
 	}
 	i.mu.Unlock()
+
+	// A binding whose tab vanished (a concurrent close) must NOT be silently dropped:
+	// Start already spawned a real detached tmux running a login shell with cwd in the
+	// worktree. Left on no tab, teardownTabs never kills it, so it outlives the
+	// session, holds the worktree open against removal (#2025/#2440), and squats the
+	// tab's persisted tmux name. Close it (kill-session) — NOT CloseAttachOnly, which
+	// is a no-op for a session we SPAWNED rather than attached to (unlike
+	// AttachShellTab's #990 attach-only path).
+	for _, bnd := range bindings {
+		if bnd.bound {
+			continue
+		}
+		if _, cerr := bnd.tmux.Close(); cerr != nil {
+			log.WarningLog.Printf("setup shell tab for %q: releasing an orphaned replacement session whose tab vanished: %v", i.Title, cerr)
+		}
+	}
 }
 
 // Kill is best-effort: each cleanup step runs independently and a failure in

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -643,95 +643,98 @@ func (b *LocalBackend) setupTabs(i *Instance) {
 	}
 
 	// Reconnect every persisted non-agent tab that carries a session (Tabs[0] is
-	// the agent tab, already restored by Start). Track whether a persisted shell
-	// tab exists at all, and whether at least one is live, to decide if the
-	// dead-shell replacement below applies.
-	hasShellTab := false
-	hasLiveShell := false
-	var replacementShell *Tab
+	// the agent tab, already restored by Start), then replace EACH shell tab that
+	// did not come back live with a fresh sibling session. Per-shell, NOT a single
+	// hasLiveShell flag: with multiple shell tabs, one live shell used to suppress
+	// replacement of every dead one, and the all-dead path replaced only the first —
+	// so restoring stranded the user on "Terminal session not available" for every
+	// shell but one (#2527).
+	var deadShells []*Tab
 	for idx, tab := range tabs {
 		if idx == 0 {
 			continue
 		}
-		if tab.Kind == TabKindShell {
-			hasShellTab = true
-			if replacementShell == nil {
-				replacementShell = tab
+		if tab.tmux != nil {
+			if err := tab.tmux.Restore(worktreePath); err != nil {
+				log.WarningLog.Printf("restore tab %q for %q failed: %v", tab.Name, i.Title, err)
 			}
 		}
-		if tab.tmux == nil {
+		if tab.Kind != TabKindShell {
 			continue
 		}
-		if err := tab.tmux.Restore(worktreePath); err != nil {
-			log.WarningLog.Printf("restore tab %q for %q failed: %v", tab.Name, i.Title, err)
-		}
-		// Only count a shell tab as live when a has-session probe ANSWERED that its
-		// tmux session exists server-side after Restore. Restore (and its re-spawn)
-		// can fail — e.g. the worktree was removed so `tmux new-session -c $workdir`
-		// errors — leaving a dead shell tab. Gating on presence alone suppressed the
-		// fresh-shell fallback below and stranded the user with a dead terminal
-		// (#991).
-		//
-		// Existence is EVIDENCE here, so probe the tri-state instead of the lossy
-		// bool (#1962): only known && exists counts as live. A wedged/timed-out
-		// has-session reports "exists" through ExistsOrUnknown, which would suppress
-		// the fallback and re-strand the user with a dead/wedged terminal — the exact
-		// #991 regression. Treating !known as "not confirmed live" means a merely-
-		// wedged server may cost a redundant fresh-shell spawn; a spare shell tab is
-		// strictly better than a dead one, so this is the deliberate tradeoff.
-		if tab.Kind == TabKindShell {
+		// Existence is EVIDENCE: only a has-session probe that ANSWERED "exists"
+		// counts a shell live. Restore (and its #386 re-spawn) can fail — e.g. the
+		// worktree was removed so `tmux new-session -c $workdir` errors — leaving a
+		// dead shell tab. Probe the tri-state, not the lossy bool (#1962): a
+		// wedged/timed-out has-session reports "exists" via ExistsOrUnknown, which
+		// would suppress replacement and re-strand the user with a dead/wedged
+		// terminal (the #991 regression). Treating !known as "not confirmed live"
+		// costs at most a redundant fresh-shell spawn — strictly better than a dead
+		// one, the deliberate tradeoff.
+		live := false
+		if tab.tmux != nil {
 			if exists, known := tab.tmux.ProbeSession(); known && exists {
-				hasLiveShell = true
+				live = true
 			}
 		}
+		if !live {
+			deadShells = append(deadShells, tab)
+		}
 	}
-	// No persisted shell tab means a fresh instance (or one whose user closed
-	// every shell tab): come up with just the agent tab — a terminal tab is
-	// never auto-created (#1100). With a live shell there is nothing to replace.
-	if !hasShellTab || hasLiveShell {
+	if len(deadShells) == 0 {
+		// A fresh instance (or one whose user closed every shell tab), or every
+		// persisted shell came back live: a terminal tab is never auto-created
+		// (#1100), and there is nothing to replace.
 		return
 	}
 
-	// A persisted shell tab restored dead (#991): create a fresh shell session
-	// as a sibling of the agent session so it inherits the agent's PTY factory /
-	// executor — real in production, mock in tests — keeping the create path
-	// hermetic.
-	//
-	// Reuse the dead tab's OWN persisted tmux name rather than re-deriving one
-	// from its display name. Re-deriving is unsafe now that the two namespaces are
-	// independent (#1957, see tab_names.go): a shell tab named "shell" may hold the
-	// session "…__shell-2" because a renamed tab still owns "…__shell", and
-	// re-deriving would have this replacement collide with that live session. Its
-	// own name is also the right answer on its merits — the session it names is
-	// dead, so retaking it is free, and the tab keeps the session name already
-	// persisted against it. uniqueTabTmuxName covers the no-persisted-name case
-	// (no shell tab to inherit from, or a legacy row with an empty TmuxName).
-	replacementShellName := shellTabName
-	replacementTmuxName := ""
-	if replacementShell != nil {
-		if replacementShell.Name != "" {
-			replacementShellName = replacementShell.Name
-		}
-		if replacementShell.tmux != nil {
-			replacementTmuxName = replacementShell.tmux.SanitizedName()
-		}
+	// Create a fresh sibling session for each dead shell so it inherits the agent's
+	// PTY factory / executor — real in production, mock in tests — keeping the
+	// create path hermetic. Reuse the dead tab's OWN persisted tmux name rather than
+	// re-deriving from its display name (#1957): the session it names is dead, so
+	// retaking it is free, and it cannot collide with a renamed tab's live session.
+	// Persisted shells always carry a distinct TmuxName (#955), so per-shell reuse
+	// never collides; uniqueTabTmuxName covers only a legacy single-shell row whose
+	// TmuxName predates that field (a multi-shell record cannot have an empty one).
+	type shellBinding struct {
+		tab  *Tab
+		tmux *tmux.TmuxSession
 	}
-	if replacementTmuxName == "" {
-		replacementTmuxName = uniqueTabTmuxName(tabs, agentTmux.SanitizedName(), replacementShellName)
+	var bindings []shellBinding
+	for _, tab := range deadShells {
+		name := shellTabName
+		if tab.Name != "" {
+			name = tab.Name
+		}
+		tmuxName := ""
+		if tab.tmux != nil {
+			tmuxName = tab.tmux.SanitizedName()
+		}
+		if tmuxName == "" {
+			tmuxName = uniqueTabTmuxName(tabs, agentTmux.SanitizedName(), name)
+		}
+		shellTmux := agentTmux.NewSiblingSession(tmuxName, defaultShell())
+		if err := shellTmux.Start(worktreePath); err != nil {
+			log.WarningLog.Printf("start shell tab %q for %q failed: %v", name, i.Title, err)
+			continue
+		}
+		bindings = append(bindings, shellBinding{tab: tab, tmux: shellTmux})
 	}
-	shellTmux := agentTmux.NewSiblingSession(replacementTmuxName, defaultShell())
-	if err := shellTmux.Start(worktreePath); err != nil {
-		log.WarningLog.Printf("start shell tab for %q failed: %v", i.Title, err)
+	if len(bindings) == 0 {
 		return
 	}
 
+	// Bind the fresh sessions under one lock, re-finding each tab by pointer so a
+	// tab removed out from under us (a concurrent close) is skipped rather than
+	// resurrected.
 	i.mu.Lock()
-	if existing := i.shellTabLocked(); existing != nil {
-		existing.tmux = shellTmux
-	} else {
-		tab := newShellTab(shellTmux)
-		tab.Name = replacementShellName
-		i.Tabs = append(i.Tabs, tab)
+	for _, bnd := range bindings {
+		for _, t := range i.Tabs {
+			if t == bnd.tab {
+				t.tmux = bnd.tmux
+				break
+			}
+		}
 	}
 	i.mu.Unlock()
 }

--- a/session/dead_respawn_test.go
+++ b/session/dead_respawn_test.go
@@ -311,6 +311,116 @@ func TestRunningInstance_DeadShellTabReplacedWithFreshShellOnLoad(t *testing.T) 
 	assert.True(t, restored.Started())
 }
 
+// TestRunningInstance_OneLiveOneDeadShell_DeadShellReplaced is the #2527
+// regression: with MULTIPLE shell tabs, a single live shell used to set
+// hasLiveShell and suppress replacement of every dead shell, leaving them pointing
+// at non-existent sessions ("Terminal session not available"). Each dead shell
+// must be replaced independently.
+func TestRunningInstance_OneLiveOneDeadShell_DeadShellReplaced(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const agentName = "af_2527_agent"
+	firstShell := agentName + shellTmuxSuffix // "…__shell"
+	secondShell := agentName + "__shell-2"
+
+	// Agent and the FIRST shell are alive; the SECOND shell is gone and its
+	// re-spawn fails (failFirstNewSessionPty fails the first new-session it sees —
+	// the second shell's Restore). On master the live first shell sets
+	// hasLiveShell=true and the whole replacement block is skipped, so the dead
+	// second shell is stranded.
+	var newSessions, ptyNewSessions int
+	exec := countingExec(map[string]bool{agentName: true, firstShell: true}, &newSessions)
+	pty := failFirstNewSessionPty{t: t, cmdExec: exec, count: &ptyNewSessions}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, exec)
+	}
+	defer func() { restoreTmuxSession = prev }()
+
+	data := deadInstanceData(t, Running, agentName, firstShell)
+	data.Tabs = append(data.Tabs, TabData{Name: "shell-2", Kind: TabKindShell, TmuxName: secondShell})
+
+	restored, err := FromInstanceData(data)
+	require.NoError(t, err)
+
+	assert.True(t, restored.TabAlive(0), "the live agent tab must stay reconnected")
+	assert.True(t, restored.TabAlive(1), "the live first shell must stay live")
+	assert.True(t, restored.TabAlive(2),
+		"the dead second shell must be replaced too — a live sibling must not suppress its replacement (#2527)")
+	assert.Equal(t, 1, newSessions,
+		"exactly one fresh shell session must be spawned (the one dead shell; the failed re-spawn never counted)")
+	// The replacement retook the dead shell's own persisted tmux name.
+	tabs := restored.GetTabs()
+	require.Len(t, tabs, 3)
+	assert.Equal(t, secondShell, tabs[2].tmux.SanitizedName(),
+		"the replacement keeps the dead shell's #930-derived tmux name")
+}
+
+// TestRunningInstance_AllShellsDead_EveryShellReplaced covers the other half of
+// #2527: when NO shell is live, the old code replaced only the FIRST dead shell.
+func TestRunningInstance_AllShellsDead_EveryShellReplaced(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const agentName = "af_2527_alldead"
+	firstShell := agentName + shellTmuxSuffix
+	secondShell := agentName + "__shell-2"
+
+	// Only the agent is alive; both shells are gone. Their Restore re-spawns are
+	// allowed to succeed (persistPtyFactory), so on master the fallback would run
+	// but replace only the first shell — here Restore itself re-spawns both, so to
+	// force the fallback we fail BOTH re-spawns and let the fresh-shell spawns win.
+	var newSessions int
+	exec := countingExec(map[string]bool{agentName: true}, &newSessions)
+	failed := 0
+	pty := failNFirstNewSessionsPty{t: t, cmdExec: exec, failFirst: 2, count: &failed}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, exec)
+	}
+	defer func() { restoreTmuxSession = prev }()
+
+	data := deadInstanceData(t, Running, agentName, firstShell)
+	data.Tabs = append(data.Tabs, TabData{Name: "shell-2", Kind: TabKindShell, TmuxName: secondShell})
+
+	restored, err := FromInstanceData(data)
+	require.NoError(t, err)
+
+	assert.True(t, restored.TabAlive(0), "the agent tab must be live")
+	assert.True(t, restored.TabAlive(1), "the first dead shell must be replaced")
+	assert.True(t, restored.TabAlive(2),
+		"the second dead shell must ALSO be replaced — the all-dead path replaced only the first (#2527)")
+	assert.Equal(t, 2, newSessions, "one fresh shell per dead shell")
+}
+
+// failNFirstNewSessionsPty fails the first N `tmux new-session` calls (the dead
+// shells' re-spawns) and lets every later one (the fresh-shell fallbacks) succeed.
+type failNFirstNewSessionsPty struct {
+	t         *testing.T
+	cmdExec   cmd_test.MockCmdExec
+	failFirst int
+	count     *int
+}
+
+func (p failNFirstNewSessionsPty) Start(cmd *exec.Cmd) (*os.File, error) {
+	if strings.Contains(cmd.String(), "new-session") {
+		*p.count++
+		if *p.count <= p.failFirst {
+			return nil, fmt.Errorf("new-session failed: worktree gone")
+		}
+	}
+	f, err := os.CreateTemp(p.t.TempDir(), "pty-")
+	if err == nil {
+		_ = p.cmdExec.Run(cmd)
+	}
+	return f, err
+}
+
+func (p failNFirstNewSessionsPty) Close() {}
+
 func TestRunningInstance_DeadNonDefaultShellTabKeepsTmuxNameOnLoad(t *testing.T) {
 	log.Initialize(false)
 	defer log.Close()

--- a/session/dead_respawn_test.go
+++ b/session/dead_respawn_test.go
@@ -369,10 +369,10 @@ func TestRunningInstance_AllShellsDead_EveryShellReplaced(t *testing.T) {
 	firstShell := agentName + shellTmuxSuffix
 	secondShell := agentName + "__shell-2"
 
-	// Only the agent is alive; both shells are gone. Their Restore re-spawns are
-	// allowed to succeed (persistPtyFactory), so on master the fallback would run
-	// but replace only the first shell — here Restore itself re-spawns both, so to
-	// force the fallback we fail BOTH re-spawns and let the fresh-shell spawns win.
+	// Only the agent is alive; both shells are gone. failNFirstNewSessionsPty fails
+	// the first TWO new-sessions — each dead shell's Restore re-spawn — so both stay
+	// dead and the setupTabs fallback must replace them; the later fresh-shell
+	// new-sessions succeed. On master the fallback replaced only the first shell.
 	var newSessions int
 	exec := countingExec(map[string]bool{agentName: true}, &newSessions)
 	failed := 0
@@ -394,6 +394,12 @@ func TestRunningInstance_AllShellsDead_EveryShellReplaced(t *testing.T) {
 	assert.True(t, restored.TabAlive(2),
 		"the second dead shell must ALSO be replaced — the all-dead path replaced only the first (#2527)")
 	assert.Equal(t, 2, newSessions, "one fresh shell per dead shell")
+	// The two replacements must take DISTINCT tmux names — never resolve to the same
+	// token and collide on the second Start (#2527 review).
+	tabs := restored.GetTabs()
+	require.Len(t, tabs, 3)
+	assert.NotEqual(t, tabs[1].tmux.SanitizedName(), tabs[2].tmux.SanitizedName(),
+		"the two replacement shells must get distinct tmux names")
 }
 
 // failNFirstNewSessionsPty fails the first N `tmux new-session` calls (the dead

--- a/session/instance.go
+++ b/session/instance.go
@@ -281,17 +281,6 @@ func (i *Instance) tmuxLocked() *tmux.TmuxSession {
 	return i.Tabs[0].tmux
 }
 
-// shellTabLocked returns the instance's Shell-kind tab (the terminal tab), or
-// nil if it has none yet. Callers must hold i.mu (read or write).
-func (i *Instance) shellTabLocked() *Tab {
-	for _, t := range i.Tabs {
-		if t.Kind == TabKindShell {
-			return t
-		}
-	}
-	return nil
-}
-
 // GetTabs returns a snapshot of the instance's tab list under the instance
 // mutex. The returned slice is a copy, so callers (the UI tab bar) can iterate
 // it without racing concurrent tab mutation.


### PR DESCRIPTION
Fixes #2527. `setupTabs` tracked shell liveness with a single `hasLiveShell` bool + a first-shell replacement capture — a single-shell-era design. With multiple shell tabs it could only express "at least one shell is live", so any live shell suppressed replacement of every dead one, and the all-dead path replaced only the first. A restore with >1 shell tab left the extras on "Terminal session not available".

**Fix:** restore now collects EACH shell tab that didn't come back live and replaces it independently, reusing the dead tab's own persisted tmux name (#1957-safe). Persisted shells always carry a distinct `TmuxName` (#955), so a multi-shell record never derives; `uniqueTabTmuxName` covers only a legacy single-shell empty-`TmuxName` row. Fresh sessions bind under one lock, re-found by pointer. The now-unused `shellTabLocked` is removed.

**Tests:** `TestRunningInstance_OneLiveOneDeadShell_DeadShellReplaced` and `_AllShellsDead_EveryShellReplaced` — both **fail on master** (dead shell unreplaced, wrong new-session count).

Gate: build, gofmt, golangci-lint, deadcode, `make test-container`. Codex rate-limited; Greptile is the live reviewer.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)