### PR TITLE
fix(bugreport): scrub usernames that end in a non-word char (#2533)

### DIFF
--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -69,53 +69,6 @@ func TestScrubRedactsSecretsPathsAndUser(t *testing.T) {
 	}
 }
 
-// TestScrubRedactsUsernameEndingInNonWordChar is the #2533 regression: an OS
-// username ending in a non-word rune (hyphen, dot, …) has no word boundary after
-// it, so the old `\b<name>\b` regex never matched it. The branch field
-// (`<username>/<session>`, left for the text scrub) then leaked the username in a
-// bundle meant to be safe to share. Against master these leak.
-func TestScrubRedactsUsernameEndingInNonWordChar(t *testing.T) {
-	for _, tc := range []struct {
-		name, user, in, leak, want string
-	}{
-		{"trailing hyphen", "test-", "branch test-/fix-login-bug", "test-/fix-login-bug", userMarker + "/fix-login-bug"},
-		{"trailing dot", "svc.", "worktree /srv/svc./repo", "svc./repo", userMarker + "/repo"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			r := &redactor{home: "/home/" + tc.user, users: []string{tc.user}}
-			out := r.scrub(tc.in)
-			if strings.Contains(out, tc.leak) {
-				t.Errorf("username ending in a non-word char leaked through scrub: %q\n%s", tc.leak, out)
-			}
-			if !strings.Contains(out, tc.want) {
-				t.Errorf("expected %q after scrub:\n%s", tc.want, out)
-			}
-		})
-	}
-}
-
-// TestScrubDoesNotOverRedactUsernameInsideAWord guards the boundary from the other
-// side: a username must not be blanked when it is only part of a longer word.
-func TestScrubDoesNotOverRedactUsernameInsideAWord(t *testing.T) {
-	r := &redactor{home: "/home/al", users: []string{"al"}}
-	if out := r.scrub("algorithm alerts"); out != "algorithm alerts" {
-		t.Errorf("username 'al' over-redacted inside a word: %q", out)
-	}
-}
-
-// TestRedactInstanceDataBranchUsernameScrubbed is the end-to-end #2533 lock: the
-// Branch field is not field-redacted (paths are left for the text scrub by design),
-// so a username with a non-word tail must still be blanked out of the rendered
-// branch by the scrub the redaction path applies.
-func TestRedactInstanceDataBranchUsernameScrubbed(t *testing.T) {
-	r := &redactor{home: "/home/test-", users: []string{"test-"}}
-	// The branch as instances.json carries it, then the text scrub the render path
-	// applies over the encoded document.
-	if out := r.scrub(`"branch":"test-/fix-login-bug"`); strings.Contains(out, "test-/fix-login-bug") {
-		t.Errorf("branch username leaked through the redaction scrub:\n%s", out)
-	}
-}
-
 func TestScrubRedactsSingleQuotedConfigSecrets(t *testing.T) {
 	r := &redactor{}
 	cases := []struct {

--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -69,6 +69,53 @@ func TestScrubRedactsSecretsPathsAndUser(t *testing.T) {
 	}
 }
 
+// TestScrubRedactsUsernameEndingInNonWordChar is the #2533 regression: an OS
+// username ending in a non-word rune (hyphen, dot, …) has no word boundary after
+// it, so the old `\b<name>\b` regex never matched it. The branch field
+// (`<username>/<session>`, left for the text scrub) then leaked the username in a
+// bundle meant to be safe to share. Against master these leak.
+func TestScrubRedactsUsernameEndingInNonWordChar(t *testing.T) {
+	for _, tc := range []struct {
+		name, user, in, leak, want string
+	}{
+		{"trailing hyphen", "test-", "branch test-/fix-login-bug", "test-/fix-login-bug", userMarker + "/fix-login-bug"},
+		{"trailing dot", "svc.", "worktree /srv/svc./repo", "svc./repo", userMarker + "/repo"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &redactor{home: "/home/" + tc.user, users: []string{tc.user}}
+			out := r.scrub(tc.in)
+			if strings.Contains(out, tc.leak) {
+				t.Errorf("username ending in a non-word char leaked through scrub: %q\n%s", tc.leak, out)
+			}
+			if !strings.Contains(out, tc.want) {
+				t.Errorf("expected %q after scrub:\n%s", tc.want, out)
+			}
+		})
+	}
+}
+
+// TestScrubDoesNotOverRedactUsernameInsideAWord guards the boundary from the other
+// side: a username must not be blanked when it is only part of a longer word.
+func TestScrubDoesNotOverRedactUsernameInsideAWord(t *testing.T) {
+	r := &redactor{home: "/home/al", users: []string{"al"}}
+	if out := r.scrub("algorithm alerts"); out != "algorithm alerts" {
+		t.Errorf("username 'al' over-redacted inside a word: %q", out)
+	}
+}
+
+// TestRedactInstanceDataBranchUsernameScrubbed is the end-to-end #2533 lock: the
+// Branch field is not field-redacted (paths are left for the text scrub by design),
+// so a username with a non-word tail must still be blanked out of the rendered
+// branch by the scrub the redaction path applies.
+func TestRedactInstanceDataBranchUsernameScrubbed(t *testing.T) {
+	r := &redactor{home: "/home/test-", users: []string{"test-"}}
+	// The branch as instances.json carries it, then the text scrub the render path
+	// applies over the encoded document.
+	if out := r.scrub(`"branch":"test-/fix-login-bug"`); strings.Contains(out, "test-/fix-login-bug") {
+		t.Errorf("branch username leaked through the redaction scrub:\n%s", out)
+	}
+}
+
 func TestScrubRedactsSingleQuotedConfigSecrets(t *testing.T) {
 	r := &redactor{}
 	cases := []struct {

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -156,9 +156,13 @@ func (r *redactor) scrub(s string) string {
 	if r.home != "" && r.home != "/" {
 		s = strings.ReplaceAll(s, r.home, "~")
 	}
+	// Blank bare username tokens with the SAME manual token boundary the title
+	// scrub uses, not a `\b<name>\b` regex: a `\b` after the username never matches
+	// when the username ends in a non-word rune (an OS username like "test-"), so
+	// "test-/fix-login-bug" in a branch leaked the username unredacted — a silent
+	// redaction failure in a bundle meant to be safe to share (#2533).
 	for _, name := range r.users {
-		re := regexp.MustCompile(`\b` + regexp.QuoteMeta(name) + `\b`)
-		s = re.ReplaceAllString(s, userMarker)
+		s = replaceBareToken(s, name, userMarker)
 	}
 	return s
 }
@@ -261,22 +265,36 @@ func redactAFTmuxTitle(match string) string {
 // of the title's own first/last character handles titles such as "client[prod]"
 // while refusing to match "." inside "1.2" or "/" inside "repo/path".
 func replaceBareTitle(s, title string) string {
-	if strings.TrimSpace(title) == "" || (!containsWordRune(title) && !strings.ContainsAny(title, "\r\n")) {
+	return replaceBareToken(s, title, redactedMarker)
+}
+
+// replaceBareToken replaces token with marker only where token occupies a
+// COMPLETE text token — start/end of text or a neighboring rune that is not a
+// letter, number, mark, or underscore. It is the manual-boundary replacement both
+// the title scrub and the username scrub use, because a `\b<token>\b` regex only
+// anchors at word↔non-word transitions: a token that itself ENDS (or starts) in a
+// non-word rune — a username like "test-", or a title like "client[prod]" — has no
+// `\b` after its trailing "-", so `\b` never matches it and it leaks (#2533). This
+// checks the actual neighboring runes instead, so "test-" is redacted in
+// "test-/fix-login-bug" (the "/" is a non-word boundary) but not inside a larger
+// word.
+func replaceBareToken(s, token, marker string) string {
+	if strings.TrimSpace(token) == "" || (!containsWordRune(token) && !strings.ContainsAny(token, "\r\n")) {
 		return s
 	}
 	var out strings.Builder
 	scan, copied := 0, 0
 	changed := false
-	for scan <= len(s)-len(title) {
-		rel := strings.Index(s[scan:], title)
+	for scan <= len(s)-len(token) {
+		rel := strings.Index(s[scan:], token)
 		if rel < 0 {
 			break
 		}
 		start := scan + rel
-		end := start + len(title)
+		end := start + len(token)
 		if titleTokenBoundary(s, start, end) && !insideRedactionMarker(s, start, end) {
 			out.WriteString(s[copied:start])
-			out.WriteString(redactedMarker)
+			out.WriteString(marker)
 			copied = end
 			scan = end
 			changed = true

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -126,11 +126,26 @@ func newRedactor() *redactor {
 	return &redactor{home: home, users: users}
 }
 
-// appendUserToken adds a username token to the scrub list, skipping empties,
-// path-ish junk, and tokens under 3 chars (too short to replace safely without
-// mangling unrelated substrings).
+// appendUserToken adds a username token to the scrub list — BOTH the raw form and,
+// when they differ, its lowercased form. The username scrub matches byte-exact, but
+// the branch stored in instances.json is strings.ToLower(username)
+// (config.BranchPrefix), so a mixed-case account ("Sachin.Iyer") would otherwise
+// ship its lowercased branch prefix ("sachin.iyer/…") verbatim — the home-to-tilde
+// collapse cannot catch it (different case, not a path). Registering both closes
+// that leak for the same class as the non-word-boundary one (#2533).
 func appendUserToken(users []string, name string) []string {
 	name = strings.TrimSpace(name)
+	users = addUserVariant(users, name)
+	if lower := strings.ToLower(name); lower != name {
+		users = addUserVariant(users, lower)
+	}
+	return users
+}
+
+// addUserVariant adds one username spelling to the scrub list, skipping empties,
+// path-ish junk, and tokens under 3 chars (too short to replace safely without
+// mangling unrelated substrings), and deduping.
+func addUserVariant(users []string, name string) []string {
 	if len(name) < 3 || name == "." || name == ".." || strings.ContainsAny(name, `/\`) {
 		return users
 	}
@@ -161,7 +176,22 @@ func (r *redactor) scrub(s string) string {
 	// when the username ends in a non-word rune (an OS username like "test-"), so
 	// "test-/fix-login-bug" in a branch leaked the username unredacted — a silent
 	// redaction failure in a bundle meant to be safe to share (#2533).
-	for _, name := range r.users {
+	//
+	// Longest-first, exactly as scrubSessionTitles orders titles and for the same
+	// reason: a shorter username can be a prefix of a longer one (a raw "jdoe" vs a
+	// home basename "jdoe.admin"), and redacting the prefix first destroys the only
+	// exact match for the longer token and strands its suffix. The manual boundary
+	// makes that prefix-shadowing easier to hit than `\b` did, so the ordering is
+	// part of the privacy invariant, not a nicety. Sort a copy so scrub stays a pure
+	// read of r.users.
+	names := append([]string(nil), r.users...)
+	sort.Slice(names, func(i, j int) bool {
+		if len(names[i]) != len(names[j]) {
+			return len(names[i]) > len(names[j])
+		}
+		return names[i] < names[j]
+	})
+	for _, name := range names {
 		s = replaceBareToken(s, name, userMarker)
 	}
 	return s

--- a/bugreport/redaction_test.go
+++ b/bugreport/redaction_test.go
@@ -1,0 +1,86 @@
+package bugreport
+
+import (
+	"strings"
+	"testing"
+)
+
+// Username / branch redaction cases (#2533). Split out of bugreport_test.go to
+// keep that file under the 1500-line limit (#1145); package and helpers are shared.
+
+// TestScrubRedactsUsernameEndingInNonWordChar is the #2533 regression: an OS
+// username ending in a non-word rune (hyphen, dot, …) has no word boundary after
+// it, so the old `\b<name>\b` regex never matched it. The branch field
+// (`<username>/<session>`, left for the text scrub) then leaked the username in a
+// bundle meant to be safe to share. Against master these leak.
+func TestScrubRedactsUsernameEndingInNonWordChar(t *testing.T) {
+	for _, tc := range []struct {
+		name, user, in, leak, want string
+	}{
+		{"trailing hyphen", "test-", "branch test-/fix-login-bug", "test-/fix-login-bug", userMarker + "/fix-login-bug"},
+		{"trailing dot", "svc.", "worktree /srv/svc./repo", "svc./repo", userMarker + "/repo"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &redactor{home: "/home/" + tc.user, users: []string{tc.user}}
+			out := r.scrub(tc.in)
+			if strings.Contains(out, tc.leak) {
+				t.Errorf("username ending in a non-word char leaked through scrub: %q\n%s", tc.leak, out)
+			}
+			if !strings.Contains(out, tc.want) {
+				t.Errorf("expected %q after scrub:\n%s", tc.want, out)
+			}
+		})
+	}
+}
+
+// TestScrubDoesNotOverRedactUsernameInsideAWord guards the boundary from the other
+// side: a username must not be blanked when it is only part of a longer word.
+func TestScrubDoesNotOverRedactUsernameInsideAWord(t *testing.T) {
+	r := &redactor{home: "/home/al", users: []string{"al"}}
+	if out := r.scrub("algorithm alerts"); out != "algorithm alerts" {
+		t.Errorf("username 'al' over-redacted inside a word: %q", out)
+	}
+}
+
+// TestRedactInstanceDataBranchUsernameScrubbed is the end-to-end #2533 lock: the
+// Branch field is not field-redacted (paths are left for the text scrub by design),
+// so a username with a non-word tail must still be blanked out of the rendered
+// branch by the scrub the redaction path applies.
+func TestRedactInstanceDataBranchUsernameScrubbed(t *testing.T) {
+	r := &redactor{home: "/home/test-", users: []string{"test-"}}
+	if out := r.scrub(`"branch":"test-/fix-login-bug"`); strings.Contains(out, "test-/fix-login-bug") {
+		t.Errorf("branch username leaked through the redaction scrub:\n%s", out)
+	}
+}
+
+// TestScrubRedactsMixedCaseUsernameLowercasedInBranch is the #2533 mixed-case half:
+// config.BranchPrefix lowercases the username, so a mixed-case account carries a
+// LOWERCASED branch prefix. Byte-exact matching against the raw username alone
+// misses it, so appendUserToken registers the lowercased form too. Against master
+// (raw token only) the username ships verbatim.
+func TestScrubRedactsMixedCaseUsernameLowercasedInBranch(t *testing.T) {
+	r := &redactor{home: "/home/Sachin.Iyer", users: appendUserToken(nil, "Sachin.Iyer")}
+	out := r.scrub(`"branch":"sachin.iyer/fix-login-bug"`)
+	if strings.Contains(out, "sachin.iyer/fix-login-bug") {
+		t.Errorf("lowercased branch username leaked for a mixed-case account:\n%s", out)
+	}
+	if !strings.Contains(out, userMarker+"/fix-login-bug") {
+		t.Errorf("expected [user]/fix-login-bug after scrub:\n%s", out)
+	}
+}
+
+// TestScrubUsernameLongestFirstAvoidsPrefixShadow is the #2533 ordering invariant:
+// a short username that is a prefix of a longer one (raw "jdoe" vs a home basename
+// "jdoe.admin") must be redacted longest-first, or redacting "jdoe" first destroys
+// the only match for the longer token and strands ".admin" — the same invariant the
+// title scrub already keeps. Without the sort this leaks ".admin".
+func TestScrubUsernameLongestFirstAvoidsPrefixShadow(t *testing.T) {
+	r := &redactor{home: "/home/jdoe.admin", users: []string{"jdoe", "jdoe.admin"}}
+	out := r.scrub("branch jdoe.admin/fix-1")
+	if strings.Contains(out, ".admin") {
+		t.Errorf("shorter username shadowed the longer one, stranding a suffix:\n%s", out)
+	}
+	if !strings.Contains(out, userMarker+"/fix-1") {
+		t.Errorf("expected [user]/fix-1 (longest-first match):\n%s", out)
+	}
+}


### PR DESCRIPTION
Fixes #2533. The Branch field of instances.json (`<username>/<session>`) is not field-redacted — by design, paths are left for the text scrub to collapse ($HOME→~, username→[user]). But `scrub` matched usernames with `\b<name>\b`, and `\b` only anchors at a word↔non-word transition: an OS username ending in a non-word rune (e.g. `test-`) has no boundary after its trailing `-`, so `test-/fix-login-bug` in a branch leaked the username. A bundle exists to be safe to share, so a silently-failing redaction is a trust break.

**Fix:** `scrub` now blanks usernames with the SAME manual token boundary the title scrub already uses (`titleTokenBoundary` via a generalized `replaceBareToken`) — it checks the actual neighboring runes, so `test-` is redacted before a non-word `/` but not inside a longer word. `replaceBareTitle` becomes a thin wrapper.

**Tests:** usernames ending in a hyphen/dot are scrubbed out of a branch/worktree string and the encoded branch field; a username inside a word is not over-redacted. Both leak cases **fail on master**.

Gate: build, gofmt, golangci-lint, deadcode, `make test-container`. Codex rate-limited; Greptile is the live reviewer.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)