### PR TITLE
fix(cli): watch timeout says "being replaced" during an agent handoff (#2530)

### DIFF
--- a/api/sessions_watch.go
+++ b/api/sessions_watch.go
@@ -116,6 +116,11 @@ func describeWatchState(d *session.InstanceData) string {
 		return "being archived"
 	case session.OpRestoring:
 		return "being restored"
+	case session.OpReplacing:
+		// An agent handoff (#2013) between its outgoing and incoming runtime — a
+		// distinct pending op (session/activity.go classifies it as such), not the
+		// generic "working" the liveness fallback below would otherwise report (#2530).
+		return "being replaced"
 	}
 	switch d.Liveness {
 	case session.LiveRunning:

--- a/api/sessions_watch_test.go
+++ b/api/sessions_watch_test.go
@@ -228,3 +228,27 @@ func TestWatchForReady_DisappearsMidWatch(t *testing.T) {
 		t.Fatalf("expected a 'disappeared' error, got: %v", err)
 	}
 }
+
+// TestDescribeWatchState_InFlightOps pins the timeout-message labels for each
+// in-flight op. #2530: OpReplacing (agent handoff) was missing, so it fell through
+// to the liveness switch and rendered as "working" during a replacement — against
+// master the OpReplacing case here reports "working".
+func TestDescribeWatchState_InFlightOps(t *testing.T) {
+	for _, tc := range []struct {
+		op   session.InFlightOp
+		want string
+	}{
+		{session.OpCreating, "being created"},
+		{session.OpKilling, "being killed"},
+		{session.OpArchiving, "being archived"},
+		{session.OpRestoring, "being restored"},
+		{session.OpReplacing, "being replaced"},
+	} {
+		// Liveness deliberately Running: without an explicit op case that would be
+		// the "working" fallback, so this proves the op wins.
+		d := &session.InstanceData{InFlightOp: tc.op, Liveness: session.LiveRunning}
+		if got := describeWatchState(d); got != tc.want {
+			t.Errorf("describeWatchState(op=%v) = %q, want %q", tc.op, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #2530. `describeWatchState` mapped every in-flight op to a phrase except `OpReplacing`, so a session mid-handoff (#2013) fell through to the liveness switch and rendered as "still working" in the watch-timeout message — inconsistent with `session/activity.go`, which classifies `OpReplacing` as a pending op. Adds the `case session.OpReplacing: return "being replaced"`.

`TestDescribeWatchState_InFlightOps` pins the label for every op; the `OpReplacing` row reports "working" on master.

Gate: build, gofmt, golangci-lint, deadcode, api package. Codex rate-limited; Greptile is the live reviewer.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)