### PR TITLE
fix(sessions): bound title-derived slug/branch/worktree names (#2528)

### DIFF
--- a/daemon/create_branch_hold_test.go
+++ b/daemon/create_branch_hold_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,6 +73,37 @@ func TestNextAvailableTitle_UncontestedNameKeepsBareForm(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "sweep", title)
+}
+
+// TestNextAvailableTitle_LongTitleWalkConverges is the #2528 P3-b regression at
+// the daemon call site. A long base title whose derived branch is already held
+// used to make the walk NON-CONVERGENT: branch truncation collapsed every
+// suffixed rung ("base-2", "base-3", …) to the SAME branch as the held base, so
+// the walk skipped all 10,000 rungs under m.mu and failed with "could not find an
+// available title". Bounding the base so the suffix survives lets it resolve at a
+// low rung.
+func TestNextAvailableTitle_LongTitleWalkConverges(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	base := strings.Repeat("a", 300)
+	// Hold the base's derived branch exactly as an archived session would, so the
+	// bare base (rung 1) is taken and the walk must find a distinct suffix.
+	holdBranchInArchivedWorktree(t, repoPath, manager.branchForTitle(base), "held")
+
+	manager.mu.Lock()
+	title, err := manager.nextAvailableTitleLocked(repoID, repoPath, base, "claude", runtimeNamespaceLocalTmux, nil)
+	manager.mu.Unlock()
+	require.NoError(t, err, "the walk must converge, not exhaust 10,000 rungs")
+
+	require.NotEqual(t, base, title, "the held bare base must be skipped")
+	assert.NotEqual(t, manager.branchForTitle(base), manager.branchForTitle(title),
+		"the resolved title must derive a DISTINCT branch, not one truncation re-collides")
+
+	// The resolved branch is actually creatable — not merely unheld on paper.
+	dest := filepath.Join(t.TempDir(), "run")
+	out, addErr := exec.Command("git", "-C", repoPath, "worktree", "add", "-b",
+		manager.branchForTitle(title), dest).CombinedOutput()
+	require.NoError(t, addErr, "resolved title %q must be usable: %s", title, string(out))
 }
 
 // TestNextAvailableTitle_ExistingBranchIsNotAHold keeps the new check as narrow

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -773,6 +773,12 @@ func (m *Manager) findArchivedOnlyCollisionLocked(repoID, repoPath, title string
 // label, not a branch to be created, so "is this branch checked out somewhere" is
 // not a question about it.
 func (m *Manager) uniqueArchivedTitleLocked(repoID, repoPath, base, program string, namespace runtimeNameNamespace, diskData []session.InstanceData) (string, error) {
+	// Bound the base so the " (archived N)" suffix survives branch truncation and
+	// each rung derives a DISTINCT branch; a long base otherwise collapses every
+	// rung to the same branch and the walk spins to 10,000 (#2528). Availability
+	// here is judged via TitlesCollide -> BranchForTitle even though no branch is
+	// created for the rename, so the same injectivity is required.
+	base = git.BoundTitleForDisambiguation(base)
 	for i := 1; i <= 10000; i++ {
 		candidate := fmt.Sprintf("%s (archived)", base)
 		if i > 1 {
@@ -801,10 +807,15 @@ func (m *Manager) nextAvailableTitleLocked(repoID, repoPath, baseTitle, program 
 	// somewhere, ONCE per walk, and skip those rungs instead of discovering the
 	// collision at add time.
 	heldBranches := m.worktreeHeldBranchesLocked(repoPath, namespace != runtimeNamespaceLocalTmux)
+	// Bound the base before suffixing so a long title's "-N" survives branch
+	// truncation and each rung derives a DISTINCT branch; otherwise every rung
+	// collapses to the taken base's branch, and the walk skips all 10,000 rungs
+	// under m.mu before failing (#2528). The bare base (i == 1) is unchanged.
+	boundedBase := git.BoundTitleForDisambiguation(baseTitle)
 	for i := 1; i <= 10000; i++ {
 		candidate := baseTitle
 		if i > 1 {
-			candidate = fmt.Sprintf("%s-%d", baseTitle, i)
+			candidate = fmt.Sprintf("%s-%d", boundedBase, i)
 		}
 		branch := m.branchForTitle(candidate)
 		if holder, held := heldBranches[branch]; held {

--- a/session/backend_hook_remote.go
+++ b/session/backend_hook_remote.go
@@ -8,15 +8,28 @@ import (
 
 var slugRegexp = regexp.MustCompile(`[^a-z0-9-]`)
 
+// maxSlugLen bounds the slug so it stays a legal filesystem component wherever a
+// backend uses it as one: the ssh backend's `mktemp -d "$HOME/<root>/<slug>.XXXXXX"`
+// and the hook backend's `mkdir -p "$STATE/<slug>"`. Linux NAME_MAX is 255 bytes
+// per component; 200 leaves room for the ssh ".XXXXXX" suffix and any prefix a hook
+// script adds. Without it a long title (creatable via the CLI/API, which don't share
+// the TUI's 32-char cap) failed deep in provisioning with a cryptic ENAMETOOLONG
+// (#2528). The slug is ASCII ([a-z0-9-]), so a byte truncation is rune-safe.
+const maxSlugLen = 200
+
 // Slugify converts a title to a slug-safe string for the remote hook scripts.
 // The slug is the stable identifier launch_cmd and delete_cmd receive via
 // --name (docs/remote-hooks.md): launch_cmd tags the provisioned sandbox with
 // it and delete_cmd reaps by it, so two sessions whose titles slugify the same
-// must not coexist (FindSlugCollision guards that at create time).
+// must not coexist (FindSlugCollision guards that at create time — including two
+// long titles that truncate to the same slug).
 func Slugify(title string) string {
 	s := strings.ToLower(title)
 	s = strings.ReplaceAll(s, " ", "-")
 	s = slugRegexp.ReplaceAllString(s, "")
+	if len(s) > maxSlugLen {
+		s = s[:maxSlugLen]
+	}
 	s = strings.Trim(s, "-")
 	if s == "" {
 		s = "session"

--- a/session/backend_instance_remote_test.go
+++ b/session/backend_instance_remote_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -65,6 +66,21 @@ func TestSlugifyNonEmpty(t *testing.T) {
 		s := Slugify(title)
 		assert.NotEmpty(t, s, "Slugify(%q) should not be empty", title)
 	}
+}
+
+// TestSlugifyBoundsLongTitles is the #2528 regression: a long title (creatable via
+// the CLI/API, which don't share the TUI's 32-char cap) must not produce a slug that
+// blows past a filesystem component limit and fails ssh mktemp / hook mkdir with
+// ENAMETOOLONG. Against master the slug is 500 chars.
+func TestSlugifyBoundsLongTitles(t *testing.T) {
+	s := Slugify(strings.Repeat("a", 500))
+	// The invariant: the slug plus ssh's ".XXXXXX" mktemp suffix stays under Linux
+	// NAME_MAX (255). Asserting the real limit, not the impl bound, so this fails on
+	// master (500 chars) rather than merely tracking the constant.
+	assert.LessOrEqual(t, len(s)+len(".XXXXXX"), 255, "slug must stay under the filesystem component limit")
+	assert.False(t, strings.HasPrefix(s, "-") || strings.HasSuffix(s, "-"), "no dangling dash from the cut: %q", s)
+	// A short title is unaffected.
+	assert.Equal(t, "my-session", Slugify("My Session"))
 }
 
 func TestSlugifyCollisionsReduce(t *testing.T) {

--- a/session/git/util.go
+++ b/session/git/util.go
@@ -52,6 +52,15 @@ func SanitizeBranchName(s string) string {
 		for strings.HasSuffix(part, ".lock") {
 			part = strings.TrimSuffix(part, ".lock")
 		}
+		// Each component becomes a directory/file under .git/refs/heads (or the
+		// worktree's refs), so it is bound by NAME_MAX. A long title creatable via
+		// the CLI/API (no TUI 32-char cap) otherwise failed with a cryptic "Unable to
+		// create ...: File name too long" (#2528). Truncate here, before the trailing
+		// edge cleanup below strips any dash/dot the cut exposed. The subset is ASCII,
+		// so a byte truncation is rune-safe.
+		if len(part) > maxNameComponentLen {
+			part = part[:maxNameComponentLen]
+		}
 		if part != "" {
 			filtered = append(filtered, part)
 		}
@@ -116,12 +125,24 @@ func sanitizeWorktreePathSegment(title string) string {
 	s := reUnsafeWorktreePathSegment.ReplaceAllString(title, "-")
 	s = strings.ReplaceAll(s, "..", "")
 	s = reMultiDash.ReplaceAllString(s, "-")
+	// One filesystem component (joined as "<repo>-<segment>"), so bound it under
+	// NAME_MAX or `git worktree add <path>` fails ENAMETOOLONG for a long title
+	// (#2528). reUnsafeWorktreePathSegment already reduced this to ASCII, so a byte
+	// truncation is rune-safe; trim afterwards so a dash the cut exposed is removed.
+	if len(s) > maxNameComponentLen {
+		s = s[:maxNameComponentLen]
+	}
 	s = strings.Trim(s, "-.")
 	if s == "" {
 		return "session"
 	}
 	return s
 }
+
+// maxNameComponentLen bounds a single title-derived filesystem/ref component. Linux
+// NAME_MAX is 255 bytes; 200 leaves margin for the "<repo>-" worktree prefix and
+// git's per-segment ".lock" reservation.
+const maxNameComponentLen = 200
 
 // TitlesCollide reports whether two session titles cannot coexist in the same
 // repo because they would derive the same git branch. Exact (case-insensitive)

--- a/session/git/util.go
+++ b/session/git/util.go
@@ -48,18 +48,25 @@ func SanitizeBranchName(s string) string {
 	parts := strings.Split(s, "/")
 	filtered := make([]string, 0, len(parts))
 	for _, part := range parts {
+		// Bound the component BEFORE the leading-dot / trailing-".lock" cleanup
+		// below. Each component becomes a directory/file under .git/refs/heads (and
+		// the worktree's refs), so it is bound by NAME_MAX; a long title creatable
+		// via the CLI/API (no TUI 32-char cap) otherwise derived a component over the
+		// limit and failed with a cryptic "Unable to create ...: File name too long"
+		// (#2528). The subset here is ASCII, so a byte truncation is rune-safe.
+		//
+		// Truncating FIRST is load-bearing (#2528 review): the cut can land inside —
+		// or newly expose a trailing — ".lock", which git reserves on EVERY
+		// slash-separated component, not just the last. The cleanup that follows only
+		// removes it because it runs AFTER the cut; the whole-ref trimBranchNameEdges
+		// below repairs only the final component, so a re-exposed ".lock" on a
+		// non-final component would otherwise survive and git would reject the ref.
+		if len(part) > maxBranchComponentLen {
+			part = part[:maxBranchComponentLen]
+		}
 		part = strings.TrimLeft(part, ".")
 		for strings.HasSuffix(part, ".lock") {
 			part = strings.TrimSuffix(part, ".lock")
-		}
-		// Each component becomes a directory/file under .git/refs/heads (or the
-		// worktree's refs), so it is bound by NAME_MAX. A long title creatable via
-		// the CLI/API (no TUI 32-char cap) otherwise failed with a cryptic "Unable to
-		// create ...: File name too long" (#2528). Truncate here, before the trailing
-		// edge cleanup below strips any dash/dot the cut exposed. The subset is ASCII,
-		// so a byte truncation is rune-safe.
-		if len(part) > maxNameComponentLen {
-			part = part[:maxNameComponentLen]
 		}
 		if part != "" {
 			filtered = append(filtered, part)
@@ -121,17 +128,15 @@ func BranchForTitle(branchPrefix, title string) string {
 // segment for AF-owned worktree directories. It preserves ordinary title case
 // for readability while removing separators/traversal and replacing whitespace
 // or shell-hostile punctuation with dashes.
+//
+// It does NOT bound the length: the worktree directory component is the JOINED
+// "<repoName>-<segment>", so the segment's NAME_MAX allowance depends on the repo
+// name and is applied by the caller at the join site (resolveWorktreePlacement),
+// where that prefix is known (#2528).
 func sanitizeWorktreePathSegment(title string) string {
 	s := reUnsafeWorktreePathSegment.ReplaceAllString(title, "-")
 	s = strings.ReplaceAll(s, "..", "")
 	s = reMultiDash.ReplaceAllString(s, "-")
-	// One filesystem component (joined as "<repo>-<segment>"), so bound it under
-	// NAME_MAX or `git worktree add <path>` fails ENAMETOOLONG for a long title
-	// (#2528). reUnsafeWorktreePathSegment already reduced this to ASCII, so a byte
-	// truncation is rune-safe; trim afterwards so a dash the cut exposed is removed.
-	if len(s) > maxNameComponentLen {
-		s = s[:maxNameComponentLen]
-	}
 	s = strings.Trim(s, "-.")
 	if s == "" {
 		return "session"
@@ -139,10 +144,43 @@ func sanitizeWorktreePathSegment(title string) string {
 	return s
 }
 
-// maxNameComponentLen bounds a single title-derived filesystem/ref component. Linux
-// NAME_MAX is 255 bytes; 200 leaves margin for the "<repo>-" worktree prefix and
-// git's per-segment ".lock" reservation.
-const maxNameComponentLen = 200
+// maxBranchComponentLen bounds a single title-derived git ref component. Linux
+// NAME_MAX is 255 bytes per path component; 200 is deliberately conservative,
+// leaving headroom for git's transient "<ref>.lock" and for the "-N" suffix a
+// worktree directory derived from the same name may carry (see worktree.go). A
+// branch ref component has no variable prefix eating into it — the branch prefix
+// is its own slash component — so this fixed budget is a real bound.
+const maxBranchComponentLen = 200
+
+// disambiguationSuffixReserve is the room BoundTitleForDisambiguation keeps free
+// within a branch component for a uniquifying suffix ("-2", " (archived 3)", …).
+// It comfortably exceeds the longest such suffix (" (archived 10000)").
+const disambiguationSuffixReserve = 32
+
+// BoundTitleForDisambiguation trims a base title so that appending a short
+// uniquifying suffix derives a DISTINCT branch instead of one that truncation
+// makes identical (#2528).
+//
+// The daemon's title walks (nextAvailableTitleLocked, uniqueArchivedTitleLocked)
+// append "-N" / " (archived N)" to a base title and decide availability on the
+// DERIVED branch. When the base is long, SanitizeBranchName truncates the suffix
+// away, so every rung derives the same branch as the taken base: the walk finds
+// nothing free and burns all 10,000 iterations under the manager lock before
+// failing. Bounding the base here keeps the suffix inside maxBranchComponentLen so
+// distinct suffixes stay injective and the walk converges at a low rung.
+//
+// Sanitization never lengthens a string (it only lowercases, replaces 1:1, and
+// removes), so bounding the base by RUNES to (budget - reserve) guarantees its
+// sanitized form leaves room for the suffix, and keeps the returned title valid
+// UTF-8.
+func BoundTitleForDisambiguation(base string) string {
+	limit := maxBranchComponentLen - disambiguationSuffixReserve
+	runes := []rune(base)
+	if len(runes) <= limit {
+		return base
+	}
+	return string(runes[:limit])
+}
 
 // TitlesCollide reports whether two session titles cannot coexist in the same
 // repo because they would derive the same git branch. Exact (case-insensitive)

--- a/session/git/util_test.go
+++ b/session/git/util_test.go
@@ -188,6 +188,34 @@ func TestBranchForTitle(t *testing.T) {
 	}
 }
 
+// TestBranchAndWorktreeNamesBoundLongTitles is the #2528 regression: a long title
+// (creatable via the CLI/API, no TUI 32-char cap) must not derive a branch ref or
+// worktree path component that overruns NAME_MAX and fails with "File name too
+// long". Against master these are 500+ chars.
+func TestBranchAndWorktreeNamesBoundLongTitles(t *testing.T) {
+	long := strings.Repeat("a", 500)
+	// The invariant: every derived filesystem/ref component stays under Linux
+	// NAME_MAX (255), with margin for git's transient "<ref>.lock". Asserting the
+	// real limit, not the impl bound, so this fails on master (500 chars).
+	const safeMax = 255 - len(".lock")
+
+	branch := BranchForTitle("af-jdoe/", long)
+	for _, part := range strings.Split(branch, "/") {
+		if len(part) > safeMax {
+			t.Errorf("branch component %q is %d bytes, over the %d NAME_MAX budget", part, len(part), safeMax)
+		}
+	}
+
+	if seg := sanitizeWorktreePathSegment(long); len(seg) > safeMax {
+		t.Errorf("worktree path segment is %d bytes, over the %d NAME_MAX budget", len(seg), safeMax)
+	}
+
+	// Short titles are unaffected.
+	if got := BranchForTitle("af-", "MyApp"); got != "af-myapp" {
+		t.Errorf("short title branch changed: %q", got)
+	}
+}
+
 // TestTitlesCollide pins the shared collision rule used by both the daemon's
 // authoritative create-time check and the TUI's naming pre-check (#936). The
 // rule is: case-insensitive equality OR sanitize-to-the-same-branch.

--- a/session/git/util_test.go
+++ b/session/git/util_test.go
@@ -1,8 +1,12 @@
 package git
 
 import (
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
 )
 
 func TestSanitizeBranchName(t *testing.T) {
@@ -206,13 +210,84 @@ func TestBranchAndWorktreeNamesBoundLongTitles(t *testing.T) {
 		}
 	}
 
-	if seg := sanitizeWorktreePathSegment(long); len(seg) > safeMax {
-		t.Errorf("worktree path segment is %d bytes, over the %d NAME_MAX budget", len(seg), safeMax)
+	// The default local placement is sibling mode (config.DefaultConfig), where the
+	// worktree DIRECTORY name is the JOINED "<repoName>-<segment>" component — the
+	// real thing that must fit NAME_MAX. A realistic repo name eats into the budget,
+	// so capping the segment alone (as the first #2528 cut did) still overruns:
+	// 60-byte repo name + a 200-byte segment cap = a 261-byte component. Assert the
+	// joined component at the join site, not the segment proxy (#2528 review).
+	repoBase := strings.Repeat("r", 60) // a plausible long repo directory name
+	repoRoot := filepath.Join(t.TempDir(), repoBase)
+	worktreeDir := t.TempDir()
+	cfg := &config.Config{WorktreeRoot: config.WorktreeRootSibling}
+	p, err := resolveWorktreePlacement(cfg, repoRoot, worktreeDir, long, branch)
+	if err != nil {
+		t.Fatalf("resolveWorktreePlacement: %v", err)
+	}
+	comp := filepath.Base(p)
+	if len(comp) > 255 {
+		t.Errorf("worktree dir component is %d bytes, over NAME_MAX 255", len(comp))
+	}
+	if !strings.HasPrefix(comp, repoBase+"-") {
+		t.Errorf("worktree dir component lost its %q- repo-name prefix", repoBase)
 	}
 
 	// Short titles are unaffected.
 	if got := BranchForTitle("af-", "MyApp"); got != "af-myapp" {
 		t.Errorf("short title branch changed: %q", got)
+	}
+}
+
+// TestSanitizeBranchName_TruncationCannotReexposeDotLock is the #2528 P3-a
+// regression: truncating a long component must run BEFORE the ".lock" cleanup, so
+// a cut that lands on — or newly exposes — a ".lock" suffix cannot leave it on a
+// NON-final component. git reserves ".lock" on every slash-separated component,
+// and trimBranchNameEdges only repairs the final one.
+func TestSanitizeBranchName_TruncationCannotReexposeDotLock(t *testing.T) {
+	// Component 0 is 195 'a's + ".lock" + filler, so a 200-byte cut lands exactly
+	// after the ".lock"; the trailing "/tail" keeps it a NON-final component. Under
+	// the old strip-then-truncate order the cut re-exposed ".lock" and nothing
+	// removed it.
+	title := strings.Repeat("a", 195) + ".lock" + strings.Repeat("b", 50) + "/tail"
+	branch := SanitizeBranchName(title)
+
+	for _, part := range strings.Split(branch, "/") {
+		if strings.HasSuffix(part, ".lock") {
+			t.Errorf("branch component %q ends in .lock — truncation re-exposed it", part)
+		}
+	}
+	// Ground truth: git itself must accept the ref.
+	if out, err := exec.Command("git", "check-ref-format", "refs/heads/"+branch).CombinedOutput(); err != nil {
+		t.Errorf("git check-ref-format rejected %q: %v\n%s", branch, err, out)
+	}
+}
+
+// TestBoundTitleForDisambiguation_KeepsSuffixesInjective is the #2528 P3-b
+// mechanism lock. The daemon's uniquifying walks append "-N" / " (archived N)" to
+// a base title and judge availability on the DERIVED branch. For a long base,
+// truncation makes every suffixed rung derive the SAME branch as the base — a
+// non-convergent walk. Bounding the base keeps distinct suffixes distinct.
+func TestBoundTitleForDisambiguation_KeepsSuffixesInjective(t *testing.T) {
+	const prefix = "jdoe/"
+	long := strings.Repeat("a", 300)
+
+	// Precondition (the bug): a RAW long base+suffix derives the same truncated
+	// branch as the base, so the reserve is load-bearing.
+	if BranchForTitle(prefix, long+"-2") != BranchForTitle(prefix, long) {
+		t.Fatal("precondition changed: a raw long base+suffix no longer collides")
+	}
+
+	bounded := BoundTitleForDisambiguation(long)
+	base := BranchForTitle(prefix, long)
+	b2 := BranchForTitle(prefix, bounded+"-2")
+	b3 := BranchForTitle(prefix, bounded+"-3")
+	if b2 == base || b3 == base || b2 == b3 {
+		t.Errorf("bounded suffixes must derive distinct branches: base=%q -2=%q -3=%q", base, b2, b3)
+	}
+
+	// Short titles pass through untouched.
+	if got := BoundTitleForDisambiguation("myapp"); got != "myapp" {
+		t.Errorf("short base was altered: %q", got)
 	}
 }
 

--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -233,12 +233,22 @@ func resolveWorktreePlacement(cfg *config.Config, repoRoot, worktreeDir, session
 		// always has a branch, so this fallback only ever engages on restore.
 		leaf := branchName
 		if strings.TrimSpace(leaf) == "" {
-			leaf = sanitizeWorktreePathSegment(sessionName)
+			// The fallback leaf is a standalone component (no repo-name prefix), so
+			// bound it against NAME_MAX on its own. Branch-derived leaves are already
+			// bounded per component by SanitizeBranchName.
+			leaf = boundWorktreeComponent("", sanitizeWorktreePathSegment(sessionName))
 		}
 		basePath = filepath.Join(worktreeDir, leaf)
 	} else {
-		// Sibling mode: {repoParent}/{repoName}-{sessionName}
-		basePath = filepath.Join(worktreeDir, filepath.Base(repoRoot)+"-"+sanitizeWorktreePathSegment(sessionName))
+		// Sibling mode: {repoParent}/{repoName}-{sessionName}. The directory name is
+		// the JOINED "<repoName>-<segment>" component — and git derives the
+		// .git/worktrees/<id> admin dir from its basename — so both must fit
+		// NAME_MAX. Budget the segment against the ACTUAL repo-name prefix here at
+		// the join site; a fixed cap on the segment alone silently overruns once the
+		// repo name is long (#2528).
+		repoBase := filepath.Base(repoRoot)
+		segment := boundWorktreeComponent(repoBase, sanitizeWorktreePathSegment(sessionName))
+		basePath = filepath.Join(worktreeDir, repoBase+"-"+segment)
 	}
 
 	// Ensure the worktree path is strictly nested inside worktreeDir. We use
@@ -251,6 +261,49 @@ func resolveWorktreePlacement(cfg *config.Config, repoRoot, worktreeDir, session
 		return "", fmt.Errorf("invalid session name %q: would place worktree outside %s", sessionName, worktreeDir)
 	}
 	return firstFreeWorktreePath(basePath)
+}
+
+const (
+	// nameMax is the Linux per-component filesystem limit (NAME_MAX). A worktree
+	// directory name — and the .git/worktrees/<id> admin dir git derives from its
+	// basename — must both satisfy it, or `git worktree add` fails ENAMETOOLONG for
+	// a long title (#2528).
+	nameMax = 255
+	// worktreeCollisionSuffixReserve leaves room within nameMax for
+	// firstFreeWorktreePath's "-N" collision suffix, which extends the SAME
+	// directory component when the base path is already occupied.
+	worktreeCollisionSuffixReserve = 16
+)
+
+// boundWorktreeComponent trims segment so the worktree directory component stays
+// within NAME_MAX with room for the collision suffix. In sibling mode the
+// component is "<repoBase>-<segment>", so the segment's allowance is derived from
+// the actual repo-name prefix — the budgeting a fixed per-segment cap got wrong by
+// ignoring that prefix entirely (#2528). Pass repoBase "" for a standalone
+// component (the subdirectory-mode fallback leaf).
+//
+// repoBase is itself a real directory name and therefore already <= NAME_MAX; when
+// it is long enough to crowd the segment out, the segment collapses to a one-byte
+// floor and the collision suffix still disambiguates. segment is ASCII
+// (sanitizeWorktreePathSegment), so a byte truncation is rune-safe.
+func boundWorktreeComponent(repoBase, segment string) string {
+	allow := nameMax - worktreeCollisionSuffixReserve
+	if repoBase != "" {
+		allow -= len(repoBase) + len("-")
+	}
+	if allow < 1 {
+		allow = 1
+	}
+	if len(segment) <= allow {
+		return segment
+	}
+	segment = strings.Trim(segment[:allow], "-.")
+	if segment == "" {
+		// Never return empty: it would collapse "<repoBase>-<segment>" to a trailing
+		// separator (and a standalone leaf to nothing).
+		segment = "s"
+	}
+	return segment
 }
 
 // firstFreeWorktreePath returns basePath, or basePath with the lowest "-N"

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -183,14 +183,28 @@ func TestNewGitWorktree_StatErrorReturns(t *testing.T) {
 	sandboxHome(t)
 
 	repoRoot := createGitRepo(t)
+	// Subdirectory mode nests the worktree under the branch-prefix path, giving an
+	// intermediate directory to sabotage. (A long title no longer works as the
+	// trigger — #2528 bounds title-derived path components under NAME_MAX.)
 	cfg := config.DefaultConfig()
-	cfg.BranchPrefix = "test/"
+	cfg.WorktreeRoot = config.WorktreeRootSubdirectory
+	cfg.BranchPrefix = "blocker/"
 	require.NoError(t, config.SaveConfig(cfg))
+
+	// Plant a FILE where the "blocker" branch-prefix subdirectory would be, so
+	// os.Stat of the worktree path (worktrees/blocker/<title>) returns a non-ENOENT
+	// error (ENOTDIR). firstFreeWorktreePath must surface it as "cannot check
+	// worktree path", never hang or treat the path as free.
+	configDir, err := config.GetConfigDir()
+	require.NoError(t, err)
+	worktreeDir := filepath.Join(configDir, "worktrees")
+	require.NoError(t, os.MkdirAll(worktreeDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(worktreeDir, "blocker"), []byte("not a dir"), 0o644))
 
 	errCh := make(chan error, 1)
 	go func() {
-		_, _, err := NewGitWorktree(repoRoot, strings.Repeat("a", 300))
-		errCh <- err
+		_, _, wErr := NewGitWorktree(repoRoot, "some-title")
+		errCh <- wErr
 	}()
 
 	select {


### PR DESCRIPTION
Fixes #2528. A long title — creatable via CLI/API (no TUI 32-char cap) — flowed unbounded into filesystem/ref components and failed deep in provisioning with a cryptic ENAMETOOLONG: ssh `mktemp` / hook `mkdir` on the slug, and git's `.git/refs/heads/<branch>` ref plus the worktree dir on local. Bound the **derived paths**, not the title.

## Review fixes (the first cut bounded the wrong quantities — all three findings were right)

**P2 — the fix did not hold in the default config, and the test hid it.** The thing that must fit NAME_MAX is not the worktree *segment* but the JOINED sibling-mode component `filepath.Base(repoRoot) + "-" + segment` — and sibling is the **default** local placement (`config.DefaultConfig` → `WorktreeRootSibling`). A fixed 200-byte segment cap left only `255−200−1=54` bytes for the repo dir name: a 60-byte repo + long title → a 261-byte component → `cannot check worktree path …: file name too long`. Same for the `.git/worktrees/<id>` admin dir git derives from that basename. The old test only measured `len(sanitizeWorktreePathSegment)` — the segment proxy — never the joined component.

- Budget at the **join site** in `resolveWorktreePlacement`. `boundWorktreeComponent` derives the segment allowance from `len(filepath.Base(repoRoot))` and reserves room for `firstFreeWorktreePath`'s `-N` collision suffix, so the whole `<repo>-<segment>` directory name (and the admin dir) fit NAME_MAX.
- `sanitizeWorktreePathSegment` no longer length-caps — bounding belongs where the prefix is known.
- The regression test asserts the **joined component** at the join site.

**P3-a — truncation could re-expose a `.lock` suffix.** The cut inside `SanitizeBranchName`'s component loop ran *after* the `.lock` strip, so it could re-expose `.lock` on a NON-final component that nothing then removes (`trimBranchNameEdges` repairs only the final component, and git rejects `.lock` on every slash-separated component).

- Truncate **before** the leading-dot/`.lock` cleanup so the cleanup runs on the cut string. New test drives the exact cut and asserts `git check-ref-format` accepts the ref (verified red under the old ordering).

**P3-b — the daemon's uniquifying walks became non-convergent** (an adjacent call site the first cut did not audit). `nextAvailableTitleLocked` appends `-2`…`-10000` to the title and `uniqueArchivedTitleLocked` appends ` (archived N)`, but availability is judged on the **derived branch**. For a long base, truncation collapses every rung to the taken base's branch, so the walk skips all 10,000 rungs under `m.mu` and fails — pre-PR it returned at rung 2.

- `git.BoundTitleForDisambiguation` trims the base so the uniquifying suffix survives the byte budget and distinct rungs stay injective; both walks use it. A git unit locks the injectivity; a daemon test proves `nextAvailableTitleLocked` converges to a usable branch when the bare base's branch is already held.

The slug bound (`backend_hook_remote.go`) is a standalone component with no prefix, so its fixed cap is a real bound and is **unchanged**.

## Original change (unchanged)

- `Slugify` → 200 (NAME_MAX 255, minus ssh's `.XXXXXX`).
- `SanitizeBranchName` → each slash-separated component bounded (each a ref path segment).

All subsets are ASCII (byte truncation is rune-safe), and the existing collision guards still reject two long titles that truncate to the same slug/branch.

Gate: build, gofmt, golangci-lint, deadcode, file-length, `session` + `session/git` packages, `make test-container`. Codex rate-limited; Greptile is the live reviewer.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
