### PR TITLE
feat(config): canonical root_agent resolver + legacy root_agents adapter (#2216)

### DIFF
--- a/config/rootagent_resolve.go
+++ b/config/rootagent_resolve.go
@@ -2,10 +2,17 @@ package config
 
 // This file is the permanent legacy `root_agents` compatibility adapter (#2216
 // Phase 6, PR1). It introduces the canonical root-agent profile and the single
-// resolver that combines every root-agent source into one effective decision,
-// so no consumer re-implements precedence. PR1 carries only the built-in and the
-// legacy path-keyed source; a later PR adds the global and personal-project
-// singleton layers to the same resolver without any consumer changing.
+// resolver, ResolveRootAgent, that combines every root-agent source into one
+// effective decision so no consumer re-implements precedence.
+//
+// PR1 is the config-package adapter ONLY: it carries the built-in base and the
+// legacy path-keyed source, with tests proving existing `root_agents` entries
+// resolve to the canonical form unchanged. The daemon still reads
+// m.cfg.RootAgents directly and is untouched here — the strongest non-breaking
+// guarantee is that its ensure loop does not change at all. PR2's daemon
+// integration is what switches EnsureRootAgents AND repoRootAgentWillMaterialize
+// (which both read the map directly today) onto this resolver, at the same time
+// it adds the global and personal-project singleton layers below the personal one.
 
 // RootAgent is the canonical root-agent profile: whether a project keeps an
 // always-ensured "root" session, and the command it runs. It is the singular
@@ -15,9 +22,17 @@ package config
 type RootAgent struct {
 	// Enabled is whether an always-ensured root session runs for the project.
 	// The built-in default is false, which keeps root agents strictly opt-in.
-	Enabled bool `json:"enabled,omitempty" toml:"enabled,omitempty"`
-	// Program is the command the root session runs. Empty selects the default
-	// root profile downstream (the repo's resolved claude with
+	//
+	// Deliberately NO omitempty: once this is the singleton [root_agent] key
+	// (PR2), an explicit `enabled = false` written to override an enabling global
+	// layer must survive a full serialization — RegisterRootAgent and
+	// saveConfigLocked toml.Marshal the whole Config — or the override is silently
+	// erased on the next write, the zero-value-elision class this repo already
+	// paid for in #1700.
+	Enabled bool `json:"enabled" toml:"enabled"`
+	// Program is the command the root session runs. Empty means UNSET, not "run
+	// an empty command": it falls through to a lower-precedence layer's program
+	// and ultimately the default root profile (the repo's resolved claude with
 	// --dangerously-skip-permissions), exactly as an empty legacy
 	// RootAgentConfig.Program does today.
 	Program string `json:"program,omitempty" toml:"program,omitempty"`
@@ -30,9 +45,13 @@ type RootAgent struct {
 // compatibility source, and adding fields keeps existing callers valid.
 type RootAgentInputs struct {
 	// Legacy is the path-keyed `root_agents` entry for this project, or nil. A
-	// present entry is always enabled with its configured program — that is what
-	// a legacy entry has always meant, and preserving it verbatim is the
-	// non-breaking compatibility guarantee.
+	// present entry always ENABLES the root (that is what a legacy entry has
+	// always meant); its program applies only when non-empty, because an empty
+	// legacy program has always meant "use the default profile" — i.e. unset. That
+	// distinction is load-bearing once a lower layer can supply a program: the
+	// common legacy entry is EMPTY (af's own register and project-switch paths
+	// write an empty RootAgentConfig for every project), so treating empty as
+	// set-to-empty would clobber a global program back to nothing.
 	Legacy *RootAgentConfig
 }
 
@@ -75,11 +94,13 @@ type RootAgentResolution struct {
 //
 // PR1 (#2216 Phase 6) carries the permanent legacy compatibility source only:
 // the built-in opt-in-false base, then the path-keyed `root_agents` entry. A
-// present legacy entry resolves to exactly {Enabled: true, Program:
-// entry.Program} — byte-for-byte the profile the daemon used when it read the
-// map directly, which is the non-breaking guarantee this PR is built to prove.
-// Later phases add the global and personal-project singleton layers to this
-// function; consumers keep calling ResolveRootAgent unchanged.
+// present legacy entry resolves to Enabled=true with its program (an empty
+// program stays unset and falls through to the default profile) — matching the
+// profile the daemon derives when it reads the map directly, which is the
+// non-breaking guarantee this PR proves by test. PR1 does NOT wire the daemon to
+// this function. PR2's daemon integration does, and adds the global layer
+// between the built-in base and the legacy source, and the personal-project
+// layer after it.
 func ResolveRootAgent(in RootAgentInputs) RootAgentResolution {
 	res := RootAgentResolution{}
 	// Built-in base: root agents are opt-in, so nothing runs unless a higher
@@ -94,14 +115,21 @@ func ResolveRootAgent(in RootAgentInputs) RootAgentResolution {
 
 	if in.Legacy != nil {
 		res.Enabled = true
-		res.Program = in.Legacy.Program
+		reason := "a path-keyed root_agents entry is an always-ensured root"
+		if in.Legacy.Program != "" {
+			res.Program = in.Legacy.Program
+		} else {
+			// An empty legacy program is UNSET, not set-to-empty: leave any
+			// lower-precedence program in place instead of clobbering it (P3-a).
+			reason += "; empty program is unset, so the default profile applies"
+		}
 		res.Candidates = append(res.Candidates, RootAgentCandidate{
 			Source:  RootAgentSourceLegacy,
 			Present: true,
 			Enabled: true,
 			Program: in.Legacy.Program,
 			Result:  "winner",
-			Reason:  "a path-keyed root_agents entry is an always-ensured root",
+			Reason:  reason,
 		})
 	} else {
 		res.Candidates = append(res.Candidates, RootAgentCandidate{

--- a/config/rootagent_resolve.go
+++ b/config/rootagent_resolve.go
@@ -1,0 +1,115 @@
+package config
+
+// This file is the permanent legacy `root_agents` compatibility adapter (#2216
+// Phase 6, PR1). It introduces the canonical root-agent profile and the single
+// resolver that combines every root-agent source into one effective decision,
+// so no consumer re-implements precedence. PR1 carries only the built-in and the
+// legacy path-keyed source; a later PR adds the global and personal-project
+// singleton layers to the same resolver without any consumer changing.
+
+// RootAgent is the canonical root-agent profile: whether a project keeps an
+// always-ensured "root" session, and the command it runs. It is the singular
+// successor to the path-keyed `root_agents` map. That map is preserved forever
+// as a read-only compatibility source and adapted into this shape by
+// ResolveRootAgent — existing configs never stop working.
+type RootAgent struct {
+	// Enabled is whether an always-ensured root session runs for the project.
+	// The built-in default is false, which keeps root agents strictly opt-in.
+	Enabled bool `json:"enabled,omitempty" toml:"enabled,omitempty"`
+	// Program is the command the root session runs. Empty selects the default
+	// root profile downstream (the repo's resolved claude with
+	// --dangerously-skip-permissions), exactly as an empty legacy
+	// RootAgentConfig.Program does today.
+	Program string `json:"program,omitempty" toml:"program,omitempty"`
+}
+
+// RootAgentInputs are the per-project candidate values ResolveRootAgent layers,
+// lowest precedence first. Each is nil when that source configured no root agent
+// for the project. The struct grows as later #2216 phases add the global and
+// personal-project singleton layers; PR1 carries only the permanent legacy
+// compatibility source, and adding fields keeps existing callers valid.
+type RootAgentInputs struct {
+	// Legacy is the path-keyed `root_agents` entry for this project, or nil. A
+	// present entry is always enabled with its configured program — that is what
+	// a legacy entry has always meant, and preserving it verbatim is the
+	// non-breaking compatibility guarantee.
+	Legacy *RootAgentConfig
+}
+
+// RootAgentSource names a candidate layer in a resolution trace.
+type RootAgentSource string
+
+const (
+	// RootAgentSourceBuiltIn is the opt-in-false base.
+	RootAgentSourceBuiltIn RootAgentSource = "built-in"
+	// RootAgentSourceLegacy is a path-keyed `root_agents` entry, kept as a
+	// permanent read-only compatibility source.
+	RootAgentSourceLegacy RootAgentSource = "legacy root_agents"
+)
+
+// RootAgentCandidate is one considered layer in a ResolveRootAgent trace. The
+// trace is produced in the same pass as the value so a later `af config get
+// root_agent --explain` renders it without a second precedence implementation
+// (#2216 §5).
+type RootAgentCandidate struct {
+	Source  RootAgentSource `json:"source"`
+	Present bool            `json:"present"`
+	Enabled bool            `json:"enabled"`
+	Program string          `json:"program,omitempty"`
+	// Result is one of "base", "winner", "shadowed", or "absent".
+	Result string `json:"result"`
+	Reason string `json:"reason"`
+}
+
+// RootAgentResolution is the effective root-agent profile plus the full trace of
+// every candidate the resolver considered.
+type RootAgentResolution struct {
+	RootAgent
+	Candidates []RootAgentCandidate `json:"candidates"`
+}
+
+// ResolveRootAgent layers the provided candidate sources into one effective
+// root-agent profile, lowest precedence first, and returns the effective value
+// together with its provenance trace. It is the single authority on how
+// root-agent config combines.
+//
+// PR1 (#2216 Phase 6) carries the permanent legacy compatibility source only:
+// the built-in opt-in-false base, then the path-keyed `root_agents` entry. A
+// present legacy entry resolves to exactly {Enabled: true, Program:
+// entry.Program} — byte-for-byte the profile the daemon used when it read the
+// map directly, which is the non-breaking guarantee this PR is built to prove.
+// Later phases add the global and personal-project singleton layers to this
+// function; consumers keep calling ResolveRootAgent unchanged.
+func ResolveRootAgent(in RootAgentInputs) RootAgentResolution {
+	res := RootAgentResolution{}
+	// Built-in base: root agents are opt-in, so nothing runs unless a higher
+	// layer turns it on.
+	res.Candidates = append(res.Candidates, RootAgentCandidate{
+		Source:  RootAgentSourceBuiltIn,
+		Present: true,
+		Enabled: false,
+		Result:  "base",
+		Reason:  "root agents are opt-in by default",
+	})
+
+	if in.Legacy != nil {
+		res.Enabled = true
+		res.Program = in.Legacy.Program
+		res.Candidates = append(res.Candidates, RootAgentCandidate{
+			Source:  RootAgentSourceLegacy,
+			Present: true,
+			Enabled: true,
+			Program: in.Legacy.Program,
+			Result:  "winner",
+			Reason:  "a path-keyed root_agents entry is an always-ensured root",
+		})
+	} else {
+		res.Candidates = append(res.Candidates, RootAgentCandidate{
+			Source:  RootAgentSourceLegacy,
+			Present: false,
+			Result:  "absent",
+			Reason:  "no root_agents entry for this project",
+		})
+	}
+	return res
+}

--- a/config/rootagent_resolve_test.go
+++ b/config/rootagent_resolve_test.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func candidateBySource(res RootAgentResolution, source RootAgentSource) (RootAgentCandidate, bool) {
+	for _, c := range res.Candidates {
+		if c.Source == source {
+			return c, true
+		}
+	}
+	return RootAgentCandidate{}, false
+}
+
+func TestResolveRootAgentBuiltInDisabledByDefault(t *testing.T) {
+	res := ResolveRootAgent(RootAgentInputs{})
+	assert.False(t, res.Enabled, "with no source configured, root agents stay opt-in off")
+	assert.Equal(t, "", res.Program)
+
+	builtin, ok := candidateBySource(res, RootAgentSourceBuiltIn)
+	require.True(t, ok)
+	assert.True(t, builtin.Present)
+	assert.False(t, builtin.Enabled)
+	assert.Equal(t, "base", builtin.Result)
+
+	legacy, ok := candidateBySource(res, RootAgentSourceLegacy)
+	require.True(t, ok, "the trace names the legacy source even when absent")
+	assert.False(t, legacy.Present)
+	assert.Equal(t, "absent", legacy.Result)
+}
+
+// TestResolveRootAgentLegacyEntryResolvesUnchanged is the load-bearing
+// compatibility proof: every existing path-keyed root_agents entry resolves to
+// exactly {Enabled: true, Program: entry.Program} — the same profile the daemon
+// used when it read the map directly. If this table ever diverges, an existing
+// user's always-ensured root would change.
+func TestResolveRootAgentLegacyEntryResolvesUnchanged(t *testing.T) {
+	cases := []struct {
+		name  string
+		entry RootAgentConfig
+	}{
+		{"default profile (empty program)", RootAgentConfig{}},
+		{"bare agent name", RootAgentConfig{Program: "claude"}},
+		{"full command with flags", RootAgentConfig{Program: "claude --model opus --dangerously-skip-permissions"}},
+		{"a non-claude program", RootAgentConfig{Program: "/usr/local/bin/codex --profile work"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := tc.entry
+			res := ResolveRootAgent(RootAgentInputs{Legacy: &entry})
+
+			assert.True(t, res.Enabled, "a present legacy entry is always an enabled root")
+			assert.Equal(t, tc.entry.Program, res.Program, "the effective program is the legacy program verbatim")
+			assert.Equal(t, RootAgent{Enabled: true, Program: tc.entry.Program}, res.RootAgent)
+
+			legacy, ok := candidateBySource(res, RootAgentSourceLegacy)
+			require.True(t, ok)
+			assert.True(t, legacy.Present)
+			assert.True(t, legacy.Enabled)
+			assert.Equal(t, tc.entry.Program, legacy.Program)
+			assert.Equal(t, "winner", legacy.Result)
+		})
+	}
+}
+
+// TestResolveRootAgentMatchesDirectMapValueForEveryEntry pins the equivalence
+// the daemon relies on: routing an entry through the resolver yields the same
+// program the old direct map read passed to ensureRootAgent.
+func TestResolveRootAgentMatchesDirectMapValueForEveryEntry(t *testing.T) {
+	legacyMap := map[string]RootAgentConfig{
+		"/home/me/repo-a": {},
+		"~/work/repo-b":   {Program: "claude --model opus"},
+		"/srv/repo-c":     {Program: "codex"},
+	}
+	for path, entry := range legacyMap {
+		entry := entry
+		res := ResolveRootAgent(RootAgentInputs{Legacy: &entry})
+		require.True(t, res.Enabled, "%s: a configured legacy entry must ensure a root", path)
+		assert.Equal(t, entry.Program, res.Program,
+			"%s: the resolver must hand ensureRootAgent the same program the map held", path)
+	}
+}

--- a/config/rootagent_resolve_test.go
+++ b/config/rootagent_resolve_test.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/pelletier/go-toml/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -83,4 +85,43 @@ func TestResolveRootAgentMatchesDirectMapValueForEveryEntry(t *testing.T) {
 		assert.Equal(t, entry.Program, res.Program,
 			"%s: the resolver must hand ensureRootAgent the same program the map held", path)
 	}
+}
+
+// TestResolveRootAgentEmptyLegacyProgramIsUnset pins P3-a: an empty legacy
+// program is UNSET, not set-to-empty, so once a lower-precedence layer supplies a
+// program (PR2's global layer) the empty legacy entry does not clobber it back to
+// empty. In PR1 the observable form is that an empty entry leaves Program "" and
+// the legacy candidate records that its program is unset; a non-empty entry sets
+// it. A regression to unconditional assignment drops the "unset" reason.
+func TestResolveRootAgentEmptyLegacyProgramIsUnset(t *testing.T) {
+	empty := ResolveRootAgent(RootAgentInputs{Legacy: &RootAgentConfig{}})
+	assert.True(t, empty.Enabled, "a present legacy entry still enables the root")
+	assert.Equal(t, "", empty.Program, "an empty legacy program leaves the effective program unset")
+	legacyEmpty, ok := candidateBySource(empty, RootAgentSourceLegacy)
+	require.True(t, ok)
+	assert.Contains(t, legacyEmpty.Reason, "unset",
+		"the trace must record that an empty legacy program is unset, not set-to-empty")
+
+	set := ResolveRootAgent(RootAgentInputs{Legacy: &RootAgentConfig{Program: "codex"}})
+	assert.Equal(t, "codex", set.Program, "a non-empty legacy program is the effective program")
+	legacySet, ok := candidateBySource(set, RootAgentSourceLegacy)
+	require.True(t, ok)
+	assert.NotContains(t, legacySet.Reason, "unset")
+}
+
+// TestRootAgentEnabledSerializesExplicitFalse pins P3-b: RootAgent.Enabled has
+// no omitempty, so an explicit `enabled = false` survives a full serialization
+// (RegisterRootAgent/saveConfigLocked marshal the whole Config). With omitempty
+// the false would be dropped and a disabling override erased on the next write
+// — the #1700 zero-value-elision class.
+func TestRootAgentEnabledSerializesExplicitFalse(t *testing.T) {
+	tomlBytes, err := toml.Marshal(RootAgent{Enabled: false})
+	require.NoError(t, err)
+	assert.Contains(t, string(tomlBytes), "enabled = false",
+		"an explicit enabled=false must be written to TOML, not omitted")
+
+	jsonBytes, err := json.Marshal(RootAgent{Enabled: false})
+	require.NoError(t, err)
+	assert.Contains(t, string(jsonBytes), "\"enabled\":false",
+		"an explicit enabled=false must be written to JSON (the --explain surface), not omitted")
 }

--- a/daemon/rootagent.go
+++ b/daemon/rootagent.go
@@ -71,19 +71,9 @@ type rootEnsureState struct {
 	suppressLogged bool
 }
 
-// EnsureRootAgents runs one ensure pass over every repo whose effective
-// root-agent profile is enabled. Called from the daemon poll loop after
-// RefreshStatuses; a no-op when nothing is configured or the initial restore
-// has not finished.
-//
-// The which-repos-and-what-profile decision routes through the canonical
-// config.ResolveRootAgent adapter (#2216 Phase 6) rather than reading the map
-// directly, so root-agent precedence lives in one place. Today the only source
-// is the legacy path-keyed root_agents map: every present entry resolves to
-// enabled with its own program, so this pass ensures exactly the same set, with
-// the same programs, that the direct map read did. Later phases add the global
-// and personal-project singleton layers to the resolver without touching this
-// loop.
+// EnsureRootAgents runs one ensure pass over every repo configured in
+// root_agents. Called from the daemon poll loop after RefreshStatuses; a
+// no-op when nothing is configured or the initial restore has not finished.
 func (m *Manager) EnsureRootAgents() {
 	if len(m.cfg.RootAgents) == 0 || !m.Ready() {
 		return
@@ -94,12 +84,7 @@ func (m *Manager) EnsureRootAgents() {
 	}
 	sort.Strings(paths)
 	for _, path := range paths {
-		legacy := m.cfg.RootAgents[path]
-		res := config.ResolveRootAgent(config.RootAgentInputs{Legacy: &legacy})
-		if !res.Enabled {
-			continue
-		}
-		m.ensureRootAgent(path, config.RootAgentConfig{Program: res.Program})
+		m.ensureRootAgent(path, m.cfg.RootAgents[path])
 	}
 }
 

--- a/daemon/rootagent.go
+++ b/daemon/rootagent.go
@@ -71,9 +71,19 @@ type rootEnsureState struct {
 	suppressLogged bool
 }
 
-// EnsureRootAgents runs one ensure pass over every repo configured in
-// root_agents. Called from the daemon poll loop after RefreshStatuses; a
-// no-op when nothing is configured or the initial restore has not finished.
+// EnsureRootAgents runs one ensure pass over every repo whose effective
+// root-agent profile is enabled. Called from the daemon poll loop after
+// RefreshStatuses; a no-op when nothing is configured or the initial restore
+// has not finished.
+//
+// The which-repos-and-what-profile decision routes through the canonical
+// config.ResolveRootAgent adapter (#2216 Phase 6) rather than reading the map
+// directly, so root-agent precedence lives in one place. Today the only source
+// is the legacy path-keyed root_agents map: every present entry resolves to
+// enabled with its own program, so this pass ensures exactly the same set, with
+// the same programs, that the direct map read did. Later phases add the global
+// and personal-project singleton layers to the resolver without touching this
+// loop.
 func (m *Manager) EnsureRootAgents() {
 	if len(m.cfg.RootAgents) == 0 || !m.Ready() {
 		return
@@ -84,7 +94,12 @@ func (m *Manager) EnsureRootAgents() {
 	}
 	sort.Strings(paths)
 	for _, path := range paths {
-		m.ensureRootAgent(path, m.cfg.RootAgents[path])
+		legacy := m.cfg.RootAgents[path]
+		res := config.ResolveRootAgent(config.RootAgentInputs{Legacy: &legacy})
+		if !res.Enabled {
+			continue
+		}
+		m.ensureRootAgent(path, config.RootAgentConfig{Program: res.Program})
 	}
 }
 


### PR DESCRIPTION
## Phase 6 PR1 of #2216 — the permanent legacy `root_agents` adapter (pure config layer)

Phase 6 is split into two PRs (per the maintainer's call): **this one** is the permanent legacy compatibility layer as a **pure config-package adapter**, shipped alone so the *never break an existing user's `root_agents`* property gets a focused review; the canonical singleton config shape + its daemon integration land as **PR2 on top**.

### What it does
- Introduces the canonical root-agent profile — `type RootAgent struct { Enabled bool; Program string }` — and **`config.ResolveRootAgent`**, the single authority on how root-agent sources combine (so no consumer re-implements precedence, per the epic §5/§7).
- Carries the built-in opt-in-`false` base and the path-keyed **`root_agents` map as a permanent read-only compatibility source**. A present legacy entry resolves to `Enabled: true` with its program (an **empty program stays unset** and falls through to the default profile).

### The non-breaking guarantee (this PR's whole point)
- **The daemon is untouched.** `EnsureRootAgents` and `repoRootAgentWillMaterialize` still read `m.cfg.RootAgents` directly and unchanged — the strongest non-breaking guarantee is that the ensure loop does not change at all here.
- `config/rootagent_resolve_test.go` proves existing entries resolve to the canonical form unchanged (empty/default, bare name, full command, non-claude), the empty-program-unset semantics, and the explicit-`false` serialization.

### Design notes (from review)
- `RootAgent.Enabled` has **no `omitempty`** so an explicit `enabled = false` survives a full `Config` marshal rather than being erased on the next write (#1700 elision class), before PR2 makes this the singleton `[root_agent]` key.
- An **empty legacy program is unset**, not set-to-empty, so PR2's global program is never clobbered by the common empty legacy entry.

### PR2 obligations (captured here, done in PR2 with the global/personal layers)
- Rewrite the ensure loop to iterate legacy ∪ registered projects via `ResolveRootAgent`.
- Migrate `repoRootAgentWillMaterialize` onto the resolver (so a layer-enabled project with no map key materializes and its prompt waits, #1835).
- Funnel `RootAgent → RootAgentConfig` through one named adapter with a test that fails when `RootAgentConfig` gains a field.

### Verification (head `c1e5aaa1`)
- gofmt · `go build ./...` · `go vet` · `deadcode -test ./...` · `golangci-lint --fast` — clean
- **`make test-container`: PASS** (`config` and `daemon` green)

Draft holds the auto-gate. Not self-merging. The importer (`af projects import-root-agents`) is Phase 4, out of scope.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
