### PR TITLE
fix(reset): retain the record when a worktree removal fails (#2531)

### DIFF
--- a/session/git/worktree_remove.go
+++ b/session/git/worktree_remove.go
@@ -110,7 +110,15 @@ func RemoveWorktreeDir(repoRoot, worktreePath string) (bool, error) {
 				return false, worktreeStillRegisteredError(repoRoot, worktreePath, err)
 			}
 			if rmErr := os.RemoveAll(worktreePath); rmErr != nil {
-				return false, fmt.Errorf("remove worktree dir %s: %w", worktreePath, rmErr)
+				// The directory is still on disk, and we reached this fallback via the
+				// "validation failed" gate — git's own remove FAILED, so it may still
+				// own the worktree (registered, or its registration undetermined). A
+				// plain error here classifies as known-state and reset DELETES the
+				// session record, orphaning a git-registered worktree and its branch with
+				// no record left to plan a re-run from (#2531). Classify it so reset
+				// RETAINS the record instead. A confirmed-deregistered path is a plain
+				// filesystem orphan, not a lost registration, so it stays a plain error.
+				return false, classifyRemoveAllFailure(worktreePath, registered, probeErr, rmErr)
 			}
 		}
 		removed = true
@@ -138,6 +146,22 @@ func RemoveWorktreeDir(repoRoot, worktreePath string) (bool, error) {
 		return removed, worktreeStillRegisteredError(repoRoot, worktreePath, nil)
 	}
 	return removed, nil
+}
+
+// classifyRemoveAllFailure reports a failed os.RemoveAll of a worktree directory to
+// the caller (the factory reset). When git may still own the path — the worktree is
+// registered, or its registration could not be determined — it wraps
+// ErrWorktreeStillRegistered so reset RETAINS the session record and a re-run can
+// finish the removal, rather than dropping the record and orphaning a git-registered
+// worktree and its branch (#2531). A CONFIRMED-deregistered path (registered==false
+// with the probe answered) is a plain filesystem orphan with no registration to
+// recover, so it stays an ordinary error.
+func classifyRemoveAllFailure(worktreePath string, registered bool, probeErr, rmErr error) error {
+	if registered || probeErr != nil {
+		return fmt.Errorf("%w: worktree %s could not be removed and git may still own it: %w",
+			ErrWorktreeStillRegistered, worktreePath, rmErr)
+	}
+	return fmt.Errorf("remove worktree dir %s: %w", worktreePath, rmErr)
 }
 
 // repoRegistersNothing reports whether repoRoot definitively cannot hold a

--- a/session/git/worktree_remove.go
+++ b/session/git/worktree_remove.go
@@ -92,7 +92,16 @@ func RemoveWorktreeDir(repoRoot, worktreePath string) (bool, error) {
 		// Remove the worktree FIRST (git refuses to delete a branch checked out in a
 		// worktree). Fall back to a manual directory removal if git can't (e.g. the
 		// worktree was relocated to the archive and is no longer registered).
-		if err := exec.Command("git", "-C", repoRoot, "worktree", "remove", "-f", worktreePath).Run(); err != nil {
+		//
+		// CombinedOutput, not Run: the shared ownership gate below (mayDeleteWorktreeDir)
+		// classifies on git's "validation failed:" message, which git writes to STDERR.
+		// Run discards stderr — (*exec.ExitError).Error() is only "exit status N" — so
+		// the gate NEVER matched here, silently disabling the #726 corrupted-pointer
+		// allowance for the factory reset (it matched for Cleanup, which folds stderr via
+		// runGitCommandContext) and leaving the os.RemoveAll fallback below unreachable.
+		// Fold stderr into the error so both callers see the same evidence (#2531 review).
+		if out, runErr := exec.Command("git", "-C", repoRoot, "worktree", "remove", "-f", worktreePath).CombinedOutput(); runErr != nil {
+			err := fmt.Errorf("git worktree remove failed: %s (%w)", strings.TrimSpace(string(out)), runErr)
 			log.ErrorLog.Printf("failed to remove worktree %s: %v", worktreePath, err)
 
 			// Ownership check, restored from Cleanup (#2110). The reset's fallback

--- a/session/git/worktree_reset_locked_test.go
+++ b/session/git/worktree_reset_locked_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,6 +11,44 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestClassifyRemoveAllFailure is the #2531 decision lock. When os.RemoveAll of a
+// worktree directory fails and git may still own the path — the worktree is
+// registered, or its registration could not be determined — the error must wrap
+// ErrWorktreeStillRegistered so the factory reset RETAINS the session record for a
+// re-run rather than dropping it and orphaning a git-registered worktree and branch.
+// Only a confirmed-deregistered path stays a plain error. (The full path — git's
+// "validation failed" gate plus a filesystem permission failure — is not
+// hermetically reproducible, so the decision is unit-tested; the one call site is a
+// direct substitution.)
+func TestClassifyRemoveAllFailure(t *testing.T) {
+	rmErr := errors.New("permission denied")
+	const wt = "/x/wt-orphan"
+
+	// Registered → retain (wrap the sentinel).
+	if err := classifyRemoveAllFailure(wt, true, nil, rmErr); !errors.Is(err, ErrWorktreeStillRegistered) {
+		t.Errorf("a registered worktree whose removal failed must be retained, got %v", err)
+	}
+	// Registration undetermined (probe errored) → retain.
+	if err := classifyRemoveAllFailure(wt, false, errors.New("probe failed"), rmErr); !errors.Is(err, ErrWorktreeStillRegistered) {
+		t.Errorf("an undetermined registration whose removal failed must be retained, got %v", err)
+	}
+	// Confirmed deregistered → plain error (a filesystem orphan, not a lost registration).
+	err := classifyRemoveAllFailure(wt, false, nil, rmErr)
+	if errors.Is(err, ErrWorktreeStillRegistered) {
+		t.Errorf("a confirmed-deregistered path must not be reported as still-registered, got %v", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), wt) {
+		t.Errorf("the error must still name the worktree, got %v", err)
+	}
+	// The underlying os.RemoveAll error is preserved in every case.
+	if !errors.Is(classifyRemoveAllFailure(wt, true, nil, rmErr), rmErr) {
+		t.Error("the underlying os.RemoveAll error must be preserved for the sentinel case")
+	}
+	if !errors.Is(classifyRemoveAllFailure(wt, false, nil, rmErr), rmErr) {
+		t.Error("the underlying os.RemoveAll error must be preserved for the plain case")
+	}
+}
 
 // resetRepoWithWorktree builds a THROWAWAY repo in t.TempDir() with one linked
 // worktree on its own branch, and returns (repoRoot, worktreePath, branch).

--- a/session/git/worktree_reset_locked_test.go
+++ b/session/git/worktree_reset_locked_test.go
@@ -12,15 +12,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestClassifyRemoveAllFailure is the #2531 decision lock. When os.RemoveAll of a
-// worktree directory fails and git may still own the path — the worktree is
-// registered, or its registration could not be determined — the error must wrap
-// ErrWorktreeStillRegistered so the factory reset RETAINS the session record for a
-// re-run rather than dropping it and orphaning a git-registered worktree and branch.
-// Only a confirmed-deregistered path stays a plain error. (The full path — git's
-// "validation failed" gate plus a filesystem permission failure — is not
-// hermetically reproducible, so the decision is unit-tested; the one call site is a
-// direct substitution.)
+// TestClassifyRemoveAllFailure pins the #2531 three-way decision directly. When
+// os.RemoveAll of a worktree directory fails and git may still own the path — the
+// worktree is registered, or its registration could not be determined — the error
+// must wrap ErrWorktreeStillRegistered so the factory reset RETAINS the session
+// record for a re-run rather than dropping it and orphaning a git-registered
+// worktree and branch. Only a confirmed-deregistered path stays a plain error. The
+// end-to-end TestRemoveWorktreeDir_CorruptedPointer* tests prove this branch is
+// actually reachable from production (it was dead code until stderr was captured).
 func TestClassifyRemoveAllFailure(t *testing.T) {
 	rmErr := errors.New("permission denied")
 	const wt = "/x/wt-orphan"
@@ -315,4 +314,66 @@ func TestRemoveWorktreeDir_MissingDirAndMetadataIsCleanNoOp(t *testing.T) {
 	removed, err = RemoveWorktreeDir(repoRoot, worktreePath)
 	require.NoError(t, err, "a second removal must be a clean no-op")
 	assert.False(t, removed)
+}
+
+// corruptWorktreePointer overwrites a linked worktree's .git file with garbage so
+// `git worktree remove -f` fails with "validation failed" — the #726 corrupted-
+// pointer case the shared ownership gate is meant to let AF clean up. Its
+// registration in the main repo's .git/worktrees survives, so git still LISTS it.
+func corruptWorktreePointer(t *testing.T, worktreePath string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(worktreePath, ".git"), []byte("garbage: not a gitdir pointer\n"), 0o644))
+}
+
+// TestRemoveWorktreeDir_CorruptedPointerIsCleanedNotDeadEnded is the #2531-review
+// P1-b regression: reset ran `git worktree remove` via .Run(), discarding the
+// stderr the shared ownership gate classifies on, so the #726 corrupted-pointer
+// allowance NEVER fired for reset. The corrupted worktree then dead-ended on the
+// unactionable "unlock a locked worktree" advice (it is not locked) with no way to
+// clear it — the #2110 class through a different door. With stderr captured, reset
+// cleans it up like Cleanup does.
+func TestRemoveWorktreeDir_CorruptedPointerIsCleanedNotDeadEnded(t *testing.T) {
+	repoRoot, worktreePath, _ := resetRepoWithWorktree(t, "corrupt")
+	corruptWorktreePointer(t, worktreePath)
+
+	removed, err := RemoveWorktreeDir(repoRoot, worktreePath)
+	require.NoError(t, err,
+		"a corrupted-pointer worktree must be cleaned up, not dead-ended on unlock advice (#2531 review)")
+	assert.True(t, removed)
+	_, statErr := os.Stat(worktreePath)
+	assert.True(t, os.IsNotExist(statErr), "the corrupted worktree directory must be removed")
+}
+
+// TestRemoveWorktreeDir_CorruptedPointerRemovalFailureRetainsRecord is the #2531
+// end-to-end lock — the scenario the direct-helper unit test could not prove
+// reachable. A corrupted pointer routes to the os.RemoveAll fallback (reachable only
+// once stderr is captured); a read-only subdir makes that os.RemoveAll fail EACCES,
+// so the removal cannot complete and reset must RETAIN the record for a re-run.
+func TestRemoveWorktreeDir_CorruptedPointerRemovalFailureRetainsRecord(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("chmod-based EACCES is bypassed by root; this scenario needs a non-root uid")
+	}
+	repoRoot, worktreePath, _ := resetRepoWithWorktree(t, "corrupt-blocked")
+
+	// A file inside a read-only subdir: os.RemoveAll cannot unlink the child, so the
+	// whole removal fails EACCES.
+	blocked := filepath.Join(worktreePath, "blocked")
+	require.NoError(t, os.MkdirAll(blocked, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(blocked, "keep.txt"), []byte("x"), 0o644))
+	corruptWorktreePointer(t, worktreePath)
+	require.NoError(t, os.Chmod(blocked, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(blocked, 0o755) }) // let t.TempDir teardown succeed
+
+	removed, err := RemoveWorktreeDir(repoRoot, worktreePath)
+	require.Error(t, err, "a removal that could not complete must not be reported as done")
+	assert.False(t, removed)
+	require.ErrorIs(t, err, ErrWorktreeStillRegistered,
+		"reset must RETAIN the record so a re-run can finish the removal (#2531)")
+	// Prove it reached the os.RemoveAll fallback (only reachable after the stderr
+	// fix), not the pre-existing early return — the message is about the failed
+	// removal, never the wrong locked-worktree "unlock" advice.
+	assert.NotContains(t, err.Error(), "unlock",
+		"a corrupted pointer must not be reported as a locked worktree")
+	_, statErr := os.Stat(worktreePath)
+	assert.NoError(t, statErr, "the directory really is still there — the failure is not crying wolf")
 }


### PR DESCRIPTION
## Summary

Addresses #2531. **The first cut was a behavioral no-op — the review was right, and this replaces it with the root-cause fix.**

## What was wrong

`RemoveWorktreeDir`'s `os.RemoveAll` fallback is guarded by `mayDeleteWorktreeDir`, which classifies on git's `validation failed:` message. But that message is on **stderr**, and this call site used `exec.Command(...).Run()`, which **discards stderr** — `(*exec.ExitError).Error()` is only `"exit status N"`. So the gate's "validation failed" branch could never match here: a registered worktree always hit the pre-existing early return, and `classifyRemoveAllFailure`'s retain branch was **dead code**. The shared #726 ownership gate was **live for `Cleanup`** (it folds stderr via `runGitCommandContext`) and **dead for the factory reset**.

## Fix (root cause)

Run `git worktree remove -f` with `CombinedOutput` and fold git's stderr into the error, so both callers feed `mayDeleteWorktreeDir` the same evidence. The #726 corrupted-pointer allowance now fires for reset too, and `classifyRemoveAllFailure` is reachable and correct.

## Corrected diagnosis (you asked me to say so)

**#2531's original "the record is deleted and orphaned" framing did not occur on master** — a registered worktree was *retained* by the early return. The real user-facing defect was the *other* consequence: a corrupted-pointer worktree dead-ended on the unactionable **"unlock a locked worktree"** advice (it's not locked; `git worktree unlock` fails "is not locked"), with no re-run that could ever clear it — the #2110 class through a different door. This fix cleans such a worktree up like `Cleanup` does, and only a genuine removal **failure** (a permission-denied `os.RemoveAll` on root-owned files) now retains the record — with an accurate message instead of the unlock dead-end.

## Tests (end-to-end, both fail on master)

- `TestRemoveWorktreeDir_CorruptedPointerIsCleanedNotDeadEnded` — a corrupted-pointer worktree is cleaned up, not dead-ended (on master: "exit status 128", unlock advice, dir remains).
- `TestRemoveWorktreeDir_CorruptedPointerRemovalFailureRetainsRecord` — when its `os.RemoveAll` fails EACCES (a file in a read-only subdir; skipped under root), the record is retained with a message about the removal, **not** the wrong unlock advice (on master: the error contains "unlock").

The direct-helper unit test's "not hermetically reproducible" note was wrong (you reproduced it; so do these) and is removed — the end-to-end tests are the reachability proof.

Gate: build, gofmt, golangci-lint, deadcode, `session/git` package, `make test-container`. Codex rate-limited; Greptile is the live reviewer.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
