### PR TITLE
docs: drop the tmux-guard here-doc appeasement note

### DIFF
--- a/docs/agent-plugins.md
+++ b/docs/agent-plugins.md
@@ -116,17 +116,6 @@ leave the Codex session unguarded. Gemini, Amp, Aider, OpenCode, and Devin must 
 treated as unguarded until af ships and verifies a blocking delivery seam for
 each one.
 
-Af-launched Claude sessions and hook-trusted Codex plugin sessions fail closed
-on shell here-documents and pipelines. The manually installed Claude marketplace
-plugin carries the usage guidance but no blocking `PreToolUse` hook, so it does
-not provide this protection. Quoting a here-document delimiter prevents shell
-expansion, but it cannot prove whether the receiving program treats the body as
-data or executable code. Use the agent's non-shell file tool to create a
-reviewable literal file, then pass its literal path—for example, `python3
-/tmp/task.py` or `gh pr comment <number> --body-file /tmp/reply.md`. The hook
-intentionally has no “trust this inline code” escape hatch because it cannot
-verify review provenance from inside the same Bash request.
-
 ## Relationship to `global_agent_skills`
 
 `af` can also *push* this skill into an agent's global config


### PR DESCRIPTION
## What

Removes the paragraph in `docs/agent-plugins.md` that instructed readers how to
phrase commands to satisfy the tmux guard — here-documents/pipelines fail closed,
quote the delimiter, "use the agent's non-shell file tool… pass its literal
path", `gh … --body-file`, "no trust-this-inline-code escape hatch".

## Why

Per maintainer directive: af's docs should describe what af **does**, not how to
appease a guard, and agent-facing surfaces must not teach agents to work around
or comply with tool restrictions. Documenting the guard's restrictions in
agent-facing docs propagates and entrenches them.

## Scope

- The **guard-coverage table** and the factual description of what the
  `hook-guard-tmux` `PreToolUse` hook blocks are **left intact** — those document
  the feature, not a workaround.
- The appeasement text lived **only** in this file — not in the injected skill
  (`session/systemprompt.go` `afUsageReference`), the generated plugin artifacts,
  `README.md`, or `CLAUDE.md`. Verified by grep across all agent-facing surfaces.

## Why a separate PR (not folded into #2505)

#2505 (the Devin supported-agent drift fix) auto-merged at its first commit
before this removal reached that branch, so the removal was stranded and never
landed — the paragraph is still on `master`. This PR re-applies the removal
against current `master`.

**Opened as a draft** so it does not auto-merge — ready for a maintainer merge
(per the "no self-merge" instruction).

## Gates

Run against the pushed head `344e1908` (docs-only — no Go source changed):

- `gofmt -l .` — clean
- `go build ./...` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `scripts/lint-file-length.sh` — passed (1046 Go files checked)
- `make test-container` — all packages `ok`, exit 0, no FAIL

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
