### PR TITLE
feat(web): add the project switcher's + Add project affordance (#2456)

### DIFF
--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -626,8 +626,8 @@
         "pointer": "app/switch_project.go:196-216 (picker '+ Add project…' row)"
       },
       "web": {
-        "status": "no",
-        "pointer": "web/src/modals.ts:153-157 'No projects yet — create a session in the TUI first'"
+        "status": "yes",
+        "pointer": "web/src/ui.ts renderProjectSwitch '+ Add project' → web/src/modals.ts addProjectModal → api.ts registerProject (RegisterProject RPC)"
       },
       "cli": {
         "status": "yes",
@@ -635,7 +635,7 @@
       },
       "verdict": "real-gap",
       "issue": "#2456",
-      "notes": "#2456 adds the daemon RegisterProject RPC (POST /v1/RegisterProject) and routes `af projects add` (register is a deprecated alias) through it, so the checkout is resolved on the daemon's filesystem and the single writer owns the registry. TUI/web adds land in the follow-up slices of #2456: the TUI row still persists a legacy root_agents entry, and the web has no registration action yet — this becomes parity once those rewire to the same RPC and the project list unions derived + registry + root_agents."
+      "notes": "#2456 adds the daemon RegisterProject RPC (POST /v1/RegisterProject); `af projects add` (register is a deprecated alias) and the web project switcher's '+ Add project' both route through it, so the checkout is resolved on the daemon's filesystem and the single writer owns the registry. The web add is the coherent zero-projects empty state (the switcher is always openable and hosts the action). Still real-gap because the TUI add persists a legacy root_agents entry rather than the registry; the remaining TUI slice rewires it and unions the project list (derived + registry + root_agents), which flips this to parity."
     },
     {
       "id": "project.rebind",
@@ -1507,6 +1507,7 @@
       "ListBackends": "backend.list",
       "ListPrograms": "enum.agent-programs",
       "ListTasks": "task.list",
+      "RegisterProject": "project.add",
       "RemoveTask": "task.remove",
       "RenameTab": "session.tab.rename",
       "ReorderTab": "session.tab.reorder",

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6298,6 +6298,10 @@ async function handoffSession(id, title, to, token2) {
 async function deleteProject(root2, token2) {
   return af("DeleteProject", { repo_path: root2, repo_id: "" }, token2);
 }
+async function registerProject(path, token2) {
+  const resp = await af("RegisterProject", { path }, token2);
+  return resp.project;
+}
 function requireSessionID(id, action) {
   if (id === "") {
     throw new ApiError(0, `cannot ${action}: this session has no stable id to target safely`);
@@ -6770,6 +6774,41 @@ function confirmDeleteProjectModal(opts) {
   asForm(card, () => {
     handle.setError(null);
     opts.onConfirm();
+  });
+  return handle;
+}
+function addProjectModal(callbacks) {
+  const { handle, body } = modalChrome({
+    title: "Add project",
+    confirmLabel: "Add project",
+    confirmClass: "af-primary",
+    onCancel: callbacks.onCancel
+  });
+  const pathInput = h("input", {
+    type: "text",
+    class: "af-input",
+    placeholder: "/path/to/repo  or  ~/repo",
+    autocomplete: "off"
+  });
+  pathInput.setAttribute("aria-label", "Repository path");
+  body.append(
+    field("Repository path", pathInput),
+    h(
+      "p",
+      { class: "af-modal-hint" },
+      "An absolute path to a git checkout on the daemon host (~ is expanded there). It becomes an empty project you can create sessions into."
+    )
+  );
+  pathInput.addEventListener("input", () => handle.setError(null));
+  const card = handle.el.firstElementChild;
+  asForm(card, () => {
+    const path = pathInput.value.trim();
+    if (path === "") {
+      handle.setError("Enter a repository path.");
+      return;
+    }
+    handle.setError(null);
+    callbacks.onSubmit(path);
   });
   return handle;
 }
@@ -11664,14 +11703,23 @@ var AppShell = class {
     const summaries = projectSummaries(state.sessions, state.tasks);
     const current = state.selectedProject;
     this.projectSwitchName.textContent = current ? projectName(current) : "No project";
-    this.projectSwitchBtn.disabled = summaries.length === 0;
+    this.projectSwitchBtn.disabled = false;
     const children = [h2("div", { class: "af-project-menu-label" }, "Switch project")];
     if (summaries.length === 0) {
-      children.push(h2("div", { class: "af-project-menu-empty" }, "No projects yet."));
+      children.push(h2("div", { class: "af-project-menu-empty" }, "No projects yet \u2014 add one below."));
     }
     for (const p of summaries) {
       children.push(this.projectItem(p, p.root === current));
     }
+    const footChildren = [];
+    const add = h2("button", { type: "button", class: "af-ghost af-project-add" }, "+ Add project");
+    add.setAttribute("title", "Register a git checkout by path as a project");
+    add.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.closeProjectMenu();
+      this.actions.addProject();
+    });
+    footChildren.push(add);
     const currentSummary = summaries.find((p) => p.root === current);
     if (currentSummary) {
       const del = h2("button", { type: "button", class: "af-ghost af-project-delete" }, "Delete project");
@@ -11689,8 +11737,9 @@ var AppShell = class {
           this.actions.deleteProject(currentSummary.root, currentSummary.name, currentSummary.liveCount);
         });
       }
-      children.push(h2("div", { class: "af-project-menu-foot" }, del));
+      footChildren.push(del);
     }
+    children.push(h2("div", { class: "af-project-menu-foot" }, ...footChildren));
     this.projectMenu.replaceChildren(...children);
   }
   /** One project row in the switcher menu: a check on the current project, the name +
@@ -12648,6 +12697,25 @@ function openDeleteProject(root2, label, sessionCount) {
     })
   );
 }
+function openAddProject() {
+  openModal(
+    addProjectModal({
+      onSubmit: (path) => {
+        const tok = token;
+        if (tok === null || !modal) {
+          return;
+        }
+        const m = modal;
+        m.setBusy(true);
+        void registerProject(path, tok).then(closeModal).catch((e) => {
+          m.setBusy(false);
+          m.setError(describeError(e));
+        });
+      },
+      onCancel: closeModal
+    })
+  );
+}
 function selectedSessionData() {
   const { sessions, selectedId } = store.get();
   return sessions.find((s) => s.id === selectedId) ?? null;
@@ -13026,6 +13094,7 @@ var actions = {
   triggerTask: doTriggerTask,
   removeTask: doRemoveTask,
   deleteProject: openDeleteProject,
+  addProject: openAddProject,
   setTheme
 };
 function syncSplit(state) {

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "59e584708334";
+const VERSION = "331421caa1f5";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -3647,6 +3647,38 @@ test("filter (feat): keyboard nav walks the VISIBLE rows — j never lands on a 
   }
 });
 
+test("add project (#2456): the switcher's + Add project drives the real RegisterProject round-trip", REAL_FIXTURE, async () => {
+  // The switcher is always openable now (the zero-projects dead end is gone), and
+  // its "+ Add project" footer action opens a path input that registers a repo
+  // through the REAL RegisterProject RPC. A non-git path is rejected by the daemon
+  // and the message shows INLINE while the modal stays open — proving this drives a
+  // real daemon round-trip, not a client-only stub.
+  await page.locator(".af-project-switch").click();
+  const add = page.locator(".af-project-menu .af-project-add");
+  await expect(add).toBeVisible();
+  await add.click();
+
+  const addModal = page.locator(".af-modal-card");
+  await expect(addModal).toBeVisible();
+  await expect(addModal.locator(".af-modal-title")).toHaveText("Add project");
+
+  const pathInput = addModal.locator('input[aria-label="Repository path"]');
+  await pathInput.fill("/work/definitely-not-a-git-repo");
+  await addModal.locator("button.af-primary").click();
+  // Rejected by the daemon: the error is shown inline and the modal stays open to
+  // correct — a failed submit does NOT dismiss it.
+  await expect(addModal.locator(".af-modal-error")).toBeVisible();
+  await expect(addModal).toBeVisible();
+
+  // Editing clears the stale error, and a VALID checkout path (mock-repo is a real
+  // git repo in the fixture; registering it is an idempotent success) submits and
+  // closes the modal.
+  await pathInput.fill("/work/mock-repo");
+  await expect(addModal.locator(".af-modal-error")).toBeHidden();
+  await addModal.locator("button.af-primary").click();
+  await expect(addModal).toBeHidden();
+});
+
 test("delete project (#1735, redesign PR2, Fix 2): deleting an archived-only-bound project makes it go away — not a no-op", REAL_FIXTURE, async () => {
   // Use the SECOND project (SESSION_C, no task): switch to it, then delete it from the
   // switcher menu footer. Delete archives its one live session; with no task left, the

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -21,6 +21,7 @@ import {
   listBackends,
   listPrograms,
   probeWebTab,
+  registerProject,
   removeTask,
   renameTab,
   reorderTab,
@@ -625,4 +626,59 @@ test("probeWebTab: the token rides the Authorization header, never the URL", asy
   await probeWebTab("/v1/webtab/s/t/", "secret-tok", 1000);
   assert.equal(seenAuth, "Bearer secret-tok", "the probe is the parent's request — header, not ?access_token");
   assert.ok(!seenUrl.includes("secret-tok"), "the token must never appear in the probe URL");
+});
+
+// --- registerProject: the web add-project affordance (#2456) -------------------
+//
+// The web is inherently the REMOTE client: the path names a directory on the
+// daemon host, which the daemon resolves and validates. So the client sends it
+// VERBATIM (no local resolution) and surfaces the daemon's rejection inline.
+
+test("registerProject sends the path verbatim to RegisterProject", async () => {
+  const cap = stubFetch();
+  await registerProject("~/repos/new", "tok");
+  assert.ok(cap.url.endsWith("/v1/RegisterProject"), `posted to ${cap.url}`);
+  assert.equal(cap.body.path, "~/repos/new", "the path is forwarded unchanged for the daemon to resolve");
+  assert.equal(cap.auth, "Bearer tok");
+});
+
+test("registerProject returns the daemon's resolved project", async () => {
+  stubFetchResponse({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      data: {
+        ok: true,
+        project: {
+          id: "prj_00000000000000000000000000000000",
+          checkout_id: "chk_00000000000000000000000000000000",
+          root: "/resolved/repo",
+          relative_root: ".",
+          path_exists: true,
+        },
+      },
+      error: null,
+    }),
+  });
+  const project = await registerProject("/some/repo", "tok");
+  assert.equal(project.id, "prj_00000000000000000000000000000000");
+  assert.equal(project.root, "/resolved/repo");
+  assert.equal(project.path_exists, true);
+});
+
+test("registerProject surfaces a non-git path error for inline display", async () => {
+  stubFetchResponse({
+    ok: false,
+    status: 400,
+    statusText: "Bad Request",
+    json: async () => ({ data: null, error: { message: "resolve git common directory: not a git repository" } }),
+  });
+  const err = await registerProject("/tmp/not-a-repo", "tok").then(
+    () => null,
+    (e: unknown) => e,
+  );
+  assert.ok(err instanceof ApiError);
+  assert.equal(err.status, 400);
+  assert.match(err.message, /not a git repository/);
+  assert.doesNotMatch(err.message, /\[object Object\]/);
 });

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -478,6 +478,32 @@ export async function deleteProject(root: string, token: string): Promise<Delete
   return af("DeleteProject", { repo_path: root, repo_id: "" }, token);
 }
 
+/** A durable project identity the daemon registered (the #2355 registry record). */
+export interface RegisteredProject {
+  id: string;
+  checkout_id: string;
+  root: string;
+  relative_root: string;
+  path_exists: boolean;
+}
+
+/** Registers a git checkout as a durable, sessionless project (mirrors
+ *  `af projects add`). `path` is a path ON THE DAEMON HOST — absolute or
+ *  ~-prefixed — which the daemon resolves on its own filesystem (expand ~, walk
+ *  to the git checkout's main-repo root, validate). It is sent VERBATIM: unlike
+ *  the CLI, a browser has no shared working directory to resolve a relative path
+ *  against, so the user supplies an absolute path and the daemon owns resolution.
+ *
+ *  Idempotent for a known checkout. On success the daemon emits projects.changed;
+ *  the repo shows as a project once a session is created into it (the derived
+ *  list), and surfacing the empty registration immediately awaits the
+ *  registry-union slice. A non-git or unreadable path throws an ApiError carrying
+ *  the daemon's actionable message, for inline display next to the input. */
+export async function registerProject(path: string, token: string): Promise<RegisteredProject> {
+  const resp = await af<{ ok: boolean; project: RegisteredProject }>("RegisterProject", { path }, token);
+  return resp.project;
+}
+
 // --- tab mutations (#1592 Phase 5 PR7) -------------------------------------
 //
 // The web tab bar's write verbs, mirroring the TUI's `t`/`w` keys: `t` creates a

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -22,6 +22,7 @@ import {
   createTab,
   createVSCodeTab,
   deleteProject,
+  registerProject,
   errorText,
   fetchSnapshot,
   killSession,
@@ -47,7 +48,14 @@ import {
 } from "./api.js";
 import { createKeyedQueue } from "./config.js";
 import { EventStream, type EventStreamStatus } from "./events.js";
-import { confirmDeleteProjectModal, confirmModal, handoffModal, type ModalHandle, newSessionModal } from "./modals.js";
+import {
+  addProjectModal,
+  confirmDeleteProjectModal,
+  confirmModal,
+  handoffModal,
+  type ModalHandle,
+  newSessionModal,
+} from "./modals.js";
 import { InstallAffordance } from "./install.js";
 import { decideKey, type KeyboardFocus, type View } from "./nav.js";
 import { defaultFilter, filterSessions, loadFilter, persistFilter, withKind } from "./filter.js";
@@ -672,6 +680,39 @@ function openDeleteProject(root: string, label: string, sessionCount: number): v
         const m = modal;
         m.setBusy(true);
         void deleteProject(root, tok)
+          .then(closeModal)
+          .catch((e) => {
+            m.setBusy(false);
+            m.setError(describeError(e));
+          });
+      },
+      onCancel: closeModal,
+    }),
+  );
+}
+
+/** Opens the add-project modal (#2456): the user types a path to a git checkout
+ *  on the daemon host, and RegisterProject resolves+validates it. A rejection
+ *  (not a git repo, unreadable) is shown inline and the modal stays open to
+ *  correct; on success the modal closes.
+ *
+ *  The registered repo becomes a visible project once a session is created into
+ *  it (the switcher list derives from sessions, projectSummaries). Surfacing the
+ *  registered EMPTY project immediately needs the registry-union slice (read the
+ *  daemon's project registry and ∪ it into the derived list); until that lands,
+ *  register-then-create is the working path. */
+function openAddProject(): void {
+  openModal(
+    addProjectModal({
+      onSubmit: (path: string) => {
+        const tok = token;
+        // `=== null` not `!tok`: "" is the authorized-tokenless credential (#1696).
+        if (tok === null || !modal) {
+          return;
+        }
+        const m = modal;
+        m.setBusy(true);
+        void registerProject(path, tok)
           .then(closeModal)
           .catch((e) => {
             m.setBusy(false);
@@ -1390,6 +1431,7 @@ const actions = {
   triggerTask: doTriggerTask,
   removeTask: doRemoveTask,
   deleteProject: openDeleteProject,
+  addProject: openAddProject,
   setTheme,
 };
 

--- a/web/src/modals.ts
+++ b/web/src/modals.ts
@@ -539,6 +539,62 @@ export function confirmDeleteProjectModal(
   return handle;
 }
 
+/** The add-project modal (#2456): a single path input that registers a git
+ *  checkout as a durable, sessionless project through the RegisterProject RPC.
+ *  The path names a directory ON THE DAEMON HOST (absolute, or ~-prefixed which
+ *  the daemon expands) — a browser has no shared cwd to resolve a relative path
+ *  against, so the daemon owns resolution and validation. A non-git or unreadable
+ *  path comes back as the daemon's actionable error, shown inline; on success the
+ *  modal closes (the repo shows as a project once a session is created into it —
+ *  surfacing the empty registration needs the registry-union slice).
+ *
+ *  onSubmit is async in index.ts, which drives setBusy/setError around it. */
+export function addProjectModal(callbacks: {
+  onSubmit: (path: string) => void;
+  onCancel: () => void;
+}): ModalHandle {
+  const { handle, body } = modalChrome({
+    title: "Add project",
+    confirmLabel: "Add project",
+    confirmClass: "af-primary",
+    onCancel: callbacks.onCancel,
+  });
+
+  const pathInput = h("input", {
+    type: "text",
+    class: "af-input",
+    placeholder: "/path/to/repo  or  ~/repo",
+    autocomplete: "off",
+  });
+  pathInput.setAttribute("aria-label", "Repository path");
+
+  body.append(
+    field("Repository path", pathInput),
+    h(
+      "p",
+      { class: "af-modal-hint" },
+      "An absolute path to a git checkout on the daemon host (~ is expanded there). It becomes an empty project you can create sessions into.",
+    ),
+  );
+
+  // Clear a stale validation/daemon error as the user edits, so the inline
+  // message always reflects the CURRENT input rather than the last rejected path.
+  pathInput.addEventListener("input", () => handle.setError(null));
+
+  const card = handle.el.firstElementChild as HTMLElement;
+  asForm(card, () => {
+    const path = pathInput.value.trim();
+    if (path === "") {
+      handle.setError("Enter a repository path.");
+      return;
+    }
+    handle.setError(null);
+    callbacks.onSubmit(path);
+  });
+
+  return handle;
+}
+
 /** A labeled field row: a caption above its control. */
 export function field(label: string, control: HTMLElement): HTMLElement {
   return h("label", { class: "af-modal-field" }, h("span", { class: "af-modal-label" }, label), control);

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -271,6 +271,9 @@ export interface Actions {
   /** Opens the reversible delete-project confirm for a project row (#1735); on
    *  confirm index.ts calls DeleteProject, which archives its live sessions. */
   deleteProject(root: string, label: string, sessionCount: number): void;
+  /** Opens the add-project modal (#2456): register a git checkout by path via
+   *  RegisterProject so it appears as an empty project you can create into. */
+  addProject(): void;
   /** Sets the theme preference (redesign PR1): persists it, stamps data-theme on
    *  <html>, and re-themes the live terminals. */
   setTheme(choice: ThemeChoice): void;
@@ -1444,19 +1447,35 @@ export class AppShell {
     const summaries = projectSummaries(state.sessions, state.tasks);
     const current = state.selectedProject;
     this.projectSwitchName.textContent = current ? projectName(current) : "No project";
-    // Disable the switcher when there are no projects to switch between.
-    this.projectSwitchBtn.disabled = summaries.length === 0;
+    // The switcher is ALWAYS openable, even with no projects (#2456): its menu now
+    // hosts "+ Add project", which is the coherent action for the zero-projects
+    // empty state. Disabling it here would restore the dead end where a fresh web
+    // user with no sessions has nowhere to register a repo.
+    this.projectSwitchBtn.disabled = false;
 
     const children: HTMLElement[] = [h("div", { class: "af-project-menu-label" }, "Switch project")];
     if (summaries.length === 0) {
-      children.push(h("div", { class: "af-project-menu-empty" }, "No projects yet."));
+      children.push(h("div", { class: "af-project-menu-empty" }, "No projects yet — add one below."));
     }
     for (const p of summaries) {
       children.push(this.projectItem(p, p.root === current));
     }
-    // The reversible delete-project control (#1735) lived on the old Projects view's
-    // header; with that view folded into the switcher it moves here, as a footer
-    // action on the CURRENT project (single-project IA). index.ts pops the confirm.
+
+    // Footer actions. Add-project is ALWAYS present (#2456): it is the empty
+    // state's coherent action and a convenience when projects already exist. The
+    // reversible delete-project control (#1735) rides alongside it, but only for
+    // the CURRENT project (single-project IA).
+    const footChildren: HTMLElement[] = [];
+
+    const add = h("button", { type: "button", class: "af-ghost af-project-add" }, "+ Add project");
+    add.setAttribute("title", "Register a git checkout by path as a project");
+    add.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.closeProjectMenu();
+      this.actions.addProject();
+    });
+    footChildren.push(add);
+
     const currentSummary = summaries.find((p) => p.root === current);
     if (currentSummary) {
       const del = h("button", { type: "button", class: "af-ghost af-project-delete" }, "Delete project");
@@ -1479,8 +1498,10 @@ export class AppShell {
           this.actions.deleteProject(currentSummary.root, currentSummary.name, currentSummary.liveCount);
         });
       }
-      children.push(h("div", { class: "af-project-menu-foot" }, del));
+      footChildren.push(del);
     }
+
+    children.push(h("div", { class: "af-project-menu-foot" }, ...footChildren));
     this.projectMenu.replaceChildren(...children);
   }
 


### PR DESCRIPTION
Part 2 of #2456 (web add-project affordance), on top of #2492 (the RegisterProject RPC, now merged). Rebased onto master; the diff is only this slice's web files.

## What this adds

The project switcher's dropdown gains a **"+ Add project"** footer action, and — the load-bearing change — the switcher is now **always openable**. It used to be disabled with no projects, which was the dead end a fresh web user hit: no sessions, no projects, nowhere to register a repo. The empty line now reads "No projects yet — add one below."

Clicking it opens an **add-project modal**: one path input, submitted through `RegisterProject`. The path names a directory on the **daemon host** (absolute or `~`-prefixed) — a browser has no shared working directory, so unlike the CLI it is sent **verbatim** and the daemon owns resolution + validation. A non-git/unreadable path returns the daemon's actionable message, shown **inline**, and the modal stays open to correct.

## Honest scope — what this does NOT yet do

The registered repo becomes a visible project once you **create a session into it** (the switcher list derives from sessions, `projectSummaries`). Surfacing the registered **empty** project immediately needs the **registry-union** slice — read the daemon's registry and `∪` it into the derived list, which needs a `ListProjects` RPC. That's the very next slice ([approved plan on #2456](https://github.com/sachiniyer/agent-factory/issues/2456)); I am **not** claiming here that the empty project appears. This PR is the affordance increment: it registers via the single-writer RPC, kills the zero-projects dead end, and surfaces daemon errors inline.

## Files

- `web/src/api.ts` — `registerProject(path, token)` → `RegisterProject`.
- `web/src/modals.ts` — `addProjectModal` (path input, inline error).
- `web/src/index.ts` — `openAddProject` wires the modal to the RPC with the standard busy/error handling.
- `web/src/ui.ts` — the switcher footer action + always-openable switcher.
- `web/dist` — rebuilt.

## Parity

`project.add` web status → **yes** (pointer: switcher → modal → RPC). `RegisterProject` added to `web_rpcs` (the derivation finds the call, so the gate requires the entry). Verdict stays **real-gap** until the union + TUI-add rewire flip it (closing #2478).

## Tests

- `web/src/api.test.ts` — the path is forwarded verbatim; the resolved project is returned; a non-git rejection surfaces as an `ApiError` for inline display.
- A **web-driver selftest step** drives the REAL `RegisterProject` round-trip: open switcher → "+ Add project" → a bad path rejected inline (modal held open) → a valid checkout submits and closes. **122/122**.

## Gate

`web-test` (typecheck + unit tests, 0 fail), `go test ./parity/`, Go host gates, `make test-container` (42 pkgs, 0 fail), and `make web-selftest-container` (122/122) — all clean on this head.

## Review

Codex is rate-limited (usage-limit notice only); requested once. An independent review runs on the head before merge. Not self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
