### PR TITLE
docs(parity): remote-hook web cell is partial, not a new checkbox (supersedes #2406)

### DIFF
--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -117,8 +117,8 @@
         "pointer": "keys/keys.go:153 (N) -> app/handle_input.go:207 ForceRemote"
       },
       "web": {
-        "status": "no",
-        "pointer": "web/src/api.ts:251-264 never sends force_remote"
+        "status": "partial",
+        "pointer": "web/src/api.ts createSession sends backend='hook' via the #1968 ListBackends picker — the SAME BackendHook force_remote selects (session/instance_factory.go resolveBackendKind)"
       },
       "cli": {
         "status": "yes",
@@ -126,7 +126,7 @@
       },
       "verdict": "real-gap",
       "issue": "#1933",
-      "notes": "TUI is 'partial' because ForceRemote resolves to the hook backend ONLY (session/instance_factory.go:106-108) — N cannot reach docker or ssh. The web has no remote affordance at all; this is the gap the owner reported."
+      "notes": "TUI is 'partial' because ForceRemote resolves to the hook backend ONLY (session/instance_factory.go resolveBackendKind) — N cannot reach docker or ssh. The web is ALSO 'partial', not 'no': the hook backend is reachable from the browser via the #1968 backend picker (backend='hook'), which resolveBackendKind routes to the same BackendHook by a STRONGER path than force_remote — an explicit backend wins over ForceRemote, and both override the repo's backend config, so the picker's 'hook' is strictly more capable than the legacy selector. The dedicated force_remote FIELD is deliberately NOT sent by the web (it stays a field_coverage gap): it adds no capability over the picker, and an ungated 'remote hooks' checkbox reintroduces the 'offered then fails at provision' trap the picker's backendSelectable gate closes (#2406 was closed in favor of this ledger correction). Same unproven-provisioning caveat as session.create.opt.backend: reachable != proven to create a WORKING remote session from the browser (#1968)."
     },
     {
       "id": "session.create.opt.inplace",


### PR DESCRIPTION
## What

Corrects the parity ledger cell `session.create.opt.remote.web` from `no` to **`partial`**, and supersedes #2406 (which added a redundant, ungated "Remote hooks" checkbox and set the cell to `yes`).

## Why the checkbox was the wrong fix

The remote hook backend is already web-reachable **today** through the gated Backend picker (`backend: 'hook'`, #1968). `force_remote` resolves to `BackendHook` and *only* that — it cannot reach docker/ssh — and it does so by a **strictly weaker** path than the picker:

```
resolveBackendKind (session/instance_factory.go):
  1. explicit opts.Backend  ->  ParseBackendKind   (wins over everything)
  2. opts.ForceRemote       ->  BackendHook        (loses to an explicit backend)
  3. repo `backend` config  ->  default local
```

So picking `hook` in the picker reaches the same `BackendHook`, unconditionally, and also overrides repo config. There is no user need `force_remote` serves that the picker does not. #2406's checkbox therefore added a **second path to an existing capability**, and it was genuinely ungated:

- `forceRemoteCheckbox` was never wired into `syncSubmitState()` (the single writer of `confirmBtn.disabled`). Ticking "Remote hooks" while leaving "Repo default" left Create **enabled** with `hook` unavailable → the create fails mid-provision after a full round trip — exactly the "offered, then fails later" trap `backend_preconditions.go` and the #1933 picker exist to close.
- It silently discarded an explicit Backend selection (`if (!input.forceRemote && backend !== "")`), so ticking it while "Docker" was selected sent `hook` with the form still reading Docker (invariant-eats-the-gesture).

## The honest cell is `partial`

`no` was already stale — the picker reaches `hook` today. `yes` is internally inconsistent with its sibling `session.create.opt.backend.web = "partial"`, which reaches the **same** backend by the **stronger** path. So this sets `remote.web = "partial"` with the same unproven-provisioning caveat as `backend` (reachable ≠ proven to create a *working* remote session from a browser, #1968).

The `force_remote` **field** stays a deliberate `field_coverage` gap (the web sends `backend`, not `force_remote`), so `honesty_test.go`'s negative pin and the field-coverage entry are unchanged.

## Test

`go test ./parity/` — green. The parity package is the only consumer of `inventory.json`; no generated doc drifts from this change.

Closes #2406 (in favor of this ledger correction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
