### PR TITLE
test(hook): poll for backgrounded-child liveness instead of one fixed window

### DIFF
--- a/session/backend_hook_reap_test.go
+++ b/session/backend_hook_reap_test.go
@@ -658,6 +658,15 @@ exit 0
 // above, pinned separately so a regression names its own cause: the capture must
 // not kill a process launch_cmd deliberately backgrounded. A heartbeat file is the
 // liveness probe — it keeps ticking only while the child lives.
+//
+// The child ticks for far longer than the polls below (300 * 50ms ≈ 15s), so its
+// liveness — never a race against its own natural exit — is what the assertions
+// measure. Liveness is asserted by POLLING for the heartbeat's mtime to advance,
+// not by comparing two fixed 250ms windows: a child the capture killed has a frozen
+// mtime that never advances no matter how long we wait, but a live child merely
+// DESCHEDULED under CI load can miss any single fixed window. The old two-window
+// form flaked exactly that way — a real non-deterministic false-negative, unrelated
+// to the reap path (launch exits 0 here, so no reap runs).
 func TestHookLaunchDoesNotKillBackgroundedChildren(t *testing.T) {
 	shrinkHookTimeouts(t, 5*time.Second, 5*time.Second)
 	dir := t.TempDir()
@@ -665,7 +674,7 @@ func TestHookLaunchDoesNotKillBackgroundedChildren(t *testing.T) {
 
 	h := hookState{dir: dir, launch: filepath.Join(dir, "launch.sh"), delete: filepath.Join(dir, "delete.sh")}
 	writeHookScript(t, h.launch, fmt.Sprintf(`
-( for i in $(seq 1 100); do echo "still here"; echo tick >> %s; sleep 0.05; done ) &
+( for i in $(seq 1 300); do echo "still here"; echo tick >> %s; sleep 0.05; done ) &
 echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
 exit 0
 `, shellsuggest.Arg(hb)))
@@ -675,14 +684,25 @@ exit 0
 	_, err := p.provisionOrReap()
 	require.NoError(t, err)
 
-	// The child must still be ticking well after the script exited.
-	time.Sleep(250 * time.Millisecond)
-	first, err := os.Stat(hb)
-	require.NoError(t, err, "the backgrounded child never ran")
-	time.Sleep(250 * time.Millisecond)
-	second, err := os.Stat(hb)
-	require.NoError(t, err)
-	assert.True(t, second.ModTime().After(first.ModTime()),
+	// Baseline: the child has appended at least once (the file exists ⇒ it started).
+	// Poll rather than trust a single fixed delay, which starves under load.
+	var first os.FileInfo
+	require.Eventually(t, func() bool {
+		fi, statErr := os.Stat(hb)
+		if statErr != nil {
+			return false
+		}
+		first = fi
+		return true
+	}, 3*time.Second, 20*time.Millisecond, "the backgrounded child never ran")
+
+	// A live child keeps appending, so its mtime advances beyond the baseline; a
+	// killed child's mtime is frozen and never will. Poll generously so a child
+	// merely descheduled under load is not misread as a kill.
+	require.Eventually(t, func() bool {
+		fi, statErr := os.Stat(hb)
+		return statErr == nil && fi.ModTime().After(first.ModTime())
+	}, 4*time.Second, 20*time.Millisecond,
 		"the process launch_cmd backgrounded stopped writing — the output capture killed a child that was not ours to kill")
 }
 


### PR DESCRIPTION
## What

`TestHookLaunchDoesNotKillBackgroundedChildren` red on PR #2546's plain-linux `-race` Test job (run 30138722920). This hardens the test against a pre-existing non-deterministic false-negative. **Test-only change.**

## It is NOT a regression from #2534

#2534 was the most recent change to `backend_hook_backend.go`, so it was the natural suspect. It is not the cause:

- This test's `launch.sh` **exits 0** with a valid endpoint, so `provisionOrReap()` **succeeds**.
- On success, `reap()` never runs — so the reap-latch change (`reapOnce` → `reapMu`/`reaped`/`reapErr`) never executes.
- On success, `runHookScriptWithResolvedEnvironment` returns `runErr == nil`, so #2534's added `DeadlineExceeded`-wrap branch is skipped.
- Nothing kills the process group on success (`quiesceLaunchGroup` runs only on the failure path), and the file-based capture predates #2534 (#2441).

**The code path this test exercises is byte-for-byte identical pre/post #2534.**

The CI failure line — `--- FAIL: ... (0.53s)` — corroborates: the test does two 250ms sleeps (500ms floor), so 0.53s means it ran to completion and only the **final `mtime`-advance assertion** failed. That is scheduler starvation of the backgrounded subshell, not a logic error. Only the plain-linux `-race` job failed; the macOS `-race` job (same `-race -count=1 ./...`) passed — a split-by-runner signature of load variance, not a hook-backend logic change.

## Reproduction

Could not reproduce the failure:

- `-race -count=20 -shuffle=on ./session/` in the container — ~13–20 full session passes before the 10m budget; target test passed every pass.
- `-race -count=3 -shuffle=on -timeout=45m ./...` (faithful CI cross-package load) — **green**, `session 136.912s ok`.

Target test ran ~16–23 times, incl. 3 under full-suite `-race` load, with zero failures — consistent with a rare, load-dependent starvation flake.

## Fix

The old assertion compared the heartbeat file's mtime across two fixed 250ms windows; a live-but-descheduled child that misses one window is misread as a kill. Replace it with a **poll** for the mtime to advance over a generous window. A KILLED child's mtime is frozen and never advances no matter how long we wait, so the invariant is preserved — verified fail-first: a child that stops after one tick fails at the 4s bound. The child now ticks ~15s (far longer than the poll budget), so its liveness, not a race against its own natural exit, is what is measured.

Verified: 8× `-race` locally + the fail-first check. PR CI runs the full `-race -count=1 ./...` gate.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
