### PR TITLE
feat(daemon): production upgrade-activation trigger, old-daemon side (#2212 R2b)

### DIFF
--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -41,6 +41,23 @@ func errDaemonUpgradeProbation(transactionID string) error {
 	return fmt.Errorf("%s (transaction %s); retry shortly", daemonUpgradeProbationErrText, transactionID)
 }
 
+// daemonQuiescingErrText is the stable wire prefix for a mutation refused because
+// the daemon is quiescing to hand off to a validated upgrade candidate: it has
+// stopped admitting new work and is about to exit so the candidate can bind the
+// socket. Retryable — the client should reach the new daemon that takes over.
+const daemonQuiescingErrText = "agent-factory daemon is handing off to an upgrade"
+
+func errDaemonQuiescing() error {
+	return errors.New(daemonQuiescingErrText + "; retry shortly")
+}
+
+// IsDaemonQuiescingErr reports whether a mutation was refused because the daemon is
+// quiescing for an upgrade hand-off. net/rpc flattens the server error to text, so
+// this matches the stable wire prefix like the other admission classifiers.
+func IsDaemonQuiescingErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), daemonQuiescingErrText)
+}
+
 // IsDaemonStartingErr reports whether an RPC client error means the daemon is
 // up but still restoring instances. Callers should treat it as retryable: the
 // daemon is alive (EnsureDaemon's ping succeeds, so it must NOT spawn another)
@@ -62,7 +79,7 @@ func IsDaemonUpgradeProbationErr(err error) bool {
 // and HTTP/TUI transports use this predicate so a new admission phase cannot
 // become retryable on one transport while failing immediately on the other.
 func IsDaemonAdmissionRetryable(err error) bool {
-	return IsDaemonStartingErr(err) || IsDaemonUpgradeProbationErr(err)
+	return IsDaemonStartingErr(err) || IsDaemonUpgradeProbationErr(err) || IsDaemonQuiescingErr(err)
 }
 
 // DaemonSocketPath returns the Unix socket path used by the local control

--- a/daemon/lifecycle.go
+++ b/daemon/lifecycle.go
@@ -29,6 +29,13 @@ const (
 	// af doctor / the HTTP health surface render it honestly (#2212 R2a).
 	DaemonPhaseHandoffPending DaemonPhase = "handoff_pending"
 	DaemonPhaseReady          DaemonPhase = "ready"
+	// DaemonPhaseQuiescing is a formerly-ready daemon that has authorized an upgrade
+	// activation and is stopping admitting new work before it exits to free the
+	// socket for the validated candidate. It is NOT ready — it is refusing mutations
+	// and about to go away — so, by the same principle as DaemonPhaseHandoffPending,
+	// it must not keep reporting DaemonPhaseReady: a daemon stuck mid-hand-off has to
+	// be VISIBLE to `af daemon status` / `af doctor`, not look healthy (#2212 R2b).
+	DaemonPhaseQuiescing DaemonPhase = "quiescing"
 )
 
 // DaemonListenerStatus reports which auxiliary HTTP surfaces this daemon
@@ -71,7 +78,11 @@ type daemonLifecycle struct {
 	// released is set when the previous-binary supervisor lifts this candidate's
 	// probation. It gates mutation ADMISSION; transactionID is kept for the whole
 	// boot as the supervisor's IDENTITY (#1947), so the two never conflate.
-	released  bool
+	released bool
+	// quiescing is set when this daemon has authorized an upgrade activation and is
+	// handing off. It closes admission (the daemon is about to exit) and drives the
+	// reported DaemonPhaseQuiescing so a stuck hand-off is visible, not silent.
+	quiescing bool
 	listeners DaemonListenerStatus
 }
 
@@ -130,6 +141,18 @@ func (l *daemonLifecycle) markReady() error {
 	}
 	l.phase = DaemonPhaseReady
 	return nil
+}
+
+// markQuiescing moves a ready daemon into the upgrade hand-off: it stops admitting
+// new mutations and reports DaemonPhaseQuiescing. The activation trigger calls it
+// AFTER AuthorizeActivation and BEFORE the daemon exits to free the socket for the
+// validated candidate, so no mutation races the hand-off window and a daemon stuck
+// mid-hand-off is visible rather than reporting ready. Idempotent.
+func (l *daemonLifecycle) markQuiescing() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.quiescing = true
+	l.phase = DaemonPhaseQuiescing
 }
 
 // releaseUpgradeProbation lifts an upgrade candidate's probation once its
@@ -195,6 +218,9 @@ func (l *daemonLifecycle) isUpgradeProbation() bool {
 func (l *daemonLifecycle) mutationAdmissionError() error {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
+	if l.quiescing {
+		return errDaemonQuiescing()
+	}
 	if l.inProbationLocked() {
 		return errDaemonUpgradeProbation(l.transactionID)
 	}

--- a/daemon/upgrade_recovery.go
+++ b/daemon/upgrade_recovery.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/pathutil"
 	"github.com/sachiniyer/agent-factory/internal/upgradetxn"
 	"github.com/sachiniyer/agent-factory/log"
 )
@@ -155,7 +156,17 @@ func recoveryHomeGuard(journal upgradetxn.Journal) error {
 	if err != nil {
 		return fmt.Errorf("resolve AF home for upgrade recovery: %w", err)
 	}
-	if dir != journal.HomeDir {
+	// Compare home IDENTITY, not string spelling. config.GetConfigDir returns
+	// AGENT_FACTORY_HOME verbatim (no symlink resolution), while upgradetxn.Prepare
+	// stored journal.HomeDir in its symlink-resolved form (canonicalExistingDir). A
+	// user whose home traverses a symlink — a symlinked home dir, or macOS
+	// /var -> /private/var — would otherwise spell the same home two ways and have
+	// EVERY op refused (StopUnknown), failing that box's upgrades closed forever with
+	// a baffling message. pathutil.ResolveForCompare canonicalizes both sides (incl.
+	// the missing-leaf case, #2110), so equal homes compare equal regardless of
+	// spelling. Today the actor's home is argv-pinned to the resolved journal.HomeDir
+	// so the raw compare happened to hold, but this removes the latent trap.
+	if pathutil.ResolveForCompare(dir) != pathutil.ResolveForCompare(journal.HomeDir) {
 		return fmt.Errorf(
 			"upgrade recovery is bound to AF home %q but the transaction recovers %q; refusing to act on the wrong daemon",
 			dir, journal.HomeDir)

--- a/daemon/upgrade_trigger.go
+++ b/daemon/upgrade_trigger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -35,6 +36,7 @@ var (
 	upgradeAuthorizeActivationFn   = func(txn *upgradetxn.Transaction, transactionID, nonce string) error {
 		return txn.AuthorizeActivation(transactionID, nonce)
 	}
+	upgradeAbortPreparedFn = upgradetxn.AbortPreparedTransaction
 )
 
 // triggerUpgradeActivation is the OLD-daemon side of an upgrade activation, run
@@ -60,18 +62,33 @@ func triggerUpgradeActivation(ctx context.Context, lifecycle *daemonLifecycle, r
 	if err != nil {
 		return fmt.Errorf("prepare upgrade transaction: %w", err)
 	}
-	if err := upgradeRecoveryJobControllerFn().InstallAndStart(ctx, txn); err != nil {
-		return fmt.Errorf("install and start the recovery actor: %w", err)
-	}
 	journal := txn.Journal()
+	// From here active.json is published (fsynced). Any failure BEFORE an actor takes
+	// authority must abort it, or one transient service-manager error wedges the
+	// upgrade path forever — every future Prepare fails "already active", with no
+	// actor able to clear it. abortPrepared refuses once an actor owns the
+	// transaction, so it is safe to call and a no-op past that point.
+	abortPrepared := func(cause error) error {
+		if abortErr := upgradeAbortPreparedFn(journal.HomeDir, journal.ID); abortErr != nil {
+			return errors.Join(cause, fmt.Errorf("abort the prepared upgrade transaction: %w", abortErr))
+		}
+		return cause
+	}
+	if err := upgradeRecoveryJobControllerFn().InstallAndStart(ctx, txn); err != nil {
+		return abortPrepared(fmt.Errorf("install and start the recovery actor: %w", err))
+	}
 	deadline := time.Now().Add(upgradeActivationSupervisorReadyGrace)
 	if err := upgradeAwaitSupervisorReadyFn(ctx, journal.HomeDir, deadline); err != nil {
 		// The actor never PROVED supervisor_ready. Do NOT authorize or exit: the
-		// daemon keeps serving. Surface it loudly — an unobservable readiness is a
-		// failure, never an assumed success.
-		return fmt.Errorf("upgrade recovery actor did not reach supervisor_ready; daemon keeps serving: %w", err)
+		// daemon keeps serving. Abort the prepared transaction (a no-op if an actor
+		// took it and its own deadline will drive teardown) so the upgrade path is not
+		// wedged, and surface the failure loudly — never an assumed success.
+		return abortPrepared(fmt.Errorf("upgrade recovery actor did not reach supervisor_ready; daemon keeps serving: %w", err))
 	}
 	if err := upgradeAuthorizeActivationFn(txn, journal.ID, journal.RecoveryNonce); err != nil {
+		// The actor is at supervisor_ready and owns the transaction; its own
+		// supervisor_ready deadline times out and aborts. Do not abort from here
+		// (abortPrepared would refuse anyway) — just surface the failure.
 		return fmt.Errorf("authorize upgrade activation: %w", err)
 	}
 	// Authorized: the actor is greenlit to replace us. Stop admitting new work so no
@@ -122,6 +139,15 @@ func captureUpgradePlan(lifecycle *daemonLifecycle, candidate []byte, toVersion 
 			Listeners:  toListenerExpectation(snap.listeners),
 		},
 		RecoveryJob: recoveryJob,
+		// MetadataPaths is intentionally empty for R2b, and this is a deferral, not a
+		// claim of completeness. Rollback only ever runs BEFORE commit; until commit
+		// the candidate is held in DaemonPhaseUpgradeProbation, which blocks every
+		// mutating RPC, and its startup restore is read-only — so no daemon-written
+		// metadata diverges from what the previous daemon left, and a binary-only
+		// restore is complete for that window. The full metadata manifest (guarding
+		// the residual migrate-on-load edge, where the new binary could rewrite a
+		// state file as it reads it) lands with the R3 release wiring that first
+		// stages a candidate; capturing it here now would be guessing at the set.
 	}, nil
 }
 

--- a/daemon/upgrade_trigger.go
+++ b/daemon/upgrade_trigger.go
@@ -139,15 +139,20 @@ func captureUpgradePlan(lifecycle *daemonLifecycle, candidate []byte, toVersion 
 			Listeners:  toListenerExpectation(snap.listeners),
 		},
 		RecoveryJob: recoveryJob,
-		// MetadataPaths is intentionally empty for R2b, and this is a deferral, not a
-		// claim of completeness. Rollback only ever runs BEFORE commit; until commit
-		// the candidate is held in DaemonPhaseUpgradeProbation, which blocks every
-		// mutating RPC, and its startup restore is read-only — so no daemon-written
-		// metadata diverges from what the previous daemon left, and a binary-only
-		// restore is complete for that window. The full metadata manifest (guarding
-		// the residual migrate-on-load edge, where the new binary could rewrite a
-		// state file as it reads it) lands with the R3 release wiring that first
-		// stages a candidate; capturing it here now would be guessing at the set.
+		// MetadataPaths is intentionally empty because R2b STARTS NO CANDIDATE — the
+		// trigger is wired to nothing yet, so no candidate daemon boots to write any
+		// metadata. It is NOT empty because probation makes divergence safe: probation
+		// blocks mutating RPCs, but migrate-on-load is not an RPC and runs anyway.
+		// config.LoadAndMigrateSchemaFile atomically REWRITES a state file as it reads
+		// it (config/schema_migration.go), and it runs at daemon load — before restore —
+		// for every per-repo instances.json (config.MigrateAllRepoInstancesForDaemonLoad)
+		// and for tasks.json (task/schema_migration.go). So a candidate that boots,
+		// migrates vN→vN+1, then FAILS validation would leave a binary-only rollback
+		// restoring the FromVersion daemon onto state files written in a schema it can no
+		// longer read. That gap is inert only while nothing is staged; it goes live the
+		// moment R3 stages a real candidate, so R3 MUST populate this manifest with those
+		// migrated paths (recorded as the R3 prerequisite on #2212). Capturing them here
+		// now, with no candidate to protect, would only be guessing at the set.
 	}, nil
 }
 

--- a/daemon/upgrade_trigger.go
+++ b/daemon/upgrade_trigger.go
@@ -1,0 +1,197 @@
+package daemon
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/upgradetxn"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// upgradeActivationSupervisorReadyGrace bounds how long the trigger waits for the
+// previous-binary recovery actor to reach supervisor_ready before giving up. The
+// actor forks, acquires the lease, and publishes its readiness proof; a minute is
+// generous without hanging forever on a wedged actor. Package var so tests shorten it.
+var upgradeActivationSupervisorReadyGrace = 60 * time.Second
+
+// Seams so the trigger runs end-to-end without spawning a real recovery actor,
+// touching the host service manager, or re-execing the real binary. The
+// lease-handshake pair (AwaitSupervisorReady / AuthorizeActivation) is seamed
+// because a genuine supervisor_ready proof requires the actor to run as the exact
+// preserved previous binary (TryAcquireRecovery's path identity) — a real spawned
+// process, which is R4's territory. AwaitSupervisorReady's own real-journal behavior
+// is proven in the upgradetxn package where that identity seam is reachable.
+var (
+	upgradeTriggerExecutableFn     = os.Executable
+	upgradeTriggerVersionFn        = Version
+	upgradeRecoveryJobControllerFn = func() upgradetxn.RecoveryJobController { return upgradetxn.RecoveryJobController{} }
+	upgradeAwaitSupervisorReadyFn  = upgradetxn.AwaitSupervisorReady
+	upgradeAuthorizeActivationFn   = func(txn *upgradetxn.Transaction, transactionID, nonce string) error {
+		return txn.AuthorizeActivation(transactionID, nonce)
+	}
+)
+
+// triggerUpgradeActivation is the OLD-daemon side of an upgrade activation, run
+// inside the serving daemon (#2212 R2b). R3's update loop will call it once it has
+// decided to install a candidate; R2b wires it to nothing. It stages the candidate,
+// hands supervision to the immutable previous binary, and quiesces + exits so the
+// candidate can bind the socket.
+//
+// It is built so the irreversible path never promotes weak evidence to proof (the
+// habit behind every R2a P1). Every conclusion about the actor is a POSITIVE
+// observation, never an error being nil/non-nil: AwaitSupervisorReady proves the
+// actor took the lease AND reached supervisor_ready before AuthorizeActivation
+// consents, and an actor that never gets there is a LOUD error that leaves the
+// daemon serving — never an assumed success. Only after authorizing does the daemon
+// quiesce (stop admitting, report DaemonPhaseQuiescing so a stuck hand-off is
+// visible) and exit; the actor's StopPrevious then confirms it is gone.
+func triggerUpgradeActivation(ctx context.Context, lifecycle *daemonLifecycle, requestExit func(), candidate []byte, toVersion string) error {
+	plan, err := captureUpgradePlan(lifecycle, candidate, toVersion)
+	if err != nil {
+		return fmt.Errorf("capture upgrade plan: %w", err)
+	}
+	txn, err := upgradetxn.Prepare(plan)
+	if err != nil {
+		return fmt.Errorf("prepare upgrade transaction: %w", err)
+	}
+	if err := upgradeRecoveryJobControllerFn().InstallAndStart(ctx, txn); err != nil {
+		return fmt.Errorf("install and start the recovery actor: %w", err)
+	}
+	journal := txn.Journal()
+	deadline := time.Now().Add(upgradeActivationSupervisorReadyGrace)
+	if err := upgradeAwaitSupervisorReadyFn(ctx, journal.HomeDir, deadline); err != nil {
+		// The actor never PROVED supervisor_ready. Do NOT authorize or exit: the
+		// daemon keeps serving. Surface it loudly — an unobservable readiness is a
+		// failure, never an assumed success.
+		return fmt.Errorf("upgrade recovery actor did not reach supervisor_ready; daemon keeps serving: %w", err)
+	}
+	if err := upgradeAuthorizeActivationFn(txn, journal.ID, journal.RecoveryNonce); err != nil {
+		return fmt.Errorf("authorize upgrade activation: %w", err)
+	}
+	// Authorized: the actor is greenlit to replace us. Stop admitting new work so no
+	// mutation races the hand-off, report DaemonPhaseQuiescing, then free the socket.
+	lifecycle.markQuiescing()
+	log.InfoLog.Printf("upgrade activation authorized for transaction %s; quiescing and exiting for the candidate", journal.ID)
+	requestExit()
+	return nil
+}
+
+// captureUpgradePlan snapshots the LIVE daemon into a transaction plan. Candidate
+// bytes and ToVersion are inputs (R3 supplies them from the release; the test a
+// stamped fake); everything else is read from this running daemon so the actor
+// validates and, on failure, restores exactly what was serving.
+func captureUpgradePlan(lifecycle *daemonLifecycle, candidate []byte, toVersion string) (upgradetxn.Plan, error) {
+	home, err := config.GetConfigDir()
+	if err != nil {
+		return upgradetxn.Plan{}, err
+	}
+	executable, err := upgradeTriggerExecutableFn()
+	if err != nil {
+		return upgradetxn.Plan{}, fmt.Errorf("resolve running executable: %w", err)
+	}
+	id, err := newUpgradeTransactionID()
+	if err != nil {
+		return upgradetxn.Plan{}, err
+	}
+	owner, err := upgradeDaemonOwner(home)
+	if err != nil {
+		return upgradetxn.Plan{}, err
+	}
+	recoveryJob, err := upgradeRecoveryJobFor(id, owner.Kind)
+	if err != nil {
+		return upgradetxn.Plan{}, err
+	}
+	snap := lifecycle.snapshot()
+	return upgradetxn.Plan{
+		ID:             id,
+		HomeDir:        home,
+		ExecutablePath: executable,
+		FromVersion:    upgradeTriggerVersionFn(),
+		ToVersion:      toVersion,
+		Candidate:      candidate,
+		Daemon: upgradetxn.DaemonSnapshot{
+			WasRunning: true,
+			BootID:     snap.bootID,
+			Owner:      owner,
+			Listeners:  toListenerExpectation(snap.listeners),
+		},
+		RecoveryJob: recoveryJob,
+	}, nil
+}
+
+func newUpgradeTransactionID() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate upgrade transaction id: %w", err)
+	}
+	return "upgrade-" + hex.EncodeToString(buf), nil
+}
+
+// upgradeDaemonOwner captures the CURRENT supervision owner so the actor restores
+// the daemon under the same owner it was serving under. A resolve failure is an
+// error, never silently coerced to ad-hoc.
+func upgradeDaemonOwner(home string) (upgradetxn.DaemonOwner, error) {
+	owner, err := ResolveSupervisionOwner(home)
+	if err != nil {
+		return upgradetxn.DaemonOwner{}, err
+	}
+	if owner != OwnerUnit {
+		return upgradetxn.DaemonOwner{Kind: upgradetxn.SupervisionAdHoc}, nil
+	}
+	switch autostartGOOS {
+	case "linux":
+		return upgradetxn.DaemonOwner{Kind: upgradetxn.SupervisionSystemd, ServiceName: autostartUnitName}, nil
+	case "darwin":
+		return upgradetxn.DaemonOwner{Kind: upgradetxn.SupervisionLaunchd, ServiceName: autostartLaunchdLabel}, nil
+	default:
+		return upgradetxn.DaemonOwner{Kind: upgradetxn.SupervisionAdHoc}, nil
+	}
+}
+
+// upgradeRecoveryJobFor derives the transaction-scoped recovery launcher for this
+// owner via the canonical NewRecoveryJob builder (so the name/path can never drift
+// from what the actor side expects). The recovery unit lives beside the autostart
+// unit; an ad-hoc daemon uses the detached actor (recovered by the all-entrypoint
+// takeover gate).
+func upgradeRecoveryJobFor(id string, kind upgradetxn.SupervisionKind) (upgradetxn.RecoveryJob, error) {
+	var jobKind upgradetxn.RecoveryJobKind
+	switch kind {
+	case upgradetxn.SupervisionSystemd:
+		jobKind = upgradetxn.RecoveryJobSystemd
+	case upgradetxn.SupervisionLaunchd:
+		jobKind = upgradetxn.RecoveryJobLaunchd
+	default:
+		return upgradetxn.RecoveryJob{Kind: upgradetxn.RecoveryJobDetached}, nil
+	}
+	dir, err := upgradeUnitDir()
+	if err != nil {
+		return upgradetxn.RecoveryJob{}, err
+	}
+	return upgradetxn.NewRecoveryJob(jobKind, id, dir)
+}
+
+func upgradeUnitDir() (string, error) {
+	path, err := autostartUnitFilePath()
+	if err != nil {
+		return "", err
+	}
+	if path == "" {
+		return "", fmt.Errorf("no autostart unit directory on %s", autostartGOOS)
+	}
+	return filepath.Dir(path), nil
+}
+
+func toListenerExpectation(l DaemonListenerStatus) upgradetxn.ListenerExpectation {
+	return upgradetxn.ListenerExpectation{
+		HTTPUnixBound: l.HTTPUnixBound,
+		TCPConfigured: l.TCPConfigured,
+		TCPListenAddr: l.TCPListenAddr,
+		TCPBound:      l.TCPBound,
+	}
+}

--- a/daemon/upgrade_trigger_test.go
+++ b/daemon/upgrade_trigger_test.go
@@ -205,18 +205,25 @@ func TestRecoveryHomeGuard_ComparesCanonically(t *testing.T) {
 func TestUpgradeRecoveryJobFor_AllKinds(t *testing.T) {
 	unitDir := withAutostartTestEnv(t, "linux")
 	const id = "upgrade-abc"
+	// NewRecoveryJob emits the symlink-RESOLVED unit path (correct product behavior:
+	// a unit file records a real path), so the expectation is built in the same
+	// canonical space — the property is "the job path is the right path under the
+	// home", not byte-identity with an unresolved temp dir (which on macOS is a
+	// /var -> /private/var symlink).
+	resolvedUnitDir, err := filepath.EvalSymlinks(unitDir)
+	require.NoError(t, err)
 
 	systemd, err := upgradeRecoveryJobFor(id, upgradetxn.SupervisionSystemd)
 	require.NoError(t, err)
 	require.Equal(t, upgradetxn.RecoveryJobSystemd, systemd.Kind)
 	require.Equal(t, "agent-factory-upgrade-recovery-"+id+".service", systemd.Name)
-	require.Equal(t, filepath.Join(unitDir, systemd.Name), systemd.UnitPath)
+	require.Equal(t, filepath.Join(resolvedUnitDir, systemd.Name), systemd.UnitPath)
 
 	launchd, err := upgradeRecoveryJobFor(id, upgradetxn.SupervisionLaunchd)
 	require.NoError(t, err)
 	require.Equal(t, upgradetxn.RecoveryJobLaunchd, launchd.Kind)
 	require.Equal(t, "com.agent-factory.upgrade-recovery."+id, launchd.Name)
-	require.Equal(t, filepath.Join(unitDir, launchd.Name+".plist"), launchd.UnitPath)
+	require.Equal(t, filepath.Join(resolvedUnitDir, launchd.Name+".plist"), launchd.UnitPath)
 
 	adhoc, err := upgradeRecoveryJobFor(id, upgradetxn.SupervisionAdHoc)
 	require.NoError(t, err)

--- a/daemon/upgrade_trigger_test.go
+++ b/daemon/upgrade_trigger_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,6 +21,11 @@ import (
 // binary path, candidate bytes).
 func stubTriggerEnv(t *testing.T) (string, string, []byte) {
 	t.Helper()
+	// A raw t.TempDir() home: on darwin it lives under /var/folders (a symlink to
+	// /private/var), so config.GetConfigDir() (unresolved) and journal.HomeDir
+	// (symlink-resolved by Prepare) spell it differently. recoveryHomeGuard now
+	// compares via pathutil.ResolveForCompare, so it accepts the same home under
+	// either spelling — do NOT canonicalize here, so this actually exercises that.
 	home := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", home)
 	withAutostartTestEnv(t, "linux") // no unit file written → ad-hoc owner
@@ -144,6 +150,115 @@ func TestTriggerUpgradeActivation_NotReadyKeepsServing(t *testing.T) {
 	require.False(t, exited, "must not exit when the actor is not ready")
 	require.Equal(t, DaemonPhaseReady, lifecycle.snapshot().phase, "the daemon must keep serving")
 	require.NoError(t, lifecycle.mutationAdmissionError(), "a still-serving daemon must keep admitting work")
+}
+
+// A failed InstallAndStart must ABORT the prepared transaction — otherwise one
+// transient service-manager error strands active.json at 'prepared' and wedges every
+// future upgrade at "already active". The abort here is the REAL one, so the journal
+// is genuinely cleared.
+func TestTriggerUpgradeActivation_AbortsPreparedOnInstallFailure(t *testing.T) {
+	home, _, candidate := stubTriggerEnv(t)
+	lifecycle := readyLifecycle(t)
+
+	upgradeRecoveryJobControllerFn = func() upgradetxn.RecoveryJobController {
+		return upgradetxn.RecoveryJobController{
+			StartDetached: func(string, ...string) error { return errors.New("detached spawn failed") },
+			RunCommand:    func(context.Context, string, ...string) error { return nil },
+			UserID:        func() int { return os.Getuid() },
+		}
+	}
+	exited := false
+	err := triggerUpgradeActivation(context.Background(), lifecycle, func() { exited = true }, candidate, "1.0.200")
+	require.Error(t, err)
+	require.False(t, exited, "a failed install must not exit the daemon")
+	require.Equal(t, DaemonPhaseReady, lifecycle.snapshot().phase, "the daemon keeps serving")
+
+	_, loadErr := upgradetxn.Load(home)
+	require.ErrorIs(t, loadErr, upgradetxn.ErrNoActiveTransaction,
+		"a failed install must abort the prepared transaction, not wedge the upgrade path")
+}
+
+// recoveryHomeGuard tests home IDENTITY, not string spelling: the same home reached
+// through a symlink (macOS /var -> /private/var, or a symlinked home dir) is accepted,
+// while a genuinely different home is refused. Without ResolveForCompare the symlinked
+// case fails closed — every op StopUnknown, upgrades permanently wedged (#2212 R2b P1).
+func TestRecoveryHomeGuard_ComparesCanonically(t *testing.T) {
+	base := t.TempDir()
+	real := filepath.Join(base, "real")
+	require.NoError(t, os.MkdirAll(real, 0o755))
+	link := filepath.Join(base, "link")
+	require.NoError(t, os.Symlink(real, link))
+
+	t.Setenv("AGENT_FACTORY_HOME", link) // bound to the symlinked spelling
+	require.NoError(t, recoveryHomeGuard(upgradetxn.Journal{HomeDir: real}),
+		"the same home spelled via symlink vs resolved must pass the guard")
+
+	other := filepath.Join(base, "other")
+	require.NoError(t, os.MkdirAll(other, 0o755))
+	require.Error(t, recoveryHomeGuard(upgradetxn.Journal{HomeDir: other}),
+		"a genuinely different home must still be refused")
+}
+
+// upgradeRecoveryJobFor covers all three owner kinds via the canonical NewRecoveryJob
+// builder — the systemd and launchd branches, not just the ad-hoc default the trigger
+// tests exercise.
+func TestUpgradeRecoveryJobFor_AllKinds(t *testing.T) {
+	unitDir := withAutostartTestEnv(t, "linux")
+	const id = "upgrade-abc"
+
+	systemd, err := upgradeRecoveryJobFor(id, upgradetxn.SupervisionSystemd)
+	require.NoError(t, err)
+	require.Equal(t, upgradetxn.RecoveryJobSystemd, systemd.Kind)
+	require.Equal(t, "agent-factory-upgrade-recovery-"+id+".service", systemd.Name)
+	require.Equal(t, filepath.Join(unitDir, systemd.Name), systemd.UnitPath)
+
+	launchd, err := upgradeRecoveryJobFor(id, upgradetxn.SupervisionLaunchd)
+	require.NoError(t, err)
+	require.Equal(t, upgradetxn.RecoveryJobLaunchd, launchd.Kind)
+	require.Equal(t, "com.agent-factory.upgrade-recovery."+id, launchd.Name)
+	require.Equal(t, filepath.Join(unitDir, launchd.Name+".plist"), launchd.UnitPath)
+
+	adhoc, err := upgradeRecoveryJobFor(id, upgradetxn.SupervisionAdHoc)
+	require.NoError(t, err)
+	require.Equal(t, upgradetxn.RecoveryJobDetached, adhoc.Kind)
+	require.Empty(t, adhoc.UnitPath)
+}
+
+// upgradeDaemonOwner covers all three owner shapes: ad-hoc (no unit), systemd, and
+// launchd — the unit-owned branches being the DEFAULT install shape, fail-closed
+// against constants in another package, so drift must be caught by a test.
+func TestUpgradeDaemonOwner_AllOwners(t *testing.T) {
+	t.Run("ad-hoc when no unit serves the home", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("AGENT_FACTORY_HOME", home)
+		withAutostartTestEnv(t, "linux") // no unit file written
+		owner, err := upgradeDaemonOwner(home)
+		require.NoError(t, err)
+		require.Equal(t, upgradetxn.SupervisionAdHoc, owner.Kind)
+		require.Empty(t, owner.ServiceName)
+	})
+	t.Run("systemd when a home-serving unit is installed", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("AGENT_FACTORY_HOME", home)
+		unitDir := withAutostartTestEnv(t, "linux")
+		unit := systemdAutostartUnit("/opt/agent-factory/bin/af", "", "", home)
+		require.NoError(t, os.WriteFile(filepath.Join(unitDir, autostartUnitName), []byte(unit), 0o600))
+		owner, err := upgradeDaemonOwner(home)
+		require.NoError(t, err)
+		require.Equal(t, upgradetxn.SupervisionSystemd, owner.Kind)
+		require.Equal(t, autostartUnitName, owner.ServiceName)
+	})
+	t.Run("launchd when a home-serving agent is installed", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("AGENT_FACTORY_HOME", home)
+		dir := withAutostartTestEnv(t, "darwin")
+		plist := launchdAutostartPlist("/opt/agent-factory/bin/af", "", "", home, filepath.Join(dir, "daemon.log"))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, autostartLaunchdLabel+".plist"), []byte(plist), 0o600))
+		owner, err := upgradeDaemonOwner(home)
+		require.NoError(t, err)
+		require.Equal(t, upgradetxn.SupervisionLaunchd, owner.Kind)
+		require.Equal(t, autostartLaunchdLabel, owner.ServiceName)
+	})
 }
 
 // The Plan captured from the live daemon produces a REAL journal (via the real

--- a/daemon/upgrade_trigger_test.go
+++ b/daemon/upgrade_trigger_test.go
@@ -1,0 +1,242 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/internal/upgradetxn"
+	"github.com/stretchr/testify/require"
+)
+
+// stubTriggerEnv binds a throwaway home with an ad-hoc owner (no autostart unit →
+// RecoveryJobDetached), stages a real previous binary the trigger's Prepare can
+// preserve, and stubs every trigger + op seam. The lease-handshake pair is stubbed
+// because a genuine supervisor_ready proof needs the actor to run as the exact
+// preserved previous binary (a real process — R4); AwaitSupervisorReady's own
+// real-journal behavior is proven in internal/upgradetxn. Returns (home, previous
+// binary path, candidate bytes).
+func stubTriggerEnv(t *testing.T) (string, string, []byte) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	withAutostartTestEnv(t, "linux") // no unit file written → ad-hoc owner
+
+	executable := filepath.Join(t.TempDir(), "af")
+	require.NoError(t, os.WriteFile(executable, []byte("previous-af-binary"), 0o755))
+	candidate := []byte("candidate-af-binary")
+
+	restore := struct {
+		exe     func() (string, error)
+		version func() string
+		ctrl    func() upgradetxn.RecoveryJobController
+		await   func(context.Context, string, time.Time) error
+		auth    func(*upgradetxn.Transaction, string, string) error
+		health  func() HealthStatus
+		launch  func(string, string) error
+		release func(string) error
+		unit    func() error
+		adhoc   func(string) error
+		stop    func() (bool, error)
+		wait    func() error
+		vg      time.Duration
+		vp      time.Duration
+	}{
+		upgradeTriggerExecutableFn, upgradeTriggerVersionFn, upgradeRecoveryJobControllerFn,
+		upgradeAwaitSupervisorReadyFn, upgradeAuthorizeActivationFn, upgradeRecoveryHealthFn,
+		launchCandidateDaemonFn, releaseCandidateProbationFn, startPreviousViaUnitFn,
+		startPreviousAdHocFn, stopDaemonFn, waitForShutdownFn, upgradeValidateGrace, upgradeValidatePoll,
+	}
+	t.Cleanup(func() {
+		upgradeTriggerExecutableFn = restore.exe
+		upgradeTriggerVersionFn = restore.version
+		upgradeRecoveryJobControllerFn = restore.ctrl
+		upgradeAwaitSupervisorReadyFn = restore.await
+		upgradeAuthorizeActivationFn = restore.auth
+		upgradeRecoveryHealthFn = restore.health
+		launchCandidateDaemonFn = restore.launch
+		releaseCandidateProbationFn = restore.release
+		startPreviousViaUnitFn = restore.unit
+		startPreviousAdHocFn = restore.adhoc
+		stopDaemonFn = restore.stop
+		waitForShutdownFn = restore.wait
+		upgradeValidateGrace, upgradeValidatePoll = restore.vg, restore.vp
+	})
+
+	upgradeTriggerExecutableFn = func() (string, error) { return executable, nil }
+	upgradeTriggerVersionFn = func() string { return "1.0.100" }
+	// A no-op controller: the fake actor is simulated by the handshake seams, so
+	// InstallAndStart must not spawn the real previous binary or call systemctl.
+	upgradeRecoveryJobControllerFn = func() upgradetxn.RecoveryJobController {
+		return upgradetxn.RecoveryJobController{
+			StartDetached: func(string, ...string) error { return nil },
+			RunCommand:    func(context.Context, string, ...string) error { return nil },
+			UserID:        func() int { return os.Getuid() },
+		}
+	}
+	upgradeValidateGrace, upgradeValidatePoll = 500*time.Millisecond, time.Millisecond
+	return home, executable, candidate
+}
+
+func readyLifecycle(t *testing.T) *daemonLifecycle {
+	t.Helper()
+	l, err := newDaemonLifecycle("", "", "")
+	require.NoError(t, err)
+	l.markRestoreComplete()
+	require.NoError(t, l.markReady())
+	return l
+}
+
+// The trigger authorizes only after a positive supervisor_ready observation, then
+// quiesces (honest phase + closed admission) and exits — in that order. The
+// hand-off never precedes the authorization.
+func TestTriggerUpgradeActivation_AuthorizesThenQuiescesAndExits(t *testing.T) {
+	_, _, candidate := stubTriggerEnv(t)
+	lifecycle := readyLifecycle(t)
+
+	var events []string
+	upgradeAwaitSupervisorReadyFn = func(context.Context, string, time.Time) error {
+		events = append(events, "await-ready")
+		return nil
+	}
+	upgradeAuthorizeActivationFn = func(_ *upgradetxn.Transaction, id, nonce string) error {
+		require.NotEmpty(t, id)
+		require.NotEmpty(t, nonce, "the trigger must authorize with the journal's recovery nonce")
+		events = append(events, "authorize")
+		return nil
+	}
+	requestExit := func() {
+		require.Equal(t, DaemonPhaseQuiescing, lifecycle.snapshot().phase,
+			"the daemon must quiesce BEFORE it exits")
+		events = append(events, "exit")
+	}
+
+	require.NoError(t, triggerUpgradeActivation(context.Background(), lifecycle, requestExit, candidate, "1.0.200"))
+	require.Equal(t, []string{"await-ready", "authorize", "exit"}, events)
+	require.Equal(t, DaemonPhaseQuiescing, lifecycle.snapshot().phase)
+	require.Error(t, lifecycle.mutationAdmissionError(), "a quiescing daemon must refuse mutations")
+	require.True(t, IsDaemonQuiescingErr(lifecycle.mutationAdmissionError()))
+}
+
+// If the actor never proves supervisor_ready, the trigger surfaces a loud error and
+// the daemon KEEPS SERVING: it must not authorize, quiesce, or exit on an
+// unobservable readiness.
+func TestTriggerUpgradeActivation_NotReadyKeepsServing(t *testing.T) {
+	_, _, candidate := stubTriggerEnv(t)
+	lifecycle := readyLifecycle(t)
+
+	upgradeAwaitSupervisorReadyFn = func(context.Context, string, time.Time) error {
+		return context.DeadlineExceeded
+	}
+	authorized := false
+	upgradeAuthorizeActivationFn = func(*upgradetxn.Transaction, string, string) error {
+		authorized = true
+		return nil
+	}
+	exited := false
+	requestExit := func() { exited = true }
+
+	err := triggerUpgradeActivation(context.Background(), lifecycle, requestExit, candidate, "1.0.200")
+	require.Error(t, err)
+	require.False(t, authorized, "must not authorize activation when the actor is not ready")
+	require.False(t, exited, "must not exit when the actor is not ready")
+	require.Equal(t, DaemonPhaseReady, lifecycle.snapshot().phase, "the daemon must keep serving")
+	require.NoError(t, lifecycle.mutationAdmissionError(), "a still-serving daemon must keep admitting work")
+}
+
+// The Plan captured from the live daemon produces a REAL journal (via the real
+// Prepare) that the production forward ops drive to a commit AND the production
+// rollback ops drive to a restore — R2a's op-level drive, now on the trigger's own
+// captured journal, home-bound and honoring the candidate-requires-id invariant
+// including the from==to rebuild shape.
+func TestUpgradeTrigger_CapturedJournalDrivesForwardCommitAndRollback(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		toVersion string
+	}{
+		{"forward upgrade", "1.0.200"},
+		{"from==to rebuild", "1.0.100"}, // same version; the candidate is told apart by its id
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, candidate := stubTriggerEnv(t)
+			lifecycle := readyLifecycle(t)
+			ctx := context.Background()
+
+			plan, err := captureUpgradePlan(lifecycle, candidate, tc.toVersion)
+			require.NoError(t, err)
+			require.Equal(t, upgradetxn.SupervisionAdHoc, plan.Daemon.Owner.Kind)
+			require.Equal(t, upgradetxn.RecoveryJobDetached, plan.RecoveryJob.Kind)
+			require.True(t, plan.Daemon.WasRunning)
+			require.NotEmpty(t, plan.Daemon.BootID)
+
+			// --- Forward commit on the captured journal ---
+			txn, err := upgradetxn.Prepare(plan)
+			require.NoError(t, err)
+			journal := txn.Journal()
+
+			state := &fakeDaemon{up: true, version: "1.0.100", httpBound: true}
+			upgradeRecoveryHealthFn = func() HealthStatus { return state.health() }
+			wireStopToState(state)
+			upgradeAwaitSupervisorReadyFn = func(context.Context, string, time.Time) error { return nil }
+			launchCandidateDaemonFn = func(_, id string) error {
+				*state = fakeDaemon{up: true, version: tc.toVersion, txnID: id, httpBound: true}
+				return nil
+			}
+			released := false
+			releaseCandidateProbationFn = func(string) error { released = true; return nil }
+
+			outcome, err := stopPreviousDaemon(ctx, journal)
+			require.NoError(t, err)
+			require.Equal(t, upgradetxn.StopConfirmed, outcome)
+			require.NoError(t, startCandidateDaemon(ctx, journal))
+			require.Equal(t, journal.ID, state.txnID, "the candidate launches WITH the transaction id")
+			require.NoError(t, validateCandidateDaemon(ctx, journal),
+				"the candidate is told apart by its id even when from==to")
+			require.NoError(t, approveCandidateDaemon(ctx, journal))
+			require.True(t, released)
+
+			// A surviving previous daemon (empty id) must NOT pass candidate validation,
+			// the from==to catastrophe the id requirement prevents.
+			*state = fakeDaemon{up: true, version: tc.toVersion, httpBound: true}
+			require.Error(t, validateCandidateDaemon(ctx, journal),
+				"an empty-id responder is the previous daemon, never the candidate")
+		})
+	}
+}
+
+// The rollback ops restore the previous daemon on the trigger's captured journal.
+func TestUpgradeTrigger_CapturedJournalRollsBack(t *testing.T) {
+	_, _, candidate := stubTriggerEnv(t)
+	lifecycle := readyLifecycle(t)
+	ctx := context.Background()
+
+	plan, err := captureUpgradePlan(lifecycle, candidate, "1.0.200")
+	require.NoError(t, err)
+	txn, err := upgradetxn.Prepare(plan)
+	require.NoError(t, err)
+	journal := txn.Journal()
+
+	state := &fakeDaemon{up: true, version: "1.0.100", httpBound: true}
+	upgradeRecoveryHealthFn = func() HealthStatus { return state.health() }
+	wireStopToState(state)
+	launchCandidateDaemonFn = func(_, id string) error {
+		*state = fakeDaemon{up: true, version: "9.9.9-broken", txnID: id, httpBound: true}
+		return nil
+	}
+	startPreviousAdHocFn = func(string) error {
+		*state = fakeDaemon{up: true, version: "1.0.100", httpBound: true} // previous restored, no id
+		return nil
+	}
+
+	require.NoError(t, startCandidateDaemon(ctx, journal))
+	require.Error(t, validateCandidateDaemon(ctx, journal), "a broken candidate must fail validation")
+
+	outcome, err := stopCandidateDaemon(ctx, journal)
+	require.NoError(t, err)
+	require.Equal(t, upgradetxn.StopConfirmed, outcome)
+	require.NoError(t, startPreviousDaemon(ctx, journal))
+	require.NoError(t, validatePreviousDaemon(ctx, journal), "the previous daemon must be restored")
+	require.Empty(t, state.txnID, "the restored previous daemon carries no transaction id")
+}

--- a/internal/upgradetxn/abort.go
+++ b/internal/upgradetxn/abort.go
@@ -1,0 +1,61 @@
+package upgradetxn
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+)
+
+// AbortPreparedTransaction lets the INITIATING daemon (never a recovery actor) undo
+// a transaction it published with Prepare but could not hand to an actor — e.g. when
+// InstallAndStart or the supervisor_ready wait failed. Without it, a single transient
+// service-manager failure strands active.json at PhasePrepared forever: every future
+// Prepare fails "already active", and no actor exists to Abort it (a lease is granted
+// only to the preserved previous binary, which the serving daemon is not).
+//
+// It is deliberately narrow so it can never race a live recovery: it serializes
+// against Prepare on prepare.lock, acts ONLY while the journal is still PhasePrepared
+// (any later phase means an actor took authority and owns teardown), and ONLY while no
+// recovery actor holds the lock. Then it removes the authority marker and the inert
+// artifacts (candidate, recovery unit, transaction directory, lock) through the exact
+// path cleanup uses. Idempotent: a missing or now-different active transaction is a
+// no-op success for this id.
+func AbortPreparedTransaction(homeDir, transactionID string) error {
+	prep, err := acquireFileLock(filepath.Join(upgradeRoot(homeDir), "prepare.lock"), false)
+	if err != nil {
+		return fmt.Errorf("lock upgrade preparation to abort: %w", err)
+	}
+	defer func() { _ = releaseFileLock(prep) }()
+
+	txn, err := Load(homeDir)
+	if errors.Is(err, ErrNoActiveTransaction) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	journal := txn.Journal()
+	if journal.ID != transactionID {
+		return nil // a different or newer transaction is active — not ours to abort
+	}
+	if journal.Phase != PhasePrepared {
+		return fmt.Errorf(
+			"cannot abort upgrade transaction %s from the initiating daemon in phase %s; a recovery actor owns it",
+			journal.ID, journal.Phase)
+	}
+	// A held recovery lock means an actor took authority and will drive the
+	// transaction; the initiating daemon must not remove it underneath.
+	lock, err := acquireRecoveryLock(recoveryLockPath(homeDir, journal.ID), journal.RecoveryLockIdentity, true)
+	if errors.Is(err, ErrRecoveryActive) {
+		return fmt.Errorf("a recovery actor holds upgrade transaction %s; not aborting from the initiating daemon", journal.ID)
+	}
+	if err != nil {
+		return fmt.Errorf("verify no recovery actor before aborting transaction %s: %w", journal.ID, err)
+	}
+	defer func() { _ = releaseFileLock(lock) }()
+
+	if err := removeRequiredDurableFile(activeJournalPath(homeDir)); err != nil {
+		return fmt.Errorf("remove active upgrade journal on abort: %w", err)
+	}
+	return txn.cleanupInactiveArtifacts()
+}

--- a/internal/upgradetxn/abort_prepared_test.go
+++ b/internal/upgradetxn/abort_prepared_test.go
@@ -1,0 +1,69 @@
+package upgradetxn
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// AbortPreparedTransaction lets the initiating daemon undo a published-but-unstarted
+// transaction so one transient InstallAndStart failure does not wedge every future
+// upgrade at "already active" (#2212 R2b). It must remove a PhasePrepared journal
+// with no live actor, and refuse the moment an actor has taken authority.
+func TestAbortPreparedTransaction(t *testing.T) {
+	txn, home, executable := prepareFixture(t)
+	id := txn.Journal().ID
+
+	require.NoError(t, AbortPreparedTransaction(home, id))
+	_, err := Load(home)
+	require.ErrorIs(t, err, ErrNoActiveTransaction, "abort must remove the active journal")
+
+	// The wedge is cleared: a fresh upgrade can be prepared again.
+	_, err = Prepare(Plan{
+		ID: "txn-after-abort", HomeDir: home, ExecutablePath: executable,
+		FromVersion: "1.0.100", ToVersion: "1.0.200", Candidate: []byte("candidate-after-abort"),
+		RecoveryJob: RecoveryJob{Kind: RecoveryJobDetached},
+	})
+	require.NoError(t, err, "a fresh upgrade must be preparable after aborting the wedged one")
+
+	// Idempotent for the original id: it is no longer the active transaction.
+	require.NoError(t, AbortPreparedTransaction(home, id))
+}
+
+func TestAbortPreparedTransaction_RefusesWhenActorLive(t *testing.T) {
+	txn, home, _ := prepareFixture(t)
+	id := txn.Journal().ID
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	defer func() { _ = lease.Release() }()
+
+	require.Error(t, AbortPreparedTransaction(home, id),
+		"a live recovery actor holds the lock; abort must refuse rather than remove under it")
+	loaded, err := Load(home)
+	require.NoError(t, err)
+	require.Equal(t, id, loaded.Journal().ID, "the journal must survive a refused abort")
+}
+
+func TestAbortPreparedTransaction_RefusesPastPrepared(t *testing.T) {
+	txn, home, _ := prepareFixture(t)
+	id := txn.Journal().ID
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, lease.Release()) // lock free, but the phase advanced past prepared
+
+	require.Error(t, AbortPreparedTransaction(home, id),
+		"once an actor advanced the phase it owns teardown; the initiating daemon must not abort")
+	loaded, err := Load(home)
+	require.NoError(t, err)
+	require.Equal(t, PhaseSupervisorReady, loaded.Journal().Phase)
+}
+
+func TestAbortPreparedTransaction_DifferentIdIsNoOp(t *testing.T) {
+	txn, home, _ := prepareFixture(t)
+	require.NoError(t, AbortPreparedTransaction(home, "some-other-transaction"),
+		"aborting an id that is not the active transaction is a no-op success")
+	loaded, err := Load(home)
+	require.NoError(t, err)
+	require.Equal(t, txn.Journal().ID, loaded.Journal().ID, "the real active transaction must survive")
+}

--- a/internal/upgradetxn/abort_prepared_test.go
+++ b/internal/upgradetxn/abort_prepared_test.go
@@ -1,10 +1,65 @@
 package upgradetxn
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+// validateDirectoryNoSymlink must accept a real directory reached through a
+// symlinked ANCESTOR (a symlinked home, macOS /var -> /private/var) — rejecting that
+// wedged the whole upgrade engine, all 14 durable-fs call sites, on those boxes —
+// while still rejecting a symlinked LEAF, which is the swap defense (#2110 class).
+func TestValidateDirectoryNoSymlink(t *testing.T) {
+	base := t.TempDir()
+	real := filepath.Join(base, "real")
+	require.NoError(t, os.MkdirAll(real, 0o755))
+
+	linkAncestor := filepath.Join(base, "link")
+	require.NoError(t, os.Symlink(base, linkAncestor)) // link -> base
+	require.NoError(t, validateDirectoryNoSymlink(filepath.Join(linkAncestor, "real")),
+		"a real directory reached through a symlinked ancestor must be accepted")
+
+	leaf := filepath.Join(base, "leaflink")
+	require.NoError(t, os.Symlink(real, leaf))
+	require.Error(t, validateDirectoryNoSymlink(leaf),
+		"a directory that is itself a symlink must be rejected (the swap defense)")
+
+	require.ErrorIs(t, validateDirectoryNoSymlink(filepath.Join(base, "absent")), os.ErrNotExist,
+		"a missing directory must surface ErrNotExist for the create/skip callers")
+
+	file := filepath.Join(base, "afile")
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0o644))
+	require.Error(t, validateDirectoryNoSymlink(file), "a non-directory must be rejected")
+}
+
+// The abort must succeed when the AF home is reached through a symlink — the exact
+// darwin failure, reproduced on linux with an explicit symlink. Before the shared
+// validator fix, removeRequiredDurableFile refused the symlinked directory path and
+// the un-wedge primitive was itself wedged.
+func TestAbortPreparedTransaction_SymlinkedHome(t *testing.T) {
+	base := t.TempDir()
+	realHome := filepath.Join(base, "real")
+	require.NoError(t, os.MkdirAll(realHome, 0o755))
+	linkHome := filepath.Join(base, "link")
+	require.NoError(t, os.Symlink(realHome, linkHome)) // like /var -> /private/var
+
+	exe := filepath.Join(base, "af")
+	require.NoError(t, os.WriteFile(exe, []byte("previous-af-binary"), 0o755))
+
+	txn, err := Prepare(Plan{
+		ID: "upgrade-symlink", HomeDir: linkHome, ExecutablePath: exe,
+		FromVersion: "1.0.100", ToVersion: "1.0.200", Candidate: []byte("candidate-symlink"),
+		RecoveryJob: RecoveryJob{Kind: RecoveryJobDetached},
+	})
+	require.NoError(t, err)
+	require.NoError(t, AbortPreparedTransaction(linkHome, txn.Journal().ID),
+		"abort must succeed when the home is reached through a symlink")
+	_, loadErr := Load(linkHome)
+	require.ErrorIs(t, loadErr, ErrNoActiveTransaction)
+}
 
 // AbortPreparedTransaction lets the initiating daemon undo a published-but-unstarted
 // transaction so one transient InstallAndStart failure does not wedge every future

--- a/internal/upgradetxn/activation.go
+++ b/internal/upgradetxn/activation.go
@@ -2,6 +2,7 @@ package upgradetxn
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -11,6 +12,43 @@ import (
 	"path/filepath"
 	"time"
 )
+
+// awaitSupervisorReadyPoll is the cadence AwaitSupervisorReady re-checks the
+// recovery actor's readiness proof. Package var so tests can shorten the path.
+var awaitSupervisorReadyPoll = 100 * time.Millisecond
+
+// AwaitSupervisorReady blocks until the previous-binary recovery actor has
+// POSITIVELY proven it reached supervisor_ready, or the bounded deadline elapses.
+// It runs the same validation AuthorizeActivation runs — the recovery lock is held
+// (the actor is alive), its readiness lock is published, its status reports
+// PhaseSupervisorReady, and that proof's deadline is still in the future — but
+// publishes nothing. It is the observation the old-daemon trigger makes BEFORE the
+// single AuthorizeActivation, so "the trigger fired" means the actor took the lease
+// and reached supervisor_ready, never that InstallAndStart returned. A missing,
+// stale, or dead-actor proof keeps polling; the deadline turns an unobservable
+// readiness into a loud error, never an assumed success.
+func AwaitSupervisorReady(ctx context.Context, homeDir string, deadline time.Time) error {
+	var lastErr error
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if txn, err := Load(homeDir); err != nil {
+			lastErr = err
+		} else if _, err := validateActivationRecoveryProof(txn.Journal(), time.Now().UTC()); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		if !time.Now().Before(deadline) {
+			if lastErr == nil {
+				lastErr = errors.New("supervisor_ready deadline elapsed before the recovery actor could be probed")
+			}
+			return fmt.Errorf("upgrade recovery actor did not reach supervisor_ready by the deadline: %w", lastErr)
+		}
+		time.Sleep(awaitSupervisorReadyPoll)
+	}
+}
 
 type activationApproval struct {
 	SchemaVersion int    `json:"schema_version"`

--- a/internal/upgradetxn/activation.go
+++ b/internal/upgradetxn/activation.go
@@ -19,14 +19,18 @@ var awaitSupervisorReadyPoll = 100 * time.Millisecond
 
 // AwaitSupervisorReady blocks until the previous-binary recovery actor has
 // POSITIVELY proven it reached supervisor_ready, or the bounded deadline elapses.
-// It runs the same validation AuthorizeActivation runs — the recovery lock is held
-// (the actor is alive), its readiness lock is published, its status reports
-// PhaseSupervisorReady, and that proof's deadline is still in the future — but
-// publishes nothing. It is the observation the old-daemon trigger makes BEFORE the
-// single AuthorizeActivation, so "the trigger fired" means the actor took the lease
-// and reached supervisor_ready, never that InstallAndStart returned. A missing,
-// stale, or dead-actor proof keeps polling; the deadline turns an unobservable
-// readiness into a loud error, never an assumed success.
+// It runs validateActivationRecoveryProof — the recovery lock is held (the actor is
+// alive), its readiness lock is published, its status reports PhaseSupervisorReady,
+// and that proof's deadline is still in the future — but publishes nothing. That is
+// the actor-liveness-and-readiness half of what AuthorizeActivation checks;
+// AuthorizeActivation additionally requires the active JOURNAL phase to be
+// PhaseSupervisorReady and the transaction id/nonce to match before it publishes,
+// and it re-runs this same proof — so the authorizing caller still gets the full
+// check. This is the observation the old-daemon trigger makes BEFORE the single
+// AuthorizeActivation, so "the trigger fired" means the actor took the lease and
+// reached supervisor_ready, never that InstallAndStart returned. A missing, stale,
+// or dead-actor proof keeps polling; the deadline turns an unobservable readiness
+// into a loud error, never an assumed success.
 func AwaitSupervisorReady(ctx context.Context, homeDir string, deadline time.Time) error {
 	var lastErr error
 	for {

--- a/internal/upgradetxn/await_ready_test.go
+++ b/internal/upgradetxn/await_ready_test.go
@@ -1,0 +1,61 @@
+package upgradetxn
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// AwaitSupervisorReady is the old-daemon trigger's POSITIVE observation that the
+// recovery actor took the lease AND reached supervisor_ready (#2212 R2b). It must
+// return nil ONLY on that proof — the recovery lock held (actor alive), the
+// readiness lock published, the status at supervisor_ready, and a live deadline —
+// and a loud error otherwise, never a silent pass on an unobservable readiness.
+func TestAwaitSupervisorReady(t *testing.T) {
+	txn, home, _ := prepareFixture(t)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	released := false
+	defer func() {
+		if !released {
+			_ = lease.Release()
+		}
+	}()
+
+	ctx := context.Background()
+	restore := awaitSupervisorReadyPoll
+	awaitSupervisorReadyPoll = time.Millisecond
+	defer func() { awaitSupervisorReadyPoll = restore }()
+
+	// The actor holds the lease but is still at PhasePrepared: not ready. The
+	// deadline turns the missing proof into a loud error, never an assumed success.
+	require.Error(t, AwaitSupervisorReady(ctx, home, time.Now().Add(30*time.Millisecond)),
+		"a lease that has not reached supervisor_ready must not be read as ready")
+
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, lease.Heartbeat(PhaseSupervisorReady, time.Now().Add(time.Minute)))
+	// The full positive proof now exists.
+	require.NoError(t, AwaitSupervisorReady(ctx, home, time.Now().Add(2*time.Second)))
+
+	// An expired readiness heartbeat is stale, not proof: the actor may be wedged.
+	require.NoError(t, lease.Heartbeat(PhaseSupervisorReady, time.Now().Add(-time.Second)))
+	require.Error(t, AwaitSupervisorReady(ctx, home, time.Now().Add(30*time.Millisecond)),
+		"a supervisor_ready proof past its deadline must not authorize activation")
+
+	// A dead actor (lease released) leaves the recovery lock free — not ready, even
+	// though the last-published status still says supervisor_ready.
+	require.NoError(t, lease.Release())
+	released = true
+	require.Error(t, AwaitSupervisorReady(ctx, home, time.Now().Add(30*time.Millisecond)),
+		"a released lease means no live actor; readiness must not be assumed from a stale status")
+}
+
+// A cancelled context ends the wait promptly instead of blocking to the deadline.
+func TestAwaitSupervisorReady_ContextCancel(t *testing.T) {
+	_, home, _ := prepareFixture(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, AwaitSupervisorReady(ctx, home, time.Now().Add(time.Hour)), context.Canceled)
+}

--- a/internal/upgradetxn/await_ready_test.go
+++ b/internal/upgradetxn/await_ready_test.go
@@ -29,10 +29,17 @@ func TestAwaitSupervisorReady(t *testing.T) {
 	awaitSupervisorReadyPoll = time.Millisecond
 	defer func() { awaitSupervisorReadyPoll = restore }()
 
-	// The actor holds the lease but is still at PhasePrepared: not ready. The
-	// deadline turns the missing proof into a loud error, never an assumed success.
+	// The actor holds the lease but has published NO status yet (tryAcquireRecoveryAs
+	// invalidated the predecessor's): the missing proof is a loud error.
 	require.Error(t, AwaitSupervisorReady(ctx, home, time.Now().Add(30*time.Millisecond)),
-		"a lease that has not reached supervisor_ready must not be read as ready")
+		"a lease with no published status must not be read as ready")
+
+	// A status that EXISTS but reports a phase short of supervisor_ready must ALSO be
+	// rejected — this exercises the phase check, distinct from the missing-status path
+	// above (Heartbeat writes whatever phase it is given, so no Advance is needed).
+	require.NoError(t, lease.Heartbeat(PhasePrepared, time.Now().Add(time.Minute)))
+	require.Error(t, AwaitSupervisorReady(ctx, home, time.Now().Add(30*time.Millisecond)),
+		"a published status short of supervisor_ready must be rejected on the phase check")
 
 	require.NoError(t, lease.Advance(PhaseSupervisorReady))
 	require.NoError(t, lease.Heartbeat(PhaseSupervisorReady, time.Now().Add(time.Minute)))

--- a/internal/upgradetxn/storage.go
+++ b/internal/upgradetxn/storage.go
@@ -505,14 +505,25 @@ func terminalPhase(phase Phase) bool {
 	return phase == PhaseCommitted || phase == PhaseRolledBack || phase == PhaseAborted
 }
 
+// validateDirectoryNoSymlink verifies that the directory an upgrade op is about to
+// write to, create, or remove under is a REAL directory whose final component is not
+// a symlink — the check that stops a swapped leaf from redirecting the operation
+// outside the home. It deliberately does NOT reject symlinks in the ANCESTORS.
+//
+// Every path passed here is package-constructed under the AF home (upgradeRoot,
+// transactionDir, activeJournalPath, …), so "the target is within the home" holds by
+// construction; the runtime risk is a directory being swapped for a symlink, which
+// the os.Lstat leaf check below catches on the validated directory itself. The old
+// "reject any symlink anywhere in the path" form (EvalSymlinks(path) != path) added
+// nothing over that for a constructed path but failed closed whenever the home was
+// reached through a symlink — every macOS TMPDIR (/var -> /private/var), a symlinked
+// $HOME or AGENT_FACTORY_HOME, an NFS/dotfiles home — which made the ENTIRE upgrade
+// engine (all 14 call sites), including the rollback that rescues a failed upgrade,
+// refuse on those boxes. os.Lstat resolves ancestor symlinks to reach the target and
+// then reports the target's own type, so a symlinked ancestor is fine while a
+// symlinked leaf is still rejected. ErrNotExist propagates unchanged for the callers
+// that treat a missing directory as a create/skip signal.
 func validateDirectoryNoSymlink(path string) error {
-	resolved, err := filepath.EvalSymlinks(path)
-	if err != nil {
-		return err
-	}
-	if filepath.Clean(resolved) != filepath.Clean(path) {
-		return errors.New("directory path contains a symlink")
-	}
 	info, err := os.Lstat(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

**#2212 R2b** — the **old-daemon side of a daemon self-upgrade**, run inside the serving daemon. R2a made the forward-activation ops live; R2b adds the trigger that *drives* them. It stages a candidate the daemon has decided to install, hands supervision to the immutable previous binary, and quiesces + exits so the candidate can bind the socket:

```
captureUpgradePlan (live snapshot) → upgradetxn.Prepare
  → RecoveryJobController.InstallAndStart
  → AwaitSupervisorReady (positive observation)
  → AuthorizeActivation → markQuiescing → exit
```

It is **an internal daemon entrypoint that R3's update loop will call**; R2b wires it to nothing. **This is the slice that makes transactions real** — nothing in the tree creates one today — so it is built so the irreversible path can never promote weak evidence to proof (the one habit behind every R2a P1).

Plan approved on the issue (Choice A as recommended, Choice B overridden to the distinct phase): https://github.com/sachiniyer/agent-factory/issues/2212#issuecomment-5076540201

### Choice A — `AwaitSupervisorReady`, a positive-observation poll
A new `upgradetxn.AwaitSupervisorReady` returns nil **only** on the full proof — the recovery lock held (actor alive), the readiness lock published, the status at `supervisor_ready`, and a live deadline — the same validation `AuthorizeActivation` runs, but publishing nothing. "The trigger fired" therefore means the actor **took the lease and reached supervisor_ready**, never that `InstallAndStart` returned; an actor that never gets there is a **loud error that leaves the daemon serving**, never an assumed success.

### Choice B (your override) — the distinct `DaemonPhaseQuiescing`
Quiesce is its own reported phase, not a hidden admission flag. A daemon refusing mutations and about to exit must not keep reporting `DaemonPhaseReady`; like `DaemonPhaseHandoffPending` (R2a), the dishonest state is made **unrepresentable**, so a stuck hand-off is **visible** on Ping / `af daemon status` / `af doctor`. `markQuiescing` closes admission (a retryable, typed `errDaemonQuiescing`) and reports the honest phase; the trigger quiesces only **after** authorizing, then exits.

### Carry-forward invariants — held on a REAL journal
The captured Plan binds `HomeDir = config.GetConfigDir()` and derives the owner + recovery job (via the canonical `NewRecoveryJob`) from the live daemon, so both invariants hold under a real transaction, not just unit mocks:
1. Every recovery op stays home-bound (`recoveryHomeGuard` → `StopUnknown`).
2. `ValidateCandidate` **requires** the transaction id; the restored previous daemon **rejects** it — proven including the `from==to` rebuild shape.

## Test plan (extends R2a's harness)
- `TestAwaitSupervisorReady` drives the **real** lease / journal / readiness proof: ready → nil; not-ready, expired heartbeat, and released-lease (dead actor) → loud error; cancelled context returns promptly.
- The trigger authorizes only after a positive ready observation, then quiesces (honest phase + closed admission) and exits, **in that order**; an unready actor is a loud error that keeps the daemon serving (no authorize / quiesce / exit).
- The captured journal drives the production **forward ops to a commit AND the rollback ops to a restore**, home-bound and honoring the id invariant, `from==to` included.
- A failed `InstallAndStart` **aborts the prepared transaction** (real abort) so the upgrade path is never wedged; all three owner kinds are covered for owner/recovery-job derivation.

## Review round 2 — fixed at head `d087b5ae`
**This PR fixes a pre-existing, package-wide defect** found by the darwin gate: **the #2212 upgrade engine failed closed whenever the AF home is reached through a symlink** — every macOS TMPDIR (`/var` → `/private/var`), a symlinked `$HOME`/`AGENT_FACTORY_HOME`, an NFS/dotfiles home — refusing **every** forward and rollback op, including the rollback that rescues a failed upgrade. Same #2110 path-identity class as the round-1 `recoveryHomeGuard` P1, one layer down: `validateDirectoryNoSymlink` (internal/upgradetxn/storage.go) compared `EvalSymlinks(path)` to `path` with plain `!=`, rejecting a symlink *anywhere* in the path, and it is called from **13 sites** across the package — so the new `AbortPreparedTransaction` (the primitive that un-wedges a prepared transaction) was itself wedged on exactly the boxes that need it.

Fixed in the **shared validator so all 13 callers inherit it** (not the call sites, not the tests): keep the `os.Lstat` **leaf** check — the validated directory's final component must be a real dir, not a swapped symlink, which is what defeats a redirected delete/write — and drop the reject-any-ancestor-symlink check. Every path passed here is package-constructed under the AF home, so "within the home" holds by construction; `os.Lstat` resolves ancestor symlinks to reach the leaf and reports the leaf's own type, so a symlinked ancestor is allowed while a symlinked leaf is still rejected. I read all 13 sites: each validates a constructed transaction-tree directory (or the unit dir), and none depended on the stricter behavior. Tests: the validator accepts a real dir through a symlinked ancestor and rejects a symlinked leaf; the abort succeeds when the home is reached through a symlink (the darwin failure reproduced on linux). The recovery-job path expectation is canonicalized to match production's resolved output (`NewRecoveryJob` resolves the unit dir — correct for a unit file).

The P2-b comment now states the real invariant: `MetadataPaths` is empty because R2b **starts no candidate**, not because probation prevents metadata divergence (probation blocks RPCs, but `config.LoadAndMigrateSchemaFile` rewrites `instances.json`/`tasks.json` at daemon load — migrate-on-load is not an RPC). The R3 prerequisite is recorded on #2212.

## Review round 1 — fixed at head `37dd001a`
The review confirmed the darwin CI failure was a **product bug**, not a test artifact — correcting my earlier claim (the required `Build` gate was RED on `b27c8fee` because `Test (macOS)` failed; the interim test-side fix is reverted). All findings addressed:
- **P1 — `recoveryHomeGuard` compared home spellings, not identity.** `config.GetConfigDir()` never resolves symlinks; `Prepare` stores the resolved `journal.HomeDir`; any symlinked home (every macOS TMPDIR, a symlinked `$HOME`/`AGENT_FACTORY_HOME`) made every forward **and rollback** op refuse — a permanent fail-closed. Fixed with `pathutil.ResolveForCompare` (#2110) on both sides.
- **P2-a — orphaned prepared transaction.** A failed `InstallAndStart` left `active.json` at `prepared` with no actor to `Abort` it, wedging every future upgrade at "already active". Added lease-free `upgradetxn.AbortPreparedTransaction` (serialized on `prepare.lock`, `PhasePrepared` only, refuses while an actor holds the lock) and call it from the trigger's pre-activation failure paths.
- **P2-b — empty `MetadataPaths`.** Documented as a *deferral*: rollback runs only pre-commit, during which the candidate is in probation (mutations blocked) with a read-only restore, so binary-only restore is complete for that window; the full manifest lands with the R3 release wiring.
- **P3-a** — corrected the `AwaitSupervisorReady` doc (it runs the readiness proof, not the full `AuthorizeActivation` validation) and added coverage for the wrong-phase branch (the old assertion passed on a missing file).
- **P3-b** — added table tests over all three owner kinds for `upgradeDaemonOwner` and `upgradeRecoveryJobFor` (systemd/launchd were uncovered).

**One acceptance note.** A fully-real *in-process* end-to-end (the actor acquiring a real lease and publishing `supervisor_ready` itself) is not reachable from the daemon package: `TryAcquireRecovery` requires the actor to run as the exact preserved previous binary (`os.Executable() == journal.PreviousBinaryPath`), a real spawned process — **R4's destructive integration** (fake release server + two stamped binaries + fake service manager). So the daemon harness seams *only* the lease-handshake pair and keeps everything else real (live Plan capture, real `Prepare`/journal, real forward/rollback ops, the real abort, quiescing); `AwaitSupervisorReady`'s real behavior is proven directly in `internal/upgradetxn`.

Gates (all on `d087b5ae`):
- [x] `gofmt -l .` · `go build ./...` · `go vet ./daemon/... ./internal/upgradetxn/...`
- [x] `golangci-lint run --timeout=3m --fast` (full repo) · `deadcode -test ./...` · `scripts/lint-file-length.sh` (split `AbortPreparedTransaction` into `abort.go` to stay under the limit)
- [x] `make test-container GOTESTARGS="./daemon/... ./internal/upgradetxn/..."` — green (daemon 195s)
- [x] full daemon + upgradetxn container suites green after the package-wide validator change (no existing test relied on the strict behavior)
- [ ] `make test-container` (full suite) — running on `d087b5ae`; **CI is the macOS gate of record** for the validator fix

No update loop, no release check, no throttle change — that is R3 (#459/#1466/#1861 untouched).

Part of #2212.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
