### PR TITLE
feat(web): config-assistant chat pane (#2467, PR2)

### DIFF
--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -2119,6 +2119,54 @@ body {
   font-size: var(--af-fs-xs);
   padding: 0.2rem 0.5rem;
 }
+.af-config-assistant-btn {
+  margin-left: auto;
+  font-size: var(--af-fs-xs);
+  padding: 0.2rem 0.6rem;
+  white-space: nowrap;
+}
+.af-assistant-card {
+  max-width: 60rem;
+  width: min(92vw, 60rem);
+  height: 80vh;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+.af-assistant-head {
+  display: flex;
+  align-items: center;
+  gap: var(--af-sp-3);
+  padding: var(--af-sp-3) var(--af-sp-4);
+  border-bottom: 1px solid var(--af-border);
+  background: var(--af-bg-surface);
+}
+.af-assistant-head .af-modal-title {
+  margin: 0;
+  flex: 0 0 auto;
+}
+.af-assistant-status {
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
+}
+.af-assistant-close {
+  margin-left: auto;
+  font-size: var(--af-fs-lg);
+  line-height: 1;
+  padding: 0 var(--af-sp-2);
+}
+.af-assistant-term {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+  padding: var(--af-sp-2);
+}
+.af-assistant-error {
+  margin: 0;
+  padding: var(--af-sp-2) var(--af-sp-4) var(--af-sp-3);
+}
 .af-config-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 22rem);

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6407,6 +6407,33 @@ async function getConfig(token2) {
 async function setConfigValue(key, value, token2) {
   return af("SetConfigValue", { key, value }, token2);
 }
+function spawnConfigAssistant(token2) {
+  return af("config-assistant", {}, token2);
+}
+async function reapConfigAssistant(token2) {
+  const headers = {};
+  if (token2 !== "") {
+    headers.Authorization = `Bearer ${token2}`;
+  }
+  let resp;
+  try {
+    resp = await fetch("/v1/config-assistant", { method: "DELETE", headers });
+  } catch (e) {
+    throw new ApiError(0, `cannot reach the daemon: ${errorText(e)}`);
+  }
+  if (!resp.ok) {
+    let env = null;
+    try {
+      env = await resp.json();
+    } catch {
+    }
+    throw new ApiError(
+      resp.status,
+      envelopeErrorText(env?.error, `${resp.status} ${resp.statusText}`.trim()),
+      envelopeErrorCode(env?.error)
+    );
+  }
+}
 
 // src/backends.ts
 var REPO_DEFAULT = "";
@@ -6924,6 +6951,13 @@ var ConfigPane = class {
     if (this.path !== "") {
       head.append(h("span", { class: "af-config-path" }, this.path));
     }
+    const assistantBtn = h(
+      "button",
+      { type: "button", class: "af-ghost af-config-assistant-btn" },
+      "Configure with assistant"
+    );
+    assistantBtn.addEventListener("click", () => this.actions.openAssistant());
+    head.append(assistantBtn);
     const sections = [];
     for (const { tier, name } of tiersInOrder(this.entries)) {
       const inTier = this.entries.filter((e) => e.tier === tier);
@@ -7052,10 +7086,998 @@ var ConfigPane = class {
   }
 };
 
-// src/events.ts
+// src/stream_endpoint.ts
+function wsScheme() {
+  return window.location.protocol === "https:" ? "wss:" : "ws:";
+}
+function sessionStreamEndpoint(sessionId, tabId, tab) {
+  return {
+    composerNewline: tab === 0,
+    url(token2, since) {
+      const base = `${wsScheme()}//${window.location.host}/v1/sessions/${encodeURIComponent(sessionId)}/stream`;
+      const params = new URLSearchParams();
+      params.set("access_token", token2);
+      if (tabId !== "") {
+        params.set("tab_id", tabId);
+      } else if (tab > 0) {
+        params.set("tab", String(tab));
+      }
+      if (since !== null) {
+        params.set("since", since.toString());
+      }
+      return `${base}?${params.toString()}`;
+    }
+  };
+}
+function configAssistantStreamEndpoint() {
+  return {
+    composerNewline: true,
+    url(token2, since) {
+      const base = `${wsScheme()}//${window.location.host}/v1/config-assistant/stream`;
+      const params = new URLSearchParams();
+      params.set("access_token", token2);
+      if (since !== null) {
+        params.set("since", since.toString());
+      }
+      return `${base}?${params.toString()}`;
+    }
+  };
+}
+
+// src/terminal.ts
+var import_addon_fit = __toESM(require_addon_fit(), 1);
+var import_xterm = __toESM(require_xterm(), 1);
+
+// src/clipboard.ts
+var ETX = "";
+var LF = "\n";
+function handleClipboardKeydown(ev, deps) {
+  if (ev.type !== "keydown") {
+    return true;
+  }
+  if (deps.composerNewline && ev.key === "Enter" && ev.shiftKey && !ev.ctrlKey && !ev.metaKey && !ev.altKey) {
+    ev.preventDefault();
+    deps.sendUserInput(LF);
+    return false;
+  }
+  if (ev.metaKey || ev.altKey || !ev.ctrlKey) {
+    return true;
+  }
+  const key = ev.key.toLowerCase();
+  if (key === "v") {
+    return false;
+  }
+  if (key === "c") {
+    if (ev.shiftKey) {
+      ev.preventDefault();
+      if (deps.hasSelection()) {
+        deps.copy(deps.getSelection());
+      }
+      return false;
+    }
+    if (deps.hasSelection()) {
+      ev.preventDefault();
+      deps.copy(deps.getSelection());
+      deps.clearSelection();
+      return false;
+    }
+    ev.preventDefault();
+    deps.sendInput(ETX);
+    return false;
+  }
+  return true;
+}
+
+// src/frame.ts
+var RESIZE_PAYLOAD_LEN = 4;
+var HELLO_PAYLOAD_LEN = 8;
+var EMPTY = new Uint8Array(0);
+function makeFrame(f) {
+  return {
+    op: f.op,
+    data: f.data ?? EMPTY,
+    rows: f.rows ?? 0,
+    cols: f.cols ?? 0,
+    seq: f.seq ?? 0n
+  };
+}
+function inputFrame(data) {
+  return makeFrame({ op: 1 /* Input */, data });
+}
+function resizeFrame(rows, cols) {
+  return makeFrame({ op: 2 /* Resize */, rows, cols });
+}
+function encode(f) {
+  switch (f.op) {
+    case 2 /* Resize */: {
+      const out = new Uint8Array(1 + RESIZE_PAYLOAD_LEN);
+      out[0] = 2 /* Resize */;
+      const dv = new DataView(out.buffer);
+      dv.setUint16(1, f.rows, false);
+      dv.setUint16(3, f.cols, false);
+      return out;
+    }
+    case 4 /* Hello */: {
+      const out = new Uint8Array(1 + HELLO_PAYLOAD_LEN);
+      out[0] = 4 /* Hello */;
+      const dv = new DataView(out.buffer);
+      dv.setBigUint64(1, f.seq, false);
+      return out;
+    }
+    default: {
+      const out = new Uint8Array(1 + f.data.length);
+      out[0] = f.op;
+      out.set(f.data, 1);
+      return out;
+    }
+  }
+}
+function decode(raw) {
+  if (raw.length === 0) {
+    throw new Error("agentproto: empty binary frame");
+  }
+  const op = raw[0];
+  const body = raw.subarray(1);
+  switch (op) {
+    case 0 /* PTYOut */:
+    case 1 /* Input */:
+    case 3 /* Repaint */:
+      return makeFrame({ op, data: body.slice() });
+    case 2 /* Resize */: {
+      if (body.length !== RESIZE_PAYLOAD_LEN) {
+        throw new Error(`agentproto: RESIZE frame body is ${body.length} bytes, want ${RESIZE_PAYLOAD_LEN}`);
+      }
+      const dv = new DataView(body.buffer, body.byteOffset, body.byteLength);
+      return makeFrame({ op, rows: dv.getUint16(0, false), cols: dv.getUint16(2, false) });
+    }
+    case 4 /* Hello */: {
+      if (body.length !== HELLO_PAYLOAD_LEN) {
+        throw new Error(`agentproto: HELLO frame body is ${body.length} bytes, want ${HELLO_PAYLOAD_LEN}`);
+      }
+      const dv = new DataView(body.buffer, body.byteOffset, body.byteLength);
+      return makeFrame({ op, seq: dv.getBigUint64(0, false) });
+    }
+    default:
+      throw new Error(`agentproto: unknown opcode 0x${op.toString(16).padStart(2, "0")}`);
+  }
+}
+
+// src/terminal-geometry.ts
+function hasVisibleTerminalGeometry(host, proposed) {
+  return host.width > 0 && host.height > 0 && !!proposed && proposed.rows > 0 && proposed.cols > 0;
+}
+function shouldRefitVisibleTerminal(host, current, proposed) {
+  if (!hasVisibleTerminalGeometry(host, proposed)) {
+    return false;
+  }
+  return proposed.rows !== current.rows || proposed.cols !== current.cols;
+}
+function viewportMarkerOffset(position) {
+  return position.viewportY - (position.baseY + position.cursorY);
+}
+function viewportAnchorLine(anchor, baseY) {
+  if (anchor.atBottom) {
+    return baseY;
+  }
+  return anchor.markerLine !== null && anchor.markerLine >= 0 ? anchor.markerLine : anchor.fallbackLine;
+}
+function shouldRestoreViewport(intent) {
+  return intent.scheduledUserScroll === intent.currentUserScroll;
+}
+function terminalUserScrollPlan(source, hasScheduledVisibleFit) {
+  switch (source) {
+    case "wheel":
+    case "touch":
+    case "scrollbar":
+      return { cancelScheduledVisibleFit: hasScheduledVisibleFit };
+  }
+}
+
+// src/theme.ts
+var THEME_CHOICES = ["auto", "light", "dark"];
+var STORAGE_KEY = "af-theme";
+function isChoice(v) {
+  return v === "auto" || v === "light" || v === "dark";
+}
+function readThemeChoice() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (isChoice(raw)) {
+      return raw;
+    }
+  } catch {
+  }
+  return "auto";
+}
+function persistThemeChoice(choice) {
+  try {
+    localStorage.setItem(STORAGE_KEY, choice);
+  } catch {
+  }
+}
+var THEME_COLOR_LIGHT = "#ffffff";
+var THEME_COLOR_DARK = "#141a22";
+function themeColorMetaContents(choice) {
+  if (choice === "auto") {
+    return { light: THEME_COLOR_LIGHT, dark: THEME_COLOR_DARK };
+  }
+  const forced = choice === "dark" ? THEME_COLOR_DARK : THEME_COLOR_LIGHT;
+  return { light: forced, dark: forced };
+}
+function syncThemeColorMeta(choice) {
+  const { light, dark } = themeColorMetaContents(choice);
+  for (const meta of document.querySelectorAll('meta[name="theme-color"]')) {
+    const isDark = (meta.getAttribute("media") ?? "").includes("dark");
+    meta.setAttribute("content", isDark ? dark : light);
+  }
+}
+function stampTheme(choice) {
+  const root2 = document.documentElement;
+  if (choice === "auto") {
+    root2.removeAttribute("data-theme");
+  } else {
+    root2.setAttribute("data-theme", choice);
+  }
+  syncThemeColorMeta(choice);
+}
+function bootStampTheme() {
+  const choice = readThemeChoice();
+  stampTheme(choice);
+  return choice;
+}
+function prefersDark() {
+  try {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches;
+  } catch {
+    return false;
+  }
+}
+function currentMode() {
+  const attr = document.documentElement.getAttribute("data-theme");
+  if (attr === "light" || attr === "dark") {
+    return attr;
+  }
+  return prefersDark() ? "dark" : "light";
+}
+var DARK_XTERM = {
+  background: "#0c1016",
+  foreground: "#e7ecf3",
+  cursor: "#e7ecf3",
+  cursorAccent: "#0c1016",
+  selectionBackground: "rgba(122, 162, 247, 0.2)",
+  black: "#484f58",
+  red: "#ff7b72",
+  green: "#3fb950",
+  yellow: "#d29922",
+  blue: "#58a6ff",
+  magenta: "#bc8cff",
+  cyan: "#39c5cf",
+  white: "#b1bac4",
+  brightBlack: "#6e7681",
+  brightRed: "#ffa198",
+  brightGreen: "#56d364",
+  brightYellow: "#e3b341",
+  brightBlue: "#79c0ff",
+  brightMagenta: "#d2a8ff",
+  brightCyan: "#56d4dd",
+  brightWhite: "#f0f6fc"
+};
+var LIGHT_XTERM = {
+  background: "#fdfefe",
+  foreground: "#17202e",
+  cursor: "#17202e",
+  cursorAccent: "#fdfefe",
+  selectionBackground: "rgba(47, 95, 216, 0.16)",
+  black: "#24292f",
+  red: "#cf222e",
+  green: "#1a7f37",
+  yellow: "#9a6700",
+  blue: "#0969da",
+  magenta: "#8250df",
+  cyan: "#1b7c83",
+  white: "#6e7781",
+  brightBlack: "#57606a",
+  brightRed: "#a40e26",
+  brightGreen: "#116329",
+  brightYellow: "#7d4e00",
+  brightBlue: "#0550ae",
+  brightMagenta: "#6639ba",
+  brightCyan: "#3192aa",
+  brightWhite: "#8c959f"
+};
+function xtermTheme(mode) {
+  return mode === "dark" ? DARK_XTERM : LIGHT_XTERM;
+}
+function currentXtermTheme() {
+  return xtermTheme(currentMode());
+}
+
+// src/terminal.ts
 var BACKOFF_BASE_MS = 500;
 var BACKOFF_MAX_MS = 1e4;
-function wsScheme() {
+var RESIZE_DEBOUNCE_MS = 120;
+var AttachTerminal = class {
+  constructor(container, token2, endpoint, cb) {
+    this.container = container;
+    this.token = token2;
+    this.endpoint = endpoint;
+    this.cb = cb;
+    this.term = new import_xterm.Terminal({
+      allowProposedApi: true,
+      cursorBlink: true,
+      fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+      fontSize: 13,
+      // Born in the active theme (theme.ts derives the xterm palette from the same
+      // tokens as the CSS chrome); setTheme() re-applies live on a toggle.
+      theme: currentXtermTheme(),
+      // The stream is the source of truth; local echo/scrollback beyond the ring is
+      // fine but the server never sees our convert-eol, so leave it raw.
+      scrollback: 5e3
+    });
+    this.fit = new import_addon_fit.FitAddon();
+    this.term.loadAddon(this.fit);
+    this.term.open(container);
+    const textarea = this.term.textarea;
+    if (textarea) {
+      textarea.addEventListener("focus", () => {
+        if (!this.stopped) {
+          this.cb.onFocusChange(true);
+        }
+      });
+      textarea.addEventListener("blur", () => {
+        if (!this.stopped) {
+          this.cb.onFocusChange(false);
+        }
+      });
+    }
+    this.term.onData((data) => this.sendInput(data));
+    this.term.attachCustomKeyEventHandler(
+      (ev) => handleClipboardKeydown(ev, {
+        composerNewline: this.endpoint.composerNewline,
+        hasSelection: () => this.term.hasSelection(),
+        getSelection: () => this.term.getSelection(),
+        clearSelection: () => this.term.clearSelection(),
+        copy: (text) => this.copyToClipboard(text),
+        sendInput: (text) => this.sendInput(text),
+        // Public Terminal.input(..., true) is xterm's genuine-user-input path:
+        // it scrolls to bottom and clears selection, then fires onData above.
+        sendUserInput: (text) => this.term.input(text, true)
+      })
+    );
+    this.ro = new ResizeObserver(() => this.scheduleFit());
+    this.ro.observe(container);
+    this.io = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.target === container && entry.isIntersecting)) {
+        this.scheduleVisibleFit();
+      }
+    });
+    this.io.observe(container);
+    window.addEventListener("focus", this.onWindowFocus);
+    document.addEventListener("visibilitychange", this.onVisibilityChange);
+    container.addEventListener("pointerenter", this.onPointerEnter);
+    container.addEventListener("wheel", this.onWheel, { capture: true, passive: true });
+    container.addEventListener("touchmove", this.onTouchMove, { capture: true, passive: true });
+    container.addEventListener("pointerdown", this.onPointerDown, true);
+    this.scheduleVisibleFit();
+  }
+  term;
+  fit;
+  enc = new TextEncoder();
+  ro;
+  io;
+  ws = null;
+  stopped = false;
+  everOpened = false;
+  retry = 0;
+  initialConnectStarted = false;
+  reconnectTimer = null;
+  resizeTimer = null;
+  visibleFitFrame = null;
+  viewportRestoreFrame = null;
+  // Incremented only by an actual user scroll input while a peer-owned anchor is
+  // pending. Output and resize reflows can move viewportY too, so position deltas
+  // alone do not prove that a user intended to override the saved reading line.
+  userScrollRevision = 0;
+  // The absolute replay cursor: seeded from OpHello, advanced by OpPTYOut byte
+  // counts (never by OpRepaint). `seeded` gates whether a reconnect can pass a
+  // real ?since; the first connect omits it (live tail + a fresh-screen repaint).
+  cursor = 0n;
+  seeded = false;
+  // The last size we told the server, so we don't re-send an unchanged fit and so
+  // an authoritative echo that matches is a no-op.
+  lastRows = 0;
+  lastCols = 0;
+  // A peer resize can temporarily collapse this client's scrollback (for example,
+  // 60 lines fit in a peer's 111-row grid). Anchor the actual visible buffer line,
+  // not a one-time distance from the bottom: output can keep arriving while this
+  // client is inactive. Null means no peer-owned grid is pending reconciliation.
+  pendingViewport = null;
+  exited = false;
+  // A peer is allowed to resize the one shared PTY and every client obeys that
+  // authoritative echo. When this window becomes active again, its visible host
+  // becomes the local writer: refit once instead of leaving a peer-sized emulator in
+  // an unchanged container until the user physically resizes the window (#2347).
+  onWindowFocus = () => this.scheduleVisibleFit();
+  onVisibilityChange = () => {
+    if (document.visibilityState === "visible") {
+      this.scheduleVisibleFit();
+    }
+  };
+  // Entering a pane is the earliest reliable activation signal for side-by-side
+  // clients: reconcile before the wheel gesture arrives so xterm can consume that
+  // first gesture rather than making the user scroll twice.
+  onPointerEnter = () => this.fitVisibleHost();
+  // A scroll can target an already-focused window after another client resized the
+  // PTY without the pointer ever leaving this pane. Capture repairs that less-common
+  // path; pointer entry above handles the ordinary first gesture. The pending-peer
+  // gate makes every ordinary input a no-op before even measuring layout.
+  onWheel = () => this.handleUserScroll("wheel");
+  onTouchMove = () => this.handleUserScroll("touch");
+  onPointerDown = (event) => {
+    if (event.target === this.container.querySelector(".xterm-viewport")) {
+      this.handleUserScroll("scrollbar");
+    }
+  };
+  handleUserScroll(source) {
+    if (this.pendingViewport === null) {
+      return;
+    }
+    const plan = terminalUserScrollPlan(source, this.visibleFitFrame !== null);
+    if (plan.cancelScheduledVisibleFit) {
+      this.cancelVisibleFitFrame();
+    }
+    this.fitVisibleHost();
+    this.userScrollRevision += 1;
+  }
+  /** Permanently closes the terminal: stops the reconnect loop, drops the socket,
+   *  disconnects the observer, and disposes xterm (freeing its DOM/renderer). */
+  dispose() {
+    this.stopped = true;
+    if (this.reconnectTimer !== null) {
+      window.clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.resizeTimer !== null) {
+      window.clearTimeout(this.resizeTimer);
+      this.resizeTimer = null;
+    }
+    this.cancelVisibleFitFrame();
+    this.clearPendingViewport();
+    this.ro.disconnect();
+    this.io.disconnect();
+    window.removeEventListener("focus", this.onWindowFocus);
+    document.removeEventListener("visibilitychange", this.onVisibilityChange);
+    this.container.removeEventListener("pointerenter", this.onPointerEnter);
+    this.container.removeEventListener("wheel", this.onWheel, true);
+    this.container.removeEventListener("touchmove", this.onTouchMove, true);
+    this.container.removeEventListener("pointerdown", this.onPointerDown, true);
+    this.closeSocket();
+    this.term.dispose();
+  }
+  /** Gives the terminal the keyboard (focuses xterm's helper textarea) so typed
+   *  keys reach the agent — the attach half of the #1693 nav/attach model. */
+  focus() {
+    this.fitVisibleHost();
+    this.term.focus();
+  }
+  /** Reconciles this terminal after an app-shell layout/visibility transition.
+   *  Coalesced onto the next painted frame so CSS has settled; the measurable-host
+   *  gate in fitVisibleHost keeps hidden or zero-sized panes inert. */
+  refit() {
+    this.scheduleVisibleFit();
+  }
+  /** Takes the keyboard away from the terminal (blurs it) so document-level rail
+   *  navigation gets the keys again — the Escape/back-to-nav half of #1693. */
+  blur() {
+    this.term.blur();
+  }
+  /** Re-applies an xterm palette live (a theme toggle): xterm repaints the canvas
+   *  from the new ITheme, so an open terminal switches light/dark without a
+   *  reconnect or losing scrollback. */
+  setTheme(theme) {
+    this.term.options.theme = theme;
+  }
+  // --- socket lifecycle ------------------------------------------------------
+  connect() {
+    if (this.stopped) {
+      return;
+    }
+    this.cb.onStatus(this.everOpened ? "reconnecting" : "connecting");
+    const url = this.endpoint.url(this.token, this.seeded ? this.cursor : null);
+    let ws;
+    try {
+      ws = new WebSocket(url);
+    } catch {
+      this.scheduleReconnect();
+      return;
+    }
+    ws.binaryType = "arraybuffer";
+    this.ws = ws;
+    ws.onopen = () => {
+      this.retry = 0;
+      this.everOpened = true;
+      this.exited = false;
+      this.cb.onStatus("open");
+      this.sendResize(this.term.rows, this.term.cols, true);
+    };
+    ws.onmessage = (e) => this.onMessage(e.data);
+    ws.onclose = () => this.scheduleReconnect();
+    ws.onerror = () => {
+      try {
+        ws.close();
+      } catch {
+      }
+    };
+  }
+  /** Starts the first connection only after a real visible-host fit. Reconnects
+   * continue through connect() directly once this boundary has been crossed. */
+  connectAfterInitialFit() {
+    if (this.initialConnectStarted || this.stopped) {
+      return;
+    }
+    this.initialConnectStarted = true;
+    this.connect();
+  }
+  onMessage(data) {
+    if (typeof data === "string") {
+      this.onControl(data);
+      return;
+    }
+    if (!(data instanceof ArrayBuffer)) {
+      return;
+    }
+    let frame;
+    try {
+      frame = decode(new Uint8Array(data));
+    } catch {
+      return;
+    }
+    switch (frame.op) {
+      case 4 /* Hello */:
+        this.cursor = frame.seq;
+        this.seeded = true;
+        break;
+      case 0 /* PTYOut */:
+        this.term.write(frame.data);
+        this.cursor += BigInt(frame.data.length);
+        break;
+      case 3 /* Repaint */:
+        this.term.write(frame.data);
+        break;
+      default:
+        break;
+    }
+  }
+  onControl(text) {
+    let msg;
+    try {
+      msg = JSON.parse(text);
+    } catch {
+      return;
+    }
+    if (msg.type === "resize" && typeof msg.rows === "number" && typeof msg.cols === "number") {
+      this.applyEchoedSize(msg.rows, msg.cols);
+    } else if (msg.type === "exit") {
+      this.exited = true;
+      const code = typeof msg.code === "number" ? msg.code : 0;
+      this.term.write(`\r
+\x1B[38;5;244m[agent exited (code ${code})]\x1B[0m\r
+`);
+      this.cb.onStatus("exited");
+      this.stopped = true;
+      this.closeSocket();
+    }
+  }
+  scheduleReconnect() {
+    if (this.stopped || this.reconnectTimer !== null) {
+      return;
+    }
+    this.ws = null;
+    this.cb.onStatus("reconnecting");
+    const delay2 = Math.min(BACKOFF_BASE_MS * 2 ** this.retry, BACKOFF_MAX_MS);
+    this.retry += 1;
+    this.reconnectTimer = window.setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, delay2);
+  }
+  closeSocket() {
+    const ws = this.ws;
+    if (!ws) {
+      return;
+    }
+    ws.onopen = null;
+    ws.onmessage = null;
+    ws.onclose = null;
+    ws.onerror = null;
+    try {
+      ws.close();
+    } catch {
+    }
+    this.ws = null;
+  }
+  // --- resize ----------------------------------------------------------------
+  /** Fits on the next painted frame, after visibility/layout changes have settled.
+   *  Repeated activation signals coalesce into one frame; unlike the resize debounce,
+   *  this is not a time guess and never repeats on its own. */
+  scheduleVisibleFit() {
+    if (this.stopped || this.visibleFitFrame !== null) {
+      return;
+    }
+    this.visibleFitFrame = window.requestAnimationFrame(() => {
+      this.visibleFitFrame = null;
+      this.fitVisibleHost();
+    });
+  }
+  /** Drops activation work queued before a direct user scroll. Leaving that frame
+   * alive lets it run after the input fit and rebase the restore onto the new user
+   * revision, which makes the first gesture appear inert. */
+  cancelVisibleFitFrame() {
+    if (this.visibleFitFrame === null) {
+      return;
+    }
+    window.cancelAnimationFrame(this.visibleFitFrame);
+    this.visibleFitFrame = null;
+  }
+  /** Reconciles xterm's grid with this host only when the host is measurable and the
+   *  FitAddon proposes a real change. A peer-owned MsgResize remains authoritative
+   *  while this client is inactive; activation/wheel makes this client the newest
+   *  writer once, without a resize-echo ping-pong between visible clients. */
+  fitVisibleHost() {
+    if (this.stopped) {
+      return;
+    }
+    let proposed;
+    try {
+      proposed = this.fit.proposeDimensions();
+    } catch {
+      return;
+    }
+    const host = { width: this.container.clientWidth, height: this.container.clientHeight };
+    if (!hasVisibleTerminalGeometry(host, proposed)) {
+      return;
+    }
+    const needsFit = shouldRefitVisibleTerminal(host, { rows: this.term.rows, cols: this.term.cols }, proposed);
+    if (needsFit) {
+      try {
+        this.fit.fit();
+      } catch {
+        return;
+      }
+      this.sendResize(this.term.rows, this.term.cols, false);
+    }
+    this.scheduleViewportRestore(this.term.rows, this.term.cols);
+    this.connectAfterInitialFit();
+  }
+  /** Restores the pre-peer reading position after xterm has rendered its new grid.
+   *  resize() schedules the buffer reflow: reading baseY synchronously after fit can
+   *  still see the peer-collapsed zero. The next painted frame is the first settled
+   *  value. A newer peer grid cancels this frame and leaves the anchor pending for
+   *  the next local activation. */
+  scheduleViewportRestore(rows, cols) {
+    if (this.pendingViewport === null) {
+      return;
+    }
+    this.cancelViewportRestoreFrame();
+    const scheduledUserScroll = this.userScrollRevision;
+    this.viewportRestoreFrame = window.requestAnimationFrame(() => {
+      this.viewportRestoreFrame = null;
+      if (this.stopped || this.term.rows !== rows || this.term.cols !== cols) {
+        return;
+      }
+      const anchor = this.pendingViewport;
+      if (anchor === null) {
+        return;
+      }
+      const buffer = this.term.buffer.active;
+      if (!shouldRestoreViewport({
+        scheduledUserScroll,
+        currentUserScroll: this.userScrollRevision
+      })) {
+        this.clearPendingViewport();
+        return;
+      }
+      const target = viewportAnchorLine(
+        {
+          atBottom: anchor.atBottom,
+          markerLine: anchor.marker?.line ?? null,
+          fallbackLine: anchor.line
+        },
+        buffer.baseY
+      );
+      this.clearPendingViewport();
+      this.term.scrollToLine(Math.max(0, target));
+    });
+  }
+  cancelViewportRestoreFrame() {
+    if (this.viewportRestoreFrame !== null) {
+      window.cancelAnimationFrame(this.viewportRestoreFrame);
+      this.viewportRestoreFrame = null;
+    }
+  }
+  clearPendingViewport() {
+    this.cancelViewportRestoreFrame();
+    this.pendingViewport?.marker?.dispose();
+    this.pendingViewport = null;
+  }
+  scheduleFit() {
+    if (this.resizeTimer !== null) {
+      window.clearTimeout(this.resizeTimer);
+    }
+    this.resizeTimer = window.setTimeout(() => {
+      this.resizeTimer = null;
+      if (this.stopped) {
+        return;
+      }
+      this.fitVisibleHost();
+    }, RESIZE_DEBOUNCE_MS);
+  }
+  /** Sends an OpResize for the given size unless it's unchanged. `force` re-sends
+   *  even an unchanged size (used on connect to (re)assert our size to the server). */
+  sendResize(rows, cols, force) {
+    if (rows <= 0 || cols <= 0) {
+      return;
+    }
+    if (!force && rows === this.lastRows && cols === this.lastCols) {
+      return;
+    }
+    this.lastRows = rows;
+    this.lastCols = cols;
+    this.send(encode(resizeFrame(rows, cols)));
+  }
+  /** Applies the server's authoritative size to xterm without echoing it back out
+   *  as an OpResize (which would ping-pong). Records it as our last-known size so a
+   *  later identical local fit doesn't re-send. */
+  applyEchoedSize(rows, cols) {
+    this.lastRows = rows;
+    this.lastCols = cols;
+    if (rows !== this.term.rows || cols !== this.term.cols) {
+      if (this.pendingViewport === null) {
+        const buffer = this.term.buffer.active;
+        const atBottom = buffer.viewportY >= buffer.baseY;
+        let marker = null;
+        if (!atBottom) {
+          try {
+            marker = this.term.registerMarker(viewportMarkerOffset(buffer));
+          } catch {
+          }
+        }
+        this.pendingViewport = { marker, line: buffer.viewportY, atBottom };
+      }
+      this.cancelViewportRestoreFrame();
+      try {
+        this.term.resize(cols, rows);
+      } catch {
+      }
+    }
+  }
+  send(bytes) {
+    const ws = this.ws;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(bytes);
+    }
+  }
+  // --- input & clipboard -----------------------------------------------------
+  /** Sends text to the PTY as OpInput — the single input path shared by typed
+   *  keys (onData) and the Ctrl+C interrupt (clipboard.ts). UTF-8 encoded so a
+   *  multibyte char reaches the PTY as the same bytes a real terminal would send. */
+  sendInput(text) {
+    this.send(encode(inputFrame(this.enc.encode(text))));
+  }
+  /** Copies text to the system clipboard, never silently. localhost is a secure
+   *  context, so navigator.clipboard.writeText works; but if it is missing (a
+   *  non-secure origin behind a proxy) or rejects, fall back to the legacy
+   *  execCommand path, and only if THAT fails surface a visible hint — a copy that
+   *  silently fails is worse than none (the user pastes stale content unaware). */
+  copyToClipboard(text) {
+    if (text === "") {
+      return;
+    }
+    const clip = navigator.clipboard;
+    if (clip && typeof clip.writeText === "function") {
+      clip.writeText(text).catch(() => {
+        if (!this.execCommandCopy(text)) {
+          this.flashCopyHint();
+        }
+      });
+      return;
+    }
+    if (!this.execCommandCopy(text)) {
+      this.flashCopyHint();
+    }
+  }
+  /** Legacy clipboard write via a throwaway off-screen textarea. Returns whether the
+   *  copy reported success. Requires a user gesture, which the key handler provides. */
+  execCommandCopy(text) {
+    try {
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      ta.setAttribute("readonly", "");
+      ta.style.position = "fixed";
+      ta.style.top = "0";
+      ta.style.left = "0";
+      ta.style.width = "1px";
+      ta.style.height = "1px";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      ta.setSelectionRange(0, text.length);
+      const ok = document.execCommand("copy");
+      ta.remove();
+      this.term.focus();
+      return ok;
+    } catch {
+      return false;
+    }
+  }
+  /** Last-resort visible cue when BOTH clipboard paths fail, so the copy is never
+   *  silently dropped. An app-level "clipboard unavailable" condition (not
+   *  pane-specific), so it is a viewport-fixed toast appended to document.body —
+   *  matching the app's own af-toast pattern and, by living outside the pane tree,
+   *  never clipped by a split pane's overflow:hidden or anchored to a transformed
+   *  ancestor. Styled inline so it needs no stylesheet plumbing and no <style>
+   *  element under the CSP. */
+  flashCopyHint() {
+    try {
+      const hint = document.createElement("div");
+      hint.textContent = "Copy failed \u2014 clipboard unavailable";
+      hint.setAttribute("role", "alert");
+      hint.style.position = "fixed";
+      hint.style.bottom = "12px";
+      hint.style.right = "12px";
+      hint.style.zIndex = "9999";
+      hint.style.padding = "4px 10px";
+      hint.style.borderRadius = "4px";
+      hint.style.font = "12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace";
+      hint.style.background = "rgba(0, 0, 0, 0.82)";
+      hint.style.color = "#fff";
+      hint.style.pointerEvents = "none";
+      document.body.appendChild(hint);
+      window.setTimeout(() => hint.remove(), 2500);
+    } catch {
+    }
+  }
+};
+
+// src/config_assistant.ts
+var SPAWN_RETRY_LIMIT = 4;
+var SPAWN_RETRY_DELAY_MS = 250;
+var CLOSED = Symbol("config-assistant-closed");
+function delay(ms) {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+function openConfigAssistant(opts) {
+  const { token: token2, mountHost, onClosed } = opts;
+  let closed = false;
+  let term = null;
+  const status = h("span", { class: "af-assistant-status" }, "Starting the assistant\u2026");
+  status.setAttribute("role", "status");
+  const closeBtn = h("button", { type: "button", class: "af-ghost af-assistant-close" }, "\xD7");
+  closeBtn.setAttribute("aria-label", "Close the config assistant");
+  const termHost2 = h("div", { class: "af-assistant-term" });
+  const errorLine = h("p", { class: "af-modal-error af-assistant-error", role: "alert" });
+  errorLine.hidden = true;
+  const card = h(
+    "div",
+    { class: "af-modal-card af-assistant-card", role: "dialog" },
+    h(
+      "div",
+      { class: "af-assistant-head" },
+      h("h2", { class: "af-modal-title" }, "Configure with assistant"),
+      status,
+      closeBtn
+    ),
+    termHost2,
+    errorLine
+  );
+  card.setAttribute("aria-modal", "true");
+  card.setAttribute("aria-label", "Config assistant");
+  card.addEventListener("click", (e) => e.stopPropagation());
+  const backdrop = h("div", { class: "af-modal-backdrop" }, card);
+  backdrop.addEventListener("click", () => close());
+  const onKeydown2 = (e) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      close();
+    }
+  };
+  document.addEventListener("keydown", onKeydown2);
+  mountHost.append(backdrop);
+  function setStatus(text) {
+    status.textContent = text;
+  }
+  function setError(msg) {
+    errorLine.textContent = msg;
+    errorLine.hidden = false;
+  }
+  function terminalStatusText(s) {
+    switch (s) {
+      case "connecting":
+        return "Connecting\u2026";
+      case "open":
+        return "Connected";
+      case "reconnecting":
+        return "Reconnecting\u2026";
+      case "exited":
+        return "Assistant ended.";
+    }
+  }
+  function close() {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    document.removeEventListener("keydown", onKeydown2);
+    if (term) {
+      term.dispose();
+      term = null;
+    }
+    backdrop.remove();
+    void reapConfigAssistant(token2).catch(() => {
+    });
+    onClosed?.();
+  }
+  async function spawn() {
+    for (let attempt = 1; ; attempt++) {
+      try {
+        await spawnConfigAssistant(token2);
+        return;
+      } catch (e) {
+        if (closed) {
+          throw CLOSED;
+        }
+        const httpStatus = e instanceof ApiError ? e.status : -1;
+        if (httpStatus === 409 && attempt < SPAWN_RETRY_LIMIT) {
+          await delay(SPAWN_RETRY_DELAY_MS);
+          if (closed) {
+            throw CLOSED;
+          }
+          continue;
+        }
+        throw e;
+      }
+    }
+  }
+  function attach() {
+    if (closed) {
+      return;
+    }
+    term = new AttachTerminal(termHost2, token2, configAssistantStreamEndpoint(), {
+      onStatus: (s) => {
+        if (!closed) {
+          setStatus(terminalStatusText(s));
+        }
+      },
+      // The assistant is a single pane; there is no nav/attach mode to keep in sync
+      // the way a session split does, so focus changes need no handling here.
+      onFocusChange: () => {
+      }
+    });
+    term.focus();
+  }
+  void spawn().then(() => attach()).catch((e) => {
+    if (e === CLOSED || closed) {
+      return;
+    }
+    const httpStatus = e instanceof ApiError ? e.status : -1;
+    if (httpStatus === 503) {
+      setStatus("Unavailable");
+      setError("The config assistant is not available in this daemon build.");
+    } else if (httpStatus === 0) {
+      setStatus("Offline");
+      setError("Could not reach the daemon. Close and try again.");
+    } else {
+      setStatus("Failed to start");
+      setError(e instanceof Error ? e.message : "Could not start the config assistant.");
+    }
+  });
+  return { close };
+}
+
+// src/events.ts
+var BACKOFF_BASE_MS2 = 500;
+var BACKOFF_MAX_MS2 = 1e4;
+function wsScheme2() {
   return window.location.protocol === "https:" ? "wss:" : "ws:";
 }
 var EventStream = class {
@@ -7091,7 +8113,7 @@ var EventStream = class {
   }
   open() {
     this.cb.onStatus(this.everOpened ? "reconnecting" : "connecting");
-    const url = `${wsScheme()}//${window.location.host}/v1/events?access_token=${encodeURIComponent(this.token)}`;
+    const url = `${wsScheme2()}//${window.location.host}/v1/events?access_token=${encodeURIComponent(this.token)}`;
     let ws;
     try {
       ws = new WebSocket(url);
@@ -7134,14 +8156,14 @@ var EventStream = class {
     }
     this.ws = null;
     this.cb.onStatus("reconnecting");
-    const delay = Math.min(BACKOFF_BASE_MS * 2 ** this.retry, BACKOFF_MAX_MS);
+    const delay2 = Math.min(BACKOFF_BASE_MS2 * 2 ** this.retry, BACKOFF_MAX_MS2);
     this.retry += 1;
     this.reconnectTimer = window.setTimeout(() => {
       this.reconnectTimer = null;
       if (!this.stopped) {
         this.open();
       }
-    }, delay);
+    }, delay2);
   }
 };
 
@@ -7302,7 +8324,7 @@ var SquareCheckBig = [
 var Square = [["rect", { width: "18", height: "18", x: "3", y: "3", rx: "2" }]];
 
 // node_modules/lucide/dist/esm/icons/terminal.mjs
-var Terminal = [
+var Terminal2 = [
   ["path", { d: "M12 19h8" }],
   ["path", { d: "m4 17 6-6-6-6" }]
 ];
@@ -7336,7 +8358,7 @@ var ICONS = {
   reload: RefreshCw,
   square: Square,
   "square-check": SquareCheckBig,
-  terminal: Terminal,
+  terminal: Terminal2,
   x: X
 };
 function icon(name, className = "") {
@@ -8295,836 +9317,6 @@ function isRenameableTab(kind) {
   return kind === TabKind.Web || kind === TabKind.Process || kind === TabKind.VSCode;
 }
 
-// src/terminal.ts
-var import_addon_fit = __toESM(require_addon_fit(), 1);
-var import_xterm = __toESM(require_xterm(), 1);
-
-// src/clipboard.ts
-var ETX = "";
-var LF = "\n";
-function handleClipboardKeydown(ev, deps) {
-  if (ev.type !== "keydown") {
-    return true;
-  }
-  if (deps.composerNewline && ev.key === "Enter" && ev.shiftKey && !ev.ctrlKey && !ev.metaKey && !ev.altKey) {
-    ev.preventDefault();
-    deps.sendUserInput(LF);
-    return false;
-  }
-  if (ev.metaKey || ev.altKey || !ev.ctrlKey) {
-    return true;
-  }
-  const key = ev.key.toLowerCase();
-  if (key === "v") {
-    return false;
-  }
-  if (key === "c") {
-    if (ev.shiftKey) {
-      ev.preventDefault();
-      if (deps.hasSelection()) {
-        deps.copy(deps.getSelection());
-      }
-      return false;
-    }
-    if (deps.hasSelection()) {
-      ev.preventDefault();
-      deps.copy(deps.getSelection());
-      deps.clearSelection();
-      return false;
-    }
-    ev.preventDefault();
-    deps.sendInput(ETX);
-    return false;
-  }
-  return true;
-}
-
-// src/frame.ts
-var RESIZE_PAYLOAD_LEN = 4;
-var HELLO_PAYLOAD_LEN = 8;
-var EMPTY = new Uint8Array(0);
-function makeFrame(f) {
-  return {
-    op: f.op,
-    data: f.data ?? EMPTY,
-    rows: f.rows ?? 0,
-    cols: f.cols ?? 0,
-    seq: f.seq ?? 0n
-  };
-}
-function inputFrame(data) {
-  return makeFrame({ op: 1 /* Input */, data });
-}
-function resizeFrame(rows, cols) {
-  return makeFrame({ op: 2 /* Resize */, rows, cols });
-}
-function encode(f) {
-  switch (f.op) {
-    case 2 /* Resize */: {
-      const out = new Uint8Array(1 + RESIZE_PAYLOAD_LEN);
-      out[0] = 2 /* Resize */;
-      const dv = new DataView(out.buffer);
-      dv.setUint16(1, f.rows, false);
-      dv.setUint16(3, f.cols, false);
-      return out;
-    }
-    case 4 /* Hello */: {
-      const out = new Uint8Array(1 + HELLO_PAYLOAD_LEN);
-      out[0] = 4 /* Hello */;
-      const dv = new DataView(out.buffer);
-      dv.setBigUint64(1, f.seq, false);
-      return out;
-    }
-    default: {
-      const out = new Uint8Array(1 + f.data.length);
-      out[0] = f.op;
-      out.set(f.data, 1);
-      return out;
-    }
-  }
-}
-function decode(raw) {
-  if (raw.length === 0) {
-    throw new Error("agentproto: empty binary frame");
-  }
-  const op = raw[0];
-  const body = raw.subarray(1);
-  switch (op) {
-    case 0 /* PTYOut */:
-    case 1 /* Input */:
-    case 3 /* Repaint */:
-      return makeFrame({ op, data: body.slice() });
-    case 2 /* Resize */: {
-      if (body.length !== RESIZE_PAYLOAD_LEN) {
-        throw new Error(`agentproto: RESIZE frame body is ${body.length} bytes, want ${RESIZE_PAYLOAD_LEN}`);
-      }
-      const dv = new DataView(body.buffer, body.byteOffset, body.byteLength);
-      return makeFrame({ op, rows: dv.getUint16(0, false), cols: dv.getUint16(2, false) });
-    }
-    case 4 /* Hello */: {
-      if (body.length !== HELLO_PAYLOAD_LEN) {
-        throw new Error(`agentproto: HELLO frame body is ${body.length} bytes, want ${HELLO_PAYLOAD_LEN}`);
-      }
-      const dv = new DataView(body.buffer, body.byteOffset, body.byteLength);
-      return makeFrame({ op, seq: dv.getBigUint64(0, false) });
-    }
-    default:
-      throw new Error(`agentproto: unknown opcode 0x${op.toString(16).padStart(2, "0")}`);
-  }
-}
-
-// src/terminal-geometry.ts
-function hasVisibleTerminalGeometry(host, proposed) {
-  return host.width > 0 && host.height > 0 && !!proposed && proposed.rows > 0 && proposed.cols > 0;
-}
-function shouldRefitVisibleTerminal(host, current, proposed) {
-  if (!hasVisibleTerminalGeometry(host, proposed)) {
-    return false;
-  }
-  return proposed.rows !== current.rows || proposed.cols !== current.cols;
-}
-function viewportMarkerOffset(position) {
-  return position.viewportY - (position.baseY + position.cursorY);
-}
-function viewportAnchorLine(anchor, baseY) {
-  if (anchor.atBottom) {
-    return baseY;
-  }
-  return anchor.markerLine !== null && anchor.markerLine >= 0 ? anchor.markerLine : anchor.fallbackLine;
-}
-function shouldRestoreViewport(intent) {
-  return intent.scheduledUserScroll === intent.currentUserScroll;
-}
-function terminalUserScrollPlan(source, hasScheduledVisibleFit) {
-  switch (source) {
-    case "wheel":
-    case "touch":
-    case "scrollbar":
-      return { cancelScheduledVisibleFit: hasScheduledVisibleFit };
-  }
-}
-
-// src/theme.ts
-var THEME_CHOICES = ["auto", "light", "dark"];
-var STORAGE_KEY = "af-theme";
-function isChoice(v) {
-  return v === "auto" || v === "light" || v === "dark";
-}
-function readThemeChoice() {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (isChoice(raw)) {
-      return raw;
-    }
-  } catch {
-  }
-  return "auto";
-}
-function persistThemeChoice(choice) {
-  try {
-    localStorage.setItem(STORAGE_KEY, choice);
-  } catch {
-  }
-}
-var THEME_COLOR_LIGHT = "#ffffff";
-var THEME_COLOR_DARK = "#141a22";
-function themeColorMetaContents(choice) {
-  if (choice === "auto") {
-    return { light: THEME_COLOR_LIGHT, dark: THEME_COLOR_DARK };
-  }
-  const forced = choice === "dark" ? THEME_COLOR_DARK : THEME_COLOR_LIGHT;
-  return { light: forced, dark: forced };
-}
-function syncThemeColorMeta(choice) {
-  const { light, dark } = themeColorMetaContents(choice);
-  for (const meta of document.querySelectorAll('meta[name="theme-color"]')) {
-    const isDark = (meta.getAttribute("media") ?? "").includes("dark");
-    meta.setAttribute("content", isDark ? dark : light);
-  }
-}
-function stampTheme(choice) {
-  const root2 = document.documentElement;
-  if (choice === "auto") {
-    root2.removeAttribute("data-theme");
-  } else {
-    root2.setAttribute("data-theme", choice);
-  }
-  syncThemeColorMeta(choice);
-}
-function bootStampTheme() {
-  const choice = readThemeChoice();
-  stampTheme(choice);
-  return choice;
-}
-function prefersDark() {
-  try {
-    return window.matchMedia("(prefers-color-scheme: dark)").matches;
-  } catch {
-    return false;
-  }
-}
-function currentMode() {
-  const attr = document.documentElement.getAttribute("data-theme");
-  if (attr === "light" || attr === "dark") {
-    return attr;
-  }
-  return prefersDark() ? "dark" : "light";
-}
-var DARK_XTERM = {
-  background: "#0c1016",
-  foreground: "#e7ecf3",
-  cursor: "#e7ecf3",
-  cursorAccent: "#0c1016",
-  selectionBackground: "rgba(122, 162, 247, 0.2)",
-  black: "#484f58",
-  red: "#ff7b72",
-  green: "#3fb950",
-  yellow: "#d29922",
-  blue: "#58a6ff",
-  magenta: "#bc8cff",
-  cyan: "#39c5cf",
-  white: "#b1bac4",
-  brightBlack: "#6e7681",
-  brightRed: "#ffa198",
-  brightGreen: "#56d364",
-  brightYellow: "#e3b341",
-  brightBlue: "#79c0ff",
-  brightMagenta: "#d2a8ff",
-  brightCyan: "#56d4dd",
-  brightWhite: "#f0f6fc"
-};
-var LIGHT_XTERM = {
-  background: "#fdfefe",
-  foreground: "#17202e",
-  cursor: "#17202e",
-  cursorAccent: "#fdfefe",
-  selectionBackground: "rgba(47, 95, 216, 0.16)",
-  black: "#24292f",
-  red: "#cf222e",
-  green: "#1a7f37",
-  yellow: "#9a6700",
-  blue: "#0969da",
-  magenta: "#8250df",
-  cyan: "#1b7c83",
-  white: "#6e7781",
-  brightBlack: "#57606a",
-  brightRed: "#a40e26",
-  brightGreen: "#116329",
-  brightYellow: "#7d4e00",
-  brightBlue: "#0550ae",
-  brightMagenta: "#6639ba",
-  brightCyan: "#3192aa",
-  brightWhite: "#8c959f"
-};
-function xtermTheme(mode) {
-  return mode === "dark" ? DARK_XTERM : LIGHT_XTERM;
-}
-function currentXtermTheme() {
-  return xtermTheme(currentMode());
-}
-
-// src/terminal.ts
-var BACKOFF_BASE_MS2 = 500;
-var BACKOFF_MAX_MS2 = 1e4;
-var RESIZE_DEBOUNCE_MS = 120;
-function wsScheme2() {
-  return window.location.protocol === "https:" ? "wss:" : "ws:";
-}
-var AttachTerminal = class {
-  constructor(container, sessionId, token2, tabId, tab, cb) {
-    this.container = container;
-    this.sessionId = sessionId;
-    this.token = token2;
-    this.tabId = tabId;
-    this.tab = tab;
-    this.cb = cb;
-    this.term = new import_xterm.Terminal({
-      allowProposedApi: true,
-      cursorBlink: true,
-      fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
-      fontSize: 13,
-      // Born in the active theme (theme.ts derives the xterm palette from the same
-      // tokens as the CSS chrome); setTheme() re-applies live on a toggle.
-      theme: currentXtermTheme(),
-      // The stream is the source of truth; local echo/scrollback beyond the ring is
-      // fine but the server never sees our convert-eol, so leave it raw.
-      scrollback: 5e3
-    });
-    this.fit = new import_addon_fit.FitAddon();
-    this.term.loadAddon(this.fit);
-    this.term.open(container);
-    const textarea = this.term.textarea;
-    if (textarea) {
-      textarea.addEventListener("focus", () => {
-        if (!this.stopped) {
-          this.cb.onFocusChange(true);
-        }
-      });
-      textarea.addEventListener("blur", () => {
-        if (!this.stopped) {
-          this.cb.onFocusChange(false);
-        }
-      });
-    }
-    this.term.onData((data) => this.sendInput(data));
-    this.term.attachCustomKeyEventHandler(
-      (ev) => handleClipboardKeydown(ev, {
-        composerNewline: this.tab === 0,
-        hasSelection: () => this.term.hasSelection(),
-        getSelection: () => this.term.getSelection(),
-        clearSelection: () => this.term.clearSelection(),
-        copy: (text) => this.copyToClipboard(text),
-        sendInput: (text) => this.sendInput(text),
-        // Public Terminal.input(..., true) is xterm's genuine-user-input path:
-        // it scrolls to bottom and clears selection, then fires onData above.
-        sendUserInput: (text) => this.term.input(text, true)
-      })
-    );
-    this.ro = new ResizeObserver(() => this.scheduleFit());
-    this.ro.observe(container);
-    this.io = new IntersectionObserver((entries) => {
-      if (entries.some((entry) => entry.target === container && entry.isIntersecting)) {
-        this.scheduleVisibleFit();
-      }
-    });
-    this.io.observe(container);
-    window.addEventListener("focus", this.onWindowFocus);
-    document.addEventListener("visibilitychange", this.onVisibilityChange);
-    container.addEventListener("pointerenter", this.onPointerEnter);
-    container.addEventListener("wheel", this.onWheel, { capture: true, passive: true });
-    container.addEventListener("touchmove", this.onTouchMove, { capture: true, passive: true });
-    container.addEventListener("pointerdown", this.onPointerDown, true);
-    this.scheduleVisibleFit();
-  }
-  term;
-  fit;
-  enc = new TextEncoder();
-  ro;
-  io;
-  ws = null;
-  stopped = false;
-  everOpened = false;
-  retry = 0;
-  initialConnectStarted = false;
-  reconnectTimer = null;
-  resizeTimer = null;
-  visibleFitFrame = null;
-  viewportRestoreFrame = null;
-  // Incremented only by an actual user scroll input while a peer-owned anchor is
-  // pending. Output and resize reflows can move viewportY too, so position deltas
-  // alone do not prove that a user intended to override the saved reading line.
-  userScrollRevision = 0;
-  // The absolute replay cursor: seeded from OpHello, advanced by OpPTYOut byte
-  // counts (never by OpRepaint). `seeded` gates whether a reconnect can pass a
-  // real ?since; the first connect omits it (live tail + a fresh-screen repaint).
-  cursor = 0n;
-  seeded = false;
-  // The last size we told the server, so we don't re-send an unchanged fit and so
-  // an authoritative echo that matches is a no-op.
-  lastRows = 0;
-  lastCols = 0;
-  // A peer resize can temporarily collapse this client's scrollback (for example,
-  // 60 lines fit in a peer's 111-row grid). Anchor the actual visible buffer line,
-  // not a one-time distance from the bottom: output can keep arriving while this
-  // client is inactive. Null means no peer-owned grid is pending reconciliation.
-  pendingViewport = null;
-  exited = false;
-  // A peer is allowed to resize the one shared PTY and every client obeys that
-  // authoritative echo. When this window becomes active again, its visible host
-  // becomes the local writer: refit once instead of leaving a peer-sized emulator in
-  // an unchanged container until the user physically resizes the window (#2347).
-  onWindowFocus = () => this.scheduleVisibleFit();
-  onVisibilityChange = () => {
-    if (document.visibilityState === "visible") {
-      this.scheduleVisibleFit();
-    }
-  };
-  // Entering a pane is the earliest reliable activation signal for side-by-side
-  // clients: reconcile before the wheel gesture arrives so xterm can consume that
-  // first gesture rather than making the user scroll twice.
-  onPointerEnter = () => this.fitVisibleHost();
-  // A scroll can target an already-focused window after another client resized the
-  // PTY without the pointer ever leaving this pane. Capture repairs that less-common
-  // path; pointer entry above handles the ordinary first gesture. The pending-peer
-  // gate makes every ordinary input a no-op before even measuring layout.
-  onWheel = () => this.handleUserScroll("wheel");
-  onTouchMove = () => this.handleUserScroll("touch");
-  onPointerDown = (event) => {
-    if (event.target === this.container.querySelector(".xterm-viewport")) {
-      this.handleUserScroll("scrollbar");
-    }
-  };
-  handleUserScroll(source) {
-    if (this.pendingViewport === null) {
-      return;
-    }
-    const plan = terminalUserScrollPlan(source, this.visibleFitFrame !== null);
-    if (plan.cancelScheduledVisibleFit) {
-      this.cancelVisibleFitFrame();
-    }
-    this.fitVisibleHost();
-    this.userScrollRevision += 1;
-  }
-  /** Permanently closes the terminal: stops the reconnect loop, drops the socket,
-   *  disconnects the observer, and disposes xterm (freeing its DOM/renderer). */
-  dispose() {
-    this.stopped = true;
-    if (this.reconnectTimer !== null) {
-      window.clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = null;
-    }
-    if (this.resizeTimer !== null) {
-      window.clearTimeout(this.resizeTimer);
-      this.resizeTimer = null;
-    }
-    this.cancelVisibleFitFrame();
-    this.clearPendingViewport();
-    this.ro.disconnect();
-    this.io.disconnect();
-    window.removeEventListener("focus", this.onWindowFocus);
-    document.removeEventListener("visibilitychange", this.onVisibilityChange);
-    this.container.removeEventListener("pointerenter", this.onPointerEnter);
-    this.container.removeEventListener("wheel", this.onWheel, true);
-    this.container.removeEventListener("touchmove", this.onTouchMove, true);
-    this.container.removeEventListener("pointerdown", this.onPointerDown, true);
-    this.closeSocket();
-    this.term.dispose();
-  }
-  /** Gives the terminal the keyboard (focuses xterm's helper textarea) so typed
-   *  keys reach the agent — the attach half of the #1693 nav/attach model. */
-  focus() {
-    this.fitVisibleHost();
-    this.term.focus();
-  }
-  /** Reconciles this terminal after an app-shell layout/visibility transition.
-   *  Coalesced onto the next painted frame so CSS has settled; the measurable-host
-   *  gate in fitVisibleHost keeps hidden or zero-sized panes inert. */
-  refit() {
-    this.scheduleVisibleFit();
-  }
-  /** Takes the keyboard away from the terminal (blurs it) so document-level rail
-   *  navigation gets the keys again — the Escape/back-to-nav half of #1693. */
-  blur() {
-    this.term.blur();
-  }
-  /** Re-applies an xterm palette live (a theme toggle): xterm repaints the canvas
-   *  from the new ITheme, so an open terminal switches light/dark without a
-   *  reconnect or losing scrollback. */
-  setTheme(theme) {
-    this.term.options.theme = theme;
-  }
-  // --- socket lifecycle ------------------------------------------------------
-  connect() {
-    if (this.stopped) {
-      return;
-    }
-    this.cb.onStatus(this.everOpened ? "reconnecting" : "connecting");
-    const base = `${wsScheme2()}//${window.location.host}/v1/sessions/${encodeURIComponent(this.sessionId)}/stream`;
-    const params = new URLSearchParams();
-    params.set("access_token", this.token);
-    if (this.tabId !== "") {
-      params.set("tab_id", this.tabId);
-    } else if (this.tab > 0) {
-      params.set("tab", String(this.tab));
-    }
-    if (this.seeded) {
-      params.set("since", this.cursor.toString());
-    }
-    let ws;
-    try {
-      ws = new WebSocket(`${base}?${params.toString()}`);
-    } catch {
-      this.scheduleReconnect();
-      return;
-    }
-    ws.binaryType = "arraybuffer";
-    this.ws = ws;
-    ws.onopen = () => {
-      this.retry = 0;
-      this.everOpened = true;
-      this.exited = false;
-      this.cb.onStatus("open");
-      this.sendResize(this.term.rows, this.term.cols, true);
-    };
-    ws.onmessage = (e) => this.onMessage(e.data);
-    ws.onclose = () => this.scheduleReconnect();
-    ws.onerror = () => {
-      try {
-        ws.close();
-      } catch {
-      }
-    };
-  }
-  /** Starts the first connection only after a real visible-host fit. Reconnects
-   * continue through connect() directly once this boundary has been crossed. */
-  connectAfterInitialFit() {
-    if (this.initialConnectStarted || this.stopped) {
-      return;
-    }
-    this.initialConnectStarted = true;
-    this.connect();
-  }
-  onMessage(data) {
-    if (typeof data === "string") {
-      this.onControl(data);
-      return;
-    }
-    if (!(data instanceof ArrayBuffer)) {
-      return;
-    }
-    let frame;
-    try {
-      frame = decode(new Uint8Array(data));
-    } catch {
-      return;
-    }
-    switch (frame.op) {
-      case 4 /* Hello */:
-        this.cursor = frame.seq;
-        this.seeded = true;
-        break;
-      case 0 /* PTYOut */:
-        this.term.write(frame.data);
-        this.cursor += BigInt(frame.data.length);
-        break;
-      case 3 /* Repaint */:
-        this.term.write(frame.data);
-        break;
-      default:
-        break;
-    }
-  }
-  onControl(text) {
-    let msg;
-    try {
-      msg = JSON.parse(text);
-    } catch {
-      return;
-    }
-    if (msg.type === "resize" && typeof msg.rows === "number" && typeof msg.cols === "number") {
-      this.applyEchoedSize(msg.rows, msg.cols);
-    } else if (msg.type === "exit") {
-      this.exited = true;
-      const code = typeof msg.code === "number" ? msg.code : 0;
-      this.term.write(`\r
-\x1B[38;5;244m[agent exited (code ${code})]\x1B[0m\r
-`);
-      this.cb.onStatus("exited");
-      this.stopped = true;
-      this.closeSocket();
-    }
-  }
-  scheduleReconnect() {
-    if (this.stopped || this.reconnectTimer !== null) {
-      return;
-    }
-    this.ws = null;
-    this.cb.onStatus("reconnecting");
-    const delay = Math.min(BACKOFF_BASE_MS2 * 2 ** this.retry, BACKOFF_MAX_MS2);
-    this.retry += 1;
-    this.reconnectTimer = window.setTimeout(() => {
-      this.reconnectTimer = null;
-      this.connect();
-    }, delay);
-  }
-  closeSocket() {
-    const ws = this.ws;
-    if (!ws) {
-      return;
-    }
-    ws.onopen = null;
-    ws.onmessage = null;
-    ws.onclose = null;
-    ws.onerror = null;
-    try {
-      ws.close();
-    } catch {
-    }
-    this.ws = null;
-  }
-  // --- resize ----------------------------------------------------------------
-  /** Fits on the next painted frame, after visibility/layout changes have settled.
-   *  Repeated activation signals coalesce into one frame; unlike the resize debounce,
-   *  this is not a time guess and never repeats on its own. */
-  scheduleVisibleFit() {
-    if (this.stopped || this.visibleFitFrame !== null) {
-      return;
-    }
-    this.visibleFitFrame = window.requestAnimationFrame(() => {
-      this.visibleFitFrame = null;
-      this.fitVisibleHost();
-    });
-  }
-  /** Drops activation work queued before a direct user scroll. Leaving that frame
-   * alive lets it run after the input fit and rebase the restore onto the new user
-   * revision, which makes the first gesture appear inert. */
-  cancelVisibleFitFrame() {
-    if (this.visibleFitFrame === null) {
-      return;
-    }
-    window.cancelAnimationFrame(this.visibleFitFrame);
-    this.visibleFitFrame = null;
-  }
-  /** Reconciles xterm's grid with this host only when the host is measurable and the
-   *  FitAddon proposes a real change. A peer-owned MsgResize remains authoritative
-   *  while this client is inactive; activation/wheel makes this client the newest
-   *  writer once, without a resize-echo ping-pong between visible clients. */
-  fitVisibleHost() {
-    if (this.stopped) {
-      return;
-    }
-    let proposed;
-    try {
-      proposed = this.fit.proposeDimensions();
-    } catch {
-      return;
-    }
-    const host = { width: this.container.clientWidth, height: this.container.clientHeight };
-    if (!hasVisibleTerminalGeometry(host, proposed)) {
-      return;
-    }
-    const needsFit = shouldRefitVisibleTerminal(host, { rows: this.term.rows, cols: this.term.cols }, proposed);
-    if (needsFit) {
-      try {
-        this.fit.fit();
-      } catch {
-        return;
-      }
-      this.sendResize(this.term.rows, this.term.cols, false);
-    }
-    this.scheduleViewportRestore(this.term.rows, this.term.cols);
-    this.connectAfterInitialFit();
-  }
-  /** Restores the pre-peer reading position after xterm has rendered its new grid.
-   *  resize() schedules the buffer reflow: reading baseY synchronously after fit can
-   *  still see the peer-collapsed zero. The next painted frame is the first settled
-   *  value. A newer peer grid cancels this frame and leaves the anchor pending for
-   *  the next local activation. */
-  scheduleViewportRestore(rows, cols) {
-    if (this.pendingViewport === null) {
-      return;
-    }
-    this.cancelViewportRestoreFrame();
-    const scheduledUserScroll = this.userScrollRevision;
-    this.viewportRestoreFrame = window.requestAnimationFrame(() => {
-      this.viewportRestoreFrame = null;
-      if (this.stopped || this.term.rows !== rows || this.term.cols !== cols) {
-        return;
-      }
-      const anchor = this.pendingViewport;
-      if (anchor === null) {
-        return;
-      }
-      const buffer = this.term.buffer.active;
-      if (!shouldRestoreViewport({
-        scheduledUserScroll,
-        currentUserScroll: this.userScrollRevision
-      })) {
-        this.clearPendingViewport();
-        return;
-      }
-      const target = viewportAnchorLine(
-        {
-          atBottom: anchor.atBottom,
-          markerLine: anchor.marker?.line ?? null,
-          fallbackLine: anchor.line
-        },
-        buffer.baseY
-      );
-      this.clearPendingViewport();
-      this.term.scrollToLine(Math.max(0, target));
-    });
-  }
-  cancelViewportRestoreFrame() {
-    if (this.viewportRestoreFrame !== null) {
-      window.cancelAnimationFrame(this.viewportRestoreFrame);
-      this.viewportRestoreFrame = null;
-    }
-  }
-  clearPendingViewport() {
-    this.cancelViewportRestoreFrame();
-    this.pendingViewport?.marker?.dispose();
-    this.pendingViewport = null;
-  }
-  scheduleFit() {
-    if (this.resizeTimer !== null) {
-      window.clearTimeout(this.resizeTimer);
-    }
-    this.resizeTimer = window.setTimeout(() => {
-      this.resizeTimer = null;
-      if (this.stopped) {
-        return;
-      }
-      this.fitVisibleHost();
-    }, RESIZE_DEBOUNCE_MS);
-  }
-  /** Sends an OpResize for the given size unless it's unchanged. `force` re-sends
-   *  even an unchanged size (used on connect to (re)assert our size to the server). */
-  sendResize(rows, cols, force) {
-    if (rows <= 0 || cols <= 0) {
-      return;
-    }
-    if (!force && rows === this.lastRows && cols === this.lastCols) {
-      return;
-    }
-    this.lastRows = rows;
-    this.lastCols = cols;
-    this.send(encode(resizeFrame(rows, cols)));
-  }
-  /** Applies the server's authoritative size to xterm without echoing it back out
-   *  as an OpResize (which would ping-pong). Records it as our last-known size so a
-   *  later identical local fit doesn't re-send. */
-  applyEchoedSize(rows, cols) {
-    this.lastRows = rows;
-    this.lastCols = cols;
-    if (rows !== this.term.rows || cols !== this.term.cols) {
-      if (this.pendingViewport === null) {
-        const buffer = this.term.buffer.active;
-        const atBottom = buffer.viewportY >= buffer.baseY;
-        let marker = null;
-        if (!atBottom) {
-          try {
-            marker = this.term.registerMarker(viewportMarkerOffset(buffer));
-          } catch {
-          }
-        }
-        this.pendingViewport = { marker, line: buffer.viewportY, atBottom };
-      }
-      this.cancelViewportRestoreFrame();
-      try {
-        this.term.resize(cols, rows);
-      } catch {
-      }
-    }
-  }
-  send(bytes) {
-    const ws = this.ws;
-    if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(bytes);
-    }
-  }
-  // --- input & clipboard -----------------------------------------------------
-  /** Sends text to the PTY as OpInput — the single input path shared by typed
-   *  keys (onData) and the Ctrl+C interrupt (clipboard.ts). UTF-8 encoded so a
-   *  multibyte char reaches the PTY as the same bytes a real terminal would send. */
-  sendInput(text) {
-    this.send(encode(inputFrame(this.enc.encode(text))));
-  }
-  /** Copies text to the system clipboard, never silently. localhost is a secure
-   *  context, so navigator.clipboard.writeText works; but if it is missing (a
-   *  non-secure origin behind a proxy) or rejects, fall back to the legacy
-   *  execCommand path, and only if THAT fails surface a visible hint — a copy that
-   *  silently fails is worse than none (the user pastes stale content unaware). */
-  copyToClipboard(text) {
-    if (text === "") {
-      return;
-    }
-    const clip = navigator.clipboard;
-    if (clip && typeof clip.writeText === "function") {
-      clip.writeText(text).catch(() => {
-        if (!this.execCommandCopy(text)) {
-          this.flashCopyHint();
-        }
-      });
-      return;
-    }
-    if (!this.execCommandCopy(text)) {
-      this.flashCopyHint();
-    }
-  }
-  /** Legacy clipboard write via a throwaway off-screen textarea. Returns whether the
-   *  copy reported success. Requires a user gesture, which the key handler provides. */
-  execCommandCopy(text) {
-    try {
-      const ta = document.createElement("textarea");
-      ta.value = text;
-      ta.setAttribute("readonly", "");
-      ta.style.position = "fixed";
-      ta.style.top = "0";
-      ta.style.left = "0";
-      ta.style.width = "1px";
-      ta.style.height = "1px";
-      ta.style.opacity = "0";
-      document.body.appendChild(ta);
-      ta.select();
-      ta.setSelectionRange(0, text.length);
-      const ok = document.execCommand("copy");
-      ta.remove();
-      this.term.focus();
-      return ok;
-    } catch {
-      return false;
-    }
-  }
-  /** Last-resort visible cue when BOTH clipboard paths fail, so the copy is never
-   *  silently dropped. An app-level "clipboard unavailable" condition (not
-   *  pane-specific), so it is a viewport-fixed toast appended to document.body —
-   *  matching the app's own af-toast pattern and, by living outside the pane tree,
-   *  never clipped by a split pane's overflow:hidden or anchored to a transformed
-   *  ancestor. Styled inline so it needs no stylesheet plumbing and no <style>
-   *  element under the CSP. */
-  flashCopyHint() {
-    try {
-      const hint = document.createElement("div");
-      hint.textContent = "Copy failed \u2014 clipboard unavailable";
-      hint.setAttribute("role", "alert");
-      hint.style.position = "fixed";
-      hint.style.bottom = "12px";
-      hint.style.right = "12px";
-      hint.style.zIndex = "9999";
-      hint.style.padding = "4px 10px";
-      hint.style.borderRadius = "4px";
-      hint.style.font = "12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace";
-      hint.style.background = "rgba(0, 0, 0, 0.82)";
-      hint.style.color = "#fff";
-      hint.style.pointerEvents = "none";
-      document.body.appendChild(hint);
-      window.setTimeout(() => hint.remove(), 2500);
-    } catch {
-    }
-  }
-};
-
 // src/split.ts
 var EDGE_BAND = 0.3;
 function el(tag, cls) {
@@ -9539,10 +9731,15 @@ var SplitView = class {
         pane.tab = leaf.tab;
         pane.identity = identity;
         pane.status = "connecting";
-        pane.term = new AttachTerminal(pane.host, this.sessionId, this.token, realId, leaf.tab, {
-          onStatus: (s) => this.onPaneStatus(leaf.id, s),
-          onFocusChange: (f) => this.onPaneFocus(leaf.id, f)
-        });
+        pane.term = new AttachTerminal(
+          pane.host,
+          this.token,
+          sessionStreamEndpoint(this.sessionId, realId, leaf.tab),
+          {
+            onStatus: (s) => this.onPaneStatus(leaf.id, s),
+            onFocusChange: (f) => this.onPaneFocus(leaf.id, f)
+          }
+        );
       } else if (moved) {
         pane.tab = leaf.tab;
       }
@@ -11238,7 +11435,8 @@ var AppShell = class {
       remove: (task) => this.actions.removeTask(task)
     });
     this.configPane = new ConfigPane({
-      save: (key, value) => this.actions.setConfigValue(key, value)
+      save: (key, value) => this.actions.setConfigValue(key, value),
+      openAssistant: () => this.actions.openConfigAssistant()
     });
     const viewport = h2("div", { class: "af-viewport" }, this.sessionsBody, this.tasksPane.el, this.configPane.el);
     this.toast = h2("div", { class: "af-toast" });
@@ -12429,6 +12627,7 @@ termHost.className = "af-term-host";
 var modalHost = document.createElement("div");
 modalHost.className = "af-modal-host";
 var modal = null;
+var configAssistant = null;
 var installAffordance = new InstallAffordance();
 var splitView = new SplitView(termHost, {
   onStatus: (s) => store.set({ termStatus: s }),
@@ -12484,6 +12683,7 @@ function rerender() {
     }
     disposeSplit();
     closeModal();
+    closeConfigAssistant();
     renderLogin(root, state, actions);
     return;
   }
@@ -12544,6 +12744,7 @@ async function fetchRegisteredProjects(tok) {
 function disconnect() {
   stopStream();
   closeModal();
+  closeConfigAssistant();
   token = null;
   clearToken();
   store.set({
@@ -12653,10 +12854,32 @@ function closeModal() {
     modal = null;
   }
 }
+function closeConfigAssistant() {
+  if (configAssistant) {
+    configAssistant.close();
+    configAssistant = null;
+  }
+}
 function openModal(m) {
   closeModal();
+  closeConfigAssistant();
   modal = m;
   modalHost.replaceChildren(m.el);
+}
+function doOpenConfigAssistant() {
+  const tok = token;
+  if (tok === null) {
+    return;
+  }
+  closeModal();
+  closeConfigAssistant();
+  configAssistant = openConfigAssistant({
+    token: tok,
+    mountHost: modalHost,
+    onClosed: () => {
+      configAssistant = null;
+    }
+  });
 }
 function newSession() {
   const projects = pickerProjects(store.get().sessions, store.get().tasks, store.get().registeredProjects);
@@ -13160,6 +13383,7 @@ var actions = {
   reorderTab: reorderSessionTab,
   switchView,
   setConfigValue: applyConfigValue,
+  openConfigAssistant: doOpenConfigAssistant,
   switchProject,
   setStatusFilter,
   resetStatusFilter,

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "4274b237d63f";
+const VERSION = "85baa8824b39";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -22,12 +22,14 @@ import {
   listPrograms,
   listProjects,
   probeWebTab,
+  reapConfigAssistant,
   registerProject,
   removeTask,
   renameTab,
   reorderTab,
   restoreSession,
   resumeFromLimit,
+  spawnConfigAssistant,
   suggestSessionName,
   triggerTask,
   updateTask,
@@ -753,4 +755,85 @@ test("listProjects tolerates a null/absent projects array", async () => {
     json: async () => ({ data: { projects: null }, error: null }),
   });
   assert.deepEqual(await listProjects("tok"), [], "an empty registry is an empty list, not a throw");
+});
+
+// --- config assistant (#2467) ----------------------------------------------
+
+test("spawnConfigAssistant POSTs /v1/config-assistant with an empty body and the bearer token", async () => {
+  const cap = stubFetch();
+  await spawnConfigAssistant("tok-1");
+  assert.equal(cap.url, "/v1/config-assistant", "posts to the config-assistant route");
+  assert.deepEqual(cap.body, {}, "the body is empty — the daemon builds the whole request server-side");
+  assert.equal(cap.auth, "Bearer tok-1");
+});
+
+test("spawnConfigAssistant surfaces a 409 as a retryable ApiError (create raced a reap)", async () => {
+  stubFetchResponse({
+    ok: false,
+    status: 409,
+    statusText: "Conflict",
+    json: async () => ({ data: null, error: { message: "config assistant creation was aborted; retry" } }),
+  });
+  const err = await spawnConfigAssistant("tok").then(
+    () => null,
+    (e: unknown) => e,
+  );
+  assert.ok(err instanceof ApiError);
+  assert.equal(err.status, 409, "the pane retries the POST on a 409, so the status must survive");
+});
+
+test("spawnConfigAssistant surfaces a 503 (assistant absent from this build)", async () => {
+  stubFetchResponse({
+    ok: false,
+    status: 503,
+    statusText: "Service Unavailable",
+    json: async () => ({ data: null, error: { message: "config assistant is not available in this build" } }),
+  });
+  const err = await spawnConfigAssistant("tok").then(
+    () => null,
+    (e: unknown) => e,
+  );
+  assert.ok(err instanceof ApiError);
+  assert.equal(err.status, 503);
+});
+
+test("reapConfigAssistant issues a DELETE to /v1/config-assistant with the bearer token", async () => {
+  let method = "";
+  let url = "";
+  let auth: string | undefined;
+  (globalThis as { fetch: unknown }).fetch = async (u: string, init: RequestInit): Promise<Response> => {
+    method = String(init.method);
+    url = u;
+    auth = (init.headers as Record<string, string>).Authorization;
+    return { ok: true, status: 200, statusText: "OK", json: async () => ({ data: {}, error: null }) } as unknown as Response;
+  };
+  await reapConfigAssistant("tok-2");
+  assert.equal(method, "DELETE");
+  assert.equal(url, "/v1/config-assistant");
+  assert.equal(auth, "Bearer tok-2");
+});
+
+test("reapConfigAssistant throws ApiError on a non-2xx so a caller that cares can see it", async () => {
+  stubFetchResponse({
+    ok: false,
+    status: 500,
+    statusText: "Internal Server Error",
+    json: async () => ({ data: null, error: { message: "reap failed" } }),
+  });
+  const err = await reapConfigAssistant("tok").then(
+    () => null,
+    (e: unknown) => e,
+  );
+  assert.ok(err instanceof ApiError);
+  assert.equal(err.status, 500);
+});
+
+test("reapConfigAssistant omits the Authorization header for a tokenless client", async () => {
+  let hadAuth = true;
+  (globalThis as { fetch: unknown }).fetch = async (_u: string, init: RequestInit): Promise<Response> => {
+    hadAuth = "Authorization" in (init.headers as Record<string, string>);
+    return { ok: true, status: 200, statusText: "OK", json: async () => ({ data: {}, error: null }) } as unknown as Response;
+  };
+  await reapConfigAssistant("");
+  assert.equal(hadAuth, false, 'a tokenless ("") client sends no Authorization header (#1696)');
 });

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -847,3 +847,66 @@ export async function getConfig(token: string): Promise<ConfigResponse> {
 export async function setConfigValue(key: string, value: string, token: string): Promise<ConfigSetResponse> {
   return af<ConfigSetResponse>("SetConfigValue", { key, value }, token);
 }
+
+// --- config assistant (#2467) ----------------------------------------------
+//
+// The web analogue of the TUI's config-agent takeover: POST spawns-or-reuses a
+// single shared assistant (a bare tmux session the daemon owns), the caller streams
+// it over /v1/config-assistant/stream (terminal.ts configAssistantStreamEndpoint),
+// and DELETE reaps it when the pane closes. The daemon builds the whole spawn request
+// server-side, so these carry no body that becomes a command.
+
+/** The POST /v1/config-assistant reply. session_name is informational (the stream
+ *  route resolves the assistant itself and accepts no name), so nothing needs it. */
+export interface ConfigAssistantResponse {
+  session_name?: string;
+}
+
+/**
+ * Spawns-or-reuses the shared config assistant (POST /v1/config-assistant). Blocks
+ * through the daemon's cold-start readiness wait (~60s) on a first spawn. The route
+ * is a plain POST (not the WS upgrade) precisely so this wait is a normal request,
+ * not a hung handshake.
+ *
+ * Throws ApiError carrying the HTTP status so the caller can honor the contract:
+ *   409 — the create raced a concurrent reap; RETRYABLE, POST again.
+ *   503 — the assistant is unavailable in this daemon build.
+ *   0   — the daemon was unreachable.
+ */
+export function spawnConfigAssistant(token: string): Promise<ConfigAssistantResponse> {
+  return af<ConfigAssistantResponse>("config-assistant", {}, token);
+}
+
+/**
+ * Reaps the shared config assistant (DELETE /v1/config-assistant) — the pane-close
+ * signal. Best-effort by design: the daemon's last-detach grace reaper is the
+ * backstop, and reaping an already-gone assistant is a no-op success, so a caller on
+ * the close path may ignore a failure here. Hand-rolled because af() is POST-only and
+ * the client has no other DELETE route; it throws ApiError like af() for callers that
+ * do care.
+ */
+export async function reapConfigAssistant(token: string): Promise<void> {
+  const headers: Record<string, string> = {};
+  if (token !== "") {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  let resp: Response;
+  try {
+    resp = await fetch("/v1/config-assistant", { method: "DELETE", headers });
+  } catch (e) {
+    throw new ApiError(0, `cannot reach the daemon: ${errorText(e)}`);
+  }
+  if (!resp.ok) {
+    let env: Envelope<unknown> | null = null;
+    try {
+      env = (await resp.json()) as Envelope<unknown>;
+    } catch {
+      // Non-JSON error body: fall through to the status line.
+    }
+    throw new ApiError(
+      resp.status,
+      envelopeErrorText(env?.error, `${resp.status} ${resp.statusText}`.trim()),
+      envelopeErrorCode(env?.error),
+    );
+  }
+}

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -34,6 +34,10 @@ import type { ConfigEntry } from "./types.js";
  *  outcome it is handed back. */
 export interface ConfigActions {
   save: (key: string, value: string) => void;
+  /** Opens the conversational config assistant (#2467) — the web analogue of the
+   *  TUI's config-agent takeover. The shell owns the token and the modal host, so
+   *  the pane only reports the intent. */
+  openAssistant: () => void;
 }
 
 /** The outcome of the last save, as the shell learned it from the daemon. */
@@ -213,6 +217,16 @@ export class ConfigPane {
       // guessing which config.toml this is.
       head.append(h("span", { class: "af-config-path" }, this.path));
     }
+    // The conversational assistant (#2467): a chat that helps configure the service,
+    // the web counterpart of the TUI's config-agent takeover. Opening it is the
+    // shell's job (it owns the token + modal host), so the button only reports intent.
+    const assistantBtn = h(
+      "button",
+      { type: "button", class: "af-ghost af-config-assistant-btn" },
+      "Configure with assistant",
+    );
+    assistantBtn.addEventListener("click", () => this.actions.openAssistant());
+    head.append(assistantBtn);
 
     const sections: HTMLElement[] = [];
     for (const { tier, name } of tiersInOrder(this.entries)) {

--- a/web/src/config_assistant.ts
+++ b/web/src/config_assistant.ts
@@ -1,0 +1,201 @@
+// The web config-assistant chat pane (#2467, PR2) — the browser counterpart of the
+// TUI's config-agent takeover (app/config_agent.go). It opens an overlay hosting a
+// live xterm bound to the daemon-owned config assistant, and drives the transport
+// contract PR1 settled:
+//
+//   POST   /v1/config-assistant   spawn-or-reuse   → 200 stream · 409 retry · 503 absent
+//   GET    /v1/config-assistant/stream             the PTY WebSocket (AttachTerminal)
+//   DELETE /v1/config-assistant   reap on close    (best-effort; a grace reaper backs it)
+//
+// It owns the whole lifecycle: spawn (with the 409 retry the contract calls for),
+// attach the terminal, and on close dispose the terminal and reap. CSP-safe like the
+// rest of the client (createElement + addEventListener via h(), no innerHTML).
+
+import { ApiError, reapConfigAssistant, spawnConfigAssistant } from "./api.js";
+import { h } from "./modals.js";
+import { configAssistantStreamEndpoint } from "./stream_endpoint.js";
+import { AttachTerminal, type TerminalStatus } from "./terminal.js";
+
+/** A live config-assistant pane. close() tears the terminal down and reaps. */
+export interface ConfigAssistantController {
+  close(): void;
+}
+
+/** How many times a 409 (create raced a concurrent reap) is retried before giving
+ *  up. A DELETE that raced our POST is done by the next attempt, so a fresh POST
+ *  spawns anew — a few tries with brief spacing covers a burst without spinning. */
+const SPAWN_RETRY_LIMIT = 4;
+const SPAWN_RETRY_DELAY_MS = 250;
+
+/** Sentinel thrown to unwind the spawn flow when the pane was closed mid-spawn, so a
+ *  late success never attaches a terminal into a removed overlay. */
+const CLOSED = Symbol("config-assistant-closed");
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+/**
+ * Opens the config-assistant chat overlay, mounting it into `mountHost` (the shell's
+ * persistent modal host). Returns a controller whose close() the shell calls to tear
+ * it down; the overlay also self-closes on Escape, a backdrop click, or the ×.
+ *
+ * `token` is the bearer credential for the spawn/stream/reap. `onClosed` fires once,
+ * after teardown, so the shell can drop its handle (one assistant pane at a time).
+ */
+export function openConfigAssistant(opts: {
+  token: string;
+  mountHost: HTMLElement;
+  onClosed?: () => void;
+}): ConfigAssistantController {
+  const { token, mountHost, onClosed } = opts;
+
+  let closed = false;
+  let term: AttachTerminal | null = null;
+
+  // --- overlay DOM ----------------------------------------------------------
+  const status = h("span", { class: "af-assistant-status" }, "Starting the assistant…");
+  status.setAttribute("role", "status");
+
+  const closeBtn = h("button", { type: "button", class: "af-ghost af-assistant-close" }, "×");
+  closeBtn.setAttribute("aria-label", "Close the config assistant");
+
+  const termHost = h("div", { class: "af-assistant-term" });
+  const errorLine = h("p", { class: "af-modal-error af-assistant-error", role: "alert" });
+  errorLine.hidden = true;
+
+  const card = h(
+    "div",
+    { class: "af-modal-card af-assistant-card", role: "dialog" },
+    h(
+      "div",
+      { class: "af-assistant-head" },
+      h("h2", { class: "af-modal-title" }, "Configure with assistant"),
+      status,
+      closeBtn,
+    ),
+    termHost,
+    errorLine,
+  );
+  card.setAttribute("aria-modal", "true");
+  card.setAttribute("aria-label", "Config assistant");
+  // A click inside the card must not bubble to the backdrop's close handler.
+  card.addEventListener("click", (e) => e.stopPropagation());
+
+  const backdrop = h("div", { class: "af-modal-backdrop" }, card);
+  backdrop.addEventListener("click", () => close());
+
+  const onKeydown = (e: KeyboardEvent): void => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      close();
+    }
+  };
+  document.addEventListener("keydown", onKeydown);
+
+  mountHost.append(backdrop);
+
+  // --- status + error surface ----------------------------------------------
+  function setStatus(text: string): void {
+    status.textContent = text;
+  }
+  function setError(msg: string): void {
+    errorLine.textContent = msg;
+    errorLine.hidden = false;
+  }
+
+  function terminalStatusText(s: TerminalStatus): string {
+    switch (s) {
+      case "connecting":
+        return "Connecting…";
+      case "open":
+        return "Connected";
+      case "reconnecting":
+        return "Reconnecting…";
+      case "exited":
+        return "Assistant ended.";
+    }
+  }
+
+  // --- lifecycle ------------------------------------------------------------
+  function close(): void {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    document.removeEventListener("keydown", onKeydown);
+    if (term) {
+      term.dispose();
+      term = null;
+    }
+    backdrop.remove();
+    // Reap the shared assistant. Best-effort: the daemon's last-detach grace reaper
+    // is the backstop, and reaping an already-gone assistant is a no-op, so a failure
+    // here (including an unreachable daemon) is not worth surfacing on a close.
+    void reapConfigAssistant(token).catch(() => {});
+    onClosed?.();
+  }
+
+  // --- spawn (with the 409 retry the contract calls for) --------------------
+  async function spawn(): Promise<void> {
+    for (let attempt = 1; ; attempt++) {
+      try {
+        await spawnConfigAssistant(token);
+        return;
+      } catch (e) {
+        if (closed) {
+          throw CLOSED;
+        }
+        const httpStatus = e instanceof ApiError ? e.status : -1;
+        // 409 = the create raced a concurrent reap; retryable — a fresh POST spawns
+        // anew once the delete has landed.
+        if (httpStatus === 409 && attempt < SPAWN_RETRY_LIMIT) {
+          await delay(SPAWN_RETRY_DELAY_MS);
+          if (closed) {
+            throw CLOSED;
+          }
+          continue;
+        }
+        throw e;
+      }
+    }
+  }
+
+  function attach(): void {
+    if (closed) {
+      return;
+    }
+    term = new AttachTerminal(termHost, token, configAssistantStreamEndpoint(), {
+      onStatus: (s) => {
+        if (!closed) {
+          setStatus(terminalStatusText(s));
+        }
+      },
+      // The assistant is a single pane; there is no nav/attach mode to keep in sync
+      // the way a session split does, so focus changes need no handling here.
+      onFocusChange: () => {},
+    });
+    term.focus();
+  }
+
+  void spawn()
+    .then(() => attach())
+    .catch((e) => {
+      if (e === CLOSED || closed) {
+        return; // the user closed the pane while spawning; nothing to show
+      }
+      const httpStatus = e instanceof ApiError ? e.status : -1;
+      if (httpStatus === 503) {
+        setStatus("Unavailable");
+        setError("The config assistant is not available in this daemon build.");
+      } else if (httpStatus === 0) {
+        setStatus("Offline");
+        setError("Could not reach the daemon. Close and try again.");
+      } else {
+        setStatus("Failed to start");
+        setError(e instanceof Error ? e.message : "Could not start the config assistant.");
+      }
+    });
+
+  return { close };
+}

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -49,6 +49,7 @@ import {
   updateTask,
 } from "./api.js";
 import { createKeyedQueue } from "./config.js";
+import { type ConfigAssistantController, openConfigAssistant } from "./config_assistant.js";
 import { EventStream, type EventStreamStatus } from "./events.js";
 import {
   addProjectModal,
@@ -196,6 +197,10 @@ termHost.className = "af-term-host";
 const modalHost = document.createElement("div");
 modalHost.className = "af-modal-host";
 let modal: ModalHandle | null = null;
+// The open config-assistant chat overlay (#2467), if any. Tracked alongside `modal`
+// so any overlay-open or teardown path reaps it — an orphaned controller would keep a
+// hidden terminal streaming and never fire its close-time DELETE.
+let configAssistant: ConfigAssistantController | null = null;
 
 // The appbar's "Install app" affordance (feat: PWA). Built ONCE here, for the same
 // reason termHost and modalHost are: rerender() drops `shell` on logout and builds a
@@ -292,6 +297,7 @@ function rerender(): void {
     }
     disposeSplit();
     closeModal();
+    closeConfigAssistant();
     renderLogin(root, state, actions);
     return;
   }
@@ -387,6 +393,7 @@ async function fetchRegisteredProjects(tok: string): Promise<string[]> {
 function disconnect(): void {
   stopStream();
   closeModal();
+  closeConfigAssistant();
   token = null;
   clearToken();
   store.set({
@@ -589,11 +596,42 @@ function closeModal(): void {
   }
 }
 
-/** Mounts a fresh modal, replacing any currently open one. */
+/** Closes the open config-assistant overlay, if any: disposes its terminal and reaps
+ *  the assistant. Idempotent — the controller's own close() latches. */
+function closeConfigAssistant(): void {
+  if (configAssistant) {
+    configAssistant.close();
+    configAssistant = null;
+  }
+}
+
+/** Mounts a fresh modal, replacing any currently open overlay (a form modal OR the
+ *  config-assistant chat) — one overlay at a time, and the assistant is torn down
+ *  (terminal disposed, session reaped) rather than left streaming behind the modal. */
 function openModal(m: ModalHandle): void {
   closeModal();
+  closeConfigAssistant();
   modal = m;
   modalHost.replaceChildren(m.el);
+}
+
+/** Opens the conversational config assistant (#2467): spawn-or-reuse, stream into a
+ *  chat overlay, reap on close. Needs a token (a tokenless "" client is authorized —
+ *  only a null token, "not authorized yet", is refused). One at a time. */
+function doOpenConfigAssistant(): void {
+  const tok = token;
+  if (tok === null) {
+    return;
+  }
+  closeModal();
+  closeConfigAssistant();
+  configAssistant = openConfigAssistant({
+    token: tok,
+    mountHost: modalHost,
+    onClosed: () => {
+      configAssistant = null;
+    },
+  });
 }
 
 /** Opens the new-session modal, its picker seeded from the live projects. Submit
@@ -1504,6 +1542,7 @@ const actions = {
   reorderTab: reorderSessionTab,
   switchView,
   setConfigValue: applyConfigValue,
+  openConfigAssistant: doOpenConfigAssistant,
   switchProject,
   setStatusFilter,
   resetStatusFilter,

--- a/web/src/split.ts
+++ b/web/src/split.ts
@@ -63,6 +63,7 @@ import {
   webProxyPath,
 } from "./tabaddr.js";
 import { tabIcon, tabLabel } from "./tablabel.js";
+import { sessionStreamEndpoint } from "./stream_endpoint.js";
 import { AttachTerminal, type TerminalStatus } from "./terminal.js";
 import { currentXtermTheme } from "./theme.js";
 import { TabKind } from "./types.js";
@@ -695,10 +696,15 @@ export class SplitView {
         // for an id-less tab, and sending that as ?tab_id= is an unknown id the
         // daemon 404s — breaking a legacy tab that attaches fine by ordinal (#1779).
         // "" is the honest "no id", which makes AttachTerminal fall back to ?tab=.
-        pane.term = new AttachTerminal(pane.host, this.sessionId, this.token, realId, leaf.tab, {
-          onStatus: (s) => this.onPaneStatus(leaf.id, s),
-          onFocusChange: (f) => this.onPaneFocus(leaf.id, f),
-        });
+        pane.term = new AttachTerminal(
+          pane.host,
+          this.token,
+          sessionStreamEndpoint(this.sessionId, realId, leaf.tab),
+          {
+            onStatus: (s) => this.onPaneStatus(leaf.id, s),
+            onFocusChange: (f) => this.onPaneFocus(leaf.id, f),
+          },
+        );
       } else if (moved) {
         // The same tab, merely at a new ordinal, streamed by ?tab_id=: the terminal's
         // captured ordinal is inert (terminal.ts sends tab_id OR tab, never both), so

--- a/web/src/stream_endpoint.test.ts
+++ b/web/src/stream_endpoint.test.ts
@@ -1,0 +1,82 @@
+// Endpoint URL shapes (#2467). The load-bearing invariant is that
+// sessionStreamEndpoint produces the EXACT URL AttachTerminal built inline before the
+// endpoint seam existed — the refactor that let the config assistant reuse the
+// terminal must not have changed a single session-stream request. These pin the wire
+// bytes for both endpoints without importing xterm (stream_endpoint.ts is pure).
+
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import { configAssistantStreamEndpoint, sessionStreamEndpoint, wsScheme } from "./stream_endpoint.js";
+
+// stream_endpoint reads window.location for the scheme and host. Node has no window,
+// so stub a minimal one and restore it after each test.
+function stubWindow(protocol: string, host: string): void {
+  (globalThis as { window?: unknown }).window = { location: { protocol, host } };
+}
+
+afterEach(() => {
+  delete (globalThis as { window?: unknown }).window;
+});
+
+test("sessionStreamEndpoint: the agent tab (tab 0, no id) carries only the token — byte-identical to the pre-seam URL", () => {
+  stubWindow("http:", "localhost:8080");
+  const ep = sessionStreamEndpoint("sess-1", "", 0);
+  assert.equal(ep.url("T0KEN", null), "ws://localhost:8080/v1/sessions/sess-1/stream?access_token=T0KEN");
+  // Tab 0 is an agent composer (Shift+Enter → LF).
+  assert.equal(ep.composerNewline, true);
+});
+
+test("sessionStreamEndpoint: a stable tab id rides ?tab_id=, and wins over an ordinal", () => {
+  stubWindow("http:", "localhost:8080");
+  const ep = sessionStreamEndpoint("sess-1", "tab-abc", 3);
+  assert.equal(
+    ep.url("T", null),
+    "ws://localhost:8080/v1/sessions/sess-1/stream?access_token=T&tab_id=tab-abc",
+  );
+  // A non-agent tab is NOT a composer.
+  assert.equal(ep.composerNewline, false);
+});
+
+test("sessionStreamEndpoint: a legacy tab with no id falls back to the ordinal ?tab=", () => {
+  stubWindow("http:", "localhost:8080");
+  const ep = sessionStreamEndpoint("sess-1", "", 2);
+  assert.equal(ep.url("T", null), "ws://localhost:8080/v1/sessions/sess-1/stream?access_token=T&tab=2");
+});
+
+test("sessionStreamEndpoint: a reconnect appends ?since= (the replay cursor), last", () => {
+  stubWindow("http:", "localhost:8080");
+  const ep = sessionStreamEndpoint("sess-1", "tab-abc", 1);
+  assert.equal(
+    ep.url("T", 4096n),
+    "ws://localhost:8080/v1/sessions/sess-1/stream?access_token=T&tab_id=tab-abc&since=4096",
+  );
+});
+
+test("sessionStreamEndpoint: the session id is URL-encoded", () => {
+  stubWindow("http:", "localhost:8080");
+  const ep = sessionStreamEndpoint("a/b c", "", 0);
+  assert.equal(ep.url("T", null), "ws://localhost:8080/v1/sessions/a%2Fb%20c/stream?access_token=T");
+});
+
+test("wsScheme / endpoints: an https page yields wss", () => {
+  stubWindow("https:", "af.example.com");
+  assert.equal(wsScheme(), "wss:");
+  const ep = sessionStreamEndpoint("s", "", 0);
+  assert.equal(ep.url("T", null), "wss://af.example.com/v1/sessions/s/stream?access_token=T");
+});
+
+test("configAssistantStreamEndpoint: names no session, carries only the token, is a composer", () => {
+  stubWindow("http:", "localhost:8080");
+  const ep = configAssistantStreamEndpoint();
+  assert.equal(ep.url("T", null), "ws://localhost:8080/v1/config-assistant/stream?access_token=T");
+  assert.equal(ep.composerNewline, true);
+});
+
+test("configAssistantStreamEndpoint: a reconnect appends ?since= but never a tab param", () => {
+  stubWindow("http:", "localhost:8080");
+  const ep = configAssistantStreamEndpoint();
+  const url = ep.url("T", 10n);
+  assert.equal(url, "ws://localhost:8080/v1/config-assistant/stream?access_token=T&since=10");
+  assert.ok(!url.includes("tab"), "config-assistant stream must not carry a tab selector");
+});

--- a/web/src/stream_endpoint.ts
+++ b/web/src/stream_endpoint.ts
@@ -1,0 +1,78 @@
+// Stream endpoints (#2467): WHICH daemon PTY an AttachTerminal renders, decoupled
+// from HOW it renders it. Every stream speaks the same broker protocol
+// (servePTYStream: OpHello/OpPTYOut/resize/exit, ?since replay) — only the URL and
+// the tab-selection params differ. Keeping the address here (a pure module, no xterm)
+// lets the terminal own the protocol, lets split.ts / config_assistant.ts pick the
+// address, and makes the URL shapes unit-testable without importing xterm's CSS.
+
+/** ws: matching the page origin — the daemon serves the SPA over plain HTTP, so this
+ *  is normally ws:. A reverse proxy serving the page over https: makes it wss: so the
+ *  stream rides the same proxied transport. */
+export function wsScheme(): string {
+  return window.location.protocol === "https:" ? "wss:" : "ws:";
+}
+
+/**
+ * A stream endpoint builds the WS URL for a (re)connect and declares whether the
+ * stream is an agent composer. The terminal owns the reconnect/replay/resize
+ * machinery; the endpoint owns only the address, which is what lets one terminal
+ * client render a session PTY and the bare-session config assistant with no fork.
+ */
+export interface StreamEndpoint {
+  /** Builds the WS URL. `since` is null on the first connect (live tail + a
+   *  fresh-screen repaint) and the absolute replay cursor on reconnects. */
+  url(token: string, since: bigint | null): string;
+  /** Whether this is an agent composer — session tab 0, or the config assistant —
+   *  which gets the Shift+Enter→LF newline (clipboard.ts). A shell/process tab does
+   *  not. */
+  composerNewline: boolean;
+}
+
+/**
+ * sessionStreamEndpoint addresses a session's per-tab PTY. It reproduces EXACTLY the
+ * URL AttachTerminal built inline before the endpoint seam: ?access_token=, then the
+ * stable ?tab_id= (#1738) or the legacy ordinal ?tab= for a tab with no id, then
+ * ?since= on a reconnect — same params in the same order, so the wire request is
+ * byte-identical and the session stream is unchanged.
+ */
+export function sessionStreamEndpoint(sessionId: string, tabId: string, tab: number): StreamEndpoint {
+  return {
+    composerNewline: tab === 0,
+    url(token, since) {
+      const base = `${wsScheme()}//${window.location.host}/v1/sessions/${encodeURIComponent(sessionId)}/stream`;
+      const params = new URLSearchParams();
+      params.set("access_token", token);
+      if (tabId !== "") {
+        params.set("tab_id", tabId);
+      } else if (tab > 0) {
+        params.set("tab", String(tab));
+      }
+      if (since !== null) {
+        params.set("since", since.toString());
+      }
+      return `${base}?${params.toString()}`;
+    },
+  };
+}
+
+/**
+ * configAssistantStreamEndpoint addresses the daemon-owned config assistant (#2467).
+ * The path names no session — the daemon resolves the single shared assistant — so it
+ * carries only ?access_token= (and ?since= on a reconnect), never a tab selector. It
+ * is an agent composer. The route is reached only after a POST /v1/config-assistant
+ * has spawned-or-reused the assistant (api.ts), so the stream finds it live.
+ */
+export function configAssistantStreamEndpoint(): StreamEndpoint {
+  return {
+    composerNewline: true,
+    url(token, since) {
+      const base = `${wsScheme()}//${window.location.host}/v1/config-assistant/stream`;
+      const params = new URLSearchParams();
+      params.set("access_token", token);
+      if (since !== null) {
+        params.set("since", since.toString());
+      }
+      return `${base}?${params.toString()}`;
+    },
+  };
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2844,6 +2844,68 @@ body {
   padding: 0.2rem 0.5rem;
 }
 
+/* The "Configure with assistant" button in the config header (#2467). Sits at the
+ * right of the header; when the config path is present it follows it, otherwise the
+ * auto margin carries it to the edge on its own. */
+.af-config-assistant-btn {
+  margin-left: auto;
+  font-size: var(--af-fs-xs);
+  padding: 0.2rem 0.6rem;
+  white-space: nowrap;
+}
+
+/* The config-assistant chat overlay (#2467): a large modal card whose body is a live
+ * xterm bound to the daemon-owned assistant. Reuses the modal backdrop; the card is
+ * roomier than a form modal and lays out head / terminal / error as a column. */
+.af-assistant-card {
+  max-width: 60rem;
+  width: min(92vw, 60rem);
+  height: 80vh;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+
+.af-assistant-head {
+  display: flex;
+  align-items: center;
+  gap: var(--af-sp-3);
+  padding: var(--af-sp-3) var(--af-sp-4);
+  border-bottom: 1px solid var(--af-border);
+  background: var(--af-bg-surface);
+}
+
+.af-assistant-head .af-modal-title {
+  margin: 0;
+  flex: 0 0 auto;
+}
+
+.af-assistant-status {
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
+}
+
+.af-assistant-close {
+  margin-left: auto;
+  font-size: var(--af-fs-lg);
+  line-height: 1;
+  padding: 0 var(--af-sp-2);
+}
+
+.af-assistant-term {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+  padding: var(--af-sp-2);
+}
+
+.af-assistant-error {
+  margin: 0;
+  padding: var(--af-sp-2) var(--af-sp-4) var(--af-sp-3);
+}
+
 /* One key. The label column is fluid and the control column fixed, so a long
  * purpose line wraps under its key instead of squeezing the field. */
 .af-config-row {

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -50,6 +50,7 @@ import {
   viewportAnchorLine,
   viewportMarkerOffset,
 } from "./terminal-geometry.js";
+import type { StreamEndpoint } from "./stream_endpoint.js";
 import { currentXtermTheme } from "./theme.js";
 
 /** The attach terminal's connection state, surfaced for a small status line. */
@@ -79,22 +80,16 @@ interface PendingViewportAnchor {
   atBottom: boolean;
 }
 
-/** ws: matching the page origin — the daemon serves the SPA over plain HTTP, so
- *  this is normally ws:. If a reverse proxy fronts the daemon and serves the page
- *  over https:, it becomes wss: so the stream rides the same proxied transport. */
-function wsScheme(): string {
-  return window.location.protocol === "https:" ? "wss:" : "ws:";
-}
 
 /**
  * One live attach terminal bound to a container element. Construct it with the
- * bearer token, a session id, and a tab index, and it owns everything from there:
- * the xterm instance, the WS to `/v1/sessions/{id}/stream?tab=<idx>`, the
+ * bearer token and a StreamEndpoint (which daemon PTY to render), and it owns
+ * everything from there: the xterm instance, the WS to the endpoint's URL, the
  * fit/resize wiring, and a self-healing reconnect loop. Call dispose() to tear it
- * all down (on selection/tab change or logout). One instance per attached
- * (session, tab) — selecting a different session OR switching tabs disposes this
- * and builds a fresh one, so scrollback and the replay cursor (which are per-tab
- * on the broker) never bleed across tabs (#1592 Phase 5 PR7).
+ * all down (on selection/tab change, logout, or closing the config-assistant pane).
+ * One instance per attached endpoint — selecting a different session OR switching
+ * tabs disposes this and builds a fresh one, so scrollback and the replay cursor
+ * (which are per-tab on the broker) never bleed across tabs (#1592 Phase 5 PR7).
  */
 export class AttachTerminal {
   private readonly term: Terminal;
@@ -179,10 +174,8 @@ export class AttachTerminal {
 
   constructor(
     private readonly container: HTMLElement,
-    private readonly sessionId: string,
     private readonly token: string,
-    private readonly tabId: string,
-    private readonly tab: number,
+    private readonly endpoint: StreamEndpoint,
     private readonly cb: TerminalCallbacks,
   ) {
     this.term = new Terminal({
@@ -232,7 +225,7 @@ export class AttachTerminal {
     // suppresses xterm's own handling.
     this.term.attachCustomKeyEventHandler((ev) =>
       handleClipboardKeydown(ev, {
-        composerNewline: this.tab === 0,
+        composerNewline: this.endpoint.composerNewline,
         hasSelection: () => this.term.hasSelection(),
         getSelection: () => this.term.getSelection(),
         clearSelection: () => this.term.clearSelection(),
@@ -332,26 +325,13 @@ export class AttachTerminal {
     }
     this.cb.onStatus(this.everOpened ? "reconnecting" : "connecting");
     // Reconnects replay the gap from our cursor; the first connect omits ?since so
-    // the broker starts at the live tail and sends a one-shot screen repaint.
-    const base = `${wsScheme()}//${window.location.host}/v1/sessions/${encodeURIComponent(this.sessionId)}/stream`;
-    const params = new URLSearchParams();
-    params.set("access_token", this.token);
-    // Address the bound tab by its STABLE id (#1738) so a reorder/close server-side
-    // resolves to the right PTY — the daemon maps ?tab_id= to the tab's current
-    // ordinal. Fall back to the ordinal ?tab= for a legacy tab with no id (parseTab
-    // in daemon/ws_pty.go: empty/absent = 0 = the agent tab), keeping the agent-tab
-    // URL unchanged when neither is needed.
-    if (this.tabId !== "") {
-      params.set("tab_id", this.tabId);
-    } else if (this.tab > 0) {
-      params.set("tab", String(this.tab));
-    }
-    if (this.seeded) {
-      params.set("since", this.cursor.toString());
-    }
+    // the broker starts at the live tail and sends a one-shot screen repaint. The
+    // endpoint owns the URL shape (session tab vs the bare config assistant); the
+    // reconnect/replay/resize machinery below is identical for either.
+    const url = this.endpoint.url(this.token, this.seeded ? this.cursor : null);
     let ws: WebSocket;
     try {
-      ws = new WebSocket(`${base}?${params.toString()}`);
+      ws = new WebSocket(url);
     } catch {
       this.scheduleReconnect();
       return;

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -219,6 +219,11 @@ export interface Actions {
    *  in the browser: a second copy of the rules is how a UI accepts a value the
    *  loader later rejects at startup. */
   setConfigValue(key: string, value: string): void;
+  /** Opens the conversational config assistant (#2467): index.ts spawns-or-reuses
+   *  the daemon-owned assistant, streams it into a chat overlay, and reaps it on
+   *  close. The config pane only reports the intent; the shell owns the token and the
+   *  modal host. */
+  openConfigAssistant(): void;
   /** Renames the tab with the stable IDENTITY `id` (tabIdentity) to `name` (#1813):
    *  the commit of the bar's inline edit. Only offered for a RENAMEABLE tab (web /
    *  process — see isRenameableTab); index.ts resolves the identity to the tab's
@@ -968,6 +973,7 @@ export class AppShell {
     });
     this.configPane = new ConfigPane({
       save: (key: string, value: string) => this.actions.setConfigValue(key, value),
+      openAssistant: () => this.actions.openConfigAssistant(),
     });
     const viewport = h("div", { class: "af-viewport" }, this.sessionsBody, this.tasksPane.el, this.configPane.el);
 


### PR DESCRIPTION
## PR2 — web config-assistant chat pane (#2467)

The web counterpart of the TUI's config-agent takeover, built on PR1's transport (#2522, now merged). A **"Configure with assistant"** button in the config header opens a chat overlay that spawns-or-reuses the daemon-owned assistant, streams it, and reaps it on close — honoring the 200/409/404/503 contract PR1 settled.

Rebased onto master after #2522 landed; **web-only, no Go**. The committed `web/dist` bundle was **regenerated** via `make web-build` (not hand-merged) after resolving the source conflicts against the web PRs that landed alongside (#2456/#2470 project + name tests in `api.test.ts`, #2517 Escape handling in `terminal.ts`).

### Terminal reuse via an endpoint seam (the structural piece)
`AttachTerminal.connect()` inlined its WS path + `tab_id`/`tab`/`since` params, so a second stream had no seam. Rather than fork ~300 lines of reconnect/replay/resize/exit protocol (which would drift), I extracted a **pure `stream_endpoint.ts`** (no xterm, so it's node-testable): `StreamEndpoint` owns only the URL + whether the stream is an agent composer; the terminal owns the protocol, unchanged.
- `sessionStreamEndpoint` reproduces the pre-seam session URL **byte-identically** (same params, same order — pinned by `stream_endpoint.test.ts`), so the existing session stream is **provably untouched**.
- `configAssistantStreamEndpoint` names no session and carries no tab selector.
- `AttachTerminal(container, token, endpoint, cb)` — one call site (`split.ts`) updated.

### API (`api.ts`)
`spawnConfigAssistant` POSTs `/v1/config-assistant` with an **empty body** (the daemon builds the whole request server-side — no client-supplied program); `reapConfigAssistant` is a hand-rolled `DELETE` (the shared `af()` helper is POST-only). Both surface `ApiError.status` so the pane honors the contract.

### The pane (`config_assistant.ts`)
A modal overlay hosting a live `AttachTerminal`:
- **200** → attach the stream. **409** → retry the POST (create raced a reap; bounded). **503** → "unavailable in this build". **status 0** → "couldn't reach the daemon".
- **Close** (×, Escape, backdrop) → dispose the terminal + `DELETE` (best-effort; the grace reaper backs it). A close mid-spawn never attaches into a removed overlay and never leaks (a closed latch).
- **MsgExit** (assistant reaped/idle-ended) → "Assistant ended."
Wired `ConfigActions.openAssistant → Actions.openConfigAssistant → index.ts`, which owns the token + modal host and tears the overlay down on any other overlay-open, logout, or disconnect — no orphaned streaming terminal.

### Tests
`stream_endpoint.test.ts` pins the byte-identical session URLs (agent tab, tab_id-wins-over-ordinal, legacy ordinal, since-last, id-encoding, wss) and the config-assistant URL (no session, no tab param). `api.test.ts` adds spawn (empty body + bearer, 409/503) and reap (DELETE verb, bearer, non-2xx throws, tokenless omits header). **455 web tests pass; typecheck clean.**

### Sequencing
- **PR3 (next):** `make web-selftest-container` browser coverage — the live spawn→stream→reap round-trip and the 409-retry get exercised in a real browser there. This PR is unit-tested only until then; the existing selftest still passes (the button is present but not yet clicked by a selftest case).

### Gate (web layer)
`npm run typecheck`, `npm run test` (455 pass), `make web-build` (bundle regenerated); `go build ./...` clean (no Go delta). CI runs the full suite + web selftest on the PR.

Draft — for the claude-subagent gate; not self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
