### PR TITLE
docs: prompt for a Closes line in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,12 @@
 
 <!-- Brief description of the changes -->
 
+Closes #<issue>
+
+<!-- The issue this PR closes, so GitHub links and auto-closes it on merge. If
+this PR closes nothing, write "no issue" here rather than deleting the line — an
+explicit "no issue" is a decision; a missing line is silence. -->
+
 ## Test Plan
 
 - [ ] `go test ./...` passes


### PR DESCRIPTION
## Summary

The PR template prompted only for a summary and a test plan, so linking the issue a PR resolves relied on the author remembering. That is the gap that left #2531 open after #2540 fixed it — the fix shipped without a closing keyword, so the issue sat looking like outstanding work until it was closed by hand.

This adds a `Closes #<issue>` line to the template, with a note that a PR which genuinely closes nothing should write "no issue" rather than delete the line: an explicit "no issue" is a decision on the record; a missing line is silence.

Template only — no `pr.yml` warn step, deliberately. A CI check would fire on every docs, chore, revert, and dependency bump that legitimately closes nothing, buying a marginal amount of the same signal at the cost of noise on PRs that do not need it, and this repo's standing preference is to trust the author over adding a gate. The template line alone would have caught #2531; the warn step stays in reserve as the escalation if this ever recurs at volume.

**Closes:** no issue — this PR adds the convention itself (there is no issue tracking it), and #2531, the trigger, is already closed. Filling this in as "no issue" is the escape hatch the change introduces, used on its own PR.

## Test Plan

- [x] Template-only change to `.github/pull_request_template.md`; no code to build, lint, or test locally. PR CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
