### PR TITLE
fix(#2549): DeleteProject is all-or-nothing — archive before deregister

### DIFF
--- a/daemon/deleteproject.go
+++ b/daemon/deleteproject.go
@@ -12,6 +12,40 @@ import (
 	"github.com/sachiniyer/agent-factory/session"
 )
 
+// repoSessionTitlesLocked returns the titles of the repo's sessions the daemon still
+// tracks, across BOTH maps a session can live in — m.pendingCreates (a create that has
+// passed validation but not finished provisioning, so it is NOT yet in m.instances,
+// #2549) and m.instances (its live, non-archived rows). This exists because
+// m.instances is not the universe (the same class the #1892 ghostTaskRuns comment in
+// manager.go warns about, reached through a different door): a delete that walked only
+// m.instances would miss a still-provisioning create, deregister the project, and let
+// the create finish into a live orphan.
+//
+// inFlightOnly selects the ones a delete cannot archive YET — every pending create,
+// plus any m.instances row with an op in flight — which is what the up-front fail-closed
+// gate refuses on. With inFlightOnly false it returns every live-or-pending session,
+// which is the concurrent-create re-check before the deregister. The caller holds m.mu.
+func (m *Manager) repoSessionTitlesLocked(repoID string, inFlightOnly bool) []string {
+	var titles []string
+	// A pending create is always in flight (still provisioning), so it counts either way.
+	for key := range m.pendingCreates {
+		if rid, title := splitDaemonInstanceKey(key); rid == repoID {
+			titles = append(titles, title)
+		}
+	}
+	for key, inst := range m.instances {
+		rid, title := splitDaemonInstanceKey(key)
+		if rid != repoID || inst == nil || inst.GetLiveness() == session.LiveArchived {
+			continue
+		}
+		if inFlightOnly && inst.GetInFlightOp() == session.OpNone {
+			continue
+		}
+		titles = append(titles, title)
+	}
+	return titles
+}
+
 // deregisterRootAgents is the durable root_agents removal DeleteProject runs. A
 // package var so tests can force a persist failure in isolation (exercising the
 // #1740-review fatal-on-config-failure path) without disturbing the real config.
@@ -83,6 +117,23 @@ func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 	}
 	result := DeleteProjectResult{RepoID: repoID}
 
+	// FAIL CLOSED, before mutating ANY state, if a session for this repo is still being
+	// created (#2549). A create lives in m.pendingCreates through its slow provisioning
+	// and only joins m.instances at the end (manager_create.go), and ArchiveSession
+	// refuses a session with an in-flight op — so such a session can neither be seen by
+	// an m.instances snapshot nor archived. Rather than block the caller on an arbitrary
+	// clock (a git clone / image pull settles in minutes, not the seconds a bounded wait
+	// could afford), refuse immediately and name the session: the create settles on its
+	// own and a retry then removes the project cleanly. Because this runs before the
+	// durable removals below, "nothing was changed" is literally true.
+	m.mu.Lock()
+	starting := m.repoSessionTitlesLocked(repoID, true)
+	m.mu.Unlock()
+	if len(starting) > 0 {
+		sort.Strings(starting)
+		return result, fmt.Errorf("delete project %s: session(s) %v are still starting; nothing was changed — delete again once they are ready", repoID, starting)
+	}
+
 	// Durably drop the repo's root_agents opt-in FIRST, before mutating ANY state,
 	// and treat a failed write as FATAL to the whole delete (#1740 review): if this
 	// removal fails, a daemon restart would re-register the root and the project
@@ -96,20 +147,10 @@ func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 		log.InfoLog.Printf("delete project %s: removed %d root_agents opt-in(s): %v", repoID, len(removed), removed)
 	}
 
-	// Also drop the repo's durable #2355 registry record, if any (#2456) — the
-	// symmetric counterpart to RegisterProject. The registry is now a project source
-	// (buildProjectListFrom and the web switcher union read config.ListProjects), so a
-	// delete that left the record behind would re-list the project forever. Fatal for
-	// the same reason as root_agents: a surviving record reappears on the next list.
-	// req.RepoPath is the project's root (both the web and TUI send it); a project that
-	// was never registered is a false no-op. Recorded so the projects-changed publish
-	// fires even when no session was archived (a registered, sessionless project).
-	if deregistered, regErr := config.DeregisterProject(config.ExpandTilde(strings.TrimSpace(req.RepoPath))); regErr != nil {
-		return result, fmt.Errorf("delete project %s: could not remove its durable registry record — the project would reappear, so nothing was changed; retry: %w", repoID, regErr)
-	} else if deregistered {
-		result.Deregistered = true
-		log.InfoLog.Printf("delete project %s: removed its durable registry record", repoID)
-	}
+	// The repo's durable #2355 registry record is dropped LATER, only after every
+	// session it promised to archive is actually archived (#2549): deregistering here,
+	// before the archive, is what let a session still finishing its create survive as a
+	// live orphan in a repo no longer in the registry. See the archive loop below.
 
 	// The durable removal succeeded, so now apply the in-memory suppression that
 	// stops the ensure loop re-creating the always-on root (m.cfg is immutable
@@ -118,9 +159,11 @@ func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 	// failed write above never leaves a dangling suppression (#1740 review).
 	m.suppressRootAgent(repoID)
 
-	// Snapshot the repo's LIVE (non-archived) sessions under the lock, then act
-	// with the lock released — ArchiveSession/KillSession take their own
-	// per-session locks and would deadlock if called while holding m.mu.
+	// Archive/kill every live session for the repo BEFORE removing its durable identity,
+	// so no session outlives the project's registry entry (#2549). The phase-1 gate above
+	// already refused if any session was mid-create, so every live session here is settled
+	// and archivable. Acting with m.mu released — ArchiveSession/KillSession take their own
+	// per-session locks and would deadlock under it.
 	type target struct {
 		id       string
 		title    string
@@ -130,10 +173,7 @@ func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 	m.mu.Lock()
 	for key, inst := range m.instances {
 		rid, title := splitDaemonInstanceKey(key)
-		if rid != repoID || inst == nil {
-			continue
-		}
-		if inst.GetLiveness() == session.LiveArchived {
+		if rid != repoID || inst == nil || inst.GetLiveness() == session.LiveArchived {
 			continue
 		}
 		targets = append(targets, target{id: inst.ID, title: title, external: inst.IsExternalWorktree()})
@@ -192,11 +232,49 @@ func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 	}
 
 	if len(errs) > 0 {
-		// Partial: some sessions were busy or errored mid-teardown. The delete is
-		// idempotent, so re-running it finishes the rest. Report what did happen.
+		// A genuine teardown failure — including a session that raced into an in-flight op
+		// after the phase-1 gate and so refused to archive. The delete is idempotent, so a
+		// retry finishes the rest; the registry is NOT deregistered below, so no orphan is
+		// left behind.
 		return result, fmt.Errorf("delete project %s: archived %d, tore down %d, but %d session(s) could not be removed (retry to finish): %w",
 			repoID, len(result.Archived), len(result.Killed), len(errs), errors.Join(errs...))
 	}
+
+	// Concurrent-create guard (#2549): re-check under m.mu, immediately before the
+	// deregister, that no session appeared for the repo while the lock was released for the
+	// archive above. A create that BEGINS after the phase-1 gate — landing in
+	// m.pendingCreates, or completing into m.instances — would otherwise orphan the same
+	// way through a narrower window. If one appeared, abort WITHOUT deregistering: the
+	// sessions archived so far stay archived (idempotent), and a retry finishes once the
+	// new session settles. A create landing in the microseconds between this check and the
+	// DeregisterProject call below is the one remaining, deliberately documented window;
+	// closing it fully would mean holding m.mu across the registry file lock (an ABBA
+	// hazard) for a gap this narrow.
+	m.mu.Lock()
+	appeared := m.repoSessionTitlesLocked(repoID, false)
+	m.mu.Unlock()
+	if len(appeared) > 0 {
+		sort.Strings(appeared)
+		return result, fmt.Errorf("delete project %s: archived %d, tore down %d, but a session started for this project meanwhile (%v); the project was NOT removed — delete again to finish",
+			repoID, len(result.Archived), len(result.Killed), appeared)
+	}
+
+	// Every session for the repo is archived and none is starting — NOW drop the durable
+	// #2355 registry record (after the archive, #2549): the deregister must never land
+	// while a session survives, or the delete leaves a live orphan in a repo no longer in
+	// the registry. req.RepoPath is the project's root (both the web and TUI send it); a
+	// project that was never registered is a false no-op. Recorded so the projects-changed
+	// publish fires even when no session was archived (a registered, sessionless project).
+	if deregistered, regErr := config.DeregisterProject(config.ExpandTilde(strings.TrimSpace(req.RepoPath))); regErr != nil {
+		// SYMMETRIC to an archive failure, and NOT "nothing changed": the sessions are
+		// already archived here, so a retry re-archives nothing and finishes the deregister
+		// — at worst an empty-but-registered project, never a live orphan.
+		return result, fmt.Errorf("delete project %s: archived %d session(s) but could not remove its durable registry record — the project still lists; retry to finish, a retry re-archives nothing: %w", repoID, len(result.Archived), regErr)
+	} else if deregistered {
+		result.Deregistered = true
+		log.InfoLog.Printf("delete project %s: removed its durable registry record", repoID)
+	}
+
 	log.InfoLog.Printf("deleted project %s: archived %d session(s), tore down %d in-place session(s)", repoID, len(result.Archived), len(result.Killed))
 	return result, nil
 }

--- a/daemon/deleteproject_test.go
+++ b/daemon/deleteproject_test.go
@@ -106,6 +106,44 @@ func TestDeleteProject_UnknownProjectIsNoOp(t *testing.T) {
 	assert.Empty(t, result.Killed)
 }
 
+// TestDeleteProject_RefusesWhileASessionIsMidCreate is #2549: a session still
+// provisioning lives in m.pendingCreates, NOT m.instances (manager_create.go), so a
+// delete that walked only m.instances would MISS it, deregister the project, report
+// success, and let the create finish into a live orphan. DeleteProject instead FAILS
+// CLOSED before any mutation — it refuses, names the session, and changes NOTHING (the
+// durable registry record survives, so a retry once the create settles removes it).
+func TestDeleteProject_RefusesWhileASessionIsMidCreate(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	// Register the project so there is a durable record a buggy delete could orphan.
+	registered, err := config.RegisterProject(repoPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, registered.ID)
+
+	// Simulate a session still provisioning: present in pendingCreates, absent from
+	// m.instances — the exact window an m.instances snapshot misses (#2549).
+	manager.mu.Lock()
+	manager.pendingCreates[daemonInstanceKey(repoID, "starting")] = session.InstanceData{
+		ID:         session.NewInstanceID(),
+		Title:      "starting",
+		InFlightOp: session.OpCreating,
+	}
+	manager.mu.Unlock()
+
+	result, err := manager.DeleteProject(DeleteProjectRequest{RepoID: repoID, RepoPath: repoPath})
+	require.Error(t, err, "a delete must refuse while a session for the repo is mid-create")
+	assert.Contains(t, err.Error(), "still starting")
+	assert.Contains(t, err.Error(), "starting", "the refusal names the session")
+	assert.False(t, result.Deregistered)
+	assert.Empty(t, result.Archived)
+
+	// NOTHING changed (the P2-a property): the durable registry record survives.
+	projects, err := config.ListProjects()
+	require.NoError(t, err)
+	require.Len(t, projects, 1, "the refused delete left the project registered")
+	assert.Equal(t, registered.ID, projects[0].ID)
+}
+
 // TestDeleteProject_RemovesRootAgentsOptInAndSuppressesRespawn: when the repo has
 // a persisted root_agents opt-in, delete removes it from config on disk AND
 // suppresses the daemon from re-ensuring the always-on root for the rest of its

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -3761,6 +3761,82 @@ test("delete project (#1735, redesign PR2, Fix 2): deleting an archived-only-bou
   await expect(row(page, SESSION_A)).toBeVisible();
 });
 
+test("#2549: deleting a registered project whose session is still STARTING is REFUSED, not half-done — and converges on retry", REAL_FIXTURE, async () => {
+  test.setTimeout(90_000); // slow by design: the session stays mid-create ~8s, then a retry converges.
+  // The composed bug no unit test can see: a create lives in m.pendingCreates through its
+  // slow provisioning and only joins m.instances at the end, so a delete that snapshotted
+  // only m.instances MISSED it, deregistered the project, reported success, and let the
+  // create finish into a LIVE ORPHAN that kept the project in the switcher forever. The
+  // fix fails CLOSED — it refuses while a session is mid-create rather than half-delete.
+  // A "probe-create-slow" title makes the fixture agent stay in OpCreating (~8s), so the
+  // mid-create window is deterministic instead of a timing race.
+  const emptyRepo = process.env.AF_MOCK_REPO_EMPTY;
+  expect(emptyRepo, "the #2549 repro needs AF_MOCK_REPO_EMPTY (set by web-selftest-entry.sh)").toBeTruthy();
+
+  // Register a fresh empty project and switch to it (an earlier test may have
+  // registered/deleted mock-repo-empty already — re-adding mints a fresh identity).
+  await page.locator(".af-project-switch").click();
+  await projectItem(page, "mock-repo").click();
+  await page.locator(".af-project-switch").click();
+  const add = page.locator(".af-project-menu .af-project-add");
+  await expect(add).toBeVisible();
+  await add.click();
+  const addModal = page.locator(".af-modal-card");
+  await addModal.locator('input[aria-label="Repository path"]').fill(emptyRepo!);
+  await addModal.locator("button.af-primary").click();
+  await expect(addModal).toBeHidden();
+  await page.locator(".af-project-switch").click();
+  await projectItem(page, "mock-repo-empty").click();
+  await expect(page.locator(".af-project-switch-name")).toHaveText("mock-repo-empty");
+
+  // Create a session that STAYS mid-create for ~8s (the probe-create-slow fixture hook).
+  const slowTitle = `probe-create-slow-${Date.now().toString(36)}`;
+  await page.locator("button.af-rail-new").click();
+  const newModal = page.locator(".af-modal-card");
+  await expect(newModal).toBeVisible();
+  await newModal.locator('input[aria-label="Session title"]').fill(slowTitle);
+  await newModal.locator("button.af-primary").click();
+  await expect(newModal).toBeHidden();
+  // Wait for its provisional (creating) row to appear — proof the create is registered in
+  // pendingCreates — so the delete below provably races a mid-create session, not a
+  // create that has not started yet.
+  await expect(row(page, slowTitle)).toBeVisible({ timeout: 15_000 });
+
+  // Immediately delete the project — the session is provably still starting.
+  await page.locator(".af-project-switch").click();
+  const del = page.locator(".af-project-menu .af-project-delete");
+  await expect(del).toBeEnabled();
+  await del.click();
+  const delModal = page.locator(".af-modal-card");
+  await expect(delModal).toBeVisible();
+  await delModal.locator("button.af-danger").click();
+  // REFUSED (fail closed): the modal stays OPEN with an inline error naming the
+  // still-starting session, and nothing was changed — no half-delete, no orphan.
+  await expect(delModal.locator(".af-modal-error")).toContainText("still starting", { timeout: 15_000 });
+  await expect(delModal).toBeVisible();
+
+  // The refuse is transient — the create settles on its own (~8s). Clicking Delete again
+  // then CONVERGES (the retry contract), archiving the now-settled session and removing
+  // the project. The modal stays open through refusals, so retry the danger button until
+  // it closes on real success (which also cleans the fixture).
+  await expect(async () => {
+    await delModal.locator("button.af-danger").click();
+    await expect(delModal).toBeHidden({ timeout: 2500 });
+  }).toPass({ timeout: 45_000 });
+
+  // The project left the switcher and stays gone after a reload — the registry record
+  // was removed only because the session was actually archived (no orphan re-derives it).
+  await expect(page.locator(".af-project-switch-name")).not.toHaveText("mock-repo-empty", { timeout: 30_000 });
+  await page.reload();
+  await expect(page.locator(".af-app")).toBeVisible();
+  await page.locator(".af-project-switch").click();
+  await expect(projectItem(page, "mock-repo-empty")).toHaveCount(0);
+  // The menu is open — selecting mock-repo both selects and closes it, leaving a
+  // deterministic selection for downstream tests.
+  await projectItem(page, "mock-repo").click();
+  await expect(page.locator(".af-project-switch-name")).toHaveText("mock-repo");
+});
+
 // NOTE on #1675 PR4 (ended PTY → "exited", not a reconnect loop): this is already
 // wired end-to-end — the daemon emits a MsgExit control frame on session-end
 // (daemon/ws_pty.go, covered by the Go handler tests), and terminal.ts settles to an


### PR DESCRIPTION
## What

Closes #2549. Deleting a project whose session was still being **created** left a live orphan: a create lives in `m.pendingCreates` through its slow provisioning and only joins `m.instances` at the very end (`manager_create.go`), and `DeleteProject` snapshotted **only** `m.instances` — so it saw zero targets, deregistered the project, reported success, and let the create finish into a live session in a repo no longer in the registry. The web faithfully re-derived that live session, so the project never left the switcher.

This is the recurring **"`m.instances` is not the universe"** class the `#1892` ghost-runs comment warns about (`manager.go:95`), reached through a different door — worth reading before the next person walks that map.

Traced end-to-end against a real daemon + browser; the initial web-reconcile and the intermediate "session in `m.instances` but `OpCreating`" hypotheses were both refuted by the evidence (the delete RPC *succeeded* — the web only closes the confirm modal on success — with zero targets).

## Fix — fail closed immediately, no wait

The earlier draft used a bounded wait on a clock; that was the wrong shape (a real create — git clone, image pull — routinely exceeds any short bound, and it blocks the delete RPC). Instead, **before any mutation**, under `m.mu`, check whether the repo has a create genuinely in flight — any `m.pendingCreates` entry for it, or any `m.instances` row with an op in flight — and if so **refuse immediately**, naming the session. No clock, no caller block, never half-succeeds; the create settles on its own and a retry then removes the project. Because the check sits above the durable removals, "nothing was changed" is finally true (the P2-a message is now honest).

- **Concurrent-create guard:** a create that *begins* after the gate, while `m.mu` is released for the archive, would orphan the same way through a narrower window. So immediately before the deregister we re-check `pendingCreates`+live sessions under `m.mu` and abort if anything appeared. **One documented window remains:** a create landing in the microseconds between that re-check and the `DeregisterProject` call; closing it fully would mean holding `m.mu` across the registry file lock (an ABBA hazard) for a gap that narrow — not worth the trade.
- **P2-b:** the deregister-failure message no longer says "nothing changed" (the sessions are archived by then) — it says a retry re-archives nothing and finishes the deregister, at worst leaving an empty-but-registered project.

## Adjacent call-site (verified, not assumed)

`af projects delete` routes through the same path: `api/projects.go:124` `var deleteProjectViaDaemon = daemon.DeleteProject` → the gob control socket → `cs.DeleteProject` → `m.DeleteProject`, and `resolveProjectDeleteTarget` (`:188`) sends `RepoPath` exactly as the web and TUI do. So the CLI, TUI, and web all inherit the fix and these corrections.

## Tests

- **Daemon (deterministic):** insert a session into `m.pendingCreates` (the exact window an `m.instances` snapshot misses) → `DeleteProject` refuses, names the session, and leaves the registry record intact (the "nothing changed" property).
- **Composed selftest:** register a project, create a session with a `probe-create-slow` title (the fixture agent stays `OpCreating` ~8s, so the mid-create window is deterministic, not a race), immediately delete → the delete is **REFUSED** with an inline error naming the session and the project is untouched; then retrying **converges** once the create settles.
- The **settled/empty case** (delete leaves the project) is covered by the existing delete tests — kept as the "does leave" half rather than re-encoding the wished-for outcome in the creating case.

## Gate

gofmt · golangci-lint --fast · deadcode · parity · file-length · typecheck · `make test-container` · `make web-selftest-container` — results in the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
