### PR TITLE
feat(daemon): per-tab preview credential (#1856 step 3a)

### DIFF
--- a/daemon/httpauth.go
+++ b/daemon/httpauth.go
@@ -46,6 +46,14 @@ type authGate struct {
 	// empty token — fails closed: the gate denies (see ConstantTimeEqual).
 	expectedToken func() (string, error)
 
+	// expectedTokenForRequest, when non-nil, SUPERSEDES expectedToken: it returns
+	// the credential THIS request must present, derived from the request itself. The
+	// web-tab PREVIEW listener (#1856) sets it to the per-tab HMAC token keyed on the
+	// sid/tid in the path, so the gate authenticates PER TAB — tab A's token is never
+	// accepted on tab B's route. Like expectedToken, an error or empty return fails
+	// closed. Only the preview listener sets it; every other listener leaves it nil.
+	expectedTokenForRequest func(*http.Request) (string, error)
+
 	// tokenDisabled drops token enforcement for ALL peers — the require_token=false
 	// posture, which is now the DEFAULT so the daemon-served web UI opens with no
 	// login (#1696). Zero value false ⇒ the token is enforced, so this struct's
@@ -95,7 +103,7 @@ func (g *authGate) authorize(r *http.Request) bool {
 	if !g.authRequired(r) {
 		return true
 	}
-	want, err := g.expectedToken()
+	want, err := g.wantToken(r)
 	if err != nil {
 		return false
 	}
@@ -104,6 +112,17 @@ func (g *authGate) authorize(r *http.Request) bool {
 		extract = webTabAwareToken
 	}
 	return ConstantTimeEqual(extract(r), want)
+}
+
+// wantToken resolves the credential this request must present. A per-request
+// resolver (expectedTokenForRequest — the preview listener's per-tab derivation)
+// supersedes the static expectedToken; every other listener uses the static one. An
+// empty return from either fails closed at the ConstantTimeEqual in authorize.
+func (g *authGate) wantToken(r *http.Request) (string, error) {
+	if g.expectedTokenForRequest != nil {
+		return g.expectedTokenForRequest(r)
+	}
+	return g.expectedToken()
 }
 
 // webTabAwareToken returns the request's bearer token, resolved differently under

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -15,17 +15,20 @@ import (
 type Manager struct {
 	cfg *config.Config
 
-	// previewToken is the ephemeral bearer credential for the web-tab PREVIEW
-	// listener (#1856 step 2). It is minted once, in memory, at daemon start
-	// (crypto/rand) and never written to disk — so it rotates on every restart and
-	// leaves no persistent secret. It is DELIBERATELY distinct from the daemon
-	// bearer token: the preview origin serves untrusted, repo/agent-controlled
-	// content, so a credential that leaked from there must authorize preview
-	// serving ONLY, never the control API (DeliverPrompt et al.). The preview
-	// listener's gate compares against this; an authenticated control-plane client
-	// learns it via GET /v1/preview-auth. Immutable after construction, read
-	// lock-free.
-	previewToken string
+	// previewSecret is the HMAC key from which the web-tab PREVIEW listener derives
+	// a PER-TAB credential (#1856 step 3): the token for (sessionID, tabID) is
+	// previewTabToken(previewSecret, sid, tid). It is minted once, in memory, at
+	// daemon start (crypto/rand, 256 bits) and never written to disk — so it rotates
+	// on every restart and leaves no persistent secret. It is DELIBERATELY distinct
+	// from the daemon bearer token: the preview origin serves untrusted,
+	// repo/agent-controlled content, so a credential that leaked from there must
+	// authorize preview serving of ITS OWN TAB only, never another tab and never the
+	// control API (DeliverPrompt et al.). The preview listener's gate derives the
+	// expected token from the sid/tid in the request and compares; an authenticated
+	// control-plane client obtains a tab's token via GET /v1/preview-auth?session=&tab=.
+	// The secret itself is NEVER vended or logged — only the per-tab derivations are.
+	// Immutable after construction, read lock-free.
+	previewSecret string
 
 	// limitDetector is the resolved usage-limit matcher set (#1146), built once
 	// from cfg.LimitPatterns at construction (it compiles the override regexes)
@@ -250,12 +253,13 @@ func newManagerShellForDaemon(cfg *config.Config, transactionID string) (*Manage
 	if err != nil {
 		return nil, err
 	}
-	// Mint the ephemeral preview credential (#1856 step 2). In memory only, so it
+	// Mint the ephemeral preview HMAC secret (#1856 step 3). In memory only, so it
 	// never touches disk and rotates on restart; generateToken is the same 256-bit
-	// crypto/rand source the daemon bearer uses.
-	previewToken, err := generateToken()
+	// crypto/rand source the daemon bearer uses. Per-tab tokens are derived from it
+	// (previewTabToken); the secret itself is never vended or logged.
+	previewSecret, err := generateToken()
 	if err != nil {
-		return nil, fmt.Errorf("mint preview token: %w", err)
+		return nil, fmt.Errorf("mint preview secret: %w", err)
 	}
 	state := config.LoadState()
 	storage, err := session.NewStorage(state, "")
@@ -274,7 +278,7 @@ func newManagerShellForDaemon(cfg *config.Config, transactionID string) (*Manage
 	}
 	m := &Manager{
 		cfg:                 cfg,
-		previewToken:        previewToken,
+		previewSecret:       previewSecret,
 		limitDetector:       task.NewLimitDetector(cfg.LimitPatterns),
 		ready:               make(chan struct{}),
 		lifecycle:           lifecycle,

--- a/daemon/preview_auth.go
+++ b/daemon/preview_auth.go
@@ -1,54 +1,57 @@
 package daemon
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/sachiniyer/agent-factory/agentproto"
 )
 
-// The web-tab PREVIEW origin's auth (#1856 step 2).
+// The web-tab PREVIEW origin's auth (#1856 steps 2-3).
 //
-// The preview listener (preview_listen_addr) is a SEPARATE origin from the SPA
-// (different port), so DOM/storage IS isolated: a framed dev server on the preview
-// origin cannot read the SPA's window or localStorage. This file gives that origin
-// its own low-privilege credential: the daemon mints an ephemeral preview token
-// (Manager.previewToken), the listener's gate compares against it, and it is
-// delivered under the #2400 clean-before-render discipline like the app-origin
-// web-tab flow — on distinct query/cookie NAMES.
+// The preview listener (preview_listen_addr) is a SEPARATE origin from the SPA. It
+// authenticates a PER-TAB credential, NOT the daemon bearer: the daemon holds an
+// in-memory HMAC secret (Manager.previewSecret) and a tab's token is
+// previewTabToken(secret, sessionID, tabID). The listener's gate DERIVES the expected
+// token from the sid/tid in the request path and compares (previewExpectedToken), and
+// the token is delivered under the #2400 clean-before-render discipline on distinct
+// query/cookie NAMES from the daemon bearer.
 //
-// What separation this actually buys, stated precisely because the naive framing
-// is wrong: cookies are scoped by (host, path) and NOT by port (RFC 6265 §8.5), so
-// the two origins share ONE cookie jar. Both credential cookies (af_webtab_token,
-// af_preview_token) are transmitted to BOTH ports on every /v1/webtab/ request.
-// The separation is enforced by the EXTRACTOR, not the browser: previewPresentedToken
-// reads only af_preview_token and webTabAwareToken reads only af_webtab_token, so
-// neither credential is HONORED on the other surface even though both are sent. The
-// consequence for the proxy is that forwardAppCookies / the upstream query strip
-// (webtab_proxy.go) MUST remove BOTH names, or the shared jar would leak the preview
-// token to the untrusted dev server — see those sites.
+// STEP 3a — the per-tab credential (this file). Step 2 shipped ONE process-global
+// preview token in a cookie scoped to the whole webtabPathPrefix; that was acceptable
+// only because the mux served nothing, and it must not survive to the moment content
+// is served (a global token on a served origin is a cross-session read — worse than
+// the status quo; see #1856). This step replaces it: the gate expects
+// previewTabToken(secret, sid, tid) for the request's OWN tab, so presenting tab A's
+// token to tab B's route is 401; the bootstrap cookie is scoped to
+// /v1/webtab/<sid>/<tid>/, not the whole prefix; and /v1/preview-auth requires a
+// session/tab selector and returns only that tab's token. The secret itself is never
+// vended or logged.
 //
-// WHAT THIS STEP DELIBERATELY DOES NOT BUY — session isolation. Manager.previewToken
-// is ONE process-global token, and the bootstrap parks it in a cookie scoped to the
-// WHOLE webtabPathPrefix. So the credential a preview page for session A would carry
-// is byte-identical to session B's, and is ambiently attached to a same-origin
-// fetch of ANY session's preview path. That is acceptable ONLY because this step
-// serves NO content: nothing sits behind the gate to read cross-session. It must NOT
-// survive into step 3. Before the preview proxy serves a single byte, the credential
-// has to become PER-TAB (an HMAC(secret, sid/tid)-derived token, gate validated
-// against the sid/tid in the request path) with the cookie scoped to
-// /v1/webtab/<sid>/<tid>/ — otherwise a global token turns the preview origin into a
-// cross-session read and makes #1856 WORSE than the status quo. Even per-tab tokens
-// only bound a page to ITS OWN credential; on this SHARED origin a concurrently-open
-// other tab's path-scoped cookie is still ambiently attached to a cross-tab
-// same-origin fetch, so FULL cross-tab isolation additionally needs per-tab ORIGINS
-// (a listener/port per tab) — the origin-model decision step 3 must make, tracked on
-// #1856. Do not read "separate origin" here as "sessions are isolated"; they are not
-// yet.
+// Why the credential is necessary but not SUFFICIENT for cross-tab isolation, stated
+// precisely because the naive framing is wrong: cookies are scoped by (host, path)
+// and NOT by port (RFC 6265 §8.5). On the CURRENT single shared preview origin, a
+// page for tab A doing a same-origin fetch of tab B's path still has B's path-scoped
+// cookie ambiently attached (attachment is by destination path, not initiator), so
+// the credential alone cannot stop a cross-tab READ. That read is closed by giving
+// each tab a distinct ORIGIN (CORS then blocks the cross-origin read) — the step 3b
+// work (subdomain-per-tab, sandbox relax, client re-addressing). The per-tab
+// credential here is what makes that safe: it authenticates the tab, so a leaked or
+// observed token for one tab never authorizes another. Both land before any content
+// is served or the sandbox relaxes (#1856 gate).
 //
-// This step opens the auth handshake only; the preview origin still serves NO
-// content (step 3 wires the proxy routes).
+// The proxy must still strip BOTH af credential names in both directions
+// (forwardAppCookies / the upstream query strip in webtab_proxy.go), because the two
+// origins share one cookie jar and the untrusted dev server must receive neither.
+//
+// This step still serves NO content: newPreviewMux 404s after the bootstrap. Step 3b
+// wires the per-tab origin + proxy routes.
 
 // previewTokenCookie and previewTokenQueryParam carry the PREVIEW credential on
 // the preview origin. They are deliberately distinct from webtabTokenCookie /
@@ -82,14 +85,75 @@ func previewPresentedToken(r *http.Request) string {
 	return ""
 }
 
-// previewListenerAuth is the token wiring the preview listener's gate uses instead
-// of the daemon token file: the in-memory ephemeral preview token for both the
-// advertised value and the per-auth-event comparison, and previewPresentedToken
-// for the request side.
+// previewTabToken derives the preview credential for one tab: the base64url
+// HMAC-SHA256 of "<sessionID>\x00<tabID>" under secret. Session and tab ids cannot
+// contain a NUL byte, so the separator makes the (sid, tid) pair unambiguous — no
+// concatenation collision can let one tab's token authenticate another. The secret
+// is the in-memory Manager.previewSecret; the derivation is deterministic, so the
+// gate (which knows the secret and the request's sid/tid) and /v1/preview-auth
+// (which mints for a requested sid/tid) agree without any shared per-tab state.
+func previewTabToken(secret, sessionID, tabID string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(sessionID))
+	mac.Write([]byte{0})
+	mac.Write([]byte(tabID))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+// parsePreviewTabPath extracts (sessionID, tabID) from a preview request's ESCAPED
+// path "/v1/webtab/<sid>/<tid>/…", unescaping each segment exactly once. It takes the
+// escaped path (r.URL.EscapedPath()) rather than the pre-decoded r.URL.Path so it
+// derives the SAME ids the mux's PathValue and /v1/preview-auth see — a segment with
+// a percent-encoded byte decodes to one id, not two path segments. ok=false for any
+// path that is not a two-segment tab route (a bare prefix, a missing tab, an unescape
+// error), which the gate treats as "no expected token" — a fail-closed deny.
+func parsePreviewTabPath(escapedPath string) (sessionID, tabID string, ok bool) {
+	rest, found := strings.CutPrefix(escapedPath, webtabPathPrefix)
+	if !found {
+		return "", "", false
+	}
+	segs := strings.SplitN(rest, "/", 3)
+	if len(segs) < 2 || segs[0] == "" || segs[1] == "" {
+		return "", "", false
+	}
+	sid, err := url.PathUnescape(segs[0])
+	if err != nil {
+		return "", "", false
+	}
+	tid, err := url.PathUnescape(segs[1])
+	if err != nil {
+		return "", "", false
+	}
+	return sid, tid, true
+}
+
+// previewExpectedToken is the preview listener's request-aware expected-token
+// function (authGate.expectedTokenForRequest). It derives the token the request's
+// OWN tab must present, so the gate authenticates PER TAB: a request to tab B's route
+// is compared only against tab B's token, and tab A's token fails closed. A path that
+// names no tab yields an empty expected token, which ConstantTimeEqual rejects.
+func previewExpectedToken(m *Manager) func(*http.Request) (string, error) {
+	return func(r *http.Request) (string, error) {
+		if r.URL == nil {
+			return "", nil
+		}
+		sid, tid, ok := parsePreviewTabPath(r.URL.EscapedPath())
+		if !ok {
+			return "", nil
+		}
+		return previewTabToken(m.previewSecret, sid, tid), nil
+	}
+}
+
+// previewListenerAuth is the credential wiring the preview listener's gate uses
+// instead of the daemon token file: a PER-TAB expected token derived from the sid/tid
+// in the request path (previewExpectedToken), and previewPresentedToken for the
+// request side. There is no single token to advertise — per-tab tokens are vended via
+// /v1/preview-auth.
 func previewListenerAuth(m *Manager) *tcpListenerAuth {
 	return &tcpListenerAuth{
-		token:     func() (string, error) { return m.previewToken, nil },
-		presented: previewPresentedToken,
+		expectedForRequest: previewExpectedToken(m),
+		presented:          previewPresentedToken,
 	}
 }
 
@@ -98,21 +162,25 @@ func previewListenerAuth(m *Manager) *tcpListenerAuth {
 // serves NOTHING yet — the preview proxy routes land in step 3.
 //
 // It is reached only AFTER withAuth's preview gate authorized the request against
-// the preview token, so the bootstrap here only moves that already-validated
-// credential from the URL into the scoped cookie and redirects to the clean URL.
-// The cookie is scoped to webtabPathPrefix — the WHOLE prefix, deliberately flagged:
-// that is the non-isolating scope the file header warns must narrow to
-// /v1/webtab/<sid>/<tid>/ before step 3 serves content. It is safe here only because
-// nothing is served yet.
+// the request's OWN tab token, so the bootstrap here only moves that already-validated
+// credential from the URL into the cookie and redirects to the clean URL. The cookie
+// is scoped to /v1/webtab/<sid>/<tid>/ — this tab only — so tab A's token cookie is
+// never sent on a request to tab B's path (the per-tab narrowing #1856 requires
+// before content is served). It is still safe that content is not served yet; step 3b
+// wires the proxy.
 func newPreviewMux() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc(webtabPathPrefix+"{sessionId}/{tabId}/{rest...}", func(w http.ResponseWriter, r *http.Request) {
-		if cleanBootstrapToken(w, r, previewTokenQueryParam, previewTokenCookie, webtabPathPrefix) {
+		// The gate already authenticated the request against this tab, so the sid/tid
+		// are trusted; scope the credential cookie to exactly this tab's path (trailing
+		// slash so it never prefix-matches a sibling tab whose id shares this prefix).
+		tabCookiePath := webtabPathPrefix + r.PathValue("sessionId") + "/" + r.PathValue("tabId") + "/"
+		if cleanBootstrapToken(w, r, previewTokenQueryParam, previewTokenCookie, tabCookiePath) {
 			return
 		}
 		// Authenticated, credential parked in the cookie — but there is nothing to
-		// serve yet. Step 3 replaces this with the preview proxy.
-		writeHTTPError(w, r, http.StatusNotFound, errors.New("web-tab preview content is not wired yet (#1856 step 3)"))
+		// serve yet. Step 3b replaces this with the preview proxy.
+		writeHTTPError(w, r, http.StatusNotFound, errors.New("web-tab preview content is not wired yet (#1856 step 3b)"))
 	})
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		writeHTTPError(w, r, http.StatusNotFound, fmt.Errorf("unknown preview route %q", r.URL.Path))
@@ -120,24 +188,29 @@ func newPreviewMux() http.Handler {
 	return mux
 }
 
-// previewAuthResponse is the body of GET /v1/preview-auth: the preview origin's
-// ephemeral bearer token, which an authenticated control-plane client (the SPA)
-// then delivers to the preview iframe. Empty token ⇒ the preview listener is not
-// bound (disabled, or its bind failed), so there is nothing to authenticate.
+// previewAuthResponse is the body of GET /v1/preview-auth?session=&tab=: the preview
+// origin's ephemeral bearer token FOR THAT TAB, which an authenticated control-plane
+// client (the SPA) then delivers to that tab's preview iframe. Empty token ⇒ the
+// preview listener is not bound (disabled, or its bind failed), so there is nothing
+// to authenticate.
 type previewAuthResponse struct {
 	Token string `json:"token"`
 }
 
-// previewAuthHandler answers GET /v1/preview-auth on the CONTROL listener with the
-// ephemeral preview token. It is behind the daemon's normal auth gate, so only a
-// client already authorized to the control plane can read it — which is fine, that
-// client can already do everything, and the preview token it learns is strictly
-// LESS privileged than the daemon bearer (it authenticates only the preview origin,
-// which serves nothing yet). It is NOT per-session: it is the one process-global
-// token, so it does not distinguish sessions — the endpoint gains a session/tab
-// selector when step 3 moves to per-tab tokens (see the file header). It is the ONLY
-// way to obtain the token: the token lives in memory, is never written to disk, and
-// is never logged.
+// previewAuthHandler answers GET /v1/preview-auth?session=<sid>&tab=<tid> on the
+// CONTROL listener with the PER-TAB preview token. It is behind the daemon's normal
+// auth gate, so only a client already authorized to the control plane can read it —
+// which is fine, that client can already do everything, and the token it learns is
+// strictly LESS privileged than the daemon bearer: it authenticates ONE tab's preview
+// origin, nothing else. It is the ONLY way to obtain a tab's token: the secret lives
+// in memory, is never written to disk, and is never logged — only the per-tab
+// derivation is returned, for the requested (session, tab).
+//
+// session and tab are REQUIRED; a missing selector is a 400 rather than a global
+// token, so the endpoint can never hand back a credential that authenticates more
+// than one tab. It does not check that the tab exists: the caller already holds the
+// daemon bearer (it could enumerate tabs anyway), and a token for a nonexistent tab
+// authenticates a route the proxy will 404 — no privilege is conferred.
 //
 // The response is no-store: it carries a raw bearer, so it must never sit in a
 // shared/proxy cache (the recommended deployment fronts af with nginx/Caddy). This
@@ -159,9 +232,16 @@ func (cs *controlServer) previewAuthHandler(w http.ResponseWriter, r *http.Reque
 		writeHTTPError(w, r, http.StatusServiceUnavailable, errors.New("daemon has no session manager"))
 		return
 	}
+	sid := r.URL.Query().Get("session")
+	tid := r.URL.Query().Get("tab")
+	if sid == "" || tid == "" {
+		writeHTTPError(w, r, http.StatusBadRequest,
+			errors.New("/v1/preview-auth requires non-empty session and tab query params"))
+		return
+	}
 	token := ""
 	if cs.manager.lifecycle != nil && cs.manager.lifecycle.snapshot().listeners.PreviewBound {
-		token = cs.manager.previewToken
+		token = previewTabToken(cs.manager.previewSecret, sid, tid)
 	}
 	// A raw credential in the body: keep it out of any shared cache.
 	w.Header().Set("Cache-Control", "no-store")

--- a/daemon/preview_auth_test.go
+++ b/daemon/preview_auth_test.go
@@ -16,11 +16,13 @@ import (
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 )
 
-// The web-tab preview origin's auth (#1856 step 2). The listener opens the auth
-// handshake — its own ephemeral credential plus the #2400 clean-before-render
+// The web-tab preview origin's auth (#1856 steps 2-3a). The listener opens the auth
+// handshake — a PER-TAB credential (previewTabToken) plus the #2400 clean-before-render
 // bootstrap — but serves no content yet. These tests pin the credential SEPARATION
-// (the daemon bearer never authorizes the preview origin, and vice-versa), the
-// bootstrap's clean-before-render behavior, and the retrieval endpoint.
+// (the daemon bearer never authorizes the preview origin, and vice-versa), the PER-TAB
+// scoping (tab A's token never authenticates tab B's route, the cookie is scoped to the
+// tab's own path), the bootstrap's clean-before-render behavior, and the retrieval
+// endpoint.
 
 // startPreviewDaemon brings up a daemon with the preview listener enabled on an
 // ephemeral port and returns the manager, the preview bound address, and the
@@ -59,7 +61,8 @@ func TestPreviewBootstrap_CleanBeforeRender(t *testing.T) {
 	m, previewAddr, _ := startPreviewDaemon(t)
 	client := noRedirectClient()
 
-	url := "http://" + previewAddr + "/v1/webtab/s1/t1/?doc=1&af_preview_token=" + m.previewToken
+	tok := previewTabToken(m.previewSecret, "s1", "t1")
+	url := "http://" + previewAddr + "/v1/webtab/s1/t1/?doc=1&af_preview_token=" + tok
 	resp, err := client.Get(url)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
@@ -78,11 +81,11 @@ func TestPreviewBootstrap_CleanBeforeRender(t *testing.T) {
 		}
 	}
 	require.NotNil(t, cookie, "the bootstrap must set the preview-token cookie")
-	require.Equal(t, m.previewToken, cookie.Value)
+	require.Equal(t, tok, cookie.Value)
 	require.True(t, cookie.HttpOnly, "the credential cookie must be HttpOnly so app JS cannot read it")
 	require.Equal(t, http.SameSiteStrictMode, cookie.SameSite)
-	require.Equal(t, webtabPathPrefix, cookie.Path,
-		"the cookie is scoped to the preview content path, not the whole origin's root")
+	require.Equal(t, "/v1/webtab/s1/t1/", cookie.Path,
+		"the cookie is scoped to THIS tab's path, so it is never sent on another tab's route (#1856 step 3a)")
 }
 
 // TestPreviewBootstrap_ScrubsEveryAfCredential pins P2-a: the clean-before-render
@@ -97,7 +100,8 @@ func TestPreviewBootstrap_ScrubsEveryAfCredential(t *testing.T) {
 	m, previewAddr, _ := startPreviewDaemon(t)
 	client := noRedirectClient()
 
-	url := "http://" + previewAddr + "/v1/webtab/s1/t1/?doc=1&af_preview_token=" + m.previewToken + "&af_webtab_token=daemon-bearer-value"
+	tok := previewTabToken(m.previewSecret, "s1", "t1")
+	url := "http://" + previewAddr + "/v1/webtab/s1/t1/?doc=1&af_preview_token=" + tok + "&af_webtab_token=daemon-bearer-value"
 	resp, err := client.Get(url)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
@@ -116,7 +120,7 @@ func TestPreviewBootstrap_ScrubsEveryAfCredential(t *testing.T) {
 		}
 	}
 	require.NotNil(t, previewCookie, "the preview flow sets its own credential cookie")
-	require.Equal(t, m.previewToken, previewCookie.Value)
+	require.Equal(t, tok, previewCookie.Value)
 	require.Nil(t, webtabCookie,
 		"the preview flow must NOT mint the daemon-bearer cookie — it strips that param, it does not adopt it")
 }
@@ -129,12 +133,13 @@ func TestPreviewGate_CookieAuthenticatesFollowUpAndRejectsOthers(t *testing.T) {
 	m, previewAddr, _ := startPreviewDaemon(t)
 	client := previewHTTPClient()
 	assetURL := "http://" + previewAddr + "/v1/webtab/s1/t1/asset.js"
+	tok := previewTabToken(m.previewSecret, "s1", "t1")
 
-	// A sub-resource GET carrying the preview cookie is authenticated — and only
-	// then finds no content (404), never a 401.
+	// A sub-resource GET carrying this tab's preview cookie is authenticated — and
+	// only then finds no content (404), never a 401.
 	withCookie, err := http.NewRequest(http.MethodGet, assetURL, nil)
 	require.NoError(t, err)
-	withCookie.AddCookie(&http.Cookie{Name: previewTokenCookie, Value: m.previewToken})
+	withCookie.AddCookie(&http.Cookie{Name: previewTokenCookie, Value: tok})
 	resp, err := client.Do(withCookie)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
@@ -148,6 +153,37 @@ func TestPreviewGate_CookieAuthenticatesFollowUpAndRejectsOthers(t *testing.T) {
 	// No credential at all is rejected — the preview origin is not loopback-exempt.
 	require.Equal(t, http.StatusUnauthorized, previewGet(t, client, assetURL, ""),
 		"the preview origin requires its credential from every peer, loopback included")
+}
+
+// TestPreviewGate_RejectsAnotherTabsToken is the per-tab isolation core (#1856
+// step 3a): a request carrying tab A's credential to tab B's ROUTE must be refused.
+// The gate derives the expected token from the sid/tid in the path, so B's route
+// only ever accepts B's token — a leaked or observed token for one tab authorizes
+// exactly that tab, never a sibling. Presented on the header, the query, and the
+// cookie, since all three are extractor inputs.
+func TestPreviewGate_RejectsAnotherTabsToken(t *testing.T) {
+	m, previewAddr, _ := startPreviewDaemon(t)
+	client := previewHTTPClient()
+
+	tabAToken := previewTabToken(m.previewSecret, "sA", "tA")
+	tabBToken := previewTabToken(m.previewSecret, "sB", "tB")
+	require.NotEqual(t, tabAToken, tabBToken, "per-tab tokens must differ, or there is no isolation to test")
+
+	bURL := "http://" + previewAddr + "/v1/webtab/sB/tB/asset.js"
+
+	// Tab A's token on tab B's route: refused on every transport.
+	require.Equal(t, http.StatusUnauthorized, previewGet(t, client, bURL, tabAToken),
+		"tab A's token (Authorization) must NOT authenticate tab B's route")
+	require.Equal(t, http.StatusUnauthorized, previewGetWithCookie(t, client, bURL, tabAToken),
+		"tab A's token (cookie) must NOT authenticate tab B's route")
+	aTokOnBQuery := "http://" + previewAddr + "/v1/webtab/sB/tB/asset.js?af_preview_token=" + tabAToken
+	require.Equal(t, http.StatusUnauthorized, previewGet(t, client, aTokOnBQuery, ""),
+		"tab A's token (query) must NOT authenticate tab B's route")
+
+	// Sanity: tab B's OWN token authenticates tab B's route (so the 401s above are
+	// isolation, not a dead route).
+	require.Equal(t, http.StatusNotFound, previewGet(t, client, bURL, tabBToken),
+		"tab B's own token authenticates tab B's route (no content yet ⇒ 404)")
 }
 
 // TestPreviewCredentialSeparation_BothDirections is the security core: the daemon
@@ -177,13 +213,14 @@ func TestPreviewCredentialSeparation_BothDirections(t *testing.T) {
 
 	daemonToken, err := LoadToken(mustTokenPath(t))
 	require.NoError(t, err)
-	require.NotEqual(t, daemonToken, m.previewToken, "the two credentials must differ")
+	tok := previewTabToken(m.previewSecret, "s1", "t1")
+	require.NotEqual(t, daemonToken, tok, "the two credentials must differ")
 
 	// Sanity: each credential DOES authorize its own surface, so a 401 below is
 	// separation, not a broken listener.
 	require.Equal(t, http.StatusNotFound,
-		previewGet(t, client, "http://"+previewAddr+"/v1/webtab/s1/t1/asset.js", m.previewToken),
-		"the preview token authenticates the preview origin (no content ⇒ 404)")
+		previewGet(t, client, "http://"+previewAddr+"/v1/webtab/s1/t1/asset.js", tok),
+		"the tab's preview token authenticates the preview origin (no content ⇒ 404)")
 	require.Equal(t, http.StatusOK,
 		previewGet(t, client, "http://"+controlAddr+"/v1/health", daemonToken),
 		"the daemon token authenticates the control plane")
@@ -196,7 +233,7 @@ func TestPreviewCredentialSeparation_BothDirections(t *testing.T) {
 	// Preview token → control plane, presented on the daemon's own webtab query
 	// transport on the webtab path: the control gate wants the daemon token, so it
 	// 401s.
-	previewAsWebtab := "http://" + controlAddr + "/v1/webtab/s1/t1/?af_webtab_token=" + m.previewToken
+	previewAsWebtab := "http://" + controlAddr + "/v1/webtab/s1/t1/?af_webtab_token=" + tok
 	require.Equal(t, http.StatusUnauthorized, previewGet(t, client, previewAsWebtab, ""),
 		"the preview token must NOT authenticate the control plane")
 }
@@ -221,13 +258,13 @@ func TestPreviewAuthEndpoint_RequiresAuthThenReturnsToken(t *testing.T) {
 
 	controlAddr := m.lifecycle.snapshot().listeners.TCPBoundAddr
 	client := previewHTTPClient()
-	url := "http://" + controlAddr + "/v1/preview-auth"
+	url := "http://" + controlAddr + "/v1/preview-auth?session=s1&tab=t1"
 
 	// No credential → 401 (the negative test the endpoint lacked).
 	require.Equal(t, http.StatusUnauthorized, previewGet(t, client, url, ""),
 		"the credential-vending endpoint must require control-plane auth")
 
-	// Daemon token → 200 with the preview token, and no-store.
+	// Daemon token → 200 with THIS tab's preview token, and no-store.
 	daemonToken, err := LoadToken(mustTokenPath(t))
 	require.NoError(t, err)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
@@ -244,8 +281,13 @@ func TestPreviewAuthEndpoint_RequiresAuthThenReturnsToken(t *testing.T) {
 		Data previewAuthResponse `json:"data"`
 	}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&env))
-	require.Equal(t, m.previewToken, env.Data.Token,
-		"an authenticated control-plane client must be able to fetch the preview token")
+	require.Equal(t, previewTabToken(m.previewSecret, "s1", "t1"), env.Data.Token,
+		"an authenticated control-plane client must be able to fetch the requested tab's preview token")
+
+	// A missing selector is a 400, never a token that authenticates more than one tab.
+	require.Equal(t, http.StatusBadRequest,
+		previewGet(t, client, "http://"+controlAddr+"/v1/preview-auth", daemonToken),
+		"the endpoint must require a session/tab selector")
 }
 
 // TestPreviewAuthEndpoint_WithholdsTokenUnlessBound pins that the token is vended
@@ -291,12 +333,13 @@ func TestPreviewAuthEndpoint_WithholdsTokenUnlessBound(t *testing.T) {
 	})
 }
 
-// fetchPreviewAuthToken calls GET /v1/preview-auth on m's control listener (over
-// its own unix-socket-trust loopback default) and returns the vended token.
+// fetchPreviewAuthToken calls GET /v1/preview-auth?session=&tab= on m's control
+// listener (over its own unix-socket-trust loopback default) and returns the vended
+// per-tab token (empty when the preview listener is not bound).
 func fetchPreviewAuthToken(t *testing.T, m *Manager) string {
 	t.Helper()
 	controlAddr := m.lifecycle.snapshot().listeners.TCPBoundAddr
-	resp, err := previewHTTPClient().Get("http://" + controlAddr + "/v1/preview-auth")
+	resp, err := previewHTTPClient().Get("http://" + controlAddr + "/v1/preview-auth?session=s1&tab=t1")
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -307,10 +350,11 @@ func fetchPreviewAuthToken(t *testing.T, m *Manager) string {
 	return env.Data.Token
 }
 
-// TestPreviewToken_EphemeralAndNeverOnDisk pins the two properties of the
-// credential: it differs between daemon lifetimes (rotates on restart) and it is
-// never written to the AF home.
-func TestPreviewToken_EphemeralAndNeverOnDisk(t *testing.T) {
+// TestPreviewSecret_EphemeralAndNeverOnDisk pins the two properties of the per-tab
+// HMAC secret: it differs between daemon lifetimes (rotates on restart) and it is
+// never written to the AF home. The secret is the root from which every tab token
+// derives, so it matters more than any single token that it never lands on disk.
+func TestPreviewSecret_EphemeralAndNeverOnDisk(t *testing.T) {
 	home := testguard.SocketTempDir(t)
 	t.Setenv("AGENT_FACTORY_HOME", home)
 	cfg := config.DefaultConfig()
@@ -320,11 +364,11 @@ func TestPreviewToken_EphemeralAndNeverOnDisk(t *testing.T) {
 	m2, err := NewManager(cfg)
 	require.NoError(t, err)
 
-	require.NotEmpty(t, m1.previewToken)
-	require.NotEqual(t, m1.previewToken, m2.previewToken,
-		"the preview token must be freshly minted per daemon, not persisted and reused")
+	require.NotEmpty(t, m1.previewSecret)
+	require.NotEqual(t, m1.previewSecret, m2.previewSecret,
+		"the preview secret must be freshly minted per daemon, not persisted and reused")
 
-	// The token value must appear in no file under the AF home.
+	// The secret value must appear in no file under the AF home.
 	require.NoError(t, filepath.WalkDir(home, func(path string, d os.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
 			return err
@@ -333,10 +377,60 @@ func TestPreviewToken_EphemeralAndNeverOnDisk(t *testing.T) {
 		if readErr != nil {
 			return nil // unreadable/special file — not where a secret would be
 		}
-		require.NotContains(t, string(data), m1.previewToken,
-			"the preview token must never be written to disk (found in %s)", path)
+		require.NotContains(t, string(data), m1.previewSecret,
+			"the preview secret must never be written to disk (found in %s)", path)
 		return nil
 	}))
+}
+
+// TestPreviewTabToken_Derivation pins the per-tab derivation: deterministic, distinct
+// per tab and per secret, and — critically — the NUL separator makes the (sid, tid)
+// pair unambiguous so no two different pairs that concatenate to the same string can
+// share a token. Without the separator, ("ab","c") and ("a","bc") would collide and
+// one tab's token would authenticate another.
+func TestPreviewTabToken_Derivation(t *testing.T) {
+	const secret = "secret-key-material"
+
+	require.Equal(t, previewTabToken(secret, "s1", "t1"), previewTabToken(secret, "s1", "t1"),
+		"derivation must be deterministic")
+	require.NotEqual(t, previewTabToken(secret, "s1", "t1"), previewTabToken(secret, "s1", "t2"),
+		"different tabs in the same session must derive different tokens")
+	require.NotEqual(t, previewTabToken(secret, "s1", "t1"), previewTabToken(secret, "s2", "t1"),
+		"the same tab id in different sessions must derive different tokens")
+	require.NotEqual(t, previewTabToken(secret, "ab", "c"), previewTabToken(secret, "a", "bc"),
+		"the separator must prevent a concatenation collision between distinct (sid, tid) pairs")
+	require.NotEqual(t, previewTabToken(secret, "s1", "t1"), previewTabToken("other-secret", "s1", "t1"),
+		"a different secret must derive a different token (rotation on restart)")
+	require.NotEmpty(t, previewTabToken(secret, "s1", "t1"))
+}
+
+// TestParsePreviewTabPath pins the gate's path parse: a two-segment tab route yields
+// its ids, a percent-encoded segment is unescaped exactly once (matching PathValue),
+// and anything that is not a tab route is a fail-closed miss.
+func TestParsePreviewTabPath(t *testing.T) {
+	sid, tid, ok := parsePreviewTabPath("/v1/webtab/s1/t1/asset.js")
+	require.True(t, ok)
+	require.Equal(t, "s1", sid)
+	require.Equal(t, "t1", tid)
+
+	// A percent-encoded segment decodes to ONE id, not two segments.
+	sid, tid, ok = parsePreviewTabPath("/v1/webtab/a%2Fb/t1/")
+	require.True(t, ok)
+	require.Equal(t, "a/b", sid, "an encoded slash is part of the id, not a segment boundary")
+	require.Equal(t, "t1", tid)
+
+	for _, miss := range []string{
+		"/v1/webtab/",     // bare prefix, no tab
+		"/v1/webtab/s1/",  // session only, no tab
+		"/v1/webtab/s1",   // no trailing structure
+		"/v1/Snapshot",    // not a webtab path at all
+		"/",               // root
+		"/v1/webtab//t1/", // empty session segment
+		"/v1/webtab/s1//", // empty tab segment
+	} {
+		_, _, ok := parsePreviewTabPath(miss)
+		require.False(t, ok, "%q is not a tab route and must be a fail-closed miss", miss)
+	}
 }
 
 // previewGetWithCookie issues a GET carrying the preview cookie and returns the

--- a/daemon/preview_listener_test.go
+++ b/daemon/preview_listener_test.go
@@ -89,18 +89,28 @@ func TestStartHTTPServer_PreviewBindsButServesNothing(t *testing.T) {
 	// the preview surface at all.
 	daemonToken, err := LoadToken(mustTokenPath(t))
 	require.NoError(t, err)
-	require.NotEqual(t, daemonToken, m.previewToken, "the preview credential must be distinct from the daemon bearer")
+	tok := previewTabToken(m.previewSecret, "s1", "t1")
+	require.NotEqual(t, daemonToken, tok, "the preview credential must be distinct from the daemon bearer")
 
 	snapWithDaemon := previewGet(t, client, "http://"+previewAddr+"/v1/Snapshot", daemonToken)
 	require.Equal(t, http.StatusUnauthorized, snapWithDaemon,
 		"the daemon token must NOT authorize the preview origin — the credentials are separate")
 
-	// The PREVIEW token authenticates, and only then do we learn there is no content
-	// and no control API: /v1/Snapshot resolves to the preview mux's 404, never a
-	// dispatch.
-	snapWithPreview := previewGet(t, client, "http://"+previewAddr+"/v1/Snapshot", m.previewToken)
-	require.Equal(t, http.StatusNotFound, snapWithPreview,
-		"authenticated, the preview origin still serves no control API — /v1/Snapshot must 404, not dispatch")
+	// A control-API path on the preview origin has NO tab identity, so the per-tab
+	// gate can derive no expected token and rejects it outright — the preview origin
+	// exposes no control API, and /v1/Snapshot never even reaches a dispatch. Even a
+	// real per-tab token cannot reach it: the token authenticates a TAB's route, and
+	// /v1/Snapshot is not one.
+	snapWithPreview := previewGet(t, client, "http://"+previewAddr+"/v1/Snapshot", tok)
+	require.Equal(t, http.StatusUnauthorized, snapWithPreview,
+		"a non-tab /v1 path on the preview origin has no per-tab credential — it must 401, never dispatch")
+
+	// A real tab route, authenticated with that tab's token, is the ONLY thing that
+	// gets past the gate — and finds no content yet (404), proving the gate works and
+	// the origin still serves nothing.
+	assetWithPreview := previewGet(t, client, "http://"+previewAddr+"/v1/webtab/s1/t1/asset.js", tok)
+	require.Equal(t, http.StatusNotFound, assetWithPreview,
+		"authenticated on its own tab route, the preview origin still serves no content (404, not a dispatch)")
 
 	// The non-/v1 404 sits OUTSIDE the gate (previewShell answers a root request
 	// UNAUTHENTICATED, before the token is consulted — so this deliberately sends no

--- a/daemon/tcpserver.go
+++ b/daemon/tcpserver.go
@@ -96,17 +96,14 @@ func webListenerPolicy(cfg *config.Config) tokenGatePolicy {
 // require_token/require_loopback_token posture.
 //
 // It returns the STRICT zero value — token mandatory for every peer, no
-// exemptions — deliberately, for the step that only opens the port. Two facts
-// make that the safe default rather than a placeholder guess:
-//
-//   - the preview listener serves NOTHING yet (an empty mux), so nothing is
-//     behind this gate to reach with or without a token; and
-//   - the preview origin's real credential is a preview-scoped one wired in a
-//     later step, and pre-committing to the control plane's require_token model
-//     here would be the wrong answer to bake in.
-//
-// So the fail-safe posture holds the seam until that step replaces it, and never
-// silently exposes a preview surface that does not exist.
+// exemptions — deliberately. The preview origin serves untrusted, repo/agent-
+// controlled content, and its credential is the PER-TAB preview token
+// (previewListenerAuth), not the daemon bearer — so it must NOT inherit the control
+// plane's require_token/require_loopback_token relaxations, under which the web UI
+// opens with no token. Here the token is mandatory for every peer, always: the gate
+// derives the request's own-tab token and compares (a loopback browser is exactly
+// the peer this must authenticate). The listener still serves no content until step
+// 3b, so the strict posture never blocks a real surface.
 func previewListenerPolicy(_ *config.Config) tokenGatePolicy {
 	return tokenGatePolicy{}
 }
@@ -141,15 +138,16 @@ const (
 // tcpListenerAuth overrides the credential a listener's gate uses. Nil selects
 // the default: the file-backed daemon bearer token (EnsureToken/LoadToken), used
 // by the control-plane and agent-server listeners. The web-tab PREVIEW listener
-// (#1856) passes a non-nil value to authenticate its SEPARATE ephemeral credential
-// on a distinct query/cookie transport, so the daemon bearer never reaches the
-// preview origin.
+// (#1856) passes a non-nil value to authenticate its SEPARATE per-tab credential on
+// a distinct query/cookie transport, so the daemon bearer never reaches the preview
+// origin.
 type tcpListenerAuth struct {
-	// token returns the credential to advertise AND to compare against, per auth
-	// event. For an in-memory preview token these are the same value; the daemon
-	// path keeps them separate (EnsureToken advertises, LoadToken compares) inside
-	// startTCPListener instead.
-	token func() (string, error)
+	// expectedForRequest returns the credential THIS request must present, derived
+	// per request (the preview listener's per-tab HMAC token, keyed on the sid/tid in
+	// the path). It becomes authGate.expectedTokenForRequest. There is no single
+	// credential to advertise, so the banner token is empty and per-tab tokens are
+	// vended via /v1/preview-auth. Fail-closed: an empty return denies (ConstantTimeEqual).
+	expectedForRequest func(*http.Request) (string, error)
 	// presented extracts the credential a request carries; it becomes
 	// authGate.presentedToken (nil there ⇒ the webTabAwareToken default).
 	presented func(*http.Request) string
@@ -177,14 +175,14 @@ type tcpListenerAuth struct {
 func startTCPListener(mux http.Handler, addr string, cfg *config.Config, policy tokenGatePolicy, shell webShell, auth *tcpListenerAuth) (func() error, tcpListenerInfo, error) {
 	var token string
 	var expectedToken func() (string, error)
+	var expectedForRequest func(*http.Request) (string, error)
 	var presentedToken func(*http.Request) string
 	if auth != nil {
-		t, err := auth.token()
-		if err != nil {
-			return nil, tcpListenerInfo{}, fmt.Errorf("resolve listener token: %w", err)
-		}
-		token = t
-		expectedToken = auth.token
+		// The preview listener authenticates a PER-TAB credential derived per request
+		// (HMAC over the sid/tid in the path); there is no single token to advertise,
+		// so the banner token stays empty and per-tab tokens are vended via
+		// /v1/preview-auth.
+		expectedForRequest = auth.expectedForRequest
 		presentedToken = auth.presented
 	} else {
 		// Generate-if-absent so enabling the listener always yields a usable token;
@@ -202,10 +200,11 @@ func startTCPListener(mux http.Handler, addr string, cfg *config.Config, policy 
 		}
 	}
 	gate := &authGate{
-		expectedToken:  expectedToken,
-		presentedToken: presentedToken,
-		tokenDisabled:  policy.tokenDisabled,
-		loopbackExempt: policy.loopbackExempt,
+		expectedToken:           expectedToken,
+		expectedTokenForRequest: expectedForRequest,
+		presentedToken:          presentedToken,
+		tokenDisabled:           policy.tokenDisabled,
+		loopbackExempt:          policy.loopbackExempt,
 	}
 
 	// A plain TCP listener — net.Listen (not tls.Listen). Addr() reports the


### PR DESCRIPTION
## #1856 step 3a — per-tab preview credential (daemon-only)

The origin-model decision on #1856 is **subdomain-per-tab, remote degrades to the sandbox** (your call). Per the two-PR sequence I posted there, this is **PR 3a: the per-tab credential** — the daemon-only half of the step-3 gate. It **serves no content and relaxes no sandbox**, so it is safe to land alone, and it immediately retires step 2's global-token hazard. **PR 3b** (subdomain origin + client re-addressing + sandbox relax + absolute-path handling) follows and is the only PR that relaxes the sandbox.

### The invariant this establishes
`no tab's credential authenticates another tab's route.` Proven by **`TestPreviewGate_RejectsAnotherTabsToken`** — tab A's token on tab B's route is 401 on the header, the query, and the cookie; tab B's own token is accepted (404, no content yet).

### What changed
- **`Manager.previewSecret`** (in-memory HMAC key, crypto/rand, rotates on restart, never on disk) replaces the global `previewToken`. A tab's token is `HMAC(secret, sid "\x00" tid)`; the secret is never vended or logged, only per-tab derivations.
- **Request-aware gate** — `authGate.expectedTokenForRequest` (wired via `tcpListenerAuth.expectedForRequest`) derives the expected token from the sid/tid in the request's *escaped* path (matching `PathValue`), so B's route only ever accepts B's token. A non-tab path (`/v1/Snapshot`) derives nothing → fail-closed 401.
- **Cookie narrowed** — the clean-before-render bootstrap scopes the credential cookie to `/v1/webtab/<sid>/<tid>/` (trailing slash), not the whole prefix, so a tab's cookie is never sent on a sibling's route.
- **`GET /v1/preview-auth`** now requires `?session=&tab=` and returns only that tab's token (400 on a missing selector — it can never hand back a credential good for more than one tab); still withheld unless the listener is BOUND.

### Why the credential alone isn't the whole gate
Cross-tab *read* isolation is a property of the ORIGIN: on today's single shared origin, a same-origin fetch still carries the destination tab's ambient cookie. Closing the read needs the per-tab origin (3b: subdomain → CORS blocks the cross-origin read). The credential here is what makes that safe — it authenticates the tab, so a leaked/observed token authorizes exactly its own tab. Both land before the sandbox relaxes (the #1856 gate).

### Gate
- `make test-container`: _running; will confirm on this head._
- Static: `go build ./...` · `gofmt -l .` · `golangci-lint --fast` · `deadcode -test ./...` · file-length — clean.
- Filtered host run of all `Preview*`/`ParsePreviewTabPath` tests: green.

Draft; not self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
