### PR TITLE
feat(config): canonical root_agent singleton + daemon integration (#2216 P6-PR2)

### DIFF
--- a/commands/configcmd.go
+++ b/commands/configcmd.go
@@ -91,6 +91,7 @@ var globalConfigReadOrder = []string{
 	"vscode_server_binary",
 	"theme",
 	"root_agents",
+	"root_agent",
 	"limit_auto_resume",
 	"global_agent_skills",
 	"docker_mount_agent_credentials",

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -203,6 +203,15 @@ type Config struct {
 	// in-repo config must never be able to opt a machine into an always-on
 	// agent just by being cloned.
 	RootAgents map[string]RootAgentConfig `json:"root_agents,omitempty" toml:"root_agents,omitempty"`
+	// RootAgent is the canonical singleton root-agent profile (#2216 Phase 6),
+	// the successor to the path-keyed RootAgents map. As a GLOBAL default it
+	// applies to registered projects only (never by scanning disk for repos);
+	// the built-in Enabled=false keeps root agents opt-in. A per-project personal
+	// override (ProjectConfig.RootAgent) and the legacy RootAgents entries layer
+	// with it in config.ResolveRootAgent. Structured [root_agent] table, so
+	// (like [theme]) it is hand-edited or set through the config assistant, not
+	// `af config set`.
+	RootAgent RootAgent `json:"root_agent,omitempty" toml:"root_agent,omitempty"`
 	// LimitPatterns optionally overrides, per agent, the built-in usage-limit
 	// banner-detection regex (#1146) so drifting vendor banners can be patched
 	// without a release. Empty keeps every built-in default. See

--- a/config/manifest.go
+++ b/config/manifest.go
@@ -421,6 +421,18 @@ var configManifest = []ManifestEntry{
 		Formats:    formatTOMLJSON,
 	},
 	{
+		Key:        "root_agent",
+		Type:       "table",
+		Default:    "not enabled",
+		Purpose:    "Whether a project keeps a session named root running, and the command it runs · the singleton successor to the root_agents list, settable per project.",
+		Tier:       TierAdvanced,
+		Settable:   false,
+		Sources:    sourceGlobalPersonal,
+		Precedence: precedenceGlobalPersonal,
+		Merge:      MergeTableByField,
+		Formats:    formatTOMLJSON,
+	},
+	{
 		Key:        "keys",
 		Type:       "table",
 		Default:    "none · the built-in bindings are used",

--- a/config/manifest_policy_test.go
+++ b/config/manifest_policy_test.go
@@ -221,7 +221,7 @@ func expectedPrecedence(entry ManifestEntry) []ConfigSource {
 		return precedenceLegacyRepo
 	case "default_program", "program_overrides":
 		return precedenceGlobalRepoPersonal
-	case "branch_prefix":
+	case "branch_prefix", "root_agent":
 		return precedenceGlobalPersonal
 	default:
 		if entry.Sources == sourceGlobalOnly {
@@ -235,7 +235,7 @@ func expectedMerge(entry ManifestEntry) MergePolicy {
 	switch entry.Key {
 	case "program_overrides", "limit_patterns", "root_agents", "keys":
 		return MergeMapByKey
-	case "theme", "docker", "ssh":
+	case "theme", "docker", "ssh", "root_agent":
 		return MergeTableByField
 	case "cors_allowed_origins", "post_worktree_commands":
 		return MergeListReplace

--- a/config/project_config.go
+++ b/config/project_config.go
@@ -38,6 +38,12 @@ type ProjectConfig struct {
 	ProgramOverrides map[string]string `toml:"program_overrides,omitempty"`
 	// BranchPrefix overrides the git branch prefix for this project's sessions.
 	BranchPrefix string `toml:"branch_prefix,omitempty"`
+	// RootAgent is the personal per-project root-agent profile (#2216 Phase 6):
+	// whether THIS project keeps an always-ensured root session on this machine,
+	// and the command it runs. It is the highest-precedence root-agent layer, so
+	// it can enable, disable, or reprogram a root the global default or a legacy
+	// root_agents entry set — see config.ResolveRootAgent.
+	RootAgent RootAgent `toml:"root_agent,omitempty"`
 
 	// setKeys records which top-level keys were present in the file so the
 	// resolver can distinguish "set to an empty value" from "absent", exactly as
@@ -52,6 +58,18 @@ type ProjectConfig struct {
 // project config file, even if its value was empty.
 func (c *ProjectConfig) IsSet(key string) bool {
 	return c != nil && c.setKeys[key]
+}
+
+// RootAgentLayer extracts the personal per-project [root_agent] singleton layer,
+// or nil when the personal config did not declare [root_agent]. Presence of
+// `enabled` comes from the decoded shape so an explicit `enabled=false` (a
+// disabling override) is distinguished from absence.
+func (c *ProjectConfig) RootAgentLayer() *RootAgentLayer {
+	if c == nil {
+		return nil
+	}
+	shape, _ := c.source.topLevel("root_agent")
+	return rootAgentLayerFromShape(c.RootAgent, shape)
 }
 
 // projectPersonalAllowedKeys is the manifest-derived allowlist of keys a

--- a/config/rootagent_resolve.go
+++ b/config/rootagent_resolve.go
@@ -138,6 +138,16 @@ func rootAgentFromLegacy(rc RootAgentConfig) RootAgent {
 	return RootAgent{Enabled: true, Program: rc.Program}
 }
 
+// rootAgentNormLayer is one precedence layer normalized to the same shape (the
+// built-in base, a singleton layer, or the adapted legacy entry) so the fold and
+// the trace treat every source uniformly.
+type rootAgentNormLayer struct {
+	source     RootAgentSource
+	enabledSet bool
+	enabled    bool
+	program    string
+}
+
 // ResolveRootAgent layers the provided sources into one effective root-agent
 // profile and returns it with the full provenance trace.
 //
@@ -157,16 +167,6 @@ func rootAgentFromLegacy(rc RootAgentConfig) RootAgent {
 // set it (an explicit false counts) and `program` only if non-empty (empty =
 // unset). So an empty legacy entry enables the root without clobbering a global
 // program, and a personal profile can flip enabled or reprogram independently.
-// rootAgentNormLayer is one precedence layer normalized to the same shape (the
-// built-in base, a singleton layer, or the adapted legacy entry) so the fold and
-// the trace treat every source uniformly.
-type rootAgentNormLayer struct {
-	source     RootAgentSource
-	enabledSet bool
-	enabled    bool
-	program    string
-}
-
 func ResolveRootAgent(in RootAgentInputs) RootAgentResolution {
 	layers := []rootAgentNormLayer{{source: RootAgentSourceBuiltIn, enabledSet: true, enabled: false}}
 	if in.Global != nil {

--- a/config/rootagent_resolve.go
+++ b/config/rootagent_resolve.go
@@ -1,34 +1,29 @@
 package config
 
-// This file is the permanent legacy `root_agents` compatibility adapter (#2216
-// Phase 6, PR1). It introduces the canonical root-agent profile and the single
-// resolver, ResolveRootAgent, that combines every root-agent source into one
-// effective decision so no consumer re-implements precedence.
+// This file is the canonical root-agent resolver and the permanent legacy
+// `root_agents` compatibility adapter (#2216 Phase 6). It defines the singleton
+// root-agent profile and ResolveRootAgent — the single authority on how every
+// root-agent source combines, so no consumer re-implements precedence.
 //
-// PR1 is the config-package adapter ONLY: it carries the built-in base and the
-// legacy path-keyed source, with tests proving existing `root_agents` entries
-// resolve to the canonical form unchanged. The daemon still reads
-// m.cfg.RootAgents directly and is untouched here — the strongest non-breaking
-// guarantee is that its ensure loop does not change at all. PR2's daemon
-// integration is what switches EnsureRootAgents AND repoRootAgentWillMaterialize
-// (which both read the map directly today) onto this resolver, at the same time
-// it adds the global and personal-project singleton layers below the personal one.
+// PR1 shipped the built-in + legacy layers as a config-only adapter with the
+// daemon untouched. PR2 adds the global and personal-project singleton layers and
+// wires the daemon (EnsureRootAgents and repoRootAgentWillMaterialize) onto this
+// function; the legacy path-keyed map is kept forever as a read-only source, so
+// existing configs never stop working.
 
 // RootAgent is the canonical root-agent profile: whether a project keeps an
 // always-ensured "root" session, and the command it runs. It is the singular
-// successor to the path-keyed `root_agents` map. That map is preserved forever
-// as a read-only compatibility source and adapted into this shape by
-// ResolveRootAgent — existing configs never stop working.
+// successor to the path-keyed `root_agents` map, which is adapted into this shape
+// by ResolveRootAgent.
 type RootAgent struct {
 	// Enabled is whether an always-ensured root session runs for the project.
 	// The built-in default is false, which keeps root agents strictly opt-in.
 	//
-	// Deliberately NO omitempty: once this is the singleton [root_agent] key
-	// (PR2), an explicit `enabled = false` written to override an enabling global
-	// layer must survive a full serialization — RegisterRootAgent and
-	// saveConfigLocked toml.Marshal the whole Config — or the override is silently
-	// erased on the next write, the zero-value-elision class this repo already
-	// paid for in #1700.
+	// Deliberately NO omitempty: an explicit `enabled = false` written to override
+	// an enabling global layer must survive a full serialization — RegisterRootAgent
+	// and saveConfigLocked toml.Marshal the whole Config — or the override is
+	// silently erased on the next write, the zero-value-elision class this repo
+	// already paid for in #1700.
 	Enabled bool `json:"enabled" toml:"enabled"`
 	// Program is the command the root session runs. Empty means UNSET, not "run
 	// an empty command": it falls through to a lower-precedence layer's program
@@ -38,21 +33,34 @@ type RootAgent struct {
 	Program string `json:"program,omitempty" toml:"program,omitempty"`
 }
 
-// RootAgentInputs are the per-project candidate values ResolveRootAgent layers,
-// lowest precedence first. Each is nil when that source configured no root agent
-// for the project. The struct grows as later #2216 phases add the global and
-// personal-project singleton layers; PR1 carries only the permanent legacy
-// compatibility source, and adding fields keeps existing callers valid.
+// RootAgentLayer is one configured singleton [root_agent] source's contribution
+// (global or personal-project). Value holds the decoded profile; EnabledSet
+// reports whether the source explicitly set `enabled`, because an explicit
+// `enabled = false` is a real value distinct from absence — presence comes from
+// the source file's shape, not from the zero value. Program needs no such flag:
+// empty means unset, the same convention the legacy source uses.
+type RootAgentLayer struct {
+	Value      RootAgent
+	EnabledSet bool
+}
+
+// RootAgentInputs are the per-project candidate sources ResolveRootAgent layers,
+// lowest precedence first. Each pointer is nil when that source configured no
+// root agent for the project. Adding a field keeps existing callers valid.
 type RootAgentInputs struct {
+	// Global is the global [root_agent] singleton (nil = not configured).
+	Global *RootAgentLayer
 	// Legacy is the path-keyed `root_agents` entry for this project, or nil. A
 	// present entry always ENABLES the root (that is what a legacy entry has
 	// always meant); its program applies only when non-empty, because an empty
-	// legacy program has always meant "use the default profile" — i.e. unset. That
-	// distinction is load-bearing once a lower layer can supply a program: the
-	// common legacy entry is EMPTY (af's own register and project-switch paths
+	// legacy program has always meant "use the default profile" — i.e. unset. The
+	// common legacy entry IS empty (af's own register and project-switch paths
 	// write an empty RootAgentConfig for every project), so treating empty as
-	// set-to-empty would clobber a global program back to nothing.
+	// set-to-empty would clobber a program back to nothing.
 	Legacy *RootAgentConfig
+	// Personal is the personal per-project [root_agent] singleton (nil = not
+	// configured). Highest precedence — see the rationale on ResolveRootAgent.
+	Personal *RootAgentLayer
 }
 
 // RootAgentSource names a candidate layer in a resolution trace.
@@ -61,15 +69,18 @@ type RootAgentSource string
 const (
 	// RootAgentSourceBuiltIn is the opt-in-false base.
 	RootAgentSourceBuiltIn RootAgentSource = "built-in"
+	// RootAgentSourceGlobal is the global [root_agent] singleton.
+	RootAgentSourceGlobal RootAgentSource = "global"
 	// RootAgentSourceLegacy is a path-keyed `root_agents` entry, kept as a
 	// permanent read-only compatibility source.
 	RootAgentSourceLegacy RootAgentSource = "legacy root_agents"
+	// RootAgentSourcePersonal is the personal per-project [root_agent] singleton.
+	RootAgentSourcePersonal RootAgentSource = "personal project"
 )
 
 // RootAgentCandidate is one considered layer in a ResolveRootAgent trace. The
-// trace is produced in the same pass as the value so a later `af config get
-// root_agent --explain` renders it without a second precedence implementation
-// (#2216 §5).
+// trace is produced in the same pass as the value so `af config get root_agent
+// --explain` renders it without a second precedence implementation (#2216 §5).
 type RootAgentCandidate struct {
 	Source  RootAgentSource `json:"source"`
 	Present bool            `json:"present"`
@@ -84,60 +95,145 @@ type RootAgentCandidate struct {
 // every candidate the resolver considered.
 type RootAgentResolution struct {
 	RootAgent
-	Candidates []RootAgentCandidate `json:"candidates"`
+	// EnabledSource / ProgramSource name the layer that supplied each effective
+	// field, for the --explain surface. EnabledSource is always set (the built-in
+	// base sets `enabled`); ProgramSource is empty when no layer supplied a
+	// program and the default profile applies.
+	EnabledSource RootAgentSource      `json:"enabled_source"`
+	ProgramSource RootAgentSource      `json:"program_source,omitempty"`
+	Candidates    []RootAgentCandidate `json:"candidates"`
 }
 
-// ResolveRootAgent layers the provided candidate sources into one effective
-// root-agent profile, lowest precedence first, and returns the effective value
-// together with its provenance trace. It is the single authority on how
-// root-agent config combines.
-//
-// PR1 (#2216 Phase 6) carries the permanent legacy compatibility source only:
-// the built-in opt-in-false base, then the path-keyed `root_agents` entry. A
-// present legacy entry resolves to Enabled=true with its program (an empty
-// program stays unset and falls through to the default profile) — matching the
-// profile the daemon derives when it reads the map directly, which is the
-// non-breaking guarantee this PR proves by test. PR1 does NOT wire the daemon to
-// this function. PR2's daemon integration does, and adds the global layer
-// between the built-in base and the legacy source, and the personal-project
-// layer after it.
-func ResolveRootAgent(in RootAgentInputs) RootAgentResolution {
-	res := RootAgentResolution{}
-	// Built-in base: root agents are opt-in, so nothing runs unless a higher
-	// layer turns it on.
-	res.Candidates = append(res.Candidates, RootAgentCandidate{
-		Source:  RootAgentSourceBuiltIn,
-		Present: true,
-		Enabled: false,
-		Result:  "base",
-		Reason:  "root agents are opt-in by default",
-	})
+// GlobalRootAgentLayer extracts the global [root_agent] singleton layer from a
+// loaded Config, or nil when the config did not declare [root_agent]. Presence of
+// `enabled` comes from the config's decoded shape, so an explicit `enabled=false`
+// is distinguished from absence (a value the zero RootAgent cannot carry).
+func GlobalRootAgentLayer(cfg *Config) *RootAgentLayer {
+	if cfg == nil {
+		return nil
+	}
+	shape, _ := cfg.source.topLevel("root_agent")
+	return rootAgentLayerFromShape(cfg.RootAgent, shape)
+}
 
+// rootAgentLayerFromShape builds a RootAgentLayer from a decoded RootAgent value
+// and the source's shape entry for "root_agent" (the shapeless decode used for
+// presence). It returns nil when [root_agent] was not declared, and sets
+// EnabledSet from whether the file's [root_agent] table carried an `enabled` key.
+func rootAgentLayerFromShape(value RootAgent, rootAgentShape any) *RootAgentLayer {
+	sub, ok := rootAgentShape.(map[string]any)
+	if !ok {
+		return nil
+	}
+	_, enabledSet := sub["enabled"]
+	return &RootAgentLayer{Value: value, EnabledSet: enabledSet}
+}
+
+// rootAgentFromLegacy adapts a legacy RootAgentConfig into the canonical profile.
+// It is the ONE place a legacy entry becomes canonical; the guard test
+// TestRootAgentConfigIsFullyAdapted fails when RootAgentConfig gains a field, so
+// a new per-repo field (the AutoYes/#2335 class) can never be silently dropped
+// from resolution — and thus from an ensured root.
+func rootAgentFromLegacy(rc RootAgentConfig) RootAgent {
+	return RootAgent{Enabled: true, Program: rc.Program}
+}
+
+// ResolveRootAgent layers the provided sources into one effective root-agent
+// profile and returns it with the full provenance trace.
+//
+// PRECEDENCE (low → high) — DO NOT REORDER legacy above personal:
+//
+//	built-in  <  global  <  legacy root_agents[path]  <  personal-project
+//
+// Legacy MUST sit BELOW personal. RegisterRootAgent and the TUI project-switch
+// write an EMPTY root_agents entry for EVERY registered project, and a present
+// legacy entry means Enabled=true. If legacy outranked personal, that ubiquitous
+// Enabled=true would override a personal `enabled=false`, so a user could NEVER
+// disable a root for a registered project through the singleton — exactly the
+// silent no-op #2216 exists to kill. Keeping legacy below personal lets a personal
+// `enabled=false` disable it. (root_agent admits no in-repo layer.)
+//
+// Merge is by FIELD on presence: a higher layer overrides `enabled` only if it
+// set it (an explicit false counts) and `program` only if non-empty (empty =
+// unset). So an empty legacy entry enables the root without clobbering a global
+// program, and a personal profile can flip enabled or reprogram independently.
+// rootAgentNormLayer is one precedence layer normalized to the same shape (the
+// built-in base, a singleton layer, or the adapted legacy entry) so the fold and
+// the trace treat every source uniformly.
+type rootAgentNormLayer struct {
+	source     RootAgentSource
+	enabledSet bool
+	enabled    bool
+	program    string
+}
+
+func ResolveRootAgent(in RootAgentInputs) RootAgentResolution {
+	layers := []rootAgentNormLayer{{source: RootAgentSourceBuiltIn, enabledSet: true, enabled: false}}
+	if in.Global != nil {
+		layers = append(layers, rootAgentNormLayer{RootAgentSourceGlobal, in.Global.EnabledSet, in.Global.Value.Enabled, in.Global.Value.Program})
+	}
 	if in.Legacy != nil {
-		res.Enabled = true
-		reason := "a path-keyed root_agents entry is an always-ensured root"
-		if in.Legacy.Program != "" {
-			res.Program = in.Legacy.Program
-		} else {
-			// An empty legacy program is UNSET, not set-to-empty: leave any
-			// lower-precedence program in place instead of clobbering it (P3-a).
-			reason += "; empty program is unset, so the default profile applies"
+		la := rootAgentFromLegacy(*in.Legacy)
+		layers = append(layers, rootAgentNormLayer{RootAgentSourceLegacy, true, la.Enabled, la.Program})
+	}
+	if in.Personal != nil {
+		layers = append(layers, rootAgentNormLayer{RootAgentSourcePersonal, in.Personal.EnabledSet, in.Personal.Value.Enabled, in.Personal.Value.Program})
+	}
+
+	var res RootAgentResolution
+	for _, l := range layers {
+		if l.enabledSet {
+			res.Enabled = l.enabled
+			res.EnabledSource = l.source
 		}
-		res.Candidates = append(res.Candidates, RootAgentCandidate{
-			Source:  RootAgentSourceLegacy,
-			Present: true,
-			Enabled: true,
-			Program: in.Legacy.Program,
-			Result:  "winner",
-			Reason:  reason,
-		})
-	} else {
-		res.Candidates = append(res.Candidates, RootAgentCandidate{
-			Source:  RootAgentSourceLegacy,
-			Present: false,
-			Result:  "absent",
-			Reason:  "no root_agents entry for this project",
-		})
+		if l.program != "" {
+			res.Program = l.program
+			res.ProgramSource = l.source
+		}
+	}
+
+	// Trace every possible source (present or not) so --explain shows the whole
+	// picture, marking which supplied each effective field.
+	present := map[RootAgentSource]rootAgentNormLayer{}
+	for _, l := range layers {
+		present[l.source] = l
+	}
+	for _, source := range []RootAgentSource{RootAgentSourceBuiltIn, RootAgentSourceGlobal, RootAgentSourceLegacy, RootAgentSourcePersonal} {
+		l, ok := present[source]
+		res.Candidates = append(res.Candidates, rootAgentCandidate(source, l, ok, res))
 	}
 	return res
+}
+
+// rootAgentCandidate builds one trace row, classifying the source against the
+// resolved per-field origins.
+func rootAgentCandidate(source RootAgentSource, l rootAgentNormLayer, present bool, res RootAgentResolution) RootAgentCandidate {
+	c := RootAgentCandidate{Source: source, Present: present, Enabled: l.enabled, Program: l.program}
+	switch {
+	case source == RootAgentSourceBuiltIn:
+		c.Result = "base"
+		c.Reason = "root agents are opt-in by default"
+	case !present:
+		c.Result = "absent"
+		c.Reason = "not configured for this project"
+	default:
+		wonEnabled := res.EnabledSource == source
+		wonProgram := res.ProgramSource == source
+		switch {
+		case wonEnabled && wonProgram:
+			c.Result, c.Reason = "winner", "supplies the effective enabled and program"
+		case wonEnabled:
+			c.Result, c.Reason = "winner", "supplies the effective enabled"
+		case wonProgram:
+			c.Result, c.Reason = "winner", "supplies the effective program"
+		default:
+			c.Result = "shadowed"
+			if source == RootAgentSourceLegacy && l.program == "" {
+				c.Reason = "enabled by a higher layer; its empty program is unset"
+			} else {
+				c.Reason = "overridden by a higher-precedence layer"
+			}
+		}
+	}
+	return c
 }

--- a/config/rootagent_resolve_test.go
+++ b/config/rootagent_resolve_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/pelletier/go-toml/v2"
@@ -87,26 +88,81 @@ func TestResolveRootAgentMatchesDirectMapValueForEveryEntry(t *testing.T) {
 	}
 }
 
-// TestResolveRootAgentEmptyLegacyProgramIsUnset pins P3-a: an empty legacy
-// program is UNSET, not set-to-empty, so once a lower-precedence layer supplies a
-// program (PR2's global layer) the empty legacy entry does not clobber it back to
-// empty. In PR1 the observable form is that an empty entry leaves Program "" and
-// the legacy candidate records that its program is unset; a non-empty entry sets
-// it. A regression to unconditional assignment drops the "unset" reason.
-func TestResolveRootAgentEmptyLegacyProgramIsUnset(t *testing.T) {
-	empty := ResolveRootAgent(RootAgentInputs{Legacy: &RootAgentConfig{}})
-	assert.True(t, empty.Enabled, "a present legacy entry still enables the root")
-	assert.Equal(t, "", empty.Program, "an empty legacy program leaves the effective program unset")
-	legacyEmpty, ok := candidateBySource(empty, RootAgentSourceLegacy)
-	require.True(t, ok)
-	assert.Contains(t, legacyEmpty.Reason, "unset",
-		"the trace must record that an empty legacy program is unset, not set-to-empty")
+// TestResolveRootAgentEmptyLegacyDoesNotClobberGlobalProgram pins P3-a with PR2's
+// global layer present: an empty legacy entry enables the root but must NOT clobber
+// a global program back to the default. This is the case that would have silently
+// broken — af writes an empty legacy entry for every registered project.
+func TestResolveRootAgentEmptyLegacyDoesNotClobberGlobalProgram(t *testing.T) {
+	res := ResolveRootAgent(RootAgentInputs{
+		Global: &RootAgentLayer{Value: RootAgent{Program: "codex"}}, // program set, enabled unset
+		Legacy: &RootAgentConfig{},                                  // empty: enables, program unset
+	})
+	assert.True(t, res.Enabled, "the legacy entry enables the root")
+	assert.Equal(t, "codex", res.Program, "an empty legacy program must not clobber the global program")
+	assert.Equal(t, RootAgentSourceGlobal, res.ProgramSource)
+	assert.Equal(t, RootAgentSourceLegacy, res.EnabledSource)
 
-	set := ResolveRootAgent(RootAgentInputs{Legacy: &RootAgentConfig{Program: "codex"}})
-	assert.Equal(t, "codex", set.Program, "a non-empty legacy program is the effective program")
-	legacySet, ok := candidateBySource(set, RootAgentSourceLegacy)
-	require.True(t, ok)
-	assert.NotContains(t, legacySet.Reason, "unset")
+	alone := ResolveRootAgent(RootAgentInputs{Legacy: &RootAgentConfig{}})
+	assert.Equal(t, "", alone.Program, "an empty legacy alone supplies no program")
+	assert.Equal(t, RootAgentSource(""), alone.ProgramSource)
+}
+
+// TestResolveRootAgentPrecedence pins the approved order built-in < global <
+// legacy < personal, merged by field.
+func TestResolveRootAgentPrecedence(t *testing.T) {
+	res := ResolveRootAgent(RootAgentInputs{
+		Global:   &RootAgentLayer{Value: RootAgent{Enabled: true, Program: "global-prog"}, EnabledSet: true},
+		Legacy:   &RootAgentConfig{Program: "legacy-prog"},
+		Personal: &RootAgentLayer{Value: RootAgent{Enabled: true, Program: "personal-prog"}, EnabledSet: true},
+	})
+	assert.True(t, res.Enabled)
+	assert.Equal(t, "personal-prog", res.Program, "personal outranks legacy and global")
+	assert.Equal(t, RootAgentSourcePersonal, res.ProgramSource)
+	assert.Equal(t, RootAgentSourcePersonal, res.EnabledSource)
+}
+
+// TestResolveRootAgentPersonalDisablesLegacy is THE case the confirmed precedence
+// exists for: a personal enabled=false must disable a root a legacy entry turned
+// on. Since af writes an empty legacy entry (enabled=true) for every registered
+// project, legacy-above-personal would make this impossible — the silent no-op
+// #2216 kills.
+func TestResolveRootAgentPersonalDisablesLegacy(t *testing.T) {
+	res := ResolveRootAgent(RootAgentInputs{
+		Legacy:   &RootAgentConfig{Program: "legacy-prog"},                            // enables
+		Personal: &RootAgentLayer{Value: RootAgent{Enabled: false}, EnabledSet: true}, // explicit disable
+	})
+	assert.False(t, res.Enabled, "a personal enabled=false disables a legacy-enabled root")
+	assert.Equal(t, RootAgentSourcePersonal, res.EnabledSource, "personal supplies the effective enabled")
+
+	// personal wins the enabled decision; the legacy program is still the
+	// effective program (moot while disabled), so its trace result is winner-by-
+	// program, not shadowed — what matters is that Enabled is false.
+	personal, _ := candidateBySource(res, RootAgentSourcePersonal)
+	assert.Equal(t, "winner", personal.Result)
+}
+
+// TestResolveRootAgentGlobalEnables: a global enabled=true (no legacy, no personal)
+// enables the root — the global default fanning out to a registered project.
+func TestResolveRootAgentGlobalEnables(t *testing.T) {
+	res := ResolveRootAgent(RootAgentInputs{
+		Global: &RootAgentLayer{Value: RootAgent{Enabled: true}, EnabledSet: true},
+	})
+	assert.True(t, res.Enabled)
+	assert.Equal(t, RootAgentSourceGlobal, res.EnabledSource)
+}
+
+// TestRootAgentConfigIsFullyAdapted is the struct-field guard (P2-a carry-forward):
+// it fails when RootAgentConfig gains or loses a field, forcing rootAgentFromLegacy
+// (and RootAgent) to carry it rather than silently dropping it — the AutoYes/#2335
+// class where a new per-repo field vanishes from every ensured root while the
+// suite stays green.
+func TestRootAgentConfigIsFullyAdapted(t *testing.T) {
+	var names []string
+	for _, f := range reflect.VisibleFields(reflect.TypeOf(RootAgentConfig{})) {
+		names = append(names, f.Name)
+	}
+	assert.Equal(t, []string{"Program"}, names,
+		"RootAgentConfig's fields changed — update rootAgentFromLegacy and RootAgent to carry the new field, then this guard")
 }
 
 // TestRootAgentEnabledSerializesExplicitFalse pins P3-b: RootAgent.Enabled has

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -113,10 +113,32 @@ type Manager struct {
 	// the rest in arrival order instead of racing creation and dropping the
 	// losers' prompts (#865). Lazily populated like repoStartLocks.
 	targetLocks map[string]*sync.Mutex
-	// rootEnsureStates tracks per-configured-repo retry state for the
-	// root-agent ensure loop (#1106), keyed by the root_agents config key
-	// (the repo path as written in config.json).
+	// rootEnsureStates tracks per-candidate retry state for the root-agent
+	// ensure loop (#1106), keyed by the root_agents config key (the repo path as
+	// written in config.json) for a legacy entry, or by the registered project's
+	// resolved root path for a singleton-only candidate (#2216 Phase 6).
 	rootEnsureStates map[string]*rootEnsureState
+	// rootAgentGlobal is the global [root_agent] singleton layer (#2216 Phase 6),
+	// snapshotted at daemon start (nil when the config declared no [root_agent]).
+	// Like the RootAgents map it is immutable in memory after construction:
+	// root_agent config changes take effect on the next daemon start.
+	rootAgentGlobal *config.RootAgentLayer
+	// rootAgentPersonal maps a registered project's repo ID to its personal
+	// [root_agent] layer, snapshotted at daemon start (projects with no such
+	// override are absent). It is the highest-precedence root-agent source,
+	// merged over global and legacy in config.ResolveRootAgent.
+	rootAgentPersonal map[string]*config.RootAgentLayer
+	// rootAgentProjectRoots maps a registered project's repo ID to its resolved
+	// root path, snapshotted at daemon start. It is the candidate set the ensure
+	// loop visits for a root enabled purely by the global/personal singleton — a
+	// project with no legacy root_agents entry — and supplies the repo root
+	// CreateSession needs. Restart-to-apply, like RootAgents.
+	rootAgentProjectRoots map[string]string
+	// rootAgentLegacyRepoIDs is the set of repo IDs a root_agents path resolved to
+	// at daemon start. The singleton-project sweep skips these so a repo named by
+	// both a legacy entry and a registered project is ensured once — by the legacy
+	// sweep, which merges the personal layer — rather than twice.
+	rootAgentLegacyRepoIDs map[string]bool
 	// rootKilledAt records repos (by repo ID) whose root agent was explicitly
 	// killed, and WHEN. The ensure loop honors the kill only for
 	// rootKillHealDelay, then self-heals a still-configured root (#1223): config
@@ -276,37 +298,42 @@ func newManagerShellForDaemon(cfg *config.Config, transactionID string) (*Manage
 		}
 		return cfg.VSCodeServerBinary
 	}
+	raGlobal, raPersonal, raProjectRoots, raLegacyIDs := buildRootAgentSnapshot(cfg)
 	m := &Manager{
-		cfg:                 cfg,
-		previewSecret:       previewSecret,
-		limitDetector:       task.NewLimitDetector(cfg.LimitPatterns),
-		ready:               make(chan struct{}),
-		lifecycle:           lifecycle,
-		storage:             storage,
-		instances:           make(map[string]*session.Instance),
-		pendingCreates:      make(map[string]session.InstanceData),
-		reservedTitles:      make(map[string]struct{}),
-		reservedTmuxNames:   make(map[string]string),
-		reservedRemoteNames: make(map[string]struct{}),
-		reservedTaskRuns:    make(map[string]int),
-		ghostTaskRuns:       make(map[string]int),
-		repoStartLocks:      make(map[string]*sync.Mutex),
-		aliveObservations:   make(map[string]uint64),
-		targetLocks:         make(map[string]*sync.Mutex),
-		rootEnsureStates:    make(map[string]*rootEnsureState),
-		rootKilledAt:        make(map[string]time.Time),
-		deletedRootRepos:    make(map[string]struct{}),
-		killsInFlight:       make(map[string]struct{}),
-		lostRestoreStates:   make(map[string]*lostRestoreState),
-		limitResumeStates:   make(map[string]*limitResumeState),
-		handoffRetryDue:     make(map[string]time.Time),
-		remoteLossStates:    make(map[string]*remoteLossState),
-		instanceOpLocks:     make(map[string]*sync.Mutex),
-		pausedPolls:         make(map[string]time.Time),
-		taskRunProbeDue:     make(map[string]time.Time),
-		events:              newEventsHub(),
-		vscode:              vscode,
-		configAgents:        configAgents,
+		cfg:                    cfg,
+		previewSecret:          previewSecret,
+		limitDetector:          task.NewLimitDetector(cfg.LimitPatterns),
+		ready:                  make(chan struct{}),
+		lifecycle:              lifecycle,
+		storage:                storage,
+		instances:              make(map[string]*session.Instance),
+		pendingCreates:         make(map[string]session.InstanceData),
+		reservedTitles:         make(map[string]struct{}),
+		reservedTmuxNames:      make(map[string]string),
+		reservedRemoteNames:    make(map[string]struct{}),
+		reservedTaskRuns:       make(map[string]int),
+		ghostTaskRuns:          make(map[string]int),
+		repoStartLocks:         make(map[string]*sync.Mutex),
+		aliveObservations:      make(map[string]uint64),
+		targetLocks:            make(map[string]*sync.Mutex),
+		rootEnsureStates:       make(map[string]*rootEnsureState),
+		rootAgentGlobal:        raGlobal,
+		rootAgentPersonal:      raPersonal,
+		rootAgentProjectRoots:  raProjectRoots,
+		rootAgentLegacyRepoIDs: raLegacyIDs,
+		rootKilledAt:           make(map[string]time.Time),
+		deletedRootRepos:       make(map[string]struct{}),
+		killsInFlight:          make(map[string]struct{}),
+		lostRestoreStates:      make(map[string]*lostRestoreState),
+		limitResumeStates:      make(map[string]*limitResumeState),
+		handoffRetryDue:        make(map[string]time.Time),
+		remoteLossStates:       make(map[string]*remoteLossState),
+		instanceOpLocks:        make(map[string]*sync.Mutex),
+		pausedPolls:            make(map[string]time.Time),
+		taskRunProbeDue:        make(map[string]time.Time),
+		events:                 newEventsHub(),
+		vscode:                 vscode,
+		configAgents:           configAgents,
 	}
 	m.configAssistants = newConfigAssistantHub(m)
 	return m, nil

--- a/daemon/rootagent.go
+++ b/daemon/rootagent.go
@@ -71,35 +71,153 @@ type rootEnsureState struct {
 	suppressLogged bool
 }
 
-// EnsureRootAgents runs one ensure pass over every repo configured in
-// root_agents. Called from the daemon poll loop after RefreshStatuses; a
-// no-op when nothing is configured or the initial restore has not finished.
-func (m *Manager) EnsureRootAgents() {
-	if len(m.cfg.RootAgents) == 0 || !m.Ready() {
-		return
+// buildRootAgentSnapshot captures the start-of-day root-agent configuration the
+// ensure loop resolves against (#2216 Phase 6): the global [root_agent]
+// singleton, every registered project's personal [root_agent] layer and resolved
+// root (both keyed by repo ID), and the repo IDs the legacy root_agents map
+// already covers (so the singleton sweep can dedupe against it). It is
+// best-effort — a project whose checkout no longer resolves, or whose personal
+// config cannot be read, is logged and skipped, never fatal, so one bad project
+// never keeps the daemon from starting. Reading the registry once at start
+// matches the RootAgents map's restart-to-apply contract: registering a project
+// or editing its personal root_agent takes effect on the next daemon start.
+func buildRootAgentSnapshot(cfg *config.Config) (global *config.RootAgentLayer, personal map[string]*config.RootAgentLayer, projectRoots map[string]string, legacyRepoIDs map[string]bool) {
+	global = config.GlobalRootAgentLayer(cfg)
+	personal = map[string]*config.RootAgentLayer{}
+	projectRoots = map[string]string{}
+	legacyRepoIDs = map[string]bool{}
+
+	for path := range cfg.RootAgents {
+		repo, err := config.RepoFromPath(config.ExpandTilde(path))
+		if err != nil {
+			// A not-yet-cloned legacy path is normal (#1122): the per-path ensure
+			// sweep retries it. It is simply not part of the dedup set until it
+			// resolves — and while it does not resolve it cannot collide with a
+			// registered project (which did resolve at start).
+			continue
+		}
+		legacyRepoIDs[repo.ID] = true
 	}
-	paths := make([]string, 0, len(m.cfg.RootAgents))
-	for path := range m.cfg.RootAgents {
-		paths = append(paths, path)
+
+	projects, err := config.ListProjects()
+	if err != nil {
+		log.WarningLog.Printf("root agent snapshot: could not list registered projects; singleton root agents are disabled until the next daemon start: %v", err)
+		return global, personal, projectRoots, legacyRepoIDs
 	}
-	sort.Strings(paths)
-	for _, path := range paths {
-		m.ensureRootAgent(path, m.cfg.RootAgents[path])
+	for _, p := range projects {
+		repo, err := config.RepoFromPath(p.Root)
+		if err != nil {
+			log.WarningLog.Printf("root agent snapshot: project %s root %s does not resolve to a git repository; skipping it until the next daemon start: %v", p.ID, p.Root, err)
+			continue
+		}
+		projectRoots[repo.ID] = repo.Root
+		pc, err := config.LoadProjectConfig(p.ID)
+		if err != nil {
+			log.WarningLog.Printf("root agent snapshot: project %s personal config is unreadable; ignoring its root_agent override until the next daemon start: %v", p.ID, err)
+			continue
+		}
+		if layer := pc.RootAgentLayer(); layer != nil {
+			personal[repo.ID] = layer
+		}
+	}
+	return global, personal, projectRoots, legacyRepoIDs
+}
+
+// rootAgentInputsFor assembles the resolver inputs for one repo from the
+// start-of-day snapshot plus its (optional) legacy entry, so every caller — the
+// ensure sweep and repoRootAgentWillMaterialize — layers the same sources and
+// can never disagree on whether a root should run or what it runs.
+func (m *Manager) rootAgentInputsFor(repoID string, legacy *config.RootAgentConfig) config.RootAgentInputs {
+	return config.RootAgentInputs{
+		Global:   m.rootAgentGlobal,
+		Legacy:   legacy,
+		Personal: m.rootAgentPersonal[repoID],
 	}
 }
 
-// ensureRootAgent guarantees the root agent for one configured repo path:
-// adopt a live root untouched, heal a Dead/Lost one in place, create a missing
-// one, and respect an explicit user kill. All outcomes are logged; failures
-// back off exponentially and settle at the rootEnsureBackoffMax cadence, so
-// the loop always heals eventually once the cause clears.
-func (m *Manager) ensureRootAgent(path string, rc config.RootAgentConfig) {
-	m.mu.Lock()
-	st := m.rootEnsureStates[path]
-	if st == nil {
-		st = &rootEnsureState{}
-		m.rootEnsureStates[path] = st
+// legacyRootAgentForRepo returns a copy of the root_agents entry whose path
+// resolves to repoID, or nil if none does. Resolved per call (not from the
+// snapshot dedup set) to preserve the legacy contract that a path pointing at a
+// not-yet-cloned repo starts applying the moment the repo appears.
+func (m *Manager) legacyRootAgentForRepo(repoID string) *config.RootAgentConfig {
+	for path, rc := range m.cfg.RootAgents {
+		repo, err := config.RepoFromPath(config.ExpandTilde(path))
+		if err != nil {
+			continue
+		}
+		if repo.ID == repoID {
+			entry := rc
+			return &entry
+		}
 	}
+	return nil
+}
+
+// rootAgentResolutionForRepo resolves the effective root-agent profile for one
+// repo ID and reports whether the repo is a candidate at all (named by a legacy
+// entry or a registered project). It is the single authority
+// repoRootAgentWillMaterialize shares with the ensure loop, so a delivery waits
+// for a root exactly when the loop will create one. Layers are merged, so a
+// personal enabled=false disables a legacy-enabled root here too.
+func (m *Manager) rootAgentResolutionForRepo(repoID string) (config.RootAgentResolution, bool) {
+	legacy := m.legacyRootAgentForRepo(repoID)
+	_, isProject := m.rootAgentProjectRoots[repoID]
+	if legacy == nil && !isProject {
+		return config.RootAgentResolution{}, false
+	}
+	return config.ResolveRootAgent(m.rootAgentInputsFor(repoID, legacy)), true
+}
+
+// EnsureRootAgents runs one ensure pass over every repo that resolves to an
+// enabled root agent: the legacy root_agents entries and the registered projects
+// a global/personal [root_agent] singleton turns on (#2216 Phase 6). Called from
+// the daemon poll loop after RefreshStatuses; a no-op until the initial restore
+// finishes.
+func (m *Manager) EnsureRootAgents() {
+	if !m.Ready() {
+		return
+	}
+
+	// Legacy root_agents paths first: this path keeps the per-path RepoFromPath
+	// retry and backoff a not-yet-cloned repo relies on (#1122). Sorted for a
+	// deterministic order.
+	if len(m.cfg.RootAgents) > 0 {
+		paths := make([]string, 0, len(m.cfg.RootAgents))
+		for path := range m.cfg.RootAgents {
+			paths = append(paths, path)
+		}
+		sort.Strings(paths)
+		for _, path := range paths {
+			m.ensureLegacyRootAgent(path, m.cfg.RootAgents[path])
+		}
+	}
+
+	// Registered projects a legacy entry did NOT already cover, enabled purely by
+	// the global or personal [root_agent] singleton. Skipping legacy-covered repo
+	// IDs is what keeps a repo named by both from being ensured twice.
+	if len(m.rootAgentProjectRoots) > 0 {
+		repoIDs := make([]string, 0, len(m.rootAgentProjectRoots))
+		for repoID := range m.rootAgentProjectRoots {
+			if m.rootAgentLegacyRepoIDs[repoID] {
+				continue
+			}
+			repoIDs = append(repoIDs, repoID)
+		}
+		sort.Strings(repoIDs)
+		for _, repoID := range repoIDs {
+			m.ensureSingletonRootAgent(repoID)
+		}
+	}
+}
+
+// ensureLegacyRootAgent ensures the root for one root_agents path, resolving its
+// full layer stack (global + this legacy entry + the project's personal layer)
+// so a personal enabled=false can disable it. It owns the per-path RepoFromPath
+// retry/backoff (#1122); resolution and the create/adopt/heal tail are shared
+// with the singleton path via ensureResolvedRoot.
+func (m *Manager) ensureLegacyRootAgent(path string, rc config.RootAgentConfig) {
+	m.mu.Lock()
+	st := m.rootEnsureStateForLocked(path)
 	skip := time.Now().Before(st.nextAttempt)
 	m.mu.Unlock()
 	if skip {
@@ -111,11 +229,59 @@ func (m *Manager) ensureRootAgent(path string, rc config.RootAgentConfig) {
 		m.rootEnsureFailed(path, st, fmt.Errorf("root_agents entry %q does not resolve to a git repository: %w", path, err))
 		return
 	}
+	resolution := config.ResolveRootAgent(m.rootAgentInputsFor(repo.ID, &rc))
+	m.ensureResolvedRoot(path, st, repo, resolution)
+}
+
+// ensureSingletonRootAgent ensures the root for a registered project enabled by
+// the global/personal singleton with no legacy root_agents entry. The repo
+// identity and root come from the start-of-day snapshot (no per-tick git
+// resolution — a registered project resolved at daemon start), and the state is
+// keyed by that resolved root path.
+func (m *Manager) ensureSingletonRootAgent(repoID string) {
+	root := m.rootAgentProjectRoots[repoID]
+	m.mu.Lock()
+	st := m.rootEnsureStateForLocked(root)
+	skip := time.Now().Before(st.nextAttempt)
+	m.mu.Unlock()
+	if skip {
+		return
+	}
+	repo := &config.RepoContext{Root: root, ID: repoID}
+	resolution := config.ResolveRootAgent(m.rootAgentInputsFor(repoID, nil))
+	m.ensureResolvedRoot(root, st, repo, resolution)
+}
+
+// rootEnsureStateForLocked returns the retry state for a candidate key, creating
+// it on first use. Caller must hold m.mu.
+func (m *Manager) rootEnsureStateForLocked(key string) *rootEnsureState {
+	st := m.rootEnsureStates[key]
+	if st == nil {
+		st = &rootEnsureState{}
+		m.rootEnsureStates[key] = st
+	}
+	return st
+}
+
+// ensureResolvedRoot is the shared create/adopt/heal tail for a resolved
+// candidate: adopt a live root untouched, heal a Dead/Lost one in place, create
+// a missing one, and respect an explicit user kill. stateKey names the retry
+// state (a legacy config path or a project root); resolution is the merged
+// profile. A candidate the config resolves to disabled is a no-op that resets
+// the retry state and leaves any existing root alone — removing an opt-in never
+// tears a live root down, it just stops re-ensuring it. All outcomes are logged;
+// failures back off exponentially and settle at rootEnsureBackoffMax, so the
+// loop always heals once the cause clears.
+func (m *Manager) ensureResolvedRoot(stateKey string, st *rootEnsureState, repo *config.RepoContext, resolution config.RootAgentResolution) {
+	if !resolution.Enabled {
+		m.rootEnsureSucceeded(st)
+		return
+	}
 
 	// A project deleted at runtime (#1735) is suppressed for the rest of this
 	// daemon's life: DeleteProject already stopped its root and removed it from
 	// root_agents on disk, so respawning it here from the still-immutable
-	// in-memory m.cfg would resurrect the project the user just deleted.
+	// in-memory config would resurrect the project the user just deleted.
 	m.mu.Lock()
 	_, deleted := m.deletedRootRepos[repo.ID]
 	m.mu.Unlock()
@@ -178,7 +344,7 @@ func (m *Manager) ensureRootAgent(path string, rc config.RootAgentConfig) {
 		log.WarningLog.Printf("root agent for %s is gone (tmux vanished); attempting to reap and re-create it in place", repo.Root)
 		reaped, err := m.reapDeadRoot(repo.ID, inst)
 		if err != nil {
-			m.rootEnsureFailed(path, st, fmt.Errorf("failed to remove dead root record: %w", err))
+			m.rootEnsureFailed(stateKey, st, fmt.Errorf("failed to remove dead root record: %w", err))
 			return
 		}
 		if !reaped {
@@ -186,7 +352,7 @@ func (m *Manager) ensureRootAgent(path string, rc config.RootAgentConfig) {
 		}
 	}
 
-	program := rootAgentProgram(repo.Root, rc)
+	program := rootAgentProgramForProfile(repo.Root, resolution.RootAgent)
 	if _, err := m.CreateSession(context.Background(), CreateSessionRequest{
 		Title:         session.RootSessionTitle,
 		RepoPath:      repo.Root,
@@ -194,7 +360,7 @@ func (m *Manager) ensureRootAgent(path string, rc config.RootAgentConfig) {
 		InPlace:       true,
 		allowReserved: true,
 	}); err != nil {
-		m.rootEnsureFailed(path, st, fmt.Errorf("failed to create root session: %w", err))
+		m.rootEnsureFailed(stateKey, st, fmt.Errorf("failed to create root session: %w", err))
 		return
 	}
 	log.InfoLog.Printf("ensured root agent for %s (in-place, program %q)", repo.Root, program)
@@ -235,21 +401,28 @@ func (m *Manager) deliverToReemergingRoot(repo *config.RepoContext, req DeliverP
 
 // repoRootAgentWillMaterialize reports whether the daemon's ensure loop is
 // responsible for (re-)creating the reserved "root" session for this repo: the
-// repo is opted into root_agents and its project has not been deleted at
-// runtime. Config is the single source of truth for "root should be running" —
-// a root that is Dead, Lost, or even explicitly killed self-heals (the kill only
-// delays re-creation by rootKillHealDelay, #1223), so a configured root always
-// materializes eventually and a delivery to a momentarily-absent one should wait
-// for the ensure loop rather than auto-create it (which the reserved-name guard
-// would reject).
+// repo's layered root_agent config resolves to enabled and its project has not
+// been deleted at runtime. Config is the single source of truth for "root should
+// be running" — a root that is Dead, Lost, or even explicitly killed self-heals
+// (the kill only delays re-creation by rootKillHealDelay, #1223), so an enabled
+// root always materializes eventually and a delivery to a momentarily-absent one
+// should wait for the ensure loop rather than auto-create it (which the
+// reserved-name guard would reject).
 //
-// A deleted project (#1735) is the one case where the still-immutable m.cfg
+// It routes through rootAgentResolutionForRepo, the SAME resolution the ensure
+// loop uses, so the two never disagree: a repo the loop will not create (a
+// personal enabled=false over a legacy entry, or a project no singleton turned
+// on) reports false, and a singleton-only project the loop WILL create reports
+// true even with no legacy root_agents entry. Otherwise a send-prompt to such a
+// root is wrongly rejected at the reserved-name gate (#1835).
+//
+// A deleted project (#1735) is the one case where the still-immutable snapshot
 // outlives the truth: DeleteProject removed the opt-in from disk but this
-// in-memory copy keeps listing the repo, and ensureRootAgent skips it for the
+// in-memory copy keeps listing the repo, and ensureResolvedRoot skips it for the
 // rest of the daemon's life. Answering from config alone would make callers wait
 // out targetDeliverWait for a root that can never come back, then blame a
-// recreation that is not happening (#1835), so deletion is checked with the same
-// lock+lookup ensureRootAgent uses.
+// recreation that is not happening, so deletion is checked with the same
+// lock+lookup the ensure loop uses, before the resolution.
 func (m *Manager) repoRootAgentWillMaterialize(repoID string) bool {
 	m.mu.Lock()
 	_, deleted := m.deletedRootRepos[repoID]
@@ -257,16 +430,8 @@ func (m *Manager) repoRootAgentWillMaterialize(repoID string) bool {
 	if deleted {
 		return false
 	}
-	for path := range m.cfg.RootAgents {
-		repo, err := config.RepoFromPath(config.ExpandTilde(path))
-		if err != nil {
-			continue
-		}
-		if repo.ID == repoID {
-			return true
-		}
-	}
-	return false
+	resolution, ok := m.rootAgentResolutionForRepo(repoID)
+	return ok && resolution.Enabled
 }
 
 // reapDeadRoot removes a Dead root instance so ensureRootAgent can re-create
@@ -369,15 +534,23 @@ func (m *Manager) rootEnsureFailed(path string, st *rootEnsureState, err error) 
 	log.WarningLog.Printf("root agent ensure for %q failed (attempt %d), retrying in %s: %v", path, st.consecutiveFailures, backoff, err)
 }
 
-// rootAgentProgram resolves the command the root agent runs. An explicit
-// per-repo program wins verbatim (an agent enum name still resolves through
-// program_overrides downstream, exactly like any session program). The
-// default profile is the repo's resolved claude command with
-// --dangerously-skip-permissions ensured — the root agent's whole purpose is
-// autonomous operation (#1106).
+// rootAgentProgram resolves the command the root agent runs from a legacy
+// per-repo entry. Retained as the thin adapter the direct-map program test and
+// any legacy-only caller use; it delegates to rootAgentProgramForProfile so the
+// resolution rule lives in exactly one place.
 func rootAgentProgram(repoRoot string, rc config.RootAgentConfig) string {
-	if strings.TrimSpace(rc.Program) != "" {
-		return rc.Program
+	return rootAgentProgramForProfile(repoRoot, config.RootAgent{Program: rc.Program})
+}
+
+// rootAgentProgramForProfile resolves the command the root agent runs from a
+// resolved root-agent profile. An explicit program wins verbatim (an agent enum
+// name still resolves through program_overrides downstream, exactly like any
+// session program). The default profile — an empty program — is the repo's
+// resolved claude command with --dangerously-skip-permissions ensured, the root
+// agent's whole purpose being autonomous operation (#1106).
+func rootAgentProgramForProfile(repoRoot string, ra config.RootAgent) string {
+	if strings.TrimSpace(ra.Program) != "" {
+		return ra.Program
 	}
 	program := "claude"
 	if resolved, err := config.ResolveConfig(repoRoot); err == nil {

--- a/daemon/rootagent_singleton_test.go
+++ b/daemon/rootagent_singleton_test.go
@@ -1,0 +1,258 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// These tests cover the #2216 Phase 6 PR2 daemon integration: the canonical
+// [root_agent] singleton (global + personal-project) resolved through
+// config.ResolveRootAgent, alongside the legacy root_agents map. They are
+// hermetic on the same rules as rootagent_test.go — temp AGENT_FACTORY_HOME,
+// the in-process fake backend, no real daemon.
+
+// registerTestProject registers repoPath as a durable project and returns it.
+func registerTestProject(t *testing.T, repoPath string) config.Project {
+	t.Helper()
+	p, err := config.RegisterProject(repoPath)
+	if err != nil {
+		t.Fatalf("RegisterProject(%s): %v", repoPath, err)
+	}
+	return p
+}
+
+// writePersonalRootAgent writes a registered project's personal config.toml with
+// a [root_agent] table whose body is the given TOML (e.g. `enabled = true`). It
+// bypasses the write path so resolver/daemon behavior is exercised directly.
+func writePersonalRootAgent(t *testing.T, projectID, body string) {
+	t.Helper()
+	path, err := config.ProjectConfigTomlPath(projectID)
+	if err != nil {
+		t.Fatalf("ProjectConfigTomlPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir personal config dir: %v", err)
+	}
+	content := "[root_agent]\n" + body + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write personal config: %v", err)
+	}
+}
+
+// loadGlobalConfigWithRootAgent writes a global config.toml carrying a
+// [root_agent] table and loads it through config.LoadConfig, so the loaded
+// Config's source shape records that `enabled` was set — the presence the global
+// layer extractor reads. AGENT_FACTORY_HOME must already point at a temp home.
+func loadGlobalConfigWithRootAgent(t *testing.T, body string) *config.Config {
+	t.Helper()
+	dir, err := config.GetConfigDir()
+	if err != nil {
+		t.Fatalf("GetConfigDir: %v", err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir AF home: %v", err)
+	}
+	content := "[root_agent]\n" + body + "\n"
+	if err := os.WriteFile(filepath.Join(dir, config.TomlConfigFileName), []byte(content), 0o600); err != nil {
+		t.Fatalf("write config.toml: %v", err)
+	}
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	return cfg
+}
+
+// repoID resolves repoPath to its daemon repo ID.
+func repoID(t *testing.T, repoPath string) string {
+	t.Helper()
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath(%s): %v", repoPath, err)
+	}
+	return repo.ID
+}
+
+// TestEnsureRootAgentsSingletonOnlyProjectMaterializes: a registered project
+// enabled purely by its personal [root_agent] — with NO legacy root_agents entry
+// — is now visited by the ensure loop (the old early-return on an empty map
+// skipped it entirely), gets a root created, and its resolved program flows
+// through losslessly. This is the whole point of PR2's enumeration rewrite.
+func TestEnsureRootAgentsSingletonOnlyProjectMaterializes(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	seen := installOptionsRecordingBackend(t)
+	repoPath := setupControlRepo(t)
+	project := registerTestProject(t, repoPath)
+	// A custom program doubles as the lossless-forward check: the resolved
+	// profile's program must reach CreateSession verbatim.
+	writePersonalRootAgent(t, project.ID, "enabled = true\nprogram = \"/opt/claude --model opus\"")
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	manager.EnsureRootAgents()
+
+	if len(*seen) != 1 {
+		t.Fatalf("a singleton-only project must materialize a root, got %d creates", len(*seen))
+	}
+	opts := (*seen)[0]
+	if opts.Title != session.RootSessionTitle || !opts.InPlace {
+		t.Fatalf("root must be the reserved title created in place, got title=%q inPlace=%v", opts.Title, opts.InPlace)
+	}
+	if opts.Program != "/opt/claude --model opus" {
+		t.Fatalf("the resolved personal program must reach CreateSession verbatim, got %q", opts.Program)
+	}
+	if findRootInstance(t, manager, repoPath) == nil {
+		t.Fatalf("root instance not registered for the singleton-only project")
+	}
+	if !manager.repoRootAgentWillMaterialize(repoID(t, repoPath)) {
+		t.Fatalf("repoRootAgentWillMaterialize must be true for a singleton-only project the loop creates — else a send-prompt to it is wrongly rejected (#1835)")
+	}
+}
+
+// TestEnsureRootAgentsGlobalEnablesRegisteredProject: a global [root_agent]
+// enabled=true fans out to a registered project with no legacy entry and no
+// personal override — the global default's registered-project-only reach.
+func TestEnsureRootAgentsGlobalEnablesRegisteredProject(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	seen := installOptionsRecordingBackend(t)
+	repoPath := setupControlRepo(t)
+	registerTestProject(t, repoPath)
+	cfg := loadGlobalConfigWithRootAgent(t, "enabled = true")
+
+	manager, err := NewManager(cfg)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	manager.EnsureRootAgents()
+
+	if len(*seen) != 1 {
+		t.Fatalf("a global enabled=true must fan out to the registered project, got %d creates", len(*seen))
+	}
+	if findRootInstance(t, manager, repoPath) == nil {
+		t.Fatalf("root instance not registered for the globally-enabled project")
+	}
+	if !manager.repoRootAgentWillMaterialize(repoID(t, repoPath)) {
+		t.Fatalf("repoRootAgentWillMaterialize must be true for a globally-enabled registered project")
+	}
+}
+
+// TestEnsureRootAgentsPersonalDisablesLegacyRoot is THE case #2216 exists for: a
+// registered project carries a legacy root_agents entry (which alone means
+// enabled=true, program unset — the empty entry af writes for every registered
+// project) AND a personal enabled=false. The personal disable must win, so NO
+// root is created and repoRootAgentWillMaterialize reports false. With legacy
+// outranking personal this would be an unbreakable always-on root — the silent
+// no-op this epic kills.
+func TestEnsureRootAgentsPersonalDisablesLegacyRoot(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	seen := installOptionsRecordingBackend(t)
+	repoPath := setupControlRepo(t)
+	project := registerTestProject(t, repoPath)
+	writePersonalRootAgent(t, project.ID, "enabled = false")
+
+	// Legacy entry present for the same repo (the ubiquitous empty entry).
+	manager, err := NewManager(rootTestConfig(repoPath, config.RootAgentConfig{}))
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	manager.EnsureRootAgents()
+
+	if len(*seen) != 0 {
+		t.Fatalf("a personal enabled=false must disable a legacy-enabled root, got %d creates", len(*seen))
+	}
+	if findRootInstance(t, manager, repoPath) != nil {
+		t.Fatalf("no root instance may exist for a personal-disabled project")
+	}
+	if manager.repoRootAgentWillMaterialize(repoID(t, repoPath)) {
+		t.Fatalf("repoRootAgentWillMaterialize must be false for a personal-disabled root — a send-prompt must not wait for a root that will never come")
+	}
+}
+
+// TestEnsureRootAgentsLegacyOnlyUnchangedThroughResolver: a plain legacy entry
+// with no project registration and no global/personal layer still ensures a
+// root, exactly as before PR2 — proving the resolver rewrite preserved the
+// legacy contract end to end (create AND willMaterialize).
+func TestEnsureRootAgentsLegacyOnlyUnchangedThroughResolver(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	seen := installOptionsRecordingBackend(t)
+	repoPath := setupControlRepo(t)
+
+	manager, err := NewManager(rootTestConfig(repoPath, config.RootAgentConfig{}))
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	manager.EnsureRootAgents()
+
+	if len(*seen) != 1 {
+		t.Fatalf("a legacy entry must still ensure a root through the resolver, got %d creates", len(*seen))
+	}
+	if !manager.repoRootAgentWillMaterialize(repoID(t, repoPath)) {
+		t.Fatalf("repoRootAgentWillMaterialize must be true for a legacy-enabled root")
+	}
+}
+
+// TestRootAgentEnsureAndWillMaterializeAgree drives the two call sites across
+// every layer combination in ONE manager and asserts they never disagree: a
+// root is created exactly when repoRootAgentWillMaterialize is true. Divergence
+// is the specific trap this PR guards — a root created but not marked
+// materializing (or vice versa) rejects a send-prompt at the reserved-name gate.
+func TestRootAgentEnsureAndWillMaterializeAgree(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	installOptionsRecordingBackend(t)
+
+	// Four repos exercising each path. legacyOnly is not registered as a project;
+	// the rest are registered so they carry personal layers.
+	legacyOnly := setupControlRepo(t)
+	personalOn := setupControlRepo(t)
+	disabledLegacy := setupControlRepo(t)
+	registeredIdle := setupControlRepo(t)
+
+	pOn := registerTestProject(t, personalOn)
+	pDisabled := registerTestProject(t, disabledLegacy)
+	registerTestProject(t, registeredIdle) // registered, no override, no legacy → idle
+
+	writePersonalRootAgent(t, pOn.ID, "enabled = true")
+	writePersonalRootAgent(t, pDisabled.ID, "enabled = false")
+
+	cfg := config.DefaultConfig()
+	cfg.RootAgents = map[string]config.RootAgentConfig{
+		legacyOnly:     {},
+		disabledLegacy: {}, // legacy-enabled, but personal disables it
+	}
+
+	manager, err := NewManager(cfg)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	manager.EnsureRootAgents()
+
+	cases := []struct {
+		name        string
+		repoPath    string
+		wantEnabled bool
+	}{
+		{"legacy only", legacyOnly, true},
+		{"personal enabled, no legacy", personalOn, true},
+		{"legacy + personal disabled", disabledLegacy, false},
+		{"registered but unconfigured", registeredIdle, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			created := findRootInstance(t, manager, tc.repoPath) != nil
+			willMaterialize := manager.repoRootAgentWillMaterialize(repoID(t, tc.repoPath))
+			if created != willMaterialize {
+				t.Fatalf("ensure loop and repoRootAgentWillMaterialize disagree: created=%v willMaterialize=%v", created, willMaterialize)
+			}
+			if created != tc.wantEnabled {
+				t.Fatalf("want root enabled=%v, got created=%v", tc.wantEnabled, created)
+			}
+		})
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ Config is [TOML](https://toml.io) — chosen so it is easy to hand-edit. If you 
 
 You can also read and write config from the CLI. Bare `af config get <key>` / `af config list` keep their script-compatible global-only output. Add `--project <repository-path>` to read the effective value after that repository's checked-in and personal per-project layers are applied, and add `--explain` to see every candidate, whether it was present and allowed, and why it won or lost. Dotted reads such as `af config get program_overrides.codex --project . --explain` show the source of one merged-table leaf. The project path is only a read-time selector: these commands do not register a project or write project identity. Displayed source locations preserve the selected/configured path spelling; symlinks are resolved only when paths must be compared for identity.
 
-`af config set <key> <value>` writes a single settable scalar key **in place**, preserving all comments and ordering (it never regenerates the file) and validating the value first. Settable keys are the scalar tunables — `default_program`, `program_overrides.<agent>`, `auto_update`, `listen_addr`, `require_token`, `require_loopback_token`, `preview_listen_addr`, `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`, `worktree_root`, `detach_keys`, `update_channel`, `vscode_server_binary`, `limit_auto_resume`, `limit_retry_interval`, `limit_patterns.<agent>`, `global_agent_skills`, `docker_mount_agent_credentials`; the structural tables (`root_agents`, `[theme]`, `[keys]`) and the `cors_allowed_origins` list are hand-edited only. Without `--project` it edits the global config; with `--project <id-or-path>` it writes a personal per-project override instead (see [Personal per-project config](#personal-per-project-config)). See [`af config`](reference/cli.md#af-config) in the CLI reference. Changes apply on the next `af`/daemon start, the same as a hand-edit.
+`af config set <key> <value>` writes a single settable scalar key **in place**, preserving all comments and ordering (it never regenerates the file) and validating the value first. Settable keys are the scalar tunables — `default_program`, `program_overrides.<agent>`, `auto_update`, `listen_addr`, `require_token`, `require_loopback_token`, `preview_listen_addr`, `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`, `worktree_root`, `detach_keys`, `update_channel`, `vscode_server_binary`, `limit_auto_resume`, `limit_retry_interval`, `limit_patterns.<agent>`, `global_agent_skills`, `docker_mount_agent_credentials`; the structural tables (`root_agents`, `[root_agent]`, `[theme]`, `[keys]`) and the `cors_allowed_origins` list are hand-edited only. Without `--project` it edits the global config; with `--project <id-or-path>` it writes a personal per-project override instead (see [Personal per-project config](#personal-per-project-config)). See [`af config`](reference/cli.md#af-config) in the CLI reference. Changes apply on the next `af`/daemon start, the same as a hand-edit.
 
 ## Global config
 
@@ -78,6 +78,7 @@ pane_border_preview = "#DC8CC3"
 | `log_max_backups` | How many rotated logs (`agent-factory.log.1`, `.2`, ...) to keep per log file; older ones are deleted (defaults to 2). `0` keeps none. |
 | `update_channel` | Release channel that auto-update and `af upgrade` follow: `stable` (default) tracks manual `1.x.y` releases only; `preview` opts into the automatic `1.x.y-preview-z` prereleases cut every 3 hours. Any other value falls back to `stable` with a warning. See [release-process.md](release-process.md). |
 | `root_agents` | Opt-in table of repositories that get an always-ensured `root` agent (default: none). See [Root agents](#root-agents-always-ensured). |
+| `root_agent` | Singleton successor to `root_agents`: whether a **registered project** keeps a `root` agent and the command it runs (default: not enabled). A global default plus an optional personal per-project override; layers with the legacy `root_agents` map. See [The `[root_agent]` singleton](#the-root_agent-singleton). |
 | `limit_auto_resume` | Opt in to the daemon auto-resuming a session parked at a usage-limit wall once its limit window elapses (default: `false`). See [Usage-limit auto-resume](#usage-limit-auto-resume). |
 | `limit_retry_interval` | Fallback retry cadence (Go duration, e.g. `30m`) used only when `limit_auto_resume` is on **and** the limit banner carried no parseable reset time (default: `30m`). Empty or `0` disables the fallback. |
 | `global_agent_skills` | Opt in to af writing its `agent-factory` skill file into your **global** codex/gemini/amp/devin config directories so those agents discover af's CLI guidance (default: `false`). See [Agent guidance and your global agent config](#agent-guidance-and-your-global-agent-config). |
@@ -306,6 +307,32 @@ Behavior and guarantees:
 
 Because the default profile skips permission prompts, only opt in repositories where you are comfortable with a fully autonomous agent running at the repo root.
 
+#### The `[root_agent]` singleton
+
+`[root_agent]` is the canonical successor to the path-keyed `root_agents` map: a single profile — whether a project keeps a `root` session, and the command it runs — that layers per **registered project** instead of per hard-coded path.
+
+```toml
+# ~/.agent-factory/config.toml — a global default applied to registered projects
+[root_agent]
+enabled = true
+program = "claude --model opus"   # optional; empty = the default root profile
+```
+
+The same table is also valid in a project's **personal** per-project config (`--project`, see [Personal per-project config](#personal-per-project-config)), where it overrides the global default for that one project on this machine:
+
+```toml
+# a registered project's personal config — disable the root here only
+[root_agent]
+enabled = false
+```
+
+Semantics:
+
+- **Precedence (low → high): built-in `enabled=false` < global `[root_agent]` < legacy `root_agents[path]` < personal per-project `[root_agent]`.** Layers merge **by field**: a higher layer overrides `enabled` only if it set it (an explicit `false` counts) and `program` only if non-empty. So a personal `enabled = false` can disable a root that the global default — or a legacy `root_agents` entry — turned on.
+- **The global default reaches registered projects only.** It never scans disk for repositories; a project must be registered (`af projects register`) to receive it. Legacy `root_agents` entries keep working unchanged and forever.
+- **Hand-edited for now.** Like `[theme]`, `[root_agent]` is not writable with `af config set` yet (`af config get root_agent` reads it); editing through the CLI/TUI lands in a later phase. Edit the file (or use the config assistant) directly.
+- **Restart-to-apply**, exactly like `root_agents`: changes take effect on the next daemon start. All the always-ensure guarantees above (adopt-never-clobber, reserved name, kill respected, back-off-but-never-give-up) apply identically to a root the singleton enables.
+
 ### Usage-limit auto-resume
 
 > This section covers the two auto-resume config keys. For the whole usage-limit feature end to end — detection, the `[limit]` badge, manual retry, auto-resume, and task park-don't-fail — see [docs/usage-limits.md](usage-limits.md).
@@ -520,7 +547,7 @@ af config set program_overrides.claude "/opt/claude --verbose" --project prj_012
 af config unset default_program --project ~/work/myrepo   # fall back to the lower layers
 ```
 
-Only preference keys admit this layer: **`default_program`**, **`program_overrides.<agent>`**, and **`branch_prefix`**. Setting a global-only key (`listen_addr`, daemon tuning, …) or a repo-contract key (`backend`, `docker`, `ssh`) per project is rejected with the location it actually belongs to. Setting a value **equal** to the lower layer is still a present, winning override — use `af config unset` to genuinely fall through again; it removes only the key you name (comments and other keys are preserved) and deletes the file once its last override is cleared.
+Only preference keys admit this layer: **`default_program`**, **`program_overrides.<agent>`**, **`branch_prefix`**, and the **`[root_agent]`** table (whether this project keeps a `root` agent — the highest-precedence root-agent layer, so it can disable one the global default or a legacy `root_agents` entry enabled). Setting a global-only key (`listen_addr`, daemon tuning, …) or a repo-contract key (`backend`, `docker`, `ssh`) per project is rejected with the location it actually belongs to. Setting a value **equal** to the lower layer is still a present, winning override — use `af config unset` to genuinely fall through again; it removes only the key you name (comments and other keys are preserved) and deletes the file once its last override is cleared.
 
 Precedence for a key that admits every layer is:
 


### PR DESCRIPTION
## #2216 Phase 6 PR2 — canonical `root_agent` singleton + daemon integration

Builds on PR1 (#2539, the pure legacy adapter). PR2 makes the canonical
`[root_agent]` singleton a real config source and wires the daemon onto the
resolver, so a project can be opted into (or out of) an always-ensured root
through the singleton — not only through the legacy path-keyed `root_agents`
map. Existing legacy configs are byte-for-byte unaffected.

### Config surface
- `Config.RootAgent` (global) and `ProjectConfig.RootAgent` (personal
  per-project), plus a `root_agent` manifest entry (`sourceGlobalPersonal`,
  `MergeTableByField`, `Settable:false`). Like `[theme]` it is hand-edited or
  set through the config assistant; CLI/TUI editing is Phase 7. It is readable
  through `af config get root_agent` / `af config list` and documented in
  `docs/configuration.md`.
- `ResolveRootAgent` gains the global and personal layers with presence-aware
  by-field merge. PR1's two rules carry forward: an empty legacy `Program`
  reads as **unset** (never clobbers a lower layer's program), and
  `RootAgent.Enabled` has **no** `omitempty` so an explicit `enabled = false`
  survives a full serialization (#1700 zero-value-elision class).

### Precedence (settled, not re-opened)
```
built-in  <  global  <  legacy root_agents[path]  <  personal-project
```
Personal is highest, merged by field on presence. Legacy **must** sit below
personal: `RegisterRootAgent` and the TUI project-switch write an *empty*
`root_agents` entry for every registered project, and a present legacy entry
means `enabled=true`. If legacy outranked personal, that ubiquitous
`enabled=true` would override a personal `enabled=false` — a user could never
disable a root for a registered project through the singleton. That silent
no-op is exactly what this epic exists to kill; the rationale is encoded next
to the precedence block in `ResolveRootAgent`.

### Daemon integration
- **Start-of-day snapshot** (`buildRootAgentSnapshot`): the global layer, every
  registered project's personal layer and resolved root (keyed by repo ID), and
  the legacy-covered repo IDs (for dedup). Best-effort — one unreadable project
  never blocks daemon startup — and restart-to-apply, matching the `root_agents`
  map's existing contract.
- **Enumeration rewrite**: `EnsureRootAgents` now visits legacy paths **∪**
  registered project roots (deduped by repo ID), instead of early-returning on
  an empty map and iterating only map keys. A project enabled purely by the
  singleton is now ensured. Legacy paths keep their per-path `RepoFromPath`
  retry/backoff (#1122); singleton-only projects resolve from the snapshot.
- **Both call sites through the resolver**: `EnsureRootAgents` (via
  `ensureResolvedRoot`) and `repoRootAgentWillMaterialize` share
  `rootAgentInputsFor`, so a singleton-only project both gets its root created
  **and** reports `willMaterialize=true`. Doing only one would reject a
  send-prompt to it at the #1835 reserved-name gate. A personal `enabled=false`
  now disables a legacy-enabled root at both sites.
- **Lossless forward**: `rootAgentProgramForProfile` consumes the resolved
  `RootAgent`; `rootAgentFromLegacy` remains the single legacy→canonical adapter,
  guarded by the struct-field test that fails when `RootAgentConfig` gains a
  field (the AutoYes/#2335 class).

### Tests
- Resolver: every layer combination incl. the decisive empty-legacy-does-not-
  clobber-global-program and personal-disables-legacy cases; the
  lossless-conversion struct-field guard; explicit-`enabled=false` serialization.
- Daemon (hermetic): singleton-only project materializes (with its resolved
  program reaching `CreateSession` verbatim); global `enabled=true` fans out to
  a registered project; personal `enabled=false` disables a legacy-enabled root;
  a plain legacy entry still ensures through the resolver; and ensure-loop ↔
  `repoRootAgentWillMaterialize` agree across every layer combination.

### Gate
`make test-container`, `golangci-lint --fast`, `gofmt -l .`, `go build ./...`,
`deadcode -test ./...`, and `scripts/lint-file-length.sh` all clean on the
branch head.

### Deferred
`af config get root_agent` and `--explain` already work through the generic
manifest resolver. Rendering `ResolveRootAgent`'s *specialized* trace
(built-in/global/legacy/personal, so `--explain` mirrors exactly what the
daemon does rather than the generic global<personal view) is a small follow-up
on the config-get surface — kept out to keep this PR focused on the daemon
integration.

— Captain Claude
