### PR TITLE
test(web): browser coverage for the config-assistant chat pane, and fix the dead × (#2467, PR3)

### DIFF
--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7954,6 +7954,7 @@ function openConfigAssistant(opts) {
   status.setAttribute("role", "status");
   const closeBtn = h("button", { type: "button", class: "af-ghost af-assistant-close" }, "\xD7");
   closeBtn.setAttribute("aria-label", "Close the config assistant");
+  closeBtn.addEventListener("click", () => close());
   const termHost2 = h("div", { class: "af-assistant-term" });
   const errorLine = h("p", { class: "af-modal-error af-assistant-error", role: "alert" });
   errorLine.hidden = true;

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "85baa8824b39";
+const VERSION = "210be27a4eaa";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -1548,6 +1548,74 @@ test("config: the editor renders from the manifest and writes through the real p
   await expect(page.locator(".af-rail-list")).toBeVisible();
 });
 
+// typeIntoAssistantAndExpectEcho is the config assistant's live-output proof. The
+// assistant runs the fake agent (`cat`), so a keystroke makes the full round trip —
+// OpInput → daemon → tmux PTY → `cat` echo → /v1/config-assistant/stream → xterm — and
+// the typed nonce, being unique and arriving after the briefing, is reliably visible.
+// The startup marker is NOT usable here: the daemon pastes the config briefing on spawn
+// (which `cat` echoes), scrolling the one-line marker out of the pane.
+async function typeIntoAssistantAndExpectEcho(page: Page, nonce: string): Promise<void> {
+  const term = page.locator(".af-assistant-term");
+  await term.click(); // focus the xterm before typing
+  await page.keyboard.type(nonce);
+  await expect(term).toContainText(nonce, { timeout: 30_000 });
+}
+
+test("config assistant (#2467): open → live stream → close reaps → reopen spawns fresh", REAL_FIXTURE, async () => {
+  // The web counterpart of the TUI's config-agent takeover, over the bare-session PTY
+  // route (#2522). This proves the COMPOSED LIFECYCLE the unit tests structurally
+  // cannot: the button opens a real overlay, the daemon spawns the config assistant
+  // (the seeded fake agent at AF home, which has no Instance and so is unreachable
+  // through the session stream route), its PTY streams into the pane and renders live
+  // output, closing disposes the terminal AND fires the DELETE reap, and reopening
+  // cold-spawns a fresh one. The individual calls — endpoint URLs, spawn/reap status
+  // handling, and the 409 retry — are pinned at the unit level (stream_endpoint.test.ts,
+  // api.test.ts). The 409 arm STAYS there deliberately: forcing a concurrent DELETE
+  // mid-spawn from a browser is impractical and would only add flake, so this exercises
+  // the wiring and the happy round-trip, not that retry.
+  await page.locator('.af-viewtab[data-view="config"]').click();
+  await expect(page.locator(".af-config")).toBeVisible();
+
+  // Open: the "Configure with assistant" button lives in the config header. The daemon
+  // spawns the assistant (POST /v1/config-assistant) and the overlay mounts its xterm.
+  await page.locator(".af-config-assistant-btn").click();
+  await expect(page.locator(".af-assistant-card")).toBeVisible();
+  await expect(page.locator(".af-assistant-term .xterm")).toBeVisible({ timeout: 30_000 });
+  // The status seam confirms the WS stream reached open, not a reconnect loop.
+  await expect(page.locator(".af-assistant-status")).toHaveText("Connected", { timeout: 30_000 });
+
+  // Live output END TO END, over the new bare-session route. See typeIntoAssistant... for
+  // why the round-trip echo is the signal rather than the startup marker.
+  await typeIntoAssistantAndExpectEcho(page, "af-pr3-probe-alpha");
+
+  // Close (the × button) disposes the terminal AND issues the best-effort DELETE reap.
+  // Arm the request wait BEFORE the click so the fetch cannot slip past it.
+  const firstReap = page.waitForRequest(
+    (r) => r.method() === "DELETE" && r.url().includes("/v1/config-assistant"),
+    { timeout: 10_000 },
+  );
+  await page.locator(".af-assistant-close").click();
+  await firstReap;
+  await expect(page.locator(".af-assistant-card")).toHaveCount(0);
+
+  // Reopen cold-spawns a fresh assistant: the DELETE reaped the last one, so the POST
+  // sees no current assistant and spawns anew. A second nonce echoing through the new
+  // pane is the browser-observable proof the reap actually tore the old session down —
+  // the config assistant is deliberately not a rail row, so there is no session-list
+  // signal, and a fresh stream carrying live output is the honest indirect check.
+  await page.locator(".af-config-assistant-btn").click();
+  await expect(page.locator(".af-assistant-card")).toBeVisible();
+  await expect(page.locator(".af-assistant-status")).toHaveText("Connected", { timeout: 30_000 });
+  await typeIntoAssistantAndExpectEcho(page, "af-pr3-probe-bravo");
+
+  // Clean up: close (reaps again) and return to sessions for the flows that follow,
+  // matching the config-editor test's own teardown.
+  await page.locator(".af-assistant-close").click();
+  await expect(page.locator(".af-assistant-card")).toHaveCount(0);
+  await page.locator('.af-viewtab[data-view="sessions"]').click();
+  await expect(page.locator(".af-rail-list")).toBeVisible();
+});
+
 test("tabs: create a shell tab, switch to it, see its distinct output, close it (#1592 PR7)", REAL_FIXTURE, async () => {
   // Capture the tab-mutation request bodies so we can assert they carry the stable
   // session id (#1592 PR7 fix 1 — the daemon must resolve by id, not the cross-repo

--- a/web/src/config_assistant.ts
+++ b/web/src/config_assistant.ts
@@ -59,6 +59,11 @@ export function openConfigAssistant(opts: {
 
   const closeBtn = h("button", { type: "button", class: "af-ghost af-assistant-close" }, "×");
   closeBtn.setAttribute("aria-label", "Close the config assistant");
+  // Wire the × explicitly: it sits inside the card, whose click handler stopPropagation()s
+  // to protect the backdrop, so the button would otherwise be dead — a click on it reaches
+  // neither the backdrop's close nor any handler of its own. (Escape and a backdrop click
+  // still close too; this makes the most obvious affordance actually work.)
+  closeBtn.addEventListener("click", () => close());
 
   const termHost = h("div", { class: "af-assistant-term" });
   const errorLine = h("p", { class: "af-modal-error af-assistant-error", role: "alert" });


### PR DESCRIPTION
## PR3 — browser coverage for the config-assistant chat pane (#2467)

The `make web-selftest-container` coverage PR2 couldn't have: a real Chromium driving the **composed lifecycle** against a real daemon — plus a fix for the defect that coverage surfaced.

### The selftest (`web/selftest/web-driver.spec.ts`)
Drives what unit tests structurally cannot:
- click **"Configure with assistant"** → the overlay opens and mounts its xterm;
- **live output end to end** — a typed nonce echoes back through the fake agent's `cat`: keystroke → OpInput → daemon → tmux PTY → `/v1/config-assistant/stream` → xterm. The startup marker `AF_SELFTEST_READY` is deliberately **not** the signal: the daemon pastes the config briefing on spawn (which `cat` echoes) and that scrolls the one-line marker out of the pane, so the round-trip echo is both correct **and** robust where reading startup output is not;
- **close (the ×) disposes the terminal AND fires the DELETE reap** (asserted via `page.waitForRequest`), and the overlay is removed;
- **reopen cold-spawns a fresh assistant** (a second nonce echoes through the new pane) — the browser-observable proof the reap tore the old session down, since the config assistant is deliberately not a rail row and has no session-list signal.

The assistant reaches readiness in the harness with **no new fixture**: its program is the harness's fake agent (`program_overrides.claude → fake-agent.sh`), which prints a marker then execs `cat`. Being a custom script it detects as agent `""` → generic "any output" readiness → and skips the Codex briefing-receipt and trust-dismissal gates, so the spawn succeeds exactly as a seeded session does.

### The defect the coverage found (and this fixes)
`config_assistant.ts`: the **× close button was created and mounted but never wired to `close()`**. The only working close paths were Escape and a backdrop click — and `card`'s own click handler `stopPropagation()`s (to protect the backdrop), so a click on the × reached **neither** the backdrop's close nor any handler of its own. The most obvious affordance was dead. Wired it to `close()`; Escape and backdrop click still close too. This is exactly the composed-lifecycle bug a unit test can't see and a browser round-trip does.

### What this deliberately does NOT cover
The **409 retry** (create raced a concurrent reap) stays pinned at the unit level (`api.test.ts`). Forcing a concurrent `DELETE` mid-spawn from a browser is impractical and would only add flake, so the test comment and this body say so plainly rather than feign coverage. A test honest about its edges is worth more than one that appears to cover everything.

### Gate
`npm run typecheck` (clean), `npm run test` (455 pass), `make web-build` (bundle regenerated), **`make web-selftest-container` (124/124 pass)**, `go build ./...` (no Go delta).

With this, the config-assistant affordance is no longer a TUI-only parity gap — it's browser-gated end to end.

Draft — for the claude-subagent gate; not self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
