### PR TITLE
fix(config): detach_keys warns and falls back instead of crashing the TUI (#2556)

### DIFF
--- a/app/home_model.go
+++ b/app/home_model.go
@@ -448,14 +448,19 @@ func newHome(ctx context.Context, program string, repo *config.RepoContext) *hom
 	}
 	applyTheme(appConfig.Theme)
 
-	// Apply configured detach key
+	// Apply configured detach key. The loader (sanitizeDetachKeys) already
+	// warns-and-defaults a bad hand-edited value, so this parse normally
+	// succeeds; if a value ever reaches here unparseable, fall back to the
+	// default rather than crashing the TUI on a config typo (#2556).
 	if appConfig.DetachKeys != "" {
-		b, err := config.ParseDetachKey(appConfig.DetachKeys)
+		detachKeys := appConfig.DetachKeys
+		b, err := config.ParseDetachKey(detachKeys)
 		if err != nil {
-			fmt.Printf("Invalid detach_keys %q in config: %v\n", appConfig.DetachKeys, err)
-			os.Exit(1)
+			log.WarningLog.Printf("invalid detach_keys %q (%v); using default", detachKeys, err)
+			detachKeys = config.DefaultDetachKeys()
+			b, _ = config.ParseDetachKey(detachKeys)
 		}
-		tmux.SetDetachKey(b, appConfig.DetachKeys)
+		tmux.SetDetachKey(b, detachKeys)
 	}
 
 	// Load application state (seen-help-screens flags; #960 PR 6 the TUI no

--- a/config/config_parse.go
+++ b/config/config_parse.go
@@ -180,6 +180,7 @@ func validateConfig(config *Config, prettyConfigPath string) (*Config, error) {
 	sanitizeThemeColors(config, prettyConfigPath)
 	config.LimitRetryInterval = sanitizeLimitRetryInterval(config.LimitRetryInterval, prettyConfigPath)
 	config.WorktreeRoot = normalizeWorktreeRoot(config.WorktreeRoot, prettyConfigPath)
+	config.DetachKeys = sanitizeDetachKeys(config.DetachKeys, prettyConfigPath)
 
 	if config.DaemonPollInterval <= 0 {
 		log.WarningLog.Printf("daemon_poll_interval=%d is non-positive; using default %dms", config.DaemonPollInterval, defaultDaemonPollInterval)

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -31,6 +31,11 @@ const (
 	// a routable host:port), and disabling the web server entirely is an explicit
 	// opt-out (listen_addr = "").
 	defaultListenAddr = "127.0.0.1:8443"
+	// defaultDetachKeys is the default attach-detach key. A bad hand-edited
+	// detach_keys value falls back to this with a warning (sanitizeDetachKeys),
+	// on the same warn-and-default footing as the other defaultable values —
+	// never a crash (#2556).
+	defaultDetachKeys = "ctrl-w"
 )
 
 // Release channels selectable via the update_channel config key (#1041).
@@ -481,7 +486,7 @@ func DefaultConfig() *Config {
 			}
 			return fmt.Sprintf("%s/", strings.ToLower(user.Username))
 		}(),
-		DetachKeys: "ctrl-w",
+		DetachKeys: defaultDetachKeys,
 	}
 
 	if claudePath, err := GetClaudeCommand(); err == nil && claudePath != "" {

--- a/config/detach_key.go
+++ b/config/detach_key.go
@@ -3,7 +3,32 @@ package config
 import (
 	"fmt"
 	"strings"
+
+	"github.com/sachiniyer/agent-factory/log"
 )
+
+// sanitizeDetachKeys puts detach_keys on the same warn-and-default footing as the
+// other defaultable values in validateConfig (#2556): an unparseable hand-edited
+// value warns and falls back to the default ctrl-w rather than crashing the TUI.
+// Typed input stays strict — `af config set detach_keys` validates eagerly and
+// rejects a bad value up front (the deliberate hand-edit-lenient / typed-strict
+// asymmetry). An empty value is left as-is; the attach path treats "" as "use the
+// built-in default".
+func sanitizeDetachKeys(value, prettyConfigPath string) string {
+	if strings.TrimSpace(value) == "" {
+		return value
+	}
+	if _, err := ParseDetachKey(value); err != nil {
+		log.WarningLog.Printf("Config issue in %s: detach_keys=%q is invalid (%v); using default %q",
+			prettyConfigPath, value, err, defaultDetachKeys)
+		return defaultDetachKeys
+	}
+	return value
+}
+
+// DefaultDetachKeys is the built-in default attach-detach key ("ctrl-w"), the
+// value a bad configured key falls back to.
+func DefaultDetachKeys() string { return defaultDetachKeys }
 
 // ParseDetachKey parses a human-readable key name like "ctrl-w" into its ASCII byte value.
 // Supported formats:

--- a/config/detach_key_test.go
+++ b/config/detach_key_test.go
@@ -46,3 +46,32 @@ func TestParseDetachKey(t *testing.T) {
 		})
 	}
 }
+
+// TestSanitizeDetachKeys pins the #2556 warn-and-default behavior: a valid value
+// passes through, an invalid hand-edited value falls back to the default (never a
+// crash — the old os.Exit(1)), and empty is left as-is ("use the default" at the
+// attach site). This is the loader-side guarantee that lets the TUI trust the
+// value instead of aborting on a config typo.
+func TestSanitizeDetachKeys(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"valid passes through", "ctrl-q", "ctrl-q"},
+		{"valid non-alpha passes through", "ctrl-]", "ctrl-]"},
+		{"empty stays empty", "", ""},
+		{"whitespace-only stays as-is", "   ", "   "},
+		{"invalid falls back to default", "ctrl-1", defaultDetachKeys},
+		{"wrong prefix falls back to default", "alt-w", defaultDetachKeys},
+		{"garbage falls back to default", "not-a-key", defaultDetachKeys},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sanitizeDetachKeys(tt.input, "test-config"))
+		})
+	}
+	// The default we fall back to must itself parse, or the fallback is a lie.
+	_, err := ParseDetachKey(DefaultDetachKeys())
+	require.NoError(t, err, "DefaultDetachKeys() must parse")
+}


### PR DESCRIPTION
## What

First slice of #2556 (let users decide their own safeguards). A bad hand-edited
`detach_keys` value called **`os.Exit(1)` and killed the entire TUI**
(`app/home_model.go`) — a crash on a typo, not a safeguard, and the one spot
inconsistent with every sibling defaultable value.

## Fix

Sanitize `detach_keys` in `validateConfig` exactly like its siblings
(`worktree_root`, `update_channel`, `limit_retry_interval`, …), per the loader's
own stated posture:

> `// validateConfig applies the format-independent semantic checks … enum validation hard-errors, range checks warn and fall back to defaults.` — `config/config_parse.go:148-150`

An unparseable value now **warns once and falls back to `ctrl-w`**. The TUI path
is hardened to fall back rather than `os.Exit` if a bad value ever reaches it.

**Typed input stays strict**: `af config set detach_keys` still validates eagerly
and rejects a bad value up front. The hand-edit-lenient / typed-strict asymmetry
is deliberate and load-bearing: a typo in a file the user hand-edited should never
brick the tool, while a value they just typed at a prompt *should* be rejected
while they're still looking at it.

The fallback path also carries a small but real guarantee — `TestSanitizeDetachKeys`
asserts the default we fall back to **itself parses**. `home_model.go` discards the
error on the fallback (`b, _ = ParseDetachKey(detachKeys)`), so if the default ever
stopped parsing you'd silently get a zero byte and a dead detach key — a worse
failure than the crash this removes. One assertion closes that hole.

## Why this shape (the #2556 principle, already in the tree)

The policy this issue asks for is already expressed in the codebase, in the best
sentence in it — `config/authposture.go`, on why the tokenless-bind notice
returns a string rather than an error:

> **"A string, not an error … an error return is an invitation to `if err != nil { return err }` — which is exactly the refusal being removed."**

A safe default plus an honest signal, never a refusal the operator can't get
past. `detach_keys` is the most clear-cut case (it wasn't even a safeguard — just
a crash), so it goes first.

## What this trades away

Nothing real. A malformed `detach_keys` used to hard-stop the TUI at launch; now
it warns and the app comes up on `ctrl-w`. No protection is removed — a bad value
was never protecting anything. Scripts/`af config set` still get an eager error.

## Changes
- `config/config_types.go` — `defaultDetachKeys` const (used by `DefaultConfig`).
- `config/detach_key.go` — `sanitizeDetachKeys` (warn + fall back) + `DefaultDetachKeys()` accessor.
- `config/config_parse.go` — wire the sanitizer into `validateConfig` beside its siblings.
- `app/home_model.go` — fall back instead of `os.Exit(1)`.
- `config/detach_key_test.go` — table test for the sanitizer.

## Verification
Local gate clean (gofmt, `go build`, golangci-lint `--fast`, `deadcode -test`, file-length); `config` tests green; full `make test-container` + CI on the pushed head.

Audit that scoped this: #2556 (comment). Not self-merging.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
