### PR TITLE
feat(daemon): af daemon adopt --force to displace a daemon of uncertain supervision (#2556)

### DIFF
--- a/commands/daemonadoptcmd.go
+++ b/commands/daemonadoptcmd.go
@@ -61,11 +61,12 @@ already owns the running daemon, adopt reports that and changes nothing.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)
 		defer log.Close()
-		return runDaemonAdopt(cmd.OutOrStdout())
+		force, _ := cmd.Flags().GetBool("force")
+		return runDaemonAdopt(cmd.OutOrStdout(), force)
 	},
 }
 
-func runDaemonAdopt(w io.Writer) error {
+func runDaemonAdopt(w io.Writer, force bool) error {
 	configDir, err := configDirFn()
 	if err != nil {
 		return fmt.Errorf("cannot resolve the config dir to find the daemon autostart unit: %w", err)
@@ -102,10 +103,18 @@ func runDaemonAdopt(w io.Writer) error {
 			return nil
 		}
 		if cannotTell != nil {
-			// Fail-closed: we could not prove the running daemon is unsupervised.
-			// Displacing it on missing evidence risks killing a healthy supervised
-			// daemon, so refuse and point at the diagnostic instead.
-			return fmt.Errorf("cannot confirm whether the running daemon is already supervised, so refusing to displace it: %w — run `af doctor` for detail", cannotTell)
+			// Fail-closed by DEFAULT: we could not prove the running daemon is
+			// unsupervised, and displacing it on missing evidence risks killing a
+			// healthy supervised daemon — so refuse and point at the diagnostic.
+			// But this is the operator's own machine and adopt is an explicit
+			// recovery verb: --force lets them assert the daemon is theirs to
+			// replace and proceed anyway, with the uncertainty stated plainly
+			// rather than an unoverridable wall (#2556).
+			if !force {
+				return fmt.Errorf("cannot confirm whether the running daemon is already supervised, so refusing to displace it: %w — run `af doctor` for detail, or pass --force to displace it anyway", cannotTell)
+			}
+			log.WarningLog.Printf("adopt --force: could not confirm the running daemon's supervision (%v); displacing it anyway at your request", cannotTell)
+			fmt.Fprintf(w, "warning: could not confirm the running daemon is unsupervised (%v); displacing it anyway (--force)\n", cannotTell)
 		}
 		// A detached, unsupervised daemon is serving. Stop it and wait for its
 		// control socket to go quiet so the unit's fresh daemon acquires the freed
@@ -176,5 +185,7 @@ func verifyAdoption() (daemon.ProbeAnswer, daemon.HealthStatus) {
 }
 
 func init() {
+	daemonAdoptCmd.Flags().Bool("force", false,
+		"displace the running daemon even if af cannot confirm it is unsupervised (you assert it is yours to replace)")
 	daemonCmd.AddCommand(daemonAdoptCmd)
 }

--- a/commands/daemonadoptcmd_test.go
+++ b/commands/daemonadoptcmd_test.go
@@ -72,7 +72,7 @@ func TestAdopt_NoUnitServingHome_RefusesWithInstallHint(t *testing.T) {
 	resolveSupervisionOwnerFn = func(string) (daemon.SupervisionOwner, error) { return daemon.OwnerAdHoc, nil }
 
 	var out bytes.Buffer
-	err := runDaemonAdopt(&out)
+	err := runDaemonAdopt(&out, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "af daemon install",
 		"with no installed unit there is nothing to adopt into; point the user at install")
@@ -86,7 +86,7 @@ func TestAdopt_OwnerUnknown_FailsClosed(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	err := runDaemonAdopt(&out)
+	err := runDaemonAdopt(&out, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "refusing to adopt",
 		"an unresolvable owner must not authorize touching a possibly-healthy daemon")
@@ -101,7 +101,7 @@ func TestAdopt_AlreadyOwned_NoOp(t *testing.T) {
 	// supervised daemon must never be cycled.
 
 	var out bytes.Buffer
-	err := runDaemonAdopt(&out)
+	err := runDaemonAdopt(&out, false)
 	require.NoError(t, err)
 	require.Contains(t, out.String(), "already adopted")
 	require.Contains(t, out.String(), "pid 222")
@@ -115,11 +115,49 @@ func TestAdopt_UndeterminedSupervision_RefusesToDisplace(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	err := runDaemonAdopt(&out)
+	err := runDaemonAdopt(&out, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "refusing to displace",
 		"a fabricated negative here would send the user to kill a healthy supervised daemon")
 	require.Contains(t, err.Error(), "af doctor")
+	require.Contains(t, err.Error(), "--force",
+		"the refusal must name the escape hatch (#2556)")
+}
+
+// TestAdopt_UndeterminedSupervision_ForceDisplaces is the #2556 escape hatch:
+// with --force the same undetermined-supervision case that refuses above instead
+// proceeds — it warns plainly, stops the running daemon, and hands supervision to
+// the unit. The operator, on their own machine, may override af's fail-closed
+// default; the default itself is unchanged.
+func TestAdopt_UndeterminedSupervision_ForceDisplaces(t *testing.T) {
+	stubAdoptVars(t)
+	started := false
+	stopCalls, restartCalls := 0, 0
+	daemonStopFn = func() (bool, error) { stopCalls++; return true, nil }
+	waitForShutdownCompletionFn = func() error { return nil }
+	restartAutostartUnitFn = func() error { started = true; restartCalls++; return nil }
+	daemonHealthFn = func() daemon.HealthStatus {
+		if started {
+			return respondingHealth(222)
+		}
+		return respondingHealth(111)
+	}
+	daemonStatusSupervisionFn = func() daemon.SupervisionInfo {
+		if started {
+			return supervisedInfo(222)
+		}
+		// Pre-adopt: supervision cannot be determined — the exact case that
+		// refuses without --force.
+		return daemon.SupervisionInfo{Supported: true, UnitPresent: true, Active: daemon.Undetermined(errors.New("user bus is down"))}
+	}
+
+	var out bytes.Buffer
+	err := runDaemonAdopt(&out, true)
+	require.NoError(t, err, "--force must displace a daemon whose supervision cannot be confirmed")
+	require.Contains(t, out.String(), "--force", "the override must state plainly that it is displacing on uncertainty")
+	require.Contains(t, out.String(), "stopped the unsupervised daemon")
+	require.Equal(t, 1, stopCalls, "--force must stop the running daemon")
+	require.Equal(t, 1, restartCalls, "--force must start the unit in its place")
 }
 
 func TestAdopt_DetachedDaemon_StopsStartsVerifies(t *testing.T) {
@@ -143,7 +181,7 @@ func TestAdopt_DetachedDaemon_StopsStartsVerifies(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	err := runDaemonAdopt(&out)
+	err := runDaemonAdopt(&out, false)
 	require.NoError(t, err)
 	require.Contains(t, out.String(), "stopped the unsupervised daemon")
 	require.Contains(t, out.String(), "pid 222")
@@ -173,7 +211,7 @@ func TestAdopt_NothingRunning_StartsUnderUnit(t *testing.T) {
 	// serving there is no detached daemon to stop.
 
 	var out bytes.Buffer
-	err := runDaemonAdopt(&out)
+	err := runDaemonAdopt(&out, false)
 	require.NoError(t, err)
 	require.Contains(t, out.String(), "now supervises the daemon")
 	require.Contains(t, out.String(), "pid 222")
@@ -196,7 +234,7 @@ func TestAdopt_VerifyFails_ReportsDoctor(t *testing.T) {
 	daemonStatusSupervisionFn = func() daemon.SupervisionInfo { return inactiveInfo() }
 
 	var out bytes.Buffer
-	err := runDaemonAdopt(&out)
+	err := runDaemonAdopt(&out, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "pid 333")
 	require.Contains(t, err.Error(), "af doctor")

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -758,8 +758,14 @@ such unit there is nothing to adopt the daemon into. If the installed unit
 already owns the running daemon, adopt reports that and changes nothing.
 
 ```
-af daemon adopt
+af daemon adopt [flags]
 ```
+
+**Flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--force` |  | displace the running daemon even if af cannot confirm it is unsupervised (you assert it is yours to replace) |
 
 **Global flags**
 

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -1571,6 +1571,7 @@
       "af config validate --help": "meta.discovery",
       "af config validate --json": "cli.json-envelope",
       "af daemon --help": "meta.discovery",
+      "af daemon adopt --force": "daemon.lifecycle",
       "af daemon adopt --help": "meta.discovery",
       "af daemon install --help": "meta.discovery",
       "af daemon restart --help": "meta.discovery",


### PR DESCRIPTION
## What

Last actionable slice of #2556. `af daemon adopt` **fail-closes** when it cannot
*prove* the running daemon is unsupervised (`commands/daemonadoptcmd.go`) — the
safe default, since displacing a healthy supervised daemon on missing evidence
would be worse than refusing. But adopt is an explicit recovery verb on the
operator's own machine, and there was no way past the uncertainty.

Add **`--force`**: it warns plainly and proceeds (stop the running daemon, hand
supervision to the installed unit) when the operator asserts the daemon is theirs
to replace.

## Scope of the change

- The **default is unchanged** — no `--force` still refuses, and the refusal now
  names the escape hatch (`… or pass --force to displace it anyway`).
- Only the **"cannot confirm supervision"** refusal gets the override. The two
  genuinely non-overridable refusals stay untouched, because no action a `--force`
  could enable exists for them:
  - an **unresolvable supervision owner** (can't start a unit it can't resolve), and
  - **"no installed unit serves this home"** (nothing to adopt into — run `af daemon install`).
- A **command-scoped flag, not a config key**: a one-shot recovery action is not
  standing posture, so it doesn't belong in the config manifest.

## Test

`TestAdopt_UndeterminedSupervision_ForceDisplaces` drives the exact case that
refuses without `--force` and asserts that with it, adopt warns, stops the daemon,
and starts the unit. The existing refuse-path test now also asserts the refusal
names `--force`.

## Surface parity

A new CLI flag trips the parity drift guard (`TestCLIFlagsAreInventoried`), so
`parity/inventory.json` maps `af daemon adopt --force` to the existing
`daemon.lifecycle` capability — no new capability, since it's the same
daemon-lifecycle surface as `adopt`/`restart`/`install` (all CLI-only recovery
verbs with no TUI/web analog). Both the container suite and the codex review
caught the missing entry; it's added.

## Verification
Local gate clean (gofmt, `go build`, golangci-lint `--fast`, `deadcode -test`, file-length, parity); `make docs` drift (the flag's CLI reference) committed; full `make test-container` + CI on the pushed head. Not self-merging.

Audit: #2556.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
