### PR TITLE
feat(config): four-layer root_agent --explain trace (#2216)

### DIFF
--- a/commands/configcmd.go
+++ b/commands/configcmd.go
@@ -187,6 +187,18 @@ prints the same resolved value with the complete source trace.`,
 			if !ok {
 				return jsonWrapError(cmd, configJSONFlag, unknownConfigKeyError(args[0]))
 			}
+			// root_agent resolves through FOUR layers in the daemon
+			// (built-in/global/legacy/personal), but the generic resolver only
+			// knows its two singleton layers. For --explain, swap in the daemon's
+			// real four-layer trace so the explanation matches what decides the
+			// root agent, not a narrower model of it (#2216).
+			if configGetExplainFlag && isRootAgentExplainKey(args[0]) {
+				specialized, err := rootAgentExplainValue(configGetProjectFlag, args[0])
+				if err != nil {
+					return jsonWrapError(cmd, configJSONFlag, err)
+				}
+				value = specialized
+			}
 			if configGetExplainFlag {
 				if configJSONFlag {
 					output := configGetExplanation{

--- a/commands/configexplain.go
+++ b/commands/configexplain.go
@@ -70,6 +70,36 @@ func selectedProjectDisplayRoot(selector, resolvedRoot string) string {
 	}
 }
 
+// isRootAgentExplainKey reports whether key names the root_agent table or one of
+// its leaves. It matches "root_agent" and "root_agent.<leaf>" but deliberately
+// NOT "root_agents" (the legacy map is a distinct key).
+func isRootAgentExplainKey(key string) bool {
+	return key == "root_agent" || strings.HasPrefix(key, "root_agent.")
+}
+
+// rootAgentExplainValue returns the specialized four-layer root_agent resolution
+// for --explain: the whole table, or a projected leaf for a dotted key. It
+// mirrors what the daemon resolves (built-in/global/legacy/personal), unlike the
+// generic global<personal resolver. A dotted leaf is projected through the same
+// ResolvedValuePath machinery every other key uses, by wrapping the specialized
+// table in a throwaway ResolvedConfig — so the leaf trace and its per-source
+// winner render identically to, say, theme.accent.
+func rootAgentExplainValue(projectSelector, keyPath string) (config.ResolvedValue, error) {
+	parent, err := config.ResolveRootAgentForInspection(projectSelector)
+	if err != nil {
+		return config.ResolvedValue{}, err
+	}
+	if keyPath == "root_agent" {
+		return parent, nil
+	}
+	synthetic := &config.ResolvedConfig{Resolution: []config.ResolvedValue{parent}}
+	projected, ok := synthetic.ResolvedValuePath(keyPath)
+	if !ok {
+		return config.ResolvedValue{}, unknownConfigKeyError(keyPath)
+	}
+	return projected, nil
+}
+
 func configEntriesFromResolution(resolved *config.ResolvedConfig) []configEntry {
 	entries := make([]configEntry, 0, len(resolved.Resolution))
 	for _, value := range resolved.Resolution {

--- a/commands/configget_rootagent_test.go
+++ b/commands/configget_rootagent_test.go
@@ -1,0 +1,99 @@
+package commands
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests drive `af config get root_agent --explain` end to end (#2216
+// Phase 6): the explanation must show the FOUR layers the daemon resolves
+// (built-in/global/legacy/personal), not the generic global<personal view, so a
+// user debugging a root agent sees the precedence model that actually decided it.
+
+// TestConfigGetRootAgentExplainGlobalNamesFourLayers: the global-scope trace
+// names every layer the daemon considers and attributes each effective field to
+// its source, even though global-only has no project to key legacy/personal by.
+func TestConfigGetRootAgentExplainGlobalNamesFourLayers(t *testing.T) {
+	_, _ = setupConfigExplainCommandTest(t, "schema_version = 1\n\n[root_agent]\nenabled = true\nprogram = \"codex\"\n")
+	setConfigGetReadFlags(t, "", true, false)
+
+	out, err := runConfigGetForTest(t, "root_agent")
+	require.NoError(t, err)
+	t.Logf("root_agent --explain (global):\n%s", out)
+
+	for _, layer := range []string{"built-in", "global", "legacy root_agents", "personal project"} {
+		assert.Containsf(t, out, layer, "the trace must name the %q layer", layer)
+	}
+	assert.Contains(t, out, `{"enabled":true,"program":"codex"}`, "the effective value must render")
+	assert.Contains(t, out, "enabled: global", "enabled must be attributed to the global layer")
+	assert.Contains(t, out, "program: global", "program must be attributed to the global layer")
+}
+
+// setupRootAgentProject git-inits and registers a repo under a fresh AF home,
+// writes the global config.toml (baseGlobalTOML, plus a [root_agents] entry keyed
+// by the real repo path when addLegacyEntry is set), and — when personalTOML !=
+// "" — the project's personal config. It returns the home and repo root.
+func setupRootAgentProject(t *testing.T, baseGlobalTOML string, addLegacyEntry bool, personalTOML string) (home, repoRoot string) {
+	t.Helper()
+	home = t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	t.Setenv("SHELL", "/bin/sh")
+
+	repoRoot = t.TempDir()
+	for _, args := range [][]string{
+		{"-C", repoRoot, "init", "-q"},
+		{"-C", repoRoot, "config", "user.email", "test@example.com"},
+		{"-C", repoRoot, "config", "user.name", "Test User"},
+		{"-C", repoRoot, "commit", "--allow-empty", "-m", "init"},
+	} {
+		require.NoError(t, exec.Command("git", args...).Run())
+	}
+
+	globalTOML := baseGlobalTOML
+	if addLegacyEntry {
+		// The legacy root_agents map is keyed by repo path; the real repo root is
+		// known only now, so it is appended after the repo exists.
+		globalTOML += "\n[root_agents]\n\"" + repoRoot + "\" = {}\n"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(home, config.TomlConfigFileName), []byte(globalTOML), 0644))
+
+	project, err := config.RegisterProject(repoRoot)
+	require.NoError(t, err)
+	if personalTOML != "" {
+		path, err := config.ProjectConfigTomlPath(project.ID)
+		require.NoError(t, err)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(personalTOML), 0644))
+	}
+	return home, repoRoot
+}
+
+// TestConfigGetRootAgentExplainProjectPersonalDisablesLegacy is the decisive
+// end-to-end case: a registered project carries a legacy root_agents entry (the
+// ubiquitous empty entry = enabled) AND a personal enabled=false. The trace must
+// make the interaction legible — the empty legacy row reading enabled=true, the
+// personal layer winning the enabled decision — and resolve the root disabled.
+// The generic two-layer explanation cannot show the legacy layer at all.
+func TestConfigGetRootAgentExplainProjectPersonalDisablesLegacy(t *testing.T) {
+	_, repoRoot := setupRootAgentProject(t, "schema_version = 1\n", true, "[root_agent]\nenabled = false\n")
+
+	setConfigGetReadFlags(t, repoRoot, true, false)
+	out, err := runConfigGetForTest(t, "root_agent")
+	require.NoError(t, err)
+	t.Logf("root_agent --explain (--project, personal disables legacy):\n%s", out)
+
+	// The legacy layer the generic trace omits must appear, and the empty entry is
+	// legible as enabled=true.
+	assert.Contains(t, out, "legacy root_agents", "the legacy layer must appear")
+	assert.Contains(t, out, `{"enabled":true}`, "the present-but-empty legacy entry must read as enabled=true")
+	// The personal disable wins the enabled decision and the root resolves off.
+	assert.Contains(t, out, "enabled: personal project", "enabled must be attributed to the personal layer")
+	assert.Contains(t, out, `root_agent = {"enabled":false}`, "the root must resolve disabled")
+}

--- a/config/rootagent_inspect.go
+++ b/config/rootagent_inspect.go
@@ -59,9 +59,33 @@ func (locs rootAgentLocations) forSource(source RootAgentSource) (path, keyPath 
 // layers by, so those layers resolve as absent; pass --project <path> to see them
 // participate.
 func ResolveRootAgentForInspection(projectSelector string) (ResolvedValue, error) {
-	global, err := LoadConfig()
+	inputs, locs, err := assembleRootAgentInspectionInputs(projectSelector)
 	if err != nil {
 		return ResolvedValue{}, err
+	}
+	return rootAgentResolvedValue(ResolveRootAgent(inputs), locs), nil
+}
+
+// assembleRootAgentInspectionInputs builds the RootAgentInputs the --explain
+// surface resolves, from on-disk config: the global [root_agent] layer, and —
+// when a project is selected — the legacy root_agents entry and personal
+// [root_agent] that resolve to its repo, with each layer's source path for the
+// LOCATION column.
+//
+// It deliberately DUPLICATES the daemon's rootAgentInputsFor rather than sharing
+// it, because the two must read from different sources: the daemon from its
+// start-of-day snapshot, this from on-disk config (--explain describes the next
+// start, not the running daemon). The shared half is ResolveRootAgent, so
+// precedence and merge never diverge. The duplication has one hazard — a new
+// RootAgentInputs layer added for the daemon but not assembled here would drop
+// silently out of --explain, the exact wrong-trace bug this file fixes. That is
+// why TestRootAgentInspectionInputsPopulateEveryLayer reflects over the assembled
+// inputs and fails when any layer is left unset: keep this in step with
+// RootAgentInputs and the guard, not with a comment.
+func assembleRootAgentInspectionInputs(projectSelector string) (RootAgentInputs, rootAgentLocations, error) {
+	global, err := LoadConfig()
+	if err != nil {
+		return RootAgentInputs{}, rootAgentLocations{}, err
 	}
 	locs := rootAgentLocations{globalPath: global.source.path}
 	if locs.globalPath == "" {
@@ -74,11 +98,11 @@ func ResolveRootAgentForInspection(projectSelector string) (ResolvedValue, error
 	if projectSelector != "" {
 		abs, err := ResolveUserPath(projectSelector)
 		if err != nil {
-			return ResolvedValue{}, fmt.Errorf("failed to resolve --project path %q: %w", projectSelector, err)
+			return RootAgentInputs{}, rootAgentLocations{}, fmt.Errorf("failed to resolve --project path %q: %w", projectSelector, err)
 		}
 		repo, err := RepoFromPath(abs)
 		if err != nil {
-			return ResolvedValue{}, fmt.Errorf("failed to resolve --project path %q: %w", projectSelector, err)
+			return RootAgentInputs{}, rootAgentLocations{}, fmt.Errorf("failed to resolve --project path %q: %w", projectSelector, err)
 		}
 		if legacy, key := legacyRootAgentForRepoID(global, repo.ID); legacy != nil {
 			inputs.Legacy = legacy
@@ -86,12 +110,12 @@ func ResolveRootAgentForInspection(projectSelector string) (ResolvedValue, error
 		}
 		project, found, err := projectForRoot(repo.Root)
 		if err != nil {
-			return ResolvedValue{}, err
+			return RootAgentInputs{}, rootAgentLocations{}, err
 		}
 		if found {
 			pc, err := LoadProjectConfig(project.ID)
 			if err != nil {
-				return ResolvedValue{}, err
+				return RootAgentInputs{}, rootAgentLocations{}, err
 			}
 			if layer := pc.RootAgentLayer(); layer != nil {
 				inputs.Personal = layer
@@ -102,7 +126,7 @@ func ResolveRootAgentForInspection(projectSelector string) (ResolvedValue, error
 		}
 	}
 
-	return rootAgentResolvedValue(ResolveRootAgent(inputs), locs), nil
+	return inputs, locs, nil
 }
 
 // legacyRootAgentForRepoID returns the root_agents entry whose path resolves to

--- a/config/rootagent_inspect.go
+++ b/config/rootagent_inspect.go
@@ -1,0 +1,198 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+)
+
+// This file backs `af config get root_agent --explain` (#2216 Phase 6). The
+// generic manifest resolver only knows root_agent's two singleton layers
+// (global < personal), but the daemon resolves FOUR — built-in < global <
+// legacy root_agents < personal-project — through config.ResolveRootAgent. A
+// two-layer explanation of a four-layer decision is confidently wrong: a user
+// debugging why a root agent is or is not running would be shown a precedence
+// model that did not decide it. ResolveRootAgentForInspection produces the full
+// four-layer trace in the same ResolvedValue shape every other key renders, so
+// --explain describes what the daemon actually does.
+
+// rootAgentLocations records, per root-agent source, the on-disk file and the
+// key-within-file that supplied (or would supply) that layer, for the --explain
+// LOCATION column. The built-in layer has no file.
+type rootAgentLocations struct {
+	// globalPath is the global config file; both root_agent and the legacy
+	// root_agents map live there.
+	globalPath string
+	// personalPath is the registered project's personal config file, "" when the
+	// project has no personal [root_agent].
+	personalPath string
+	// legacyKey is the matched root_agents map key, "" when no entry resolves to
+	// the inspected repo.
+	legacyKey string
+}
+
+func (locs rootAgentLocations) forSource(source RootAgentSource) (path, keyPath string) {
+	switch source {
+	case RootAgentSourceGlobal:
+		return locs.globalPath, "root_agent"
+	case RootAgentSourceLegacy:
+		if locs.legacyKey == "" {
+			return locs.globalPath, "root_agents"
+		}
+		return locs.globalPath, "root_agents[" + strconv.Quote(locs.legacyKey) + "]"
+	case RootAgentSourcePersonal:
+		return locs.personalPath, "root_agent"
+	default: // built-in has no on-disk location
+		return "", "root_agent"
+	}
+}
+
+// ResolveRootAgentForInspection resolves the on-disk root-agent profile for the
+// `af config get root_agent --explain` surface and returns it as a ResolvedValue
+// whose trace names all FOUR layers the daemon resolves — built-in < global <
+// legacy root_agents < personal-project — with a per-field origin (Enabled and
+// Program can come from different layers). It mirrors the daemon's
+// rootAgentInputsFor, so --explain describes the decision the daemon makes at its
+// NEXT start; it reads on-disk config, never the running daemon.
+//
+// Global scope (an empty selector) has no project to key the legacy and personal
+// layers by, so those layers resolve as absent; pass --project <path> to see them
+// participate.
+func ResolveRootAgentForInspection(projectSelector string) (ResolvedValue, error) {
+	global, err := LoadConfig()
+	if err != nil {
+		return ResolvedValue{}, err
+	}
+	locs := rootAgentLocations{globalPath: global.source.path}
+	if locs.globalPath == "" {
+		if path, err := globalConfigTomlPath(); err == nil {
+			locs.globalPath = path
+		}
+	}
+	inputs := RootAgentInputs{Global: GlobalRootAgentLayer(global)}
+
+	if projectSelector != "" {
+		abs, err := ResolveUserPath(projectSelector)
+		if err != nil {
+			return ResolvedValue{}, fmt.Errorf("failed to resolve --project path %q: %w", projectSelector, err)
+		}
+		repo, err := RepoFromPath(abs)
+		if err != nil {
+			return ResolvedValue{}, fmt.Errorf("failed to resolve --project path %q: %w", projectSelector, err)
+		}
+		if legacy, key := legacyRootAgentForRepoID(global, repo.ID); legacy != nil {
+			inputs.Legacy = legacy
+			locs.legacyKey = key
+		}
+		project, found, err := projectForRoot(repo.Root)
+		if err != nil {
+			return ResolvedValue{}, err
+		}
+		if found {
+			pc, err := LoadProjectConfig(project.ID)
+			if err != nil {
+				return ResolvedValue{}, err
+			}
+			if layer := pc.RootAgentLayer(); layer != nil {
+				inputs.Personal = layer
+				if path, err := ProjectConfigTomlPath(project.ID); err == nil {
+					locs.personalPath = path
+				}
+			}
+		}
+	}
+
+	return rootAgentResolvedValue(ResolveRootAgent(inputs), locs), nil
+}
+
+// legacyRootAgentForRepoID returns the root_agents entry whose path resolves to
+// repoID (and the matched key), or nil. Keys are checked in sorted order so the
+// match is deterministic when two spellings resolve to the same repo — the same
+// stability the daemon's snapshot relies on.
+func legacyRootAgentForRepoID(global *Config, repoID string) (*RootAgentConfig, string) {
+	keys := make([]string, 0, len(global.RootAgents))
+	for key := range global.RootAgents {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		repo, err := RepoFromPath(ExpandTilde(key))
+		if err != nil {
+			continue
+		}
+		if repo.ID == repoID {
+			entry := global.RootAgents[key]
+			return &entry, key
+		}
+	}
+	return nil, ""
+}
+
+// rootAgentResolvedValue maps a RootAgentResolution into the generic
+// ResolvedValue trace so --explain renders it identically to every other key: a
+// candidate row per layer (present or not), a per-field origin (Enabled and
+// Program can come from different layers), and the by-field merge policy. Pure —
+// no disk — so the per-field layer naming is unit-tested directly against the
+// decisive fixtures (empty-legacy, personal-disable).
+func rootAgentResolvedValue(res RootAgentResolution, locs rootAgentLocations) ResolvedValue {
+	rv := ResolvedValue{
+		Key:     "root_agent",
+		Value:   res.RootAgent,
+		Default: "not enabled",
+		Merge:   MergeTableByField.String(),
+		Precedence: []string{
+			string(RootAgentSourceBuiltIn),
+			string(RootAgentSourceGlobal),
+			string(RootAgentSourceLegacy),
+			string(RootAgentSourcePersonal),
+		},
+		Candidates: make([]CandidateTrace, 0, len(res.Candidates)),
+	}
+	for _, c := range res.Candidates {
+		path, keyPath := locs.forSource(c.Source)
+		rv.Candidates = append(rv.Candidates, CandidateTrace{
+			Layer:   string(c.Source),
+			Path:    path,
+			KeyPath: keyPath,
+			Allowed: true,
+			Present: c.Present,
+			Value:   rootAgentCandidateLeaves(c),
+			Result:  c.Result,
+			Reason:  c.Reason,
+		})
+	}
+	origins := map[string]SourceRef{
+		"enabled": rootAgentOrigin(res.EnabledSource, locs),
+	}
+	// Program falls through to the default root profile when no layer sets it, so
+	// it has a config origin only when some layer actually supplied a program.
+	if res.ProgramSource != "" {
+		origins["program"] = rootAgentOrigin(res.ProgramSource, locs)
+	}
+	rv.Origins = origins
+	return rv
+}
+
+// rootAgentCandidateLeaves is one layer's own contribution as a leaf map — only
+// the fields it set — so an absent layer shows "—", a program-only global shows
+// just its program, and a present-but-empty legacy entry shows enabled=true with
+// no program (the interaction nobody predicts, made legible). Returns nil for an
+// absent layer so the renderer prints "—".
+func rootAgentCandidateLeaves(c RootAgentCandidate) any {
+	if !c.Present {
+		return nil
+	}
+	leaves := map[string]any{}
+	if c.EnabledSet {
+		leaves["enabled"] = c.Enabled
+	}
+	if c.Program != "" {
+		leaves["program"] = c.Program
+	}
+	return leaves
+}
+
+func rootAgentOrigin(source RootAgentSource, locs rootAgentLocations) SourceRef {
+	path, keyPath := locs.forSource(source)
+	return SourceRef{Layer: string(source), Path: path, KeyPath: keyPath}
+}

--- a/config/rootagent_inspect_test.go
+++ b/config/rootagent_inspect_test.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -92,4 +95,42 @@ func TestRootAgentExplainTraceCoversAllFourLayers(t *testing.T) {
 	// a program (it falls through to the default profile — no config origin).
 	assert.Equal(t, string(RootAgentSourceBuiltIn), rv.Origins["enabled"].Layer)
 	assert.NotContains(t, rv.Origins, "program")
+}
+
+// TestRootAgentInspectionInputsPopulateEveryLayer is the drift guard for the
+// --explain input assembly. assembleRootAgentInspectionInputs DUPLICATES the
+// daemon's RootAgentInputs assembly (rootAgentInputsFor) on purpose — the two
+// must read different sources (on-disk config vs the daemon's start-of-day
+// snapshot) — and only the downstream ResolveRootAgent is shared. The hazard of
+// that split: a FIFTH layer added to RootAgentInputs for the daemon could go
+// unassembled here and silently vanish from the trace, reintroducing the
+// wrong-precedence explanation this whole change fixes. So, given a fixture that
+// configures every layer, every RootAgentInputs field MUST be populated; a new
+// unset field fails this loudly, forcing the assembler and this fixture to carry
+// it. It mirrors TestRootAgentConfigIsFullyAdapted, which guards the legacy
+// adapter the same way.
+func TestRootAgentInspectionInputsPopulateEveryLayer(t *testing.T) {
+	home, repoRoot, project := registeredTestProject(t)
+	require.NoError(t, os.MkdirAll(home, 0o755))
+	// A fixture exercising every non-built-in layer: a global [root_agent], a
+	// legacy root_agents entry that resolves to the repo, and the project's
+	// personal [root_agent]. built-in is synthesized inside ResolveRootAgent, not
+	// a RootAgentInputs field, so it needs no fixture.
+	globalTOML := "schema_version = 1\n\n[root_agent]\nenabled = true\n\n[root_agents]\n\"" + repoRoot + "\" = {}\n"
+	require.NoError(t, os.WriteFile(filepath.Join(home, TomlConfigFileName), []byte(globalTOML), 0o644))
+	writePersonalConfig(t, project.ID, "[root_agent]\nenabled = false\n")
+
+	inputs, _, err := assembleRootAgentInspectionInputs(repoRoot)
+	require.NoError(t, err)
+
+	v := reflect.ValueOf(inputs)
+	require.NotZero(t, v.NumField(), "RootAgentInputs must have layer fields")
+	for i := 0; i < v.NumField(); i++ {
+		name := v.Type().Field(i).Name
+		field := v.Field(i)
+		require.Equalf(t, reflect.Ptr, field.Kind(),
+			"RootAgentInputs.%s is not a pointer layer; the drift guard assumes every input is a nilable layer source — update it deliberately for a new shape", name)
+		require.Falsef(t, field.IsNil(),
+			"RootAgentInputs.%s was left nil by assembleRootAgentInspectionInputs even though the fixture configures every layer — a new root-agent layer must be assembled for --explain too, or it silently drops out of the trace (the drift this guard prevents)", name)
+	}
 }

--- a/config/rootagent_inspect_test.go
+++ b/config/rootagent_inspect_test.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func rootAgentCandidateByLayer(rv ResolvedValue, layer RootAgentSource) (CandidateTrace, bool) {
+	for _, c := range rv.Candidates {
+		if c.Layer == string(layer) {
+			return c, true
+		}
+	}
+	return CandidateTrace{}, false
+}
+
+// TestRootAgentExplainTraceNamesLayerPerField is the load-bearing --explain
+// proof: the rendered trace must name the RIGHT layer PER FIELD for the decisive
+// interactions, because Enabled and Program can be supplied by different layers
+// (merge is by field on presence). It reuses the exact fixtures the resolver
+// tests pin, but asserts on the ResolvedValue the CLI renders, so a two-layer or
+// wrong-winner explanation of a four-layer decision cannot ship.
+func TestRootAgentExplainTraceNamesLayerPerField(t *testing.T) {
+	t.Run("empty legacy does not clobber the global program", func(t *testing.T) {
+		res := ResolveRootAgent(RootAgentInputs{
+			Global: &RootAgentLayer{Value: RootAgent{Program: "codex"}}, // program set, enabled unset
+			Legacy: &RootAgentConfig{},                                  // empty: enables, program unset
+		})
+		rv := rootAgentResolvedValue(res, rootAgentLocations{})
+
+		// Per-field winners: enabled from legacy, program from global.
+		require.Contains(t, rv.Origins, "enabled")
+		require.Contains(t, rv.Origins, "program")
+		assert.Equal(t, string(RootAgentSourceLegacy), rv.Origins["enabled"].Layer,
+			"enabled must be attributed to the legacy entry, not the global layer")
+		assert.Equal(t, string(RootAgentSourceGlobal), rv.Origins["program"].Layer,
+			"program must be attributed to the global layer the empty legacy entry did not clobber")
+
+		// Effective value is enabled with the global program preserved.
+		assert.Equal(t, RootAgent{Enabled: true, Program: "codex"}, rv.Value)
+
+		// The empty-legacy row is legible: enabled=true, no program of its own.
+		legacy, ok := rootAgentCandidateByLayer(rv, RootAgentSourceLegacy)
+		require.True(t, ok)
+		assert.Equal(t, map[string]any{"enabled": true}, legacy.Value,
+			"a present-but-empty legacy entry must read as enabled=true with no program")
+
+		// The global row shows its program and does NOT imply it set enabled.
+		global, ok := rootAgentCandidateByLayer(rv, RootAgentSourceGlobal)
+		require.True(t, ok)
+		assert.Equal(t, map[string]any{"program": "codex"}, global.Value)
+	})
+
+	t.Run("personal disables a legacy-enabled root", func(t *testing.T) {
+		res := ResolveRootAgent(RootAgentInputs{
+			Legacy:   &RootAgentConfig{Program: "legacy-prog"},                            // enables, program set
+			Personal: &RootAgentLayer{Value: RootAgent{Enabled: false}, EnabledSet: true}, // explicit disable
+		})
+		rv := rootAgentResolvedValue(res, rootAgentLocations{})
+
+		// The disable must be attributed to the personal layer.
+		require.Contains(t, rv.Origins, "enabled")
+		assert.Equal(t, string(RootAgentSourcePersonal), rv.Origins["enabled"].Layer,
+			"a personal enabled=false must be attributed to the personal layer, not the legacy entry it overrode")
+		assert.Equal(t, RootAgent{Enabled: false, Program: "legacy-prog"}, rv.Value,
+			"the root resolves disabled even though the legacy program is still the effective program")
+
+		personal, ok := rootAgentCandidateByLayer(rv, RootAgentSourcePersonal)
+		require.True(t, ok)
+		assert.Equal(t, map[string]any{"enabled": false}, personal.Value,
+			"the personal row must show its explicit enabled=false")
+	})
+}
+
+// TestRootAgentExplainTraceCoversAllFourLayers pins that the trace always names
+// every layer the daemon considers — built-in, global, legacy, personal — so an
+// absent layer reads as "not participating" rather than vanishing from the
+// explanation.
+func TestRootAgentExplainTraceCoversAllFourLayers(t *testing.T) {
+	rv := rootAgentResolvedValue(ResolveRootAgent(RootAgentInputs{}), rootAgentLocations{})
+	for _, layer := range []RootAgentSource{
+		RootAgentSourceBuiltIn, RootAgentSourceGlobal, RootAgentSourceLegacy, RootAgentSourcePersonal,
+	} {
+		_, ok := rootAgentCandidateByLayer(rv, layer)
+		assert.Truef(t, ok, "the trace must name the %s layer even when absent", layer)
+	}
+	assert.Equal(t, MergeTableByField.String(), rv.Merge)
+	assert.Equal(t, []string{"built-in", "global", "legacy root_agents", "personal project"}, rv.Precedence)
+	// With nothing configured, enabled is the built-in base and no layer supplies
+	// a program (it falls through to the default profile — no config origin).
+	assert.Equal(t, string(RootAgentSourceBuiltIn), rv.Origins["enabled"].Layer)
+	assert.NotContains(t, rv.Origins, "program")
+}

--- a/config/rootagent_resolve.go
+++ b/config/rootagent_resolve.go
@@ -85,7 +85,13 @@ type RootAgentCandidate struct {
 	Source  RootAgentSource `json:"source"`
 	Present bool            `json:"present"`
 	Enabled bool            `json:"enabled"`
-	Program string          `json:"program,omitempty"`
+	// EnabledSet reports whether THIS layer set `enabled` (an explicit false
+	// counts). It distinguishes a layer that contributed enabled from one that
+	// left it to a lower layer, so the --explain trace can show each layer's own
+	// fields — e.g. a present-but-empty legacy entry as `enabled=true` with no
+	// program, rather than implying it also set enabled=false or a program.
+	EnabledSet bool   `json:"enabled_set"`
+	Program    string `json:"program,omitempty"`
 	// Result is one of "base", "winner", "shadowed", or "absent".
 	Result string `json:"result"`
 	Reason string `json:"reason"`
@@ -208,7 +214,7 @@ func ResolveRootAgent(in RootAgentInputs) RootAgentResolution {
 // rootAgentCandidate builds one trace row, classifying the source against the
 // resolved per-field origins.
 func rootAgentCandidate(source RootAgentSource, l rootAgentNormLayer, present bool, res RootAgentResolution) RootAgentCandidate {
-	c := RootAgentCandidate{Source: source, Present: present, Enabled: l.enabled, Program: l.program}
+	c := RootAgentCandidate{Source: source, Present: present, Enabled: l.enabled, EnabledSet: l.enabledSet, Program: l.program}
 	switch {
 	case source == RootAgentSourceBuiltIn:
 		c.Result = "base"


### PR DESCRIPTION
## Four-layer `root_agent --explain` trace — finishes #2216 Phase 6

`af config get root_agent --explain` showed a **two-layer** trace (the generic
`global < personal` manifest resolver) while the daemon resolves **four** layers
through `config.ResolveRootAgent` — `built-in < global < legacy root_agents <
personal-project`. A two-layer explanation of a four-layer decision is
confidently wrong: a user debugging why a root agent is or is not running was
shown a precedence model that did not decide it — the same family of bug this
epic has been closing (a notice describing behavior that isn't what happened).

This renders the real four-layer resolution instead, in the **same
`ResolvedValue` shape every other key uses**, so it doesn't read as a bolt-on.

### What it shows
- **Every layer that participated**, present or not — so an absent layer reads
  as "not participating" rather than vanishing.
- **A winner per FIELD.** The merge is by field on presence, so `enabled` and
  `program` can come from different layers; the `origins:` section attributes
  each independently.
- **The empty-legacy case, made legible.** A present-but-empty `root_agents`
  entry means `enabled=true` with the program unset — the interaction nobody
  predicts — and the trace now shows exactly that.

```
root_agent = {"enabled":false}
policy: table-by-field · built-in < global < legacy root_agents < personal project

SOURCE              VALUE              RESULT
built-in            {"enabled":false}  base · root agents are opt-in by default
global              —                  absent · not configured for this project
legacy root_agents  {"enabled":true}   shadowed · enabled by a higher layer; its empty program is unset
personal project    {"enabled":false}  winner · supplies the effective enabled
origins:
  enabled: personal project · …/config.toml:root_agent
```

### How
- `config.ResolveRootAgentForInspection` assembles the daemon's own inputs
  (`rootAgentInputsFor`) from on-disk config for an optional `--project`, then
  maps the `RootAgentResolution` into a `ResolvedValue`: a candidate row per
  layer, a per-field origin, and the by-field merge policy. It mirrors the
  daemon, so `--explain` describes the decision the daemon makes at its next
  start (on-disk config, not the running daemon).
- `RootAgentCandidate` gains `EnabledSet` so each layer's own contribution
  renders accurately (a program-only global shows just its program; the empty
  legacy entry shows `enabled=true` with no program).
- The CLI swaps this specialized trace in for `root_agent` (and its dotted
  leaves) **only under `--explain`**; bare reads are unchanged.

### Drift guard
The inspection path DUPLICATES the daemon's `RootAgentInputs` assembly on
purpose — the two must read different sources (on-disk config vs the daemon's
start-of-day snapshot), and only the downstream `ResolveRootAgent` is shared, so
precedence never diverges. The residual risk is that a future FIFTH layer added
to `RootAgentInputs` for the daemon could go unassembled on the inspection side
and silently drop out of the trace. `TestRootAgentInspectionInputsPopulateEveryLayer`
reflects over the assembled inputs under a fixture that configures every layer
and fails when any field is left nil — converting that silent future regression
into a test-time failure. (Verified it fails on a temporarily-added unpopulated
field.) Mirrors the `RootAgentConfig` struct-field guard.

### Tests
- Resolver-mapping (pure, no disk): the trace names the right layer per field
  for both decisive fixtures — empty-legacy-does-not-clobber-global-program and
  personal-disables-legacy — plus four-layer coverage.
- End to end through the CLI: global scope names all four layers and attributes
  each field; `--project` personal-disables-legacy shows the legacy layer the
  generic trace omits, the empty legacy row as `enabled=true`, and personal
  winning the enabled decision.
- Drift guard (above): a new unassembled `RootAgentInputs` layer fails loudly.

### Gate
`make test-container` (config + commands), `golangci-lint --fast`, `gofmt -l .`,
`go build ./...`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all
clean.

This was the one deferred item from Phase 6 PR2 (#2558); with it, the epic is
complete.

Closes #2216

— Captain Claude
