### PR TITLE
feat(daemon): reap orphaned docker session containers on startup (#2194)

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -25,6 +25,16 @@ import (
 // control socket binds and serves before the restore completes (#829).
 var restoreManagerForStartup = func(m *Manager) error { return m.RestoreInstances() }
 
+// sweepOrphanContainers reaps docker session containers this daemon leaked, at
+// startup (#2194 slice 4). Package-level so a test can assert startup passes the
+// live-plus-pending protected slugs and can stub out the docker work.
+var sweepOrphanContainers = session.SweepOrphanContainers
+
+// configDirForReap resolves the AF home the orphan sweep scopes its container
+// query to (it must match the af.home label runContainer stamps). A seam, mirroring
+// the above, so a test can supply a deterministic home.
+var configDirForReap = config.GetConfigDir
+
 // RunDaemon runs the daemon process: it serves the local control plane,
 // evaluates task cron schedules in-process, supervises watch-task scripts,
 // and iterates over all sessions each poll to compute their authoritative
@@ -269,6 +279,18 @@ func runDaemon(cfg *config.Config, upgradeTransactionID string) error {
 	// Remove per-task timer units left behind by pre-#782 versions; the
 	// in-process scheduler below replaces them.
 	sweepLegacyTaskUnits()
+
+	// Reap docker session containers this daemon leaked — a container that outlived
+	// its session because a previous daemon died without reaping, its record is
+	// gone, or a reap raced a create. Runs after the restore above so the live
+	// roster (and its pending-create window) is authoritative. Best-effort and
+	// non-fatal like sweepLegacyTaskUnits: a sweep problem must never block
+	// startup, and it no-ops when docker is not installed (#2194 slice 4).
+	if homeID, err := configDirForReap(); err != nil {
+		log.WarningLog.Printf("orphan sweep: cannot resolve the AF home; skipping: %v", err)
+	} else {
+		sweepOrphanContainers(homeID, manager.dockerReapProtectedSlugs())
+	}
 
 	// Start schedule evaluation only after the control server is up and the
 	// restore has finished: a task firing immediately goes through the

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -392,6 +392,33 @@ func (m *Manager) SaveInstances() error {
 	return m.storage.SaveInstances(m.InstancesSnapshot())
 }
 
+// dockerReapProtectedSlugs returns the af.session label slugs of every session
+// the manager knows about — live instances AND still-provisioning pending creates
+// (the #2549 window where a container exists but no Instance does yet) — so the
+// orphan-container sweep (#2194) never reaps a container whose session is alive or
+// mid-create. Titles are collected under the lock; slugging happens after so the
+// lock stays short.
+func (m *Manager) dockerReapProtectedSlugs() map[string]bool {
+	m.mu.Lock()
+	titles := make([]string, 0, len(m.instances)+len(m.pendingCreates))
+	for _, inst := range m.instances {
+		titles = append(titles, inst.Title)
+	}
+	for key, pending := range m.pendingCreates {
+		if _, settled := m.instances[key]; settled {
+			continue
+		}
+		titles = append(titles, pending.Title)
+	}
+	m.mu.Unlock()
+
+	slugs := make(map[string]bool, len(titles))
+	for _, t := range titles {
+		slugs[session.Slugify(t)] = true
+	}
+	return slugs
+}
+
 // Snapshot returns the authoritative InstanceData for every session the manager
 // owns, scoped to repoID (all repos when repoID is empty). It is the read side
 // of the single-writer model (#960 PR 3): the manager's settled instance map plus

--- a/daemon/orphan_reaper_test.go
+++ b/daemon/orphan_reaper_test.go
@@ -1,0 +1,42 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// TestDockerReapProtectedSlugs: the orphan sweep's protected set covers live
+// instances AND still-provisioning pending creates (the #2549 window where a
+// container exists but no Instance does yet), each as its af.session title slug —
+// so the sweep can never reap a container whose session is alive or mid-create.
+func TestDockerReapProtectedSlugs(t *testing.T) {
+	repoID := "repo1"
+	m := &Manager{
+		instances:      make(map[string]*session.Instance),
+		pendingCreates: make(map[string]session.InstanceData),
+	}
+	m.instances[daemonInstanceKey(repoID, "live one")] = &session.Instance{Title: "live one"}
+	m.pendingCreates[daemonInstanceKey(repoID, "mid create")] = session.InstanceData{Title: "mid create"}
+
+	got := m.dockerReapProtectedSlugs()
+
+	assert.True(t, got[session.Slugify("live one")], "a live instance's slug must be protected")
+	assert.True(t, got[session.Slugify("mid create")], "a mid-create pending session's slug must be protected (#2549)")
+	assert.Len(t, got, 2)
+}
+
+// TestDockerReapProtectedSlugsSettledPendingNotDoubleCounted: a pending row that
+// has already settled into a real instance is not processed twice.
+func TestDockerReapProtectedSlugsSettledPendingNotDoubleCounted(t *testing.T) {
+	key := daemonInstanceKey("repo1", "worker")
+	m := &Manager{
+		instances:      map[string]*session.Instance{key: {Title: "worker"}},
+		pendingCreates: map[string]session.InstanceData{key: {Title: "worker"}},
+	}
+	got := m.dockerReapProtectedSlugs()
+	assert.True(t, got[session.Slugify("worker")])
+	assert.Len(t, got, 1, "a settled pending create must not be counted twice")
+}

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -205,8 +205,17 @@ RUN npm install -g @anthropic-ai/claude-code @openai/codex
 
 ### Operations
 
-- **List managed containers:** `docker ps -a --filter label=af.session`
-- **Reap a leaked container** (should never be needed — kill reaps automatically):
+- **List managed containers:** `docker ps -a --filter label=af.session`. Each also
+  carries `af.home=<AF home>`, the daemon (home) that created it.
+- **Automatic orphan reaping:** on daemon startup, af removes any leaked session
+  container **this home** created (`af.home` matches) that no live or
+  mid-provisioning session owns — the cases where a previous daemon died without
+  reaping, a session record was deleted, or a reap raced a create. It is scoped to
+  this AF home and to the currently-targeted Docker engine, so it never touches
+  another home's or another engine's containers, and a container with no `af.home`
+  label (created by a pre-upgrade af) is left alone. Kill still reaps synchronously;
+  this is only the backstop for the container that outlived its session.
+- **Reap a leaked container by hand** (should never be needed):
   `docker rm -f <id>`
 
 ### Requirements on the daemon host
@@ -227,6 +236,37 @@ kill. A second case commits real work on the session branch, **archives** it
 **restores** it (asserting a fresh container clones the branch back, the commit
 is present, and the session is drivable again). It skips cleanly where Docker is
 unavailable.
+
+### Making docker the default backend for a repo
+
+To run a repo's sessions in containers by default, set `backend = "docker"` in
+its `.agent-factory/config.json`. This is an operator decision, not a default af
+ships — the steps below must be done in order, because the flip does **not**
+degrade gracefully on an unprepared box:
+
+1. **Build the image:** `make session-image` (or point `docker.image` at your own
+   — see [Image requirements](#image-requirements-bring-your-own-image)).
+2. **Grant credentials (operator, global):**
+   `af config set docker_mount_agent_credentials true`, so the containerised agent
+   can authenticate (see [Agent credentials in a container](#agent-credentials-in-a-container)).
+   This is global-only on purpose and cannot be set from the repo config.
+3. **Set the repo default:** put `"backend": "docker"` and `"docker": {"image": …}`
+   in the repo's `.agent-factory/config.json`.
+
+Only after all three does a **new** session in that repo come up in a container. A
+flip with no image built, no reachable Docker daemon, or the grant unset does not
+fall back to local — it **fails session creation** with a backend error. So make
+docker the default only once the box is ready.
+
+**Existing sessions are unaffected by the flip.** A session's backend is recorded
+on its own row (`InstanceData.BackendType`, written from `backend.Type()`), and
+the daemon reconstructs each session from that **stored** discriminator on
+restart/restore — it never re-reads `backend` from config after create (which is
+consulted only when a session is first created). So a running local session comes
+back local regardless of the repo's new default; only new creates read it. This is
+pinned by `TestFromInstanceData_SandboxBackends`, so a future change that made
+restore re-resolve from config would fail a test rather than silently reinterpret
+someone's session.
 
 ---
 

--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -78,6 +78,13 @@ const (
 	// `docker ps -aq -f label=af.session` (documented in docs/backends.md). The
 	// runtime reaps by container ID; the label is for operators.
 	dockerSessionLabel = "af.session"
+	// dockerHomeLabel scopes a container to the AF home (daemon) that created it,
+	// stamped with config.GetConfigDir() at `docker run`. The orphan sweeper
+	// (#2194) filters on it so a shared Docker engine hosting more than one af
+	// home never lets one daemon reap another's containers, and so a container
+	// with no af.home label (a pre-upgrade one) is treated as not-ours and left
+	// alone. The value is the AF home path — human-legible in `docker inspect`.
+	dockerHomeLabel = "af.home"
 	// dockerEngineIDFormat selects the daemon's stable, non-secret identity from
 	// `docker info`. Cleanup tombstones persist this value so a daemon restart
 	// cannot redirect `docker rm -f` to whichever engine the client happens to
@@ -206,12 +213,21 @@ func (dockerRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 	// Resolve once in the trusted host process. The agent-server receives this
 	// exact command with --program-resolved and must not reinterpret its enum.
 	resolvedProgram := config.ResolveProgram(&cfg.Config, spec.Program)
+	// Stamp the AF home onto the container (af.home label) so the orphan sweeper
+	// can scope to this daemon's home. If it can't be resolved, omit the label —
+	// the container just won't be sweep-tracked, which is the safe direction.
+	homeID, homeErr := config.GetConfigDir()
+	if homeErr != nil {
+		log.WarningLog.Printf("backend=docker: cannot resolve the AF home for the af.home container label; this container will not be orphan-sweep-tracked: %v", homeErr)
+		homeID = ""
+	}
 	p := &dockerProvisioner{
 		spec:    spec,
 		image:   image,
 		runArgs: runArgs,
 		afBin:   afBin,
 		program: resolvedProgram,
+		homeID:  homeID,
 	}
 	// docker_mount_agent_credentials is a GLOBAL-only operator grant (config.Config,
 	// resolved from the global layer here — a repo cannot set it: the key is absent
@@ -247,6 +263,12 @@ type dockerProvisioner struct {
 	credentialMounts []string
 	afBin            string
 	program          string
+	// homeID is the AF home (config.GetConfigDir()) stamped into the af.home
+	// container label so the orphan sweeper can scope to this daemon's home
+	// (#2194). Empty when the home cannot be resolved — the label is then omitted
+	// and the container is simply never sweep-tracked (fail-safe: unlabelled is
+	// not-ours), never mis-attributed.
+	homeID string
 
 	containerID        string
 	engineID           string
@@ -330,6 +352,11 @@ func (p *dockerProvisioner) runContainer() error {
 		"--label", dockerSessionLabel + "=" + Slugify(p.spec.Title),
 		"-e", "HOME=" + dockerContainerHome,
 		"-p", "127.0.0.1::" + dockerAgentPort,
+	}
+	// Scope the container to this daemon's AF home for the orphan sweeper (#2194).
+	// Omitted when the home is unknown, so it is simply never sweep-tracked.
+	if p.homeID != "" {
+		args = append(args, "--label", dockerHomeLabel+"="+p.homeID)
 	}
 	for _, name := range p.containerEnvironmentNames() {
 		// Docker looks the value up in the CLI process's filtered environment;

--- a/session/orphan_reaper.go
+++ b/session/orphan_reaper.go
@@ -1,0 +1,156 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/internal/sessionenv"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// OrphanSweepResult summarizes one orphan-container sweep (#2194).
+type OrphanSweepResult struct {
+	Listed  int // af containers on this engine+home the sweep saw
+	Reaped  int // orphans removed
+	Skipped int // containers spared as a live or mid-create session
+	Unknown int // orphans left for a later sweep (state unknown)
+	Errors  int // orphans docker refused to remove for a definite reason
+}
+
+// afContainer is one listed managed container: its id and its af.session slug.
+type afContainer struct {
+	id   string
+	slug string
+}
+
+// dockerSweepListFormat prints "<id>\t<af.session slug>" per container so the
+// sweep can decide ownership from the slug without a second inspect call.
+const dockerSweepListFormat = "{{.ID}}\t{{.Label \"" + dockerSessionLabel + "\"}}"
+
+// SweepOrphanContainers removes docker containers this daemon leaked — a session
+// container that outlived its session because the daemon died without reaping, the
+// session record is gone, or a reap raced a create. Nothing else ever cleans
+// these up, so they hold memory, disk, and a published port on the box forever.
+//
+// It is safe by construction — the hard part of reaping here is not destroying a
+// workload you do not own:
+//
+//   - It lists ONLY containers labelled af.session AND af.home=<homeID> (this
+//     daemon's home). A container with no af.home label — one a pre-upgrade af
+//     created, or one from another af home — never matches, so an unlabelled
+//     container is treated as NOT ours and left alone, never as ours.
+//   - `docker ps` runs under the daemon's own docker environment, so the query is
+//     scoped to the currently-targeted engine; the sweep never sees, and so can
+//     never reap, a container on another engine (the #2382 cross-engine hazard).
+//   - A listed container whose af.session slug is in protectedSlugs — the slug of
+//     a live OR still-provisioning session (the #2549 mid-create window) — is
+//     spared. The label is a many-to-one title slug, so this errs toward sparing:
+//     a genuinely orphaned same-slug container is left for a later sweep once the
+//     colliding session ends, which is the correct default for a destructive pass.
+//   - Each orphan is removed through the SAME reap the per-session Kill uses
+//     (dockerProvisioner.reap with verifyEngineOnReap), inheriting its
+//     engine-identity guard, its three-valued outcome (an ErrWorkspaceStateUnknown
+//     result leaves the container for the next sweep rather than claiming it gone),
+//     and its bounded exec — no raw `docker rm -f`, no unbounded wait.
+//
+// homeID must equal the value runContainer stamps into af.home
+// (config.GetConfigDir()). An empty homeID disables the sweep — there is nothing
+// to scope to safely, and a broad sweep is exactly what must never happen.
+func SweepOrphanContainers(homeID string, protectedSlugs map[string]bool) OrphanSweepResult {
+	var result OrphanSweepResult
+	if strings.TrimSpace(homeID) == "" {
+		return result
+	}
+	if _, err := lookPath("docker"); err != nil {
+		return result // no docker CLI → nothing this daemon could have created
+	}
+
+	env := sessionenv.DockerCLIEnvironment(os.Environ(), "", nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), dockerShortStepTimeout)
+	engineID, err := currentDockerEngineID(ctx, env)
+	cancel()
+	if err != nil {
+		log.WarningLog.Printf("orphan sweep: cannot read the Docker engine identity; skipping this sweep: %v", err)
+		return result
+	}
+
+	containers, err := listAfContainers(env, homeID)
+	if err != nil {
+		log.WarningLog.Printf("orphan sweep: cannot list af containers; skipping this sweep: %v", err)
+		return result
+	}
+
+	for _, c := range containers {
+		result.Listed++
+		if protectedSlugs[c.slug] {
+			result.Skipped++
+			continue
+		}
+		// Reuse the per-session reap verbatim: it re-verifies the engine identity
+		// before the destructive rm, so building it with the engine we just read is
+		// safe even if the daemon's docker context changes under us.
+		p := &dockerProvisioner{
+			spec:               ProvisionSpec{Title: c.slug},
+			containerID:        c.id,
+			engineID:           engineID,
+			verifyEngineOnReap: true,
+		}
+		switch err := p.reap(); {
+		case err == nil:
+			result.Reaped++
+			log.InfoLog.Printf("orphan sweep: reaped leaked container %s (af.session=%q) — no live session owns it", shortContainerID(c.id), c.slug)
+		case errors.Is(err, ErrWorkspaceStateUnknown):
+			result.Unknown++
+			log.WarningLog.Printf("orphan sweep: leaving container %s for a later sweep (state unknown): %v", shortContainerID(c.id), err)
+		default:
+			result.Errors++
+			log.WarningLog.Printf("orphan sweep: could not reap container %s: %v", shortContainerID(c.id), err)
+		}
+	}
+	if result.Reaped > 0 || result.Unknown > 0 || result.Errors > 0 {
+		log.InfoLog.Printf("orphan sweep: listed=%d reaped=%d skipped=%d unknown=%d errors=%d",
+			result.Listed, result.Reaped, result.Skipped, result.Unknown, result.Errors)
+	}
+	return result
+}
+
+// listAfContainers lists this home's managed containers (any state) with their
+// af.session slug. The two label filters run engine-scoped under env.
+func listAfContainers(env []string, homeID string) ([]afContainer, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), dockerShortStepTimeout)
+	defer cancel()
+	out, err := dockerExec(ctx, env,
+		"ps", "-a",
+		"--filter", "label="+dockerSessionLabel,
+		"--filter", "label="+dockerHomeLabel+"="+homeID,
+		"--format", dockerSweepListFormat,
+	)
+	if err != nil {
+		return nil, err
+	}
+	var containers []afContainer
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		id, slug, _ := strings.Cut(line, "\t")
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		containers = append(containers, afContainer{id: id, slug: strings.TrimSpace(slug)})
+	}
+	return containers, nil
+}
+
+// shortContainerID trims a container id to its short form for logs.
+func shortContainerID(id string) string {
+	if len(id) > 12 {
+		return id[:12]
+	}
+	return id
+}

--- a/session/orphan_reaper_test.go
+++ b/session/orphan_reaper_test.go
@@ -1,0 +1,154 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunContainerStampsHomeLabel: a container is tagged af.home=<homeID> so the
+// orphan sweep can scope to this daemon's home, alongside the af.session slug.
+func TestRunContainerStampsHomeLabel(t *testing.T) {
+	var runArgs []string
+	defer SetDockerExecForTest(func(_ context.Context, _ []string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "run" {
+			runArgs = append([]string(nil), args...)
+		}
+		return nil, fmt.Errorf("stop after capturing docker run")
+	})()
+
+	p := &dockerProvisioner{image: "img:latest", spec: ProvisionSpec{Title: "my session"}, homeID: "/home/af"}
+	_ = p.runContainer()
+
+	require.Contains(t, runArgs, "af.home=/home/af", "container must carry the af.home ownership label")
+	require.Contains(t, runArgs, "af.session=my-session", "container must carry the af.session slug label")
+}
+
+// TestRunContainerOmitsHomeLabelWhenUnknown: when the home can't be resolved the
+// label is omitted (the container is simply never sweep-tracked — the safe way).
+func TestRunContainerOmitsHomeLabelWhenUnknown(t *testing.T) {
+	var runArgs []string
+	defer SetDockerExecForTest(func(_ context.Context, _ []string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "run" {
+			runArgs = append([]string(nil), args...)
+		}
+		return nil, fmt.Errorf("stop after capturing docker run")
+	})()
+
+	p := &dockerProvisioner{image: "img:latest", spec: ProvisionSpec{Title: "s"}, homeID: ""}
+	_ = p.runContainer()
+
+	for _, a := range runArgs {
+		require.NotContains(t, a, "af.home=", "no af.home label when the home is unknown")
+	}
+}
+
+// dockerExecStub builds a fake docker CLI for sweep tests: `info` returns an
+// engine id (per call, so a changed id can force an engine mismatch), `ps` returns
+// the given "<id>\t<slug>" lines, `rm` records the removed id.
+func dockerExecStub(t *testing.T, infoIDs []string, psOutput string, removed *[]string) func() {
+	t.Helper()
+	infoCall := 0
+	return SetDockerExecForTest(func(_ context.Context, _ []string, args ...string) ([]byte, error) {
+		require.NotEmpty(t, args)
+		switch args[0] {
+		case "info":
+			id := infoIDs[min(infoCall, len(infoIDs)-1)]
+			infoCall++
+			return []byte(id + "\n"), nil
+		case "ps":
+			// Record the filter so tests can assert home-scoping.
+			return []byte(psOutput), nil
+		case "rm":
+			*removed = append(*removed, args[len(args)-1])
+			return nil, nil
+		default:
+			return nil, fmt.Errorf("unexpected docker call: %v", args)
+		}
+	})
+}
+
+// TestSweepReapsOrphanSparesProtected is the core contract: a listed container
+// whose slug is not a live/pending session is reaped; one whose slug IS protected
+// is spared. Only the orphan's id reaches `docker rm`.
+func TestSweepReapsOrphanSparesProtected(t *testing.T) {
+	defer SetLookPathForTest(func(string) (string, error) { return "/usr/bin/docker", nil })()
+	var removed []string
+	defer dockerExecStub(t, []string{"engine-1"}, "cid-orphan\tgone\ncid-live\talive\n", &removed)()
+
+	got := SweepOrphanContainers("/home/af", map[string]bool{"alive": true})
+
+	assert.Equal(t, 2, got.Listed)
+	assert.Equal(t, 1, got.Reaped)
+	assert.Equal(t, 1, got.Skipped)
+	assert.Equal(t, []string{"cid-orphan"}, removed, "only the unprotected orphan is removed")
+}
+
+// TestSweepScopesQueryToHome asserts the listing filters on BOTH af.session and
+// af.home=<homeID> — the fail-safe scoping that leaves a foreign/unlabelled
+// container out of the candidate set entirely.
+func TestSweepScopesQueryToHome(t *testing.T) {
+	defer SetLookPathForTest(func(string) (string, error) { return "/usr/bin/docker", nil })()
+	var psArgs []string
+	defer SetDockerExecForTest(func(_ context.Context, _ []string, args ...string) ([]byte, error) {
+		switch args[0] {
+		case "info":
+			return []byte("engine-1\n"), nil
+		case "ps":
+			psArgs = append([]string(nil), args...)
+			return []byte(""), nil
+		default:
+			return nil, fmt.Errorf("unexpected docker call: %v", args)
+		}
+	})()
+
+	SweepOrphanContainers("/home/af", nil)
+
+	require.True(t, slices.Contains(psArgs, "label="+dockerSessionLabel), "must filter on the af.session label")
+	require.True(t, slices.Contains(psArgs, "label="+dockerHomeLabel+"=/home/af"), "must scope to this home")
+}
+
+// TestSweepLeavesUnknownStateForNextSweep: when a reap can't confirm the outcome
+// (here: the engine identity changed under it → ErrWorkspaceStateUnknown), the
+// container is NOT counted reaped and NOT removed — it is left for a later sweep.
+func TestSweepLeavesUnknownStateForNextSweep(t *testing.T) {
+	defer SetLookPathForTest(func(string) (string, error) { return "/usr/bin/docker", nil })()
+	var removed []string
+	// First info (sweep's own read) = engine-1; the reap's verify sees engine-2 →
+	// #2382 mismatch → ErrWorkspaceStateUnknown, no rm.
+	defer dockerExecStub(t, []string{"engine-1", "engine-2"}, "cid-orphan\tgone\n", &removed)()
+
+	got := SweepOrphanContainers("/home/af", nil)
+
+	assert.Equal(t, 1, got.Listed)
+	assert.Equal(t, 0, got.Reaped)
+	assert.Equal(t, 1, got.Unknown)
+	assert.Empty(t, removed, "an unknown-state container must not be removed")
+}
+
+// TestSweepNoOpWithoutHomeOrDocker: an empty home disables the sweep, and a
+// missing docker CLI makes it a no-op — neither touches docker.
+func TestSweepNoOpWithoutHomeOrDocker(t *testing.T) {
+	called := false
+	restoreExec := SetDockerExecForTest(func(_ context.Context, _ []string, _ ...string) ([]byte, error) {
+		called = true
+		return nil, fmt.Errorf("docker must not be called")
+	})
+	defer restoreExec()
+
+	// Empty home: disabled even if docker is present.
+	restoreLook := SetLookPathForTest(func(string) (string, error) { return "/usr/bin/docker", nil })
+	assert.Equal(t, OrphanSweepResult{}, SweepOrphanContainers("", map[string]bool{"x": true}))
+	restoreLook()
+
+	// No docker CLI: no-op.
+	restoreLook = SetLookPathForTest(func(string) (string, error) { return "", fmt.Errorf("not found") })
+	assert.Equal(t, OrphanSweepResult{}, SweepOrphanContainers("/home/af", nil))
+	restoreLook()
+
+	assert.False(t, called, "the sweep must not invoke docker in either no-op path")
+}


### PR DESCRIPTION
## What

Finishes #2194 — **slice 4 (orphan-container reaper)** plus the **slice 3
operator runbook** (documentation, not a committed config flip, per the
maintainer decision).

A docker session container that outlives its session — a daemon that died without
reaping, a deleted session record, or a reap that raced a create — was cleaned up
by **nothing**, holding memory, disk, and a published loopback port on the box
forever. This adds a startup sweep that removes them.

## Reuse, not reinvent

Each orphan is removed through the **same `dockerProvisioner.reap`** the per-session
Kill uses (built exactly as `restoreRuntimeCleanup` does). It inherits, for free:
the conditional latch, the **#2382 engine-identity guard** before any `rm -f`, the
**three-valued outcome** (an `ErrWorkspaceStateUnknown` result *leaves the container
for the next sweep* rather than claiming it gone), and the bounded exec. No raw
`docker rm -f`, no unbounded wait.

## Safe by construction — never destroy a workload you don't own

- **`af.home` scoping.** New containers are tagged `af.home=<AF home>` at
  `docker run`; the sweep filters on it, so it only ever *sees* this home's
  containers. A container with **no `af.home` label** (a pre-upgrade one) or from
  **another home** is never listed → never reaped. *Treating unlabelled as
  not-ours is the fail-safe direction.*
- **Engine-scoped.** `docker ps` runs under the daemon's docker environment, so
  the query is pinned to the currently-targeted engine — the sweep can't see or
  reap across engines (the shared-engine hazard, given the label is a many-to-one
  title slug with no engine/owner component).
- **Live + mid-create spared (#2549).** A listed container whose `af.session` slug
  belongs to a live instance **or** a still-provisioning pending create
  (`m.instances ∪ m.pendingCreates`) is spared — covering the window where the
  container exists before its `Instance` does. The slug is many-to-one, so this
  errs toward sparing a same-slug orphan (reaped on a later sweep once the
  colliding session ends) — the right default for a destructive pass.

## Where

Best-effort at daemon startup, right after `RestoreInstances` (beside
`sweepLegacyTaskUnits`), **non-fatal** — a sweep problem never blocks startup — and
a **no-op when docker isn't installed**. That's when "daemon died without reaping"
and "record gone" orphans surface.

## Slice 3 — operator runbook (docs only)

Per the decision, this repo's default is **not** flipped. `docs/backends.md` gains
a runbook for making docker a repo's default: `make session-image` → the global
`docker_mount_agent_credentials` grant → set `backend=docker` in the repo config,
stated in order because a flip on an unprepared box *fails session creation* rather
than degrading. It records — with the citation and its pinning test
(`TestFromInstanceData_SandboxBackends`) — that **existing sessions are unaffected**:
backend is stored per-record (`InstanceData.BackendType`) and restore never
re-reads `config.Backend`, so the next person to consider the flip needn't
re-derive it.

## Tests (container-free, via the docker-exec seam)

- `TestSweepReapsOrphanSparesProtected` — orphan reaped, protected slug spared, only the orphan's id reaches `docker rm`.
- `TestSweepScopesQueryToHome` — the listing filters on `af.session` **and** `af.home=<home>`.
- `TestSweepLeavesUnknownStateForNextSweep` — an `ErrWorkspaceStateUnknown` reap is left, not counted reaped, not removed.
- `TestSweepNoOpWithoutHomeOrDocker` — empty home and missing docker CLI both no-op without touching docker.
- `TestRunContainerStampsHomeLabel` / `…OmitsHomeLabelWhenUnknown` — the `af.home` label is set (and omitted when the home is unknown).
- `TestDockerReapProtectedSlugs` (daemon) — the protected set covers live **and** mid-create sessions, and doesn't double-count a settled pending.

## Verification
Local gate clean (gofmt, `go build`, golangci-lint `--fast`, `deadcode -test`, file-length); `make docs` no drift; full `make test-container` + CI on the pushed head. Not self-merging.

Closes #2194.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
