### PR TITLE
feat(daemon): populate the upgrade metadata manifest from migrate-on-load stores (#2212 R3 part one)

### DIFF
--- a/config/instances_schema.go
+++ b/config/instances_schema.go
@@ -56,28 +56,45 @@ func MigrateRepoInstancesForDaemonLoad(repoID string) (SchemaMigrationResult, er
 	return result, err
 }
 
+// repoInstanceIDsForDaemonLoad lists the repo-scoped subdirectories under the
+// instances directory. It is the single walk shared by the daemon-load migrator
+// (MigrateAllRepoInstancesForDaemonLoad) and the upgrade manifest
+// (RepoInstancesMigrateOnLoadPaths) so the two can never enumerate a different
+// set. A missing instances directory is not an error: a daemon with no per-repo
+// state has nothing to migrate.
+func repoInstanceIDsForDaemonLoad() ([]string, error) {
+	dir, err := instancesDirPath()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read instances directory: %w", err)
+	}
+	ids := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		ids = append(ids, entry.Name())
+	}
+	return ids, nil
+}
+
 // MigrateAllRepoInstancesForDaemonLoad upgrades every readable per-repo
 // instances.json before daemon restore/refresh reads it. Corrupted legacy files
 // keep the existing skip-and-warn behavior; newer schema versions and write
 // failures are returned so the daemon never overwrites a file it cannot safely
 // understand or migrate.
 func MigrateAllRepoInstancesForDaemonLoad() error {
-	dir, err := instancesDirPath()
+	ids, err := repoInstanceIDsForDaemonLoad()
 	if err != nil {
 		return err
 	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to read instances directory: %w", err)
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		repoID := entry.Name()
+	for _, repoID := range ids {
 		if _, err := MigrateRepoInstancesForDaemonLoad(repoID); err != nil {
 			var newer *UnsupportedSchemaVersionError
 			switch {
@@ -95,6 +112,31 @@ func MigrateAllRepoInstancesForDaemonLoad() error {
 		}
 	}
 	return nil
+}
+
+// RepoInstancesMigrateOnLoadPaths returns the absolute path of every per-repo
+// instances.json that MigrateAllRepoInstancesForDaemonLoad rewrites in place at
+// daemon load. It walks the SAME repo set as that migrator, so the upgrade
+// transaction manifest (#2212 R3) snapshots exactly the files a candidate would
+// migrate on boot — letting a binary-only rollback to the previous daemon restore
+// state in a schema it can still read, instead of stranding it on a vN+1 file it
+// cannot parse. Errors propagate rather than skip: an incomplete manifest silently
+// under-protects the rollback, which is the failure mode this whole path exists to
+// prevent.
+func RepoInstancesMigrateOnLoadPaths() ([]string, error) {
+	ids, err := repoInstanceIDsForDaemonLoad()
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(ids))
+	for _, repoID := range ids {
+		path, err := repoInstancesPath(repoID)
+		if err != nil {
+			return nil, fmt.Errorf("resolve instances path for repo %s: %w", repoID, err)
+		}
+		paths = append(paths, path)
+	}
+	return paths, nil
 }
 
 func migrateInstancesSchemaBytes(raw []byte, path string) ([]byte, SchemaMigrationResult, error) {

--- a/config/instances_schema_test.go
+++ b/config/instances_schema_test.go
@@ -84,6 +84,46 @@ func TestMigrateRepoInstancesWriteFailurePreservesLegacyArray(t *testing.T) {
 	assert.Equal(t, legacy, backup)
 }
 
+// RepoInstancesMigrateOnLoadPaths must list exactly the per-repo instances.json
+// files the daemon-load migrator walks — one per repo subdirectory, non-directory
+// entries skipped — because the upgrade manifest snapshots this set. Under-listing
+// would leave a rolled-back daemon on a file it cannot read (#2212 R3).
+func TestRepoInstancesMigrateOnLoadPaths(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tempHome)
+
+	alpha := RepoIDFromRoot("/repo/alpha")
+	beta := RepoIDFromRoot("/repo/beta")
+	alphaPath, err := repoInstancesPath(alpha)
+	require.NoError(t, err)
+	betaPath, err := repoInstancesPath(beta)
+	require.NoError(t, err)
+	for _, path := range []string{alphaPath, betaPath} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+		require.NoError(t, os.WriteFile(path, []byte(`[]`), 0644))
+	}
+
+	// A stray non-directory entry in the instances dir must not appear: the migrator
+	// skips it, so the manifest must too.
+	dir, err := instancesDirPath()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "not-a-repo"), []byte("x"), 0644))
+
+	paths, err := RepoInstancesMigrateOnLoadPaths()
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{alphaPath, betaPath}, paths,
+		"the manifest must list exactly the per-repo instances.json files the migrator walks")
+}
+
+// A daemon with no per-repo state (no instances directory) has nothing to migrate,
+// so the manifest is empty rather than an error.
+func TestRepoInstancesMigrateOnLoadPathsNoInstancesDir(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	paths, err := RepoInstancesMigrateOnLoadPaths()
+	require.NoError(t, err)
+	assert.Empty(t, paths)
+}
+
 func TestSaveRepoInstancesWritesEnvelopeAndLoadReturnsArray(t *testing.T) {
 	tempHome := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", tempHome)

--- a/daemon/upgrade_trigger.go
+++ b/daemon/upgrade_trigger.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/upgradetxn"
 	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/task"
 )
 
 // upgradeActivationSupervisorReadyGrace bounds how long the trigger waits for the
@@ -124,6 +126,10 @@ func captureUpgradePlan(lifecycle *daemonLifecycle, candidate []byte, toVersion 
 	if err != nil {
 		return upgradetxn.Plan{}, err
 	}
+	metadataPaths, err := upgradeMetadataPaths(home)
+	if err != nil {
+		return upgradetxn.Plan{}, err
+	}
 	snap := lifecycle.snapshot()
 	return upgradetxn.Plan{
 		ID:             id,
@@ -138,22 +144,55 @@ func captureUpgradePlan(lifecycle *daemonLifecycle, candidate []byte, toVersion 
 			Owner:      owner,
 			Listeners:  toListenerExpectation(snap.listeners),
 		},
-		RecoveryJob: recoveryJob,
-		// MetadataPaths is intentionally empty because R2b STARTS NO CANDIDATE — the
-		// trigger is wired to nothing yet, so no candidate daemon boots to write any
-		// metadata. It is NOT empty because probation makes divergence safe: probation
-		// blocks mutating RPCs, but migrate-on-load is not an RPC and runs anyway.
-		// config.LoadAndMigrateSchemaFile atomically REWRITES a state file as it reads
-		// it (config/schema_migration.go), and it runs at daemon load — before restore —
-		// for every per-repo instances.json (config.MigrateAllRepoInstancesForDaemonLoad)
-		// and for tasks.json (task/schema_migration.go). So a candidate that boots,
-		// migrates vN→vN+1, then FAILS validation would leave a binary-only rollback
-		// restoring the FromVersion daemon onto state files written in a schema it can no
-		// longer read. That gap is inert only while nothing is staged; it goes live the
-		// moment R3 stages a real candidate, so R3 MUST populate this manifest with those
-		// migrated paths (recorded as the R3 prerequisite on #2212). Capturing them here
-		// now, with no candidate to protect, would only be guessing at the set.
+		RecoveryJob:   recoveryJob,
+		MetadataPaths: metadataPaths,
 	}, nil
+}
+
+// upgradeMetadataPaths lists, relative to the upgrade home, every state file the
+// daemon MIGRATES IN PLACE at load — rewriting it to a newer schema as it reads it
+// (config.LoadAndMigrateSchemaFile). The transaction snapshots each so a
+// binary-only rollback to the FromVersion daemon restores state in a schema it can
+// still read; without them a candidate that boots, migrates vN→vN+1, then fails
+// validation leaves the rolled-back daemon unable to read its own sessions or tasks
+// (#2212 R3).
+//
+// The set is derived from the daemon-load migrators themselves — every per-repo
+// instances.json (config.RepoInstancesMigrateOnLoadPaths, the same directory walk
+// config.MigrateAllRepoInstancesForDaemonLoad runs) and tasks.json
+// (task.MigrateOnLoadPath) — so it cannot drift from what actually gets rewritten.
+// A new migrate-on-load store must add its path here. TUI state is excluded on
+// purpose: it migrates in memory only (config.decodeTUIStateFile via
+// MigrateSchemaBytes, no writeback) and is TUI-owned, never rewritten at daemon
+// load.
+//
+// Every path is package-built from config.GetConfigDir(), the same value bound to
+// the plan's HomeDir, so each resolves cleanly inside the home; a path that does
+// not is a loud error rather than a silently dropped file — an incomplete manifest
+// under-protects exactly the rollback this exists to guard.
+func upgradeMetadataPaths(home string) ([]string, error) {
+	instancePaths, err := config.RepoInstancesMigrateOnLoadPaths()
+	if err != nil {
+		return nil, fmt.Errorf("resolve per-repo instances migrate-on-load paths: %w", err)
+	}
+	tasksPath, err := task.MigrateOnLoadPath()
+	if err != nil {
+		return nil, fmt.Errorf("resolve tasks migrate-on-load path: %w", err)
+	}
+	absolute := make([]string, 0, len(instancePaths)+1)
+	absolute = append(absolute, instancePaths...)
+	absolute = append(absolute, tasksPath)
+
+	relative := make([]string, 0, len(absolute))
+	for _, path := range absolute {
+		rel, err := filepath.Rel(home, path)
+		if err != nil || !filepath.IsLocal(rel) {
+			return nil, fmt.Errorf("migrate-on-load path %q is not inside the upgrade home %q", path, home)
+		}
+		relative = append(relative, rel)
+	}
+	sort.Strings(relative)
+	return relative, nil
 }
 
 func newUpgradeTransactionID() (string, error) {

--- a/daemon/upgrade_trigger_test.go
+++ b/daemon/upgrade_trigger_test.go
@@ -5,12 +5,63 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/upgradetxn"
+	"github.com/sachiniyer/agent-factory/task"
 	"github.com/stretchr/testify/require"
 )
+
+// captureUpgradePlan must populate the metadata manifest with every state file the
+// daemon rewrites in place at load — each per-repo instances.json and tasks.json,
+// home-relative — so a binary-only rollback restores state in a schema the previous
+// daemon can read (#2212 R3). Proven end-to-end: the real Prepare snapshots each
+// listed file into the journal as an existing rollback input.
+func TestCaptureUpgradePlan_PopulatesMetadataManifest(t *testing.T) {
+	_, _, candidate := stubTriggerEnv(t)
+	lifecycle := readyLifecycle(t)
+
+	configDir, err := config.GetConfigDir()
+	require.NoError(t, err)
+	writeState := func(rel string) {
+		abs := filepath.Join(configDir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o755))
+		require.NoError(t, os.WriteFile(abs, []byte(`[]`), 0o644))
+	}
+	alphaRel := filepath.Join("instances", config.RepoIDFromRoot("/repo/alpha"), config.InstancesFileName)
+	betaRel := filepath.Join("instances", config.RepoIDFromRoot("/repo/beta"), config.InstancesFileName)
+	tasksRel, err := task.MigrateOnLoadPath()
+	require.NoError(t, err)
+	tasksRel, err = filepath.Rel(configDir, tasksRel)
+	require.NoError(t, err)
+	writeState(alphaRel)
+	writeState(betaRel)
+	writeState(tasksRel)
+
+	plan, err := captureUpgradePlan(lifecycle, candidate, "1.0.200")
+	require.NoError(t, err)
+
+	expected := []string{alphaRel, betaRel, tasksRel}
+	sort.Strings(expected)
+	require.Equal(t, expected, plan.MetadataPaths,
+		"the manifest must list every migrate-on-load state file, home-relative")
+
+	// The real Prepare must accept the manifest and snapshot each listed file as an
+	// existing rollback input — proving the paths resolve inside the home and drive a
+	// real snapshot, not just a list.
+	txn, err := upgradetxn.Prepare(plan)
+	require.NoError(t, err)
+	snapshotted := map[string]bool{}
+	for _, m := range txn.Journal().Metadata {
+		snapshotted[m.Path] = m.Existed
+	}
+	for _, rel := range expected {
+		require.True(t, snapshotted[rel], "Prepare must snapshot the migrate-on-load file %s", rel)
+	}
+}
 
 // stubTriggerEnv binds a throwaway home with an ad-hoc owner (no autostart unit →
 // RecoveryJobDetached), stages a real previous binary the trigger's Prepare can

--- a/task/task.go
+++ b/task/task.go
@@ -226,6 +226,15 @@ func getTasksPath() (string, error) {
 	return filepath.Join(configDir, tasksFileName), nil
 }
 
+// MigrateOnLoadPath returns the absolute path of tasks.json, which LoadTasks
+// rewrites in place when it migrates a legacy file to the current schema at daemon
+// load (task/schema_migration.go -> config.LoadAndMigrateSchemaFile). The upgrade
+// transaction manifest (#2212 R3) snapshots it so a binary-only rollback restores
+// tasks in a schema the previous daemon can read.
+func MigrateOnLoadPath() (string, error) {
+	return getTasksPathFn()
+}
+
 func LoadTasks() ([]Task, error) {
 	path, err := getTasksPathFn()
 	if err != nil {

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -11,9 +11,36 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// MigrateOnLoadPath must point at the exact tasks.json that LoadTasks migrates in
+// place — the upgrade manifest snapshots this path, so if it named a different file
+// the rollback would protect the wrong one (#2212 R3).
+func TestMigrateOnLoadPathIsTheFileLoadTasksMigrates(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", dir)
+
+	path, err := MigrateOnLoadPath()
+	require.NoError(t, err)
+	configDir, err := config.GetConfigDir()
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(configDir, tasksFileName), path)
+
+	// A legacy array-root file at that path is migrated to the envelope schema by
+	// LoadTasks — proving MigrateOnLoadPath names the file the daemon rewrites.
+	legacy := []byte(`[{"id":"t1","name":"n","prompt":"p","cron_expr":"0 9 * * *","project_path":"/tmp","enabled":true,"created_at":"2025-01-01T00:00:00Z"}]`)
+	require.NoError(t, os.WriteFile(path, legacy, 0644))
+	_, err = LoadTasks()
+	require.NoError(t, err)
+
+	onDisk, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, string(onDisk), `"schema_version"`,
+		"LoadTasks must migrate the file MigrateOnLoadPath points at to the envelope schema")
+}
 
 // setupTestTasks writes a tasks file to a temp dir and overrides
 // getTasksPath for the duration of the test.


### PR DESCRIPTION
## Summary

**#2212 R3 (part one)** — populate the upgrade transaction's **metadata manifest**, the recorded blocking prerequisite for the daemon self-upgrade. R2b's `captureUpgradePlan` built the Plan with an empty `MetadataPaths`; this PR fills it with every state file the daemon **rewrites in place at load**, so a binary-only rollback restores state in a schema the previous daemon can still read.

### Why it matters — the data-loss gap
The daemon migrates two stores on load, atomically rewriting each to a newer `schema_version` as it reads it (`config.LoadAndMigrateSchemaFile`):
- every per-repo `instances.json` — `config.MigrateAllRepoInstancesForDaemonLoad` (`daemon.go`)
- `tasks.json` — `task.LoadTasks` (scheduler / watcher / control server)

A candidate that boots, migrates vN→vN+1, then **fails validation** triggers a binary-only rollback to the FromVersion daemon — now facing state files it can no longer parse. It **fails safe** (refuses rather than corrupts), but the daemon cannot read its own sessions or tasks until someone hand-restores a `.backup`, on a box whose whole premise is that nobody opens the TUI. The manifest closes that gap: the transaction snapshots these files before handoff so rollback restores a readable schema.

### Shape — derived from the migrators, cannot drift
The set is owned by the packages that do the migrating, so the manifest can never list a different set than what actually gets rewritten:
- `config.RepoInstancesMigrateOnLoadPaths` walks the **same** repo set as the daemon-load migrator (extracted into the shared `repoInstanceIDsForDaemonLoad`).
- `task.MigrateOnLoadPath` returns the exact `tasks.json` `LoadTasks` migrates.

`captureUpgradePlan` collects both, converts to **home-relative** paths, sorts, and treats a path that does not resolve inside the home as a **loud error** — an incomplete manifest silently under-protects exactly the rollback it guards (the R2a "irreversible path must not promote weak evidence" lesson, applied to the manifest).

**TUI state is excluded on purpose**: `config.decodeTUIStateFile` migrates in memory only (`MigrateSchemaBytes`, **no writeback**) and is TUI-owned, so a daemon rollback never faces a TUI-rewritten file. Grepped every `LoadAndMigrateSchemaFile` / `MigrateSchemaBytes` / `SchemaMigrationPlan` site — those two writeback stores are the complete daemon-load set.

## Test plan
- `config.TestRepoInstancesMigrateOnLoadPaths` — lists exactly the per-repo files the migrator walks; skips non-directory entries; empty (not error) when there is no instances dir.
- `task.TestMigrateOnLoadPathIsTheFileLoadTasksMigrates` — the path names the exact file `LoadTasks` rewrites (legacy array → envelope round-trip proves it).
- `daemon.TestCaptureUpgradePlan_PopulatesMetadataManifest` — with per-repo `instances.json` + `tasks.json` on disk, the captured plan lists exactly those files home-relative, and the **real** `Prepare` snapshots each into the journal as an existing rollback input (proves the paths resolve inside the home and drive a real snapshot, not just a list).

The full forward-then-rollback proof that the **restored** daemon can read the migrated files is **R4's destructive integration** — deliberately not weakened to a unit assertion here.

## Scope
- **Part two** (wire release check → staged candidate → `triggerUpgradeActivation`, respecting the existing update loop / throttle / channel selection — #459/#1466/#1861, no parallel path) is a separate PR; it has more than one reasonable shape, so a short plan goes on #2212 first.
- Per the epic plan, `Closes #2212` lands with the **last** R3/R4 PR, not this one — so this PR is intentionally `Part of #2212`, not a closer.

Gates (all on `d1d3dd7b`):
- [x] `gofmt -l .` · `go build ./...` · `go vet ./config/... ./task/... ./daemon/... ./internal/upgradetxn/...`
- [x] `golangci-lint run --timeout=3m --fast` · `deadcode -test ./...` · `scripts/lint-file-length.sh`
- [x] `make test-container GOTESTARGS="./daemon/... ./config/... ./task/... ./internal/upgradetxn/..."` — green (daemon 197s)
- [ ] full `make test-container` — CI is the full-suite gate of record on the pushed head

Part of #2212.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
