### PR TITLE
fix(docs): add the missing devin to the --program enum in the af usage reference

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "agent-factory",
       "source": "./plugins/claude/agent-factory",
       "description": "Run and schedule AI coding agents in isolated git worktrees with the Agent Factory (af) CLI",
-      "version": "3.4.1656353382+sha256.62b9f2661f7c23f7"
+      "version": "3.5.2729790649+sha256.a2b54cb9209becd7"
     }
   ]
 }

--- a/commands/plugins_gen.go
+++ b/commands/plugins_gen.go
@@ -67,6 +67,7 @@ var pluginReleaseDigests = []string{
 	"d5bf3050bea0bcdbcd41e436738b56d2dd4e25e82b508a751e3c2d1435473f09", // 3.2
 	"fb450d6ee2a3cf923ace4ef7dd693b5d9790bb52ec33328bc242fea910f0be95", // 3.3 — instance/session/tab/pane model + dispatched-parent escalation + tightened web-tab guidance (#2473)
 	"62b9f2661f7c23f7c5d53dbd7e3ed3a5b3339396663299419b356f9e63f07407", // 3.4 — remove the tmux-command guard hook; agents run unrestricted (#2175 precedent)
+	"a2b54cb9209becd766678828fd09ff7bd597b683802305850bcb40cefe61b9e7", // 3.5 — add the missing devin to the --program enum in the af usage reference (#2410 drift)
 }
 
 // pluginGenBanner marks a generated Markdown/shell artifact. Like genBanner it

--- a/plugins/amp/agent-factory/SKILL.md
+++ b/plugins/amp/agent-factory/SKILL.md
@@ -10,7 +10,7 @@ Sessions (one agent per isolated worktree):
   af sessions whoami                                   Identify your own session
   af sessions list                                     List sessions
   af sessions get <title>                              Fetch one session
-  af sessions create --name <title> [--prompt <p>] [--program claude|codex|aider|gemini|amp|opencode]
+  af sessions create --name <title> [--prompt <p>] [--program claude|codex|aider|gemini|amp|opencode|devin]
   af sessions send-prompt <title> <prompt> [--create]  Send a prompt (--create makes the session first if missing)
   af sessions preview <title>                          Snapshot another session's terminal output
   af sessions watch <title>                            Block until the session goes idle (agent done, ready for review); exits 0 when ready, non-zero on lost/dead/archived or --timeout (default 30m)

--- a/plugins/claude/agent-factory/.claude-plugin/plugin.json
+++ b/plugins/claude/agent-factory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-factory",
   "description": "Run and schedule AI coding agents in isolated git worktrees with the Agent Factory (af) CLI",
-  "version": "3.4.1656353382+sha256.62b9f2661f7c23f7",
+  "version": "3.5.2729790649+sha256.a2b54cb9209becd7",
   "author": {
     "name": "Agent Factory",
     "url": "https://github.com/sachiniyer/agent-factory"

--- a/plugins/claude/agent-factory/skills/agent-factory/SKILL.md
+++ b/plugins/claude/agent-factory/skills/agent-factory/SKILL.md
@@ -10,7 +10,7 @@ Sessions (one agent per isolated worktree):
   af sessions whoami                                   Identify your own session
   af sessions list                                     List sessions
   af sessions get <title>                              Fetch one session
-  af sessions create --name <title> [--prompt <p>] [--program claude|codex|aider|gemini|amp|opencode]
+  af sessions create --name <title> [--prompt <p>] [--program claude|codex|aider|gemini|amp|opencode|devin]
   af sessions send-prompt <title> <prompt> [--create]  Send a prompt (--create makes the session first if missing)
   af sessions preview <title>                          Snapshot another session's terminal output
   af sessions watch <title>                            Block until the session goes idle (agent done, ready for review); exits 0 when ready, non-zero on lost/dead/archived or --timeout (default 30m)

--- a/plugins/codex/agent-factory/.codex-plugin/plugin.json
+++ b/plugins/codex/agent-factory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-factory",
-  "version": "3.4.1656353382+sha256.62b9f2661f7c23f7",
+  "version": "3.5.2729790649+sha256.a2b54cb9209becd7",
   "description": "Run and schedule AI coding agents in isolated git worktrees with the Agent Factory (af) CLI",
   "author": {
     "name": "Agent Factory",

--- a/plugins/codex/agent-factory/skills/agent-factory/SKILL.md
+++ b/plugins/codex/agent-factory/skills/agent-factory/SKILL.md
@@ -10,7 +10,7 @@ Sessions (one agent per isolated worktree):
   af sessions whoami                                   Identify your own session
   af sessions list                                     List sessions
   af sessions get <title>                              Fetch one session
-  af sessions create --name <title> [--prompt <p>] [--program claude|codex|aider|gemini|amp|opencode]
+  af sessions create --name <title> [--prompt <p>] [--program claude|codex|aider|gemini|amp|opencode|devin]
   af sessions send-prompt <title> <prompt> [--create]  Send a prompt (--create makes the session first if missing)
   af sessions preview <title>                          Snapshot another session's terminal output
   af sessions watch <title>                            Block until the session goes idle (agent done, ready for review); exits 0 when ready, non-zero on lost/dead/archived or --timeout (default 30m)

--- a/plugins/gemini/agent-factory/SKILL.md
+++ b/plugins/gemini/agent-factory/SKILL.md
@@ -10,7 +10,7 @@ Sessions (one agent per isolated worktree):
   af sessions whoami                                   Identify your own session
   af sessions list                                     List sessions
   af sessions get <title>                              Fetch one session
-  af sessions create --name <title> [--prompt <p>] [--program claude|codex|aider|gemini|amp|opencode]
+  af sessions create --name <title> [--prompt <p>] [--program claude|codex|aider|gemini|amp|opencode|devin]
   af sessions send-prompt <title> <prompt> [--create]  Send a prompt (--create makes the session first if missing)
   af sessions preview <title>                          Snapshot another session's terminal output
   af sessions watch <title>                            Block until the session goes idle (agent done, ready for review); exits 0 when ready, non-zero on lost/dead/archived or --timeout (default 30m)

--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -87,7 +87,7 @@ Sessions (one agent per isolated worktree):
   af sessions whoami                                   Identify your own session
   af sessions list                                     List sessions
   af sessions get <title>                              Fetch one session
-  af sessions create --name <title> [--prompt <p>] [--program claude|codex|aider|gemini|amp|opencode]
+  af sessions create --name <title> [--prompt <p>] [--program claude|codex|aider|gemini|amp|opencode|devin]
   af sessions send-prompt <title> <prompt> [--create]  Send a prompt (--create makes the session first if missing)
   af sessions preview <title>                          Snapshot another session's terminal output
   af sessions watch <title>                            Block until the session goes idle (agent done, ready for review); exits 0 when ready, non-zero on lost/dead/archived or --timeout (default 30m)

--- a/session/systemprompt_test.go
+++ b/session/systemprompt_test.go
@@ -557,6 +557,21 @@ func TestAfUsageReference_CoversFullSurface(t *testing.T) {
 	}
 }
 
+// TestAfUsageReference_ProgramEnumMatchesSupportedPrograms pins the hardcoded
+// --program enum in the usage text to tmux.SupportedPrograms. Every other
+// --program surface (CLI validation, the config manifest, the web picker)
+// derives from that slice, but this one is prose inside a const, so adding an
+// agent silently leaves it behind: #1959 had to fix the enum by hand when it
+// added opencode, and #2410 then added devin without touching it, so every
+// agent's af reference claimed devin was not a valid --program.
+func TestAfUsageReference_ProgramEnumMatchesSupportedPrograms(t *testing.T) {
+	want := "--program " + strings.Join(tmux.SupportedPrograms, "|")
+	if !strings.Contains(afUsageReference, want) {
+		t.Errorf("afUsageReference must spell the --program enum as %q; add the new agent to the "+
+			"'af sessions create' line in afUsageBody (it also feeds the generated plugin SKILL.md files)", want)
+	}
+}
+
 func TestEnsureAmpSkillDir(t *testing.T) {
 	// These agents write into the USER'S global config dir, which af only does
 	// under the global_agent_skills opt-in (#1977). Grant it: this test is about

--- a/session/testdata/af_usage_reference.golden
+++ b/session/testdata/af_usage_reference.golden
@@ -14,7 +14,7 @@ Sessions (one agent per isolated worktree):
   af sessions whoami                                   Identify your own session
   af sessions list                                     List sessions
   af sessions get <title>                              Fetch one session
-  af sessions create --name <title> [--prompt <p>] [--program claude|codex|aider|gemini|amp|opencode]
+  af sessions create --name <title> [--prompt <p>] [--program claude|codex|aider|gemini|amp|opencode|devin]
   af sessions send-prompt <title> <prompt> [--create]  Send a prompt (--create makes the session first if missing)
   af sessions preview <title>                          Snapshot another session's terminal output
   af sessions watch <title>                            Block until the session goes idle (agent done, ready for review); exits 0 when ready, non-zero on lost/dead/archived or --timeout (default 30m)


### PR DESCRIPTION
## `devin` was missing from the `--program` enum in the af usage reference

`devin` became a first-class supported agent in #2410. That PR did the right
thing structurally — it appended `ProgramDevin` to `tmux.SupportedPrograms` and
let every *derived* surface pick it up for free:

```go
// session/tmux/session.go:28
var SupportedPrograms = []string{ProgramClaude, ProgramCodex, ProgramAider, ProgramGemini, ProgramAmp, ProgramOpencode, ProgramDevin}
```

One surface is not derived. The `--program` enum on the `af sessions create`
line of `afUsageBody` is prose inside a `const`, so it was left behind:

```
  af sessions create --name <title> [--prompt <p>] [--program claude|codex|aider|gemini|amp|opencode]
```

### Why this matters

That text is the af reference delivered to **every agent af launches**, and it is
also the source of the four generated plugin `SKILL.md` files. So every
claude/codex/amp/gemini session has been reading that `--program` accepts
`claude|codex|aider|gemini|amp|opencode` — i.e. that `devin` is not a valid
choice. Per #2410 devin exists specifically to give the fleet capacity while the
codex account is rate-limited, so an agent that believes devin is unavailable is
working against the reason it was added.

The capability was never actually missing — only the sentence describing it.
`af sessions create --program devin` has worked since #2410:

```
$ af sessions create --help
--program string   Program to run (one of: claude, codex, aider, gemini, amp, opencode, devin; defaults to config default)
```

`docs/reference/cli.md` is therefore **unchanged** by this PR: the generated flag
help was always right. Only the hand-written enum was wrong.

### This is a known-recurring seam, so it now has a guard

Not a one-off: #1959 had to hand-fix this same hardcoded enum when it added
opencode. Nothing protected it —
`TestAfUsageReference_CoversFullSurface` asserts command *names* only, never the
agent enum — so #2410 silently reintroduced the drift.

The new test pins the enum to the canonical slice:

```go
want := "--program " + strings.Join(tmux.SupportedPrograms, "|")
```

so the next agent addition fails a test instead of shipping a usage reference
that denies the agent exists. I confirmed it fails on the pre-fix text before
fixing it:

```
--- FAIL: TestAfUsageReference_ProgramEnumMatchesSupportedPrograms
    systemprompt_test.go:570: afUsageReference must spell the --program enum as
    "--program claude|codex|aider|gemini|amp|opencode|devin"; add the new agent to
    the 'af sessions create' line in afUsageBody (it also feeds the generated
    plugin SKILL.md files)
```

### Changes

| File | Why |
|---|---|
| `session/systemprompt.go` | Append `\|devin` to the enum — the one real edit. |
| `session/systemprompt_test.go` | New guard pinning the enum to `tmux.SupportedPrograms`. |
| `commands/plugins_gen.go` | Append the release-3.5 digest. The generator *panics* rather than emit a changed payload without an explicit serial bump (append-only ledger, #2179 review), so this is required, not cosmetic. |
| `plugins/**` (4 `SKILL.md`, 2 `plugin.json`), `.claude-plugin/marketplace.json`, `session/testdata/af_usage_reference.golden` | Regenerated via `scripts/gen-docs.sh` / `AF_UPDATE_USAGE_GOLDEN=1`. |

Every generated file is output — regenerating twice is byte-identical, and
`TestGeneratedPluginsAreCommitted` passes.

### Gates

All six run **after** the final commit, against the pushed head
`cb4adf56e2d9f4f163fe69ffb5ffa1b1d70e8874`, with a clean tree:

| Gate | Result |
|---|---|
| `golangci-lint run --timeout=3m --fast` | pass (exit 0, no findings) |
| `gofmt -l .` | pass (no output) |
| `go build ./...` | pass |
| `make test-container` | pass — 42 packages ok, 0 failures, incl. `daemon` 196.8s, `session` 39.7s, `commands` 5.2s |
| `deadcode -test ./...` | pass (no output) |
| `scripts/lint-file-length.sh` | pass (1082 Go files, 0 grandfathered) |

### Scope

Found by the daily documentation-drift audit. The rest of that run's findings —
5 broken doc anchors, a `gate-pr.md` skill that gates on a reviewer this repo no
longer uses, and two uses of the deprecated `af projects register` — are filed
in #2583 rather than bundled here, to keep this PR to one concern.

The audit found the CLI surface, all 32 config keys and their defaults, the 34
rebindable key actions, and the `mkdocs.yml` nav otherwise clean.

Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
