### PR TITLE
feat(cli): af sessions backends — the daemon's backend catalog on the CLI (parity: backend.list)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -612,7 +612,11 @@ func init() {
 	sessionsCreateCmd.Flags().StringVar(&createProgramFlag, "program", "", "Program to run (one of: "+tmux.SupportedProgramsString()+"; defaults to config default)")
 	sessionsCreateCmd.Flags().BoolVar(&createHereFlag, "here", false, "Run in the repo's existing working tree at its current branch (no new worktree/branch; kill preserves both)")
 	sessionsCreateCmd.Flags().BoolVar(&createInPlaceFlag, "in-place", false, "Alias for --here")
-	sessionsCreateCmd.Flags().StringVar(&createBackendFlag, "backend", "", "Runtime to run the session on (one of: "+config.SupportedBackendsString()+"; defaults to the repo's backend config, or local). docker runs the session in a container (set docker.image in the repo config); ssh runs it on a remote host (set ssh.host in the repo config)")
+	// The enum comes from config.SupportedBackendsString() so the help can never
+	// advertise a stale set — but knowing a backend EXISTS is not knowing this
+	// project can use it, which is what "af sessions backends" answers (#1933).
+	// Naming that verb here is the only place a --backend reader will look.
+	sessionsCreateCmd.Flags().StringVar(&createBackendFlag, "backend", "", "Runtime to run the session on (one of: "+config.SupportedBackendsString()+"; defaults to the repo's backend config, or local). docker runs the session in a container (set docker.image in the repo config); ssh runs it on a remote host (set ssh.host in the repo config). Run \"af sessions backends\" for which of these this project can actually use, and why not")
 	sessionsCreateCmd.MarkFlagRequired("name")
 
 	// Tab addressing for `sessions preview` (#1948). The daemon's PreviewRequest
@@ -669,6 +673,7 @@ func init() {
 	SessionsCmd.AddCommand(sessionsListCmd)
 	SessionsCmd.AddCommand(sessionsGetCmd)
 	SessionsCmd.AddCommand(sessionsCreateCmd)
+	SessionsCmd.AddCommand(sessionsBackendsCmd)
 	SessionsCmd.AddCommand(sessionsSendPromptCmd)
 	SessionsCmd.AddCommand(sessionsTabCreateCmd)
 	SessionsCmd.AddCommand(sessionsTabDeleteCmd)

--- a/api/sessions_backends.go
+++ b/api/sessions_backends.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// listBackendsViaDaemon is the SAME catalog the web's backend picker renders
+// (web/src/backends.ts over POST /v1/ListBackends). Both transports dispatch the
+// one daemon method — daemon/httproutes.go wires the HTTP route to
+// controlServer.ListBackends and the gob control socket exposes that same method
+// — so the CLI cannot report a different catalog than the web, and a backend
+// added server-side reaches both with no client change. Held in a var so tests
+// can answer without a live daemon, like the other *ViaDaemon seams.
+var listBackendsViaDaemon = daemon.ListBackends
+
+var sessionsBackendsCmd = &cobra.Command{
+	Use:   "backends",
+	Short: "List the runtimes this project can create sessions on",
+	Long: `Report which backends 'af sessions create --backend' accepts for this
+project, whether each one is usable as the project is configured right now, and
+which backend a create with no --backend resolves to.
+
+--backend names the enum, but knowing that "docker" is spelled correctly is not
+the same as knowing this project can use it. The daemon checks each backend's
+preconditions against the project's config and answers one of three things:
+
+  available    every precondition that can be checked was checked and passed
+  unavailable  a precondition FAILED — a create would fail; "reason" says what to fix
+  unknown      the preconditions could NOT be evaluated (e.g. the project's
+               config would not parse) — neither yes nor no is honest, so
+               "reason" says what stopped the check
+
+"unknown" is deliberately not folded into either of the other two: reporting an
+unchecked backend as available is a promise nobody verified.
+
+"default" is the backend a create with no --backend resolves to here. It is
+EMPTY when the project's 'backend' config key names something unrecognized —
+such a create fails rather than quietly running local, and "default_reason"
+names the offending value.
+
+The reasons are the same text a create prints when it refuses, because both come
+from the same precondition checks.
+
+Example:
+  af sessions backends
+  af sessions backends --repo ~/src/myproject`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		// resolveRepo is the resolver `sessions create` itself uses, so the
+		// catalog describes the project a create run here would bind to —
+		// including its "--repo is required" and af-home refusals. A separate
+		// resolver could answer about a different project than the create it is
+		// meant to predict.
+		repo, err := resolveRepo()
+		if err != nil {
+			return jsonError(err)
+		}
+
+		resp, err := listBackendsViaDaemon(daemon.ListBackendsRequest{RepoPath: repo.Root})
+		if err != nil {
+			return jsonError(err)
+		}
+		return jsonOut(resp)
+	},
+}

--- a/api/sessions_backends_test.go
+++ b/api/sessions_backends_test.go
@@ -1,0 +1,150 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
+)
+
+// catalogFixture is a daemon answer exercising all three availability outcomes
+// plus a reported default, so every branch of the contract has to survive the
+// CLI's rendering.
+func catalogFixture() daemon.ListBackendsResponse {
+	return daemon.ListBackendsResponse{
+		Backends: []daemon.BackendOption{
+			{Name: config.BackendLocal, Label: config.BackendLocal, Status: daemon.BackendAvailable},
+			{Name: config.BackendDocker, Label: config.BackendDocker, Status: daemon.BackendUnavailable,
+				Reason: "set docker.image in the repo config"},
+			{Name: config.BackendSSH, Label: config.BackendSSH, Status: daemon.BackendUnknown,
+				Reason: "the repo's config could not be read"},
+		},
+		Default:       config.BackendLocal,
+		DefaultStatus: daemon.BackendAvailable,
+	}
+}
+
+// TestSessionsBackends_AsksTheDaemonAboutTheCreateRepo pins the parity fix's
+// premise: the catalog must describe the project a create run here would bind
+// to, resolved by the same resolveRepo `sessions create` uses. A backends answer
+// about a different project than the create it predicts is worse than no answer.
+func TestSessionsBackends_AsksTheDaemonAboutTheCreateRepo(t *testing.T) {
+	setupRepoForCmd(t)
+	wantRoot := repoFlag
+
+	var gotReq daemon.ListBackendsRequest
+	prev := listBackendsViaDaemon
+	listBackendsViaDaemon = func(req daemon.ListBackendsRequest) (daemon.ListBackendsResponse, error) {
+		gotReq = req
+		return catalogFixture(), nil
+	}
+	t.Cleanup(func() { listBackendsViaDaemon = prev })
+
+	if _, err := runCmdCaptureStdout(t, sessionsBackendsCmd, nil); err != nil {
+		t.Fatalf("backends returned error: %v", err)
+	}
+	if gotReq.RepoPath != wantRoot {
+		t.Fatalf("ListBackends RepoPath = %q, want the resolved project root %q", gotReq.RepoPath, wantRoot)
+	}
+}
+
+// TestSessionsBackends_EmitsTheDaemonCatalogVerbatim is the anti-drift half. The
+// web renders this exact JSON (web/src/backends.ts BackendCatalog), so the CLI
+// must pass the daemon's answer through unreshaped — same keys, same tri-state,
+// reasons intact. Collapsing "unknown" into available or unavailable, or dropping
+// a reason, would make the two surfaces describe one repo differently, which is
+// the drift this capability exists to remove.
+func TestSessionsBackends_EmitsTheDaemonCatalogVerbatim(t *testing.T) {
+	setupRepoForCmd(t)
+
+	prev := listBackendsViaDaemon
+	listBackendsViaDaemon = func(daemon.ListBackendsRequest) (daemon.ListBackendsResponse, error) {
+		return catalogFixture(), nil
+	}
+	t.Cleanup(func() { listBackendsViaDaemon = prev })
+
+	out, err := runCmdCaptureStdout(t, sessionsBackendsCmd, nil)
+	if err != nil {
+		t.Fatalf("backends returned error: %v", err)
+	}
+
+	// Decoded into the wire struct, not a map, so a renamed JSON tag fails here
+	// rather than silently reaching the web's parser as an unknown key.
+	var got daemon.ListBackendsResponse
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("output is not the catalog JSON (%q): %v", out, err)
+	}
+	want := catalogFixture()
+	if got.Default != want.Default || got.DefaultStatus != want.DefaultStatus {
+		t.Fatalf("default = %q/%q, want %q/%q", got.Default, got.DefaultStatus, want.Default, want.DefaultStatus)
+	}
+	if len(got.Backends) != len(want.Backends) {
+		t.Fatalf("emitted %d backends, want %d — the CLI must not filter the catalog", len(got.Backends), len(want.Backends))
+	}
+	for i, opt := range got.Backends {
+		if opt != want.Backends[i] {
+			t.Fatalf("backend %d = %+v, want %+v (order, tri-state, and reason are all part of the contract)",
+				i, opt, want.Backends[i])
+		}
+	}
+}
+
+// TestSessionsBackends_PassesThroughAnUnknownBackendName is the #1970 property
+// one surface over: a backend added server-side must reach the CLI with no CLI
+// change. The CLI holds no backend enum of its own here — it prints what the
+// daemon said — so a name this binary has never heard of must survive to stdout
+// rather than being filtered by a client-side allowlist.
+func TestSessionsBackends_PassesThroughAnUnknownBackendName(t *testing.T) {
+	setupRepoForCmd(t)
+
+	prev := listBackendsViaDaemon
+	listBackendsViaDaemon = func(daemon.ListBackendsRequest) (daemon.ListBackendsResponse, error) {
+		return daemon.ListBackendsResponse{
+			Backends: []daemon.BackendOption{
+				{Name: "warpdrive", Label: "warpdrive", Status: daemon.BackendAvailable},
+			},
+			Default:       "warpdrive",
+			DefaultStatus: daemon.BackendAvailable,
+		}, nil
+	}
+	t.Cleanup(func() { listBackendsViaDaemon = prev })
+
+	out, err := runCmdCaptureStdout(t, sessionsBackendsCmd, nil)
+	if err != nil {
+		t.Fatalf("backends returned error: %v", err)
+	}
+	var got daemon.ListBackendsResponse
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("output is not the catalog JSON (%q): %v", out, err)
+	}
+	if len(got.Backends) != 1 || got.Backends[0].Name != "warpdrive" || got.Default != "warpdrive" {
+		t.Fatalf("catalog = %+v, want the daemon's unrecognized backend passed through untouched", got)
+	}
+}
+
+// TestSessionsBackends_SurfacesDaemonError keeps the CLI from inventing an answer
+// when the daemon could not give one. "I could not check" must not become an
+// empty-but-successful catalog, which a script would read as "no backends here".
+func TestSessionsBackends_SurfacesDaemonError(t *testing.T) {
+	setupRepoForCmd(t)
+
+	prev := listBackendsViaDaemon
+	listBackendsViaDaemon = func(daemon.ListBackendsRequest) (daemon.ListBackendsResponse, error) {
+		return daemon.ListBackendsResponse{}, errors.New("agent-factory daemon is starting (restoring sessions); retry shortly")
+	}
+	t.Cleanup(func() { listBackendsViaDaemon = prev })
+
+	out, err := runCmdCaptureStdout(t, sessionsBackendsCmd, nil)
+	if err == nil {
+		t.Fatalf("backends must surface the daemon failure, got output %q", out)
+	}
+	if !strings.Contains(err.Error(), "daemon is starting") {
+		t.Fatalf("error = %v, want the daemon's message", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("stdout = %q, want nothing: a failed read must not print a catalog", out)
+	}
+}

--- a/daemon/backends.go
+++ b/daemon/backends.go
@@ -155,7 +155,11 @@ func backendOptionFor(kind session.BackendKind, cfg *config.ResolvedConfig, cfgE
 			return opt
 		}
 		opt.Status = BackendUnknown
-		opt.Reason = fmt.Sprintf("cannot tell whether this repo can use backend=%s: its %s could not be read (%v). Fix that file, then reopen this form.", kind, config.InRepoConfigFileName(repoRoot), cfgErr)
+		// Surface-neutral phrasing. These reasons are rendered verbatim by every
+		// client — the web's picker, and `af sessions backends` in a terminal — so
+		// telling the reader to "reopen this form" names a thing a CLI user does
+		// not have. Say what to fix; each surface knows how to re-ask.
+		opt.Reason = fmt.Sprintf("cannot tell whether this repo can use backend=%s: its %s could not be read (%v). Fix that file to get a definite answer.", kind, config.InRepoConfigFileName(repoRoot), cfgErr)
 		return opt
 	}
 
@@ -205,7 +209,9 @@ func defaultFor(backends []BackendOption, cfg *config.ResolvedConfig, cfgErr err
 		if cfgErr == nil && cfg != nil {
 			raw = cfg.Backend
 		}
-		return "", BackendUnavailable, fmt.Sprintf("this repo's %s sets backend = %q, which is not a known backend (valid: %s). A session created here fails rather than falling back to local — fix that key, or pick a backend above.", config.InRepoConfigFileName(repoRoot), raw, config.SupportedBackendsString())
+		// "or pick a backend above" assumed a rendered list above the reader; see the
+		// note on the unknown-status reason. Name the ACTION both surfaces have.
+		return "", BackendUnavailable, fmt.Sprintf("this repo's %s sets backend = %q, which is not a known backend (valid: %s). A session created here fails rather than falling back to local — fix that key, or choose a backend explicitly for this session.", config.InRepoConfigFileName(repoRoot), raw, config.SupportedBackendsString())
 	}
 
 	// The default's usability IS the resolved backend's usability; reuse the answer

--- a/daemon/backends_test.go
+++ b/daemon/backends_test.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"encoding/json"
+	"net"
+	"net/rpc"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -374,4 +376,48 @@ func TestListBackends_RequiresARepo(t *testing.T) {
 	var resp ListBackendsResponse
 	err := (&controlServer{}).ListBackends(ListBackendsRequest{RepoPath: t.TempDir()}, &resp)
 	assert.Error(t, err, "a non-repo path cannot answer which backends its sessions may use")
+}
+
+// TestListBackends_AnswersOverTheControlSocket proves the CLI's transport reaches
+// the same catalog the web's HTTP route does. `af sessions backends` calls
+// daemon.ListBackends, which goes over the gob control socket, while the web POSTs
+// /v1/ListBackends — two transports, one controlServer.ListBackends. What is NOT
+// obvious is that the gob half works at all: net/rpc only exposes a method whose
+// signature fits, and gob must carry BackendAvailability (a named string type) and
+// the reason strings intact. A tri-state that arrived empty over gob would have the
+// CLI quietly report every backend as usable, which is the promise this catalog
+// exists to keep honest.
+func TestListBackends_AnswersOverTheControlSocket(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	stubLookPath(t)
+	repo := setupControlRepo(t)
+	addOrigin(t, repo)
+	writeRepoBackendConfig(t, repo, map[string]any{
+		"docker": map[string]any{"image": "my-runtime:latest"},
+	})
+
+	server := rpc.NewServer()
+	require.NoError(t, server.RegisterName(controlServiceName, &controlServer{}),
+		"the control service must expose ListBackends — it is the CLI's only path to the catalog")
+	srvConn, cliConn := net.Pipe()
+	go server.ServeConn(srvConn)
+	client := rpc.NewClient(cliConn)
+	t.Cleanup(func() { _ = client.Close() })
+
+	var resp ListBackendsResponse
+	require.NoError(t, client.Call(controlServiceName+".ListBackends",
+		ListBackendsRequest{RepoPath: repo}, &resp))
+
+	assert.Equal(t, listBackends(t, repo), resp,
+		"the socket answer must be the in-process answer verbatim — same order, same tri-state, same reasons")
+
+	// Spelled out rather than left to the whole-struct compare, because these are
+	// the values a transport bug would silently blank.
+	assert.Equal(t, BackendAvailable, optionByName(t, resp, config.BackendDocker).Status,
+		"docker is configured in this repo, so the socket must report it selectable")
+	hook := optionByName(t, resp, config.BackendHook)
+	assert.Equal(t, BackendUnavailable, hook.Status)
+	assert.NotEmpty(t, hook.Reason, "the actionable reason is what the CLI prints; gob must carry it")
+	assert.Equal(t, config.BackendLocal, resp.Default)
+	assert.Equal(t, BackendAvailable, resp.DefaultStatus)
 }

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -319,6 +319,24 @@ func CreateSession(req CreateSessionRequest) (*session.InstanceData, error) {
 	return &resp.Instance, nil
 }
 
+// ListBackends asks the daemon which runtimes a create against req.RepoPath may
+// select, and which one an unspecified create resolves to. It is the read that
+// makes CreateSession's Backend field choosable rather than guessable, and it
+// answers from the same controlServer.ListBackends the web's picker reaches over
+// /v1/ListBackends — one catalog, two transports, so the CLI and the web can
+// never describe a repo's backends differently.
+//
+// Read-only: it provisions nothing and dials nothing. Like every other CLI
+// control call it goes to the LOCAL daemon, which is the daemon that would serve
+// the create it describes.
+func ListBackends(req ListBackendsRequest) (ListBackendsResponse, error) {
+	var resp ListBackendsResponse
+	if err := callDaemon("ListBackends", req, &resp); err != nil {
+		return ListBackendsResponse{}, err
+	}
+	return resp, nil
+}
+
 // CreateTab asks the daemon to spawn, persist, and report a new tab on an
 // existing session. Returning the response object keeps the daemon-minted ID
 // together with its resolved and tmux names across the gob transport.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -41,6 +41,7 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 - [`af sessions`](#af-sessions) — Manage sessions
 - [`af sessions archive`](#af-sessions-archive) — Finish with a session by archiving it for later restore
 - [`af sessions attach`](#af-sessions-attach) — Attach to a session's terminal
+- [`af sessions backends`](#af-sessions-backends) — List the runtimes this project can create sessions on
 - [`af sessions create`](#af-sessions-create) — Create a new session
 - [`af sessions get`](#af-sessions-get) — Get a session by title
 - [`af sessions handoff`](#af-sessions-handoff) — Continue a session under a different agent, in place
@@ -1174,6 +1175,7 @@ af sessions
 
 - [`af sessions archive`](#af-sessions-archive) — Finish with a session by archiving it for later restore
 - [`af sessions attach`](#af-sessions-attach) — Attach to a session's terminal
+- [`af sessions backends`](#af-sessions-backends) — List the runtimes this project can create sessions on
 - [`af sessions create`](#af-sessions-create) — Create a new session
 - [`af sessions get`](#af-sessions-get) — Get a session by title
 - [`af sessions handoff`](#af-sessions-handoff) — Continue a session under a different agent, in place
@@ -1262,6 +1264,52 @@ af sessions attach <title>
 | `--repo` | `string` | Path to the project's git repository (default: the current directory's project) |
 | `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
+## af sessions backends
+
+List the runtimes this project can create sessions on
+
+Report which backends 'af sessions create --backend' accepts for this
+project, whether each one is usable as the project is configured right now, and
+which backend a create with no --backend resolves to.
+
+--backend names the enum, but knowing that "docker" is spelled correctly is not
+the same as knowing this project can use it. The daemon checks each backend's
+preconditions against the project's config and answers one of three things:
+
+  available    every precondition that can be checked was checked and passed
+  unavailable  a precondition FAILED — a create would fail; "reason" says what to fix
+  unknown      the preconditions could NOT be evaluated (e.g. the project's
+               config would not parse) — neither yes nor no is honest, so
+               "reason" says what stopped the check
+
+"unknown" is deliberately not folded into either of the other two: reporting an
+unchecked backend as available is a promise nobody verified.
+
+"default" is the backend a create with no --backend resolves to here. It is
+EMPTY when the project's 'backend' config key names something unrecognized —
+such a create fails rather than quietly running local, and "default_reason"
+names the offending value.
+
+The reasons are the same text a create prints when it refuses, because both come
+from the same precondition checks.
+
+Example:
+  af sessions backends
+  af sessions backends --repo ~/src/myproject
+
+```
+af sessions backends
+```
+
+**Global flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--daemon-url` | `string` | Target a REMOTE daemon at this http:// or ws:// URL instead of the local unix socket (env: AF_DAEMON_URL). The daemon is HTTP-only; terminate TLS at your own proxy if needed. |
+| `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
+| `--repo` | `string` | Path to the project's git repository (default: the current directory's project) |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
+
 ## af sessions create
 
 Create a new session
@@ -1282,7 +1330,7 @@ af sessions create [flags]
 
 | Flag | Type | Description |
 |------|------|-------------|
-| `--backend` | `string` | Runtime to run the session on (one of: local, docker, ssh, hook; defaults to the repo's backend config, or local). docker runs the session in a container (set docker.image in the repo config); ssh runs it on a remote host (set ssh.host in the repo config) |
+| `--backend` | `string` | Runtime to run the session on (one of: local, docker, ssh, hook; defaults to the repo's backend config, or local). docker runs the session in a container (set docker.image in the repo config); ssh runs it on a remote host (set ssh.host in the repo config). Run "af sessions backends" for which of these this project can actually use, and why not |
 | `--here` |  | Run in the repo's existing working tree at its current branch (no new worktree/branch; kill preserves both) |
 | `--in-place` |  | Alias for --here |
 | `--name` | `string` | Session name (required) |

--- a/parity/derive_go_test.go
+++ b/parity/derive_go_test.go
@@ -63,6 +63,7 @@ var auditedRequests = map[string]reflect.Type{
 	"DeliverPromptRequest":    reflect.TypeOf(daemon.DeliverPromptRequest{}),
 	"HandoffSessionRequest":   reflect.TypeOf(daemon.HandoffSessionRequest{}),
 	"KillSessionRequest":      reflect.TypeOf(daemon.KillSessionRequest{}),
+	"ListBackendsRequest":     reflect.TypeOf(daemon.ListBackendsRequest{}),
 	"ListTasksRequest":        reflect.TypeOf(daemon.ListTasksRequest{}),
 	"PauseStatusPollRequest":  reflect.TypeOf(daemon.PauseStatusPollRequest{}),
 	"PingRequest":             reflect.TypeOf(daemon.PingRequest{}),

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -1248,11 +1248,11 @@
         "pointer": "web/src/api.ts:260 ListBackends -> web/src/backends.ts renders the picker"
       },
       "cli": {
-        "status": "no",
-        "pointer": ""
+        "status": "yes",
+        "pointer": "api/sessions_backends.go:19 sessionsBackendsCmd -> daemon/control_client.go:332 ListBackends"
       },
-      "verdict": "unclear",
-      "notes": "POST /v1/ListBackends (#1968) serves config.SupportedBackends per-repo with a tri-state answer (available / unavailable+reason / unknown+reason). The web needs the round-trip because it cannot import the Go enum; the CLI and TUI read config.SupportedBackends directly and the CLI validates --backend at create time with session.BackendConfigError. So upfront availability DISCOVERY is web-only, while create-time validation is not. Whether the CLI/TUI should also surface availability upfront (vs erroring at create) is an owner call — the #1968/#1970 session owns the serve-the-enum direction. Not filed."
+      "verdict": "deliberate",
+      "notes": "POST /v1/ListBackends (#1968) serves config.SupportedBackends per-repo with a tri-state answer (available / unavailable+reason / unknown+reason). CLI half CLOSED: `af sessions backends` prints that catalog verbatim, reaching the SAME controlServer.ListBackends the web's picker calls over /v1/ListBackends (daemon/httproutes.go wires the route to that method; the gob control socket exposes it) — one catalog, two transports, so the two surfaces cannot describe a repo's backends differently and a backend added server-side reaches both with no client change (pinned by TestSessionsBackends_PassesThroughAnUnknownBackendName). It resolves the project through the same resolveRepo `sessions create` uses, so it describes the create it predicts, and the --backend flag help names it — the flag advertised the enum but not which values this project can use. The TUI cell stays 'no' DELIBERATELY, and not as a second gap: the web's 'yes' here IS its create-time picker rendering availability, not a standalone catalog view, and the TUI has no backend surface at all (grep-verified — nothing under app/ or ui/ reads config.SupportedBackends or calls ListBackends). A TUI catalog with no way to select a backend would be a dead-end read, so the TUI's analogue is the create-time picker, tracked as session.create.opt.backend's TUI half; recording it here too would double-count one piece of work. This cell flips to 'yes' with that picker, not before."
     },
     {
       "id": "config-agent",
@@ -1365,6 +1365,7 @@
       "af reset": "install.reset",
       "af sessions archive": "session.archive",
       "af sessions attach": "session.attach",
+      "af sessions backends": "backend.list",
       "af sessions create": "session.create",
       "af sessions get": "session.get",
       "af sessions handoff": "session.handoff",
@@ -1584,6 +1585,7 @@
       "af sessions archive --help": "meta.discovery",
       "af sessions archive --self": "session.archive",
       "af sessions attach --help": "meta.discovery",
+      "af sessions backends --help": "meta.discovery",
       "af sessions create --backend": "session.create.opt.backend",
       "af sessions create --help": "meta.discovery",
       "af sessions create --here": "session.create.opt.inplace",


### PR DESCRIPTION
## The gap

`parity/inventory.json` row **`backend.list`** — *"Discover which backends are
available for a repo (with availability + reason)"* — was `tui=no web=yes
cli=no`, verdict `unclear`.

Since [#1968](https://github.com/sachiniyer/agent-factory/issues/1968) the daemon
serves `POST /v1/ListBackends`: every supported backend for a repo, each with a
**three-outcome** answer (`available` / `unavailable`+reason / `unknown`+reason),
plus the backend an unspecified create resolves to. Only the web could read it.

The CLI is the surface that owns the flag which consumes that answer.
`af sessions create --backend` advertises the enum — `local, docker, ssh, hook` —
and there was no way from the CLI to ask which of those values *this project can
actually use*, why not, or what a create with **no** `--backend` will do here. The
only way to find out was to attempt a create and read the failure. That is the
gap I picked: not an obscure flag, but the discovery half of the entry point to
the container/remote backends, missing on the scripting surface.

## The change

```
$ af sessions backends
{
  "backends": [
    { "name": "local",  "label": "local",  "status": "available" },
    { "name": "docker", "label": "docker", "status": "available" },
    { "name": "ssh",    "label": "ssh",    "status": "unavailable",
      "reason": "backend=ssh requires ssh.host to be set in this repo's .agent-factory/config.json (…)" },
    { "name": "hook",   "label": "Remote sandbox (hook)", "status": "unavailable", "reason": "…" }
  ],
  "default": "local",
  "default_status": "available"
}
```

**One catalog, two transports — no second implementation.** The command calls
`daemon.ListBackends` over the gob control socket, which lands on the *same*
`controlServer.ListBackends` the web reaches over `/v1/ListBackends`
(`daemon/httproutes.go` wires that route to that method). There is no client-side
backend enum, no filtering and no re-derivation: the response is printed verbatim,
so the two surfaces cannot describe a repo's backends differently, and a backend
added server-side reaches both with no client change — the #1970 "serve the enum"
property, pinned here by `TestSessionsBackends_PassesThroughAnUnknownBackendName`.

**It describes the create it predicts.** The project is resolved through the same
`resolveRepo` `af sessions create` uses — including its `--repo is required` and
af-home refusals — so the catalog can never answer about a different project than
the create it is meant to predict.

**It is reachable.** A capability nobody can find is a parity failure the ledger
scores as a pass, so `--backend`'s own help now names the verb: *"Run `af sessions
backends` for which of these this project can actually use, and why not."*

### Copy fix carried along

Two reason strings in `daemon/backends.go` were written when the web modal was the
only consumer and told the reader to **"reopen this form"** and **"pick a backend
above"**. They are rendered verbatim in a terminal now, where there is no form and
nothing above. Both now name the fix instead of a widget. This is a real
cross-surface bug — the ledger records existence, so it scored "yes" on both
surfaces while the copy only made sense on one.

## Ledger

`backend.list` → `cli: yes` (pointer `api/sessions_backends.go:19`), verdict
`unclear` → **`deliberate`**, with the TUI decision recorded so it is not
re-reported:

> The TUI cell stays `no` deliberately, and not as a second gap: the web's `yes`
> here IS its create-time picker rendering availability, not a standalone catalog
> view, and the TUI has no backend surface at all (grep-verified — nothing under
> `app/` or `ui/` reads `config.SupportedBackends` or calls `ListBackends`). A TUI
> catalog with no way to select a backend would be a dead-end read, so the TUI's
> analogue is the create-time picker, tracked as `session.create.opt.backend`'s TUI
> half; recording it here too would double-count one piece of work.

`ListBackendsRequest` joins `auditedRequests` — the audit failed closed on the new
construction site (*"cli constructs ListBackendsRequest … but it is not in
auditedRequests"*), which is the coverage rule working as designed.

## Tests

- `api/sessions_backends_test.go` — the request carries the resolved project root;
  the catalog is emitted verbatim (order, tri-state and reasons all asserted); an
  unrecognized backend name passes through; a daemon failure surfaces instead of
  printing an empty catalog a script would read as *"no backends here"*.
- `daemon/backends_test.go` — `TestListBackends_AnswersOverTheControlSocket`
  stands up `net/rpc` over an in-memory pipe and proves the **CLI's** transport
  reaches the same answer as the in-process call. That half was not obvious: gob
  has to carry `BackendAvailability` (a named string type) and the reason strings,
  and a tri-state arriving blank would have the CLI report every backend as usable.

Each test was watched failing first — wrong repo path, a client-side
available-only filter, and a `config.SupportedBackends` allowlist each trip the
test that owns them; renaming the RPC method trips the socket test.

Also exercised end-to-end against a real daemon on a throwaway `AGENT_FACTORY_HOME`
(listener off, daemon stopped by pid and home removed afterwards): the configured,
unconfigured, unreadable-config (`unknown`) and unrecognized-`backend`-key (empty
`default` + `default_reason`) cases all render as documented.

Closes the CLI half of `backend.list`.

— Captain Claude
