### PR TITLE
refactor(session): FakeBackend delegates its capability descriptor to LocalBackend (#1241)

### DIFF
--- a/session/fake_backend.go
+++ b/session/fake_backend.go
@@ -126,18 +126,16 @@ func (b *FakeBackend) PrepareAgentSwap(_ *Instance, target string) (AgentSwapPla
 func (b *FakeBackend) SwapAgent(*Instance, AgentSwapPlan) error { return nil }
 func (b *FakeBackend) Type() string                             { return "local" }
 
-// Capabilities reports local full parity by default, mirroring LocalBackend so
-// the fake stands in for a local session (#1592 Phase 1). Test doubles that
-// impersonate a remote backend override this to return a WorkspaceRemote
-// descriptor.
+// Capabilities reports local full parity by default so the fake stands in for a
+// local session (#1592 Phase 1). Test doubles that impersonate a remote backend
+// override this to return a WorkspaceRemote descriptor.
+//
+// It DELEGATES to LocalBackend rather than restating the descriptor. A copy here
+// would only be a claim to mirror the local runtime, and nothing would check it:
+// a capability added to Capabilities and wired into LocalBackend would leave
+// every FakeBackend-driven test silently asserting against a stale descriptor —
+// the fake would keep reporting the op unsupported while the real local backend
+// supports it. Delegation makes the mirror true by construction.
 func (b *FakeBackend) Capabilities() Capabilities {
-	return Capabilities{
-		Workspace:        WorkspaceLocalWorktree,
-		Archive:          true,
-		Recover:          true,
-		TabManagement:    true,
-		TerminalTab:      true,
-		InteractiveInput: true,
-		Handoff:          true,
-	}
+	return (&LocalBackend{}).Capabilities()
 }


### PR DESCRIPTION
## What abstraction got simpler

`FakeBackend.Capabilities()` restated `LocalBackend`'s full-parity descriptor
field for field, under a comment that said it was *"mirroring LocalBackend"*.
Nothing enforced that claim — it was a promise in prose, checked by no one.

```go
// before — a copy that only claims to mirror
func (b *FakeBackend) Capabilities() Capabilities {
	return Capabilities{
		Workspace:        WorkspaceLocalWorktree,
		Archive:          true,
		// ...5 more fields, byte-identical to LocalBackend
	}
}

// after — the mirror is true by construction
func (b *FakeBackend) Capabilities() Capabilities {
	return (&LocalBackend{}).Capabilities()
}
```

Net: 13 lines out, 11 in (all comment), one duplicated descriptor gone.

## Why it matters

`FakeBackend` is the stand-in for a local session across `app/`, `task/`,
`daemon/`, and `session/` tests. The drift this prevents fails in the direction
that **hides** bugs: add a capability to `Capabilities`, wire it into
`LocalBackend`, and the fake keeps reporting the op *unsupported* while the real
local backend supports it. Every FakeBackend-driven test then asserts against a
stale descriptor and still passes — a green suite that no longer describes the
runtime it claims to model.

`Capabilities` has grown before (`Handoff` arrived with #2013) and the struct
doc says surfaces branch on these bits instead of on `Type()=="remote"`, so it
is a live growth point, not a frozen one.

## Why it's behavior-preserving

The two literals were **byte-identical** — same seven fields, same values — so
every caller observes exactly the descriptor it observed before. `LocalBackend`
is an empty struct with a pure-literal `Capabilities()`, so constructing one
costs nothing and reads no state.

The one place that consumes the fake's descriptor as a *base* rather than
wholesale is `session/agentserver_recursion_test.go`, which calls
`b.FakeBackend.Capabilities()` and overrides `Workspace` to remote. It reads the
same values as before and is unaffected.

## Gates — all six green on the pushed head `041a52cd`

| gate | result |
| --- | --- |
| `golangci-lint run --timeout=3m --fast` | exit 0 |
| `gofmt -l .` | empty |
| `go build ./...` | ok |
| `make test-container` | exit 0, **0** `FAIL` lines, every package `ok` |
| `deadcode -test ./...` | empty |
| `scripts/lint-file-length.sh` | passed (1082 files, 0 grandfathered) |

## Scope

Daily abstraction-simplification sweep (#1241), same lens as the #1195
structural-health audit. One focused, behavior-preserving cleanup. Larger
structural-debt items surfaced by this run are written up as a comment on #1195
rather than attempted here — notably the six-way shell-quoting sprawl, where
unification would change output text and is **not** a safe drive-by.

Closes nothing on its own — #1241 and #1195 are both closed trackers, referenced
here for lineage.

Not self-merging: root reviews this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
