### PR TITLE
feat(tui): choose a session's backend from the naming form (parity: session.create.opt.backend, #1933)

### DIFF
--- a/apiclient/control.go
+++ b/apiclient/control.go
@@ -189,7 +189,9 @@ func (c *Client) SnapshotWithAlarms(req daemon.SnapshotRequest) (daemon.Snapshot
 // ListBackends asks the daemon which runtimes a create against this repo may
 // select, with the tri-state availability answer per backend (#1933). It is the
 // TUI's backend picker's only source of truth — the same route the web's picker
-// calls, so both surfaces render one catalog computed in one place.
+// calls, so both surfaces render one catalog computed in one place. HTTP twin of
+// daemon.ListBackends, which `af sessions backends` takes over the gob socket
+// (#2584): three transports, one controlServer.ListBackends, no second catalog.
 //
 // This one IS a round trip, unlike the in-process reads described below, and the
 // difference is not stylistic: a backend's availability is a property of the box

--- a/apiclient/control.go
+++ b/apiclient/control.go
@@ -186,6 +186,26 @@ func (c *Client) SnapshotWithAlarms(req daemon.SnapshotRequest) (daemon.Snapshot
 	return resp, nil
 }
 
+// ListBackends asks the daemon which runtimes a create against this repo may
+// select, with the tri-state availability answer per backend (#1933). It is the
+// TUI's backend picker's only source of truth — the same route the web's picker
+// calls, so both surfaces render one catalog computed in one place.
+//
+// This one IS a round trip, unlike the in-process reads described below, and the
+// difference is not stylistic: a backend's availability is a property of the box
+// that will PROVISION it (is `docker` on its PATH? does the repo's config parse
+// there?) and of the repo as the daemon sees it. apiclient.NewTargeted may point
+// at a REMOTE daemon, so deriving the answer from the client's own host would
+// confidently describe the wrong machine — the fabricated-answer failure the
+// tri-state exists to prevent.
+func (c *Client) ListBackends(req daemon.ListBackendsRequest) (daemon.ListBackendsResponse, error) {
+	var resp daemon.ListBackendsResponse
+	if err := c.call("ListBackends", req, &resp); err != nil {
+		return daemon.ListBackendsResponse{}, err
+	}
+	return resp, nil
+}
+
 // There is deliberately no ListProjects here. The web reads the registry over HTTP
 // (web/src/api.ts listProjects hits the daemon's /v1/ListProjects route directly),
 // but the two GO consumers read it in-process: the TUI's switcher union

--- a/app/backend_picker.go
+++ b/app/backend_picker.go
@@ -1,0 +1,263 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/sachiniyer/agent-factory/apiclient"
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui"
+	"github.com/sachiniyer/agent-factory/ui/overlay"
+)
+
+// The naming form's backend field (#1933).
+//
+// The daemon has always accepted a backend on create (CreateSessionRequest.Backend,
+// the CLI's `--backend`), and #1968 gave the web a picker over the daemon's
+// ListBackends catalog. The TUI was the surface left out: `N` reaches the hook
+// backend and nothing else, so a docker or ssh session could not be created from
+// the primary interface at all — a user had to edit the repo's checked-in `backend`
+// key, which is all-or-nothing per repo, or drop to the CLI.
+//
+// Two rules this file exists to hold, both borrowed from its web twin
+// (web/src/backends.ts), because a second implementation of either is how the two
+// pickers would start disagreeing:
+//
+//  1. THE TUI KNOWS NO BACKEND NAMES. There is no local enum here and no
+//     name→label map: every row is built from the daemon's response, so a backend
+//     added server-side is offered by this picker with no change to this file.
+//  2. AVAILABILITY IS THE DAEMON'S ANSWER, VERBATIM. Its tri-state
+//     (available / unavailable+reason / unknown+reason) is rendered as three
+//     outcomes, never collapsed into two. "Could not check" is not "fine".
+
+// repoDefaultBackend is the sentinel for the picker's "repo default" row. It is
+// the EMPTY STRING on purpose: it is exactly what the create request omits on, so
+// choosing the default sends no backend and the repo's own config decides. Any
+// other sentinel would eventually be transmitted as a literal backend name.
+const repoDefaultBackend = ""
+
+// backendChoice is one row of the picker.
+type backendChoice struct {
+	// value is what goes on CreateSessionRequest.Backend: repoDefaultBackend, or a
+	// backend name to send verbatim.
+	value string
+	// label is the daemon-supplied presentation text (BackendOption.Label), which is
+	// repo-aware — the hook backend names the launcher the repo configured.
+	label string
+	// status is the daemon's checked answer for this choice.
+	status daemon.BackendAvailability
+	// reason is the actionable explanation whenever status is not available — the
+	// same sentence the CLI prints at create time. Empty when available.
+	reason string
+}
+
+// backendChoicesFrom turns the daemon's catalog into the picker's rows: the
+// repo-default row first, labelled with the backend it actually resolves to, then
+// every backend the daemon listed in its canonical order.
+//
+// Unusable backends are LISTED, not hidden. A user who read docs/backends.md and
+// looks for docker deserves the reason it is unusable here; a mystery absence
+// leaves them re-reading their config for something that is not wrong with it.
+func backendChoicesFrom(catalog daemon.ListBackendsResponse) []backendChoice {
+	label := "Repo default"
+	if catalog.Default != "" {
+		// Name the resolved backend from the catalog's own label for it, so a repo
+		// defaulting to docker says so without the user having to pick docker.
+		resolved := catalog.Default
+		for _, opt := range catalog.Backends {
+			if opt.Name == catalog.Default {
+				resolved = opt.Label
+				break
+			}
+		}
+		label = fmt.Sprintf("Repo default (%s)", resolved)
+	}
+	// A repo whose `backend` key names something unrecognized has NO default: such a
+	// create fails rather than falling back to local, so the row stays "Repo default"
+	// with no parenthetical and carries the daemon's misconfiguration reason.
+	choices := []backendChoice{{
+		value:  repoDefaultBackend,
+		label:  label,
+		status: catalog.DefaultStatus,
+		reason: catalog.DefaultReason,
+	}}
+	if catalog.DefaultStatus == daemon.BackendAvailable {
+		choices[0].reason = ""
+	}
+
+	for _, opt := range catalog.Backends {
+		choice := backendChoice{value: opt.Name, label: opt.Label, status: opt.Status, reason: opt.Reason}
+		if opt.Status == daemon.BackendAvailable {
+			choice.reason = ""
+		}
+		choices = append(choices, choice)
+	}
+	return choices
+}
+
+// item is the row as the selection overlay renders it: the label plus a marker for
+// a status that is not available.
+//
+// The marker exists so the LIST is honest before a keypress — a bare "docker"
+// among usable rows is the picker-as-a-promise problem the catalog's tri-state was
+// built to avoid. The reason itself is deliberately not inlined: the overlay
+// truncates each row to its text rect, so a sentence naming a config key and a
+// file would be cut mid-word. It is shown in full when the row is chosen.
+func (c backendChoice) item() string {
+	switch c.status {
+	case daemon.BackendUnavailable:
+		return c.label + " — unavailable"
+	case daemon.BackendUnknown:
+		return c.label + " — cannot check"
+	default:
+		return c.label
+	}
+}
+
+// backendCatalogMsg carries a fetched catalog back onto the event loop. naming is
+// the instance whose form asked for it: the fetch is async, so by the time it
+// lands the user may have submitted, cancelled, or started naming a different
+// session, and the picker must not open over an unrelated form.
+type backendCatalogMsg struct {
+	naming  *session.Instance
+	catalog daemon.ListBackendsResponse
+	err     error
+}
+
+// listBackendsThroughDaemon is the fetch seam, mirroring startSessionThroughDaemon:
+// a package var so the unit suite can answer with a fixture instead of a daemon.
+var listBackendsThroughDaemon = func(repoPath string) (daemon.ListBackendsResponse, error) {
+	var resp daemon.ListBackendsResponse
+	err := withDaemonHTTP(func(c *apiclient.Client) error {
+		var e error
+		resp, e = c.ListBackends(daemon.ListBackendsRequest{RepoPath: repoPath})
+		return e
+	})
+	if err != nil {
+		return daemon.ListBackendsResponse{}, err
+	}
+	return resp, nil
+}
+
+// SetBackendListerForTest swaps the catalog seam so a test can answer with a
+// fixture — including backends no local enum knows about, which is how the
+// "the TUI knows no backend names" property is provable rather than asserted.
+func SetBackendListerForTest(f func(repoPath string) (daemon.ListBackendsResponse, error)) func() {
+	prev := listBackendsThroughDaemon
+	listBackendsThroughDaemon = f
+	return func() { listBackendsThroughDaemon = prev }
+}
+
+// openBackendPicker starts the round trip that opens the backend field. The
+// catalog is fetched on demand rather than prefetched with every `n`: most creates
+// never touch this field, and a stale catalog is worse than a fresh one — a repo's
+// config can change between opening the form and opening the field.
+func (m *home) openBackendPicker() (tea.Model, tea.Cmd) {
+	naming := m.namingInstance
+	if naming == nil {
+		return m, nil
+	}
+	repoPath := naming.Path
+	fetch := listBackendsThroughDaemon
+	return m, func() tea.Msg {
+		catalog, err := fetch(repoPath)
+		return backendCatalogMsg{naming: naming, catalog: catalog, err: err}
+	}
+}
+
+// handleBackendCatalog opens the picker over a delivered catalog.
+//
+// The staleness guard is the whole reason this is a message rather than a direct
+// call: naming may have ended (Enter/Esc/ctrl+c) or moved to a different session
+// while the fetch was in flight, and an overlay opened over that would be a modal
+// the user never asked for, editing a create that no longer exists.
+func (m *home) handleBackendCatalog(msg backendCatalogMsg) (tea.Model, tea.Cmd) {
+	if m.state != stateNew || m.namingInstance == nil || m.namingInstance != msg.naming {
+		return m, nil
+	}
+	if msg.err != nil {
+		// Lead with what failed and what it blocks; the daemon's own error text
+		// follows. The naming form stays open — the field is optional, so a catalog
+		// we could not read must not cost the user their half-typed create.
+		return m, m.handleError(fmt.Errorf("cannot list backends for this repo: %w", msg.err))
+	}
+	choices := backendChoicesFrom(msg.catalog)
+	if len(choices) == 0 {
+		// Defensive: the response always carries at least the repo-default row. Say
+		// so rather than opening an empty modal the user has to escape from.
+		return m, m.handleError(errors.New("the daemon returned no backends for this repo"))
+	}
+
+	selected := 0
+	for i, choice := range choices {
+		if choice.value == m.pendingBackend {
+			selected = i
+			break
+		}
+	}
+	m.backendPickerChoices = choices
+	items := make([]string, len(choices))
+	for i, choice := range choices {
+		items[i] = choice.item()
+	}
+	m.selectionOverlay = overlay.NewSelectionOverlay("Select backend", items)
+	m.selectionOverlay.SetSelectedIndex(selected)
+	// layoutSelectionOverlay sizes it to the same 60% box the program field opens
+	// to, so the naming form's three fields are one form and not three dialogs.
+	m.layoutSelectionOverlay()
+	m.state = stateSelectBackend
+	return m, nil
+}
+
+// handleStateSelectBackend handles key events while the backend field is open.
+// Mirrors handleStateSelectProgram: the field is part of the create form, so
+// submitting or escaping returns to naming rather than abandoning the create.
+//
+// An unusable choice is REFUSED here, at pick time, with the daemon's reason. The
+// web's picker keeps such a row selectable and blocks the submit instead; a modal
+// TUI overlay has nowhere to show a blocking explanation, and refusing on choice
+// tells the user what to fix at the moment they asked for it — while their create
+// is still open and retryable. Either way the invariant is the same: no surface
+// offers a backend it was told would fail.
+func (m *home) handleStateSelectBackend(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.selectionOverlay == nil {
+		m.backendPickerChoices = nil
+		m.state = stateNew
+		m.menu.SetState(ui.StateNewInstance)
+		return m, nil
+	}
+	if !m.selectionOverlay.HandleKeyPress(msg) {
+		return m, nil
+	}
+
+	submitted := m.selectionOverlay.IsSubmitted()
+	idx := m.selectionOverlay.GetSelectedIndex()
+	choices := m.backendPickerChoices
+
+	m.selectionOverlay = nil
+	m.backendPickerChoices = nil
+	m.state = stateNew
+	m.menu.SetState(ui.StateNewInstance)
+
+	if !submitted || idx < 0 || idx >= len(choices) {
+		return m, nil
+	}
+	choice := choices[idx]
+	if choice.status != daemon.BackendAvailable {
+		// The reason is the daemon's, verbatim: it names the key and the file to fix,
+		// and it is the SAME sentence a create would have failed with, so the picker
+		// cannot describe a precondition differently from the thing that enforces it.
+		// The fallback covers a reasonless non-available answer, which would otherwise
+		// flash an empty notice — the keypress must always say something (#2020).
+		if choice.reason == "" {
+			return m, m.handleError(fmt.Errorf("backend %q is not usable for this repo, and the daemon gave no reason", choice.label))
+		}
+		return m, m.handleError(errors.New(choice.reason))
+	}
+	m.pendingBackend = choice.value
+	m.menu.SetNamingBackend(m.pendingBackend != repoDefaultBackend)
+	return m, nil
+}

--- a/app/backend_picker_test.go
+++ b/app/backend_picker_test.go
@@ -1,0 +1,517 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// #1933: no surface but the CLI could choose a session's backend. The web half
+// landed in #1968 (a picker over the daemon's ListBackends catalog); the TUI was
+// the surface left out — `N` forces the hook backend and nothing else, so a docker
+// or ssh session could not be started from the primary interface at all.
+//
+// These tests drive the REAL key path (handleKeyPress plus the async catalog
+// message), because every interesting failure in this flow lives in the hops: a
+// key swallowed on the way to handleStateNew, a picker opened over a form that
+// closed while the fetch was in flight, a choice the daemon said would fail.
+
+// stubBackends points the catalog seam at a fixture and returns how many times it
+// was asked, so a test can prove the fetch happens on demand rather than never.
+func stubBackends(t *testing.T, catalog daemon.ListBackendsResponse, err error) *int {
+	t.Helper()
+	calls := 0
+	t.Cleanup(SetBackendListerForTest(func(string) (daemon.ListBackendsResponse, error) {
+		calls++
+		return catalog, err
+	}))
+	return &calls
+}
+
+// twoUsableBackends is the ordinary answer: local and docker usable, ssh not
+// configured for this repo, and local as the resolved default.
+func twoUsableBackends() daemon.ListBackendsResponse {
+	return daemon.ListBackendsResponse{
+		Backends: []daemon.BackendOption{
+			{Name: config.BackendLocal, Label: "local", Status: daemon.BackendAvailable},
+			{Name: config.BackendDocker, Label: "docker", Status: daemon.BackendAvailable},
+			{Name: config.BackendSSH, Label: "ssh", Status: daemon.BackendUnavailable,
+				Reason: "backend=ssh requires ssh.host to be set in this repo's .agent-factory/config.json"},
+		},
+		Default:       config.BackendLocal,
+		DefaultStatus: daemon.BackendAvailable,
+	}
+}
+
+// openBackendField presses ctrl+r and delivers the catalog message the press
+// produced, the way the event loop would. It returns the messages the press
+// produced so a test can assert on a fetch that never happened.
+func openBackendField(t *testing.T, h *home) []tea.Msg {
+	t.Helper()
+	produced := pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyCtrlR})
+	for _, msg := range produced {
+		if catalog, ok := msg.(backendCatalogMsg); ok {
+			h.handleBackendCatalog(catalog)
+		}
+	}
+	return produced
+}
+
+// pickBackend moves the picker's cursor to the row whose label matches and
+// submits it.
+//
+// The submit goes through handleKeyPress but its cmd is discarded rather than
+// drained: a modal state takes no highlight re-emit hop, and a REFUSED choice
+// answers with a transient notice whose cmd is the clear TIMER — draining that
+// would just wait out a deadline.
+func pickBackend(t *testing.T, h *home, label string) {
+	t.Helper()
+	require.Equal(t, stateSelectBackend, h.state, "the backend field must be open")
+	idx := -1
+	for i, choice := range h.backendPickerChoices {
+		if choice.label == label {
+			idx = i
+			break
+		}
+	}
+	require.NotEqual(t, -1, idx, "picker has no row labelled %q", label)
+	h.selectionOverlay.SetSelectedIndex(idx)
+	_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+}
+
+// pressExpectingNotice presses a naming-form key that answers with a transient
+// notice. It replays the highlight re-emit hop like pressFormKey — the hop is
+// where a swallowed key would hide — but never waits on the notice's own cmd.
+func pressExpectingNotice(t *testing.T, h *home, msg tea.KeyMsg) {
+	t.Helper()
+	_, cmd := h.handleKeyPress(msg)
+	for _, produced := range drainCmd(t, cmd, time.Second) {
+		if km, ok := produced.(tea.KeyMsg); ok {
+			_, _ = h.handleKeyPress(km)
+		}
+	}
+}
+
+// TestNamingFormBackendReachesSessionStartRequest is the #1933 regression guard
+// for the TUI half: a backend picked in the naming form must arrive on the request
+// the TUI hands the daemon. Before this field existed the request had no Backend
+// member at all, so this asserted nothing could carry it.
+func TestNamingFormBackendReachesSessionStartRequest(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+	got := recordStartRequest(t)
+	calls := stubBackends(t, twoUsableBackends(), nil)
+	startNaming(t, h, "in-a-container")
+
+	openBackendField(t, h)
+	require.Equal(t, 1, *calls, "opening the field must ask the daemon for the catalog")
+	pickBackend(t, h, "docker")
+	require.Equal(t, stateNew, h.state, "submitting the field returns to naming, not out of the create")
+
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Equal(t, config.BackendDocker, got.Backend,
+		"the picked backend must ride the sessionStartRequest to the daemon")
+	// Guard the siblings: a change that populated Backend by rebuilding the struct
+	// must not drop another field on the way.
+	assert.Equal(t, "in-a-container", got.Title)
+	assert.Equal(t, "claude", got.Program)
+}
+
+// TestNamingFormWithoutBackendSendsEmpty pins the unchanged default: a user who
+// never opens the field submits exactly what they submitted before this field
+// existed, and the repo's own config decides. This is the half that keeps
+// "populate Backend" from becoming "always send a backend", which would freeze
+// today's resolution into every request and ignore a later config change.
+func TestNamingFormWithoutBackendSendsEmpty(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+	got := recordStartRequest(t)
+	stubBackends(t, twoUsableBackends(), nil)
+	startNaming(t, h, "repo-default")
+
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Empty(t, got.Backend, "an untouched backend field must send no backend")
+	assert.Equal(t, "repo-default", got.Title)
+}
+
+// TestBackendFieldRepoDefaultRowSendsNoBackend covers the sentinel: choosing the
+// "repo default" row explicitly must be identical to never opening the field. A
+// non-empty sentinel here would eventually be transmitted as a literal backend
+// name and pin the create to whatever the repo resolved to today.
+func TestBackendFieldRepoDefaultRowSendsNoBackend(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+	got := recordStartRequest(t)
+	catalog := twoUsableBackends()
+	catalog.Default = config.BackendDocker
+	stubBackends(t, catalog, nil)
+	startNaming(t, h, "explicit-default")
+
+	openBackendField(t, h)
+	require.Contains(t, h.backendPickerChoices[0].label, "docker",
+		"the repo-default row must name the backend it actually resolves to")
+	pickBackend(t, h, h.backendPickerChoices[0].label)
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Empty(t, got.Backend,
+		"the repo-default row must send NO backend, letting the repo config decide")
+}
+
+// TestBackendPickerRefusesAnUnusableChoice pins the promise a picker makes: every
+// row it lets you keep is one the daemon said would work. The refusal carries the
+// daemon's own reason, which is the same sentence a create would have failed
+// with — so the picker cannot describe a precondition differently from the code
+// that enforces it.
+func TestBackendPickerRefusesAnUnusableChoice(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(200, 1)
+	got := recordStartRequest(t)
+	stubBackends(t, twoUsableBackends(), nil)
+	startNaming(t, h, "no-ssh-here")
+
+	openBackendField(t, h)
+	pickBackend(t, h, "ssh")
+
+	assert.Equal(t, stateNew, h.state, "a refused choice returns to the form, still retryable")
+	require.NotNil(t, h.namingInstance, "a refused choice must not cancel the create")
+	assert.Empty(t, h.pendingBackend, "a refused choice must not be attached")
+	assert.Contains(t, h.errBox.FullError(), "ssh.host",
+		"the refusal must name what to fix, in the daemon's own words")
+
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+	assert.Empty(t, got.Backend, "a refused choice must not reach the daemon")
+}
+
+// TestBackendPickerRefusesAnUncheckableChoice is the tri-state half. "unknown"
+// means the daemon COULD NOT CHECK (a repo config that would not parse), which is
+// a different answer from yes and from no. Collapsing it into "available" would
+// make the picker promise something nobody verified.
+func TestBackendPickerRefusesAnUncheckableChoice(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(200, 1)
+	stubBackends(t, daemon.ListBackendsResponse{
+		Backends: []daemon.BackendOption{
+			{Name: config.BackendLocal, Label: "local", Status: daemon.BackendAvailable},
+			{Name: config.BackendDocker, Label: "docker", Status: daemon.BackendUnknown,
+				Reason: "cannot tell whether this repo can use backend=docker: its .agent-factory/config.json could not be read"},
+		},
+		Default:       config.BackendLocal,
+		DefaultStatus: daemon.BackendAvailable,
+	}, nil)
+	startNaming(t, h, "unparseable-config")
+
+	openBackendField(t, h)
+	require.Contains(t, h.backendPickerChoices[2].item(), "cannot check",
+		"an uncheckable row must be marked as such in the list, before any keypress")
+	pickBackend(t, h, "docker")
+
+	assert.Empty(t, h.pendingBackend, "an uncheckable backend must not be attached")
+	assert.Contains(t, h.errBox.FullError(), "could not be read",
+		"the notice must say what stopped the check, not that docker is unavailable")
+}
+
+// TestBackendPickerOffersWhateverTheDaemonListed is the anti-drift property, and
+// the reason this picker reads the catalog instead of config.SupportedBackends: a
+// backend added server-side must be offered here with no change to app/. The
+// fixture names a backend no enum in this process knows, so a local list — or a
+// name→label map — would drop it or render it blank.
+func TestBackendPickerOffersWhateverTheDaemonListed(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+	got := recordStartRequest(t)
+	stubBackends(t, daemon.ListBackendsResponse{
+		Backends: []daemon.BackendOption{
+			{Name: "moonbase", Label: "Moonbase (experimental)", Status: daemon.BackendAvailable},
+		},
+		Default:       "moonbase",
+		DefaultStatus: daemon.BackendAvailable,
+	}, nil)
+	startNaming(t, h, "future-backend")
+
+	openBackendField(t, h)
+	pickBackend(t, h, "Moonbase (experimental)")
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Equal(t, "moonbase", got.Backend,
+		"a backend the TUI has never heard of must still be selectable and sent verbatim")
+}
+
+// TestBackendPickerSkipsTheLocalAgentPreflight guards against re-creating #2592's
+// shape in the TUI: local prerequisites (the agent binary on this box) do not apply
+// to a session whose agent runs in a container or on another host. The naming
+// placeholder cannot answer that — it is built when the form opens, before the
+// choice — so the pending choice has to.
+func TestBackendPickerSkipsTheLocalAgentPreflight(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(200, 1)
+	got := recordStartRequest(t)
+	stubBackends(t, twoUsableBackends(), nil)
+	t.Cleanup(SetLocalSessionPreflightForTest(func(*config.Config, string) error {
+		return errors.New("claude is not installed on this machine")
+	}))
+	startNaming(t, h, "agentless-host")
+
+	// Precondition: with no backend picked, the local preflight still gates.
+	pressExpectingNotice(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+	require.Equal(t, stateNew, h.state, "a local create must still fail the local preflight")
+	require.Contains(t, h.errBox.FullError(), "not installed")
+
+	openBackendField(t, h)
+	pickBackend(t, h, "docker")
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Equal(t, stateDefault, h.state, "a docker create must not be gated on a local agent binary")
+	assert.Equal(t, config.BackendDocker, got.Backend)
+}
+
+// TestStaleBackendCatalogNeverOpensAPicker is why the catalog arrives as a message
+// rather than being fetched inline. The round trip is async, so by the time it
+// lands the user may have submitted, cancelled, or begun naming a different
+// session — and a modal opened over that edits a create that no longer exists.
+func TestStaleBackendCatalogNeverOpensAPicker(t *testing.T) {
+	cases := []struct {
+		name string
+		end  func(t *testing.T, h *home)
+	}{
+		{"the form was submitted", func(t *testing.T, h *home) {
+			pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+		}},
+		{"the form was cancelled", func(t *testing.T, h *home) {
+			pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEsc})
+		}},
+		{"a different session is being named", func(t *testing.T, h *home) {
+			pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEsc})
+			startNaming(t, h, "someone-else")
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			h.errBox.SetSize(120, 1)
+			recordStartRequest(t)
+			stubBackends(t, twoUsableBackends(), nil)
+			naming := startNaming(t, h, "abandoned")
+
+			// The keypress that started the fetch, then the form ends before it lands.
+			pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyCtrlR})
+			tc.end(t, h)
+
+			h.handleBackendCatalog(backendCatalogMsg{naming: naming, catalog: twoUsableBackends()})
+
+			assert.NotEqual(t, stateSelectBackend, h.state, "a stale catalog must not open a modal")
+			assert.Nil(t, h.selectionOverlay)
+			assert.Nil(t, h.backendPickerChoices)
+		})
+	}
+}
+
+// TestBackendCatalogFailureKeepsTheFormOpen: the field is optional, so a catalog
+// the daemon could not produce must cost the user a notice, not their half-typed
+// create. The notice leads with what failed — the transient notice clips its TAIL
+// at real terminal widths (#1973).
+func TestBackendCatalogFailureKeepsTheFormOpen(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(200, 1)
+	stubBackends(t, daemon.ListBackendsResponse{}, errors.New("daemon is not running"))
+	startNaming(t, h, "no-daemon")
+
+	openBackendField(t, h)
+
+	assert.Equal(t, stateNew, h.state, "a failed fetch must leave the naming form open")
+	require.NotNil(t, h.namingInstance)
+	full := h.errBox.FullError()
+	assert.Contains(t, full, "cannot list backends")
+	assert.Contains(t, full, "daemon is not running", "the daemon's own error must survive")
+	assert.Less(t, strings.Index(full, "cannot list backends"), strings.Index(full, "daemon is not running"),
+		"the cause must precede the detail: the notice clips its tail")
+}
+
+// TestBackendDoesNotLeakIntoNextCreate is the leak guard. pendingBackend is
+// home-scoped state that outlives one create, so a submitted or cancelled create
+// must not hand its backend to the next session the user makes — which would
+// silently put a session somewhere the user never chose.
+func TestBackendDoesNotLeakIntoNextCreate(t *testing.T) {
+	cases := []struct {
+		name string
+		end  tea.KeyMsg
+	}{
+		{"submitted", tea.KeyMsg{Type: tea.KeyEnter}},
+		{"cancelled with esc", tea.KeyMsg{Type: tea.KeyEsc}},
+		{"cancelled with ctrl+c", tea.KeyMsg{Type: tea.KeyCtrlC}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			h.errBox.SetSize(120, 1)
+			got := recordStartRequest(t)
+			stubBackends(t, twoUsableBackends(), nil)
+
+			startNaming(t, h, "first")
+			openBackendField(t, h)
+			pickBackend(t, h, "docker")
+			pressFormKey(t, h, tc.end)
+			require.Empty(t, h.pendingBackend, "leaving the naming form must clear the pending backend")
+
+			*got = sessionStartRequest{}
+			startNaming(t, h, "second")
+			pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+
+			assert.Empty(t, got.Backend,
+				"the previous create's backend must not ride the next session's request")
+			assert.Equal(t, "second", got.Title)
+		})
+	}
+}
+
+// TestStartNewInstanceResetsTheBackendField covers the authoritative half of the
+// leak guard: whatever route the previous create exited by, beginning a new one
+// starts from the repo default.
+func TestStartNewInstanceResetsTheBackendField(t *testing.T) {
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+	h.pendingBackend = config.BackendDocker
+
+	model, cmd := h.startNewInstance(false)
+	require.Same(t, h, model)
+	require.Nil(t, cmd)
+	require.Equal(t, stateNew, h.state)
+
+	assert.Empty(t, h.pendingBackend, "beginning a create must start from the repo default")
+}
+
+// TestNamingMenuAdvertisesTheBackendField covers discoverability, which for a
+// modal field is the whole game: the status bar is the only surface that can tell
+// a user the field exists, and the only confirmation that the create is going
+// somewhere other than the repo default before they press Enter.
+func TestNamingMenuAdvertisesTheBackendField(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(200, 1)
+	h.menu.SetSize(200, 3)
+	stubBackends(t, twoUsableBackends(), nil)
+	startNaming(t, h, "hints")
+
+	require.Contains(t, h.menu.String(), "backend",
+		"the naming form must advertise its backend field")
+	require.NotContains(t, h.menu.String(), "backend ✓", "precondition: repo default")
+
+	openBackendField(t, h)
+	pickBackend(t, h, "docker")
+
+	assert.Contains(t, h.menu.String(), "backend ✓",
+		"the hint must confirm a non-default backend is attached")
+}
+
+// TestBackendHintClickOpensTheField pins the mouse half. The hint registers a
+// click zone every frame, and a zone whose key string no handler recognizes is
+// decoration that swallows the click — the shape of the dead × in #2467.
+func TestBackendHintClickOpensTheField(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+	stubBackends(t, twoUsableBackends(), nil)
+	startNaming(t, h, "clicked")
+
+	msg, ok := keyMsgFromString("ctrl+r")
+	require.True(t, ok, "the backend hint's key must map back to a key message")
+	_, cmd := h.handleHintClick("ctrl+r")
+	require.NotNil(t, cmd, "clicking the hint must start the catalog fetch")
+	require.Equal(t, tea.KeyCtrlR, msg.Type)
+}
+
+// TestNamingFormBackendAndForceRemoteAgree pins the interaction with `N`, the
+// legacy hook selector. Both can be set on one request; the daemon's precedence is
+// explicit-backend-first (session/instance_factory.go resolveBackendKind), so the
+// field must win over ForceRemote rather than being masked by it.
+func TestNamingFormBackendAndForceRemoteAgree(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+	got := recordStartRequest(t)
+	stubBackends(t, twoUsableBackends(), nil)
+
+	restore := session.SetBackendFactoryForTest(func(opts session.InstanceOptions, _ string) (session.Backend, error) {
+		if opts.ForceRemote {
+			return &session.HookBackend{}, nil
+		}
+		return &session.LocalBackend{}, nil
+	})
+	defer restore()
+
+	remote, err := session.NewInstance(session.InstanceOptions{
+		Title:       "forced-remote",
+		Path:        t.TempDir(),
+		Program:     "claude",
+		ForceRemote: true,
+	})
+	require.NoError(t, err)
+	h.store.AddInstance(remote)
+	h.namingInstance = remote
+	h.pendingProgram = "claude"
+	h.state = stateNew
+
+	openBackendField(t, h)
+	pickBackend(t, h, "docker")
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Equal(t, config.BackendDocker, got.Backend, "the picked backend must be sent")
+	assert.True(t, got.ForceRemote,
+		"N's selector is still reported; the daemon resolves the explicit backend first")
+}
+
+// TestBackendChoicesFromDescribesTheDefaultHonestly covers the pure mapping,
+// including the case the web's twin exists to get right: a repo whose `backend`
+// key names something unrecognized has NO default — such a create FAILS rather
+// than falling back to local — so the row must not invent one.
+func TestBackendChoicesFromDescribesTheDefaultHonestly(t *testing.T) {
+	t.Run("names the resolved default", func(t *testing.T) {
+		catalog := twoUsableBackends()
+		catalog.Default = config.BackendDocker
+		choices := backendChoicesFrom(catalog)
+		require.NotEmpty(t, choices)
+		assert.Equal(t, repoDefaultBackend, choices[0].value)
+		assert.Equal(t, "Repo default (docker)", choices[0].label)
+		assert.Equal(t, daemon.BackendAvailable, choices[0].status)
+		assert.Empty(t, choices[0].reason)
+	})
+
+	t.Run("invents no default for a misconfigured repo", func(t *testing.T) {
+		const reason = `this repo's .agent-factory/config.json sets backend = "dokcer", which is not a known backend`
+		choices := backendChoicesFrom(daemon.ListBackendsResponse{
+			Backends:      []daemon.BackendOption{{Name: config.BackendLocal, Label: "local", Status: daemon.BackendAvailable}},
+			Default:       "",
+			DefaultStatus: daemon.BackendUnavailable,
+			DefaultReason: reason,
+		})
+		require.NotEmpty(t, choices)
+		assert.Equal(t, "Repo default", choices[0].label, "no parenthetical when there is no default")
+		assert.Equal(t, daemon.BackendUnavailable, choices[0].status)
+		assert.Equal(t, reason, choices[0].reason)
+		assert.Contains(t, choices[0].item(), "unavailable")
+	})
+
+	t.Run("uses the daemon's label for a repo-aware backend", func(t *testing.T) {
+		label := "Remote sandbox · launch.sh (hook)"
+		choices := backendChoicesFrom(daemon.ListBackendsResponse{
+			Backends:      []daemon.BackendOption{{Name: config.BackendHook, Label: label, Status: daemon.BackendAvailable}},
+			Default:       config.BackendHook,
+			DefaultStatus: daemon.BackendAvailable,
+		})
+		require.Len(t, choices, 2)
+		assert.Equal(t, fmt.Sprintf("Repo default (%s)", label), choices[0].label)
+		assert.Equal(t, label, choices[1].label, "the hook row must read as the launcher the repo configured")
+		assert.Equal(t, config.BackendHook, choices[1].value, "…while still sending the literal wire key")
+	})
+}

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -30,6 +30,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.namingInstance = nil
 		m.clearNamingPlaceholder()
 		m.pendingPrompt = ""
+		m.pendingBackend = ""
 		// Menu.SetState rebuilds the options slice; call it synchronously
 		// on the event-loop goroutine rather than from a tea.Cmd closure
 		// that runs off-loop and races with home.View -> Menu.String.
@@ -125,6 +126,10 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// rather than a stray newline delivered to the agent.
 		prompt := strings.TrimSpace(m.pendingPrompt)
 		m.pendingPrompt = ""
+		// Same reasoning for the backend picked in the ctrl+r field (#1933): read it
+		// on the loop, clear it with the rest of the naming state.
+		backend := m.pendingBackend
+		m.pendingBackend = ""
 		m.namingInstance = nil
 		m.clearNamingPlaceholder()
 		m.state = stateDefault
@@ -145,7 +150,13 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				// which delivers it once the agent is ready — the same path
 				// `af sessions create --prompt` takes. Empty means "no prompt",
 				// exactly as before this field existed.
-				Prompt:      prompt,
+				Prompt: prompt,
+				// The backend picked in the naming form's ctrl+r field (#1933),
+				// forwarded verbatim as CreateSessionRequest.Backend — the field
+				// `af sessions create --backend` fills. Empty means "resolve from
+				// the repo's config", so an untouched field is byte-identical to
+				// every create before this field existed.
+				Backend:     backend,
 				ForceRemote: instance.Capabilities().Workspace == session.WorkspaceRemote,
 			}
 			started, err := start(instance, req)
@@ -180,6 +191,12 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.layoutPromptOverlay()
 		m.state = statePromptInput
 		return m, nil
+	case tea.KeyCtrlR:
+		// Open the backend field (#1933). Unlike the program and prompt fields this
+		// one needs the daemon's answer before it can render an honest list, so the
+		// keypress starts a fetch and the overlay opens when it lands — see
+		// openBackendPicker.
+		return m.openBackendPicker()
 	case tea.KeyRunes:
 		newTitle := instance.Title + string(msg.Runes)
 		if runewidth.StringWidth(newTitle) > 32 {
@@ -213,6 +230,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.namingInstance = nil
 		m.clearNamingPlaceholder()
 		m.pendingPrompt = ""
+		m.pendingBackend = ""
 		m.state = stateDefault
 		cmd := m.selectionChanged()
 
@@ -230,10 +248,11 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // If remote is true, the instance is forced to use the remote hook backend.
 func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 	m.pendingProgram = m.program
-	// Every create starts with an empty prompt field. The cancel paths clear it
-	// too, but this is the authoritative reset: it also covers a create that
-	// ended by any route other than Enter/Esc/ctrl+c.
+	// Every create starts with an empty prompt field and an unchosen backend. The
+	// cancel paths clear both too, but this is the authoritative reset: it also
+	// covers a create that ended by any route other than Enter/Esc/ctrl+c.
 	m.pendingPrompt = ""
+	m.pendingBackend = ""
 	if m.pendingProgram == "" && m.appConfig != nil {
 		m.pendingProgram = m.appConfig.DefaultProgram
 	}
@@ -288,6 +307,7 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 	m.sidebar.SetNamingPlaceholder(instance, m.namingPlaceholder)
 	m.state = stateNew
 	m.menu.SetNamingHasPrompt(false)
+	m.menu.SetNamingBackend(false)
 	m.menu.SetState(ui.StateNewInstance)
 	return m, nil
 }

--- a/app/handle_mouse.go
+++ b/app/handle_mouse.go
@@ -632,6 +632,17 @@ func (m *home) handleModalClick(id string) (tea.Model, tea.Cmd) {
 			m.selectionOverlay.SetSelectedIndex(idx)
 			return m.handleStateSelectHandoffAgent(tea.KeyMsg{Type: tea.KeyEnter})
 		}
+	// The backend picker (#1933) is the same selection overlay again, so it needs
+	// the same click routing — a list that answers the keyboard and ignores the
+	// mouse is the #1819 class.
+	case stateSelectBackend:
+		if m.selectionOverlay == nil {
+			return m, nil
+		}
+		if idx, ok := zones.OverlaySelectIdx(id); ok {
+			m.selectionOverlay.SetSelectedIndex(idx)
+			return m.handleStateSelectBackend(tea.KeyMsg{Type: tea.KeyEnter})
+		}
 	case stateSearch:
 		if m.searchOverlay == nil {
 			return m, nil
@@ -750,6 +761,11 @@ func keyMsgFromString(s string) (tea.KeyMsg, bool) {
 		return tea.KeyMsg{Type: tea.KeyCtrlD}, true
 	case "ctrl+p":
 		return tea.KeyMsg{Type: tea.KeyCtrlP}, true
+	// The naming form's backend hint (#1933) registers a click zone like every
+	// other hint; without this its zone would be decoration that swallows the
+	// click and does nothing.
+	case "ctrl+r":
+		return tea.KeyMsg{Type: tea.KeyCtrlR}, true
 	case "ctrl+]":
 		return tea.KeyMsg{Type: tea.KeyCtrlCloseBracket}, true
 	}

--- a/app/help.go
+++ b/app/help.go
@@ -146,6 +146,11 @@ func (h helpTypeGeneral) toContent() string {
 		{title: "Managing:", rows: []helpRow{
 			{helpKey(keys.KeyNew), "Create a new session"},
 			{helpKey(keys.KeyNewRemote), "Create a new remote session (requires remote_hooks config)"},
+			// The naming form's three optional fields, named here because its own
+			// status-bar hints shed by terminal width (ui/menu.go hintDropOrder): on a
+			// narrow bar this is the only surface that still advertises them.
+			{helpKey(keys.KeyChangeProgram) + " / " + helpKey(keys.KeySetPrompt) + " / " + helpKey(keys.KeySetBackend),
+				"While naming a new session: pick its agent / initial prompt / backend"},
 			{helpKey(keys.KeySwitchProject), "Switch to another project (repo) in place"},
 			{helpKey(keys.KeyTaskList), "Manage tasks (n inside the manager creates one, r runs one)"},
 			{helpKey(keys.KeyKill), "Kill (delete) the selected session"},

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -67,6 +67,11 @@ const (
 	// overlay stateSelectProgram uses at create time; the two differ only in what
 	// happens on submit — create stashes the choice, handoff confirms and swaps.
 	stateSelectHandoffAgent
+	// stateSelectBackend is the state when the backend field of the naming form
+	// is open (#1933): the runtime the session will be created on, listed from the
+	// daemon's ListBackends catalog. Like stateSelectProgram and statePromptInput
+	// it is a sub-state of stateNew — closing it returns to naming.
+	stateSelectBackend
 )
 
 type home struct {
@@ -415,6 +420,17 @@ type home struct {
 	// `af sessions create --prompt` fills. Reset by startNewInstance so a
 	// cancelled create can never leak its prompt into the next one.
 	pendingPrompt string
+	// pendingBackend tracks the backend picked during naming (#1933). "" means
+	// "let the repo config decide", which is what CreateSessionRequest.Backend
+	// omits on — the same defaulting `af sessions create` gets with no --backend,
+	// so an untouched field keeps today's behavior byte-identical. Reset by
+	// startNewInstance so a cancelled create cannot leak a backend into the next.
+	pendingBackend string
+	// backendPickerChoices is the option list the open backend picker is showing,
+	// held alongside the overlay for the same reason handoffChoices is: the list is
+	// built from the daemon's response (plus a leading "repo default" row), so the
+	// overlay's index cannot be mapped back through any local enum.
+	backendPickerChoices []backendChoice
 
 	// attached is set while the user is inside an attached tmux session.
 	// While true, periodic background work that hits the shared tmux server

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -386,6 +386,10 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case panePreviewStaleExpiredMsg:
 		m.expireStalePanePreview(msg)
 		return m, nil
+	case backendCatalogMsg:
+		// The naming form's backend field asked the daemon which backends this repo
+		// can use (#1933); open the picker over the answer, if the form is still open.
+		return m.handleBackendCatalog(msg)
 	case instanceStartedMsg:
 		// The user may have navigated elsewhere while the instance was
 		// starting. Don't yank their selection or pop a modal onto them.
@@ -504,6 +508,12 @@ func (m *home) handleMenuHighlighting(msg tea.KeyMsg) (cmd tea.Cmd, returnEarly 
 			if strings.TrimSpace(m.pendingPrompt) != "" {
 				name = keys.KeyEditPrompt
 			}
+		case "ctrl+r":
+			// Same swap for the backend hint (#1933).
+			name = keys.KeySetBackend
+			if m.pendingBackend != repoDefaultBackend {
+				name = keys.KeyEditBackend
+			}
 		case "esc":
 			name = keys.KeyCancelName
 		default:
@@ -585,6 +595,8 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		return m.handleStateInitialPrompt(msg)
 	case stateSelectHandoffAgent:
 		return m.handleStateSelectHandoffAgent(msg)
+	case stateSelectBackend:
+		return m.handleStateSelectBackend(msg)
 	case stateHooks:
 		return m.handleStateHooks(msg)
 	case stateTasks:

--- a/app/home_view.go
+++ b/app/home_view.go
@@ -193,7 +193,7 @@ func (m *home) View() string {
 			log.ErrorLog.Printf("project picker overlay is nil")
 		}
 		return overlay.PlaceOverlay(0, 0, m.projectPickerOverlay.Render(), mainView, true)
-	} else if m.state == stateSelectProgram || m.state == stateSelectHandoffAgent {
+	} else if m.state == stateSelectProgram || m.state == stateSelectHandoffAgent || m.state == stateSelectBackend {
 		if m.selectionOverlay == nil {
 			log.ErrorLog.Printf("selection overlay is nil")
 		}

--- a/app/preflight.go
+++ b/app/preflight.go
@@ -11,6 +11,15 @@ import (
 var localSessionPreflight = preflight.LocalSessionPrereqs
 
 func (m *home) preflightSessionCreate(instance *session.Instance) error {
+	// A backend picked in the naming form's field (#1933) decides this, and the
+	// placeholder instance cannot: it is constructed when the form OPENS, before the
+	// user has chosen anything, so its capabilities describe the repo default rather
+	// than the create about to be submitted. Checking the local agent binary for a
+	// docker/ssh/hook create would refuse a session whose agent runs somewhere else
+	// entirely — the shape of #2592 on the CLI side.
+	if m.pendingBackend != "" && m.pendingBackend != config.BackendLocal {
+		return nil
+	}
 	// Local-session prerequisites (the agent binary, etc.) only apply to a
 	// backend that runs the agent on a local worktree.
 	if instance == nil || instance.Capabilities().Workspace != session.WorkspaceLocalWorktree {

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -84,11 +84,18 @@ func httpCallRetryable(err error) bool {
 }
 
 type sessionStartRequest struct {
-	Title       string
-	TitleBase   string
-	RepoPath    string
-	Program     string
-	Prompt      string
+	Title     string
+	TitleBase string
+	RepoPath  string
+	Program   string
+	Prompt    string
+	// Backend is the runtime picked in the naming form's backend field (#1933),
+	// or "" to let the repo's `backend` config key decide — the same defaulting
+	// `af sessions create` applies when --backend is absent. It takes precedence
+	// over ForceRemote in the daemon (session/instance_factory.go
+	// resolveBackendKind), which is why the TUI can offer the whole catalog
+	// through one field while `N` keeps its hook-only shortcut.
+	Backend     string
 	ForceRemote bool
 }
 
@@ -102,6 +109,7 @@ var startSessionThroughDaemon = func(_ *session.Instance, req sessionStartReques
 			RepoPath:    req.RepoPath,
 			Program:     req.Program,
 			Prompt:      req.Prompt,
+			Backend:     req.Backend,
 			ForceRemote: req.ForceRemote,
 		})
 		return e

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -15,8 +15,15 @@ fixed single agent tab.
 | `ssh` | a remote host over SSH | `backend = "ssh"` + `ssh.host` |
 | `hook` | wherever your provisioner scripts put it | `backend = "hook"` (see [Hook backend](#hook-backend-bring-your-own-provisioner)) |
 
-Select a backend per-repo in `.agent-factory/config.json`, or per-session with
-`af sessions create --backend <name>` (the flag overrides the repo config).
+Select a backend per-repo in `.agent-factory/config.json`, or per-session on any
+surface — each overrides the repo config for that one session:
+
+- **CLI** — `af sessions create --backend <name>`.
+- **TUI** — press `ctrl+r` while naming the new session and pick from the list.
+  Its rows come from the daemon, so each one says whether *this* repo can use that
+  backend; picking one it cannot names the config key to fix. Leaving the field
+  alone (or choosing **Repo default**) keeps the repo's own setting.
+- **Web** — the backend select in the new-session modal, same list, same rule.
 
 !!! note "`af agent-server` is a backend, not the web UI"
     The non-local backends work by running an **`af agent-server`** in the remote

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -18,7 +18,8 @@ fixed single agent tab.
 Select a backend per-repo in `.agent-factory/config.json`, or per-session on any
 surface — each overrides the repo config for that one session:
 
-- **CLI** — `af sessions create --backend <name>`.
+- **CLI** — `af sessions create --backend <name>`; `af sessions backends` first if
+  you want to see which values this repo can actually use.
 - **TUI** — press `ctrl+r` while naming the new session and pick from the list.
   Its rows come from the daemon, so each one says whether *this* repo can use that
   backend; picking one it cannot names the config key to fix. Leaving the field

--- a/docs/surface-parity.md
+++ b/docs/surface-parity.md
@@ -33,19 +33,30 @@ audit (#1937) found gaps pointing in every direction:
   had no exit from the same `[limit]` state. `af sessions retry-limit <title>`
   now sends the same daemon action, closing that gap without duplicating the
   recovery logic client-side.
-- **Only the CLI** can choose a backend per session
-  ([#1933](https://github.com/sachiniyer/agent-factory/issues/1933)).
+- **Only the CLI** could choose a backend per session
+  ([#1933](https://github.com/sachiniyer/agent-factory/issues/1933)) — the web
+  gained a picker over the daemon's `ListBackends` catalog in #1968, and the TUI's
+  naming form gained the same field on `ctrl+r`. Both read the daemon's catalog
+  rather than a copy of the enum, for the reason the enum level below explains.
 
 The sharpest way to hold this: on `CreateSession`, **no surface is a superset of
-another**. All three accept different subsets of the same eight-field request.
+another**. All three accept different subsets of the same nine-field request — the
+TUI now sends a backend but still cannot send `title_base` or `auto_yes`, which
+the web does.
 
 | Create option | TUI | Web | CLI |
 |---|---|---|---|
 | Title, program | yes | yes | yes |
 | Initial prompt | yes | yes | yes |
-| Backend (docker/ssh/hook) | **no** | **no** | yes |
-| Force-remote (hook) | partial | **no** | yes |
+| Backend (docker/ssh/hook) | yes | partial | yes |
+| Force-remote (hook) | yes | partial | yes |
 | In-place (`--here`) | **no** | **no** | yes |
+
+The web's two `partial` cells are not missing controls: the browser sends
+`backend` and can select `hook`, but no one has yet shown a **working** remote
+session created from it (#1968 watched provisioning succeed and the session then
+time out waiting for its program). Reachable is not the same as proven — see
+"Known blind spots".
 
 So when this check fails, the question is never "does the web need to catch up?"
 It is "which surfaces should have this, and which deliberately should not?" —
@@ -96,7 +107,9 @@ verb that looks present. Two of the same shape so far — a field the daemon
 accepts that a surface never sends:
 
 - [#1933](https://github.com/sachiniyer/agent-factory/issues/1933) — the TUI
-  never sets `CreateSessionRequest.Backend`
+  never set `CreateSessionRequest.Backend`, so every TUI session ran on whatever
+  the repo's checked-in `backend` key said (now closed; its fixture stays,
+  repointed, and `in_place` is the field still unsent)
 - [#1948](https://github.com/sachiniyer/agent-factory/issues/1948) — the CLI
   never set `PreviewRequest.Tab` / `TabID` / `Full` (now closed; the fixture
   stays, repointed, in the honesty table below)
@@ -229,7 +242,7 @@ know are real, filed, and field-level — as fixtures, not aspirations:
 |---|---|
 | cobra's lazy surface — `af completion bash`, `af help`, `--help`, `--version` | the tree is walked **after** cobra finishes building it |
 | [#1933](https://github.com/sachiniyer/agent-factory/issues/1933) — the web now **does** send `CreateSession.backend` (#1968 landed), via a `const body` variable | the web body parser, incl. variable resolution |
-| #1933 (TUI half) — `sessionStartRequest` has no `Backend` | the Go AST walk |
+| #1933 (TUI half) — closed; `sessionStartRequest` now carries `Backend`, so the fixture is repointed to track that the walk still sees the TUI's use of `backend`/`prompt`/`force_remote` **and** its non-use of `in_place` | the Go AST walk |
 | [#1948](https://github.com/sachiniyer/agent-factory/issues/1948) — closed; the CLI now sets `Preview.Tab/TabID/TabName/Full`, so the fixture is repointed to track that the walk still sees both the CLI's usage and the TUI's non-use of `tab_name` | the AST **on an internal route**, invisible to the public catalog |
 | [#1935](https://github.com/sachiniyer/agent-factory/issues/1935) — the web's `TaskUpdate` omits `project_path` | nested recursion **behind a wrapper route**, plus the TS-interface read and the CLI's field-by-field assignment walk |
 
@@ -267,25 +280,28 @@ go test ./parity/ -v -run TestAuditCoverageReport
 
 ```
 === surface-parity audit coverage ===
-  cli.arg-concepts                 73
-  cli.commands                     59
-  cli.flags                        150
+  cli.arg-concepts                 87
+  cli.commands                     68
+  cli.flags                        177
   cli.noun-groups                  9
-  cli.verbs                        51
-  daemon.audited-request-types     24
-  daemon.public-routes             23
-  go.cli.files                     10
-  go.cli.request-sites             26
-  go.tui.files                     41
-  go.tui.request-sites             18
-  inventory.capabilities           67
-  tui.bindings                     44
-  web.enum-sites                   2
-  web.rpcs                         18
-  web.source-files                 26
-  verdicts:  parity=20  deliberate=20  real-gap=10  unclear=17
+  cli.verbs                        60
+  daemon.audited-request-types     29
+  daemon.public-routes             30
+  go.cli.files                     12
+  go.cli.request-sites             31
+  go.tui.files                     47
+  go.tui.request-sites             23
+  inventory.capabilities           72
+  tui.bindings                     49
+  web.hardcoded-enum-sites         0
+  web.rpcs                         24
+  web.source-files                 32
+  verdicts:  parity=31  deliberate=21  real-gap=8  unclear=12
   SKIPPED: none — every surface above was read
 ```
+
+(A sample, not a contract: the counts move with the program. Only the floors are
+enforced.)
 
 Three rules make that number honest:
 

--- a/docs/tui-manual-testing.md
+++ b/docs/tui-manual-testing.md
@@ -338,6 +338,29 @@ af_send Escape                                # esc keeps the text (field, not d
 af_wait_for 'initial prompt ✓'
 ```
 
+The backend field (#1933) is the third field and needs a wide terminal: its hint
+sheds below ~93 columns (`ui/menu.go` hintDropOrder), so drive this at 120+ or the
+marker will legitimately be absent.
+
+```bash
+af_boot                                       # 120 cols or wider
+af_ensure_nav; af_focus_tree
+af_send n; af_wait_for 'backend'               # the field is advertised
+af_send C-r; af_wait_for 'Select backend'      # daemon round trip, then the list
+af_wait_for 'Repo default'                     # first row names the resolved default
+af_send Escape; af_wait_for 'submit name'      # esc backs out of the field only
+af_send C-r; af_wait_for 'Select backend'
+af_send Down; af_send Enter                    # pick the row below Repo default
+af_wait_for 'backend ✓'                        # hint confirms a non-default backend
+```
+
+A backend the repo cannot use is listed with `— unavailable` (or `— cannot check`)
+and refuses the pick with the daemon's own reason — the same sentence
+`af sessions create --backend <that one>` prints. Selecting it must leave the form
+open with the hint back to `backend` and no `✓`. Then finish a create on a backend
+the repo CAN use and confirm the session actually comes up there: the round trip is
+the whole point and no marker stands in for it.
+
 `enter newline` is the overlay's own hint row, used as the marker rather than
 its `Initial prompt` title: the status-bar hint underneath says `initial
 prompt` too, so the title alone cannot tell "field open" from "field

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -140,6 +140,24 @@ const (
 	// its worktree and branch (#2013). Appended at the end of this iota block for
 	// the same reason KeyConfigAgent was.
 	KeyHandoff
+
+	// KeySetBackend and KeyEditBackend are the two faces of the naming form's
+	// backend field (#1933): the runtime the session will be created on, chosen
+	// from the daemon's own ListBackends catalog. Same display-only swap as
+	// KeySetPrompt/KeyEditPrompt — the picker is modal, so the status bar is the
+	// only place that can confirm a non-default backend is attached before Enter.
+	//
+	// ctrl+r, not the obvious ctrl+b: ctrl+b is tmux's DEFAULT PREFIX, so for every
+	// user running af inside tmux the terminal multiplexer would swallow it and the
+	// field would be unreachable — a shipped capability nobody can press. ctrl+r is
+	// unbound in af, unclaimed by tmux, and delivered in raw mode by every terminal
+	// we support; "r" reads as the runtime this picker selects (session.ResolveRuntime
+	// is the same concept the `backend` key names on the wire). It is deliberately NOT
+	// added to reservedKeys: a user whose [keys] table already binds ctrl+r keeps that
+	// binding everywhere except inside this modal form, exactly as tab/shift+tab are
+	// the form's keys while it is open.
+	KeySetBackend
+	KeyEditBackend
 )
 
 // spec is one action's canonical binding definition: its default keys, help
@@ -239,6 +257,8 @@ var specs = []spec{
 	{name: KeyChangeProgram, keys: []string{"tab"}, desc: "change program"},
 	{name: KeySetPrompt, keys: []string{"shift+tab"}, desc: "initial prompt"},
 	{name: KeyEditPrompt, keys: []string{"shift+tab"}, desc: "initial prompt ✓"},
+	{name: KeySetBackend, keys: []string{"ctrl+r"}, desc: "backend"},
+	{name: KeyEditBackend, keys: []string{"ctrl+r"}, desc: "backend ✓"},
 	{name: KeyCancelName, keys: []string{"esc"}, desc: "cancel"},
 }
 

--- a/parity/derive_go_test.go
+++ b/parity/derive_go_test.go
@@ -6,8 +6,10 @@ package parity
 // surface that calls the right verb while silently declining half its request —
 // which is where real parity gaps live: `af sessions preview` reaches the
 // Preview RPC but never sets Tab/TabID/Full, so the CLI can only ever see tab 0
-// (#1948), and the TUI reaches CreateSession but never sets Backend (#1933).
-// Same shape, different route.
+// (#1948), and the TUI reached CreateSession while never setting Backend, so no
+// TUI session could run anywhere but the repo default (#1933). Same shape,
+// different route. Both are now fixed; in_place is the one still open on
+// CreateSession (session.create.opt.inplace).
 //
 // Both Go surfaces build their requests as `daemon.XxxRequest{...}` composite
 // literals, so which fields a surface can populate is a fact in the AST. This

--- a/parity/field_coverage_test.go
+++ b/parity/field_coverage_test.go
@@ -7,7 +7,8 @@ package parity
 // actually live. Three found so far are the same shape — a field the daemon
 // accepts that a surface never sends:
 //
-//   #1933  the TUI never sets CreateSessionRequest.Backend
+//   #1933  the TUI never sets CreateSessionRequest.Backend  (fixed: the naming
+//          form's ctrl+r backend field; in_place is the field still unsent)
 //   #1948  the CLI never sets PreviewRequest.Tab/TabID/Full
 //
 // The earlier version of this check was hand-wired to CreateSession alone, so it

--- a/parity/honesty_test.go
+++ b/parity/honesty_test.go
@@ -12,9 +12,13 @@ package parity
 // filed, and field-level. They are fixtures, not aspirations: if the derivation
 // cannot rediscover a gap we found by hand, it will not find the next one.
 //
-//	#1933  the web never sends CreateSessionRequest.backend  (and neither does the TUI)
+//	#1933  the web never sends CreateSessionRequest.backend  (and neither did the TUI)
 //	#1948  the CLI never sets PreviewRequest.Tab/TabID/Full
 //	#1935  the web's TaskUpdate omits project_path, nested inside a wrapper route
+//
+// Both halves of #1933 are now FIXED (#1968 for the web, the TUI's ctrl+r backend
+// field for the TUI), so both fixtures are repointed rather than deleted — see
+// each test for what it proves now.
 //
 // Each is deliberately a DIFFERENT derivation path — web request bodies, the Go
 // AST, and nested payloads behind a wrapper — so a hole in any one path fails
@@ -151,30 +155,47 @@ func TestWebPromptParityNamesTheLiveTerminalTransport(t *testing.T) {
 	}
 }
 
-// TestDerivationSeesTUIBackendGap pins the other half of #1933 through the Go
-// AST: the TUI's sessionStartRequest has no Backend field at all.
-func TestDerivationSeesTUIBackendGap(t *testing.T) {
+// TestDerivationTracksTUICreateFieldUse is the successor to the TUI half of the
+// #1933 fixture. That half ("the TUI's sessionStartRequest has no Backend field at
+// all") is now CLOSED — the naming form has a backend field (ctrl+r) whose choice
+// rides sessionStartRequest.Backend — and the old test said what to do when that
+// happened: retire the fixture deliberately.
+//
+// It is repointed rather than deleted, for the same reason the #1948 fixture below
+// was: deleting it would take the meta-check with it, and the post-fix state is a
+// strictly better fixture because one request type now exercises BOTH failure
+// directions at once.
+//
+//   - under-reporting: the TUI sets title/program/prompt/backend/force_remote, so a
+//     walk that missed real usage would report them unreached and manufacture a
+//     false gap — including reporting #1933 as still open after it was fixed.
+//   - over-reporting: the TUI sets no in_place (session.create.opt.inplace, still
+//     open), so a walk that credited construction it never saw would report nothing
+//     unreached and hide a real gap.
+func TestDerivationTracksTUICreateFieldUse(t *testing.T) {
 	use := deriveGoRequestUse(t, "tui")
 	typeUse := deriveTypeFieldUse(t, "tui")
 
 	u, ok := use["CreateSessionRequest"]
 	if !ok {
 		t.Fatal("AST found no TUI CreateSessionRequest construction — the walk is blind " +
-			"(expected app/session_control.go:101)")
+			"(expected app/session_control.go, startSessionThroughDaemon)")
 	}
 	unreached := unreachedFields(auditedRequests["CreateSessionRequest"], u, typeUse)
-	for _, f := range []string{"backend", "in_place"} {
+	// The remaining gap: --here has no TUI analogue (session.create.opt.inplace).
+	for _, f := range []string{"in_place"} {
 		if !contains(unreached, f) {
-			t.Errorf("derivation says the TUI reaches CreateSession.%s, but app/session_control.go:88-95 "+
+			t.Errorf("derivation says the TUI reaches CreateSession.%s, but sessionStartRequest "+
 				"has no such field. Either the gap was fixed (retire the fixture) or the AST "+
 				"walk is over-crediting.", f)
 		}
 	}
 	// Not blind: the TUI provably does set these.
-	for _, f := range []string{"program", "prompt", "force_remote"} {
+	for _, f := range []string{"program", "prompt", "force_remote", "backend"} {
 		if contains(unreached, f) {
 			t.Errorf("derivation says the TUI never sets CreateSession.%s, but it does "+
-				"(app/session_control.go:101-109) — the AST walk is under-reporting.", f)
+				"(app/session_control.go startSessionThroughDaemon) — the AST walk is "+
+				"under-reporting.", f)
 		}
 	}
 }

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -94,8 +94,8 @@
       "id": "session.create.opt.backend",
       "title": "Choose the session's backend (local/docker/ssh/hook) per session",
       "tui": {
-        "status": "no",
-        "pointer": "app/session_control.go:88-95 sessionStartRequest has no Backend field"
+        "status": "yes",
+        "pointer": "keys/keys.go KeySetBackend (ctrl+r) -> app/backend_picker.go openBackendPicker + handleStateSelectBackend -> app/session_control.go sessionStartRequest.Backend"
       },
       "web": {
         "status": "partial",
@@ -107,14 +107,14 @@
       },
       "verdict": "real-gap",
       "issue": "#1933",
-      "notes": "#1968 landed the web's backend picker: createSession now sends `backend` when the user picks one (absent = let the repo config decide, matching `af sessions create` with no --backend). web is `partial`, NOT `yes`: what is proven is that the web SENDS the field and the daemon offers an honest ListBackends picker; what is NOT proven is that a user can create a WORKING remote session from the browser — #1968 observed provisioning (launch_cmd ran, an agent-server came up) but the session timed out waiting for its program, cause unresolved. The TUI still cannot pick a backend per session (N is hook-only, app/session_control.go has no Backend field), so this stays a real-gap. See docs/surface-parity.md 'reachable != user-settable'."
+      "notes": "The TUI half is CLOSED: the naming form has a backend field (ctrl+r) whose list is the daemon's ListBackends catalog — the same RPC the web picker reads, reached through apiclient.ListBackends — and the choice rides sessionStartRequest.Backend to CreateSessionRequest.Backend, the field `af sessions create --backend` fills. It is a control and not merely a reachable field: the picker offers exactly the backends the daemon named (no enum in app/), refuses an `unavailable`/`unknown` row with the daemon's own reason rather than promising it, and its 'repo default' row sends NO backend so the repo config still decides. The hint sheds below ~93 columns (ui/menu.go hintDropOrder); the help overlay names the field at every width. web stays `partial`, NOT `yes`: what is proven is that the web SENDS the field and the daemon offers an honest picker; what is NOT proven is that a user can create a WORKING remote session from the browser — #1968 observed provisioning (launch_cmd ran, an agent-server came up) but the session timed out waiting for its program, cause unresolved. That unproven end-to-end remote create is now the whole of what keeps this row off 'parity'. See docs/surface-parity.md 'reachable != user-settable'."
     },
     {
       "id": "session.create.opt.remote",
       "title": "Force a session onto the remote hook backend",
       "tui": {
-        "status": "partial",
-        "pointer": "keys/keys.go:153 (N) -> app/handle_input.go:207 ForceRemote"
+        "status": "yes",
+        "pointer": "keys/keys.go:153 (N) -> app/handle_input.go ForceRemote; PLUS the naming form's backend field (ctrl+r) reaching backend='hook' — app/backend_picker.go"
       },
       "web": {
         "status": "partial",
@@ -126,7 +126,7 @@
       },
       "verdict": "real-gap",
       "issue": "#1933",
-      "notes": "TUI is 'partial' because ForceRemote resolves to the hook backend ONLY (session/instance_factory.go resolveBackendKind) — N cannot reach docker or ssh. The web is ALSO 'partial', not 'no': the hook backend is reachable from the browser via the #1968 backend picker (backend='hook'), which resolveBackendKind routes to the same BackendHook by a STRONGER path than force_remote — an explicit backend wins over ForceRemote, and both override the repo's backend config, so the picker's 'hook' is strictly more capable than the legacy selector. The dedicated force_remote FIELD is deliberately NOT sent by the web (it stays a field_coverage gap): it adds no capability over the picker, and an ungated 'remote hooks' checkbox reintroduces the 'offered then fails at provision' trap the picker's backendSelectable gate closes (#2406 was closed in favor of this ledger correction). Same unproven-provisioning caveat as session.create.opt.backend: reachable != proven to create a WORKING remote session from the browser (#1968)."
+      "notes": "TUI is now 'yes': `N` still resolves to the hook backend ONLY (session/instance_factory.go resolveBackendKind), but the naming form's backend field reaches backend='hook' explicitly, by the same STRONGER path described below for the web — and the TUI additionally sends the dedicated force_remote field, so it is a superset of both other surfaces here. The web is 'partial', not 'no': the hook backend is reachable from the browser via the #1968 backend picker (backend='hook'), which resolveBackendKind routes to the same BackendHook by a STRONGER path than force_remote — an explicit backend wins over ForceRemote, and both override the repo's backend config, so the picker's 'hook' is strictly more capable than the legacy selector. The dedicated force_remote FIELD is deliberately NOT sent by the web (it stays a field_coverage gap): it adds no capability over the picker, and an ungated 'remote hooks' checkbox reintroduces the 'offered then fails at provision' trap the picker's backendSelectable gate closes (#2406 was closed in favor of this ledger correction). Same unproven-provisioning caveat as session.create.opt.backend: reachable != proven to create a WORKING remote session from the browser (#1968)."
     },
     {
       "id": "session.create.opt.inplace",
@@ -1240,8 +1240,8 @@
       "id": "backend.list",
       "title": "Discover which backends are available for a repo (with availability + reason)",
       "tui": {
-        "status": "no",
-        "pointer": ""
+        "status": "yes",
+        "pointer": "app/backend_picker.go openBackendPicker -> apiclient/control.go ListBackends -> the naming form's backend field renders label + status + reason"
       },
       "web": {
         "status": "yes",
@@ -1251,8 +1251,8 @@
         "status": "yes",
         "pointer": "api/sessions_backends.go:19 sessionsBackendsCmd -> daemon/control_client.go:332 ListBackends"
       },
-      "verdict": "deliberate",
-      "notes": "POST /v1/ListBackends (#1968) serves config.SupportedBackends per-repo with a tri-state answer (available / unavailable+reason / unknown+reason). CLI half CLOSED: `af sessions backends` prints that catalog verbatim, reaching the SAME controlServer.ListBackends the web's picker calls over /v1/ListBackends (daemon/httproutes.go wires the route to that method; the gob control socket exposes it) — one catalog, two transports, so the two surfaces cannot describe a repo's backends differently and a backend added server-side reaches both with no client change (pinned by TestSessionsBackends_PassesThroughAnUnknownBackendName). It resolves the project through the same resolveRepo `sessions create` uses, so it describes the create it predicts, and the --backend flag help names it — the flag advertised the enum but not which values this project can use. The TUI cell stays 'no' DELIBERATELY, and not as a second gap: the web's 'yes' here IS its create-time picker rendering availability, not a standalone catalog view, and the TUI has no backend surface at all (grep-verified — nothing under app/ or ui/ reads config.SupportedBackends or calls ListBackends). A TUI catalog with no way to select a backend would be a dead-end read, so the TUI's analogue is the create-time picker, tracked as session.create.opt.backend's TUI half; recording it here too would double-count one piece of work. This cell flips to 'yes' with that picker, not before."
+      "verdict": "parity",
+      "notes": "POST /v1/ListBackends (#1968) serves config.SupportedBackends per-repo with a tri-state answer (available / unavailable+reason / unknown+reason). CLI half CLOSED by #2584: `af sessions backends` prints that catalog verbatim, reaching the SAME controlServer.ListBackends the web's picker calls over /v1/ListBackends (daemon/httproutes.go wires the route to that method; the gob control socket exposes it), so the surfaces cannot describe a repo's backends differently and a backend added server-side reaches all of them with no client change (pinned by TestSessionsBackends_PassesThroughAnUnknownBackendName). It resolves the project through the same resolveRepo `sessions create` uses, so it describes the create it predicts, and the --backend flag help names it. TUI half CLOSED by #1933's create-form backend field, which is exactly the flip #2584's note anticipated ('this cell flips to yes with that picker, not before'): the TUI reaches the same catalog over apiclient.ListBackends and renders the daemon's labels/statuses/reasons rather than deriving availability locally — which would answer about the CLIENT's host, since apiclient.NewTargeted may point at a REMOTE daemon. Note what 'yes' means uniformly here: on both UIs this capability IS the create-time picker rendering availability, not a standalone catalog view — a catalog with no way to act on it would be a dead-end read. The CLI's standalone verb is the shape that fits a scripting surface. Three surfaces, one catalog, one implementation: parity."
     },
     {
       "id": "config-agent",
@@ -1440,6 +1440,8 @@
       "down": "tui.navigation",
       "error_details": "tui.navigation",
       "expand": "tui.navigation",
+      "fixed:backend": "session.create.opt.backend",
+      "fixed:backend ✓": "session.create.opt.backend",
       "fixed:cancel": "session.create",
       "fixed:change program": "session.create.opt.program",
       "fixed:delete project": "project.delete",
@@ -1722,9 +1724,6 @@
           }
         },
         "tui": {
-          "backend": {
-            "gap": "session.create.opt.backend"
-          },
           "in_place": {
             "gap": "session.create.opt.inplace"
           }

--- a/scripts/tui-1933-scenario.sh
+++ b/scripts/tui-1933-scenario.sh
@@ -53,7 +53,14 @@ drive_backend_field() {
     _af_log 'assert OK: the backend field lists the daemon catalog with per-row status'
 
     # Esc backs out of the FIELD, not the create.
+    #
+    # Wait on the overlay being GONE, never on 'submit name': the naming form's
+    # status bar is painted UNDERNEATH the overlay, so a wait for it matches
+    # instantly and synchronizes nothing — the next keypress would race the close
+    # and land in whichever surface won. That level-vs-edge mistake is the whole
+    # reason this file waits the way it does.
     af_send Escape
+    af_wait_gone 'Select backend' "$AF_DRIVER_TIMEOUT" 'esc closed the field' || return 1
     af_wait_for 'submit name' "$AF_DRIVER_TIMEOUT" 'esc returns to naming' || return 1
 
     # Refusal path: docker is the row two below "Repo default" (local sits between
@@ -143,6 +150,10 @@ drive_backend_field_at_80_cols() {
     # the sandbox's C locale (#1994).
     af_wait_for 'esc cancel' "$AF_DRIVER_TIMEOUT" 'picker painted in full at 80 cols' || return 1
     af_send Escape
+    # Edge, not level — see the note in drive_backend_field. Without this the C-c
+    # below can arrive while the overlay still owns the keyboard, where it cancels
+    # the FIELD rather than the create.
+    af_wait_gone 'Select backend' "$AF_DRIVER_TIMEOUT" 'esc closed the field' || return 1
     af_wait_for 'submit name' "$AF_DRIVER_TIMEOUT" 'esc returns to naming' || return 1
     af_send C-c
     af_wait_gone 'submit name' "$AF_DRIVER_TIMEOUT" 'naming form cancelled' || return 1

--- a/scripts/tui-1933-scenario.sh
+++ b/scripts/tui-1933-scenario.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Real-TUI drive for #1933 (the naming form's backend field), via:
+#
+#   scripts/testbox.sh scenario scripts/tui-1933-scenario.sh
+#
+# The behavior under test: the TUI can choose a session's BACKEND per session,
+# the way `af sessions create --backend` and the web's picker already could. The
+# field is the third field of the naming form (ctrl+r), and its rows come from the
+# daemon's ListBackends catalog — so this scenario is also the only place that
+# proves the round trip happens against a real daemon rather than a fixture.
+#
+# Why a driver scenario and not only unit tests: the app/ tests swap the catalog
+# seam, so they prove the wiring but not that a user can REACH the field. The
+# three ways a shipped capability turns out to be unreachable — an unlabeled
+# affordance, a picker rendering internal names, a hint clipped away by width —
+# are all invisible to a unit test and all visible here.
+#
+# The mock sandbox repo has no `origin` remote and no docker/ssh/remote_hooks
+# config, so the catalog's honest answer is: local available, everything else
+# unavailable with a reason. That makes it a good fixture for the refusal path.
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source /src/scripts/tui-driver.sh
+
+# drive_backend_field is the wide-terminal pass: the hint is advertised, the field
+# opens over the daemon's catalog, an unusable row is refused with the daemon's
+# reason, and an explicit pick is confirmed in the status bar and reaches a create.
+drive_backend_field() {
+    export AF_DRIVER_COLS=120 AF_DRIVER_ROWS=30
+    export AF_DRIVER_REPO="$HOME/sandbox/mock-repo"
+
+    af_reset_sandbox
+    af_boot
+    af_ensure_nav
+    af_focus_tree
+
+    af_send n
+    af_wait_for 'submit name' "$AF_DRIVER_TIMEOUT" 'naming form' || return 1
+    # Discoverability: at 120 columns the status bar advertises the field. This is
+    # the assertion an unreachable-but-shipped capability fails.
+    af_wait_for 'ctrl\+r backend' "$AF_DRIVER_TIMEOUT" 'backend hint advertised' || return 1
+
+    af_send C-r
+    af_wait_for 'Select backend' "$AF_DRIVER_TIMEOUT" 'backend field opened' || return 1
+    # The first row names the backend the repo actually resolves to, so a user can
+    # see the default without picking it. A round trip that returned nothing would
+    # leave this row missing.
+    af_wait_for 'Repo default' "$AF_DRIVER_TIMEOUT" 'repo-default row' || return 1
+    # The catalog is honest about what this repo cannot use. Without the daemon's
+    # answer every row would render as usable — the promise this must not make.
+    af_wait_for 'unavailable|cannot check' "$AF_DRIVER_TIMEOUT" 'an unusable row is marked' || return 1
+    _af_log 'assert OK: the backend field lists the daemon catalog with per-row status'
+
+    # Esc backs out of the FIELD, not the create.
+    af_send Escape
+    af_wait_for 'submit name' "$AF_DRIVER_TIMEOUT" 'esc returns to naming' || return 1
+
+    # Refusal path: docker is the row two below "Repo default" (local sits between
+    # them, config.SupportedBackends order), and this repo has no origin remote or
+    # docker.image, so the daemon reports it unusable. Picking it must state the
+    # reason and leave the field unset.
+    af_send C-r
+    af_wait_for 'Select backend' "$AF_DRIVER_TIMEOUT" 'backend field reopened' || return 1
+    af_send Down; af_send Down
+    af_send Enter
+    # Wait on the NOTICE, not on 'submit name': the status bar is still painted
+    # under the overlay, so waiting for it would return before the refusal lands
+    # and capture a screen that has not been drawn yet.
+    af_wait_for 'backend=docker|docker\.image|origin' "$AF_DRIVER_TIMEOUT" \
+        'refusal states the daemon reason' || return 1
+    af_wait_gone 'Select backend' "$AF_DRIVER_TIMEOUT" 'refusal closed the field' || return 1
+    local screen
+    screen="$(af_capture)"
+    if printf '%s\n' "$screen" | grep -qE 'backend ✓'; then
+        _af_fail '#1933: a REFUSED backend was attached to the create anyway:'
+        printf '%s\n' "$screen" >&2
+        return 1
+    fi
+    _af_log 'assert OK: an unusable backend is refused with the daemon reason, nothing attached'
+
+    # Explicit pick: local is the row directly below "Repo default" and is usable
+    # here, so it must attach and the hint must confirm it.
+    af_send C-r
+    af_wait_for 'Select backend' "$AF_DRIVER_TIMEOUT" 'backend field reopened' || return 1
+    af_send Down
+    af_send Enter
+    af_wait_for 'backend ✓' "$AF_DRIVER_TIMEOUT" 'hint confirms an explicit backend' || return 1
+    _af_log 'assert OK: an explicit backend is attached and confirmed in the status bar'
+
+    # And the create still completes with the backend on the request.
+    af_send_literal 'picked-backend'
+    af_send Enter
+    af_wait_for 'picked-backend.*●' "$AF_DRIVER_TIMEOUT" "session 'picked-backend' ready" || return 1
+    _af_log 'assert OK: a create with an explicit backend reaches Ready'
+
+    # The next create starts from the repo default — no leak.
+    af_send n
+    af_wait_for 'submit name' "$AF_DRIVER_TIMEOUT" 'second naming form' || return 1
+    screen="$(af_capture)"
+    if printf '%s\n' "$screen" | grep -qE 'backend ✓'; then
+        _af_fail '#1933: the previous create leaked its backend into the next form:'
+        printf '%s\n' "$screen" >&2
+        return 1
+    fi
+    af_send C-c
+    af_wait_gone 'submit name' "$AF_DRIVER_TIMEOUT" 'naming form cancelled' || return 1
+
+    echo 'PASS: #1933 backend field at 120x30'
+}
+
+# drive_backend_field_at_80_cols is the narrow-terminal pass. The hint SHEDS below
+# ~93 columns (ui/menu.go hintDropOrder gives the prompt hint the last slot, per
+# #1936's commitment), and that is a deliberate degradation — so the field itself
+# must still work at 80 columns, and the picker must still fit on screen. A field
+# that only functions when its hint is visible would make the shed a real break.
+drive_backend_field_at_80_cols() {
+    export AF_DRIVER_COLS=80 AF_DRIVER_ROWS=24
+    export AF_DRIVER_REPO="$HOME/sandbox/mock-repo"
+
+    af_reset_sandbox
+    af_boot
+    af_ensure_nav
+    af_focus_tree
+
+    af_send n
+    af_wait_for 'submit name' "$AF_DRIVER_TIMEOUT" 'naming form' || return 1
+    local screen
+    screen="$(af_capture)"
+    if printf '%s\n' "$screen" | grep -qE 'ctrl\+r backend'; then
+        _af_log 'note: the backend hint fits at 80 columns after all — the shed threshold moved'
+    fi
+    # The prompt hint is the one #1936 promised an 80-column bar would keep.
+    af_wait_for 'initial prompt' "$AF_DRIVER_TIMEOUT" 'prompt hint survives 80 cols' || return 1
+
+    af_send C-r
+    af_wait_for 'Select backend' "$AF_DRIVER_TIMEOUT" 'backend field opens at 80 cols' || return 1
+    af_wait_for 'Repo default' "$AF_DRIVER_TIMEOUT" 'repo-default row at 80 cols' || return 1
+    # The overlay's own bottom hint proves it painted in full inside the pane: an
+    # overlay wider or taller than the terminal loses its last rows to the clamp
+    # (the #1998 class). Line LENGTH is deliberately not measured here — capture
+    # output is bytes, and the frame's box glyphs make every row look 80+ wide in
+    # the sandbox's C locale (#1994).
+    af_wait_for 'esc cancel' "$AF_DRIVER_TIMEOUT" 'picker painted in full at 80 cols' || return 1
+    af_send Escape
+    af_wait_for 'submit name' "$AF_DRIVER_TIMEOUT" 'esc returns to naming' || return 1
+    af_send C-c
+    af_wait_gone 'submit name' "$AF_DRIVER_TIMEOUT" 'naming form cancelled' || return 1
+
+    echo 'PASS: #1933 backend field at 80x24 (hint shed, field still reachable)'
+}
+
+drive_backend_field
+drive_backend_field_at_80_cols
+af_quit || true
+echo 'PASS: #1933 TUI backend field'

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -90,6 +90,11 @@ type Menu struct {
 	// initial prompt (#1936), which swaps the naming form's prompt hint to its
 	// "✓" variant. Only meaningful in StateNewInstance.
 	namingHasPrompt bool
+	// namingHasBackend: the session being named has an explicitly picked backend
+	// (#1933), so the backend hint renders its "✓" variant. Only meaningful in
+	// StateNewInstance. False for the repo default, which is not a choice the user
+	// needs confirmed — it is what every create did before the field existed.
+	namingHasBackend bool
 
 	// keyDown is the key which is pressed. The default is -1.
 	keyDown keys.KeyName
@@ -104,12 +109,13 @@ type Menu struct {
 
 var defaultMenuOptions = []keys.KeyName{keys.KeyNew, keys.KeyNewRemote, keys.KeySearch, keys.KeyHelp, keys.KeyQuit}
 
-// newInstanceMenuOptions are the naming-form hints. The third slot is the
-// initial-prompt field (#1936) and swaps its verb once a prompt is typed —
-// newInstanceOptions picks the variant, mirroring the archive/restore swap in
+// newInstanceMenuOptions are the naming-form hints. The third and fourth slots
+// are the form's optional fields — the initial prompt (#1936) and the backend
+// (#1933) — and each swaps its verb once the field holds a non-default value;
+// newInstanceOptions picks the variants, mirroring the archive/restore swap in
 // addInstanceOptions.
 var newInstanceMenuOptions = []keys.KeyName{
-	keys.KeySubmitName, keys.KeyChangeProgram, keys.KeySetPrompt, keys.KeyCancelName,
+	keys.KeySubmitName, keys.KeyChangeProgram, keys.KeySetPrompt, keys.KeySetBackend, keys.KeyCancelName,
 }
 
 // automationsMenuOptions are the status-bar hints while the in-rail
@@ -288,19 +294,23 @@ func (m *Menu) updateOptions() {
 	}
 }
 
-// newInstanceOptions returns the naming-form hints with the initial-prompt slot
-// reading "initial prompt ✓" once the pending prompt holds text. The overlay
-// that edits it is modal, so the status bar is the only surface that can tell
-// the user a prompt is attached before they press Enter (#1936).
+// newInstanceOptions returns the naming-form hints with each optional field's slot
+// reading "… ✓" once that field holds a non-default value: "initial prompt ✓" once
+// the pending prompt holds text (#1936), "backend ✓" once a backend other than the
+// repo default is picked (#1933). Both overlays are modal, so the status bar is the
+// only surface that can tell the user what is attached before they press Enter.
 func (m *Menu) newInstanceOptions() []keys.KeyName {
-	if !m.namingHasPrompt {
+	if !m.namingHasPrompt && !m.namingHasBackend {
 		return newInstanceMenuOptions
 	}
 	opts := make([]keys.KeyName, len(newInstanceMenuOptions))
 	copy(opts, newInstanceMenuOptions)
 	for i, name := range opts {
-		if name == keys.KeySetPrompt {
+		if name == keys.KeySetPrompt && m.namingHasPrompt {
 			opts[i] = keys.KeyEditPrompt
+		}
+		if name == keys.KeySetBackend && m.namingHasBackend {
+			opts[i] = keys.KeyEditBackend
 		}
 	}
 	return opts
@@ -313,6 +323,19 @@ func (m *Menu) SetNamingHasPrompt(has bool) {
 		return
 	}
 	m.namingHasPrompt = has
+	m.updateOptions()
+}
+
+// SetNamingBackend records whether the session being named carries an explicitly
+// picked backend (rather than the repo default), and rebuilds the hints if that
+// changed. Same purpose as SetNamingHasPrompt: the picker is modal, so the bar is
+// the only confirmation that the create is going somewhere other than the default
+// (#1933).
+func (m *Menu) SetNamingBackend(picked bool) {
+	if m.namingHasBackend == picked {
+		return
+	}
+	m.namingHasBackend = picked
 	m.updateOptions()
 }
 
@@ -505,7 +528,17 @@ func centerStart(box, content int) int {
 // list: it advertises an OPTIONAL field, and losing it costs a user far less
 // than losing the way out of the form. Submit/change-program/cancel stay absent
 // — those are the form's three load-bearing verbs.
+//
+// #1933's backend hint took the same row to ~91 cells, so it sheds BEFORE the
+// prompt hint — deliberately, and not because it matters less in the abstract.
+// An 80-column bar can advertise exactly one of the two, #1936 committed that it
+// would be the prompt (TestMenuNewInstanceDropsPromptHintBeforeTheWayOut pins the
+// 80-column case), and taking an affordance away from users who already have it is
+// worse than a new field arriving unadvertised at that one width. The field itself
+// still works when its hint is shed, and the help overlay names all three fields
+// at every width so the narrow case is not a dead end.
 var hintDropOrder = [][]keys.KeyName{
+	{keys.KeySetBackend, keys.KeyEditBackend},
 	{keys.KeySetPrompt, keys.KeyEditPrompt},
 	{keys.KeyShiftUp, keys.KeyShiftDown},
 	{keys.KeyAttach},

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -273,6 +273,88 @@ func TestMenuNewInstancePromptHintSwapsAndDoesNotAlias(t *testing.T) {
 	}
 }
 
+// TestMenuNewInstanceBackendHintSwapsAndDoesNotAlias is the #1933 twin of the
+// test above, and it exists as its own test because the two swaps now share one
+// copy of the options slice: a second swap written in place would leak a "✓" into
+// every later naming form, and a swap that rebuilt from the shared slice would
+// undo its sibling.
+func TestMenuNewInstanceBackendHintSwapsAndDoesNotAlias(t *testing.T) {
+	m := NewMenu()
+	m.SetState(StateNewInstance)
+	m.SetSize(120, 1)
+
+	if out := m.String(); !strings.Contains(out, "backend") {
+		t.Fatalf("new-instance footer missing the backend hint:\n%s", out)
+	}
+	if out := m.String(); strings.Contains(out, "backend ✓") {
+		t.Fatalf("an unpicked backend must not be marked as attached:\n%s", out)
+	}
+
+	m.SetNamingBackend(true)
+	if out := m.String(); !strings.Contains(out, "backend ✓") {
+		t.Fatalf("footer must mark an explicitly picked backend:\n%s", out)
+	}
+
+	// Both optional fields marked at once: neither swap may drop the other.
+	m.SetNamingHasPrompt(true)
+	out := m.String()
+	if !strings.Contains(out, "backend ✓") || !strings.Contains(out, "initial prompt ✓") {
+		t.Fatalf("both field hints must survive together:\n%s", out)
+	}
+
+	fresh := NewMenu()
+	fresh.SetState(StateNewInstance)
+	fresh.SetSize(120, 1)
+	if out := fresh.String(); strings.Contains(out, "backend ✓") {
+		t.Fatalf("the backend-hint swap leaked into the shared options slice:\n%s", out)
+	}
+}
+
+// TestMenuNewInstanceShedsBackendHintBeforeThePromptHint pins the shed ORDER the
+// #1933 hint forced. Five hints take the naming row to ~92 cells, so an
+// 80-column bar can advertise exactly one of the two optional fields, and #1936
+// already committed that it would be the prompt: taking an affordance away from
+// users who have it is worse than a new field arriving unadvertised at that one
+// width. `esc cancel` — the only advertised way out of the form — survives every
+// width, which is the property the drop list exists for at all (#1083).
+func TestMenuNewInstanceShedsBackendHintBeforeThePromptHint(t *testing.T) {
+	// 93 is where the full five-hint row starts fitting; below it the backend
+	// hint sheds first and the prompt hint holds down to ~71.
+	for _, tc := range []struct {
+		width                   int
+		wantBackend, wantPrompt bool
+	}{
+		{200, true, true},
+		{120, true, true},
+		{95, true, true},
+		{88, false, true},
+		{80, false, true},
+		{70, false, false},
+	} {
+		m := NewMenu()
+		m.SetState(StateNewInstance)
+		m.SetSize(tc.width, 1)
+		out := m.String()
+
+		if got := strings.Contains(out, "backend"); got != tc.wantBackend {
+			t.Fatalf("width %d: backend hint present=%v, want %v:\n%s", tc.width, got, tc.wantBackend, out)
+		}
+		if got := strings.Contains(out, "initial prompt"); got != tc.wantPrompt {
+			t.Fatalf("width %d: prompt hint present=%v, want %v:\n%s", tc.width, got, tc.wantPrompt, out)
+		}
+		for _, want := range []string{"enter submit name", "tab change program", "esc cancel"} {
+			if !strings.Contains(out, want) {
+				t.Fatalf("width %d dropped the load-bearing hint %q:\n%s", tc.width, want, out)
+			}
+		}
+		for i, line := range strings.Split(out, "\n") {
+			if got := lipgloss.Width(line); got > tc.width {
+				t.Fatalf("width %d: hint row line %d is %d cells wide:\n%s", tc.width, i, got, out)
+			}
+		}
+	}
+}
+
 // (removed) TestMenuRemoteInstanceOmitsUnsupportedTabKeys — obsolete after
 // #1592 Phase 4 PR7: the remote HookBackend now reports full parity
 // (TabManagement=true), so a remote instance surfaces the t/w tab keys exactly


### PR DESCRIPTION
## The gap

`parity/inventory.json` row **`session.create.opt.backend`** — *"Choose the
session's backend (local/docker/ssh/hook) per session"* — was `tui=no web=partial
cli=yes`, verdict `real-gap`, issue
[#1933](https://github.com/sachiniyer/agent-factory/issues/1933).

I picked it on impact. Sachin hit this one **twice himself** ("remote instances
does not work on the web — I can only create a remote instance from the TUI"),
which is what jumped #1933 the queue; #1968 answered the web half and the **TUI
half was left open**. Meanwhile #2194 delivered container sessions, so `docker` is
a headline backend whose only per-session selector was `af sessions create
--backend` — from the interface most people actually use, a docker or ssh session
could not be created at all. `N` reaches the hook backend and nothing else
(`resolveBackendKind`), and the repo `backend` key is all-or-nothing per repo, so
"one throwaway ssh session in an otherwise-local repo" meant dropping to the CLI.
It is also the row `docs/surface-parity.md` leads with as the canonical
option-level gap.

## The change

A third field on the naming form, `ctrl+r`, beside `tab` (program) and
`shift+tab` (initial prompt):

```
            enter submit name · tab change program · shift+tab initial prompt · ctrl+r backend · esc cancel

                       ╭────────────────────────────────────────────────────────────────────────╮
                       │  Select backend                                                        │
                       │                                                                        │
                       │  ▸ Repo default (local)                                                │
                       │    local                                                               │
                       │    docker — unavailable                                                │
                       │    ssh — unavailable                                                   │
                       │    Remote sandbox (hook) — unavailable                                 │
                       │                                                                        │
                       │  ↑/↓ navigate · enter select · esc cancel                              │
                       ╰────────────────────────────────────────────────────────────────────────╯
```

(Real capture, container sandbox, 120x30. That repo has no `origin`, no
`docker.image`, no `ssh.host` and no `remote_hooks` — so the honest answer *is*
one usable backend.)

**One catalog, no second implementation.** The picker's rows come from
`POST /v1/ListBackends` — the same route `web/src/backends.ts` renders — through a
new `apiclient.ListBackends`. Nothing in `app/` knows a backend name, computes
availability, or maps a name to a label, so a backend added server-side is offered
here with no change to this package (a test picks a fixture backend called
`moonbase` to prove it).

It is a **round trip and not an in-process read**, unlike `af projects list`'s
deliberate direct read: availability is a property of the box that will provision
(`lookPath("docker")`, the repo's config *there*), and `apiclient.NewTargeted` may
point at a remote daemon — deriving it locally would confidently describe the
wrong machine.

The daemon's tri-state survives to the screen. An `unavailable`/`unknown` row is
marked in the list *before* any keypress, and picking one is **refused with the
daemon's own reason** — the same sentence the create would have failed with:

```
backend=docker requires docker.image to be set in this repo's .agent-factory/config.json (the container imag…  E details
```

The web keeps such a row selectable and blocks the submit instead; a modal
overlay has nowhere to host a blocking explanation, and refusing on pick tells the
user what to fix while their create is still open and retryable. Same invariant
either way: no surface offers a backend it was told would fail.

Defaults are untouched. The `Repo default (…)` row sends **no** backend, so an
unopened field — and an explicit default pick — is byte-identical to every create
before this existed, and a later config change still decides. `pendingBackend` is
cleared on submit, Esc and ctrl+c, and authoritatively in `startNewInstance`.

Two smaller things the field forced:

- **Preflight.** The placeholder instance is built when the form *opens*, so its
  capabilities describe the repo default, not the create being submitted. Local
  agent-binary prereqs are now skipped when the picked backend is non-local —
  otherwise a docker create would be refused for a missing local `claude`, which
  is #2592's shape.
- **Hint width.** Five hints take the naming row to ~92 cells, so an 80-column bar
  can advertise exactly one optional field, and #1936 already committed that it
  would be the prompt. The backend hint therefore sheds **first** (taking an
  affordance from users who have it is worse than a new one arriving unadvertised
  at one width) — and because a shed hint is how a shipped capability becomes
  unfindable, the help overlay now names all three naming-form fields at every
  width. `TestMenuNewInstanceShedsBackendHintBeforeThePromptHint` pins the order;
  `esc cancel` still survives every width (#1083).

## Verification

`scripts/tui-1933-scenario.sh` (`scripts/testbox.sh scenario …`) drives the real
TUI against a real daemon in the container sandbox — the unit tests swap the
catalog seam, so they prove the wiring but not that a user can *reach* the field:

```
[tui-driver] assert OK: the backend field lists the daemon catalog with per-row status
[tui-driver] assert OK: an unusable backend is refused with the daemon reason, nothing attached
[tui-driver] assert OK: an explicit backend is attached and confirmed in the status bar
[tui-driver] assert OK: a create with an explicit backend reaches Ready
PASS: #1933 backend field at 120x30
PASS: #1933 backend field at 80x24 (hint shed, field still reachable)
```

The 80-column leg exists because a field that only works when its hint is visible
would make the shed a real break rather than a degradation.

Unit side: `app/backend_picker_test.go` drives `handleKeyPress` (including the
naming form's highlight re-emit hop, where a swallowed key hides) for the request
plumbing, both refusal statuses, the unknown-backend case, the stale-catalog guard
in all three ways naming can end, the leak guard, the hint swap, and the
`ctrl+r` → key-message mapping that keeps the clickable hint zone from being
decoration.

## Ledger

- `session.create.opt.backend` — tui `no` → **`yes`**, with the pointer chain and
  what the picker proves. Verdict stays `real-gap`: the web cell stays `partial`,
  and that unproven end-to-end remote create from the browser (#1968) is now the
  *whole* of what keeps the row off `parity`. I have no new evidence about the
  web, so I did not touch its cell.
- `session.create.opt.remote` — tui `partial` → **`yes`**: `N` is still hook-only,
  but the field reaches `backend=hook` by the stronger path, and the TUI also
  sends `force_remote`, making it a superset of both other surfaces here.
- `backend.list` — tui `no` → **`yes`** (the picker *is* availability discovery),
  and with #2584 landed first the row is **`parity`**: three surfaces, one
  `controlServer.ListBackends`, no second catalog. That is the flip #2584's own
  note predicted (*"this cell flips to 'yes' with that picker, not before"*), and
  it is verified against the harness rather than by arithmetic — with all three
  cells `yes`, `TestVerdictAgreesWithStatuses` rejects `unclear` and `real-gap` by
  name and accepts `parity`.
- `field_coverage` — the TUI's `backend` gap declaration is **removed** (the
  declaration walk runs both ways, so a surface that *starts* sending a field
  fails until the ledger agrees). `in_place` is now the only field the TUI
  declines.
- `parity/honesty_test.go` — the TUI half of the #1933 fixture is **repointed, not
  deleted**, exactly as the #1948 fixture was: it now proves the walk sees the
  TUI's use of `backend`/`prompt`/`force_remote` *and* its non-use of `in_place`,
  so it still fails in both the over- and under-reporting directions.
- `ListBackendsRequest` joins `auditedRequests` — the new construction site failed
  the coverage check until it did, which is the check working.

Nothing to close: #1933 was already closed after the web half. Docs updated —
`docs/backends.md` (how to select a backend on each surface),
`docs/surface-parity.md` (the create-option table, the fixture table, refreshed
coverage sample), `docs/tui-manual-testing.md` (the create-form gate recipe).

## Found while here, filed not fixed

**#2599 — the TUI provisions the repo's backend at naming time.**
`startNewInstance` builds its placeholder row through `session.NewInstance`, which
runs the runtime's `Provision`. In a repo whose config says `backend = "docker"`,
pressing `n` is refused *before the form opens*, by an error thrown from inside
`dockerRuntime.Provision` — so such a repo cannot create a session from the TUI at
all. Observed in the sandbox and quoted in the issue. It predates this change and
is orthogonal to it (this picker sends a field; that bug provisions a placeholder),
and it is the reason the app-package tests cannot see it: they swap the backend
factory away.

Worth knowing for this PR's scope: the field is fully useful in the common case (a
local-default repo opting one session into docker/ssh/hook), and #2599 is what
stands between a *non-local-default* repo and its TUI.

## Gates

All six, from a run **after** the final commit, against the pushed head
`942899f42e1aff10a2523f6e297f13b50e500325` (rebased onto master at #2584):

| Gate | Result |
|---|---|
| `golangci-lint run --timeout=3m --fast` | clean |
| `gofmt -l .` | no output |
| `go build ./...` | clean |
| `make test-container` | every package `ok`, zero failures |
| `deadcode -test ./...` | no output |
| `scripts/lint-file-length.sh` | passed (1086 files, 0 grandfathered) |

Plus `scripts/testbox.sh scenario scripts/tui-1933-scenario.sh` — re-run **after**
the rebase, green twice. That re-run earned its keep: #2584 reworded the catalog's
reasons and rebuilt the path the picker reads, and the scenario surfaced a
synchronization bug of its own — it waited on `submit name` to know the field had
closed, which is LEVEL-triggered (the naming form's status bar is painted
underneath the overlay), so the wait matched instantly and the next keypress raced
the close. It passed before the rebase by timing alone. Both legs now wait on the
overlay being gone. The product behaviour was never wrong; a hand-driven capture
confirmed the picker and the refusal before the harness was touched.

## One more finding — #2609, filed not fixed

Resolving this conflict exposed a hole in the checker itself: `deliberate` is
exempt from `TestVerdictAgreesWithStatuses`, so a `deliberate` verdict that goes
stale passes silently. Had this PR and #2584 not collided in `git`, the merged row
would have read `tui=yes web=yes cli=yes, verdict: deliberate` — a deliberate
omission that no longer exists — **with the whole suite green**. `deliberate`
cannot simply join the `real-gap`/`unclear` branch (16 rows are legitimately
`deliberate` with all-yes/n-a cells, carried by an `n/a`), so #2609 states the rule
that does hold and the data check behind it.

— Captain Claude
