### PR TITLE
test(parity): check every verdict against its own cells, count the ones nothing checks (#2609)

### DIFF
--- a/docs/surface-parity.md
+++ b/docs/surface-parity.md
@@ -216,11 +216,19 @@ positionally.
   declared, in both directions — a field a surface has quietly *started* sending
   also fails, so a fixed gap cannot keep being described as broken.
 - **The table cannot contradict itself.** A ledger mapping proves a surface
-  reaches a capability, so the row cannot still say that surface is `no`; and a
-  verdict cannot say `parity` while a surface is missing it, or `real-gap` once
-  every surface has it. Otherwise "add the ledger entry" would be enough to make
-  the check pass while the table went stale — which would make the inventory
-  lie in exactly the way it exists to prevent.
+  reaches a capability, so the row cannot still say that surface is `no`; and
+  every verdict is checked against its own cells (see Verdicts) — `parity` cannot
+  outlive a missing surface, `real-gap`/`unclear` cannot outlive the gap closing,
+  and a `deliberate` omission cannot outlive every surface making it. Otherwise
+  "add the ledger entry" would be enough to make the check pass while the table
+  went stale — which would make the inventory lie in exactly the way it exists to
+  prevent.
+- **No verdict passes by omission.** A verdict with no rule is reported as
+  `unchecked` and fails the run, so adding a fifth verdict value forces a decision
+  about what it promises rather than inheriting a silent pass.
+- **A declaration that silences a check must say why.** An `ok` in
+  `field_coverage` or `argument_shapes` carries the reason the absence is
+  correct; a blank one is rejected, so silencing is never free.
 - Quality bar: a surface marked `yes`/`partial` must cite code, a `deliberate`
   verdict must explain itself, and a `real-gap` must name an issue.
 
@@ -281,14 +289,14 @@ go test ./parity/ -v -run TestAuditCoverageReport
 ```
 === surface-parity audit coverage ===
   cli.arg-concepts                 87
-  cli.commands                     68
-  cli.flags                        177
+  cli.commands                     69
+  cli.flags                        178
   cli.noun-groups                  9
-  cli.verbs                        60
+  cli.verbs                        61
   daemon.audited-request-types     29
   daemon.public-routes             30
-  go.cli.files                     12
-  go.cli.request-sites             31
+  go.cli.files                     13
+  go.cli.request-sites             32
   go.tui.files                     47
   go.tui.request-sites             23
   inventory.capabilities           72
@@ -296,7 +304,7 @@ go test ./parity/ -v -run TestAuditCoverageReport
   web.hardcoded-enum-sites         0
   web.rpcs                         24
   web.source-files                 32
-  verdicts:  parity=31  deliberate=21  real-gap=8  unclear=12
+  verdicts:  deliberate=21  parity=32  real-gap=8  unclear=11  unchecked=0
   SKIPPED: none — every surface above was read
 ```
 
@@ -419,16 +427,36 @@ does, and every declared field must still exist on the wire struct.
 
 ## Verdicts
 
-| Verdict | Meaning |
-|---|---|
-| `parity` | every applicable surface exposes it |
-| `real-gap` | a surface should have it and does not — `issue` names the ticket |
-| `deliberate` | the surface legitimately cannot or should not; `notes` says why, so it is never re-reported as a gap |
-| `unclear` | needs an owner decision; not filed |
+Each verdict is a claim about the row's own cells, so each one owes those cells a
+check. The checks live in `verdictRules` (`parity/parity_test.go`) — a table, not
+a switch, because `TestAuditCoverageReport` reads it too, to count the rows whose
+verdict nothing checks:
+
+| Verdict | Meaning | What must be true of the cells |
+|---|---|---|
+| `parity` | every applicable surface exposes it | no surface is `no`/`partial` |
+| `real-gap` | a surface should have it and does not — `issue` names the ticket | some surface is `no`/`partial` |
+| `deliberate` | the surface legitimately cannot or should not; `notes` says why, so it is never re-reported as a gap | some surface is `no`/`partial`, **or** some surface is `n/a` |
+| `unclear` | needs an owner decision; not filed | some surface is `no`/`partial` |
 
 `n/a` as a *status* means the surface has no analogue by nature — `af doctor`
 diagnoses a broken install, including the case where the daemon is down and
 neither UI can run.
+
+`deliberate` is the one whose rule needed care, and it is worth reading before
+changing it. It legitimately coexists with *nothing missing*, because its
+deliberateness usually lives in an `n/a` cell — 21 rows are that shape. So it
+cannot join the `real-gap`/`unclear` rule ("something must be missing"); its rule
+is that the deliberateness must live **somewhere**. A row whose every cell is a
+plain `yes` has nothing deliberate left about it.
+
+That rule is late ([#2609](https://github.com/sachiniyer/agent-factory/issues/2609)).
+Until it existed, `deliberate` fell through the switch and was the one verdict
+never compared to its cells — so a row could keep asserting an omission that every
+surface had since closed, with the suite green. It was found when two PRs
+collided in `git` over one row, which is not a detector: two PRs touching
+*different* rows would have left it standing. Hence `unchecked=N` in the coverage
+report — the number that surfaces this class without needing a collision.
 
 ## What is deliberately NOT held to parity
 

--- a/docs/surface-parity.md
+++ b/docs/surface-parity.md
@@ -445,10 +445,15 @@ neither UI can run.
 
 `deliberate` is the one whose rule needed care, and it is worth reading before
 changing it. It legitimately coexists with *nothing missing*, because its
-deliberateness usually lives in an `n/a` cell — 21 rows are that shape. So it
-cannot join the `real-gap`/`unclear` rule ("something must be missing"); its rule
-is that the deliberateness must live **somewhere**. A row whose every cell is a
-plain `yes` has nothing deliberate left about it.
+deliberateness usually lives in an `n/a` cell — `af doctor` has no UI analogue by
+nature. So it cannot join the `real-gap`/`unclear` rule ("something must be
+missing"); its rule is that the deliberateness must live **somewhere**. A row
+whose every cell is a plain `yes` has nothing deliberate left about it.
+
+For how many rows that is, run `TestAuditCoverageReport` — this page does not
+restate the number. The first draft of this section did, in two places, and the
+two disagreed with each other and with the subset the sentence described, inside
+the PR that added the rule against unchecked claims. Derived tally or nothing.
 
 That rule is late ([#2609](https://github.com/sachiniyer/agent-factory/issues/2609)).
 Until it existed, `deliberate` fell through the switch and was the one verdict

--- a/parity/argshape_test.go
+++ b/parity/argshape_test.go
@@ -170,10 +170,21 @@ func TestArgumentShapeParity(t *testing.T) {
 				t.Errorf("%s declares both gap and ok — pick one", key)
 			case d.Gap == "" && d.OK == "":
 				t.Errorf("%s declares neither gap nor ok", key)
+			case strings.TrimSpace(d.OK) == "" && d.OK != "":
+				// Same tightening as field_coverage's ok arm (#2609): a declaration
+				// that silences a check must carry a reason, and whitespace is not one.
+				t.Errorf("%s declares ok with a blank reason. An `ok` silences this check, "+
+					"so it has to say WHY the two shapes are fine as they are.", key)
 			case d.Gap != "":
 				if _, ok := caps[d.Gap]; !ok {
 					t.Errorf("%s names unknown capability %q", key, d.Gap)
 				}
+				// Deliberately NOT the status-agreement check field_coverage's gap arm
+				// runs. There, a gap declaration asserts the surface cannot send a
+				// field, so the row saying that surface HAS the capability is a
+				// contradiction. Here the divergence is CLI-vs-CLI shape: a verb can
+				// fully have a capability (cli=yes) while its flag name still diverges
+				// from its siblings, so requiring cli != yes would invent one.
 			}
 		}
 	}

--- a/parity/coverage_test.go
+++ b/parity/coverage_test.go
@@ -139,8 +139,17 @@ func TestAuditCoverageReport(t *testing.T) {
 	// --- Inventory ---------------------------------------------------------
 	c.count("inventory.capabilities", len(inv.Capabilities))
 	byVerdict := map[string]int{}
+	// uncheckedVerdicts counts rows whose verdict no rule in verdictRules judges.
+	// It is the audit's OWN denominator, and it is here because the coverage
+	// report is the only place that asks "what did we not look at" — the number
+	// that would have surfaced #2609 with no merge conflict to force it. A verdict
+	// nothing checks is a claim about the cells that the suite goes green over.
+	uncheckedVerdicts := 0
 	for _, cap := range inv.Capabilities {
 		byVerdict[cap.Verdict]++
+		if _, ok := verdictRules[cap.Verdict]; !ok {
+			uncheckedVerdicts++
+		}
 	}
 
 	// --- Report ------------------------------------------------------------
@@ -156,9 +165,12 @@ func TestAuditCoverageReport(t *testing.T) {
 		b.WriteString(fmt.Sprintf("  %-32s %d\n", k, c.Scanned[k]))
 	}
 	b.WriteString("  verdicts:")
-	for _, v := range []string{"parity", "deliberate", "real-gap", "unclear"} {
+	// Iterate the RULE TABLE, not a hand-written list: a verdict added without a
+	// rule then shows up in `unchecked` instead of quietly missing this line too.
+	for _, v := range strings.Split(verdictNames(), ", ") {
 		b.WriteString(fmt.Sprintf("  %s=%d", v, byVerdict[v]))
 	}
+	b.WriteString(fmt.Sprintf("  unchecked=%d", uncheckedVerdicts))
 	b.WriteString("\n")
 	if len(c.Skipped) == 0 {
 		b.WriteString("  SKIPPED: none — every surface above was read\n")
@@ -171,6 +183,15 @@ func TestAuditCoverageReport(t *testing.T) {
 		t.Errorf("audit blind spot: %s\n\nThis is under-coverage, which is worse than a missing "+
 			"check: the suite would go green while asserting parity over something it never "+
 			"read. Fix the derivation — do not silence this.", s)
+	}
+
+	// An unchecked verdict is the same blind spot one level in: the row is read,
+	// its verdict is spelled correctly, and nothing compares that verdict to the
+	// cells it makes a claim about.
+	if uncheckedVerdicts > 0 {
+		t.Errorf("%d capabilities carry a verdict with no rule in verdictRules (valid: %s). "+
+			"That verdict passes by omission — give it a rule rather than leaving the audit "+
+			"green over a claim it never evaluated (#2609).", uncheckedVerdicts, verdictNames())
 	}
 
 	// A denominator that collapses is itself a blind spot: these floors are the

--- a/parity/field_coverage_test.go
+++ b/parity/field_coverage_test.go
@@ -71,6 +71,13 @@ func validateFieldDecls(t *testing.T, caps map[string]capability, surface, label
 			t.Errorf("%s field %q declares both gap and ok — pick one", label, f)
 		case d.Gap == "" && d.OK == "":
 			t.Errorf("%s field %q declares neither gap nor ok", label, f)
+		case strings.TrimSpace(d.OK) == "" && d.OK != "":
+			// The `ok` arm used to validate nothing beyond being non-empty, so a
+			// whitespace reason silenced the check while recording no reason at
+			// all — "add the declaration and it passes", the shape #2609 found in
+			// the verdict switch. An `ok` IS its reason; blank is not one.
+			t.Errorf("%s field %q declares ok with a blank reason. An `ok` silences this "+
+				"check, so it has to say WHY the absence is correct.", label, f)
 		case d.Gap != "":
 			c, ok := caps[d.Gap]
 			if !ok {

--- a/parity/parity_test.go
+++ b/parity/parity_test.go
@@ -328,9 +328,16 @@ var verdictRules = map[string]func(c verdictCells) string{
 	// This one cannot join real-gap/unclear above, and that is the trap worth
 	// naming: `deliberate` coexists legitimately with no missing surface, because
 	// its deliberateness usually lives in an "n/a" cell — `af doctor` has no UI
-	// analogue by nature, and 22 rows are that shape today. So the rule is not
-	// "something must be missing" but "the deliberateness must live SOMEWHERE": a
-	// row whose every cell is a plain "yes" has nothing deliberate left about it.
+	// analogue by nature. So the rule is not "something must be missing" but "the
+	// deliberateness must live SOMEWHERE": a row whose every cell is a plain "yes"
+	// has nothing deliberate left about it.
+	//
+	// How many rows are that shape is deliberately NOT written here. Run
+	// TestAuditCoverageReport for the live tally: a hand-written count in this
+	// file would be an unchecked claim inside the rule that exists to catch
+	// unchecked claims, and the first draft of this comment proved it — it shipped
+	// a count that was stale on arrival, and disagreed with the count its own docs
+	// page carried, before the PR introducing both had even merged.
 	"deliberate": func(c verdictCells) string {
 		if len(c.missing) == 0 && !c.hasNA {
 			return "verdict 'deliberate' but every surface reports yes. A deliberate omission " +

--- a/parity/parity_test.go
+++ b/parity/parity_test.go
@@ -8,9 +8,11 @@ package parity
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -271,34 +273,120 @@ func TestLedgerAgreesWithSurfaceStatus(t *testing.T) {
 	check("web", inv.Ledger.WebRPCs, func(c capability) string { return c.Web.Status })
 }
 
+// verdictCells is what a verdict is judged against: the surfaces that lack the
+// capability, and whether any surface has no analogue for it at all.
+type verdictCells struct {
+	// missing lists the surfaces reporting "no" or "partial", as "web=no".
+	missing []string
+	// hasNA reports whether any surface is "n/a" — the cell that carries a
+	// deliberate omission ("this surface has no analogue by nature").
+	hasNA bool
+	// issue is the row's ticket, quoted back in the failure.
+	issue string
+}
+
+// verdictRules is the whole meaning of a verdict: the check each one owes its own
+// cells, keyed by verdict, returning "" when the row is consistent.
+//
+// It is a TABLE and not a switch because two readers need it — this file enforces
+// it, and TestAuditCoverageReport counts the rows whose verdict no rule covers. A
+// switch can only be read by the code inside it, so a `case` that validates
+// nothing is indistinguishable from a verdict nobody thought about. That is not
+// hypothetical: `deliberate` fell through the old switch silently, and the stale
+// verdict it permitted was caught by a MERGE CONFLICT rather than by this suite
+// (#2609 — two PRs touching different rows would have left it standing).
+//
+// Adding a verdict value now means adding its rule here, or the row is reported
+// as unchecked rather than passing by omission.
+var verdictRules = map[string]func(c verdictCells) string{
+	// Every applicable surface has it.
+	"parity": func(c verdictCells) string {
+		if len(c.missing) > 0 {
+			return fmt.Sprintf("verdict 'parity' but %v. An applicable surface is missing it — "+
+				"the verdict should be real-gap, deliberate, or unclear.", c.missing)
+		}
+		return ""
+	},
+	// A surface should have it and does not; the issue names the ticket.
+	"real-gap": func(c verdictCells) string {
+		if len(c.missing) == 0 {
+			return fmt.Sprintf("verdict 'real-gap' but every surface reports yes/n-a. If the gap "+
+				"was closed, flip the verdict to 'parity' and close %s.", c.issue)
+		}
+		return ""
+	},
+	// Needs an owner decision — which presupposes something still undecided.
+	"unclear": func(c verdictCells) string {
+		if len(c.missing) == 0 {
+			return "verdict 'unclear' but every surface reports yes/n-a. If the gap was closed, " +
+				"flip the verdict to 'parity'."
+		}
+		return ""
+	},
+	// The surface legitimately cannot or should not have it.
+	//
+	// This one cannot join real-gap/unclear above, and that is the trap worth
+	// naming: `deliberate` coexists legitimately with no missing surface, because
+	// its deliberateness usually lives in an "n/a" cell — `af doctor` has no UI
+	// analogue by nature, and 22 rows are that shape today. So the rule is not
+	// "something must be missing" but "the deliberateness must live SOMEWHERE": a
+	// row whose every cell is a plain "yes" has nothing deliberate left about it.
+	"deliberate": func(c verdictCells) string {
+		if len(c.missing) == 0 && !c.hasNA {
+			return "verdict 'deliberate' but every surface reports yes. A deliberate omission " +
+				"needs a surface that omits it (a 'no'/'partial' cell) or one with no analogue " +
+				"(an 'n/a' cell) — with all three present the row is at 'parity'."
+		}
+		return ""
+	},
+}
+
+// verdictNames lists the verdicts that have a rule, for error messages and the
+// coverage report — derived from the table so it cannot drift from it.
+func verdictNames() string {
+	names := make([]string, 0, len(verdictRules))
+	for v := range verdictRules {
+		names = append(names, v)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+// verdictCellsOf reads a row's cells into the shape verdictRules judges.
+func verdictCellsOf(c capability) verdictCells {
+	cells := verdictCells{issue: c.Issue}
+	for name, s := range map[string]string{"tui": c.TUI.Status, "web": c.Web.Status, "cli": c.CLI.Status} {
+		switch s {
+		case "no", "partial":
+			cells.missing = append(cells.missing, name+"="+s)
+		case "n/a":
+			cells.hasNA = true
+		}
+	}
+	sort.Strings(cells.missing)
+	return cells
+}
+
 // TestVerdictAgreesWithStatuses stops a stale verdict outliving the statuses it
 // was derived from: a row cannot claim "parity" while an applicable surface is
-// still missing it, and cannot claim "real-gap" once every surface has it.
+// still missing it, cannot claim "real-gap" once every surface has it, and cannot
+// claim a "deliberate" omission that every surface now makes.
 func TestVerdictAgreesWithStatuses(t *testing.T) {
 	inv := loadInventory(t)
 
 	for _, c := range inv.Capabilities {
-		statuses := map[string]string{"tui": c.TUI.Status, "web": c.Web.Status, "cli": c.CLI.Status}
-
-		var missing []string
-		for name, s := range statuses {
-			if s == "no" || s == "partial" {
-				missing = append(missing, name+"="+s)
-			}
+		rule, ok := verdictRules[c.Verdict]
+		if !ok {
+			// Not merely an invalid value (TestCapabilitiesAreWellFormed reports
+			// that): a verdict with no rule is a claim nothing compares to the
+			// cells, which is the exact hole #2609 closed.
+			t.Errorf("%s: verdict %q has no rule in verdictRules, so nothing checks it against "+
+				"this row's cells. Add its rule rather than letting the verdict pass by "+
+				"omission.", c.ID, c.Verdict)
+			continue
 		}
-		sort.Strings(missing)
-
-		switch c.Verdict {
-		case "parity":
-			if len(missing) > 0 {
-				t.Errorf("%s: verdict 'parity' but %v. An applicable surface is missing it — "+
-					"the verdict should be real-gap, deliberate, or unclear.", c.ID, missing)
-			}
-		case "real-gap", "unclear":
-			if len(missing) == 0 {
-				t.Errorf("%s: verdict %q but every surface reports yes/n-a. If the gap was "+
-					"closed, flip the verdict to 'parity' and close %s.", c.ID, c.Verdict, c.Issue)
-			}
+		if msg := rule(verdictCellsOf(c)); msg != "" {
+			t.Errorf("%s: %s", c.ID, msg)
 		}
 	}
 }
@@ -308,7 +396,10 @@ func TestVerdictAgreesWithStatuses(t *testing.T) {
 func TestCapabilitiesAreWellFormed(t *testing.T) {
 	inv := loadInventory(t)
 	validStatus := map[string]bool{"yes": true, "no": true, "partial": true, "n/a": true}
-	validVerdict := map[string]bool{"parity": true, "real-gap": true, "deliberate": true, "unclear": true}
+	// The valid verdicts ARE the ones with a rule. Keeping a second hand-written
+	// list here would let a verdict be spelled correctly and checked by nothing —
+	// the pair of facts #2609 was about.
+	validVerdict := verdictRules
 
 	seen := map[string]bool{}
 	for _, c := range inv.Capabilities {
@@ -320,8 +411,8 @@ func TestCapabilitiesAreWellFormed(t *testing.T) {
 		if c.Title == "" {
 			t.Errorf("%s: missing title", c.ID)
 		}
-		if !validVerdict[c.Verdict] {
-			t.Errorf("%s: invalid verdict %q", c.ID, c.Verdict)
+		if _, ok := validVerdict[c.Verdict]; !ok {
+			t.Errorf("%s: invalid verdict %q (valid: %s)", c.ID, c.Verdict, verdictNames())
 		}
 		for name, cl := range map[string]cell{"tui": c.TUI, "web": c.Web, "cli": c.CLI} {
 			if !validStatus[cl.Status] {


### PR DESCRIPTION
Closes #2609.

## The hole

`TestVerdictAgreesWithStatuses` switched on the verdict and handled three of the
four values. `deliberate` fell through — and it is the one verdict whose entire
content is a claim about a cell, so it was the one verdict never compared to the
cells it claims about. A row could keep asserting an omission that every surface
had since closed, with the whole suite green.

That is this package's own failure mode reproduced inside the package: a checker
green over something it never looked at.

It is also not hypothetical. #2584 wrote `backend.list` as `deliberate` with
`tui=no` and the note *"this cell flips to 'yes' with that picker, not before"*;
#2600 was that picker. What caught the stale verdict was a **merge conflict** —
the two PRs happened to edit the same JSON object, so a human had to look. Two
PRs touching *different* rows would have left it standing.

## The change

The switch becomes `verdictRules`, a **table**, because two readers need it: the
test enforces it, and `TestAuditCoverageReport` counts the rows whose verdict no
rule covers. That is the structural half — a `case` that validates nothing is
indistinguishable from a verdict nobody thought about, while a missing map entry
is a fact another test can read:

```
verdicts:  deliberate=21  parity=32  real-gap=8  unclear=11  unchecked=0
```

`unchecked` fails above zero, so adding a fifth verdict value forces a decision
about what it promises instead of inheriting a silent pass. `TestCapabilities-
AreWellFormed`'s separate hand-written list of valid verdicts now derives from the
same table, closing the adjacent version of the same problem: a verdict spelled
correctly and checked by nothing.

`deliberate`'s rule is the one that needed care, and the reasoning is in the code
so nobody has to rediscover it. It cannot join the `real-gap`/`unclear` rule
("something must be missing") because it legitimately coexists with nothing
missing — its deliberateness usually lives in an `n/a` cell, and 21 rows are that
shape. The rule is that the deliberateness must live **somewhere**: a row whose
every cell is a plain `yes` has nothing deliberate left about it. Checked against
the inventory before writing it — no row on master fails, so this is a straight
tightening with nothing to fix first.

## Watched failing before trusted

A guard nobody has seen fail is the same unchecked claim this issue is about, so
both new guards were driven red on scratch mutations, then reverted:

```
backend.list -> deliberate, cells untouched   (the #2600/#2584 near-miss row)
  FAIL  backend.list: verdict 'deliberate' but every surface reports yes. A deliberate
        omission needs a surface that omits it (a 'no'/'partial' cell) or one with no
        analogue (an 'n/a' cell) — with all three present the row is at 'parity'.

session.tab.rename -> verdict "probably-fine"  (no rule covers it)
  FAIL  session.tab.rename: verdict "probably-fine" has no rule in verdictRules, so
        nothing checks it against this row's cells.
  FAIL  1 capabilities carry a verdict with no rule in verdictRules … (unchecked=1)
  FAIL  session.tab.rename: invalid verdict "probably-fine" (valid: deliberate, parity,
        real-gap, unclear)
```

The third line is the derived `validVerdict` proving it tracks the table.

## The grep — one more arm of the same shape

Every `switch` in the harness, read for arms that validate nothing:

| Switch | Arms that validate nothing | Action |
|---|---|---|
| `parity_test.go` verdict switch | `deliberate` | fixed above |
| `field_coverage_test.go` declaration switch | the `ok` arm | **fixed** |
| `argshape_test.go` declaration switch | the `ok` arm | **fixed** |
| `parity_test.go` `surfaceStatus` | none — an unknown surface returns `""`, which fails the caller's check closed | none |
| `enum_coverage_test.go` lexer states | none — it is a tokenizer, every state consumes | none |

The `ok` arm accepted any non-empty string, so `{"ok": "   "}` silenced a check
while recording no reason — "add the declaration and it passes", one level down
from the verdict hole. There are **54** `ok` declarations carrying the reasons 54
checks are not run; a blank one is now rejected in both places. Watched failing
too:

```
  FAIL  CreateSessionRequest (cli, …) field "title_base" declares ok with a blank reason.
        An `ok` silences this check, so it has to say WHY the absence is correct.
```

One asymmetry I deliberately did **not** "fix", now commented so the next reader
doesn't: `argument_shapes`' `gap` arm does not get `field_coverage`'s
status-agreement check. There, a gap declaration asserts a surface cannot send a
field, so the row saying that surface HAS the capability is a contradiction. Here
the divergence is CLI-vs-CLI *shape* — a verb can fully have a capability
(`cli=yes`) while its flag name still diverges from its siblings, so requiring
`cli != yes` would invent a contradiction rather than catch one.

## Docs

`docs/surface-parity.md`'s Verdicts section gains a column for what each verdict
must be true of, the `deliberate` reasoning, and the honest note that the rule is
late and what found it (a collision, not the suite). The "what the check
enforces" list gains the two new invariants; the coverage sample is refreshed.

## Gates

All six, from a run **after** the final commit, against the pushed head
`eb37fb7d150668d248fe14bf0882c15709f369f2`:

| Gate | Result |
|---|---|
| `golangci-lint run --timeout=3m --fast` | clean |
| `gofmt -l .` | no output |
| `go build ./...` | clean |
| `make test-container` | exit 0, zero `FAIL` lines, `parity ok 1.626s` |
| `deadcode -test ./...` | no output |
| `scripts/lint-file-length.sh` | passed (1086 files, 0 grandfathered) |

Tests only — no production code changes, so no TUI drive applies.

— Captain Claude
