### PR TITLE
fix(cli): local prerequisites gate on the resolved backend, not every create (#2592)

### DIFF
--- a/api/sessions.go
+++ b/api/sessions.go
@@ -329,10 +329,6 @@ pointing at one).`,
 		} else if err := config.ValidateProgramEnum("--program flag", "--program flag", program, ""); err != nil {
 			return jsonError(err)
 		}
-		if err := preflightLocalSession(&cfg.Config, program); err != nil {
-			return jsonError(err)
-		}
-
 		// Validate --backend up front so a typo fails on the client with a clear
 		// message rather than after a daemon round trip (#1592 Phase 4 PR3). An
 		// empty flag defers to the repo's `backend` config key.
@@ -341,6 +337,26 @@ pointing at one).`,
 		}
 		if inPlace && createBackendFlag != "" && createBackendFlag != config.BackendLocal {
 			return jsonError(fmt.Errorf("--here runs in the local working tree and is incompatible with --backend %s", createBackendFlag))
+		}
+
+		// Backend resolution now runs BEFORE preflight, because it decides
+		// whether preflight applies at all (#2592): a docker/ssh/hook session
+		// runs tmux and the agent inside the sandbox, so refusing the create
+		// for a missing local `claude` blocks a session that would have
+		// worked. The RAW flag goes in, not the parsed kind —
+		// ParseBackendKind turns "" into BackendLocal, and passing that
+		// through would override the repo's `backend` key with a default the
+		// user never typed.
+		local, err := session.LocalPrereqsRequired(session.InstanceOptions{
+			Backend: session.BackendKind(createBackendFlag),
+		}, repo.Root)
+		if err != nil {
+			return jsonError(err)
+		}
+		if local {
+			if err := preflightLocalSession(&cfg.Config, program); err != nil {
+				return jsonError(err)
+			}
 		}
 
 		data, err := createSessionViaDaemon(daemon.CreateSessionRequest{

--- a/api/sessions_backend_preflight_test.go
+++ b/api/sessions_backend_preflight_test.go
@@ -1,0 +1,266 @@
+package api
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// newBackendRepo makes a git repo whose in-repo config declares backend, and
+// returns its root. An empty backend writes no in-repo config at all, which is
+// the local default every create took before backends existed.
+func newBackendRepo(t *testing.T, backend string) string {
+	t.Helper()
+	repoRoot := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", repoRoot, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v (%s)", err, out)
+	}
+	if backend == "" {
+		return repoRoot
+	}
+	cfgDir := filepath.Join(repoRoot, config.InRepoConfigDirName)
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir in-repo config dir: %v", err)
+	}
+	body := "backend = \"" + backend + "\"\n"
+	if err := os.WriteFile(filepath.Join(cfgDir, config.TomlConfigFileName), []byte(body), 0o644); err != nil {
+		t.Fatalf("write in-repo config: %v", err)
+	}
+	return repoRoot
+}
+
+// recordPreflight swaps the local-prereq seam for one that records whether it
+// ran, and returns a pointer to that record.
+func recordPreflight(t *testing.T) *bool {
+	t.Helper()
+	called := false
+	prev := preflightLocalSession
+	preflightLocalSession = func(*config.Config, string) error {
+		called = true
+		return nil
+	}
+	t.Cleanup(func() { preflightLocalSession = prev })
+	return &called
+}
+
+// stubCreate captures the daemon create request instead of making a session.
+func stubCreate(t *testing.T) **daemon.CreateSessionRequest {
+	t.Helper()
+	var got *daemon.CreateSessionRequest
+	prev := createSessionViaDaemon
+	createSessionViaDaemon = func(req daemon.CreateSessionRequest) (*session.InstanceData, error) {
+		got = &req
+		return &session.InstanceData{Title: req.Title}, nil
+	}
+	t.Cleanup(func() { createSessionViaDaemon = prev })
+	return &got
+}
+
+// setCreateFlags points `af sessions create` at repo with the given --backend,
+// restoring every flag afterwards. Unlike setSessionsCreateFlags it leaves the
+// preflight seam alone, because whether preflight RUNS is what these tests are
+// measuring.
+func setCreateFlags(t *testing.T, name, repo, backend string) {
+	t.Helper()
+	prevName, prevPrompt, prevProgram, prevBackend := createNameFlag, createPromptFlag, createProgramFlag, createBackendFlag
+	prevHere, prevInPlace, prevRepo := createHereFlag, createInPlaceFlag, repoFlag
+	createNameFlag, createPromptFlag, createProgramFlag, createBackendFlag = name, "", "", backend
+	createHereFlag, createInPlaceFlag, repoFlag = false, false, repo
+	t.Cleanup(func() {
+		createNameFlag, createPromptFlag, createProgramFlag, createBackendFlag = prevName, prevPrompt, prevProgram, prevBackend
+		createHereFlag, createInPlaceFlag, repoFlag = prevHere, prevInPlace, prevRepo
+	})
+}
+
+// TestSessionsCreatePreflightFollowsResolvedBackend is #2592 for
+// `af sessions create`: the local prerequisites (tmux, the agent binary on
+// PATH) decide whether a create can succeed only when the agent will run on
+// THIS box. For docker/ssh/hook the agent runs in the sandbox, so a machine
+// without local tmux or `claude` must still be able to create the session.
+//
+// Both ways a backend is selected are covered, because they take different
+// routes into the resolver: the in-repo `backend` config key (no flag at all,
+// which is the shape #2194 documents for opting a repo into containers) and an
+// explicit --backend on an otherwise-local repo.
+func TestSessionsCreatePreflightFollowsResolvedBackend(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		repoBackend   string
+		flagBackend   string
+		wantPreflight bool
+	}{
+		{name: "local default", wantPreflight: true},
+		{name: "explicit --backend local", flagBackend: "local", wantPreflight: true},
+		{name: "repo config docker", repoBackend: "docker"},
+		{name: "repo config ssh", repoBackend: "ssh"},
+		{name: "repo config hook", repoBackend: "hook"},
+		{name: "--backend docker on a local repo", flagBackend: "docker"},
+		{name: "--backend ssh on a local repo", flagBackend: "ssh"},
+		{name: "--backend hook on a local repo", flagBackend: "hook"},
+		// An explicit --backend outranks the repo's key (resolveBackendKind's
+		// precedence), so a local flag in a docker repo is a LOCAL create and
+		// does need the local prerequisites.
+		{name: "--backend local overrides a docker repo", repoBackend: "docker", flagBackend: "local", wantPreflight: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+			silenceStdio(t)
+
+			repoRoot := newBackendRepo(t, tc.repoBackend)
+			called := recordPreflight(t)
+			got := stubCreate(t)
+			setCreateFlags(t, "backend-preflight", repoRoot, tc.flagBackend)
+
+			if err := sessionsCreateCmd.RunE(sessionsCreateCmd, nil); err != nil {
+				t.Fatalf("sessions create: %v", err)
+			}
+			if *got == nil {
+				t.Fatal("daemon create was never called")
+			}
+			if (*got).Backend != tc.flagBackend {
+				t.Errorf("CreateSessionRequest.Backend = %q, want %q — the create must still honor the picked backend", (*got).Backend, tc.flagBackend)
+			}
+			if *called != tc.wantPreflight {
+				t.Errorf("local preflight ran = %v, want %v", *called, tc.wantPreflight)
+			}
+		})
+	}
+}
+
+// TestSessionsCreateStillRefusesOnLocalPreflightFailure keeps the gate honest
+// in the other direction: skipping preflight for a sandbox backend must not
+// turn into skipping it everywhere. A local create with a missing agent binary
+// is still refused before the daemon is asked to do anything.
+func TestSessionsCreateStillRefusesOnLocalPreflightFailure(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	silenceStdio(t)
+
+	repoRoot := newBackendRepo(t, "")
+	prev := preflightLocalSession
+	preflightLocalSession = func(*config.Config, string) error {
+		return errors.New("claude is not installed or not on PATH")
+	}
+	t.Cleanup(func() { preflightLocalSession = prev })
+
+	prevCreate := createSessionViaDaemon
+	createSessionViaDaemon = func(daemon.CreateSessionRequest) (*session.InstanceData, error) {
+		t.Fatal("a create that failed local preflight must not reach the daemon")
+		return nil, nil
+	}
+	t.Cleanup(func() { createSessionViaDaemon = prevCreate })
+
+	setCreateFlags(t, "still-gated", repoRoot, "")
+
+	err := sessionsCreateCmd.RunE(sessionsCreateCmd, nil)
+	if err == nil {
+		t.Fatal("sessions create: want the local preflight failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "not on PATH") {
+		t.Fatalf("sessions create: want the preflight message, got %v", err)
+	}
+}
+
+// TestSessionsCreateSurfacesUnresolvableBackend covers the third outcome. A
+// repo whose `backend` key names something that does not exist is neither a
+// local create nor a sandbox one — the kind cannot be resolved at all, so
+// there is no honest answer to "do the local prerequisites apply". That is not
+// the same as the prerequisites failing, and it must not be reported as one:
+// the user hears about the backend value they typed, not about tmux.
+func TestSessionsCreateSurfacesUnresolvableBackend(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	silenceStdio(t)
+
+	repoRoot := newBackendRepo(t, "moonbase")
+	prev := preflightLocalSession
+	preflightLocalSession = func(*config.Config, string) error {
+		return errors.New("tmux is not installed or not on PATH")
+	}
+	t.Cleanup(func() { preflightLocalSession = prev })
+
+	prevCreate := createSessionViaDaemon
+	createSessionViaDaemon = func(daemon.CreateSessionRequest) (*session.InstanceData, error) {
+		t.Fatal("a create whose backend does not resolve must not reach the daemon")
+		return nil, nil
+	}
+	t.Cleanup(func() { createSessionViaDaemon = prevCreate })
+
+	setCreateFlags(t, "unresolvable", repoRoot, "")
+
+	err := sessionsCreateCmd.RunE(sessionsCreateCmd, nil)
+	if err == nil {
+		t.Fatal("sessions create: want the unknown-backend error, got nil")
+	}
+	if !strings.Contains(err.Error(), "moonbase") {
+		t.Fatalf("sessions create: want the offending backend value named, got %v", err)
+	}
+	if strings.Contains(err.Error(), "tmux") {
+		t.Fatalf("sessions create: an unresolvable backend was reported as a local-prerequisite failure: %v", err)
+	}
+}
+
+// TestSendPromptCreatePreflightFollowsResolvedBackend is #2592 for
+// `af sessions send-prompt --create`. It has no --backend flag, so the repo's
+// `backend` key is the whole decision.
+func TestSendPromptCreatePreflightFollowsResolvedBackend(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		repoBackend   string
+		wantPreflight bool
+	}{
+		{name: "local default", wantPreflight: true},
+		{name: "repo config docker", repoBackend: "docker"},
+		{name: "repo config ssh", repoBackend: "ssh"},
+		{name: "repo config hook", repoBackend: "hook"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+			silenceStdio(t)
+			resetSendPromptState(t)
+
+			repoRoot := newBackendRepo(t, tc.repoBackend)
+			called := recordPreflight(t)
+
+			delivered := false
+			prevDeliver := deliverPromptViaDaemon
+			deliverPromptViaDaemon = func(daemon.DeliverPromptRequest) (string, error) {
+				delivered = true
+				return "started", nil
+			}
+			prevSend := sendPromptViaDaemon
+			sendPromptViaDaemon = func(req daemon.SendPromptRequest) error {
+				t.Fatalf("--create must stay on the deliver path; got %+v", req)
+				return nil
+			}
+			t.Cleanup(func() {
+				deliverPromptViaDaemon = prevDeliver
+				sendPromptViaDaemon = prevSend
+			})
+
+			clearSendPromptFlags()
+			prevRepo := repoFlag
+			repoFlag = repoRoot
+			sendPromptCreateFlag = true
+			t.Cleanup(func() { repoFlag = prevRepo })
+
+			if err := sessionsSendPromptCmd.RunE(sessionsSendPromptCmd, []string{"captain", "triage the queue"}); err != nil {
+				t.Fatalf("sessions send-prompt --create: %v", err)
+			}
+			if !delivered {
+				t.Fatal("the prompt never reached the daemon")
+			}
+			if *called != tc.wantPreflight {
+				t.Errorf("local preflight ran = %v, want %v", *called, tc.wantPreflight)
+			}
+		})
+	}
+}

--- a/api/sessions_sendprompt.go
+++ b/api/sessions_sendprompt.go
@@ -185,8 +185,19 @@ results.`,
 			} else if err := config.ValidateProgramEnum("--program flag", "--program flag", program, ""); err != nil {
 				return jsonError(err)
 			}
-			if err := preflightLocalSession(&cfg.Config, program); err != nil {
+			// The local prerequisites (tmux, the agent binary on PATH) only
+			// decide this create when the agent will run on THIS box (#2592).
+			// send-prompt has no --backend flag, so the repo's `backend` key is
+			// the whole selection; a docker/ssh/hook repo runs the agent in the
+			// sandbox and must not be refused for a missing local one.
+			local, err := session.LocalPrereqsRequired(session.InstanceOptions{}, repo.Root)
+			if err != nil {
 				return jsonError(err)
+			}
+			if local {
+				if err := preflightLocalSession(&cfg.Config, program); err != nil {
+					return jsonError(err)
+				}
 			}
 
 			if _, err := deliverPromptViaDaemon(daemon.DeliverPromptRequest{

--- a/app/preflight.go
+++ b/app/preflight.go
@@ -17,11 +17,33 @@ func (m *home) preflightSessionCreate(instance *session.Instance) error {
 	// than the create about to be submitted. Checking the local agent binary for a
 	// docker/ssh/hook create would refuse a session whose agent runs somewhere else
 	// entirely — the shape of #2592 on the CLI side.
-	if m.pendingBackend != "" && m.pendingBackend != config.BackendLocal {
+	//
+	// Both surfaces now ask the same question through session.LocalPrereqsRequired
+	// rather than each hand-rolling "is the picked backend local", so the
+	// precedence between an explicit pick and the repo's `backend` key is decided
+	// in exactly one place (#2592). Passing the pick RAW is what preserves that
+	// precedence: an untouched field is "", which defers to the repo's key, while
+	// an explicit `local` pick outranks it.
+	//
+	// The resolve error is deliberately not surfaced here, and the bool is still
+	// exactly right when it arrives: unresolvable is NOT local. The picker offers
+	// whatever the daemon's catalog lists, which may name a backend this process's
+	// enum has never heard of (#2600's anti-drift property) — refusing it here
+	// would substitute a client-side enum for the catalog the TUI deliberately
+	// does not hold. `local` is the one name this side can always recognize, so a
+	// name that does not resolve cannot be the local backend, and a missing local
+	// `claude` is not what is wrong with it. The daemon owns the verdict on a
+	// backend it could not resolve, and states it when the create is submitted.
+	local, _ := session.LocalPrereqsRequired(session.InstanceOptions{
+		Backend: session.BackendKind(m.pendingBackend),
+	}, m.repoRoot)
+	if !local {
 		return nil
 	}
-	// Local-session prerequisites (the agent binary, etc.) only apply to a
-	// backend that runs the agent on a local worktree.
+	// The legacy `N` selector is not a backend pick — it lives on the placeholder,
+	// which is provisioned as a remote runtime — so its locality still reads from
+	// the instance. Local-session prerequisites only apply to a backend that runs
+	// the agent on a local worktree.
 	if instance == nil || instance.Capabilities().Workspace != session.WorkspaceLocalWorktree {
 		return nil
 	}

--- a/app/preflight_backend_test.go
+++ b/app/preflight_backend_test.go
@@ -1,0 +1,112 @@
+package app
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// repoDeclaringBackend makes a git repo whose in-repo config selects backend,
+// the way #2194 documents opting a repo into container sessions.
+func repoDeclaringBackend(t *testing.T, backend string) string {
+	t.Helper()
+	repoRoot := filepath.Join(t.TempDir(), "repo")
+	require.NoError(t, os.MkdirAll(repoRoot, 0o755))
+	out, err := exec.Command("git", "-C", repoRoot, "init").CombinedOutput()
+	require.NoError(t, err, "git init: %s", out)
+	if backend == "" {
+		return repoRoot
+	}
+	cfgDir := filepath.Join(repoRoot, config.InRepoConfigDirName)
+	require.NoError(t, os.MkdirAll(cfgDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(cfgDir, config.TomlConfigFileName),
+		[]byte("backend = \""+backend+"\"\n"), 0o644))
+	return repoRoot
+}
+
+// TestNamingPreflightFollowsTheRepoDeclaredBackend closes the half of #2592 the
+// TUI's own gate was missing. #2600 skipped the local agent preflight for a
+// backend PICKED in the naming form, which leaves the other way a session
+// becomes non-local — the repo's `backend` config key, with the field never
+// opened — still gated on a local `claude` that will never run the session.
+//
+// Both surfaces now ask session.LocalPrereqsRequired, so the precedence between
+// the two is decided once rather than per-surface.
+func TestNamingPreflightFollowsTheRepoDeclaredBackend(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		repoBackend string
+		wantRefused bool
+	}{
+		{name: "local repo still gates", wantRefused: true},
+		{name: "docker repo", repoBackend: "docker"},
+		{name: "ssh repo", repoBackend: "ssh"},
+		{name: "hook repo", repoBackend: "hook"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			h.errBox.SetSize(200, 1)
+			got := recordStartRequest(t)
+			t.Cleanup(SetLocalSessionPreflightForTest(func(*config.Config, string) error {
+				return errors.New("claude is not installed on this machine")
+			}))
+			h.repoRoot = repoDeclaringBackend(t, tc.repoBackend)
+			startNaming(t, h, "repo-declared-backend")
+
+			// A refusal ends in a transient notice whose cmd is a timer, so the
+			// refused leg drains one hop (pressExpectingNotice) rather than
+			// following the re-emitted key's cmd to completion.
+			if tc.wantRefused {
+				pressExpectingNotice(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+			} else {
+				pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+			}
+
+			if tc.wantRefused {
+				require.Equal(t, stateNew, h.state,
+					"a local create must still be refused when the agent binary is missing")
+				assert.Contains(t, h.errBox.FullError(), "not installed")
+				return
+			}
+			require.Equal(t, stateDefault, h.state,
+				"a repo that declares a sandbox backend must not be refused for a missing local agent")
+			assert.Empty(t, h.errBox.FullError(),
+				"nothing about the local agent applies to a session that runs off-box")
+			assert.Empty(t, got.Backend,
+				"an untouched backend field still sends nothing — the repo key decides, as it always did")
+		})
+	}
+}
+
+// TestNamingPreflightDoesNotRefuseABackendItCannotResolve keeps the gate from
+// becoming a second, stale copy of the backend catalog. The picker offers
+// whatever the daemon lists (#2600), so a name this process's enum has never
+// heard of is normal — it means the daemon knows more, not that the create is
+// wrong. Unresolvable is not local, and it is certainly not "the local agent is
+// missing": the gate stands aside and lets the daemon answer.
+func TestNamingPreflightDoesNotRefuseABackendItCannotResolve(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(200, 1)
+	got := recordStartRequest(t)
+	t.Cleanup(SetLocalSessionPreflightForTest(func(*config.Config, string) error {
+		return errors.New("claude is not installed on this machine")
+	}))
+	h.repoRoot = repoDeclaringBackend(t, "")
+	startNaming(t, h, "future-backend")
+	h.pendingBackend = "moonbase"
+
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+
+	require.Equal(t, stateDefault, h.state,
+		"a backend only the daemon knows about must still submit")
+	assert.Equal(t, "moonbase", got.Backend,
+		"and reach the daemon verbatim")
+}

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -160,6 +160,40 @@ func BackendKindFor(opts InstanceOptions, absPath string) (BackendKind, error) {
 	return resolveBackendKind(opts, absPath)
 }
 
+// LocalPrereqsRequired reports whether a create with these options against
+// absPath will run its agent on THIS machine — the only case where the local
+// prerequisites (tmux, the agent binary on PATH) decide whether the create can
+// succeed. A docker/ssh/hook create runs tmux and the agent inside the sandbox,
+// so checking the client's PATH for them refuses a session that would have
+// worked (#2592).
+//
+// It is the ONE predicate behind that gate: the CLI's `sessions create` and
+// `send-prompt --create` and the TUI's naming form all ask this rather than
+// each deciding for itself which backends are local. That matters because the
+// selection has precedence rules (explicit --backend, then ForceRemote, then
+// the repo's `backend` key) and a surface that reimplements them drifts —
+// gating on the explicit flag alone silently misses the repo-config case, which
+// is the shape #2592 arrived in.
+//
+// The answer is THREE-valued, which is why it returns an error rather than a
+// bare bool. A backend value that names nothing resolvable is neither a local
+// create nor a sandbox one: the question has no answer, and neither default is
+// honest. Reporting it as "local" makes the user hear about missing tmux when
+// their `backend` key is the problem; reporting it as "sandbox" skips a check
+// that should have run. Callers surface the error.
+//
+// It answers from the backend KIND rather than a provisioned backend's
+// Capabilities on purpose: Capabilities is per-instance, so reading it means
+// having provisioned a runtime — the exact thing a pre-create gate must not do
+// (#2599).
+func LocalPrereqsRequired(opts InstanceOptions, absPath string) (bool, error) {
+	kind, err := BackendKindFor(opts, absPath)
+	if err != nil {
+		return false, err
+	}
+	return kind == BackendLocal, nil
+}
+
 // SetBackendFactoryForTest replaces the backend factory with f and returns a
 // restore function. Intended for use in tests that need to swap in a
 // FakeBackend so NewInstance-driven creation flows stay on the hot path. f

--- a/session/local_prereqs_test.go
+++ b/session/local_prereqs_test.go
@@ -1,0 +1,81 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLocalPrereqsRequired is the one predicate behind every surface's
+// local-prerequisite gate (#2592). It follows the same selection precedence
+// NewInstance uses, which is the whole reason it exists: a surface that gates
+// on the explicit pick alone misses the repo's `backend` key, and that is the
+// shape the CLI bug arrived in.
+func TestLocalPrereqsRequired(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	t.Run("no selection anywhere is a local create", func(t *testing.T) {
+		got, err := LocalPrereqsRequired(InstanceOptions{}, t.TempDir())
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("an explicit sandbox backend is not", func(t *testing.T) {
+		for _, kind := range []BackendKind{BackendDocker, BackendSSH, BackendHook} {
+			got, err := LocalPrereqsRequired(InstanceOptions{Backend: kind}, t.TempDir())
+			require.NoError(t, err, "backend %s", kind)
+			assert.False(t, got, "backend %s runs the agent off-box", kind)
+		}
+	})
+
+	t.Run("an explicit local backend is", func(t *testing.T) {
+		got, err := LocalPrereqsRequired(InstanceOptions{Backend: BackendLocal}, t.TempDir())
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("the legacy ForceRemote selector is not", func(t *testing.T) {
+		got, err := LocalPrereqsRequired(InstanceOptions{ForceRemote: true}, t.TempDir())
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+
+	// The case the CLI gate was missing: nothing is passed in at all, and the
+	// repo's own config is what makes the session non-local.
+	t.Run("the repo backend key decides an unflagged create", func(t *testing.T) {
+		repoRoot := initTempGitRepo(t)
+		writeInRepoConfig(t, repoRoot, map[string]any{
+			"backend": "docker",
+			"docker":  map[string]any{"image": "alpine:3.20"},
+		})
+		got, err := LocalPrereqsRequired(InstanceOptions{}, repoRoot)
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+
+	// An explicit pick outranks the repo key in BOTH directions, so a `local`
+	// pick in a docker repo still needs the local prerequisites.
+	t.Run("an explicit local pick outranks a docker repo", func(t *testing.T) {
+		repoRoot := initTempGitRepo(t)
+		writeInRepoConfig(t, repoRoot, map[string]any{
+			"backend": "docker",
+			"docker":  map[string]any{"image": "alpine:3.20"},
+		})
+		got, err := LocalPrereqsRequired(InstanceOptions{Backend: BackendLocal}, repoRoot)
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	// The third outcome. A backend nobody can resolve is neither answer, and the
+	// error is how a caller tells "the prerequisites do not apply" apart from
+	// "we could not work out whether they apply" — collapsing the two is what
+	// made an unknown backend read as a missing tmux.
+	t.Run("an unresolvable backend answers neither way", func(t *testing.T) {
+		repoRoot := initTempGitRepo(t)
+		writeInRepoConfig(t, repoRoot, map[string]any{"backend": "moonbase"})
+		_, err := LocalPrereqsRequired(InstanceOptions{}, repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "moonbase")
+	})
+}


### PR DESCRIPTION
Closes #2592.

## The bug

`af sessions create` and `af sessions send-prompt --create` called
`preflightLocalSession` for every create. A repo configured with
`backend = "docker"` / `"ssh"` / `"hook"` was therefore refused with

```
tmux is not installed or not on PATH
Claude Code is not installed or not on PATH
```

on a machine that needs neither — those run inside the sandbox. The check was
always meant to be caller-gated (`preflight/preflight.go` says remote sessions
skip local-session prereqs); only the two CLI call sites never gated it.

## One predicate, not a third copy

`session.LocalPrereqsRequired(opts, absPath)` answers "do the local
prerequisites apply to this create", following the same selection precedence
`NewInstance` uses — explicit `--backend`, then `ForceRemote`, then the repo's
`backend` key. It sits next to `BackendKindFor`, which already exists for
exactly this "decide without creating anything" purpose.

That sharing is the point, not tidiness. **Correction to an earlier draft of
this description:** I first claimed the TUI's gate left the repo-config path
live-broken. It did not, and the review that caught it is right.

Walk it pre-this-PR, docker repo, field untouched: `pendingBackend == ""` falls
through the first gate to `instance.Capabilities().Workspace`, and in production
that placeholder *is* the repo's runtime — so it reports `WorkspaceRemote` and
the old code skipped too. No user was refused by that path. What I have is a
**latent conflation**: the old gate infers *where the agent runs* from *where the
workspace lives*, and those are different properties that happen to agree today.

I checked whether any production kind separates them, since that was the
review's proposed counter-example. None does: `session/backend_docker.go`,
`backend_ssh.go` and `backend_hook_backend.go` all embed `remoteAgentBackend`,
and production has exactly two `Workspace:` literals — `LocalBackend`
(`WorkspaceLocalWorktree`) and `remoteAgentBackend` (`WorkspaceRemote`). So hook
is not the candidate either; the conflation is currently harmless.

What makes it worth fixing now is #2599, not #2592. That fix pins the naming
placeholder to the local runtime so pressing `n` stops provisioning a container,
which means `instance.Capabilities().Workspace` becomes *permanently local* and
the old gate would start refusing docker/ssh/hook creates for a missing local
`claude` — a real TUI instance of #2592, introduced by the very next PR. This
change is the prerequisite that stops that, and it is the more robust shape
regardless: agent locality is read from the resolved backend kind, not inferred
from a workspace property.

It answers from the backend KIND, not from a provisioned backend's
`Capabilities()`: reading capabilities means having provisioned a runtime, which
is precisely what a pre-create gate must not do (#2599).

## The third outcome

`LocalPrereqsRequired` returns `(bool, error)`, and the error is not decoration.
A backend value that resolves to nothing is neither a local create nor a sandbox
one — the question has no answer, and both defaults lie. Answering "local" makes
a user with a typo'd `backend` key hear about missing tmux; answering "sandbox"
skips a check that should have run.

The two surfaces then take that unknown differently, on purpose:

- **CLI** surfaces it. `af sessions create` in a repo whose config says
  `backend = "moonbase"` now reports the offending value, up front, the way it
  already did for a typo'd `--backend`. Before this it reported *"tmux is not
  installed"* — `TestSessionsCreateSurfacesUnresolvableBackend` pins that it
  no longer does.
- **TUI** stands aside. Its catalog is the daemon's (#2600 deliberately reads
  `ListBackends` rather than a local enum), so a name this process has never
  heard of means the daemon knows more, not that the create is wrong. Refusing
  there would substitute a client-side enum for the catalog the picker does not
  hold. Unresolvable is still not *local* — `local` is the one name this side
  can always recognize — so the bool is correct either way and the daemon states
  the verdict at submit.

I found that second case by breaking it: my first cut returned the error from
the TUI gate and turned `TestBackendPickerOffersWhateverTheDaemonListed` — the
anti-drift guard #2600 added for exactly this — red.

Ordering in `sessions create` changed as a consequence: `--backend` validation
and the `--here` incompatibility check now run *before* preflight, because
backend resolution is what decides whether preflight runs at all.

## Watched fail first

Every test here was observed red against `e3102793` before the fix:

```
--- FAIL: TestSessionsCreatePreflightFollowsResolvedBackend/repo_config_docker
        local preflight ran = true, want false
    ... ssh, hook, --backend docker/ssh/hook on a local repo — 6 more
--- FAIL: TestSessionsCreateSurfacesUnresolvableBackend
        want the offending backend value named, got tmux is not installed or not on PATH
--- FAIL: TestSendPromptCreatePreflightFollowsResolvedBackend/repo_config_{docker,ssh,hook}
--- FAIL: TestNamingPreflightFollowsTheRepoDeclaredBackend/{docker,ssh,hook}_repo
```

The last one needs its red read honestly. `newTestHome` does **not** swap the
backend factory (I checked — zero `SetBackendFactoryForTest` in
`creation_test.go`), so the placeholder there is a real `LocalBackend`; it is
local because `startNaming` builds it against a `t.TempDir()` while `h.repoRoot`
is the docker repo. That divergence is not today's production shape — but it is
exactly the **post-#2599** production shape, where the placeholder is local by
construction and the repo still declares docker. So it is a valid guard for the
world the next PR creates, and not evidence that users are being refused today.
A driver leg against the real factory settles it end to end; it belongs with
#2599, where the form can actually open in such a repo, and I am building it
there.

The local legs passed throughout, which is the half that matters most:
`TestSessionsCreateStillRefusesOnLocalPreflightFailure` proves a local create
with a missing agent binary is still refused before the daemon is asked for
anything. Skipping the check for a sandbox backend must not become skipping it
everywhere.

Both directions of precedence are covered too — `--backend local` in a docker
repo is a local create and *does* need the local binaries.

## Not in scope

`af sessions create --backend <x>` still validates `x` against this process's
enum, so the CLI cannot name a backend only the daemon knows. That predates this
change; `af sessions backends` (#2584) is the CLI's window onto the real
catalog. Worth revisiting, not here.

## Gates

All six, run **after** the final commit against the pushed head
`c9c9a16ea4f0c221c302518144c4b06b3b923a65`:

| Gate | Result |
|---|---|
| `golangci-lint run --timeout=3m --fast` | clean |
| `gofmt -l .` | no output |
| `go build ./...` | clean |
| `make test-container` | 42 packages `ok`, zero failures |
| `deadcode -test ./...` | no output |
| `scripts/lint-file-length.sh` | passed (1086 files, 0 grandfathered) |

— Captain Claude
