### PR TITLE
fix(tui): the naming row is a row, not a runtime (#2599)

### DIFF
--- a/app/backend_picker_test.go
+++ b/app/backend_picker_test.go
@@ -442,24 +442,23 @@ func TestNamingFormBackendAndForceRemoteAgree(t *testing.T) {
 	got := recordStartRequest(t)
 	stubBackends(t, twoUsableBackends(), nil)
 
-	restore := session.SetBackendFactoryForTest(func(opts session.InstanceOptions, _ string) (session.Backend, error) {
-		if opts.ForceRemote {
-			return &session.HookBackend{}, nil
-		}
-		return &session.LocalBackend{}, nil
-	})
-	defer restore()
-
+	// `N` is now recorded on the model, not inferred from the naming row's
+	// provisioned runtime (#2599 — the row provisions nothing at all any more), so
+	// this is what startNewInstance(true) leaves behind. The end-to-end wiring from
+	// the keypress to this field is covered by
+	// TestStartNewRemoteThreadsForceRemoteFromTheKeypress; here it is set directly
+	// so the assertion stays about the request, not about how the flag got set.
 	remote, err := session.NewInstance(session.InstanceOptions{
-		Title:       "forced-remote",
-		Path:        t.TempDir(),
-		Program:     "claude",
-		ForceRemote: true,
+		Title:   "forced-remote",
+		Path:    t.TempDir(),
+		Program: "claude",
+		Backend: session.BackendLocal,
 	})
 	require.NoError(t, err)
 	h.store.AddInstance(remote)
 	h.namingInstance = remote
 	h.pendingProgram = "claude"
+	h.pendingForceRemote = true
 	h.state = stateNew
 
 	openBackendField(t, h)

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -31,6 +31,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.clearNamingPlaceholder()
 		m.pendingPrompt = ""
 		m.pendingBackend = ""
+		m.pendingForceRemote = false
 		// Menu.SetState rebuilds the options slice; call it synchronously
 		// on the event-loop goroutine rather than from a tea.Cmd closure
 		// that runs off-loop and races with home.View -> Menu.String.
@@ -89,7 +90,22 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m, m.handleError(fmt.Errorf("a session titled %q conflicts with existing session %q", title, other.Title))
 			}
 		}
-		if instance.Capabilities().Workspace == session.WorkspaceRemote {
+		// Which runtime this create lands on, resolved from the PENDING selection
+		// rather than read off the placeholder's capabilities (#2599): the
+		// placeholder is pinned local and provisions nothing, so it no longer knows.
+		// This is the same decision the daemon will make, by the same precedence,
+		// and it creates nothing — BackendKindFor exists for exactly this.
+		//
+		// A kind that does not resolve is left to the daemon. The backend field
+		// offers whatever the daemon's catalog lists (#2600), so a name this
+		// process's enum has never heard of is normal; refusing it here, or guessing
+		// that it is remote, would both be this side inventing an answer it does not
+		// have.
+		backendKind, backendKindErr := session.BackendKindFor(session.InstanceOptions{
+			Backend:     session.BackendKind(m.pendingBackend),
+			ForceRemote: m.pendingForceRemote,
+		}, instance.Path)
+		if backendKindErr == nil && backendKind != session.BackendLocal {
 			existing := make([]*session.Instance, 0, m.store.NumInstances())
 			for _, other := range m.store.GetInstances() {
 				if other == instance || other.Capabilities().Workspace != session.WorkspaceRemote {
@@ -106,7 +122,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		// preflightSessionCreate reads only the backend/program, not the title, so it
 		// runs before the title is committed.
-		if err := m.preflightSessionCreate(instance); err != nil {
+		if err := m.preflightSessionCreate(); err != nil {
 			return m, m.handleError(err)
 		}
 		// Every gate passed — commit the resolved title exactly once.
@@ -130,6 +146,11 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// on the loop, clear it with the rest of the naming state.
 		backend := m.pendingBackend
 		m.pendingBackend = ""
+		// And for `N`. It is read from the model, not from instance.Capabilities(),
+		// because the placeholder no longer resolves a runtime to carry it (#2599) —
+		// this is the value that keeps a remote create remote.
+		forceRemote := m.pendingForceRemote
+		m.pendingForceRemote = false
 		m.namingInstance = nil
 		m.clearNamingPlaceholder()
 		m.state = stateDefault
@@ -157,7 +178,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				// the repo's config", so an untouched field is byte-identical to
 				// every create before this field existed.
 				Backend:     backend,
-				ForceRemote: instance.Capabilities().Workspace == session.WorkspaceRemote,
+				ForceRemote: forceRemote,
 			}
 			started, err := start(instance, req)
 			return instanceStartedMsg{
@@ -231,6 +252,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.clearNamingPlaceholder()
 		m.pendingPrompt = ""
 		m.pendingBackend = ""
+		m.pendingForceRemote = false
 		m.state = stateDefault
 		cmd := m.selectionChanged()
 
@@ -253,6 +275,7 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 	// covers a create that ended by any route other than Enter/Esc/ctrl+c.
 	m.pendingPrompt = ""
 	m.pendingBackend = ""
+	m.pendingForceRemote = false
 	if m.pendingProgram == "" && m.appConfig != nil {
 		m.pendingProgram = m.appConfig.DefaultProgram
 	}
@@ -287,11 +310,36 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 				"remote sessions need a remote_hooks backend configured for this repo — press n for a local session, or configure remote_hooks and try again. Guide: https://sachiniyer.github.io/agent-factory/remote-hooks/"))
 		}
 	}
+	m.pendingForceRemote = remote
+	// The naming row needs a ROW, not a runtime (#2599).
+	//
+	// This instance exists so the rail has something to type a title into. It is
+	// thrown away on submit — startSessionThroughDaemon ignores it entirely and
+	// rebuilds the session from what the daemon returns — and killed on cancel. Yet
+	// NewInstance resolves the create's backend and PROVISIONS it, and for a
+	// non-local kind that is real work: dockerRuntime.Provision runs `docker run` +
+	// clone + `af agent-server`, hookRuntime.Provision runs the repo's launch_cmd.
+	// So in a repo whose config says backend = "docker"/"ssh"/"hook", pressing `n`
+	// was refused before the form ever opened, by an error thrown from inside a
+	// provisioner — the TUI could not create a session in that repo at all. It also
+	// contradicts #960: the daemon is the sole provisioner.
+	//
+	// Pinning the placeholder to the local runtime is what makes it inert.
+	// localRuntime.Provision is a pure constructor (ProvisionResult{Backend:
+	// &LocalBackend{}}) — no worktree, no tmux, no container, no git subprocess —
+	// so nothing is established anywhere until the daemon creates the real session.
+	//
+	// It costs no information: the placeholder's kind was never an input to the
+	// create. Both selectors travel to the daemon explicitly on
+	// sessionStartRequest — the naming form's backend field as Backend (#1933) and
+	// `N` as ForceRemote, now carried in m.pendingForceRemote rather than read back
+	// off this instance's capabilities — and the repo's own `backend` key is
+	// resolved daemon-side. All three still decide the session that gets built.
 	instance, err := session.NewInstance(session.InstanceOptions{
 		Title:                          "",
 		Path:                           repoPath,
 		Program:                        m.pendingProgram,
-		ForceRemote:                    remote,
+		Backend:                        session.BackendLocal,
 		ProvisionSessionEnvPassthrough: append([]string(nil), m.appConfig.SessionEnvPassthrough...),
 	})
 	if err != nil {

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -480,6 +480,8 @@ func TestHandleStateNewRejectsRemoteSlugCollision(t *testing.T) {
 	})
 	defer restore()
 
+	// The ALREADY-CREATED session really is remote — it was provisioned by the
+	// daemon — so it keeps its hook runtime; that is what the collision is against.
 	existing, err := session.NewInstance(session.InstanceOptions{
 		Title:       "myapp",
 		Path:        t.TempDir(),
@@ -489,14 +491,19 @@ func TestHandleStateNewRejectsRemoteSlugCollision(t *testing.T) {
 	require.NoError(t, err)
 	h.store.AddInstance(existing)
 
+	// The naming row does not. It provisions nothing (#2599), so `N` is carried on
+	// the model and the gate resolves the create's kind from that instead of from
+	// this instance's capabilities. A repo path with no `backend` key plus
+	// ForceRemote resolves to hook — the same answer the daemon will reach.
 	naming, err := session.NewInstance(session.InstanceOptions{
-		Title:       "my_app",
-		Path:        t.TempDir(),
-		Program:     "claude",
-		ForceRemote: true,
+		Title:   "my_app",
+		Path:    t.TempDir(),
+		Program: "claude",
+		Backend: session.BackendLocal,
 	})
 	require.NoError(t, err)
 	h.namingInstance = naming
+	h.pendingForceRemote = true
 
 	_, _ = h.handleStateNew(tea.KeyMsg{Type: tea.KeyEnter})
 

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -426,6 +426,15 @@ type home struct {
 	// so an untouched field keeps today's behavior byte-identical. Reset by
 	// startNewInstance so a cancelled create cannot leak a backend into the next.
 	pendingBackend string
+	// pendingForceRemote records that this naming flow began with `N` (new remote)
+	// rather than `n`. It used to be read back off the naming placeholder's
+	// capabilities, which only worked because the placeholder was PROVISIONED with
+	// the hook runtime while the user was still typing a title (#2599). The
+	// placeholder no longer resolves any runtime, so the selector has to be
+	// remembered here — it is a fact about the keypress, not about a session that
+	// does not exist yet. Reset by startNewInstance and cleared on every way the
+	// naming flow ends, exactly like pendingBackend.
+	pendingForceRemote bool
 	// backendPickerChoices is the option list the open backend picker is showing,
 	// held alongside the overlay for the same reason handoffChoices is: the list is
 	// built from the daemon's response (plus a leading "repo default" row), so the

--- a/app/naming_placeholder_test.go
+++ b/app/naming_placeholder_test.go
@@ -1,0 +1,235 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordPlaceholderProvision captures every InstanceOptions the backend factory
+// is asked to provision, and hands back a LocalBackend so the flow continues.
+// The factory is the boundary #2599 is about: everything past it is a real
+// runtime being established (docker run, a clone, launch_cmd), so what the
+// naming flow puts INTO it is the whole question.
+func recordPlaceholderProvision(t *testing.T) *[]session.InstanceOptions {
+	t.Helper()
+	var seen []session.InstanceOptions
+	t.Cleanup(session.SetBackendFactoryForTest(func(opts session.InstanceOptions, _ string) (session.Backend, error) {
+		seen = append(seen, opts)
+		return &session.LocalBackend{}, nil
+	}))
+	return &seen
+}
+
+// TestStartNewInstanceNeverProvisionsTheRepoBackend is the #2599 regression
+// guard. Pressing `n` builds a placeholder row so the rail has something to type
+// a title into — and that went through session.NewInstance, which RESOLVES the
+// create's backend and provisions it. In a repo whose config declares
+// backend = "docker"/"ssh"/"hook" that is a real provision before the user has
+// typed anything: dockerRuntime.Provision runs `docker run` + a clone + an
+// agent-server, hookRuntime.Provision runs the repo's launch_cmd.
+//
+// The observable damage was that the provision could REFUSE, and then the naming
+// form never opened at all — such a repo could not create a session from the TUI
+// by any keystroke. So this asserts both halves: the placeholder is never asked
+// to provision the repo's runtime, and the form opens regardless of what the repo
+// declares.
+//
+// A unit test cannot see the provision itself (a real dockerRuntime would need a
+// daemon and a container), which is why scripts/tui-2599-scenario.sh drives the
+// real TUI against the real factory. This pins the input that decides it.
+func TestStartNewInstanceNeverProvisionsTheRepoBackend(t *testing.T) {
+	for _, repoBackend := range []string{"", "docker", "ssh", "hook"} {
+		name := repoBackend
+		if name == "" {
+			name = "local default"
+		}
+		t.Run(name, func(t *testing.T) {
+			h := newTestHome(t)
+			h.errBox.SetSize(200, 1)
+			seen := recordPlaceholderProvision(t)
+			h.repoRoot = repoDeclaringBackend(t, repoBackend)
+
+			model, cmd := h.startNewInstance(false)
+
+			require.Same(t, h, model)
+			require.Nil(t, cmd, "pressing n must open the form, not report an error")
+			assert.Equal(t, stateNew, h.state,
+				"the naming form must open no matter which backend the repo declares")
+			require.NotNil(t, h.namingInstance, "the rail needs a row to name")
+
+			require.Len(t, *seen, 1, "exactly one placeholder is built")
+			got := (*seen)[0]
+			assert.Equal(t, session.BackendLocal, got.Backend,
+				"the placeholder must pin the local runtime; anything else provisions a sandbox for a row")
+			assert.False(t, got.ForceRemote,
+				"and must not reach the hook runtime through the legacy selector either")
+		})
+	}
+}
+
+// TestStartNewRemoteThreadsForceRemoteFromTheKeypress is the other half of the
+// same change, and the reason pinning the placeholder local is safe. `N`'s
+// selector used to be recoverable from the placeholder's capabilities BECAUSE it
+// had been provisioned as a hook runtime. Now that it is not, the flag has to
+// survive as a fact about the keypress — or a remote create would be silently
+// downgraded to a local one, which is the failure mode that makes #2599 look
+// fixed while breaking what it was fixing.
+//
+// This drives the REAL startNewInstance, not a hand-set field, so the whole chain
+// from keypress to request is covered: nothing here would notice if
+// m.pendingForceRemote were only ever set by tests.
+func TestStartNewRemoteThreadsForceRemoteFromTheKeypress(t *testing.T) {
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+
+	h := newTestHome(t)
+	h.errBox.SetSize(200, 1)
+	got := recordStartRequest(t)
+	seen := recordPlaceholderProvision(t)
+
+	repo, err := config.CurrentRepo()
+	require.NoError(t, err)
+	require.NoError(t, config.SaveRepoConfig(repo.ID, &config.RepoConfig{
+		RemoteHooks: &config.RemoteHooks{
+			LaunchCmd: "/bin/echo",
+			DeleteCmd: "/bin/echo",
+		},
+	}))
+	h.repoRoot = repoDir
+
+	model, cmd := h.startNewInstance(true)
+	require.Same(t, h, model)
+	require.Nil(t, cmd, "N in a hook-configured repo must open the form")
+	require.Equal(t, stateNew, h.state)
+
+	// The placeholder is inert even for N: launch_cmd must not run while the user
+	// is still choosing a name.
+	require.Len(t, *seen, 1)
+	assert.Equal(t, session.BackendLocal, (*seen)[0].Backend)
+	assert.False(t, (*seen)[0].ForceRemote,
+		"N must not provision the hook runtime at naming time")
+	require.True(t, h.pendingForceRemote, "the keypress itself must record the selector")
+
+	typeRunes(t, h, "remote-one")
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+
+	require.Equal(t, stateDefault, h.state, "the create must submit")
+	assert.True(t, got.ForceRemote,
+		"a create started with N must still reach the daemon as a remote create")
+	assert.Equal(t, "remote-one", got.Title)
+}
+
+// TestNamingCancelClearsTheRemoteSelector mirrors #1933's leak guard for the new
+// piece of naming state: a cancelled `N` must not make the NEXT `n` remote.
+func TestNamingCancelClearsTheRemoteSelector(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{name: "esc", key: tea.KeyMsg{Type: tea.KeyEsc}},
+		{name: "ctrl+c", key: tea.KeyMsg{Type: tea.KeyCtrlC}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			h.errBox.SetSize(200, 1)
+			recordPlaceholderProvision(t)
+			h.repoRoot = repoDeclaringBackend(t, "")
+			startNaming(t, h, "")
+			h.pendingForceRemote = true
+
+			_, _ = h.handleStateNew(tc.key)
+
+			assert.Equal(t, stateDefault, h.state)
+			assert.False(t, h.pendingForceRemote,
+				"a cancelled remote create must not leak its selector into the next one")
+		})
+	}
+}
+
+// TestNamingPlaceholderIgnoresAnUnreadableRepoConfig keeps the pin honest at the
+// edge that used to hard-fail. A repo whose `backend` key names nothing
+// resolvable made session.NewInstance return that error, so `n` was refused
+// before the form opened. The placeholder no longer resolves the repo's key at
+// all, so the form opens and the daemon states the verdict at submit — where the
+// user can still see the name they typed.
+func TestNamingPlaceholderIgnoresAnUnreadableRepoConfig(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(200, 1)
+	recordPlaceholderProvision(t)
+	h.repoRoot = repoDeclaringBackend(t, "moonbase")
+
+	model, cmd := h.startNewInstance(false)
+
+	require.Same(t, h, model)
+	assert.Nil(t, cmd, "an unresolvable repo backend must not refuse the keypress")
+	assert.Equal(t, stateNew, h.state, "the naming form must still open")
+	assert.Empty(t, h.errBox.FullError())
+}
+
+// TestNamingPlaceholderDoesNotReachDockerRuntime is the sharpest statement of
+// the bug, and the only one that does not depend on the factory seam: with the
+// REAL factory in place, a repo declaring backend = "docker" with no docker.image
+// used to fail inside dockerRuntime.Provision — the error quoted in #2599 — and
+// the form never opened. Nothing here stubs the runtime, so a regression that
+// restores the repo-config resolution fails on the real provisioner's refusal.
+func TestNamingPlaceholderDoesNotReachDockerRuntime(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(200, 1)
+	repoRoot := repoDeclaringBackend(t, "docker")
+	// No docker.image: exactly the config from the issue's repro.
+	h.repoRoot = repoRoot
+
+	model, cmd := h.startNewInstance(false)
+
+	require.Same(t, h, model)
+	require.Nil(t, cmd, "the docker runtime must never be asked to provision a naming row")
+	assert.Equal(t, stateNew, h.state)
+	assert.NotContains(t, h.errBox.FullError(), "docker.image",
+		"a BackendConfigError here means the provisioner ran for a placeholder")
+	require.NotNil(t, h.namingInstance)
+	assert.Equal(t, session.WorkspaceLocalWorktree, h.namingInstance.Capabilities().Workspace,
+		"the placeholder row is a row, not a sandbox")
+}
+
+// writeRepoDockerImage is a small helper for the config shape #2194 documents,
+// kept next to the tests that need a resolvable docker repo.
+func writeRepoDockerImage(t *testing.T, repoRoot, image string) {
+	t.Helper()
+	cfgDir := filepath.Join(repoRoot, config.InRepoConfigDirName)
+	require.NoError(t, os.MkdirAll(cfgDir, 0o755))
+	body := "backend = \"docker\"\n\n[docker]\nimage = \"" + image + "\"\n"
+	require.NoError(t, os.WriteFile(filepath.Join(cfgDir, config.TomlConfigFileName), []byte(body), 0o644))
+}
+
+// TestNamingPlaceholderSkipsAResolvableDockerRepo covers the second half of
+// #2599 — the half the issue inferred rather than observed. Where the docker
+// preconditions PASS nothing refuses the create, so the provision SUCCEEDS: a
+// container came up at naming time, named from Slugify("") because no title had
+// been typed, and the daemon then provisioned the real session on submit — one
+// create, two sandboxes, with the orphan reaped only if cancel got there.
+//
+// With the real factory and a repo that would satisfy the config check, the
+// placeholder must still be local: no container, one create, one sandbox.
+func TestNamingPlaceholderSkipsAResolvableDockerRepo(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(200, 1)
+	repoRoot := repoDeclaringBackend(t, "")
+	writeRepoDockerImage(t, repoRoot, "alpine:3.20")
+	h.repoRoot = repoRoot
+
+	model, cmd := h.startNewInstance(false)
+
+	require.Same(t, h, model)
+	require.Nil(t, cmd)
+	require.Equal(t, stateNew, h.state)
+	require.NotNil(t, h.namingInstance)
+	assert.Equal(t, session.WorkspaceLocalWorktree, h.namingInstance.Capabilities().Workspace,
+		"a satisfiable docker config must not be provisioned for a naming row either")
+}

--- a/app/preflight.go
+++ b/app/preflight.go
@@ -10,7 +10,7 @@ import (
 
 var localSessionPreflight = preflight.LocalSessionPrereqs
 
-func (m *home) preflightSessionCreate(instance *session.Instance) error {
+func (m *home) preflightSessionCreate() error {
 	// A backend picked in the naming form's field (#1933) decides this, and the
 	// placeholder instance cannot: it is constructed when the form OPENS, before the
 	// user has chosen anything, so its capabilities describe the repo default rather
@@ -34,17 +34,19 @@ func (m *home) preflightSessionCreate(instance *session.Instance) error {
 	// name that does not resolve cannot be the local backend, and a missing local
 	// `claude` is not what is wrong with it. The daemon owns the verdict on a
 	// backend it could not resolve, and states it when the create is submitted.
+	//
+	// Every input is now a fact about the CREATE rather than about the placeholder
+	// (#2599): the picked backend, and `N` via m.pendingForceRemote. The placeholder
+	// used to answer the `N` half through its capabilities, which only worked
+	// because it had been provisioned as a hook runtime while the user was still
+	// typing a title. It is pinned local now and provisions nothing, so reading its
+	// capabilities would report every create local and refuse a docker/ssh/hook
+	// session for a missing local `claude` — #2592, reintroduced in the TUI.
 	local, _ := session.LocalPrereqsRequired(session.InstanceOptions{
-		Backend: session.BackendKind(m.pendingBackend),
+		Backend:     session.BackendKind(m.pendingBackend),
+		ForceRemote: m.pendingForceRemote,
 	}, m.repoRoot)
 	if !local {
-		return nil
-	}
-	// The legacy `N` selector is not a backend pick — it lives on the placeholder,
-	// which is provisioned as a remote runtime — so its locality still reads from
-	// the instance. Local-session prerequisites only apply to a backend that runs
-	// the agent on a local worktree.
-	if instance == nil || instance.Capabilities().Workspace != session.WorkspaceLocalWorktree {
 		return nil
 	}
 	cfg, err := m.preflightConfig()

--- a/docs/tui-manual-testing.md
+++ b/docs/tui-manual-testing.md
@@ -371,6 +371,29 @@ first input — that round trip is the whole point of the feature and no marker
 can stand in for it. Re-run `n` afterwards and confirm the hint is back to
 `initial prompt` with no `✓`: a prompt must never leak into the next session.
 
+**Test the form in a repo that declares a non-local backend, too (#2599).** The
+naming row used to be built by provisioning the create's runtime, so in a repo
+whose `.agent-factory/config.json` says `backend = "docker"` (or `ssh`/`hook`)
+pressing `n` ran a real provisioner and the form never opened at all. Every
+create-form gate above passes in a local repo while that is broken, which is why
+this is its own step:
+
+```bash
+mkdir -p "$AF_DRIVER_REPO/.agent-factory"
+printf '{"backend": "docker"}\n' >"$AF_DRIVER_REPO/.agent-factory/config.json"
+af_boot; af_ensure_nav; af_focus_tree
+af_send n; af_wait_for 'submit name'          # the form opens at all
+af_send_literal 'declared'; af_send Enter
+af_wait_for 'docker'                          # the DAEMON refuses, naming docker
+```
+
+The second wait is the load-bearing one. A create that succeeds here as a local
+session means the placeholder's backend was pinned local and the repo's declared
+backend went with it — which passes "the form opens" and silently gives the user
+a session their repo did not ask for. The refusal has to come from the daemon
+and has to name the backend. `scripts/tui-2599-scenario.sh` automates all three
+legs (form opens, backend honored, `ctrl+r` → `local` still creates).
+
 ### Tree / selection / focus changes (the #1156, #1084 class)
 
 ```bash

--- a/scripts/tui-2599-scenario.sh
+++ b/scripts/tui-2599-scenario.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Real-TUI drive for #2599 (the naming form provisioned the repo's backend), via:
+#
+#   scripts/testbox.sh scenario scripts/tui-2599-scenario.sh
+#
+# The bug: pressing `n` built its placeholder row through session.NewInstance,
+# which RESOLVES the create's backend and provisions it. In a repo whose config
+# declares backend = "docker"/"ssh"/"hook" that ran a real provisioner before the
+# user had typed anything — and when the provisioner refused, the refusal came
+# out INSTEAD of the naming form. Such a repo could not create a session from the
+# TUI at all, by any keystroke.
+#
+# Why this cannot be a unit test alone, and why it cannot be written against
+# master: the app/ tests swap the backend factory (session.SetBackendFactoryForTest),
+# so the naming flow never reaches a real Provision under test — a green unit
+# suite proves nothing here. And the assertion "the form opens" is unreachable on
+# master by construction, because the form not opening IS the bug.
+#
+# The sandbox has no docker daemon inside it and the mock repo has no `origin`,
+# so `backend = "docker"` is a config the daemon will refuse AT CREATE. That is
+# the useful fixture: the refusal has to arrive from the daemon, after a naming
+# form the user could type into — not from a provisioner running behind a
+# keypress.
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source /src/scripts/tui-driver.sh
+
+# declare_repo_backend <backend> — write the in-repo config that opts this repo
+# into a non-local backend, the way docs/backends.md tells a user to (#2194).
+# Removing the file is how a leg goes back to the local default.
+declare_repo_backend() {
+    mkdir -p "$AF_DRIVER_REPO/.agent-factory"
+    printf '{"backend": "%s"}\n' "$1" >"$AF_DRIVER_REPO/.agent-factory/config.json"
+}
+
+clear_repo_backend() {
+    rm -f "$AF_DRIVER_REPO/.agent-factory/config.json"
+}
+
+# drive_form_opens_in_a_backend_repo is the bug itself. `n`, field untouched, in
+# a repo that declares docker: the naming form must open, and the refusal must
+# come from the DAEMON at submit and must NAME docker.
+#
+# Both halves matter and they fail in opposite directions. If the form does not
+# open, #2599 is unfixed. If the form opens and the create SUCCEEDS as a local
+# session, the fix silently downgraded the repo's declared backend to local —
+# which looks fixed, passes every "did the form open" check, and is worse than
+# the bug, because the user gets a session that is not the one their repo asked
+# for. The daemon naming docker in its refusal is what rules that out.
+drive_form_opens_in_a_backend_repo() {
+    export AF_DRIVER_COLS=120 AF_DRIVER_ROWS=30
+    export AF_DRIVER_REPO="$HOME/sandbox/mock-repo"
+
+    af_reset_sandbox
+    declare_repo_backend docker
+    af_boot
+    af_ensure_nav
+    af_focus_tree
+
+    af_send n
+    # THE assertion. On master this times out: the keypress is answered by a
+    # BackendConfigError thrown from inside dockerRuntime.Provision and the form
+    # never exists.
+    af_wait_for 'submit name' "$AF_DRIVER_TIMEOUT" \
+        'naming form opens in a docker-declared repo' || return 1
+
+    # And no provisioner ran behind the keypress: the config error the docker
+    # runtime raises must not be on screen while we are still naming.
+    local screen
+    screen="$(af_capture)"
+    if printf '%s\n' "$screen" | grep -qE 'docker\.image|requires docker'; then
+        _af_fail '#2599: a provisioner refused during naming — the placeholder was provisioned:'
+        printf '%s\n' "$screen" >&2
+        return 1
+    fi
+    _af_log 'assert OK: n opens the naming form in a repo declaring a non-local backend'
+
+    # Submit. The repo's declared backend has to survive to the daemon, which is
+    # the only thing that provisions (#960).
+    af_send_literal 'declared-docker'
+    af_send Enter
+    af_wait_for 'docker' "$AF_DRIVER_TIMEOUT" \
+        'the daemon refuses the create naming the declared backend' || return 1
+    screen="$(af_capture)"
+    if ! printf '%s\n' "$screen" | grep -qE 'docker\.image|requires docker|backend=docker'; then
+        _af_fail '#2599: the create was not refused for docker — the declared backend was downgraded to local:'
+        printf '%s\n' "$screen" >&2
+        return 1
+    fi
+    _af_log 'assert OK: the create still honors the repo backend — refused by the daemon, naming docker'
+
+    echo 'PASS: #2599 naming form opens in a backend-declaring repo'
+}
+
+# drive_create_completes_from_a_backend_repo answers the user-facing complaint:
+# "a docker/ssh/hook repo cannot create a session from the TUI at all". Opening
+# the form is necessary but not sufficient — the user has to be able to finish.
+#
+# The sandbox cannot run a container, so the create that completes is one the
+# user explicitly points at `local` in the ctrl+r field (#1933). That is the real
+# escape hatch this unblocks, and it also re-proves the field's precedence: an
+# explicit pick outranks the repo's key, in a repo where the key is not local.
+drive_create_completes_from_a_backend_repo() {
+    export AF_DRIVER_COLS=120 AF_DRIVER_ROWS=30
+    export AF_DRIVER_REPO="$HOME/sandbox/mock-repo"
+
+    af_reset_sandbox
+    declare_repo_backend docker
+    af_boot
+    af_ensure_nav
+    af_focus_tree
+
+    af_send n
+    af_wait_for 'submit name' "$AF_DRIVER_TIMEOUT" 'naming form' || return 1
+
+    af_send C-r
+    af_wait_for 'Select backend' "$AF_DRIVER_TIMEOUT" 'backend field opened' || return 1
+    # "local" is the row directly below "Repo default"; the repo default here is
+    # docker, which this sandbox cannot satisfy.
+    af_send Down
+    af_send Enter
+    af_wait_for 'backend ✓' "$AF_DRIVER_TIMEOUT" 'explicit local pick attached' || return 1
+    # Edge, not level: the naming status bar is painted UNDER the overlay, so a
+    # wait on 'submit name' would match while the picker still owns the keyboard
+    # and the title below would be typed into it (#1933's scenario learned this
+    # the expensive way).
+    af_wait_gone 'Select backend' "$AF_DRIVER_TIMEOUT" 'field closed' || return 1
+
+    af_send_literal 'escaped-to-local'
+    af_send Enter
+    af_wait_for 'escaped-to-local.*●' "$AF_DRIVER_TIMEOUT" \
+        "session 'escaped-to-local' reaches Ready" || return 1
+    _af_log 'assert OK: a session can be created from the TUI in a repo declaring a non-local backend'
+
+    echo 'PASS: #2599 create completes from a backend-declaring repo'
+}
+
+# drive_local_repo_unchanged is the no-regression leg. Everything above changes
+# how the placeholder is built for EVERY create, so the ordinary path — a repo
+# with no `backend` key, `n`, type, enter — has to be exactly what it was.
+drive_local_repo_unchanged() {
+    export AF_DRIVER_COLS=120 AF_DRIVER_ROWS=30
+    export AF_DRIVER_REPO="$HOME/sandbox/mock-repo"
+
+    af_reset_sandbox
+    clear_repo_backend
+    af_boot
+    af_ensure_nav
+    af_focus_tree
+
+    af_send n
+    af_wait_for 'submit name' "$AF_DRIVER_TIMEOUT" 'naming form' || return 1
+    af_send_literal 'plain-local'
+    af_send Enter
+    af_wait_for 'plain-local.*●' "$AF_DRIVER_TIMEOUT" "session 'plain-local' reaches Ready" || return 1
+    _af_log 'assert OK: the ordinary local create is unchanged'
+
+    echo 'PASS: #2599 local repo unchanged'
+}
+
+drive_form_opens_in_a_backend_repo
+drive_create_completes_from_a_backend_repo
+drive_local_repo_unchanged
+clear_repo_backend
+af_quit || true
+echo 'PASS: #2599 TUI naming form does not provision'


### PR DESCRIPTION
Closes #2599. Builds on #2611 (merged), which is the prerequisite — see *Why the order matters* below.

## The bug

Pressing `n` builds a placeholder `session.Instance` so the rail has a row to
type a title into. That went through `session.NewInstance`, which resolves the
create's backend and **provisions** it. For a non-local kind that is real work:
`dockerRuntime.Provision` runs `docker run` + a clone + an `af agent-server`;
`hookRuntime.Provision` runs the repo's `launch_cmd`.

So in a repo whose `.agent-factory/config.json` declares
`backend = "docker"`/`"ssh"`/`"hook"`, the provisioner ran behind the keypress —
and when it refused, the refusal arrived *instead of the naming form*. That repo
could not create a session from the TUI at all, by any keystroke, while the CLI
and web could. It also contradicts #960: the daemon is the sole provisioner, and
this was the TUI provisioning.

## The fix

The placeholder pins the local runtime. `localRuntime.Provision` is a pure
constructor — `ProvisionResult{Backend: &LocalBackend{}}`, no worktree, no tmux,
no container, not even the `originRemoteURL` subprocess — so nothing is
established anywhere until the daemon creates the real session.

That costs no information: the placeholder's kind was never an input to the
create. It is thrown away on submit (`startSessionThroughDaemon` ignores it and
rebuilds from `FromInstanceData`). But two facts *were* being read back off it,
and both had to move to stay correct:

- **`N`** was recovered as `instance.Capabilities().Workspace == WorkspaceRemote`
  — which only worked because the placeholder had been provisioned as a hook
  runtime while the user was still typing. It is now `m.pendingForceRemote`, a
  fact about the keypress, cleared on submit/Esc/ctrl+c like `pendingBackend`.
- **The hook-slug pre-check** resolved through the same capabilities. It now
  calls `session.BackendKindFor` on the pending selection — the same decision the
  daemon makes, by the same precedence, creating nothing. Its predicate is
  unchanged (`!= BackendLocal`, exactly equivalent to the old `WorkspaceRemote`
  test, since docker/ssh/hook all embed `remoteAgentBackend`), so this PR changes
  lifecycle, not gate semantics. An unresolvable kind defers to the daemon rather
  than guessing remote.

**Missing either of those is the failure mode that matters**, and it is worse
than the bug: a remote create silently downgraded to a local one passes every
"did the form open" check and hands the user a session their repo did not ask
for. `TestStartNewRemoteThreadsForceRemoteFromTheKeypress` drives the real
`startNewInstance(true)` rather than setting the field by hand, so nothing here
would stay green if `pendingForceRemote` were only ever set by tests.

## Why the order matters

#2611 had to land first, and its own description now says so. Pinning the
placeholder local makes `instance.Capabilities().Workspace` **permanently local**
— so the pre-#2611 preflight gate, which inferred agent locality from that
workspace property, would have started refusing every docker/ssh/hook create for
a missing local `claude`. That is #2592, reintroduced in the TUI by this PR. With
#2611 merged the gate reads the resolved backend kind instead, and this change is
safe.

## Verification — the real TUI, not the unit suite

The app tests swap the backend factory (`session.SetBackendFactoryForTest`), so
the naming flow never reaches a real `Provision` under test. **A green unit suite
proves nothing about this bug.** `scripts/tui-2599-scenario.sh` drives the real
TUI against a real daemon and the real factory, in a mock repo whose in-repo
config declares docker.

Against the pre-fix tree — the issue's repro, reproduced:

```
[tui-driver] TIMEOUT 25s waiting for: naming form opens in a docker-declared repo
[tui-driver] ----- last screen -----
 Agent Factory                │  No sessions yet — press n to create one.
                                   n new · N new remote │ / search │ ? help · q quit
```

After:

```
[tui-driver] assert OK: n opens the naming form in a repo declaring a non-local backend
[tui-driver] assert OK: the create still honors the repo backend — refused by the daemon, naming docker
[tui-driver] assert OK: a session can be created from the TUI in a repo declaring a non-local backend
[tui-driver] assert OK: the ordinary local create is unchanged
PASS: #2599 TUI naming form does not provision
```

The middle two are the ones worth reading. **"refused by the daemon, naming
docker"** is what proves the declared backend survived to the daemon instead of
being downgraded — a fix that pinned the whole *create* local would make that leg
create a session successfully, and pass every other assertion here. **"a session
can be created"** answers the actual complaint: `ctrl+r` → `local` now completes
a create in a repo where nothing could be created before.

Two unit guards run against the **real** factory, no seam, so they fail on the
provisioner's own refusal if the repo-config resolution ever comes back:
`TestNamingPlaceholderDoesNotReachDockerRuntime` (the issue's exact config) and
`TestNamingPlaceholderSkipsAResolvableDockerRepo` (the half the issue *inferred*
— where the preconditions pass, the provision used to **succeed**, so one create
came up twice, the first named from `Slugify("")`).

Every test here was watched red first:

```
--- FAIL: TestStartNewInstanceNeverProvisionsTheRepoBackend/{docker,ssh,hook}
--- FAIL: TestStartNewRemoteThreadsForceRemoteFromTheKeypress
        Backend: expected "local", actual ""; ForceRemote should be false
        the keypress itself must record the selector
--- FAIL: TestNamingPlaceholderDoesNotReachDockerRuntime
        the docker runtime must never be asked to provision a naming row
--- FAIL: TestNamingPlaceholderSkipsAResolvableDockerRepo
```

## Two existing tests changed, and why that is not defanging

`TestNamingFormBackendAndForceRemoteAgree` and
`TestHandleStateNewRejectsRemoteSlugCollision` both put the model into the `N`
state by building the naming instance with `ForceRemote: true` behind a swapped
factory. That state no longer exists — the naming row is never a hook runtime —
so they now set `h.pendingForceRemote`, which is what `startNewInstance(true)`
leaves behind. Same product assertions, same direction; only the setup moved. The
slug test keeps its *existing* session on the hook backend, because that one
really was provisioned by the daemon and is what the collision is against.

Because that edit is exactly the shape of a test being made to pass, the new
end-to-end guard above exists specifically to cover the wiring those two now
assume.

## A visible side effect

While naming, the row's capabilities read local even for `N` (nothing is
provisioned, so there is nothing else they could honestly say). Only the naming
row is affected, and only until submit.

## Gates

All six, run **after** the final commit against the pushed head
`cb59e9f1c2d1eb4c241329a6485ce20b8af82698`:

| Gate | Result |
|---|---|
| `golangci-lint run --timeout=3m --fast` | clean |
| `gofmt -l .` | no output |
| `go build ./...` | clean |
| `make test-container` | 42 packages `ok`, zero failures |
| `deadcode -test ./...` | no output |
| `scripts/lint-file-length.sh` | passed (1089 files, 0 grandfathered) |

Plus `scripts/testbox.sh scenario scripts/tui-2599-scenario.sh` — red before,
green after, output quoted above.

— Captain Claude
