### PR TITLE
fix(ci): build the integration images from a local-only base (#2521)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -118,33 +118,48 @@ jobs:
       - name: Install zsh
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends zsh
 
-      # Warm the base image the integration docker/ssh round-trip tests build
-      # (FROM alpine:3.20) ONCE, with retry, so each per-test `docker build`
-      # resolves it from the local cache instead of hammering Docker Hub. A
-      # registry blip there reddened master twice in an hour (#2521); warming
-      # absorbs the transient blips that caused that. Each pull is bounded by
-      # `timeout` so a black-holed registry cannot hang the step; there is no
-      # sleep after the final attempt. Best-effort: if the registry stays down
-      # for the whole warm window the step still succeeds, and the test build
-      # then fails loudly on the real registry error rather than being silently
-      # skipped — a sustained outage is rare and honest, a misclassified skip is
-      # not.
-      - name: Warm the integration base image (alpine:3.20)
-        run: |
-          for i in 1 2 3 4 5; do
-            if timeout 120 docker pull alpine:3.20; then
-              echo "warmed alpine:3.20 on attempt $i"
-              exit 0
-            fi
-            if [ "$i" -lt 5 ]; then
-              echo "::warning::alpine:3.20 pull attempt $i failed; retrying"
-              sleep $((i * 5))
-            fi
-          done
-          echo "::warning::could not warm alpine:3.20 after 5 attempts; the integration docker builds will fail loudly if the registry stays unreachable (#2521)"
-
+      # There is deliberately no "warm alpine:3.20" step here any more (#2521).
+      # It used to live in this job alone, which was the whole problem: FOUR
+      # lanes run the full suite — this one, build.yml, auto-release.yml and
+      # stable-release.yml — and the warm only ever reached this one. Both
+      # observed failures landed on lanes that never had it, and the test's own
+      # "base image is pre-pulled by CI" message then misattributed them to
+      # buildkit re-resolving a cached tag. The base is now obtained by the test
+      # binary itself (integration/base_image_test.go), once, with retry, so
+      # every lane and every developer machine gets the same guarantee and no
+      # future workflow can forget it.
       - name: Run tests
         run: go test -v -race -count=1 ./...
+
+  # The round-trip image builds must resolve NOTHING against a registry (#2521).
+  #
+  # That property is an absence — no request went out — and the ordinary suite
+  # cannot tell an absent request from a healthy network, which is exactly how
+  # the first fix attempt shipped believing it had removed a dependency it had
+  # not. This job stands up a second docker daemon with its egress dropped and
+  # measures it directly: the block is proven real, the bug's own reproduction
+  # is re-run (the public base, absent locally, must still fail in `load
+  # metadata`), and only then are the real Dockerfiles built.
+  #
+  # It runs on every PR rather than behind an `integration/**` filter: the thing
+  # it protects is a property of the whole test harness, and the change most
+  # likely to reintroduce a registry fetch is a Dockerfile or workflow edit
+  # nobody thought of as touching integration.
+  registry-free:
+    name: Registry-free image build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - name: Prove the image builds need no registry
+        run: make registry-free-check
 
   # KillMode=process is the compatibility fence that keeps pre-scope tmux
   # servers alive, so the daemon's abrupt-failure cleanup cannot be proven by
@@ -330,7 +345,7 @@ jobs:
     # blocks anyway, since it demands conclusion === "success", but the native path
     # would not.) So: run ALWAYS, and fail loudly on any unsuccessful need. Now a
     # red macOS job turns the REQUIRED check red instead of quietly skipping it.
-    needs: [lint, test, test-systemd, test-macos, web]
+    needs: [lint, test, test-systemd, test-macos, web, registry-free]
     if: always()
     steps:
       - name: Gate on the jobs this check stands in for
@@ -339,7 +354,7 @@ jobs:
           echo "::error::A required job failed — failing Build so the required check goes RED rather than skipping."
           # needs['test-macos'], not needs.test-macos: a hyphen in a property path is
           # parsed as subtraction, so the dotted form silently yields an empty string.
-          echo "lint=${{ needs.lint.result }} test=${{ needs.test.result }} test-systemd=${{ needs['test-systemd'].result }} test-macos=${{ needs['test-macos'].result }} web=${{ needs.web.result }}"
+          echo "lint=${{ needs.lint.result }} test=${{ needs.test.result }} test-systemd=${{ needs['test-systemd'].result }} test-macos=${{ needs['test-macos'].result }} web=${{ needs.web.result }} registry-free=${{ needs['registry-free'].result }}"
           exit 1
 
       - uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 .PHONY: test-container remote-roundtrip-container ws-pty-roundtrip-container \
 	agent-server-roundtrip-container remote-agent-server-roundtrip-container \
-	backend-docker-roundtrip backend-ssh-roundtrip \
+	backend-docker-roundtrip backend-ssh-roundtrip registry-free-check \
 	playtest-container playtest-container-detached tui-driver tui-driver-selftest \
 	lifecycle-container lifecycle-selftest \
 	testbox-image testbox-clean testbox-selftest \
@@ -89,6 +89,16 @@ backend-docker-roundtrip:
 # where docker is unavailable. See docs/backends.md.
 backend-ssh-roundtrip:
 	go test ./integration -run 'TestSSHBackend(RoundTrip|ArchiveRestore)' -v -count=1 -timeout 20m
+
+# Registry-free build check (#2521): proves the round-trip image builds above
+# resolve NOTHING against a registry, by standing up a second docker daemon with
+# its egress dropped and building the real Dockerfiles inside it. It also runs
+# the bug's own reproduction every time — FROM the public base, with that base
+# absent, must still fail in `load metadata` — so the check can never pass by
+# measuring a network that was quietly reachable. Runs ON THE HOST (needs a real
+# docker daemon and privileged containers); SKIPS where docker is unavailable.
+registry-free-check:
+	AF_REGISTRY_BLOCKED_CHECK=1 go test ./integration -run TestImageBuildsWithRegistryBlocked -v -count=1 -timeout 20m
 
 # Session runtime image (#2194): the bring-your-own container image the docker
 # backend runs sessions in. There is NO af-published image (Sachin-locked

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -245,6 +245,14 @@ kill. A second case commits real work on the session branch, **archives** it
 is present, and the session is drivable again). It skips cleanly where Docker is
 unavailable.
 
+These builds resolve nothing against a registry. The public base is fetched once
+per test binary, with retry, and retagged to a local-only name the Dockerfiles
+build `FROM`; a base that cannot be fetched at all skips, the same way a missing
+Docker daemon does. `make registry-free-check` proves it, by building the real
+Dockerfiles inside a second Docker daemon whose egress is dropped — and re-running
+this bug's own reproduction each time, so it cannot pass by measuring a network
+that was quietly reachable (#2521).
+
 ### Making docker the default backend for a repo
 
 To run a repo's sessions in containers by default, set `backend = "docker"` in

--- a/integration/backend_docker_test.go
+++ b/integration/backend_docker_test.go
@@ -227,20 +227,18 @@ func buildDockerRoundTripImage(t *testing.T) string {
 	t.Helper()
 	const tag = "af-docker-roundtrip:test"
 	dir := t.TempDir()
-	dockerfile := "FROM alpine:3.20\nRUN apk add --no-cache git tmux bash\n"
+	// FROM a local-only base, so this build resolves no remote reference at all
+	// (#2521). requireRoundTripBaseImage is the one step that may reach a
+	// registry, and it has already run by the time the Dockerfile is written.
+	dockerfile := dockerRoundTripDockerfile(requireRoundTripBaseImage(t))
 	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte(dockerfile), 0644); err != nil {
 		t.Fatalf("write Dockerfile: %v", err)
 	}
-	// The base image (FROM alpine:3.20) is pre-pulled by CI's warm step (pr.yml)
-	// with retry, so this build normally resolves it from the local cache and
-	// never touches the registry (#2521). A failure here therefore means either a
-	// real image/Dockerfile problem or the registry stayed unreachable for the
-	// whole run — both loud, neither silently skipped.
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "docker", "build", "-t", tag, dir)
 	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("building the round-trip image failed (base image is pre-pulled by CI; a failure here is a real build error or a registry unreachable for the whole run): %v\n%s", err, out)
+		t.Fatalf("building the round-trip image failed. Its base is already in the local image store and its FROM names no registry, so this is a real build error, not a registry outage: %v\n%s", err, out)
 	}
 	return tag
 }

--- a/integration/backend_ssh_test.go
+++ b/integration/backend_ssh_test.go
@@ -222,40 +222,21 @@ func buildSSHDRoundTripImage(t *testing.T) string {
 	t.Helper()
 	const tag = "af-sshd-roundtrip:test"
 	dir := t.TempDir()
-	dockerfile := "FROM alpine:3.20\n" +
-		"RUN apk add --no-cache git tmux bash openssh-server\n" +
-		"RUN ssh-keygen -A && mkdir -p /root/.ssh && chmod 700 /root/.ssh\n" +
-		// The ssh runtime reaches the remote agent-server through an ssh
-		// local-forward (direct-tcpip) tunnel, which the sshd must permit — alpine's
-		// default sshd_config ships an active `AllowTcpForwarding no` (first-match
-		// wins, so replace it in place rather than appending an override).
-		"RUN sed -i 's/^AllowTcpForwarding.*/AllowTcpForwarding yes/' /etc/ssh/sshd_config\n" +
-		"COPY entrypoint.sh /entrypoint.sh\n" +
-		"RUN chmod +x /entrypoint.sh\n" +
-		"ENTRYPOINT [\"/entrypoint.sh\"]\n"
-	entrypoint := "#!/bin/sh\n" +
-		"set -e\n" +
-		"if [ -f /authorized_keys ]; then\n" +
-		"  cp /authorized_keys /root/.ssh/authorized_keys\n" +
-		"  chmod 600 /root/.ssh/authorized_keys\n" +
-		"fi\n" +
-		"exec /usr/sbin/sshd -D -e\n"
+	// FROM a local-only base, so this build resolves no remote reference at all
+	// (#2521). requireRoundTripBaseImage is the one step that may reach a
+	// registry, and it has already run by the time the Dockerfile is written.
+	dockerfile := sshdRoundTripDockerfile(requireRoundTripBaseImage(t))
 	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte(dockerfile), 0644); err != nil {
 		t.Fatalf("write Dockerfile: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "entrypoint.sh"), []byte(entrypoint), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "entrypoint.sh"), []byte(sshdRoundTripEntrypoint()), 0644); err != nil {
 		t.Fatalf("write entrypoint.sh: %v", err)
 	}
-	// The base image (FROM alpine:3.20) is pre-pulled by CI's warm step (pr.yml)
-	// with retry, so this build normally resolves it from the local cache and
-	// never touches the registry (#2521). A failure here therefore means either a
-	// real image/Dockerfile problem or the registry stayed unreachable for the
-	// whole run — both loud, neither silently skipped.
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "docker", "build", "-t", tag, dir)
 	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("building the sshd round-trip image failed (base image is pre-pulled by CI; a failure here is a real build error or a registry unreachable for the whole run): %v\n%s", err, out)
+		t.Fatalf("building the sshd round-trip image failed. Its base is already in the local image store and its FROM names no registry, so this is a real build error, not a registry outage: %v\n%s", err, out)
 	}
 	return tag
 }

--- a/integration/base_image_test.go
+++ b/integration/base_image_test.go
@@ -1,0 +1,182 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The round-trip image builds are registry-free by construction (#2521).
+//
+// Four tests here (TestDockerBackendRoundTrip, TestSSHBackendRoundTrip and the
+// two ArchiveRestore variants) build a throwaway image on top of a public base.
+// While the Dockerfiles said `FROM alpine:3.20`, every one of those builds
+// resolved that tag through docker.io, so a Docker Hub blip reddened whatever
+// happened to be running: master on the #2581 merge, then the v1.0.211 stable
+// release an hour later.
+//
+// The fix splits the two jobs that build was doing at once:
+//
+//  1. OBTAINING the base. Happens here, at most once per test binary, with
+//     bounded retry, and is the ONLY step that may touch a registry.
+//  2. BUILDING on top of it. Happens FROM roundTripBaseImage, a name no
+//     registry serves, so buildkit has nothing it could resolve remotely.
+//
+// Measured against docker 28.5.2 with the daemon's egress dropped: a build whose
+// base is already in the local image store completes without a single registry
+// request, and a build whose base is absent fails in `[internal] load metadata`
+// with exactly the CI signature. So presence in the local store — not the
+// spelling of the FROM line — is what removes the round trip; the local-only
+// name is what keeps it removed, since no future resolve-mode or `--pull`
+// change can turn it back into a fetch. TestImageBuildsWithRegistryBlocked
+// holds both halves of that claim.
+//
+// Doing this here rather than in CI is the other half of the fix. #2525 warmed
+// the base in a workflow step, but four separate lanes run `go test ./...`
+// (pr.yml, build.yml, auto-release.yml, stable-release.yml) and only pr.yml
+// ever got the step — which is why both observed failures happened on lanes
+// that never had it. A guarantee that lives in the test binary covers every
+// lane, plus every developer machine, and cannot be forgotten by the next
+// workflow.
+const (
+	// roundTripBaseUpstream is the public base the round-trip images are built
+	// on, and the one reference in these tests that a registry may serve.
+	roundTripBaseUpstream = "alpine:3.20"
+
+	// roundTripBaseImage is the LOCAL-ONLY name the Dockerfiles FROM. Nothing
+	// publishes `af-integration-base`, so the reference can only ever be
+	// satisfied from the local image store. The tag carries the upstream
+	// version so that bumping roundTripBaseUpstream cannot silently keep
+	// serving a retag of the old one.
+	roundTripBaseImage = "af-integration-base:alpine-3.20"
+)
+
+var (
+	baseImageOnce sync.Once
+	// baseImageUnavailable records that the base could not be obtained at all —
+	// environmental, the same class as docker being absent, so it skips.
+	baseImageUnavailable error
+	// baseImageBroken records a docker failure that is NOT about reachability
+	// (a `docker tag` that fails is not a registry outage), so it fails loudly.
+	baseImageBroken error
+)
+
+// requireRoundTripBaseImage guarantees roundTripBaseImage is in the local image
+// store and returns it, fetching the upstream base at most once per test binary.
+//
+// It skips ONLY when the base cannot be obtained at all — an unreachable
+// registry is environmental unavailability, exactly like requireDocker's missing
+// daemon, and no product defect can produce it. Every build failure after this
+// point is a real one and still fails loudly.
+func requireRoundTripBaseImage(t *testing.T) string {
+	t.Helper()
+	baseImageOnce.Do(func() { baseImageUnavailable, baseImageBroken = ensureRoundTripBaseImage() })
+	if baseImageBroken != nil {
+		t.Fatalf("preparing the round-trip base image failed for a reason that is not registry reachability: %v", baseImageBroken)
+	}
+	if baseImageUnavailable != nil {
+		t.Skipf("could not obtain the round-trip base image %s, so there is nothing to build on: %v\n"+
+			"This is the one registry-dependent step left in these tests (#2521); the builds themselves "+
+			"never resolve a remote reference. A failure anywhere past this point is a real defect, not this skip.",
+			roundTripBaseUpstream, baseImageUnavailable)
+	}
+	return roundTripBaseImage
+}
+
+// ensureRoundTripBaseImage populates the local-only base tag. It returns
+// (unavailable, broken): at most one is non-nil.
+func ensureRoundTripBaseImage() (unavailable, broken error) {
+	if dockerImagePresent(roundTripBaseImage) {
+		return nil, nil
+	}
+	if !dockerImagePresent(roundTripBaseUpstream) {
+		if err := pullRoundTripBase(); err != nil {
+			return err, nil
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "docker", "tag", roundTripBaseUpstream, roundTripBaseImage)
+	cmd.WaitDelay = 10 * time.Second
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("docker tag %s %s: %v: %s", roundTripBaseUpstream, roundTripBaseImage, err, strings.TrimSpace(string(out)))
+	}
+	return nil, nil
+}
+
+// pullRoundTripBase fetches the public base with bounded retry. The blips that
+// caused #2521 lasted seconds, so a few spaced attempts absorb them; a sustained
+// outage returns the last error and the caller skips.
+func pullRoundTripBase() error {
+	var last error
+	for i, wait := range []time.Duration{0, 5 * time.Second, 15 * time.Second} {
+		if wait > 0 {
+			time.Sleep(wait)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		cmd := exec.CommandContext(ctx, "docker", "pull", roundTripBaseUpstream)
+		cmd.WaitDelay = 10 * time.Second
+		out, err := cmd.CombinedOutput()
+		cancel()
+		if err == nil {
+			return nil
+		}
+		last = fmt.Errorf("pull attempt %d/3: %v: %s", i+1, err, strings.TrimSpace(string(out)))
+	}
+	return last
+}
+
+// dockerImagePresent reports whether a reference is in the local image store.
+// `docker image inspect` is local-only — it answers with the registry
+// unreachable, which is what makes it a usable precondition here.
+func dockerImagePresent(ref string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "docker", "image", "inspect", ref)
+	cmd.WaitDelay = 10 * time.Second
+	return cmd.Run() == nil
+}
+
+// dockerRoundTripDockerfile is the docker round-trip image: the minimum a BYO
+// image needs for the in-container agent-server (git worktree + tmux PTY).
+//
+// It takes the base as a parameter rather than baking it in so that
+// TestImageBuildsWithRegistryBlocked builds THIS text, not a copy of it — a
+// second spelling of the FROM line is exactly how the property under test would
+// rot without anything going red.
+func dockerRoundTripDockerfile(base string) string {
+	return "FROM " + base + "\nRUN apk add --no-cache git tmux bash\n"
+}
+
+// sshdRoundTripDockerfile is the ssh round-trip image: a real sshd target for
+// the ssh runtime, with host keys baked at build time so they are stable for
+// known_hosts pinning.
+func sshdRoundTripDockerfile(base string) string {
+	return "FROM " + base + "\n" +
+		"RUN apk add --no-cache git tmux bash openssh-server\n" +
+		"RUN ssh-keygen -A && mkdir -p /root/.ssh && chmod 700 /root/.ssh\n" +
+		// The ssh runtime reaches the remote agent-server through an ssh
+		// local-forward (direct-tcpip) tunnel, which the sshd must permit — alpine's
+		// default sshd_config ships an active `AllowTcpForwarding no` (first-match
+		// wins, so replace it in place rather than appending an override).
+		"RUN sed -i 's/^AllowTcpForwarding.*/AllowTcpForwarding yes/' /etc/ssh/sshd_config\n" +
+		"COPY entrypoint.sh /entrypoint.sh\n" +
+		"RUN chmod +x /entrypoint.sh\n" +
+		"ENTRYPOINT [\"/entrypoint.sh\"]\n"
+}
+
+// sshdRoundTripEntrypoint installs the mounted authorized_keys and runs sshd in
+// the foreground.
+func sshdRoundTripEntrypoint() string {
+	return "#!/bin/sh\n" +
+		"set -e\n" +
+		"if [ -f /authorized_keys ]; then\n" +
+		"  cp /authorized_keys /root/.ssh/authorized_keys\n" +
+		"  chmod 600 /root/.ssh/authorized_keys\n" +
+		"fi\n" +
+		"exec /usr/sbin/sshd -D -e\n"
+}

--- a/integration/registry_blocked_test.go
+++ b/integration/registry_blocked_test.go
@@ -1,0 +1,223 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// registryBlockedEnv gates the check. It stands up a privileged docker-in-docker
+// container and is far too heavy for every `go test ./...`, so it skips unless
+// asked for: `make registry-free-check`, and one job in pr.yml.
+const registryBlockedEnv = "AF_REGISTRY_BLOCKED_CHECK"
+
+// dindImage is the isolated daemon. Pinned: a moving tag would make this check's
+// own setup a registry dependency with unpredictable content.
+const dindImage = "docker:28-dind"
+
+// TestImageBuildsWithRegistryBlocked is the assertion that separates the #2521
+// fix from another mitigation that merely works while Docker Hub is healthy.
+//
+// Everything else about the fix is observable only as an absence — no request
+// went out — and an absence is exactly what a passing test cannot normally
+// distinguish from a healthy network. So this stands up a second docker daemon
+// with its egress dropped and measures the property directly, in three parts:
+//
+//	the block is real  — a pull of a not-local tag must FAIL, or the check is vacuous
+//	the bug is real    — FROM the public base, absent locally, must fail in `load
+//	                     metadata` with the exact signature that reddened master
+//	                     and the v1.0.211 release
+//	the fix works      — the REAL round-trip Dockerfiles, FROM the local-only
+//	                     base, must BUILD with the registry unreachable
+//
+// The middle part is the one worth keeping honest about: it is this bug's
+// reproduction, run every time, so the check can never pass by measuring
+// nothing. It also encodes the correction to the original diagnosis — the
+// round trip is caused by the base being ABSENT, not by buildkit re-resolving a
+// tag it already holds. A build whose base is in the local store completes with
+// no registry request at all, which is why the pre-pull in #2525 was the right
+// idea; it just only ever reached one of the four lanes that needed it.
+//
+// The Dockerfiles come from the same functions the real tests use, so this
+// cannot drift into proving a property about a copy of them.
+func TestImageBuildsWithRegistryBlocked(t *testing.T) {
+	if os.Getenv(registryBlockedEnv) != "1" {
+		t.Skipf("set %s=1 to run the registry-blocked build check (make registry-free-check); it needs a privileged docker-in-docker container", registryBlockedEnv)
+	}
+	requireDocker(t)
+	base := requireRoundTripBaseImage(t)
+
+	d := startIsolatedDaemon(t)
+	d.seedImage(t, base)
+
+	// Drop the daemon's OWN egress. Locally-generated packets traverse OUTPUT,
+	// so this kills registry resolution; a build's RUN steps are forwarded
+	// instead of locally generated, so `apk add` still reaches the network and
+	// the REAL Dockerfiles remain buildable. That asymmetry is what lets this
+	// check exercise the actual images rather than a network-free stand-in.
+	d.mustRun(t, 30*time.Second, "drop the isolated daemon's egress",
+		"iptables -A OUTPUT -o lo -j ACCEPT && iptables -P OUTPUT DROP")
+
+	// The block is real. Without this the whole check could pass by measuring a
+	// daemon that was never actually cut off.
+	if out, err := d.run(60*time.Second, "docker pull "+roundTripBaseUpstream); err == nil {
+		t.Fatalf("the registry block is not in effect — a pull of %s SUCCEEDED, so this check proves nothing:\n%s", roundTripBaseUpstream, out)
+	}
+	t.Logf("registry block verified: %s cannot be pulled inside the isolated daemon", roundTripBaseUpstream)
+
+	// The bug is real. Nothing seeded `alpine:3.20` into this daemon — only the
+	// local-only retag — so a Dockerfile naming the public base has to resolve
+	// it remotely, and cannot.
+	ctl := d.buildContext(t, "control", dockerRoundTripDockerfile(roundTripBaseUpstream), nil)
+	out, err := d.run(300*time.Second, "docker build -t af-registry-blocked-control "+ctl)
+	if err == nil {
+		t.Fatalf("FROM %s built with the registry blocked and the base absent — the reproduction no longer reproduces, so this check is no longer measuring #2521:\n%s", roundTripBaseUpstream, out)
+	}
+	if !strings.Contains(out, "failed to resolve source metadata") {
+		t.Fatalf("FROM %s failed, but not with the #2521 signature (`failed to resolve source metadata`), so this check may be measuring an unrelated breakage:\n%s", roundTripBaseUpstream, out)
+	}
+	t.Logf("reproduction confirmed: FROM %s fails in `load metadata` exactly as it did on master and on the v1.0.211 release", roundTripBaseUpstream)
+
+	// The fix works: the real images, from the local-only base, with the
+	// registry unreachable.
+	for _, tc := range []struct {
+		name       string
+		dockerfile string
+		extra      map[string]string
+	}{
+		{"docker round-trip image", dockerRoundTripDockerfile(base), nil},
+		{"sshd round-trip image", sshdRoundTripDockerfile(base), map[string]string{"entrypoint.sh": sshdRoundTripEntrypoint()}},
+	} {
+		dir := d.buildContext(t, strings.ReplaceAll(tc.name, " ", "-"), tc.dockerfile, tc.extra)
+		out, err := d.run(600*time.Second, "docker build -t af-registry-blocked-subject "+dir)
+		if err != nil {
+			t.Fatalf("the %s did NOT build with the registry blocked — the fix does not hold: %v\n%s", tc.name, err, out)
+		}
+		if strings.Contains(out, "registry-1.docker.io") {
+			t.Fatalf("the %s built, but its output names registry-1.docker.io, so something still reached for it:\n%s", tc.name, out)
+		}
+		t.Logf("%s built with registry-1.docker.io unreachable", tc.name)
+	}
+}
+
+// --- isolated daemon helpers ------------------------------------------------
+
+// isolatedDaemon is a throwaway dockerd in its own container, so its egress can
+// be cut without touching the host's daemon or anything else running on the box.
+type isolatedDaemon struct{ name string }
+
+// startIsolatedDaemon boots the daemon and registers its teardown.
+func startIsolatedDaemon(t *testing.T) *isolatedDaemon {
+	t.Helper()
+	if !dockerImagePresent(dindImage) {
+		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "docker", "pull", dindImage)
+		cmd.WaitDelay = 10 * time.Second
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Skipf("cannot fetch %s, so the isolated daemon cannot be started: %v\n%s", dindImage, err, out)
+		}
+	}
+
+	d := &isolatedDaemon{name: fmt.Sprintf("af-registry-blocked-%d", os.Getpid())}
+	dockerCLI(t, 60*time.Second, false, "rm", "-f", d.name)
+	t.Cleanup(func() { dockerCLI(t, 60*time.Second, false, "rm", "-f", d.name) })
+
+	// vfs, not the default overlay2: the host's own storage is already an
+	// overlay on most CI runners and in the test container, and overlay-on-overlay
+	// is the classic dind failure. The images here are small enough that vfs's
+	// layer duplication does not matter.
+	dockerCLI(t, 120*time.Second, true, "run", "-d", "--privileged", "--name", d.name, dindImage, "--storage-driver", "vfs")
+
+	deadline := time.Now().Add(90 * time.Second)
+	for {
+		if _, err := d.run(15*time.Second, "docker version"); err == nil {
+			return d
+		}
+		if time.Now().After(deadline) {
+			logs, _ := dockerCLIOutput(60*time.Second, "logs", "--tail", "40", d.name)
+			t.Fatalf("the isolated daemon never became ready:\n%s", logs)
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+// seedImage copies an image from the host's store into the isolated daemon's,
+// without either of them contacting a registry. A save/cp/load round trip rather
+// than a pipeline: nothing streams on stdin, so nothing can be truncated.
+func (d *isolatedDaemon) seedImage(t *testing.T, ref string) {
+	t.Helper()
+	tar := filepath.Join(t.TempDir(), "base.tar")
+	dockerCLI(t, 300*time.Second, true, "save", "-o", tar, ref)
+	dockerCLI(t, 300*time.Second, true, "cp", tar, d.name+":/base.tar")
+	d.mustRun(t, 300*time.Second, "load the base image into the isolated daemon", "docker load -i /base.tar")
+}
+
+// buildContext materialises a build context inside the isolated daemon and
+// returns its path.
+func (d *isolatedDaemon) buildContext(t *testing.T, name, dockerfile string, extra map[string]string) string {
+	t.Helper()
+	dir := "/contexts/" + name
+	d.mustRun(t, 30*time.Second, "create the build context dir", "mkdir -p "+dir)
+	d.writeFile(t, dir+"/Dockerfile", dockerfile)
+	for filename, content := range extra {
+		d.writeFile(t, dir+"/"+filename, content)
+	}
+	return dir
+}
+
+// writeFile pipes content into a file inside the isolated daemon. No WaitDelay:
+// this streams on stdin, and a WaitDelay on a stdin-streaming child truncates it
+// silently.
+func (d *isolatedDaemon) writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "docker", "exec", "-i", d.name, "sh", "-c", "cat > "+path)
+	cmd.Stdin = strings.NewReader(content)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("writing %s inside the isolated daemon: %v\n%s", path, err, out)
+	}
+}
+
+// run executes a shell command inside the isolated daemon.
+func (d *isolatedDaemon) run(timeout time.Duration, script string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "docker", "exec", d.name, "sh", "-c", script)
+	cmd.WaitDelay = 10 * time.Second
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func (d *isolatedDaemon) mustRun(t *testing.T, timeout time.Duration, what, script string) {
+	t.Helper()
+	if out, err := d.run(timeout, script); err != nil {
+		t.Fatalf("%s: %v\n%s", what, err, out)
+	}
+}
+
+// dockerCLI runs a docker command on the HOST daemon. `must` distinguishes the
+// steps the check depends on from the best-effort ones (a pre-emptive `rm -f` of
+// a container that is not there yet is expected to fail).
+func dockerCLI(t *testing.T, timeout time.Duration, must bool, args ...string) {
+	t.Helper()
+	out, err := dockerCLIOutput(timeout, args...)
+	if err != nil && must {
+		t.Fatalf("docker %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+func dockerCLIOutput(timeout time.Duration, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.WaitDelay = 10 * time.Second
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}

--- a/scripts/testbox.sh
+++ b/scripts/testbox.sh
@@ -229,10 +229,40 @@ finish_image_start() {
     release_image_lock
 }
 
+# retry_image_build — build an image, retrying a transient registry failure.
+#
+# Every image here sits on a public base (golang:1.25-bookworm, the playwright
+# image), and a build whose base is not already in the local store has to resolve
+# it through a registry — the failure mode that reddened master and blocked the
+# v1.0.211 release from the integration side (#2521). Unlike those round-trip
+# bases there is nothing to pre-seed: on a cold CI runner the base HAS to be
+# fetched, so these builds cannot be made registry-free, only resilient. The
+# blips in #2521 lasted seconds, which a few spaced attempts absorb.
+#
+# The Dockerfile path is a parameter rather than a `<` on the call because stdin
+# is CONSUMED by the first attempt — a retry redirected by the caller would feed
+# the second attempt an empty Dockerfile and "fail" for a reason of our own
+# making. Redirecting the caller's stdout is still fine; only stdin is spent.
+retry_image_build() {
+    local dockerfile="$1"
+    shift
+    local attempt
+    for attempt in 1 2 3; do
+        if "$ENGINE" build "$@" - <"$dockerfile"; then
+            return 0
+        fi
+        if [ "$attempt" -lt 3 ]; then
+            echo "testbox: image build attempt $attempt failed; retrying in $((attempt * 5))s" >&2
+            sleep $((attempt * 5))
+        fi
+    done
+    return 1
+}
+
 build_image() {
     # Dockerfile via stdin: no build context is sent (the Dockerfile has no
     # COPY), so this is instant when layers are cached.
-    "$ENGINE" build -q --label "$LABEL" -t "$IMAGE" - <"$REPO_ROOT/scripts/container/Dockerfile.test" >/dev/null
+    retry_image_build "$REPO_ROOT/scripts/container/Dockerfile.test" -q --label "$LABEL" -t "$IMAGE" >/dev/null
 }
 
 # ensure_cache_volumes — create the named cache volumes up front, labelled.
@@ -446,7 +476,7 @@ fi
 
 case "$cmd" in
 build)
-    "$ENGINE" build --label "$LABEL" -t "$IMAGE" - <"$REPO_ROOT/scripts/container/Dockerfile.test"
+    retry_image_build "$REPO_ROOT/scripts/container/Dockerfile.test" --label "$LABEL" -t "$IMAGE"
     finish_image_start
     ;;
 test)
@@ -575,7 +605,7 @@ lifecycle)
     if [ "$lc_teardown" = yes ]; then
         trap lifecycle_teardown EXIT INT TERM
     fi
-    "$ENGINE" build -q --label "$LABEL" -t "$LIFECYCLE_IMAGE" - <"$REPO_ROOT/scripts/container/Dockerfile.test" >/dev/null
+    retry_image_build "$REPO_ROOT/scripts/container/Dockerfile.test" -q --label "$LABEL" -t "$LIFECYCLE_IMAGE" >/dev/null
     fix_cache_perms "$LIFECYCLE_IMAGE"
     rc=0
     watch_image_start "$LIFECYCLE_NAME"
@@ -596,7 +626,7 @@ web-selftest)
     # listener, and drives the embedded SPA in a headless Chromium. Everything
     # (daemon, tmux, browser) lives on 127.0.0.1 inside the container: no
     # published ports, no host tmux, no real AF home.
-    "$ENGINE" build -q --label "$LABEL" -t "$WEB_IMAGE" - <"$REPO_ROOT/scripts/container/Dockerfile.web-selftest" >/dev/null
+    retry_image_build "$REPO_ROOT/scripts/container/Dockerfile.web-selftest" -q --label "$LABEL" -t "$WEB_IMAGE" >/dev/null
     # Dedicated cache volumes (not the shared testbox ones): this container runs
     # as root, so mixing caches would leave root-owned files the dev-user testbox
     # can't write. Chromium wants more memory + pids than the default suite.


### PR DESCRIPTION
Closes #2521.

The four real-backend tests built `FROM alpine:3.20`, so every run resolved that tag through docker.io and a Docker Hub blip reddened whatever was running. This makes the builds resolve nothing against a registry, and ships a check that measures that property directly rather than asserting it.

## One correction to the diagnosis first

The issue's latest comment reasoned that pre-pulling cannot help because buildkit re-resolves a tag against the registry even when the image is already in the local store. **It does not.** Measured on docker 28.5.2, in a throwaway daemon with its egress to `registry-1.docker.io` dropped:

| local image store | `FROM alpine:3.20` |
| --- | --- |
| `alpine:3.20` present | **builds**, no registry request at all |
| `alpine:3.20` absent | fails in `[internal] load metadata`, byte-for-byte the CI signature |

So `load metadata` reads the local store first. What actually happened is simpler, and visible in the tree: **the #2525 warm step only ever existed in `pr.yml`, and four lanes run the full suite.**

| lane | runs `go test ./...` | warmed the base |
| --- | --- | --- |
| `pr.yml` → Test | yes | yes |
| `build.yml` → Build Binary and Test | yes | **no** |
| `stable-release.yml` → Release preflight | yes | **no** |
| `auto-release.yml` → Release preflight | yes | **no** |

Both observed failures landed on lanes that never had it. The failing release job's own step list (run 30252629501) has no warm step, and the attempt-1 log of the master red (run 30240122792, `build.yml`) contains no warm step either. The mitigation was not defeated — it was not there.

That matters beyond bookkeeping: the test's failure message asserted "base image is pre-pulled by CI" as a static string, so on a lane where nothing had pre-pulled anything, the test confidently reported a precondition that was false and sent the diagnosis after buildkit. That message is gone.

## What changed

The build was doing two things at once; they are now separate.

**Obtaining the base** happens in `integration/base_image_test.go`, once per test binary, with bounded retry — the only step here that may touch a registry. If it cannot be obtained at all, the tests **skip**, narrowly: this is the same class as `requireDocker`'s missing daemon, no product defect can produce it, and it is the outcome that would have kept tonight's release green. Anything that fails after this point still fails loudly.

**Building on top of it** happens `FROM af-integration-base:alpine-3.20`, a name no registry serves. Presence in the local store is what removes the round trip; the local-only name is what keeps it removed — no future resolve-mode default, `--pull`, or moved tag can turn it back into a fetch.

Putting this in the test binary rather than in CI is the other half. It covers all four lanes plus every developer machine, and no future workflow can forget it. The `pr.yml` warm step is removed as redundant, with a comment saying why so it does not come back.

## The check

`make registry-free-check` / the `Registry-free image build` job. It stands up a second docker daemon, drops its egress, and measures the absence directly, in three parts:

1. **The block is real** — a pull of a not-local tag must fail, or the check is vacuous.
2. **The bug is real** — `FROM alpine:3.20`, with that base absent, must still fail with `failed to resolve source metadata`. This bug's own reproduction, re-run every time, so the check can never pass by measuring a network that was quietly reachable.
3. **The fix works** — the real Dockerfiles, from the local-only base, must build.

It builds the Dockerfiles from the same functions the real tests use, so it cannot drift into proving a property about a copy of them. Confirmed to have teeth: pointed back at `alpine:3.20`, it fails. It is wired into `Build`'s `needs` — a standalone job would gate nothing.

## Other places that build FROM a public base

- **`scripts/testbox.sh`** (4 sites: `Dockerfile.test` ×3, `Dockerfile.web-selftest`) — same class, and it has just been luckier. These **cannot** be made registry-free: the image *is* the environment, so a cold CI runner has to fetch the base and there is nothing to pre-seed. They get bounded retry instead, which is the available remedy for the seconds-long blips in #2521. The Dockerfile path is passed as a parameter rather than redirected by the caller, because stdin is consumed by the first attempt and a retry would otherwise feed attempt two an empty Dockerfile.
- **`Makefile: session-image`, `scripts/container/record-demo.sh`** — not fixed, deliberately. Neither is on any CI path; both are developer-invoked one-shots where a registry error is visible to a human who can rerun. Adding retry there would buy nothing and hide the error.

## Follow-up, not fixed here

These four tests are not `testing.Short()`-gated, so `build.yml`'s three `-short` cells run the full docker/ssh round-trips anyway — the (darwin, amd64) cell is where the master red actually landed. That partly defeats #2052's "run the heavy suite once" intent and is worth its own issue; it is unrelated to the registry dependency.

## Gate

Full suite run last, against the pushed head **f087942ff6c39e57d45c40757b51b2759b43171e**.

- `gofmt -l .` — clean
- `go build ./...` — OK
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `scripts/lint-file-length.sh` — passed (1092 files, 0 grandfathered)
- `make test-container` — PASS (exit 0, 0 failures; `integration` ok 52.3s)
- `make registry-free-check` — PASS locally, and PASS on the GitHub runner: block verified, reproduction confirmed, both real images built with `registry-1.docker.io` unreachable
- `make backend-docker-roundtrip` — PASS (both cases)
- `make backend-ssh-roundtrip` — PASS (both cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
