### PR TITLE
refactor(shell): one home for the executed-side POSIX quoter (#1241)

### DIFF
--- a/daemon/httpserver.go
+++ b/daemon/httpserver.go
@@ -304,8 +304,15 @@ func healthHandler(cs *controlServer) http.HandlerFunc {
 }
 
 // decodeHTTPRequest reads the size-capped body and unmarshals it into dst. An
-// empty body is treated as a zero-value request so no-argument RPCs (ListTasks,
-// an all-repo Snapshot, health) work with `curl -d ”` or no body at all.
+// empty body is treated as a zero-value request, so no-argument RPCs (ListTasks,
+// an all-repo Snapshot, health) work with no body at all — or with an explicit
+// empty one:
+//
+//	curl -d ''
+//
+// (Indented so gofmt cannot rewrite the doubled quote into a typographic ”
+// character, which is what this line used to print — a curl example that fails
+// if pasted.)
 //
 // Unknown-field handling depends on WHO sent the request, because the same
 // "unknown field" means opposite things to the two populations of caller:

--- a/internal/sessionenv/exec_unix.go
+++ b/internal/sessionenv/exec_unix.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	"github.com/sachiniyer/agent-factory/internal/shellquote"
 )
 
 var processExec = syscall.Exec
@@ -25,7 +27,7 @@ func WrapCommand(executable, agent string, extras []string, command string) (str
 	args = append(args, command)
 	quoted := make([]string, len(args))
 	for idx, arg := range args {
-		quoted[idx] = shellQuote(arg)
+		quoted[idx] = shellquote.Quote(arg)
 	}
 	return strings.Join(quoted, " "), nil
 }
@@ -65,16 +67,4 @@ func execInvocation(args []string) error {
 	// interpret differently.
 	shell := "/bin/sh"
 	return processExec(shell, []string{shell, "-c", command}, environ)
-}
-
-func shellQuote(arg string) string {
-	if arg != "" && strings.IndexFunc(arg, func(r rune) bool {
-		return !((r >= 'a' && r <= 'z') ||
-			(r >= 'A' && r <= 'Z') ||
-			(r >= '0' && r <= '9') ||
-			strings.ContainsRune("_@%+=:,./-", r))
-	}) == -1 {
-		return arg
-	}
-	return "'" + strings.ReplaceAll(arg, "'", `'"'"'`) + "'"
 }

--- a/internal/shellquote/shellquote.go
+++ b/internal/shellquote/shellquote.go
@@ -1,0 +1,48 @@
+// Package shellquote renders values as POSIX shell words for the command
+// strings af builds and then EXECUTES — the tmux shell-command sessionenv
+// wraps, the program string a resumed pane re-runs.
+//
+// It exists because one nine-line quoter had been copy-pasted into two
+// packages: internal/sessionenv.shellQuote and session/tmux.shellQuoteArg were
+// byte-identical. That is how a quoting fix lands at one call site and silently
+// misses the other — the failure mode #1978 already hit once, when the class was
+// understood and fixed at a single site while nine others kept interpolating raw
+// values. One home means one place to fix.
+//
+// Sibling, not duplicate: internal/shellsuggest quotes the commands af PRINTS
+// for a human to paste. Its Arg additionally guards zsh start-of-word expansions
+// because a pasted command lands in the reader's interactive shell, and that
+// guard changes the rendered string — so the two stay separate deliberately, not
+// by neglect. The other in-tree quoters (session.shellQuote,
+// config.ShellQuotePath) quote unconditionally and so also render differently
+// for the same input. Consolidating all of them is a behavior-visible change
+// tracked on the structural audit (#1195); this package is the home it lands in.
+package shellquote
+
+import "strings"
+
+// shellSafeRunes are the punctuation runes POSIX sh treats literally in an
+// unquoted word, so a value built only from these plus alphanumerics needs no
+// quoting.
+const shellSafeRunes = "_@%+=:,./-"
+
+// Quote renders arg as exactly one POSIX shell word.
+//
+// A value made only of alphanumerics and shellSafeRunes passes through bare, so
+// the common case stays readable in a program string a user may see or edit.
+// Anything else is single-quoted, with each embedded single quote escaped as
+// '"'"' (close the quote, emit an escaped one, reopen). That makes every other
+// metacharacter — space, ", $, backtick, ;, newline — literal. The empty string
+// takes that branch too, so it renders as an explicit empty word rather than
+// vanishing from the command.
+func Quote(arg string) string {
+	if arg != "" && strings.IndexFunc(arg, func(r rune) bool {
+		return !((r >= 'a' && r <= 'z') ||
+			(r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') ||
+			strings.ContainsRune(shellSafeRunes, r))
+	}) == -1 {
+		return arg
+	}
+	return "'" + strings.ReplaceAll(arg, "'", `'"'"'`) + "'"
+}

--- a/internal/shellquote/shellquote.go
+++ b/internal/shellquote/shellquote.go
@@ -9,14 +9,28 @@
 // understood and fixed at a single site while nine others kept interpolating raw
 // values. One home means one place to fix.
 //
-// Sibling, not duplicate: internal/shellsuggest quotes the commands af PRINTS
-// for a human to paste. Its Arg additionally guards zsh start-of-word expansions
-// because a pasted command lands in the reader's interactive shell, and that
-// guard changes the rendered string — so the two stay separate deliberately, not
-// by neglect. The other in-tree quoters (session.shellQuote,
-// config.ShellQuotePath) quote unconditionally and so also render differently
-// for the same input. Consolidating all of them is a behavior-visible change
-// tracked on the structural audit (#1195); this package is the home it lands in.
+// Siblings, not duplicates. Three other quoters remain in the tree, and NO TWO
+// OF THEM AGREE on some input — which is the whole reason none of them was
+// folded in here. Stated precisely, because the differences are one line each
+// and invisible to a reader merging them by eye:
+//
+//   - internal/shellsuggest.Arg quotes the commands af PRINTS for a human to
+//     paste. It additionally guards zsh start-of-word expansions, because a
+//     pasted command lands in the reader's interactive shell: Arg("=x") quotes,
+//     Quote("=x") does not.
+//   - session.shellQuote (session/systemprompt.go) quotes UNCONDITIONALLY, for
+//     the ssh/docker/sandbox provisioning scripts: shellQuote("x") is 'x' where
+//     Quote("x") is x. The empty string becomes a quoted empty word.
+//   - config.ShellQuotePath quotes unconditionally TOO, and uses the same escape
+//     idiom — but it carves out the empty string and returns it UNCHANGED. So
+//     the pair that looks most alike disagrees on "": one emits a quoted empty
+//     word, the other emits nothing at all. Folding them would break one caller
+//     or the other depending purely on which body survived, and an empty value
+//     reaching a shell is exactly where that stops being cosmetic.
+//
+// Folding any of them in is therefore a behavior-visible change, not a
+// mechanical move. It is tracked on the structural audit (#1195); this package
+// is the home it lands in when someone takes it deliberately.
 package shellquote
 
 import "strings"

--- a/internal/shellquote/shellquote_test.go
+++ b/internal/shellquote/shellquote_test.go
@@ -1,0 +1,61 @@
+package shellquote
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestQuoteRendering pins the exact strings both former copies produced, so the
+// consolidation is provably a move rather than a rewrite. The first three cases
+// are session/tmux's TestShellQuoteArg verbatim.
+func TestQuoteRendering(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"safe value passes through bare", "abc-123_./:@%+=", "abc-123_./:@%+="},
+		{"metacharacters are quoted", "thread id?x=1&y=2", "'thread id?x=1&y=2'"},
+		{"embedded quote is escaped", "it's", `'it'"'"'s'`},
+		{"empty becomes an explicit empty word", "", "''"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, Quote(tc.in))
+		})
+	}
+}
+
+// TestQuoteSurvivesTheShell is the guard that matters: the quoted word must
+// reach /bin/sh as one argument, byte-for-byte, with nothing executed on the
+// way. The payloads below run destructive or observable commands if the quoting
+// is wrong, so a regression fails loudly instead of quietly mangling a value.
+func TestQuoteSurvivesTheShell(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skipf("no sh on PATH: %v", err)
+	}
+	payloads := []string{
+		"plain",
+		"has space",
+		"it's",
+		"$(touch /tmp/af-shellquote-should-not-exist)",
+		"`id`",
+		"a;b",
+		"a|b",
+		"a\nb",
+		`double"quote`,
+		"back\\slash",
+		"*",
+		"~/tilde",
+		"$HOME",
+	}
+	for _, raw := range payloads {
+		t.Run(raw, func(t *testing.T) {
+			out, err := exec.Command("sh", "-c", "printf %s "+Quote(raw)).CombinedOutput()
+			require.NoError(t, err, "Quote(%q) produced a command the shell rejects: %s", raw, out)
+			require.Equal(t, raw, string(out), "Quote(%q) did not survive the shell verbatim", raw)
+		})
+	}
+}

--- a/internal/shellsuggest/shellsuggest.go
+++ b/internal/shellsuggest/shellsuggest.go
@@ -57,9 +57,15 @@ const shellSafeChars = "_@%+=:,./-"
 // Values that need no quoting pass through, so the common suggestion stays clean
 // and readable (`af sessions restore captain`, not `af sessions restore 'captain'`)
 // — readability matters for a string whose whole purpose is to be read and pasted.
-// Anything else is single-quoted, with embedded single quotes escaped by the
-// standard POSIX idiom ('\”), which makes every other metacharacter — space, ",
-// $, backtick, ;, newline — literal in all three shells.
+// Anything else is single-quoted, with each embedded single quote escaped by
+// the standard POSIX idiom:
+//
+//	'   ->   '\''
+//
+// which makes every other metacharacter — space, ", $, backtick, ;, newline —
+// literal in all three shells. (The idiom is an indented code block because
+// gofmt rewrites a doubled quote in doc prose into a typographic ” character;
+// this comment used to read '\” for exactly that reason.)
 //
 // Prefer Command: a bare Arg still leaves a caller assembling a command by hand.
 // Arg is exported for the rare site that must interleave quoted values with

--- a/internal/shellsuggest/shellsuggest.go
+++ b/internal/shellsuggest/shellsuggest.go
@@ -26,9 +26,14 @@
 //
 // # Scope
 //
-// This is for commands we PRINT. Strings af itself feeds to a shell (ssh scripts,
-// tmux program strings) are a different job with different helpers; consolidating
-// those is #1529.
+// This is for commands we PRINT. Strings af itself feeds to a shell (ssh
+// scripts, tmux program strings) are a different job: internal/shellquote is the
+// shared quoter for the executed side. The two stay separate because Arg's zsh
+// start-of-word guards only earn their keep when the command lands in a human's
+// interactive shell, and they change the rendered string. The always-quote
+// helpers still in the tree (session.shellQuote, config.ShellQuotePath) render
+// differently again, so folding them in is a behavior-visible change tracked on
+// the structural audit (#1195), not a mechanical move.
 package shellsuggest
 
 import "strings"

--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -129,8 +129,21 @@ const afUsageOutroPlugin = `Finishing up: the sessions you create keep running a
 // afUsageOutro closes the reference for both audiences.
 const afUsageOutro = `Maintenance: af version, af debug (print resolved config), af upgrade (self-upgrade). Never run "af reset": it kills every session and deletes ALL linked worktrees and their branches across repos.`
 
-// shellQuote wraps a string in single quotes, escaping any embedded single quotes
-// using the standard shell idiom: replace ' with '\"
+// shellQuote wraps a string in single quotes, escaping any embedded single
+// quote with the standard POSIX idiom:
+//
+//	'   ->   '\''
+//
+// The idiom is written above as an indented code block on purpose: gofmt
+// rewrites a doubled quote in doc PROSE into a typographic ” character, which
+// is how this very comment previously came to claim the escape was '\" — an
+// incorrect description of a security-relevant primitive, produced by the
+// formatter rather than by a typo.
+//
+// It quotes UNCONDITIONALLY, so the empty string renders as a quoted empty word
+// rather than vanishing — unlike config.ShellQuotePath, which returns ""
+// unchanged. See internal/shellquote for why the tree's quoters are not
+// interchangeable.
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }

--- a/session/tmux/resume.go
+++ b/session/tmux/resume.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/sachiniyer/agent-factory/internal/envcommand"
+	"github.com/sachiniyer/agent-factory/internal/shellquote"
 )
 
 // resumeProgram derives a "resume the most recent session in cwd" variant of
@@ -243,7 +244,7 @@ func ResumeProgramWithConversationID(program, recordedAgent, id string) (rewritt
 				return program, false
 			}
 		}
-		return program + " --resume " + shellQuoteArg(id), true
+		return program + " --resume " + shellquote.Quote(id), true
 	case ProgramCodex:
 		insertAt := agentIdx + 1
 		if insertAt < len(tokens) && tokens[insertAt] == "exec" {
@@ -253,28 +254,16 @@ func ResumeProgramWithConversationID(program, recordedAgent, id string) (rewritt
 			return program, false
 		}
 		off := ends[insertAt-1]
-		return program[:off] + " resume " + shellQuoteArg(id) + program[off:], true
+		return program[:off] + " resume " + shellquote.Quote(id) + program[off:], true
 	case ProgramAmp:
 		insertAt, alreadyResume := ampResumeInsertIndex(tokens, agentIdx)
 		if alreadyResume || insertAt < 0 {
 			return program, false
 		}
 		off := ends[insertAt-1]
-		return program[:off] + " threads continue " + shellQuoteArg(id) + program[off:], true
+		return program[:off] + " threads continue " + shellquote.Quote(id) + program[off:], true
 	}
 	return program, false
-}
-
-func shellQuoteArg(arg string) string {
-	if arg != "" && strings.IndexFunc(arg, func(r rune) bool {
-		return !((r >= 'a' && r <= 'z') ||
-			(r >= 'A' && r <= 'Z') ||
-			(r >= '0' && r <= '9') ||
-			strings.ContainsRune("_@%+=:,./-", r))
-	}) == -1 {
-		return arg
-	}
-	return "'" + strings.ReplaceAll(arg, "'", `'"'"'`) + "'"
 }
 
 // ClaudeProgramWithSessionID appends Claude Code's explicit conversation id flag

--- a/session/tmux/resume_test.go
+++ b/session/tmux/resume_test.go
@@ -556,7 +556,7 @@ func TestResumeProgramWithConversationID(t *testing.T) {
 		// deliberately falls through to ok=false and Restore uses the
 		// latest-session path (resumeProgram's --continue) — the same degradation
 		// gemini and aider get. If opencode id capture is ever implemented, add a
-		// ProgramOpencode case returning `program + " --session " + shellQuoteArg(id)`
+		// ProgramOpencode case returning `program + " --session " + shellquote.Quote(id)`
 		// and flip this row.
 		{"opencode has no id-resume path in af", ProgramOpencode, "opencode", "opencode", false},
 		{"opencode with flag still no id-resume", ProgramOpencode, "opencode --model anthropic/claude-opus-4-5", "opencode --model anthropic/claude-opus-4-5", false},
@@ -596,12 +596,6 @@ func TestResumeProgramWithConversationIDQuotesUnsafeID(t *testing.T) {
 			require.Equal(t, tc.want, got)
 		})
 	}
-}
-
-func TestShellQuoteArg(t *testing.T) {
-	require.Equal(t, "abc-123_./:@%+=", shellQuoteArg("abc-123_./:@%+="))
-	require.Equal(t, "'thread id?x=1&y=2'", shellQuoteArg("thread id?x=1&y=2"))
-	require.Equal(t, `'it'"'"'s'`, shellQuoteArg("it's"))
 }
 
 // TestResumeProgram_CodexProfileResumeFalsePositive guards #632: the codex

--- a/session/tmux/session_env_e2e_linux_test.go
+++ b/session/tmux/session_env_e2e_linux_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/sachiniyer/agent-factory/internal/shellquote"
 )
 
 // TestRealPaneEnvironmentIsFiltered reads variable names from the pane
@@ -87,7 +89,7 @@ func TestRealPaneEnvironmentIsFiltered(t *testing.T) {
 	}
 
 	session := NewTmuxSession("real-env-boundary", strings.Join([]string{
-		shellQuoteArg(agentPath), shellQuoteArg(namesPath), shellQuoteArg(workspacePath), shellQuoteArg(pushMarkerPath),
+		shellquote.Quote(agentPath), shellquote.Quote(namesPath), shellquote.Quote(workspacePath), shellquote.Quote(pushMarkerPath),
 	}, " "))
 	if err := session.SetEnvPassthrough([]string{customName}); err != nil {
 		t.Fatal(err)

--- a/session/tmux/submit_bracketed_test.go
+++ b/session/tmux/submit_bracketed_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/internal/shellquote"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 )
 
@@ -33,7 +34,7 @@ const receiverReadyMarker = "AF-RECEIVER-READY"
 // that pastes before the DECSET lands would get an unbracketed paste for a
 // legitimate reason and blame the code under test.
 //
-// outPath is shell-quoted (shellQuoteArg, the package's existing POSIX quoter):
+// outPath is shell-quoted (shellquote.Quote, the shared POSIX quoter):
 // t.TempDir() inherits TMPDIR, so the path can hold a space or a metacharacter
 // even though Go sanitizes the subtest name out of it. Unquoted, `cat > /tmp/af
 // space dir/received.bin` redirects to `/tmp/af` — the fixture breaks, and it
@@ -49,7 +50,7 @@ const receiverReadyMarker = "AF-RECEIVER-READY"
 // test never skips in CI for want of an agent binary.
 func receiverProgram(outPath string) string {
 	return fmt.Sprintf(`stty raw -echo; printf "\033[?2004h%s\r\n"; cat > %s`,
-		receiverReadyMarker, shellQuoteArg(outPath))
+		receiverReadyMarker, shellquote.Quote(outPath))
 }
 
 // startReceiverPane brings up a real tmux session running the receiver and
@@ -139,11 +140,11 @@ func TestReceiverProgramQuotesOutputPath(t *testing.T) {
 			// through a real shell rather than asserting on the string: `sh -c`
 			// echoing the quoted arg answers the only question that matters —
 			// what the shell resolves it to.
-			out, err := exec.Command("sh", "-c", "printf %s "+shellQuoteArg(path)).Output()
+			out, err := exec.Command("sh", "-c", "printf %s "+shellquote.Quote(path)).Output()
 			require.NoError(t, err)
 			require.Equal(t, path, string(out),
 				"shell must resolve the quoted path back to exactly one intact word")
-			require.Contains(t, prog, shellQuoteArg(path),
+			require.Contains(t, prog, shellquote.Quote(path),
 				"receiver program must embed the QUOTED path, never the raw one")
 			require.NotContains(t, prog, "cat > "+path,
 				"receiver program must not splice the raw path into the redirect")

--- a/session/tmux/submit_strand_probe_test.go
+++ b/session/tmux/submit_strand_probe_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/internal/shellquote"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 )
 
@@ -25,7 +26,7 @@ import (
 // "two separate submissions" from "one concatenated submission".
 func lineComposerProgram(outPath string) string {
 	return fmt.Sprintf(`stty -echo; printf "AF-RECEIVER-READY\r\n"; while IFS= read -r l; do printf "[%%s]" "$l" >> %s; done`,
-		shellQuoteArg(outPath))
+		shellquote.Quote(outPath))
 }
 
 func startLineComposerPane(t *testing.T, name string) (*TmuxSession, string) {


### PR DESCRIPTION
## What abstraction got simpler

One primitive, one home. `internal/sessionenv.shellQuote` and
`session/tmux.shellQuoteArg` were the **same nine-line POSIX shell quoter,
byte for byte**, sitting in two packages that never referenced each other:

```go
// internal/sessionenv/exec_unix.go:70   AND   session/tmux/resume.go:268
func shellQuote(arg string) string {          func shellQuoteArg(arg string) string {
	if arg != "" && strings.IndexFunc(...)        if arg != "" && strings.IndexFunc(...)
	...identical...                               ...identical...
```

Both now call `internal/shellquote.Quote`.

This is the duplication that actually costs something: quoting is the seam
between af's own strings and a shell that will happily execute a session title.
Two copies means a fix lands at one call site and silently misses the other —
the exact failure mode #1978 hit, where the class was understood and fixed at
**one** site while nine others kept interpolating raw values (documented in
`shellsuggest`'s own package doc).

## Why it is behavior-preserving

`Quote` is those bodies moved verbatim — the only edit is lifting the
passthrough set `"_@%+=:,./-"` to a named const. Proven, not asserted: a
differential run compared `Quote` against **both** former implementations
(copied from `5748a69b`) over **301,860 inputs** — every single byte, every
2-byte pair over a metacharacter alphabet (`' " $ \` ; | & < > * ? ( ) { } [ ]
# ! ~ \n \t \\` + space), and 300k random strings including non-ASCII — with
**0 mismatches**. The scratch harness was removed before commit; what ships is
`TestQuoteRendering` (the three assertions from the retired `TestShellQuoteArg`,
verbatim, plus the empty-string case) and `TestQuoteSurvivesTheShell`, which
round-trips 13 payloads through a real `sh -c` and fails if a value does not
come back byte-identical.

Call sites are a rename only: 1 in `sessionenv.WrapCommand`, 3 in
`resumeProgram`, and the tmux test helpers that already used the package
quoter for temp paths.

## What this deliberately does NOT do

The tree has three more quoters. They are **not** duplicates of this one — they
render different strings for the same input, so folding them in is a
behavior-visible change, not a mechanical move:

| quoter | safe value `x` | empty string | consumer |
|---|---|---|---|
| `internal/shellquote.Quote` (this PR) | `x` | quoted empty word | strings af **executes** |
| `internal/shellsuggest.Arg` | `x` (**+ zsh start-of-word guards**, so `=x` quotes) | quoted empty word | commands af **prints** to paste |
| `session.shellQuote` | `'x'` | quoted empty word | ssh / docker / sandbox scripts (~30 sites) |
| `config.ShellQuotePath` | `'x'` | **empty, unchanged** | persisted `program_overrides`, pasteable paths |

**No two rows agree on every input** — including the bottom pair, which looks
identical until the empty string: `session.shellQuote("")` emits a quoted empty
word, `config.ShellQuotePath("")` emits nothing at all. Folding those two would
break one caller or the other depending purely on which body survived, and an
empty value reaching a shell is exactly where that stops being cosmetic. (Caught
in review — the earlier version of this table described those two rows
identically, which read as "these are duplicates the PR left behind".)

That map is now in `internal/shellquote`'s package doc, with the reason each
one differs, and the consolidation is filed on the #1195 structural audit
rather than smuggled into a cleanup PR.

**Two drive-by corrections, both the same class — prose asserting behavior
incorrectly about a security-relevant primitive:**

1. `shellsuggest`'s package doc told the reader "consolidating those is #1529".
   #1529 is an unrelated **closed** Detail bug about `DeliverPrompt` and
   archived sessions — the pointer was dead on arrival, so a reader following it
   learned nothing. It now describes the real state of the tree.
2. `session/systemprompt.go` documented its escape as `'\"` when the code does
   `'\''`. The cause turned out to be mechanical, not a typo, and it would have
   re-broken any naive one-line fix: **gofmt's doc-comment typography rewrites a
   doubled quote in prose into a single `”` character.** (It did exactly that to
   this PR's own package doc mid-review, which is how the mechanism surfaced.)
   The idiom is now an indented code block, which gofmt leaves alone, with a note
   saying why it is written that way — verified by re-running `gofmt -l`.

## Gates

`gofmt -l .` empty · `go build ./...` · `golangci-lint run --timeout=3m --fast`
· `deadcode -test ./...` empty · `scripts/lint-file-length.sh` (1092 files, 0
grandfathered) · `make test-container` — all on the PR head.

Found by the #1241 daily abstraction-simplification sweep. Not self-merged:
root reviews, per the practice's own rule.

Refs #1241, #1195

— Captain Claude
