### PR TITLE
docs: fix five dead anchors, a deprecated verb, and the stale auto_yes parity claim

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -54,7 +54,7 @@ With `backend = "docker"`, a session runs entirely inside a container:
 The container is **disposable**: durability lives in GitHub (the workspace is a
 clone of `repo@origin`), not in the container filesystem — so archive pushes the
 branch and reaps the container, and restore re-provisions a fresh container that
-clones the branch back (see [Archive & restore](#archive--restore)).
+clones the branch back (see [Archive & restore](#archive-restore)).
 
 ### Configuration
 
@@ -312,7 +312,7 @@ built-in, opinionated version of what a `hook` `launch_cmd` did by hand:
 Like docker, the workspace is **disposable**: durability lives in GitHub (the
 workspace is a clone of `repo@origin`) — archive pushes the branch and reaps the
 remote session, and restore re-provisions a fresh remote that clones the branch
-back (see [Archive & restore](#archive--restore)).
+back (see [Archive & restore](#archive-restore)).
 
 ### Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -330,7 +330,7 @@ enabled = false
 Semantics:
 
 - **Precedence (low → high): built-in `enabled=false` < global `[root_agent]` < legacy `root_agents[path]` < personal per-project `[root_agent]`.** Layers merge **by field**: a higher layer overrides `enabled` only if it set it (an explicit `false` counts) and `program` only if non-empty. So a personal `enabled = false` can disable a root that the global default — or a legacy `root_agents` entry — turned on.
-- **The global default reaches registered projects only.** It never scans disk for repositories; a project must be registered (`af projects register`) to receive it. Legacy `root_agents` entries keep working unchanged and forever.
+- **The global default reaches registered projects only.** It never scans disk for repositories; a project must be registered (`af projects add`) to receive it. Legacy `root_agents` entries keep working unchanged and forever.
 - **Hand-edited for now.** Like `[theme]`, `[root_agent]` is not writable with `af config set` yet (`af config get root_agent` reads it); editing through the CLI/TUI lands in a later phase. Edit the file (or use the config assistant) directly.
 - **Restart-to-apply**, exactly like `root_agents`: changes take effect on the next daemon start. All the always-ensure guarantees above (adopt-never-clobber, reserved name, kill respected, back-off-but-never-give-up) apply identically to a root the singleton enables.
 
@@ -536,8 +536,8 @@ so it is never committed and never imposed on collaborators. Because it is your 
 **It attaches to a registered project, not a path.** A project has a durable, opaque id (`prj_…`) that survives the checkout moving or being cloned twice, so a personal override does not silently stop applying when you move a repo. Register a repository once:
 
 ```bash
-af projects register ~/work/myrepo   # prints the project's prj_ id
-af projects list                     # every registered project
+af projects add ~/work/myrepo   # prints the project's prj_ id
+af projects list                # every registered project
 ```
 
 Then set and clear overrides. `--project` accepts either the `prj_` id or any path inside the registered repository:

--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -2,7 +2,7 @@
 
 Agent Factory ships two first-class off-box backends — [`docker` and `ssh`](backends.md) — that need zero scripting. The **remote-hook backend** is the escape hatch for infrastructure those don't model (Kubernetes, Modal, Daytona, a bastion with exotic auth, a bespoke orchestrator): you provide two shell scripts and `af` runs your session on whatever you provision.
 
-Since **#1592 Phase 4 PR7** the hook backend follows the same **provision-and-expose** contract as `docker`/`ssh`: your `launch_cmd` starts an [`af agent-server`](backends.md) in the remote workspace and echoes its authed URL; the daemon then drives the session over that `ws://` stream. A remote-hook session matches a local one on attach, type, resize, preview, archive/restore, and kill — the one exception is tab management (see [Capabilities & the agent-server](#capabilities--the-agent-server)).
+Since **#1592 Phase 4 PR7** the hook backend follows the same **provision-and-expose** contract as `docker`/`ssh`: your `launch_cmd` starts an [`af agent-server`](backends.md) in the remote workspace and echoes its authed URL; the daemon then drives the session over that `ws://` stream. A remote-hook session matches a local one on attach, type, resize, preview, archive/restore, and kill — the one exception is tab management (see [Capabilities & the agent-server](#capabilities-the-agent-server)).
 
 > **Transport:** the `af agent-server` serves **plain HTTP** (no TLS — af terminates none of its own). The URL must be `http://` (or `ws://`), and the bearer token travels over the connection, so your `launch_cmd` must make the agent-server reachable from the daemon over a private network or tunnel it controls (a container's published loopback port, an SSH forward, a tailnet address).
 
@@ -67,7 +67,7 @@ Provisions the workspace on your infrastructure, starts an `af agent-server` the
 | `--name <slug>` | Stable session slug (also passed to `delete_cmd`). |
 | `--title <title>` | The session title — pass it to `af agent-server --title` so the daemon dials the right workspace. |
 | `--repo <url>` | The repo's `origin` URL to clone the workspace from (GitHub is the durable store). |
-| `--branch <branch>` | **Only on restore** — the archived branch to materialize (see [Archive & restore](#archive--restore)). Absent on a fresh create. |
+| `--branch <branch>` | **Only on restore** — the archived branch to materialize (see [Archive & restore](#archive-restore)). Absent on a fresh create. |
 | `--program <p>` | The agent program to run (optional; forward to `af agent-server --program`). |
 | `--program-resolved` | Present with `--program`; forward it to `af agent-server` so the cloned repo cannot apply a second `program_overrides` lookup. |
 | `--session-env <name>` | Repeated for each global `session_env_passthrough` name; forward each one to `af agent-server --session-env`. Values are never command arguments. |
@@ -140,7 +140,7 @@ A script that exceeds its budget is killed and the operation fails.
 
 **A reap stops the whole launch tree first, then runs `delete_cmd`.** If your `launch_cmd` shells out to a provisioner (`terraform`, `gcloud`, `kubectl`) and is killed at its budget while that provisioner is still working, af kills the entire process group it started *before* running `delete_cmd`. Without that, the surviving provisioner would finish creating infrastructure **after** `delete_cmd` had already reaped and reported success — a resource that bills with nothing pointing at it, since a failed provision leaves af no record of the session.
 
-This applies only to a `launch_cmd` that **just failed**, where everything it started is garbage by definition. It never applies to one that succeeded — see [Backgrounding a tunnel](#backgrounding-a-tunnel-is-supported--you-need-do-nothing) — and it does not apply on kill or archive, where the launch ended long ago. Making `delete_cmd` idempotent is still worthwhile, and a `launch_cmd` that cleans up after itself on `EXIT`/`TERM` is still good practice.
+This applies only to a `launch_cmd` that **just failed**, where everything it started is garbage by definition. It never applies to one that succeeded — see [Backgrounding a tunnel](#backgrounding-a-tunnel-is-supported-you-need-do-nothing) — and it does not apply on kill or archive, where the launch ended long ago. Making `delete_cmd` idempotent is still worthwhile, and a `launch_cmd` that cleans up after itself on `EXIT`/`TERM` is still good practice.
 
 ### Backgrounding a tunnel is supported — you need do nothing
 

--- a/docs/surface-parity.md
+++ b/docs/surface-parity.md
@@ -40,9 +40,9 @@ audit (#1937) found gaps pointing in every direction:
   rather than a copy of the enum, for the reason the enum level below explains.
 
 The sharpest way to hold this: on `CreateSession`, **no surface is a superset of
-another**. All three accept different subsets of the same nine-field request — the
-TUI now sends a backend but still cannot send `title_base` or `auto_yes`, which
-the web does.
+another**. All three accept different subsets of the same eight-field request —
+the TUI now sends a backend but still cannot send `title_base`, which the web
+does.
 
 | Create option | TUI | Web | CLI |
 |---|---|---|---|


### PR DESCRIPTION
Found by the daily documentation-drift audit. Every change is verified against
the code or the real slugifier — not against other prose. Three unrelated-looking
fixes, one theme: each is a doc claim the code no longer supports.

## 1. Five same-file anchors pointed at a doubled dash

Each target heading contains `&` or an em dash, and the links assumed the removed
character leaves an empty slug segment. It does not — python-markdown's
`toc.slugify` collapses `[-\s]+` to **one** dash, so every one of these scrolled
nowhere.

| Site | Was | Now |
|---|---|---|
| `docs/backends.md:57`, `:315` | `#archive--restore` | `#archive-restore` |
| `docs/remote-hooks.md:5` | `#capabilities--the-agent-server` | `#capabilities-the-agent-server` |
| `docs/remote-hooks.md:70` | `#archive--restore` | `#archive-restore` |
| `docs/remote-hooks.md:143` | `#backgrounding-a-tunnel-is-supported--you-need-do-nothing` | `…-supported-you-need-do-nothing` |

Verified against the real slugifier (`markdown` 3.10.2), not by eye:

```
'Archive & restore'                                          -> 'archive-restore'
'Capabilities & the agent-server'                            -> 'capabilities-the-agent-server'
'Backgrounding a tunnel is supported — you need do nothing'  -> 'backgrounding-a-tunnel-is-supported-you-need-do-nothing'
```

**Why CI never caught it:** `mkdocs.yml` sets `validation.anchors: ignore`, so
`mkdocs build --strict` passes with these dead. After this PR a full re-scan of
every internal link and anchor in `docs/` + `README.md` reports **0 broken**.

## 2. `docs/configuration.md` taught the deprecated `af projects register`

`api/projects.go:44` declares `Aliases: []string{"register"}`, and the command's
own help text at `api/projects.go:64` reads:

```
'register' is a deprecated alias for 'add'.
```

`docs/configuration.md:539` sits inside a copy-pasteable block, so it actively
taught the deprecated spelling. **The alias still works and stays supported** —
`api/projects_registry_test.go:37` pins it so preview-build users are not broken
(#2456). Only the docs move to the canonical verb.

## 3. The `CreateSession` parity claim still cited `auto_yes`

`docs/surface-parity.md` read:

> All three accept different subsets of the same **nine-field** request — the TUI
> now sends a backend but still cannot send `title_base` or **`auto_yes`**, which
> the web does.

`auto_yes` no longer exists. `daemon/httpserver.go:351` rejects the field for
every client version via `config.RemovedAutoYesError()`, pinned by
`daemon/httpserver_test.go:219`
(`TestHTTP_RemovedAutoYesIsRejectedForEveryClientVersion`). So the web cannot
send it either — the text described a live parity gap on a field that is gone.

The count went with it. `daemon/control_types.go:16` now carries **eight**
client-settable JSON fields — `title`, `title_base`, `repo_path`, `program`,
`prompt`, `in_place`, `force_remote`, `backend`. `TaskID` and
`MaxConcurrentRuns` are `json:"-"` and `allowReserved` is unexported, so none of
the three is client-settable.

The surrounding **"no surface is a superset of another"** claim is unchanged and
still holds — re-verified rather than assumed:

- CLI sends `in_place`, not `force_remote`/`title_base` (`api/sessions.go:362`)
- TUI sends `force_remote`; its only construction site never populates
  `TitleBase` (`app/handle_input.go:165`, forwarded at
  `app/session_control.go:108`)
- Web sends `title_base` (`web/src/api.ts:371`)

## Scope

Fixes items **1** and **3** of #2583. Written as `Refs`, **not** a closing
keyword, on purpose — this must not auto-close the issue.

Item **2** — `gate-pr.md` gating on a reviewer we no longer use — is
**deliberately untouched**. That one needs an ops decision about what the gate
should require ("Codex verdict clean", "clean *or* usage-limited", something
else), not a rename. #2583 stays open for it.

## What the same audit checked and found clean

Recording this so tomorrow's run does not redo it:

- **Every `af …` invocation** in `docs/`, `README.md`, `CLAUDE.md`, and
  `.claude/skills/` — 213 distinct invocations extracted from code spans and
  fenced blocks only, walked against the live Cobra tree including aliases and
  per-command flags. **0 unknown command paths, 0 unknown flags.** The only two
  hits were false positives: `af agent-server --auto-yes` in `release-notes.md`
  (correctly documenting its own removal) and a `--watch` inside the quoted
  string `npm test -- --watch`.
- **All 32 config keys** (27 global via `af config list --json` + 5 repo-scoped
  in `config/manifest.go`). Every documented key exists; every documented default
  matches its manifest `Default`.
- **Effect-timing prose vs `config/effect.go`** — `configuration.md:15`, `:335`,
  `:354` and `cli.md:198` all agree with `keyEffectClasses`, including that
  `branch_prefix` is the only settable `NextDaemonStart` key and that
  `limit_auto_resume`/`limit_retry_interval` are applied live. (#2598 holding.)
- **Agent enum** — all 7 (`claude`, `codex`, `aider`, `gemini`, `amp`,
  `opencode`, `devin`) consistent across 15 prose sites and
  `tmux.SupportedPrograms`.
- **Built-in limit matchers** — `configuration.md:375`'s "claude, codex, devin
  only" matches `task/limit.go:102` exactly, devin detect-only included.
- **Detach keys** — the `Ctrl-]` (interactive→nav) vs `detach_keys`/`Ctrl-w`
  (full-screen attach) split is documented correctly everywhere; not drift.
- **Generated reference** — `docs/reference/cli.md` and `docs/reference/api.md`
  regenerate byte-identical from `gen-docs`, and `plugins/**` is in sync.
- **`mkdocs.yml` nav** — every target exists.
- **`CLAUDE.md`** — Go floor `1.25` matches `go.mod`, `deadcode@v0.48.0` matches
  both workflows, all 5 named `make` targets exist.

Docs-only change; no Go files touched.

Captain Claude