### PR TITLE
refactor(upgrade): remove extraction shim (#1241)

### DIFF
--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -373,9 +373,3 @@ func reportUpgradeRestart(out, errOut io.Writer, outcome restartOutcome, restart
 		fmt.Fprintln(errOut, "Re-register this home's unit with `af daemon install` to restore supervision.")
 	}
 }
-
-// extractBinaryFromTarGz reads a tar.gz stream and returns the contents of the
-// file whose name matches binaryName (or ends with /binaryName).
-func extractBinaryFromTarGz(r io.Reader, binaryName string) ([]byte, error) {
-	return autoupdate.ExtractBinaryFromTarGz(r, binaryName)
-}

--- a/commands/upgrade_test.go
+++ b/commands/upgrade_test.go
@@ -46,53 +46,6 @@ func upgradeReleaseURL(t *testing.T, archive []byte, archiveHandler http.Handler
 	return server.URL + "/" + testUpgradeArchiveName
 }
 
-func TestExtractBinaryFromTarGz(t *testing.T) {
-	archive := makeTarGz(t, map[string][]byte{
-		"agent-factory": []byte("binary-content"),
-		"README":        []byte("not the binary"),
-	})
-
-	got, err := extractBinaryFromTarGz(bytes.NewReader(archive), "agent-factory")
-	if err != nil {
-		t.Fatalf("extractBinaryFromTarGz returned error: %v", err)
-	}
-	if string(got) != "binary-content" {
-		t.Fatalf("extracted %q, want binary-content", string(got))
-	}
-}
-
-func TestExtractBinaryFromTarGzNestedPath(t *testing.T) {
-	archive := makeTarGz(t, map[string][]byte{
-		"dist/agent-factory": []byte("nested-binary"),
-	})
-
-	got, err := extractBinaryFromTarGz(bytes.NewReader(archive), "agent-factory")
-	if err != nil {
-		t.Fatalf("extractBinaryFromTarGz returned error: %v", err)
-	}
-	if string(got) != "nested-binary" {
-		t.Fatalf("extracted %q, want nested-binary", string(got))
-	}
-}
-
-func TestExtractBinaryFromTarGzMissingBinary(t *testing.T) {
-	archive := makeTarGz(t, map[string][]byte{
-		"other": []byte("content"),
-	})
-
-	_, err := extractBinaryFromTarGz(bytes.NewReader(archive), "agent-factory")
-	if err == nil || !strings.Contains(err.Error(), "not found") {
-		t.Fatalf("expected not found error, got %v", err)
-	}
-}
-
-func TestExtractBinaryFromTarGzInvalidGzip(t *testing.T) {
-	_, err := extractBinaryFromTarGz(strings.NewReader("not gzip"), "agent-factory")
-	if err == nil || !strings.Contains(err.Error(), "gzip") {
-		t.Fatalf("expected gzip error, got %v", err)
-	}
-}
-
 // TestDownloadBinarySuccess covers the happy path: an httptest server serves
 // a valid tar.gz and downloadBinary returns the embedded bytes.
 func TestDownloadBinarySuccess(t *testing.T) {

--- a/internal/autoupdate/staging_test.go
+++ b/internal/autoupdate/staging_test.go
@@ -15,8 +15,51 @@ import (
 
 const testReleaseArchiveName = "agent-factory-linux-amd64.tar.gz"
 
+func TestExtractBinaryFromTarGz(t *testing.T) {
+	archive := testTarGz(t, map[string][]byte{
+		"agent-factory": []byte("binary-content"),
+		"README":        []byte("not the binary"),
+	})
+
+	got, err := ExtractBinaryFromTarGz(bytes.NewReader(archive), "agent-factory")
+	if err != nil {
+		t.Fatalf("ExtractBinaryFromTarGz returned error: %v", err)
+	}
+	if string(got) != "binary-content" {
+		t.Fatalf("extracted %q, want binary-content", string(got))
+	}
+}
+
+func TestExtractBinaryFromTarGzNestedPath(t *testing.T) {
+	archive := testTarGz(t, map[string][]byte{"dist/agent-factory": []byte("nested-binary")})
+
+	got, err := ExtractBinaryFromTarGz(bytes.NewReader(archive), "agent-factory")
+	if err != nil {
+		t.Fatalf("ExtractBinaryFromTarGz returned error: %v", err)
+	}
+	if string(got) != "nested-binary" {
+		t.Fatalf("extracted %q, want nested-binary", string(got))
+	}
+}
+
+func TestExtractBinaryFromTarGzMissingBinary(t *testing.T) {
+	archive := testTarGz(t, map[string][]byte{"other": []byte("content")})
+
+	_, err := ExtractBinaryFromTarGz(bytes.NewReader(archive), "agent-factory")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+}
+
+func TestExtractBinaryFromTarGzInvalidGzip(t *testing.T) {
+	_, err := ExtractBinaryFromTarGz(strings.NewReader("not gzip"), "agent-factory")
+	if err == nil || !strings.Contains(err.Error(), "gzip") {
+		t.Fatalf("expected gzip error, got %v", err)
+	}
+}
+
 func TestCandidateStagerDownloadsNestedBinary(t *testing.T) {
-	archive := testTarGz(t, "dist/agent-factory", []byte("candidate-binary"))
+	archive := testTarGz(t, map[string][]byte{"dist/agent-factory": []byte("candidate-binary")})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/sha256sums.txt":
@@ -126,21 +169,23 @@ func testChecksumManifest(archiveName string, archive []byte) []byte {
 	return []byte(fmt.Sprintf("%x  %s\n", sha256.Sum256(archive), archiveName))
 }
 
-func testTarGz(t *testing.T, name string, contents []byte) []byte {
+func testTarGz(t *testing.T, files map[string][]byte) []byte {
 	t.Helper()
 	var buffer bytes.Buffer
 	gzipWriter := gzip.NewWriter(&buffer)
 	tarWriter := tar.NewWriter(gzipWriter)
-	if err := tarWriter.WriteHeader(&tar.Header{
-		Name:     name,
-		Mode:     0755,
-		Size:     int64(len(contents)),
-		Typeflag: tar.TypeReg,
-	}); err != nil {
-		t.Fatalf("write tar header: %v", err)
-	}
-	if _, err := tarWriter.Write(contents); err != nil {
-		t.Fatalf("write tar body: %v", err)
+	for name, contents := range files {
+		if err := tarWriter.WriteHeader(&tar.Header{
+			Name:     name,
+			Mode:     0755,
+			Size:     int64(len(contents)),
+			Typeflag: tar.TypeReg,
+		}); err != nil {
+			t.Fatalf("write tar header: %v", err)
+		}
+		if _, err := tarWriter.Write(contents); err != nil {
+			t.Fatalf("write tar body: %v", err)
+		}
 	}
 	if err := tarWriter.Close(); err != nil {
 		t.Fatalf("close tar: %v", err)


### PR DESCRIPTION
## What changed

- Removed the private `commands.extractBinaryFromTarGz` forwarding shim.
- Moved its four extraction cases beside `internal/autoupdate.ExtractBinaryFromTarGz`, the implementation they actually exercise.

## Why this is simpler

The manual-upgrade path moved to the shared `internal/autoupdate` stager in #2215, leaving a one-line command-layer wrapper kept alive only by command-package tests. Deleting that vestigial layer leaves one extraction API and keeps its tests with its owner.

This is behavior-preserving: no extraction implementation or production call site changed. The same success, nested-path, missing-binary, and invalid-gzip cases still run against the same function.

Refs #1241. Relates to the structural-health cleanup tracked in #1195.

## Validation

- `GOTOOLCHAIN=go1.25.0 go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --timeout=3m --out-format=line-number --fast --max-issues-per-linter=0 --max-same-issues=0`
- `gofmt -l .` (empty)
- `go build ./...`
- `make test-container`
- `deadcode -test ./...` (empty)
- `scripts/lint-file-length.sh` (1,094 Go files; 0 grandfathered)

— Captain Claude