### PR TITLE
docs: correct destructive kill semantics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,8 @@ Working style:
   hourly self-review.
 - Use `af sessions preview` to spot-check, `af sessions send-prompt` to
   refine, and `af sessions archive` as the default "done" action so the session
-  stays restorable. Use `af sessions kill --force` only when you explicitly mean
-  to permanently destroy the session and prune its branch. Don't let sessions
+  stays restorable. Use `af sessions kill` only when you explicitly mean to
+  permanently destroy the session and prune its owned branch. Don't let sessions
   accumulate.
 - Never run `pkill tmux`/`pkill af` or bare `tmux kill-server` on a shared host; tmux teardown must name an isolated socket with `-L` or `-S`.
 - Run `golangci-lint run --timeout=3m --fast`, `gofmt -l .`, `go build ./...`,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -88,7 +88,7 @@ af sessions archive <title>                               # default done action:
 af sessions archive --self                                # archive the current session (resolved via whoami)
 af sessions handoff <title> --to <agent>                  # continue under a different agent, same worktree/branch
 af sessions retry-limit <title>                           # retry a session parked at a usage-limit wall
-af sessions kill <title> [--force]                        # permanently destroy + prune branch
+af sessions kill <title>                                  # permanently destroy + prune owned branch
 af sessions restore <title>                               # restore an archived/lost/dead session
 ```
 

--- a/docs/concepts/worktree-agents.md
+++ b/docs/concepts/worktree-agents.md
@@ -23,8 +23,8 @@ Because each session gets its own worktree:
   Factory is in the way of `git diff`, `gh pr create`, or your CI.
 - **Finishing work is restorable by default.** Archive a session and `af` moves
   the worktree aside with the branch and changes intact, ready for restore. If
-  you really want to discard it, kill refuses recoverable branch/worktree work
-  unless you force the permanent cleanup.
+  you really want to discard it, kill permanently removes the session even when
+  its branch has uncommitted or unmerged work.
 
 ## The lifecycle of a session
 
@@ -43,10 +43,9 @@ Because each session gets its own worktree:
    and branch. Restore it later and the worktree comes back and the agent
    re-spawns.
 4. **Kill.** Killing a session permanently ends the agent, removes the worktree,
-   and deletes the branch when Agent Factory owns it. It refuses by default
-   unless it can confirm the worktree is clean and HEAD has no commits
-   unreachable from the session's base/default branch; use `--force` only when
-   you mean to discard that work.
+   and deletes the branch when Agent Factory owns it. It always destroys the
+   session, including uncommitted or unmerged work; use archive instead when you
+   need the work to remain restorable.
 
 ## In-place sessions
 


### PR DESCRIPTION
## Summary

- Remove the deprecated `--force` no-op from the narrative CLI synopsis and maintainer cleanup instructions.
- Correct the worktree concepts page: `af sessions kill` always destroys a session, including dirty or unmerged work, while archive is the restorable path.
- The old text was contradicted by the live implementation: [`--force` is registered as a deprecated no-op](https://github.com/sachiniyer/agent-factory/blob/b5325f5bc25d56624e9c335ece197790a21c26d0/api/api.go#L641-L644), [`KillSessionRequest` has no force field](https://github.com/sachiniyer/agent-factory/blob/b5325f5bc25d56624e9c335ece197790a21c26d0/daemon/control_types.go#L78-L82), and [tests require dirty and unmerged sessions to be destroyed without it](https://github.com/sachiniyer/agent-factory/blob/b5325f5bc25d56624e9c335ece197790a21c26d0/daemon/kill_test.go#L124-L155).

no issue

## Test Plan

All required gates ran after the final commit was pushed, against `4291bd9f3be547cbf3e6b9645afd88a1d7e65713`:

- [x] `golangci-lint run --timeout=3m --fast` passes
- [x] `gofmt -l .` produces no output
- [x] `go build ./...` passes
- [x] `make test-container` passes
- [x] `deadcode -test ./...` produces no output
- [x] `scripts/lint-file-length.sh` passes
- [x] `mkdocs build --strict` passes
- [x] Live-Cobra generated CLI/API output matches the committed generated references

— Captain Claude
