### PR TITLE
refactor(config): share struct tag name parsing

### DIFF
--- a/config/config_schema.go
+++ b/config/config_schema.go
@@ -22,19 +22,10 @@ func knownJSONConfigKeys() map[string]bool {
 	out := map[string]bool{}
 	t := reflect.TypeOf(Config{})
 	for i := 0; i < t.NumField(); i++ {
-		name := jsonTagName(t.Field(i).Tag.Get("json"))
+		name := structTagName(t.Field(i).Tag.Get("json"))
 		if name != "" && name != "-" {
 			out[name] = true
 		}
 	}
 	return out
-}
-
-func jsonTagName(tag string) string {
-	for i := range tag {
-		if tag[i] == ',' {
-			return tag[:i]
-		}
-	}
-	return tag
 }

--- a/config/manifest_policy_test.go
+++ b/config/manifest_policy_test.go
@@ -32,7 +32,7 @@ func manifestSchemaFields(t *testing.T, schema manifestSchema) map[string]reflec
 		if !field.IsExported() {
 			continue
 		}
-		key := tomlTagName(field.Tag.Get("toml"))
+		key := structTagName(field.Tag.Get("toml"))
 		switch key {
 		case "-":
 			continue
@@ -161,10 +161,10 @@ func TestAllManifestScalarDefaultsMatchBuiltInResolution(t *testing.T) {
 
 func formatsForManifestField(field reflect.StructField) FormatSet {
 	var formats FormatSet
-	if key := tomlTagName(field.Tag.Get("toml")); key != "" && key != "-" {
+	if key := structTagName(field.Tag.Get("toml")); key != "" && key != "-" {
 		formats |= FormatSet(1) << FormatTOML
 	}
-	if key := jsonTagName(field.Tag.Get("json")); key != "" && key != "-" {
+	if key := structTagName(field.Tag.Get("json")); key != "" && key != "-" {
 		formats |= FormatSet(1) << FormatJSON
 	}
 	return formats
@@ -324,7 +324,7 @@ func TestManifestDerivedInRepoPolicyViews(t *testing.T) {
 		if _, shared := repoFields[key]; !shared {
 			wantGlobalOnly[key] = true
 		}
-		if jsonTagName(field.Tag.Get("json")) == "-" {
+		if structTagName(field.Tag.Get("json")) == "-" {
 			wantTOMLOnly[key] = true
 		}
 	}

--- a/config/manifest_test.go
+++ b/config/manifest_test.go
@@ -57,8 +57,8 @@ func configTomlFields(t *testing.T) map[string]string {
 			continue
 		}
 		tag := f.Tag.Get("toml")
-		// tomlTagName strips the ",omitempty" suffix (config/theme.go).
-		key := tomlTagName(tag)
+		// structTagName strips the ",omitempty" suffix.
+		key := structTagName(tag)
 		if key == "-" {
 			continue // explicit opt-out: deliberately not a config key
 		}
@@ -267,7 +267,7 @@ func TestManifestTypeMatchesTheRealField(t *testing.T) {
 	for _, e := range Manifest() {
 		field, ok := rt.FieldByNameFunc(func(name string) bool {
 			f, found := rt.FieldByName(name)
-			return found && tomlTagName(f.Tag.Get("toml")) == e.Key
+			return found && structTagName(f.Tag.Get("toml")) == e.Key
 		})
 		if !ok {
 			// TestManifestCoversEveryConfigKey owns the phantom-entry failure;

--- a/config/manifest_value.go
+++ b/config/manifest_value.go
@@ -44,7 +44,7 @@ func configFieldByTomlKey(cfg *Config, key string) (reflect.Value, bool) {
 		if !f.IsExported() {
 			continue
 		}
-		if tomlTagName(f.Tag.Get("toml")) != key {
+		if structTagName(f.Tag.Get("toml")) != key {
 			continue
 		}
 		return rv.Field(i), true

--- a/config/provenance.go
+++ b/config/provenance.go
@@ -417,7 +417,7 @@ func taggedFieldByKey(value reflect.Value, key string) (reflect.Value, bool) {
 		if !field.IsExported() {
 			continue
 		}
-		if tomlTagName(field.Tag.Get("toml")) == key || jsonTagName(field.Tag.Get("json")) == key || field.Tag.Get("config") == key {
+		if structTagName(field.Tag.Get("toml")) == key || structTagName(field.Tag.Get("json")) == key || field.Tag.Get("config") == key {
 			return value.Field(i), true
 		}
 	}
@@ -496,7 +496,7 @@ func compositeNames(value reflect.Value) []string {
 			if !field.IsExported() {
 				continue
 			}
-			name := tomlTagName(field.Tag.Get("toml"))
+			name := structTagName(field.Tag.Get("toml"))
 			if name != "" && name != "-" {
 				names = append(names, name)
 			}

--- a/config/struct_tag.go
+++ b/config/struct_tag.go
@@ -1,0 +1,11 @@
+package config
+
+// structTagName returns the field name before any comma-separated tag options.
+func structTagName(tag string) string {
+	for i := range tag {
+		if tag[i] == ',' {
+			return tag[:i]
+		}
+	}
+	return tag
+}

--- a/config/theme.go
+++ b/config/theme.go
@@ -73,7 +73,7 @@ func sanitizeThemeColors(config *Config, prettyConfigPath string) {
 		field := cfgValue.Field(i)
 		raw := strings.TrimSpace(field.String())
 		fallback := defaultValue.Field(i).String()
-		key := tomlTagName(cfgType.Field(i).Tag.Get("toml"))
+		key := structTagName(cfgType.Field(i).Tag.Get("toml"))
 		if key == "" {
 			key = cfgType.Field(i).Name
 		}
@@ -93,13 +93,4 @@ func sanitizeThemeColors(config *Config, prettyConfigPath string) {
 // nothing else pinning the two together.
 func ThemeSlotCount() int {
 	return reflect.TypeOf(ThemeConfig{}).NumField()
-}
-
-func tomlTagName(tag string) string {
-	for i := range tag {
-		if tag[i] == ',' {
-			return tag[:i]
-		}
-	}
-	return tag
 }


### PR DESCRIPTION
## Summary

Replace the byte-identical `jsonTagName` and `tomlTagName` parsers in `config` with one neutral `structTagName` helper, then point all JSON and TOML reflection callers at that single implementation.

This makes the comma-option stripping rule single-source across config key discovery, manifest policy, provenance lookup, manifest value resolution, and theme warnings. It removes the misleading implication that JSON and TOML require different parsing logic.

This is one small cleanup from the #1241 daily abstraction-simplification practice, using the duplication lens from #1195.

no issue

## Why this preserves behavior

The two deleted helpers were byte-identical. `structTagName` retains that exact body, and every changed call passes the same `reflect.StructTag.Get("json")` or `Get("toml")` value it passed before. No tags, branches, output strings, or exported APIs changed.

## Test Plan

- [x] `GOTOOLCHAIN=go1.25.0 go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --timeout=3m --out-format=line-number --fast --max-issues-per-linter=0 --max-same-issues=0`
- [x] `gofmt -l .` — empty
- [x] `GOTOOLCHAIN=go1.25.0 go build ./...`
- [x] `make test-container` — full container-fenced suite passed
- [x] `GOTOOLCHAIN=go1.25.0 deadcode -test ./...` — empty
- [x] `scripts/lint-file-length.sh` — 1,094 Go files, 0 grandfathered
- [x] TUI manual test not applicable; no UI behavior changed

Not self-merging; held for root review.

— Captain Claude