### PR TITLE
docs: retire pre-PR7 remote-hook claims

### DIFF
--- a/commands/agentservercmd.go
+++ b/commands/agentservercmd.go
@@ -12,16 +12,15 @@ import (
 )
 
 // `af agent-server` (#1592 Phase 4 PR1) runs a headless, single-workspace
-// agent-server over the HTTP/WS+token protocol — the process that will later
-// run INSIDE each docker/ssh sandbox and be driven by a remote daemon over an
-// authed URL. It is the standalone, out-of-process form of the daemon's
+// agent-server over the HTTP/WS+token protocol — the process that runs inside
+// each docker/SSH/hook workspace and is driven by a remote daemon over an authed
+// URL. It is the standalone, out-of-process form of the daemon's
 // in-process local agent-server: one session's workspace (worktree + tmux),
 // exposed over the exact wire the daemon already speaks, behind a bearer token on
 // a plain-HTTP listener.
 //
-// It is DARK in this PR: nothing provisions a sandbox to run it and nothing in the
-// daemon drives it yet. Run it by hand and drive it directly to prove the process
-// boundary.
+// Docker, SSH, and hook runtimes provision it; it can also be run directly for
+// testing.
 
 var (
 	agentServerListen          string

--- a/commands/doctorcmd.go
+++ b/commands/doctorcmd.go
@@ -49,8 +49,8 @@ accumulate silently on a machine running agent-factory:
     different af binary than yours, several af installs at different versions,
     sockets left behind with no daemon answering, and an autostart unit that
     is installed but not actually supervising anything
-  - remote-hook setup for the current repo: config completeness, hook-script
-    presence/executability, and a bounded list_cmd connectivity probe
+  - remote-hook setup for the current repo: config completeness and
+    launch_cmd/delete_cmd script presence/executability
     (skipped cleanly when no remote backend is configured)
 
 The version-skew check exists because a skewed daemon fails quietly: it keeps

--- a/daemon/agentserver_headless.go
+++ b/daemon/agentserver_headless.go
@@ -18,19 +18,17 @@ import (
 )
 
 // The headless single-workspace agent-server (#1592 Phase 4 PR1) — the process
-// that will later run INSIDE each docker/ssh sandbox (§1.1). It is the mirror
+// that runs inside each docker/SSH/hook workspace. It is the mirror
 // image of the daemon's in-process localAgentServer: where the daemon drives a
 // local session through session.AgentServer directly, this exposes ONE session's
 // AgentServer over the exact HTTP/WS+token wire the daemon already speaks, so
-// a remote daemon (PR2's remoteAgentServer) can drive it across the process
+// a remote daemon's remoteAgentServer can drive it across the process
 // boundary exactly like the in-process one.
 //
 // It is deliberately NOT the orchestrator (§1.1): no task scheduler, no watch
 // supervisor, no multi-session Manager, no disk-state ownership. It owns exactly
-// one live session.AgentServer and exposes it. The workspace is DARK in this PR:
-// nothing provisions a sandbox to run it (PR4/PR5) and nothing in the daemon
-// drives it yet (PR2) — it is a standalone `af agent-server` you run and hit
-// directly.
+// one live session.AgentServer and exposes it. Docker, SSH, and hook runtimes
+// provision this process; it can also be run directly for testing.
 //
 // Reuse, not reimplementation: the HTTP+token listener (startTCPListener), the
 // auth+CORS gate (withAuth), the WS PTY broker fan-out (servePTYStream), the
@@ -102,7 +100,7 @@ type AgentServerInfo struct {
 // listener's token is loopback-exempt): the agent-server exists to be reached
 // over the network by a remote daemon. The transport is plain HTTP (no TLS) — the
 // token travels over it, so a driver reaches the agent-server over a private
-// network or tunnel (the docker/ssh runtimes forward a loopback port). It reuses
+// network or tunnel controlled by the off-box runtime. It reuses
 // startTCPListener verbatim — the same token/gate wiring the daemon's
 // `listen_addr` opt-in uses.
 func RunAgentServer(opts AgentServerOptions, stdout io.Writer) error {
@@ -134,9 +132,8 @@ func RunAgentServer(opts AgentServerOptions, stdout io.Writer) error {
 		SessionEnvPassthrough: opts.SessionEnvPassthrough,
 		// The in-sandbox agent-server ALWAYS runs the local runtime (tmux + git
 		// worktree against RepoPath) — it IS the sandbox (§1.2). Force it explicitly
-		// so a workspace whose repo config declares backend=docker/ssh (cloned into
-		// the container by the docker runtime, #1592 Phase 4 PR4) does not make the
-		// agent-server recursively try to provision another sandbox inside itself.
+		// so a workspace whose repo config declares backend=docker/ssh/hook does
+		// not recursively provision another sandbox inside itself.
 		Backend: session.BackendLocal,
 	})
 	if err != nil {

--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -114,8 +114,8 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, session.Ins
 		return "", session.InstanceData{}, fmt.Errorf("session %q changed state before archive could start", req.Title)
 	}
 
-	// A sandbox session (docker/ssh) archives by pushing its branch to origin and
-	// reaping the sandbox, not by relocating a worktree it does not have (#1592
+	// An off-box session (docker/ssh/hook) archives by pushing its branch to origin
+	// and reaping the sandbox, not by relocating a worktree it does not have (#1592
 	// Phase 4 PR6). Route it to the remote body, which shares this method's guards,
 	// locks, and archive fence.
 	if instance.Capabilities().Workspace == session.WorkspaceRemote {
@@ -238,7 +238,7 @@ func (m *Manager) undoCommittedArchive(repoID string, instance *session.Instance
 	return nil
 }
 
-// archiveRemoteSession archives a sandbox-backed session (docker/ssh) by pushing
+// archiveRemoteSession archives an off-box session (docker/ssh/hook) by pushing
 // its branch to origin then reaping the sandbox (#1592 Phase 4 PR6) — the remote
 // analogue of ArchiveSession's worktree-move body, sharing its guards, locks, and
 // archive fence. GitHub holds the durable branch, so unlike the local path there
@@ -277,7 +277,7 @@ func (m *Manager) archiveRemoteSession(repoID string, instance *session.Instance
 	return branch, nil
 }
 
-// restoreRemoteSession restores an archived sandbox session (docker/ssh) by
+// restoreRemoteSession restores an archived off-box session (docker/ssh/hook) by
 // re-provisioning a fresh sandbox that clones the pushed branch back and
 // relaunching the agent (#1592 Phase 4 PR6) — the remote analogue of
 // RestoreArchived's worktree-move body, sharing its guards + locks. It reuses
@@ -379,8 +379,9 @@ func (m *Manager) restoreArchivedInstance(instance *session.Instance, repoID, ti
 		return "", fmt.Errorf("cannot restore: %w", err)
 	}
 
-	// A sandbox session (docker/ssh) restores by re-provisioning a fresh sandbox
-	// that clones the pushed branch back, not by moving a worktree it does not have
+	// An off-box session (docker/ssh/hook) restores by re-provisioning a fresh
+	// sandbox that clones the pushed branch back, not by moving a worktree it does
+	// not have
 	// (#1592 Phase 4 PR6). Route it to the remote body, which shares this method's
 	// guards + locks.
 	if instance.Capabilities().Workspace == session.WorkspaceRemote {

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -31,8 +31,8 @@ const daemonUpgradeProbationErrText = "agent-factory daemon is validating an upg
 
 // errDaemonStarting is returned by state-dependent RPC handlers in the window
 // between the control-socket bind and the completion of the instance restore
-// (#829). The socket now binds before the restore, which can take minutes on
-// remote-hook repos, so this window is user-visible.
+// (#829). The socket now binds before the restore so this window is observable
+// without admitting state-dependent work against a partial instance map.
 func errDaemonStarting() error {
 	return errors.New(daemonStartingErrText)
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -41,13 +41,12 @@ var configDirForReap = config.GetConfigDir
 // status (Ready/Dead/Running, #935/#960 PR 5).
 //
 // Startup ordering matters (#829): the control socket binds BEFORE the
-// instance restore, which can take minutes on remote-hook repos (list_cmd /
-// ssh per session). Pre-#829 the restore ran first, so every concurrent
-// EnsureDaemon found no socket and spawned another daemon that burned a full
+// instance restore. Pre-#829 the restore ran first, so every concurrent
+// EnsureDaemon found no socket and spawned another daemon that performed a full
 // restore before losing the bind race. During the warm-up window Ping and
-// Shutdown work and state-dependent RPCs return errDaemonStarting; the
-// scheduler, watcher supervisor, and session-status poll loop start only after the
-// restore because they act on restored state.
+// Shutdown work and state-dependent RPCs return errDaemonStarting; the scheduler,
+// watcher supervisor, and session-status poll loop start only after the restore
+// because they act on restored state.
 func RunDaemon(cfg *config.Config) error {
 	return runDaemon(cfg, "")
 }
@@ -239,8 +238,8 @@ func runDaemon(cfg *config.Config, upgradeTransactionID string) error {
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 
-	// Run the restore concurrently so a shutdown or signal during warm-up
-	// exits promptly instead of hanging behind minutes of list_cmd/ssh. The
+	// Run the restore concurrently so a shutdown or signal during warm-up exits
+	// promptly instead of waiting for the restore to finish. The
 	// warm-up exit paths deliberately skip SaveInstances: nothing has been
 	// restored, and saving the empty instance map would wipe every persisted
 	// session.

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -271,8 +271,8 @@ type Manager struct {
 // NewManager constructs a manager and synchronously restores all persisted
 // instances into it, returning only once the manager is ready. RunDaemon
 // deliberately does NOT use this: it builds the shell with newManagerShell,
-// binds the control socket, and only then runs RestoreInstances — the restore
-// can take minutes on remote-hook repos and must not delay the bind (#829).
+// binds the control socket, and only then runs RestoreInstances so rehydrating
+// persisted state cannot delay the bind (#829).
 func NewManager(cfg *config.Config) (*Manager, error) {
 	manager, err := newManagerShell(cfg)
 	if err != nil {
@@ -377,10 +377,9 @@ func newManagerShellForDaemon(cfg *config.Config, transactionID string) (*Manage
 }
 
 // RestoreInstances loads every repo's persisted instances into the manager
-// and marks it ready. This is the slow part of daemon startup — restoring a
-// remote-hook session shells out to the repo's list_cmd (often ssh) per
-// session — which is why RunDaemon runs it only after the control socket is
-// bound (#829). Replacing the instance map wholesale is safe: every RPC that
+// and marks it ready. RunDaemon does this only after the control socket is bound
+// (#829), keeping Ping and Shutdown available while persisted state is
+// rehydrated. Replacing the instance map wholesale is safe: every RPC that
 // mutates it is gated on Ready, and the refresh poll loop starts after the
 // restore completes.
 func (m *Manager) RestoreInstances() error {

--- a/daemon/manager_tabs.go
+++ b/daemon/manager_tabs.go
@@ -22,11 +22,10 @@ import (
 // the same repo can't race the tab list or derive a duplicate name. The new tab
 // is persisted immediately (ToInstanceData serializes its command + tmux name,
 // and restoreLocalTabs reconnects it by exact name on reload) so it survives a
-// daemon/af restart — Sachin's hard #930 requirement. Rejected for remote/hook
-// instances (no local worktree, and the hook protocol can't run arbitrary
-// commands — a remote session's only terminal tab is the terminal_cmd one), an
-// empty command, or an instance already at the soft cap (maxTabs, enforced by
-// AddProcessTab).
+// daemon/af restart — Sachin's hard #930 requirement. Rejected for off-box
+// instances, which have no daemon-side worktree from which to spawn a
+// user-managed tab; also rejected for an empty command or an instance already at
+// the soft cap (maxTabs, enforced by AddProcessTab).
 func (m *Manager) CreateTab(req CreateTabRequest) (CreateTabResponse, error) {
 	// An empty kind is the default (shell-or-process, per req.Shell), not a kind;
 	// every explicit kind resolves through session.ParseTabKindName, the shared

--- a/daemon/preview.go
+++ b/daemon/preview.go
@@ -10,13 +10,12 @@ import (
 	"github.com/sachiniyer/agent-factory/terminal"
 )
 
-// The Preview RPC (#1592 Phase 2 PR6) is the daemon's SOLE capture path for the
-// session content the TUI cannot stream live over the WS PTY plane: remote/hook
-// sessions (whose output is captured by the daemon-side hook process, not the
-// TUI), scroll-mode scrollback (the live stream carries only the visible screen),
-// the transient #1321 preview target, and any transitional state. Before PR6 the
-// TUI shelled out to `tmux capture-pane` itself; deleting that made the daemon the
-// one capturer, and this RPC is how the read-only TUI reaches it.
+// The Preview RPC (#1592 Phase 2 PR6) is the daemon's SOLE capture path for
+// scroll-mode scrollback (the live stream carries only the visible screen), the
+// transient #1321 preview target, and any transitional state. Local capture and
+// off-box AgentServer snapshots both terminate here. Before PR6 the TUI shelled
+// out to `tmux capture-pane` itself; deleting that made the daemon the one
+// capturer, and this RPC is how the read-only TUI reaches it.
 //
 // It is an internal, non-cataloged route (like the Pause/ResumeStatusPoll attach-
 // coordination RPCs): it is TUI render plumbing, not a client-facing `af` verb, so

--- a/daemon/stream_warmup_test.go
+++ b/daemon/stream_warmup_test.go
@@ -14,11 +14,10 @@ import (
 // The warm-up contract for the WebSocket stream plane (#2109), the same contract
 // the web-tab proxy was brought under in #1878.
 //
-// RunDaemon binds the HTTP listener long BEFORE the restore finishes (#829,
-// deliberately: the restore shells out per remote-hook session and can take
-// minutes). Both stream routes are HTTP rather than net/rpc, so — exactly like the
-// proxy did — they slipped the requireManagerReady gate that every state-reading
-// RPC goes through. A stream request landing in that window runs
+// RunDaemon binds the HTTP listener before the restore finishes (#829). Both
+// stream routes are HTTP rather than net/rpc, so — exactly like the proxy did —
+// they slipped the requireManagerReady gate that every state-reading RPC goes
+// through. A stream request landing in that window runs
 // agentServerForStream → resolveStreamSession → refreshLocked, which builds
 // instances off disk and puts them in m.instances. RestoreInstances then rebuilds
 // that map from scratch, so the instance already handed to the client is no longer

--- a/daemon/webtab_warmup_test.go
+++ b/daemon/webtab_warmup_test.go
@@ -11,12 +11,12 @@ import (
 // The warm-up contract (#1878): the web-tab proxy must not serve — or touch
 // session state — until the daemon's restore has finished.
 //
-// RunDaemon binds the HTTP listener long BEFORE the restore (#829, deliberately:
-// the restore shells out per remote-hook session and can take minutes). So a stale
-// iframe left open across a daemon restart starts re-requesting the instant the
-// port answers. Every one of those requests resolves through resolveStreamSession,
-// which calls refreshLocked and REPLACES the instance map from disk — the proxy
-// driving its own restore. RestoreInstances documents the invariant it broke:
+// RunDaemon binds the HTTP listener before the restore finishes (#829). So a
+// stale iframe left open across a daemon restart starts re-requesting the instant
+// the port answers. Every one of those requests resolves through
+// resolveStreamSession, which calls refreshLocked and REPLACES the instance map
+// from disk — the proxy driving its own restore. RestoreInstances documents the
+// invariant it broke:
 // "every RPC that mutates it is gated on Ready". This route is HTTP, not net/rpc,
 // so it slipped the gate entirely.
 

--- a/docs/concepts/worktree-agents.md
+++ b/docs/concepts/worktree-agents.md
@@ -62,10 +62,10 @@ attaches to a repo.
 
 Everything above describes **local** sessions — worktrees on the machine running
 `af`. Sessions can also run on a **remote** backend you define, through
-[remote hooks](../remote-hooks.md): your own scripts launch, list, attach to,
-and delete sessions elsewhere, and they show up in the same sidebar with the
-same Agent tab, attach, and kill experience. The worktree-isolation model is the same;
-only the machine changes.
+[remote hooks](../remote-hooks.md): your `launch_cmd` provisions a workspace and
+exposes an `af agent-server`, while `delete_cmd` tears that workspace down. The
+session shows up in the same sidebar with the same Agent tab, attach, and kill
+experience. The worktree-isolation model is the same; only the machine changes.
 
 ## Who owns the state
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -908,8 +908,8 @@ accumulate silently on a machine running agent-factory:
     different af binary than yours, several af installs at different versions,
     sockets left behind with no daemon answering, and an autostart unit that
     is installed but not actually supervising anything
-  - remote-hook setup for the current repo: config completeness, hook-script
-    presence/executability, and a bounded list_cmd connectivity probe
+  - remote-hook setup for the current repo: config completeness and
+    launch_cmd/delete_cmd script presence/executability
     (skipped cleanly when no remote backend is configured)
 
 The version-skew check exists because a skewed daemon fails quietly: it keeps

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -7,10 +7,11 @@
 //
 // It also validates the remote-hook backend (#1039) for the repository
 // containing the current working directory: config completeness, hook-script
-// presence/executability, and a bounded read-only connectivity probe via
-// list_cmd. When no remote backend is configured — the common case — the
-// remote checks record a single informational "n/a" line and add no findings,
-// so local-only users see no new noise.
+// presence, and executability. The provision-and-expose contract has no
+// read-only connectivity verb, so doctor does not run either mutating hook.
+// When no remote backend is configured — the common case — the remote checks
+// record a single informational "n/a" line and add no findings, so local-only
+// users see no new noise.
 //
 // The safety stance is asymmetric by design: detection is generous,
 // remediation is conservative. A process is only ever killed when its

--- a/doctor/remote.go
+++ b/doctor/remote.go
@@ -39,11 +39,11 @@ func defaultRemoteConfig() (*config.RemoteHooks, string, error) {
 }
 
 // checkRemoteSetup validates the remote-hook backend for the current repo:
-// config completeness, hook-script presence/executability, and a bounded
-// read-only connectivity probe via list_cmd. When no remote backend is
-// configured (the common case for local-only users), it records a single
-// informational "n/a" line and adds no findings — running `af doctor` outside
-// a remote setup must produce zero new noise.
+// config completeness and launch_cmd/delete_cmd script presence/executability.
+// There is no read-only connectivity probe in the provision-and-expose contract.
+// When no remote backend is configured (the common case for local-only users),
+// it records a single informational "n/a" line and adds no findings — running
+// `af doctor` outside a remote setup must produce zero new noise.
 func checkRemoteSetup(ctx *scanContext, report *Report) {
 	resolve := ctx.opts.remoteConfig
 	if resolve == nil {

--- a/session/agentserver.go
+++ b/session/agentserver.go
@@ -77,7 +77,7 @@ type TabAddressableServer interface {
 // bites.
 type AgentServer interface {
 	// Provision establishes WHERE the agent runs — the local git worktree for the
-	// local runtime, an off-box workspace for a future remote/container runtime.
+	// local runtime, or an off-box workspace for docker, SSH, and hook runtimes.
 	// It is the first half of Phase-1's Start split (backend provision phase).
 	Provision(firstTimeSetup bool) error
 	// Launch starts WHAT runs in the provisioned workspace — the agent process and
@@ -93,14 +93,14 @@ type AgentServer interface {
 	// Snapshot returns the current non-interactive observation the daemon's
 	// liveness poll reads each tick, dismissing any pending trust/permission
 	// prompt as a side effect (the poll always did both, in that order). See
-	// Observation. The local implementation never errors; the error is for a future
-	// remote runtime whose observation channel can fail.
+	// Observation. The local implementation never errors; off-box AgentServer
+	// observation can fail across the network.
 	Snapshot() (Observation, error)
 	// Preview returns tab `tab`'s visible output; full=true returns the entire
 	// scrollback history. tab 0 is the agent tab (the backend preview); tab>0 is a
-	// shell/process tab. This is the daemon's SOLE capture path for content the TUI
-	// can't stream live (remote/hook sessions, scroll-mode scrollback, the transient
-	// preview target) — the TUI no longer captures tmux itself (#1592 Phase 2 PR6).
+	// shell/process tab. This is the daemon's SOLE capture path for scroll-mode
+	// scrollback and the transient preview target — the TUI no longer captures tmux
+	// itself (#1592 Phase 2 PR6), and off-box snapshots use this same path.
 	Preview(tab int, full bool) (PreviewSnapshot, error)
 	// PreviewByID is Preview addressed by the tab's stable identity. Implementations
 	// must either bind directly to the identified capture target or keep identity
@@ -161,7 +161,7 @@ type AgentServer interface {
 	// Phase 4 PR6): it commits any uncommitted work and pushes the session branch
 	// to origin (GitHub is the durable workspace store, epic decision 4),
 	// returning the pushed branch so the orchestrator can clone it back on
-	// restore. It is the primitive the disposable sandbox runtimes (docker/ssh)
+	// restore. It is the primitive the disposable off-box runtimes (docker/ssh/hook)
 	// archive through — the daemon calls it over the wire, and the in-sandbox
 	// local agent-server pushes the branch it owns. The local in-process runtime
 	// implements it too (a plain commit+push of its worktree), but the daemon

--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -157,9 +157,8 @@ func (s *localAgentServer) Snapshot() (Observation, error) {
 }
 
 func (s *localAgentServer) Preview(tab int, full bool) (PreviewSnapshot, error) {
-	// The agent tab (0) keeps the backend preview path — a backend may format its
-	// agent output specially (e.g. the remote hook's sanitized stream). Shell/process
-	// tabs (>0) capture their own tmux session, mirroring TabPane's former
+	// The agent tab (0) keeps the backend preview path. Shell/process tabs (>0)
+	// capture their own tmux session, mirroring TabPane's former
 	// updateAgent/updateShell split now that the daemon is the sole capturer.
 	if tab != 0 {
 		return s.inst.PreviewTabSnapshot(tab, full)
@@ -426,7 +425,7 @@ func (s *localAgentServer) Resize(tab int, rows, cols uint16) error {
 
 // Archive commits any uncommitted work and pushes this session's branch to
 // origin (#1592 Phase 4 PR6). Running INSIDE a sandbox as the in-process
-// agent-server, this is where a docker/ssh session's push actually happens — it
+// agent-server, this is where an off-box session's push actually happens — it
 // owns the git worktree, so it can snapshot the working tree and push the branch
 // GitHub will hold as the durable workspace. Returns the pushed branch name.
 func (s *localAgentServer) Archive() (string, error) {

--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -50,9 +50,9 @@ import (
 // (agentproto.ReadMessage/WriteFrame), and the {data,error} envelope (apiproto).
 // The thin HTTP/WS plumbing below is the only local piece.
 //
-// DARK for users in PR2: no docker/ssh runtime provisions a sandbox to point one
-// at yet (PR3-PR5). It is proven by an out-of-process integration test that
-// starts a real `af agent-server` on loopback and drives it through here.
+// The off-box runtimes all terminate here after provisioning an `af agent-server`;
+// an out-of-process integration test also starts one on loopback and drives it
+// through this client.
 type remoteAgentServer struct {
 	rc *remoteAgentClient
 	// inst owns the authoritative stable-id→ordinal roster for daemon-created
@@ -60,11 +60,10 @@ type remoteAgentServer struct {
 	// holds inst's roster lock across the bounded REST capture (#2200). nil only
 	// for the transport-only NewRemoteAgentServer constructor used by integrations.
 	inst *Instance
-	// teardown reaps the sandbox the agent runs in AFTER the in-sandbox workspace
-	// is killed over REST (#1592 Phase 4 PR4): `docker rm -f` the container. nil
-	// for the PR2 out-of-process case (an `af agent-server` the test owns — nothing
-	// for this client to reap). Run best-effort in Kill so a session kill also
-	// removes its container; idempotent (the runtime guards it with a sync.Once).
+	// teardown reaps the off-box workspace AFTER its in-sandbox agent is killed over
+	// REST. nil for an out-of-process `af agent-server` the caller owns. Run
+	// best-effort in Kill so a session kill also removes its sandbox; idempotent
+	// (the runtime serializes it).
 	teardown func() error
 
 	mu sync.Mutex

--- a/session/archive_sandbox.go
+++ b/session/archive_sandbox.go
@@ -32,8 +32,8 @@ func (i *Instance) pushBranchForArchive() (string, error) {
 	return gw.SnapshotAndPushBranch()
 }
 
-// ArchiveSandbox makes a sandbox-backed session (docker/ssh) durable and reaps
-// its sandbox (#1592 Phase 4 PR6): it pushes the branch to origin over the
+// ArchiveSandbox makes an off-box session (docker/ssh/hook) durable and reaps
+// its sandbox (#1592 Phase 4 PR6/PR7): it pushes the branch to origin over the
 // agent-server, then tears the in-sandbox workspace down and reaps the sandbox
 // (the AgentServer.Kill path), and finally clears the now-dead remote wiring so a
 // later restore rebuilds it. Returns the pushed branch, which the caller records
@@ -241,8 +241,8 @@ func (i *Instance) teardownAfterStartFailure() {
 }
 
 // isSandboxBackendType reports whether a persisted backend Type() names a
-// disposable sandbox runtime (docker/ssh) — the runtimes archive/restore
-// re-provision (#1592 Phase 4 PR6).
+// disposable sandbox runtime (docker/ssh/hook) — the runtimes archive/restore
+// re-provision (#1592 Phase 4 PR6/PR7).
 func isSandboxBackendType(t string) bool {
 	_, err := backendKindForType(t)
 	return err == nil

--- a/session/archive_sandbox_test.go
+++ b/session/archive_sandbox_test.go
@@ -354,7 +354,7 @@ func (r *specCapturingRuntime) Provision(s ProvisionSpec) (ProvisionResult, erro
 // a partial archive (push OK, teardown failed) the instance the daemon persists as
 // Lost is one whose subsequent re-provision — the exact call the Lost-restore loop
 // makes via Recover → recoverSandbox → reprovisionRemote — carries the PUSHED branch
-// as RestoreBranch. That is what makes the docker/ssh runtimes fetch the branch back
+// as RestoreBranch. That is what makes the off-box runtimes fetch the branch back
 // (backend_docker.go: an empty RestoreBranch skips the fetch and lands on the repo's
 // default branch) instead of silently recovering onto the wrong one.
 func TestArchiveSandbox_PartialFailureReprovisionsOnPushedBranch(t *testing.T) {

--- a/session/backend.go
+++ b/session/backend.go
@@ -10,11 +10,11 @@ type WorkspaceKind int
 
 const (
 	// WorkspaceLocalWorktree: a git worktree on the daemon's own machine, driven
-	// by tmux (today's LocalBackend). Zero value — a backend-less instance reads
+	// by tmux (LocalBackend). Zero value — a backend-less instance reads
 	// as a local workspace.
 	WorkspaceLocalWorktree WorkspaceKind = iota
 	// WorkspaceRemote: the workspace lives off-box; there is no local worktree or
-	// tmux to drive (today's HookBackend; tomorrow's ssh/container runtimes).
+	// tmux to drive (docker, SSH, and remote-hook runtimes).
 	WorkspaceRemote
 )
 
@@ -41,9 +41,8 @@ type Capabilities struct {
 	Recover bool
 	// TabManagement: the user can add/close arbitrary tabs (new process tab).
 	TabManagement bool
-	// TerminalTab: an interactive terminal tab is available. May depend on
-	// per-session config (remote_hooks.terminal_cmd), so it is computed per
-	// instance rather than being a static per-type constant.
+	// TerminalTab: an interactive terminal surface is available. Off-box runtimes
+	// provide it through their AgentServer stream rather than a daemon-local tmux.
 	TerminalTab bool
 	// InteractiveInput: raw key / prompt injection works — SendKeys/
 	// SendPrompt drive a live PTY rather than returning "not supported".
@@ -60,17 +59,16 @@ type Capabilities struct {
 // callers can render the restriction rather than match on prose.
 var ErrHandoffUnsupported = errors.New("agent handoff is only supported for local-worktree sessions")
 
-// Backend abstracts the session lifecycle so that instances can be backed
-// by local tmux+git worktrees (the default) or by user-provided remote
-// hook scripts.
+// Backend abstracts the session lifecycle so instances can be backed by local
+// tmux+git worktrees (the default) or an off-box docker, SSH, or hook runtime.
 type Backend interface {
 	// Start initialises the session. When firstTimeSetup is true a brand-new
 	// session is created; otherwise an existing one is restored from storage.
 	//
 	// Each backend implements Start as two phases (#1592 Phase 1 PR4): a PROVISION
-	// step that establishes WHERE the agent runs (the local git worktree, or the
-	// remote workspace via launch_cmd) and a LAUNCH step that starts WHAT runs in
-	// it (the tmux/PTY/agent process and its tabs). Start is Provision then Launch.
+	// step that establishes WHERE the agent runs (the local git worktree, or a
+	// provisioned off-box workspace) and a LAUNCH step that starts WHAT runs in it
+	// (the tmux/PTY/agent process and its tabs). Start is Provision then Launch.
 	// The two halves are on the interface (#1592 Phase 2 PR4) so the local
 	// agent-server's provision-and-expose model can drive them separately; Start
 	// stays as the combined lifecycle entry point its existing callers use.
@@ -92,12 +90,11 @@ type Backend interface {
 	// Kill terminates the session and cleans up all associated resources.
 	Kill(instance *Instance) error
 
-	// CloseAttachOnly releases the resources this Instance opened to view or
-	// drive the session (a tmux attach PTY, a remote preview process) WITHOUT
-	// destroying the underlying session, worktree, or remote record. It is the
-	// non-destructive sibling of Kill, used to discard a duplicate Instance
-	// built from disk that lost a race to the canonical, still-tracked
-	// Instance — see the daemon's findSession (#867). Killing such a duplicate
+	// CloseAttachOnly releases resources this Instance opened to view or drive the
+	// session WITHOUT destroying the underlying session, worktree, or off-box
+	// workspace. It is the non-destructive sibling of Kill, used to discard a
+	// duplicate Instance built from disk that lost a race to the canonical,
+	// still-tracked Instance — see the daemon's findSession (#867). Killing such a duplicate
 	// would tear down state the canonical Instance shares; closing only its
 	// attach resources reclaims the PTY without that collateral damage.
 	CloseAttachOnly(instance *Instance) error
@@ -119,8 +116,8 @@ type Backend interface {
 	// HasUpdated reports whether the session output changed since the last
 	// check and whether the program is showing a prompt, and returns the raw
 	// captured pane content so the daemon's usage-limit detector (#1146) can
-	// inspect it without a second capture. content is "" for backends with no
-	// live pane (remote/hook) or when the capture is unavailable.
+	// inspect it without a second capture. content is "" when the capture or
+	// remote observation is unavailable.
 	HasUpdated(instance *Instance) (updated bool, hasPrompt bool, content string)
 
 	// SendPromptCommand sends a prompt using a reliable command-based approach
@@ -198,16 +195,14 @@ type Backend interface {
 	PrepareAgentSwap(instance *Instance, target string) (AgentSwapPlan, error)
 	SwapAgent(instance *Instance, plan AgentSwapPlan) error
 
-	// Type returns the backend type identifier ("local" or "remote"). Since
-	// #1592 Phase 1 this is the persisted serialization discriminator only (the
+	// Type returns the persisted backend identifier (local, docker, ssh, or
+	// remote). Since #1592 Phase 1 this is the serialization discriminator only (the
 	// load-time factory in instance_data.go) — runtime branching goes through
 	// Capabilities, never Type().
 	Type() string
 
 	// Capabilities reports which optional operations this backend can service,
-	// replacing Type()-based special-casing (#1592 Phase 1). Computed per
-	// instance because some capabilities (TerminalTab) depend on per-session
-	// config.
+	// replacing Type()-based special-casing (#1592 Phase 1).
 	Capabilities() Capabilities
 }
 

--- a/session/git/worktree_push.go
+++ b/session/git/worktree_push.go
@@ -11,10 +11,10 @@ import (
 const archiveSnapshotMessage = "af: pre-archive snapshot (uncommitted work)"
 
 // SnapshotAndPushBranch makes the session's branch durable on origin (#1592
-// Phase 4 PR6) — the archive-side primitive for the disposable sandbox backends
-// (docker/ssh). Because a sandbox is thrown away on archive and re-cloned from
-// GitHub on restore, the branch on origin IS the durable workspace (epic
-// decision 4), so archive pushes it there before the sandbox is torn down.
+// Phase 4 PR6/PR7) — the archive-side primitive for the disposable off-box
+// backends (docker/ssh/hook). Because a sandbox is thrown away on archive and
+// re-cloned from GitHub on restore, the branch on origin IS the durable workspace
+// (epic decision 4), so archive pushes it there before the sandbox is torn down.
 //
 // It first snapshots any uncommitted work as a WIP commit so archive preserves
 // the working tree, matching the local worktree-move archive's "nothing lost"

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -338,11 +338,10 @@ func (i *Instance) RestoreFromArchive() error {
 	return nil
 }
 
-// CloseAttachOnly releases the resources this instance opened to view or drive
-// its session (a tmux attach PTY, a remote preview process) without destroying
-// the session, worktree, or remote record. Use it — never Kill — to discard a
-// duplicate Instance built from disk that lost a race to the canonical tracked
-// Instance (#867); see Backend.CloseAttachOnly.
+// CloseAttachOnly releases resources this instance opened to view or drive its
+// session without destroying the session, worktree, or off-box workspace. Use it
+// — never Kill — to discard a duplicate Instance built from disk that lost a
+// race to the canonical tracked Instance (#867); see Backend.CloseAttachOnly.
 func (i *Instance) CloseAttachOnly() error {
 	return i.currentBackend().CloseAttachOnly(i)
 }

--- a/session/instance_data.go
+++ b/session/instance_data.go
@@ -83,14 +83,11 @@ func (i *Instance) toInstanceDataLocked() InstanceData {
 	// whether it is Running, limit-parked, mid-archive, or Lost.
 	data.TaskRunActive = i.taskRunActive
 
-	// Persist each tab so the full agent+shell tab list survives a restart
+	// Persist each tab so the full local agent+shell tab list survives a restart
 	// (Sachin's hard requirement for #930): on reload FromInstanceData restores
-	// each local tab's tmux session by its exact persisted name, reconnecting
-	// live sessions across an af/daemon restart. Remote tabs (agent + optional
-	// terminal) carry no tmux session, so they serialize with an empty TmuxName;
-	// on restore HookBackend.Start re-derives them from the live terminal_cmd
-	// config (syncRemoteTabs) rather than from this serialized list, so a
-	// terminal_cmd added or removed while af was down is honored.
+	// each local tab's tmux session by its exact persisted name. An off-box
+	// session's fixed Agent tab has no daemon-side tmux, so it serializes with an
+	// empty TmuxName and is re-seeded when the AgentServer is launched.
 	for _, tab := range i.Tabs {
 		td := TabData{ID: tab.ID, Name: tab.Name, Kind: tab.Kind, Command: tab.Command, URL: tab.URL}
 		if tab.tmux != nil {
@@ -311,7 +308,7 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 		return instance, nil
 	}
 
-	// A non-archived sandbox session (docker/ssh) cannot be driven on load: its
+	// A non-archived sandbox session (docker/ssh/hook) cannot be driven on load: its
 	// container/remote is gone after a daemon restart and only its pushed branch
 	// on origin survives (#1592 Phase 4 PR6). Load it INERT + Lost — started stays
 	// false, so the status poll and the Lost-restore loop both pass it by (the

--- a/session/runtime.go
+++ b/session/runtime.go
@@ -13,7 +13,7 @@ import (
 type BackendKind string
 
 const (
-	// BackendLocal is today's in-process runtime: the agent runs as a tmux
+	// BackendLocal is the in-process runtime: the agent runs as a tmux
 	// session in a git worktree on the daemon's own box. The default — an empty
 	// `backend` selection resolves here, unchanged from before Phase 4.
 	BackendLocal BackendKind = config.BackendLocal
@@ -47,12 +47,10 @@ func ParseBackendKind(s string) (BackendKind, error) {
 }
 
 // ProvisionSpec is the input a Runtime needs to establish a session's execution
-// environment. The local/hook runtimes provision from the repo root alone; the
-// sandboxed runtimes (docker/ssh) additionally need the session's identity
-// (Title/Program) to start an `af agent-server` for exactly one
-// workspace, and the clone source so the sandbox can pull the repo from GitHub
-// (epic decision 4: GitHub is the durable workspace store). They read their own
-// section (docker.*/ssh.*) from the repo's resolved config by RepoRoot.
+// environment. The local runtime provisions from the repo root; off-box runtimes
+// (docker/ssh/hook) additionally need the session identity (Title/Program), clone
+// source, and optional restore branch used to start an `af agent-server` for one
+// workspace. Each runtime reads its own settings from the resolved repo config.
 type ProvisionSpec struct {
 	// RepoRoot is the absolute repo root the session is created against.
 	RepoRoot string
@@ -64,20 +62,19 @@ type ProvisionSpec struct {
 	// Program is the agent program to run in the workspace (empty ⇒ the config
 	// default). Passed through to the sandbox's `af agent-server --program`.
 	Program string
-	// CloneURL is the git remote the sandbox clones the workspace from — the
-	// repo's `origin` for a docker/ssh session (GitHub for a real repo, a
-	// file:// or bind-mounted path for a self-contained test). Empty for the
-	// in-process local/hook runtimes, which never clone. On a fresh create the
-	// sandbox clones its default branch and the in-sandbox worktree derives the
-	// session branch from Title.
+	// CloneURL is the git remote an off-box runtime clones the workspace from —
+	// the repo's `origin` for a real repo, or a file:// / bind-mounted path for a
+	// self-contained test. Empty for the in-process local runtime. On a fresh
+	// create the sandbox clones its default branch and the in-sandbox worktree
+	// derives the session branch from Title.
 	CloneURL string
 	// RestoreBranch, when set, makes this a RESTORE provision rather than a fresh
 	// create (#1592 Phase 4 PR6): after cloning, the sandbox materializes this
 	// exact branch (the one archive pushed to origin) as a LOCAL ref so the
 	// in-sandbox local backend's Setup reuses it — bringing the pushed commits
 	// back — instead of branching fresh off the default. Empty on a fresh create.
-	// Only the sandbox runtimes (docker/ssh) honor it; the in-process runtimes
-	// never clone, so it is a no-op for them.
+	// Only off-box runtimes (docker/ssh/hook) honor it; the in-process local
+	// runtime never clones, so it is a no-op there.
 	RestoreBranch string
 	// SessionEnvPassthrough contains exact global-only variable names approved
 	// for the agent. Sandboxed runtimes pass names, never values, to their
@@ -99,10 +96,10 @@ type ProvisionResult struct {
 	// exercises the non-nil path via a fake runtime.
 	Endpoint *AgentServerEndpoint
 	// Teardown reaps the sandbox this Runtime provisioned — `docker rm -f` the
-	// container (PR4), close the ssh tunnel + remove the remote dir (PR5). nil for
-	// an in-process runtime (nothing off-box to reap). NewInstance stashes it on
-	// the instance so the agent-server Kill path runs it AFTER tearing the remote
-	// workspace down over REST, and NewInstance itself runs it if wiring the
+	// container (PR4), close the ssh tunnel + remove the remote dir (PR5), or run
+	// the hook's delete_cmd (PR7). nil for the in-process local runtime. NewInstance
+	// stashes it on the instance so the agent-server Kill path runs it AFTER tearing
+	// the remote workspace down over REST, and NewInstance runs it if wiring the
 	// remote client fails, so a provisioned sandbox never leaks. Repeated calls are
 	// serialized by the runtime; docker/SSH latch answered outcomes and leave
 	// unknown outcomes retryable, while hook runs its idempotent delete once.
@@ -112,17 +109,14 @@ type ProvisionResult struct {
 // Runtime is the provision-and-expose seam (#1592 Phase 4 PR3): given a session
 // spec it establishes the workspace/sandbox and exposes an agent-server in it,
 // returning the wiring a new Instance needs. It is the extensibility point the
-// docker and ssh runtimes plug into — the registry below maps a `backend` value
-// to a Runtime, and session creation resolves one from config instead of
-// hard-coding local-vs-hook.
+// docker, SSH, and hook runtimes plug into — the registry below maps a `backend`
+// value to a Runtime, and session creation resolves one from config.
 //
-// The local and hook runtimes provision in-process on the daemon's box, so they
-// expose an in-process endpoint (Endpoint nil) and the session keeps using the
-// local AgentServer over tmux — byte-identical to before Phase 4. The docker and
-// ssh runtimes (PR4/PR5) provision a real sandbox, start an `af agent-server`,
-// and expose its authed http:// URL; the session then drives it through the
-// remoteAgentServer client (PR2). Both satisfy this one interface, so the create
-// flow above does not branch on locality.
+// The local runtime exposes an in-process endpoint (Endpoint nil) and uses the
+// local AgentServer over tmux. Every off-box runtime provisions a workspace,
+// starts an `af agent-server`, and exposes its authed http:// URL; the session
+// then drives it through the remoteAgentServer client. All satisfy this one
+// interface, so the create flow does not branch on locality.
 type Runtime interface {
 	// Provision establishes the session's execution environment and returns the
 	// backend (+ optional remote endpoint) the instance is built with.
@@ -131,9 +125,8 @@ type Runtime interface {
 
 // runtimeRegistry maps a BackendKind to the constructor for its Runtime. It is
 // the single source of truth for "which runtimes exist"; ResolveRuntime looks a
-// kind up here. Keeping it a map (not a switch) is what makes the set
-// extensible — PR4/PR5 register real docker/ssh runtimes by swapping their
-// entries, and a future out-of-tree runtime could register here too.
+// kind up here. Keeping it a map (not a switch) also gives tests one seam for
+// substituting a runtime without changing production dispatch.
 var runtimeRegistry = map[BackendKind]func() Runtime{
 	BackendLocal:  func() Runtime { return localRuntime{} },
 	BackendHook:   func() Runtime { return hookRuntime{} },
@@ -173,7 +166,7 @@ func ResolveRuntime(kind BackendKind) (Runtime, error) {
 // localRuntime is the default in-process runtime: a git worktree + tmux agent on
 // the daemon's own box. Its Provision is exactly what defaultBackendFactory
 // returned for a non-remote session before Phase 4 — a bare LocalBackend, no
-// endpoint — so a local session is byte-identical to today.
+// endpoint — so the local session contract stays unchanged.
 type localRuntime struct{}
 
 func (localRuntime) Provision(ProvisionSpec) (ProvisionResult, error) {
@@ -201,8 +194,8 @@ func (localRuntime) Provision(ProvisionSpec) (ProvisionResult, error) {
 // an ssh local-forward tunnel. The type is declared there.
 
 // resolveRepoConfig loads the resolved config for the repo containing absPath.
-// Shared by the runtime resolver (to read the `backend` key) and the docker/ssh
-// runtimes (to read their sections).
+// Shared by the runtime resolver (to read the `backend` key) and off-box runtimes
+// (to read their docker, SSH, or hook settings).
 func resolveRepoConfig(absPath string) (*config.ResolvedConfig, error) {
 	repo, err := config.RepoFromPath(absPath)
 	if err != nil {

--- a/session/runtime_test.go
+++ b/session/runtime_test.go
@@ -158,8 +158,8 @@ func TestDockerRuntime_ConfigValidation(t *testing.T) {
 }
 
 // fakeRuntime is a Runtime that returns a fixed provision result — used to
-// exercise the interface contract, including the remote-endpoint half that the
-// real local/hook runtimes leave nil and docker/ssh don't reach yet.
+// exercise the interface contract, including the remote-endpoint half used by
+// every off-box runtime.
 type fakeRuntime struct {
 	res ProvisionResult
 	err error
@@ -169,8 +169,8 @@ func (f fakeRuntime) Provision(ProvisionSpec) (ProvisionResult, error) { return 
 
 // TestRuntimeContract_SurfacesEndpoint proves the Runtime contract carries a
 // remote agent-server endpoint end-to-end: a runtime that provisions a sandbox
-// returns its authed endpoint alongside the backend, which is exactly what the
-// docker/ssh runtimes will fill in PR4/PR5.
+// returns its authed endpoint alongside the backend, exactly as the real off-box
+// runtimes do.
 func TestRuntimeContract_SurfacesEndpoint(t *testing.T) {
 	ep := &AgentServerEndpoint{URL: "http://127.0.0.1:9", Token: "tok"}
 	var rt Runtime = fakeRuntime{res: ProvisionResult{Backend: &LocalBackend{}, Endpoint: ep}}

--- a/session/tab.go
+++ b/session/tab.go
@@ -211,9 +211,8 @@ func newShellTab(ts *tmux.TmuxSession) *Tab {
 
 // newRemoteAgentTab returns the Agent tab for a remote/hook-backed instance
 // (#930 PR 6). Like every remote tab it carries no tmux session: the agent
-// surface is driven by attach_cmd and the hook preview process, not a local
-// tmux session. It lets remote instances be tab-driven through the same Tabs
-// list as local ones.
+// surface is driven through the off-box AgentServer's WS stream, not a local
+// tmux session. It lets off-box instances use the same Tabs list as local ones.
 func newRemoteAgentTab() *Tab {
 	return &Tab{ID: newTabID(), Name: agentTabName, Kind: TabKindAgent}
 }

--- a/session/tab_spawn.go
+++ b/session/tab_spawn.go
@@ -255,9 +255,9 @@ func (i *Instance) appendReconciledTab(matchID, name string, tab *Tab) bool {
 // name is requestedName when non-empty, otherwise "web", made unique
 // within the instance ("web", "web-2", …). Local instances only, matching
 // shell/process tabs: a web tab is persisted on the local instance record and
-// rebuilt from it on restart, and remote/hook sessions rebuild their tabs from
-// hook config instead (callers reject non-TabManagement backends first). Errors
-// when the instance is not started/has no worktree or already holds maxTabs tabs.
+// rebuilt from it on restart. Off-box sessions have a fixed runtime-provided tab
+// roster instead (callers reject non-TabManagement backends first). Errors when
+// the instance is not started/has no worktree or already holds maxTabs tabs.
 func (i *Instance) AddWebTab(url, requestedName string) (*Tab, error) {
 	if strings.TrimSpace(url) == "" {
 		return nil, fmt.Errorf("a web tab requires a non-empty URL")

--- a/session/tmux/terminal_restore.go
+++ b/session/tmux/terminal_restore.go
@@ -5,15 +5,15 @@ package tmux
 // full-screen program leaves behind on exit: main screen, cursor visible, no
 // scroll region, no mouse/focus/paste reporting, and legacy keyboard encoding.
 //
-// A raw attach stream — the remote hook's attach_cmd PTY, or (since #1592 Phase
-// 2 PR7) the local session's clientless WS PTY stream — is copied byte-for-byte
-// to the local terminal, so whatever modes the streamed program set (tmux/agents
-// enter the alt screen, set a scroll region, enable mouse and focus reporting)
-// are set on the local terminal too. On a graceful exit the program emits its own
-// restore sequences, but the detach key ends the stream mid-flight and nothing
-// resets those modes — a caller that then repaints into the terminal inherits a
-// stale scroll region and screen buffer, the "messed up UI until I resize" of
-// #845. Both drivers write this on every exit path.
+// The clientless WS PTY stream — backed by local tmux or proxied from an off-box
+// AgentServer — is copied byte-for-byte to the local terminal, so whatever modes
+// the streamed program set (tmux/agents enter the alt screen, set a scroll region,
+// enable mouse and focus reporting) are set on the local terminal too. On a
+// graceful exit the program emits its own restore sequences, but the detach key
+// ends the stream mid-flight and nothing resets those modes — a caller that then
+// repaints into the terminal inherits a stale scroll region and screen buffer,
+// the "messed up UI until I resize" of #845. Both drivers write this on every exit
+// path.
 //
 // The keyboard-encoding modes matter for the same reason and were missed until
 // #1833 made them reachable: a modern agent CLI negotiates the kitty keyboard


### PR DESCRIPTION
## Summary

- describe the remote-hook contract as `launch_cmd` provisioning and exposing an `af agent-server`, with `delete_cmd` handling teardown
- remove pre-PR7 `list_cmd` / `attach_cmd` / `terminal_cmd` claims from `af doctor` help and codebase explanatory comments
- describe current docker, SSH, and hook behavior through the shared off-box AgentServer path
- regenerate `docs/reference/cli.md` with `scripts/gen-docs.sh`

## Code evidence

The old prose was wrong because:

- `config/repo_config.go` exposes only `launch_cmd` and `delete_cmd`; removed keys are compatibility tripwires that `RemoteHooks.Validate` rejects
- `doctor/remote.go` checks those two scripts and explicitly avoids a connectivity probe because both live verbs mutate infrastructure
- `session/backend_hook_backend.go` parses the endpoint returned by `launch_cmd` and wires a `remoteAgentServer`
- `session/backend_remote_agent.go` drives attach, preview, prompt, liveness, and lifecycle through that shared AgentServer path

This addresses the remote-hook half of #2648 without closing it; the separate lifecycle/version-harness drift remains open.

## Validation

Required gates passed after pushing exact head `9ee4098175ca7e0b9ba172d7dd6bb63fffdc1074`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`

Additional documentation validation on the same committed tree:

- `mkdocs build --strict`
- `scripts/gen-docs.sh`

— Captain Claude