### PR TITLE
feat(cli): expose task project rebinding

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "agent-factory",
       "source": "./plugins/claude/agent-factory",
       "description": "Run and schedule AI coding agents in isolated git worktrees with the Agent Factory (af) CLI",
-      "version": "3.6.527962995+sha256.1f781373e8d7964b"
+      "version": "3.7.435612295+sha256.19f6ea8788b212bd"
     }
   ]
 }

--- a/api/api.go
+++ b/api/api.go
@@ -719,6 +719,7 @@ func init() {
 	tasksUpdateCmd.Flags().StringVar(&taskUpdateWatchCmdFlag, "watch-cmd", "", "New watch command (clears cron)")
 	tasksUpdateCmd.Flags().StringVar(&taskUpdateTargetSessionFlag, "target-session", "", "New target session; pass an empty value to revert to a new session per run")
 	tasksUpdateCmd.Flags().IntVar(&taskUpdateMaxConcurrentRunsFlag, "max-concurrent-runs", 0, "New in-flight session cap for this watch task; pass 0 to revert to unlimited")
+	tasksUpdateCmd.Flags().StringVar(&taskUpdateProjectPathFlag, "project-path", "", "Move the task to this git repository (distinct from --repo, which scopes its current project)")
 	tasksUpdateCmd.Flags().StringVar(&taskUpdateEnabledFlag, "enabled", "", "Enable or disable the task (true/false)")
 	tasksUpdateCmd.Flags().StringVar(&taskUpdateProgramFlag, "program", "", "New program to run (one of: "+tmux.SupportedProgramsString()+"; leave unset to keep the current one)")
 

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -553,11 +553,20 @@ var tasksUpdateCmd = &cobra.Command{
 		// then send the existing ProjectPath patch through daemonUpdateTask — the
 		// same task.UpdateTask path every other surface already uses.
 		if cmd.Flags().Changed("project-path") {
-			rawPath := strings.TrimSpace(taskUpdateProjectPathFlag)
-			if rawPath == "" {
+			// Trim only to reject an all-whitespace value; resolve the flag as
+			// typed. A directory name may legitimately begin or end with a
+			// space, and the shell already makes the user quote one to get it
+			// here, so the whitespace is intent rather than a slip. Resolving a
+			// trimmed spelling would make such a repository unreachable — or
+			// worse, silently rebind the task to a different repository that
+			// happens to answer to the trimmed name. `af projects register`
+			// passes its path argument through untrimmed for the same reason;
+			// the TUI editor trims because a text field offers no quoting with
+			// which to express the intent.
+			if strings.TrimSpace(taskUpdateProjectPathFlag) == "" {
 				return jsonError(errors.New("project path must be non-empty"))
 			}
-			absPath, err := config.ResolveUserPath(rawPath)
+			absPath, err := config.ResolveUserPath(taskUpdateProjectPathFlag)
 			if err != nil {
 				return jsonError(fmt.Errorf("failed to resolve --project-path %q: %w", taskUpdateProjectPathFlag, err))
 			}

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -417,6 +417,7 @@ var (
 	taskUpdateWatchCmdFlag          string
 	taskUpdateTargetSessionFlag     string
 	taskUpdateMaxConcurrentRunsFlag int
+	taskUpdateProjectPathFlag       string
 	taskUpdateEnabledFlag           string
 	taskUpdateProgramFlag           string
 )
@@ -429,8 +430,9 @@ var tasksUpdateCmd = &cobra.Command{
 		"the current directory's project. Updating another project's task requires " +
 		"naming it with --repo. Outside a git repository there is no project context " +
 		"and the id resolves globally.\n\n" +
-		"--repo only scopes which task may be updated; it never re-binds one. A " +
-		"task's project is fixed at creation.",
+		"--repo scopes which task may be updated; it never re-binds one. Pass " +
+		"--project-path to move that task to another existing git repository. The " +
+		"new path becomes the task's working directory and project binding.",
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)
@@ -543,6 +545,26 @@ var tasksUpdateCmd = &cobra.Command{
 		// control socket because TaskUpdate round-trips through JSON (#1700).
 		if cmd.Flags().Changed("max-concurrent-runs") {
 			patch.MaxConcurrentRuns = intPtr(taskUpdateMaxConcurrentRunsFlag)
+		}
+		// --repo authorizes the task against its CURRENT project. Keep the new
+		// binding separate so a caller can say `--repo old --project-path new`
+		// without either path changing meaning. Resolve user shorthand at the CLI
+		// boundary, require the same real-git-repo invariant as the TUI editor,
+		// then send the existing ProjectPath patch through daemonUpdateTask — the
+		// same task.UpdateTask path every other surface already uses.
+		if cmd.Flags().Changed("project-path") {
+			rawPath := strings.TrimSpace(taskUpdateProjectPathFlag)
+			if rawPath == "" {
+				return jsonError(errors.New("project path must be non-empty"))
+			}
+			absPath, err := config.ResolveUserPath(rawPath)
+			if err != nil {
+				return jsonError(fmt.Errorf("failed to resolve --project-path %q: %w", taskUpdateProjectPathFlag, err))
+			}
+			if _, err := config.RepoFromPath(absPath); err != nil {
+				return jsonError(fmt.Errorf("--project-path %q is not a valid git repository: %w", absPath, err))
+			}
+			patch.ProjectPath = strPtr(absPath)
 		}
 
 		// Only patch Enabled when --enabled was passed: an absent flag must

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/task"
@@ -139,13 +140,15 @@ func resetUpdateFlags(t *testing.T) {
 		taskUpdateWatchCmdFlag = ""
 		taskUpdateTargetSessionFlag = ""
 		taskUpdateMaxConcurrentRunsFlag = 0
+		taskUpdateProjectPathFlag = ""
 		taskUpdateEnabledFlag = ""
 		taskUpdateProgramFlag = ""
-		// --target-session and --max-concurrent-runs use Changed() semantics
-		// ("" / 0 are meaningful values), so the cobra-level Changed markers
-		// must reset too.
+		// --target-session, --max-concurrent-runs, and --project-path use
+		// Changed() semantics (zero values are either meaningful or invalid), so
+		// the cobra-level Changed markers must reset too.
 		tasksUpdateCmd.Flags().Lookup("target-session").Changed = false
 		tasksUpdateCmd.Flags().Lookup("max-concurrent-runs").Changed = false
+		tasksUpdateCmd.Flags().Lookup("project-path").Changed = false
 	}
 	t.Cleanup(reset)
 	reset()
@@ -944,6 +947,68 @@ func TestTasksUpdate_OmittingProgramLeavesUnchanged(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "renamed", got.Name)
 	assert.Equal(t, "aider", got.Program, "absent --program must not change the program")
+}
+
+// TestTasksUpdate_ProjectPathChange closes the CLI half of the project-rebind
+// parity gap. --repo authorizes the task in its old project while
+// --project-path becomes the existing TaskUpdate.ProjectPath patch that the TUI
+// and web already send. A subdirectory stays the working directory, while the
+// shared task writer derives its stable RepoID from the repository root.
+func TestTasksUpdate_ProjectPathChange(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	calls := stubDaemon(t)
+	previousRepoFlag := repoFlag
+	t.Cleanup(func() { repoFlag = previousRepoFlag })
+
+	oldProject := setupAddRepo(t)
+	newProject := setupAddRepo(t)
+	newWorkingDir := filepath.Join(newProject, "automation")
+	require.NoError(t, os.Mkdir(newWorkingDir, 0o755))
+	repoFlag = oldProject
+	seedTask(t, task.Task{
+		ID: "move0001", Name: "watcher", WatchCmd: "tail -f events.log",
+		ProjectPath: oldProject, Enabled: true,
+	})
+
+	require.NoError(t, tasksUpdateCmd.Flags().Set("project-path", newWorkingDir))
+	require.NoError(t, tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"move0001"}))
+
+	got, err := task.GetTask("move0001")
+	require.NoError(t, err)
+	assert.Equal(t, newWorkingDir, got.ProjectPath)
+	assert.Equal(t, config.RepoIDFromRoot(newProject), got.RepoID)
+	require.NotNil(t, calls.lastUpdate.ProjectPath)
+	assert.Equal(t, newWorkingDir, *calls.lastUpdate.ProjectPath)
+	assert.True(t, calls.lastExpect.Enforce)
+	assert.Equal(t, oldProject, calls.lastExpect.ProjectPath,
+		"--repo must keep authorizing the pre-move binding")
+	assert.Equal(t, 1, calls.writes)
+}
+
+func TestTasksUpdate_ProjectPathRejectsNonRepository(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	calls := stubDaemon(t)
+	previousRepoFlag := repoFlag
+	t.Cleanup(func() { repoFlag = previousRepoFlag })
+
+	oldProject := setupAddRepo(t)
+	seedTask(t, task.Task{
+		ID: "move0002", Name: "watcher", WatchCmd: "tail -f events.log",
+		ProjectPath: oldProject, Enabled: true,
+	})
+
+	notRepo := t.TempDir()
+	require.NoError(t, tasksUpdateCmd.Flags().Set("project-path", notRepo))
+	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"move0002"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a valid git repository")
+	assert.Zero(t, calls.writes, "an invalid destination must not reach the daemon")
+
+	got, getErr := task.GetTask("move0002")
+	require.NoError(t, getErr)
+	assert.Equal(t, oldProject, got.ProjectPath)
 }
 
 // --- Read path: list/get non-spawn + disk fallback (#1029 PR 3) ---

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -213,11 +213,20 @@ func seedTask(t *testing.T, tsk task.Task) {
 func setupAddRepo(t *testing.T) string {
 	t.Helper()
 	repo := filepath.Join(t.TempDir(), "repo")
+	real := initRepoAt(t, repo)
+	repoFlag = repo
+	return real
+}
+
+// initRepoAt creates a git repository at an exact path — including one whose
+// directory name carries leading or trailing whitespace — and returns its
+// symlink-resolved location.
+func initRepoAt(t *testing.T, repo string) string {
+	t.Helper()
 	require.NoError(t, exec.Command("git", "init", repo).Run(), "git init")
 	require.NoError(t, exec.Command("git", "-C", repo, "config", "user.email", "test@example.com").Run())
 	require.NoError(t, exec.Command("git", "-C", repo, "config", "user.name", "Test User").Run())
 	require.NoError(t, exec.Command("git", "-C", repo, "commit", "--allow-empty", "-m", "init").Run())
-	repoFlag = repo
 	real, err := filepath.EvalSymlinks(repo)
 	require.NoError(t, err)
 	return real
@@ -1007,6 +1016,77 @@ func TestTasksUpdate_ProjectPathRejectsNonRepository(t *testing.T) {
 	assert.Zero(t, calls.writes, "an invalid destination must not reach the daemon")
 
 	got, getErr := task.GetTask("move0002")
+	require.NoError(t, getErr)
+	assert.Equal(t, oldProject, got.ProjectPath)
+}
+
+// TestTasksUpdate_ProjectPathPreservesWhitespace pins that --project-path is
+// resolved exactly as typed. A directory name may legitimately begin or end
+// with a space, and the shell makes the user quote one to get it this far, so
+// the whitespace is intent. Trimming before resolution would make such a
+// repository unreachable — and when the trimmed spelling names a different
+// repository, as it does here, it would silently move the task to the wrong
+// project rather than failing loudly.
+func TestTasksUpdate_ProjectPathPreservesWhitespace(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	calls := stubDaemon(t)
+	previousRepoFlag := repoFlag
+	t.Cleanup(func() { repoFlag = previousRepoFlag })
+
+	oldProject := setupAddRepo(t)
+
+	// Sibling repositories whose names differ only by a trailing space, so the
+	// trimmed spelling resolves to a real — but wrong — destination.
+	parent := t.TempDir()
+	trimmedTwin := initRepoAt(t, filepath.Join(parent, "repo"))
+	spacedRepo := initRepoAt(t, filepath.Join(parent, "repo "))
+	require.NotEqual(t, trimmedTwin, spacedRepo, "the two spellings must be distinct repositories")
+
+	repoFlag = oldProject
+	seedTask(t, task.Task{
+		ID: "move0003", Name: "watcher", WatchCmd: "tail -f events.log",
+		ProjectPath: oldProject, Enabled: true,
+	})
+
+	require.NoError(t, tasksUpdateCmd.Flags().Set("project-path", spacedRepo))
+	require.NoError(t, tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"move0003"}))
+
+	got, err := task.GetTask("move0003")
+	require.NoError(t, err)
+	assert.Equal(t, spacedRepo, got.ProjectPath,
+		"the trailing space is part of the directory name, not padding to strip")
+	assert.NotEqual(t, trimmedTwin, got.ProjectPath,
+		"trimming would have silently rebound the task to the sibling repository")
+	require.NotNil(t, calls.lastUpdate.ProjectPath)
+	assert.Equal(t, spacedRepo, *calls.lastUpdate.ProjectPath)
+}
+
+// TestTasksUpdate_ProjectPathRejectsAllWhitespace pins the other half: trimming
+// still decides whether the flag carries a value at all, so a value that is
+// nothing but whitespace is refused instead of being resolved into a cwd-
+// relative directory named " ".
+func TestTasksUpdate_ProjectPathRejectsAllWhitespace(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	calls := stubDaemon(t)
+	previousRepoFlag := repoFlag
+	t.Cleanup(func() { repoFlag = previousRepoFlag })
+
+	oldProject := setupAddRepo(t)
+	repoFlag = oldProject
+	seedTask(t, task.Task{
+		ID: "move0004", Name: "watcher", WatchCmd: "tail -f events.log",
+		ProjectPath: oldProject, Enabled: true,
+	})
+
+	require.NoError(t, tasksUpdateCmd.Flags().Set("project-path", "   "))
+	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"move0004"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be non-empty")
+	assert.Zero(t, calls.writes, "an empty destination must not reach the daemon")
+
+	got, getErr := task.GetTask("move0004")
 	require.NoError(t, getErr)
 	assert.Equal(t, oldProject, got.ProjectPath)
 }

--- a/commands/plugins_gen.go
+++ b/commands/plugins_gen.go
@@ -69,6 +69,7 @@ var pluginReleaseDigests = []string{
 	"62b9f2661f7c23f7c5d53dbd7e3ed3a5b3339396663299419b356f9e63f07407", // 3.4 — remove the tmux-command guard hook; agents run unrestricted (#2175 precedent)
 	"a2b54cb9209becd766678828fd09ff7bd597b683802305850bcb40cefe61b9e7", // 3.5 — add the missing devin to the --program enum in the af usage reference (#2410 drift)
 	"1f781373e8d7964be4288de32c946098896b6fe3567dba73925fedc2fab995c1", // 3.6 — teach agents the canonical --kind shell parity path (#2619)
+	"19f6ea8788b212bd41fb90f66947b82b1fc4dd17887c9ddc1780e20fb178938b", // 3.7 — teach agents to rebind a task with update --project-path (parity: task.edit.project-path)
 }
 
 // pluginGenBanner marks a generated Markdown/shell artifact. Like genBanner it

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -127,7 +127,7 @@ Exactly one of `--cron` / `--watch-cmd` per task. On `update`, setting one trigg
 
 ### Project binding
 
-A task is bound to exactly one project when it is created, and every run's worktree is created inside it. The binding comes from `--repo`, or from the current directory's project. It is fixed at creation: `--repo` on `update` scopes *which* task may be edited, and never re-binds one.
+A task is bound to exactly one project when it is created, and every run's worktree is created inside it. The binding comes from `--repo`, or from the current directory's project. The two flags on `update` do different jobs: `--repo` scopes *which* task may be edited and never re-binds one, while `--project-path <repo>` moves the task to another existing git repository — that path becomes both its new working directory and its project binding. So `af tasks update <id> --repo /repos/alpha --project-path /repos/beta` authorizes the task in alpha and moves it to beta.
 
 The project a task belongs to is recorded as an id resolved when the task is bound, not re-derived from its path on each read. This is why deleting a directory a task points at — a subdirectory or a linked worktree — never hides the task from its own project.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -117,13 +117,13 @@ af tasks list [--all]
 af tasks add --name <n> --prompt <p> --cron "0 9 * * *" [--target-session <title>] [--program <agent>]
 af tasks add --name <n> --watch-cmd <cmd> [--prompt "... {{line}} ..."] [--target-session <title>]
 af tasks get <id>
-af tasks update <id> [--cron ...|--watch-cmd ...] [--prompt ...] [--target-session ...] [--program <agent>] [--enabled true|false]
+af tasks update <id> [--cron ...|--watch-cmd ...] [--prompt ...] [--target-session ...] [--project-path <repo>] [--program <agent>] [--enabled true|false]
 af tasks restart <id>          # reload an edited watch script (watch tasks only)
 af tasks trigger <id>          # run a cron task immediately (cron tasks only)
 af tasks remove <id>
 ```
 
-Exactly one of `--cron` / `--watch-cmd` per task. On `update`, setting one trigger clears the other. `--target-session ""` explicitly reverts to create-a-session-per-run; omitting the flag leaves it untouched. `--program` accepts the same agent enum as `tasks add`; omitting it keeps the task's current program.
+Exactly one of `--cron` / `--watch-cmd` per task. On `update`, setting one trigger clears the other. `--target-session ""` explicitly reverts to create-a-session-per-run; omitting the flag leaves it untouched. `--project-path` moves the task to that repository; `--repo` still names the task's current project for authorization. `--program` accepts the same agent enum as `tasks add`; omitting it keeps the task's current program.
 
 ### Project binding
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2202,7 +2202,7 @@ Update a task in the current project.
 
 The task must belong to the resolved project: --repo when given, otherwise the current directory's project. Updating another project's task requires naming it with --repo. Outside a git repository there is no project context and the id resolves globally.
 
---repo only scopes which task may be updated; it never re-binds one. A task's project is fixed at creation.
+--repo scopes which task may be updated; it never re-binds one. Pass --project-path to move that task to another existing git repository. The new path becomes the task's working directory and project binding.
 
 ```
 af tasks update <id> [flags]
@@ -2217,6 +2217,7 @@ af tasks update <id> [flags]
 | `--max-concurrent-runs` | `int` | New in-flight session cap for this watch task; pass 0 to revert to unlimited (default `0`) |
 | `--name` | `string` | New task name |
 | `--program` | `string` | New program to run (one of: claude, codex, aider, gemini, amp, opencode, devin; leave unset to keep the current one) |
+| `--project-path` | `string` | Move the task to this git repository (distinct from --repo, which scopes its current project) |
 | `--prompt` | `string` | New prompt |
 | `--target-session` | `string` | New target session; pass an empty value to revert to a new session per run |
 | `--watch-cmd` | `string` | New watch command (clears cron) |

--- a/docs/surface-parity.md
+++ b/docs/surface-parity.md
@@ -242,8 +242,9 @@ suite goes green — which is *worse than having no parity check*, because the
 green gets trusted. A detector that manufactures confidence is the failure mode
 this package exists to prevent, so it must not be one.
 
-`parity/honesty_test.go` therefore pins the derivation against gaps we already
-know are real, filed, and field-level — as fixtures, not aspirations:
+`parity/honesty_test.go` therefore pins the derivation against verified
+field-level behavior — both shipped reaches and declared gaps — as fixtures, not
+aspirations:
 
 | Fixture | Derivation path it proves |
 |---|---|
@@ -251,7 +252,7 @@ know are real, filed, and field-level — as fixtures, not aspirations:
 | [#1933](https://github.com/sachiniyer/agent-factory/issues/1933) — the web now **does** send `CreateSession.backend` (#1968 landed), via a `const body` variable | the web body parser, incl. variable resolution |
 | #1933 (TUI half) — closed; `sessionStartRequest` now carries `Backend`, so the fixture is repointed to track that the walk still sees the TUI's use of `backend`/`prompt`/`force_remote` **and** its non-use of `in_place` | the Go AST walk |
 | [#1948](https://github.com/sachiniyer/agent-factory/issues/1948) — closed; the CLI now sets `Preview.Tab/TabID/TabName/Full`, so the fixture is repointed to track that the walk still sees both the CLI's usage and the TUI's non-use of `tab_name` | the AST **on an internal route**, invisible to the public catalog |
-| [#1935](https://github.com/sachiniyer/agent-factory/issues/1935) — the web's `TaskUpdate` omits `project_path` | nested recursion **behind a wrapper route**, plus the TS-interface read and the CLI's field-by-field assignment walk |
+| [#1935](https://github.com/sachiniyer/agent-factory/issues/1935) — `TaskUpdate.project_path` is now sent by every surface; the web still omits `max_concurrent_runs` | nested recursion **behind a wrapper route**, plus the TS-interface read, web value walk, and the CLI's field-by-field assignment walk |
 
 Each fixture asserts in **both** directions: that the known gap is seen, *and*
 that a field the surface demonstrably does send is not reported as a gap. A

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -141,13 +141,13 @@ af tasks list [--all]
 af tasks add --name <n> --prompt <p> --cron "0 9 * * *" [--target-session <title>] [--program <agent>]
 af tasks add --name <n> --watch-cmd <cmd> [--prompt "… {{line}} …"] [--target-session <title>] [--max-concurrent-runs <n>]
 af tasks get <id>
-af tasks update <id> [--cron …|--watch-cmd …] [--prompt …] [--target-session …] [--max-concurrent-runs <n>] [--program <agent>] [--enabled true|false]
+af tasks update <id> [--cron …|--watch-cmd …] [--prompt …] [--target-session …] [--max-concurrent-runs <n>] [--project-path <repo>] [--program <agent>] [--enabled true|false]
 af tasks restart <id>          # enabled watch tasks only; reloads an edited script
 af tasks trigger <id>          # cron tasks only
 af tasks remove <id>
 ```
 
-Every subcommand is scoped to one project — the current directory's, or the one `--repo` names — so `tasks list` shows this project's tasks (`--all` spans every project) and an id belonging to another project is refused rather than acted on. `tasks add` binds the task to the resolved project and reports it as `project_path`. See [Project scoping](cli.md#project-scoping) for the full contract.
+Every subcommand is scoped to one project — the current directory's, or the one `--repo` names — so `tasks list` shows this project's tasks (`--all` spans every project) and an id belonging to another project is refused rather than acted on. `tasks add` binds the task to the resolved project and reports it as `project_path`. On `tasks update`, `--repo` authorizes the task in its current project while `--project-path` moves it to a new project and working directory. See [Project scoping](cli.md#project-scoping) for the full contract.
 
 On `update`, setting one trigger clears the other (switching watch→cron requires a prompt when the resulting cron task is enabled). `--target-session ""` explicitly reverts to create-per-run; omitting the flag leaves it untouched. `--max-concurrent-runs 0` explicitly reverts to unlimited; omitting the flag leaves the current cap untouched. `--program` accepts the same agent enum as `tasks add`; omitting it keeps the task's current program.
 

--- a/parity/derive_go_test.go
+++ b/parity/derive_go_test.go
@@ -104,7 +104,8 @@ const maxNestDepth = 3
 // AddTaskRequest is {task}. Counting only top-level fields would mark the whole
 // payload covered the moment a surface sends the wrapper — which is precisely how
 // task.TaskUpdate.ProjectPath stayed invisible: every surface "sends update", but
-// only the TUI can populate project_path.
+// at the time only the TUI could populate project_path. All three can now, and the
+// same recursion continues to expose still-missing nested fields independently.
 //
 // Keys are Go field paths ("Update.ProjectPath"), values the JSON path
 // ("update.project_path"). Mirrors the daemon's jsonFields semantics: skip
@@ -313,8 +314,9 @@ func typeExprName(e ast.Expr, pkgName string) string {
 // api/tasks.go:172 builds a task.Task composite literal, while
 // api/tasks.go:296 declares `var patch task.TaskUpdate` and assigns
 // `patch.Name = …` field by field. Both forms are read here, so
-// task.TaskUpdate.ProjectPath shows up as genuinely unreachable from the CLI
-// rather than being hidden behind a covered wrapper.
+// task.TaskUpdate.ProjectPath now shows up as genuinely reachable from the CLI;
+// fields a surface does not assign still remain visible as gaps rather than being
+// hidden behind a covered wrapper.
 func deriveTypeFieldUse(t *testing.T, surface string) map[string]map[string]bool {
 	t.Helper()
 	fset := token.NewFileSet()

--- a/parity/honesty_test.go
+++ b/parity/honesty_test.go
@@ -8,13 +8,14 @@ package parity
 // under-reports and the suite goes green, which is worse than having no parity
 // check at all, because the green would be trusted.
 //
-// So these tests pin the derivation against gaps we already know are real,
-// filed, and field-level. They are fixtures, not aspirations: if the derivation
-// cannot rediscover a gap we found by hand, it will not find the next one.
+// So these tests pin the derivation against field-level behavior whose ground
+// truth we have verified, including both shipped reaches and declared gaps. They
+// are fixtures, not aspirations: if the derivation cannot rediscover a gap we
+// found by hand, it will not find the next one.
 //
 //	#1933  the web never sends CreateSessionRequest.backend  (and neither did the TUI)
 //	#1948  the CLI never sets PreviewRequest.Tab/TabID/Full
-//	#1935  the web's TaskUpdate omits project_path, nested inside a wrapper route
+//	#1935  TaskUpdate fields nested inside the UpdateTask wrapper
 //
 // Both halves of #1933 are now FIXED (#1968 for the web, the TUI's ctrl+r backend
 // field for the TUI), so both fixtures are repointed rather than deleted — see
@@ -258,19 +259,17 @@ func TestDerivationTracksPreviewTabUse(t *testing.T) {
 	}
 }
 
-// TestDerivationSeesNestedProjectPathGap pins the wrapper case that motivated
+// TestDerivationSeesNestedTaskUpdateFields pins the wrapper case that motivated
 // #1935. UpdateTask is {id, update}: a top-level-only check calls it covered the
-// moment the web sends `update`, hiding every option inside task.TaskUpdate —
+// moment a surface sends `update`, hiding every option inside task.TaskUpdate —
 // exactly how project_path stayed invisible.
 //
-// #1935 LANDED (like #1968 for the sibling fixture above): the web now edits tasks,
-// and its edit call site sends project_path as an inline literal. So this fixture
-// asserts the reverse of what it did before — project_path is IN the TS interface
-// AND reachable BY VALUE (the derivation real coverage uses) — while still proving
-// the recursion and the CLI-side assignment walk see what they must. The CLI has no
-// --project-path flag, so the assignment walk must still report TaskUpdate.ProjectPath
-// unreached: the surviving CLI half of task.edit.project-path.
-func TestDerivationSeesNestedProjectPathGap(t *testing.T) {
+// #1935 landed for the web, and the CLI now sends the same project_path field.
+// The fixture therefore proves both positive paths — inline web values and
+// field-by-field CLI assignments — while retaining a negative control: the web
+// still does not send max_concurrent_runs. A walk that credits the wrapper as
+// every nested field would fail that live task.max-concurrent-runs assertion.
+func TestDerivationSeesNestedTaskUpdateFields(t *testing.T) {
 	paths := jsonFieldPaths(auditedRequests["UpdateTaskRequest"])
 	var nested []string
 	for _, p := range paths {
@@ -319,19 +318,23 @@ func TestDerivationSeesNestedProjectPathGap(t *testing.T) {
 				f, reach.Sites)
 		}
 	}
+	if reach.Fields["max_concurrent_runs"] {
+		t.Error("derivation says the web reaches TaskUpdate.max_concurrent_runs, but its " +
+			"task form never sends that field — the nested value walk is over-crediting.")
+	}
 
 	// The CLI reaches the payload field-by-field (`patch.Name = …`), not as a
-	// literal, so this also proves the assignment-tracking half of the walk. It still
-	// has no --project-path flag, so ProjectPath must stay unreached.
+	// literal, so this also proves the assignment-tracking half of the walk. Both
+	// Name and the newly reachable ProjectPath must be visible to that walk.
 	typeUse := deriveTypeFieldUse(t, "cli")
 	fields := typeUse["task.TaskUpdate"]
 	if len(fields) == 0 {
 		t.Fatal("derivation sees the CLI populating NO task.TaskUpdate fields — the " +
 			"var-assignment walk is blind (expected api/tasks.go:296-320 `patch.Name = …`)")
 	}
-	if fields["ProjectPath"] {
-		t.Error("derivation says the CLI sets TaskUpdate.ProjectPath — `af tasks update` has " +
-			"no --project-path flag (api/api.go:644-650). Over-crediting.")
+	if !fields["ProjectPath"] {
+		t.Error("derivation says the CLI never sets TaskUpdate.ProjectPath, but " +
+			"`af tasks update --project-path` assigns patch.ProjectPath — under-reporting.")
 	}
 	if !fields["Name"] {
 		t.Error("derivation says the CLI never sets TaskUpdate.Name, but api/tasks.go does " +

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -1176,7 +1176,7 @@
       },
       "cli": {
         "status": "yes",
-        "pointer": "api/api.go:723 --project-path -> api/tasks.go:538-550 TaskUpdate.ProjectPath -> daemonUpdateTask"
+        "pointer": "api/api.go:722 --project-path -> api/tasks.go:576 patch.ProjectPath = strPtr(absPath) -> daemonUpdateTask"
       },
       "verdict": "parity",
       "notes": "The web half was subsumed by #1935: its seeded project picker sends update.project_path. The CLI now sends the same TaskUpdate.ProjectPath patch with `af tasks update --project-path`; `--repo` remains the authorization scope for the task's current project, so `--repo old --project-path new` is unambiguous. This also supplies a repair path for the wrong-project automation incident in #1891 without duplicating the daemon's rebind and RepoID logic."

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -1175,11 +1175,11 @@
         "pointer": "web/src/tasks.ts editTaskModal project picker (seeded, editable) -> web/src/index.ts openEditTask sends update.project_path"
       },
       "cli": {
-        "status": "no",
-        "pointer": "api/api.go:644-650 af tasks update has no --project-path flag"
+        "status": "yes",
+        "pointer": "api/api.go:723 --project-path -> api/tasks.go:538-550 TaskUpdate.ProjectPath -> daemonUpdateTask"
       },
-      "verdict": "unclear",
-      "notes": "The web half was subsumed by #1935 and is now closed: the edit form's project picker is seeded from the task and can move it to another project, so the edit call site sends update.project_path. The CLI still cannot — `af tasks update` has no --project-path flag. That remaining CLI gap overlaps #1891 (tasks add should surface and guard the resolved project binding), so it wants triaging with that rather than a fresh issue."
+      "verdict": "parity",
+      "notes": "The web half was subsumed by #1935: its seeded project picker sends update.project_path. The CLI now sends the same TaskUpdate.ProjectPath patch with `af tasks update --project-path`; `--repo` remains the authorization scope for the task's current project, so `--repo old --project-path new` is unambiguous. This also supplies a repair path for the wrong-project automation incident in #1891 without duplicating the daemon's rebind and RepoID logic."
     },
     {
       "id": "cli.shell-completion",
@@ -1675,6 +1675,7 @@
       "af tasks update --max-concurrent-runs": "task.max-concurrent-runs",
       "af tasks update --name": "task.edit",
       "af tasks update --program": "task.edit",
+      "af tasks update --project-path": "task.edit.project-path",
       "af tasks update --prompt": "task.edit",
       "af tasks update --target-session": "task.edit",
       "af tasks update --watch-cmd": "task.edit",
@@ -1833,11 +1834,6 @@
         }
       },
       "UpdateTaskRequest": {
-        "cli": {
-          "update.project_path": {
-            "gap": "task.edit.project-path"
-          }
-        },
         "tui": {
           "update.cron_expr": {
             "ok": "Reached via task.DiffTask over the edited task.Task (ui/task_pane_state.go:91): the TUI never writes a task.TaskUpdate literal, so the AST cannot prove the field statically. Derivation reports it unreached — the SAFE direction, since unprovable forces a declaration rather than a silent pass."

--- a/plugins/amp/agent-factory/SKILL.md
+++ b/plugins/amp/agent-factory/SKILL.md
@@ -33,10 +33,10 @@ Tasks (deliver a prompt on a cron schedule, or whenever a long-running watch scr
   af tasks get <id>                                    Fetch one task
   af tasks add --name <n> --prompt <p> --cron "0 9 * * *" [--target-session <title>] [--program <agent>]
   af tasks add --name <n> --watch-cmd <cmd> [--prompt "... {{line}} ..."] [--target-session <title>] [--program <agent>]
-  af tasks update <id> [--cron ...|--watch-cmd ...] [--prompt ...] [--target-session ...] [--program ...] [--enabled true|false]
+  af tasks update <id> [--cron ...|--watch-cmd ...] [--prompt ...] [--target-session ...] [--project-path <repo>] [--program ...] [--enabled true|false]
   af tasks trigger <id>                                Run a cron task immediately
   af tasks remove <id>
-Without --target-session each run creates a fresh session; {{line}} in a watch prompt is replaced by the emitted stdout line. On update, setting one trigger clears the other, and --target-session "" reverts to session-per-run. A task is bound to one project at creation and "tasks add" echoes the binding as project_path — check it matches the project you meant, and never create a task from a scratch clone of a repo, which binds the automation to the clone instead of the real project. The background daemon runs all schedules; "af daemon install" / "af daemon uninstall" manage its login autostart.
+Without --target-session each run creates a fresh session; {{line}} in a watch prompt is replaced by the emitted stdout line. On update, setting one trigger clears the other, --target-session "" reverts to session-per-run, and --project-path moves the task to another project (--repo still scopes its current project). A task is bound to one project at creation and "tasks add" echoes the binding as project_path — check it matches the project you meant, and never create a task from a scratch clone of a repo, which binds the automation to the clone instead of the real project. The background daemon runs all schedules; "af daemon install" / "af daemon uninstall" manage its login autostart.
 
 Creating or prompting a session: the prompt is the entire contract, because the receiving agent inherits no context from your conversation. State everything it needs, including the expected output shape, e.g. "Open a PR titled X, link it back, do not merge" or "Write a report to <file> and stop; no code changes".
 

--- a/plugins/claude/agent-factory/.claude-plugin/plugin.json
+++ b/plugins/claude/agent-factory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-factory",
   "description": "Run and schedule AI coding agents in isolated git worktrees with the Agent Factory (af) CLI",
-  "version": "3.6.527962995+sha256.1f781373e8d7964b",
+  "version": "3.7.435612295+sha256.19f6ea8788b212bd",
   "author": {
     "name": "Agent Factory",
     "url": "https://github.com/sachiniyer/agent-factory"

--- a/plugins/claude/agent-factory/skills/agent-factory/SKILL.md
+++ b/plugins/claude/agent-factory/skills/agent-factory/SKILL.md
@@ -33,10 +33,10 @@ Tasks (deliver a prompt on a cron schedule, or whenever a long-running watch scr
   af tasks get <id>                                    Fetch one task
   af tasks add --name <n> --prompt <p> --cron "0 9 * * *" [--target-session <title>] [--program <agent>]
   af tasks add --name <n> --watch-cmd <cmd> [--prompt "... {{line}} ..."] [--target-session <title>] [--program <agent>]
-  af tasks update <id> [--cron ...|--watch-cmd ...] [--prompt ...] [--target-session ...] [--program ...] [--enabled true|false]
+  af tasks update <id> [--cron ...|--watch-cmd ...] [--prompt ...] [--target-session ...] [--project-path <repo>] [--program ...] [--enabled true|false]
   af tasks trigger <id>                                Run a cron task immediately
   af tasks remove <id>
-Without --target-session each run creates a fresh session; {{line}} in a watch prompt is replaced by the emitted stdout line. On update, setting one trigger clears the other, and --target-session "" reverts to session-per-run. A task is bound to one project at creation and "tasks add" echoes the binding as project_path — check it matches the project you meant, and never create a task from a scratch clone of a repo, which binds the automation to the clone instead of the real project. The background daemon runs all schedules; "af daemon install" / "af daemon uninstall" manage its login autostart.
+Without --target-session each run creates a fresh session; {{line}} in a watch prompt is replaced by the emitted stdout line. On update, setting one trigger clears the other, --target-session "" reverts to session-per-run, and --project-path moves the task to another project (--repo still scopes its current project). A task is bound to one project at creation and "tasks add" echoes the binding as project_path — check it matches the project you meant, and never create a task from a scratch clone of a repo, which binds the automation to the clone instead of the real project. The background daemon runs all schedules; "af daemon install" / "af daemon uninstall" manage its login autostart.
 
 Creating or prompting a session: the prompt is the entire contract, because the receiving agent inherits no context from your conversation. State everything it needs, including the expected output shape, e.g. "Open a PR titled X, link it back, do not merge" or "Write a report to <file> and stop; no code changes".
 

--- a/plugins/codex/agent-factory/.codex-plugin/plugin.json
+++ b/plugins/codex/agent-factory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-factory",
-  "version": "3.6.527962995+sha256.1f781373e8d7964b",
+  "version": "3.7.435612295+sha256.19f6ea8788b212bd",
   "description": "Run and schedule AI coding agents in isolated git worktrees with the Agent Factory (af) CLI",
   "author": {
     "name": "Agent Factory",

--- a/plugins/codex/agent-factory/skills/agent-factory/SKILL.md
+++ b/plugins/codex/agent-factory/skills/agent-factory/SKILL.md
@@ -33,10 +33,10 @@ Tasks (deliver a prompt on a cron schedule, or whenever a long-running watch scr
   af tasks get <id>                                    Fetch one task
   af tasks add --name <n> --prompt <p> --cron "0 9 * * *" [--target-session <title>] [--program <agent>]
   af tasks add --name <n> --watch-cmd <cmd> [--prompt "... {{line}} ..."] [--target-session <title>] [--program <agent>]
-  af tasks update <id> [--cron ...|--watch-cmd ...] [--prompt ...] [--target-session ...] [--program ...] [--enabled true|false]
+  af tasks update <id> [--cron ...|--watch-cmd ...] [--prompt ...] [--target-session ...] [--project-path <repo>] [--program ...] [--enabled true|false]
   af tasks trigger <id>                                Run a cron task immediately
   af tasks remove <id>
-Without --target-session each run creates a fresh session; {{line}} in a watch prompt is replaced by the emitted stdout line. On update, setting one trigger clears the other, and --target-session "" reverts to session-per-run. A task is bound to one project at creation and "tasks add" echoes the binding as project_path — check it matches the project you meant, and never create a task from a scratch clone of a repo, which binds the automation to the clone instead of the real project. The background daemon runs all schedules; "af daemon install" / "af daemon uninstall" manage its login autostart.
+Without --target-session each run creates a fresh session; {{line}} in a watch prompt is replaced by the emitted stdout line. On update, setting one trigger clears the other, --target-session "" reverts to session-per-run, and --project-path moves the task to another project (--repo still scopes its current project). A task is bound to one project at creation and "tasks add" echoes the binding as project_path — check it matches the project you meant, and never create a task from a scratch clone of a repo, which binds the automation to the clone instead of the real project. The background daemon runs all schedules; "af daemon install" / "af daemon uninstall" manage its login autostart.
 
 Creating or prompting a session: the prompt is the entire contract, because the receiving agent inherits no context from your conversation. State everything it needs, including the expected output shape, e.g. "Open a PR titled X, link it back, do not merge" or "Write a report to <file> and stop; no code changes".
 

--- a/plugins/gemini/agent-factory/SKILL.md
+++ b/plugins/gemini/agent-factory/SKILL.md
@@ -33,10 +33,10 @@ Tasks (deliver a prompt on a cron schedule, or whenever a long-running watch scr
   af tasks get <id>                                    Fetch one task
   af tasks add --name <n> --prompt <p> --cron "0 9 * * *" [--target-session <title>] [--program <agent>]
   af tasks add --name <n> --watch-cmd <cmd> [--prompt "... {{line}} ..."] [--target-session <title>] [--program <agent>]
-  af tasks update <id> [--cron ...|--watch-cmd ...] [--prompt ...] [--target-session ...] [--program ...] [--enabled true|false]
+  af tasks update <id> [--cron ...|--watch-cmd ...] [--prompt ...] [--target-session ...] [--project-path <repo>] [--program ...] [--enabled true|false]
   af tasks trigger <id>                                Run a cron task immediately
   af tasks remove <id>
-Without --target-session each run creates a fresh session; {{line}} in a watch prompt is replaced by the emitted stdout line. On update, setting one trigger clears the other, and --target-session "" reverts to session-per-run. A task is bound to one project at creation and "tasks add" echoes the binding as project_path — check it matches the project you meant, and never create a task from a scratch clone of a repo, which binds the automation to the clone instead of the real project. The background daemon runs all schedules; "af daemon install" / "af daemon uninstall" manage its login autostart.
+Without --target-session each run creates a fresh session; {{line}} in a watch prompt is replaced by the emitted stdout line. On update, setting one trigger clears the other, --target-session "" reverts to session-per-run, and --project-path moves the task to another project (--repo still scopes its current project). A task is bound to one project at creation and "tasks add" echoes the binding as project_path — check it matches the project you meant, and never create a task from a scratch clone of a repo, which binds the automation to the clone instead of the real project. The background daemon runs all schedules; "af daemon install" / "af daemon uninstall" manage its login autostart.
 
 Creating or prompting a session: the prompt is the entire contract, because the receiving agent inherits no context from your conversation. State everything it needs, including the expected output shape, e.g. "Open a PR titled X, link it back, do not merge" or "Write a report to <file> and stop; no code changes".
 

--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -110,10 +110,10 @@ Tasks (deliver a prompt on a cron schedule, or whenever a long-running watch scr
   af tasks get <id>                                    Fetch one task
   af tasks add --name <n> --prompt <p> --cron "0 9 * * *" [--target-session <title>] [--program <agent>]
   af tasks add --name <n> --watch-cmd <cmd> [--prompt "... {{line}} ..."] [--target-session <title>] [--program <agent>]
-  af tasks update <id> [--cron ...|--watch-cmd ...] [--prompt ...] [--target-session ...] [--program ...] [--enabled true|false]
+  af tasks update <id> [--cron ...|--watch-cmd ...] [--prompt ...] [--target-session ...] [--project-path <repo>] [--program ...] [--enabled true|false]
   af tasks trigger <id>                                Run a cron task immediately
   af tasks remove <id>
-Without --target-session each run creates a fresh session; {{line}} in a watch prompt is replaced by the emitted stdout line. On update, setting one trigger clears the other, and --target-session "" reverts to session-per-run. A task is bound to one project at creation and "tasks add" echoes the binding as project_path — check it matches the project you meant, and never create a task from a scratch clone of a repo, which binds the automation to the clone instead of the real project. The background daemon runs all schedules; "af daemon install" / "af daemon uninstall" manage its login autostart.
+Without --target-session each run creates a fresh session; {{line}} in a watch prompt is replaced by the emitted stdout line. On update, setting one trigger clears the other, --target-session "" reverts to session-per-run, and --project-path moves the task to another project (--repo still scopes its current project). A task is bound to one project at creation and "tasks add" echoes the binding as project_path — check it matches the project you meant, and never create a task from a scratch clone of a repo, which binds the automation to the clone instead of the real project. The background daemon runs all schedules; "af daemon install" / "af daemon uninstall" manage its login autostart.
 
 Creating or prompting a session: the prompt is the entire contract, because the receiving agent inherits no context from your conversation. State everything it needs, including the expected output shape, e.g. "Open a PR titled X, link it back, do not merge" or "Write a report to <file> and stop; no code changes".`
 

--- a/session/testdata/af_usage_reference.golden
+++ b/session/testdata/af_usage_reference.golden
@@ -37,10 +37,10 @@ Tasks (deliver a prompt on a cron schedule, or whenever a long-running watch scr
   af tasks get <id>                                    Fetch one task
   af tasks add --name <n> --prompt <p> --cron "0 9 * * *" [--target-session <title>] [--program <agent>]
   af tasks add --name <n> --watch-cmd <cmd> [--prompt "... {{line}} ..."] [--target-session <title>] [--program <agent>]
-  af tasks update <id> [--cron ...|--watch-cmd ...] [--prompt ...] [--target-session ...] [--program ...] [--enabled true|false]
+  af tasks update <id> [--cron ...|--watch-cmd ...] [--prompt ...] [--target-session ...] [--project-path <repo>] [--program ...] [--enabled true|false]
   af tasks trigger <id>                                Run a cron task immediately
   af tasks remove <id>
-Without --target-session each run creates a fresh session; {{line}} in a watch prompt is replaced by the emitted stdout line. On update, setting one trigger clears the other, and --target-session "" reverts to session-per-run. A task is bound to one project at creation and "tasks add" echoes the binding as project_path — check it matches the project you meant, and never create a task from a scratch clone of a repo, which binds the automation to the clone instead of the real project. The background daemon runs all schedules; "af daemon install" / "af daemon uninstall" manage its login autostart.
+Without --target-session each run creates a fresh session; {{line}} in a watch prompt is replaced by the emitted stdout line. On update, setting one trigger clears the other, --target-session "" reverts to session-per-run, and --project-path moves the task to another project (--repo still scopes its current project). A task is bound to one project at creation and "tasks add" echoes the binding as project_path — check it matches the project you meant, and never create a task from a scratch clone of a repo, which binds the automation to the clone instead of the real project. The background daemon runs all schedules; "af daemon install" / "af daemon uninstall" manage its login autostart.
 
 Creating or prompting a session: the prompt is the entire contract, because the receiving agent inherits no context from your conversation. State everything it needs, including the expected output shape, e.g. "Open a PR titled X, link it back, do not merge" or "Write a report to <file> and stop; no code changes".
 


### PR DESCRIPTION
## Summary

- add `af tasks update --project-path <repo>` so the CLI can move an existing task to another project
- keep `--repo` as the authorization scope for the task's current project, making `--repo old --project-path new` explicit and unambiguous
- reuse the existing `TaskUpdate.ProjectPath` -> `daemonUpdateTask` -> `task.UpdateTask` path already used by TUI and web, including shared RepoID derivation and watcher refresh
- update the parity ledger and honesty fixture, then regenerate CLI docs and agent plugins

## Why this gap

Parity gap: `task.edit.project-path`.

Both TUI and web could already repair a task's project binding, while the CLI could not. This has concrete operator impact: #1891 records a maintainer DLQ watcher being bound to a scratch clone and running under the wrong project. The new CLI flag makes that binding repairable without creating a second rebind implementation.

The ledger moves from 40 to 39 capabilities not `yes` on all three surfaces (72 total). `task.edit.project-path` moves from `unclear` to `parity`. The 21 existing `deliberate` rows remain unchanged: scripting-only reads/blocking verbs, host lifecycle, and surface-local navigation still have no meaningful analogue on every surface.

No additional behavioral or shipped-but-unreachable parity gap was found while tracing this path.

## Review follow-up (`8db56050`)

Three P2 findings from the Codex review of `9c21f36c` are addressed:

1. **Destination path was trimmed before resolution.** `TrimSpace` now only decides whether the flag carries a value at all; the path is resolved exactly as typed. A directory name may legitimately begin or end with a space, and the shell already makes the user quote one to get it this far. The pre-fix behavior was worse than an unreachable repo: with two sibling repositories whose names differ only by a trailing space, the task bound to the *wrong* sibling with **no error raised**. `TestTasksUpdate_ProjectPathPreservesWhitespace` reproduces exactly that (it fails on the pre-fix code with `actual: …/repo` vs `expected: …/repo `), and `TestTasksUpdate_ProjectPathRejectsAllWhitespace` pins that an all-whitespace value is still refused before reaching the daemon. `af projects register` already passes its path argument through untrimmed; the TUI editor trims because a text field offers no quoting with which to express the intent.
2. **`docs/cli.md` still said the binding was fixed at creation**, contradicting the flag table two lines above. The Project binding paragraph now separates `--repo` (scopes *which* task may be edited) from `--project-path` (moves it), with a worked `--repo alpha --project-path beta` example.
3. **The parity pointer cited the wrong lines on both sides** — `api/api.go:723` is `--enabled`, and `api/tasks.go:538-550` is target-session/max-concurrency handling. It now reads `api/api.go:722 --project-path -> api/tasks.go:576 patch.ProjectPath = strPtr(absPath)`, both verified against this head, with the assignment expression carried in the pointer text so a future line shift leaves a searchable anchor instead of a silently-wrong citation.

## Validation

All required gates were run against the pushed head `8db56050e8cb5f7d0522b68f5d6ca75b22c66ff4`, on a clean tree with no diff against `origin/siyer/surface-parity-gap-9`:

- `golangci-lint run --timeout=3m --fast` — clean
- `gofmt -l .` — no output
- `go build ./...` — clean
- `make test-container` — every package `ok`, no failures
- `deadcode -test ./...` — no output
- `scripts/lint-file-length.sh` — passed (1112 files, 0 grandfathered)
- `make docs` — no drift; the regenerated reference and plugin files are unchanged

Also checked by hand: `af tasks update --help` from a freshly built binary renders the new flag and the corrected long description.

**Not covered:** the flag was not driven end-to-end against a live daemon, since that path spawns a real daemon and this repo keeps daemon work inside the container harness. Coverage comes from the unit tests (daemon stubbed) plus the container suite.

— Captain Claude
