### PR TITLE
docs: describe project delete deregistration

### DIFF
--- a/api/projects.go
+++ b/api/projects.go
@@ -125,25 +125,27 @@ var deleteProjectViaDaemon = daemon.DeleteProject
 
 var projectsDeleteCmd = &cobra.Command{
 	Use:   "delete [repo]",
-	Short: "Archive and remove a project's sessions (reversibly)",
-	Long: `Archive and remove every live session for a git repository.
+	Short: "Delete a project, archiving its restorable sessions",
+	Long: `Delete a project for a git repository and remove its live sessions.
 
-This is archive-then-remove and reversible. Every live session of the repo is
-archived (its tmux is torn down and its worktree moved to the archive dir, but
-its branch and uncommitted changes are preserved), and its always-on root agent
-(if any) is stopped and its root-agent opt-in removed. In-place sessions (the
-root agent, 'af sessions create --here') are torn down instead of archived —
-their cleanup never touches your working tree or branch.
+Every regular worktree session is archived (its tmux is torn down and its
+worktree moved to the archive dir, but its branch and uncommitted changes are
+preserved). The always-on root agent (if any) is stopped and its root-agent
+opt-in removed. In-place sessions (the root agent, 'af sessions create --here')
+are torn down instead of archived — their cleanup never touches your working
+tree or branch.
 
-The durable project registration, if any, is preserved. This command removes
-session state; it does not unregister the project.
+The durable project registration, if any, is removed so the project leaves the
+project list. Restoring an archived session makes its repository active again,
+but does not restore the durable registration or root-agent opt-in.
 
 Your real git repository is never touched. To undo a mis-click, restore any
 archived session with 'af sessions restore <title>'.
 
 [repo] is a path inside the repository to delete (default: the current repo).
-Deleting an unknown or already-empty project is a clean no-op. Prints how many
-sessions were archived.`,
+Deleting an unknown project is a clean no-op; deleting a registered project
+with no live sessions still removes its registration. Prints how many sessions
+were archived.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)

--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -183,8 +183,9 @@ func (m *home) handleProjectsFocus(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 		m.focusRegion(layout.RegionTree)
 		return m, nil, true
 	}
-	// Delete the cursor's project (#1735): archive-then-remove, reversible. Routed
-	// explicitly like `/` so the captive-section no-op below does not swallow it.
+	// Delete the cursor's project (#1735): archive restorable worktree sessions,
+	// tear down in-place ones, and remove its project registration. Routed explicitly
+	// like `/` so the captive-section no-op below does not swallow it.
 	if key.Matches(msg, keys.GlobalKeyBindings[keys.KeyDeleteProject]) {
 		if proj, ok := m.projects.SelectedProject(); ok {
 			mod, cmd := m.handleDeleteProject(proj)

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -144,16 +144,18 @@ type RestoreSessionResponse struct {
 }
 
 // DeleteProjectRequest asks the daemon to delete a project — a repo grouping of
-// sessions (#1735). The delete is ARCHIVE-THEN-REMOVE and reversible: every live
-// session of the repo is archived (worktree relocated, branch/state preserved,
-// restorable via RestoreArchived), the repo's root_agents opt-in is dropped, and
-// the always-on root agent (if any) is stopped — the user's real git repo is
-// never touched. Restoring any archived session brings the project back.
+// sessions (#1735). Every regular live session is archived (worktree relocated,
+// branch/state preserved, restorable via RestoreArchived); in-place/external
+// sessions are torn down. The repo's root_agents opt-in is removed, as is any
+// durable registration whose root matches RepoPath, and the always-on root agent
+// (if any) is stopped. The user's real git repo is never touched. Restoring an
+// archived session makes the repo active again, but does not restore its
+// registration or root opt-in.
 //
 // RepoPath is the repo root (the stable project id clients group by:
 // worktree.repo_path). RepoID is the precomputed id; when empty the daemon
-// derives it from RepoPath. At least one must be set. Deleting an unknown or
-// already-empty project is a clean no-op, not an error.
+// derives it from RepoPath. At least one must be set. Deleting an unknown project
+// is a clean no-op; a registered project with no live sessions is deregistered.
 type DeleteProjectRequest struct {
 	RepoPath string `json:"repo_path"`
 	RepoID   string `json:"repo_id"`

--- a/daemon/deleteproject.go
+++ b/daemon/deleteproject.go
@@ -70,7 +70,7 @@ type DeleteProjectResult struct {
 }
 
 // DeleteProject deletes a project — a repo grouping of sessions (#1735) — with
-// ARCHIVE-THEN-REMOVE, reversible semantics, under the single-writer daemon:
+// archive-then-remove semantics under the single-writer daemon:
 //
 //   - Every LIVE session of the repo is ARCHIVED (tmux torn down, worktree moved
 //     to the archive dir, branch + state preserved) so it stays restorable via
@@ -83,12 +83,16 @@ type DeleteProjectResult struct {
 //   - The repo's root_agents opt-in is dropped (in-memory suppression for this
 //     daemon's life + removed from config on disk) so the project does not linger
 //     empty in the picker and no always-on root respawns.
+//   - A durable project registration whose root matches req.RepoPath is removed
+//     after every session settles, so a registered-but-sessionless project also
+//     disappears.
 //
 // The user's real git repository is never touched. Because the active-projects
 // list is derived from LIVE sessions, archiving them all removes the project from
-// it; restoring any archived session brings the project back — the reversible
-// contract. Idempotent: deleting an unknown or already-empty project archives
-// nothing, drops no opt-in, and returns a zero-count success.
+// it; restoring any archived session makes the repo active again, but does not
+// restore its durable registration or root_agents opt-in. Idempotent: deleting an
+// unknown project archives nothing, drops no opt-in or registration, and returns
+// a zero-count success; a registered project with no sessions is deregistered.
 func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, error) {
 	repoID := strings.TrimSpace(req.RepoID)
 	if repoID == "" {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -34,7 +34,7 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 - [`af keys`](#af-keys) — Show the effective TUI key bindings (defaults plus [keys] rebinds)
 - [`af projects`](#af-projects) — Manage projects and durable registrations
 - [`af projects add`](#af-projects-add) — Add a project: register a repo by path with a stable local identity
-- [`af projects delete`](#af-projects-delete) — Archive and remove a project's sessions (reversibly)
+- [`af projects delete`](#af-projects-delete) — Delete a project, archiving its restorable sessions
 - [`af projects list`](#af-projects-list) — List registered projects
 - [`af projects rebind`](#af-projects-rebind) — Rebind a registered project after its checkout moves
 - [`af reset`](#af-reset) — Factory-reset Agent Factory: remove AF sessions, tasks, project registrations, worktrees, and state (keeps repos and config)
@@ -985,7 +985,7 @@ af projects
 **Subcommands**
 
 - [`af projects add`](#af-projects-add) — Add a project: register a repo by path with a stable local identity
-- [`af projects delete`](#af-projects-delete) — Archive and remove a project's sessions (reversibly)
+- [`af projects delete`](#af-projects-delete) — Delete a project, archiving its restorable sessions
 - [`af projects list`](#af-projects-list) — List registered projects
 - [`af projects rebind`](#af-projects-rebind) — Rebind a registered project after its checkout moves
 
@@ -1042,26 +1042,28 @@ af projects add <path>
 
 ## af projects delete
 
-Archive and remove a project's sessions (reversibly)
+Delete a project, archiving its restorable sessions
 
-Archive and remove every live session for a git repository.
+Delete a project for a git repository and remove its live sessions.
 
-This is archive-then-remove and reversible. Every live session of the repo is
-archived (its tmux is torn down and its worktree moved to the archive dir, but
-its branch and uncommitted changes are preserved), and its always-on root agent
-(if any) is stopped and its root-agent opt-in removed. In-place sessions (the
-root agent, 'af sessions create --here') are torn down instead of archived —
-their cleanup never touches your working tree or branch.
+Every regular worktree session is archived (its tmux is torn down and its
+worktree moved to the archive dir, but its branch and uncommitted changes are
+preserved). The always-on root agent (if any) is stopped and its root-agent
+opt-in removed. In-place sessions (the root agent, 'af sessions create --here')
+are torn down instead of archived — their cleanup never touches your working
+tree or branch.
 
-The durable project registration, if any, is preserved. This command removes
-session state; it does not unregister the project.
+The durable project registration, if any, is removed so the project leaves the
+project list. Restoring an archived session makes its repository active again,
+but does not restore the durable registration or root-agent opt-in.
 
 Your real git repository is never touched. To undo a mis-click, restore any
 archived session with 'af sessions restore <title>'.
 
 [repo] is a path inside the repository to delete (default: the current repo).
-Deleting an unknown or already-empty project is a clean no-op. Prints how many
-sessions were archived.
+Deleting an unknown project is a clean no-op; deleting a registered project
+with no live sessions still removes its registration. Prints how many sessions
+were archived.
 
 ```
 af projects delete [repo]

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -479,10 +479,10 @@ export interface DeleteProjectResult {
   killed_count: number;
 }
 
-/** Deletes a project (mirrors `af projects delete`) — archive-then-remove and
- *  reversible: the repo's live sessions are archived (restorable), it drops out
- *  of the projects view, and its real git repo is untouched. `root` is the repo
- *  path (worktree.repo_path, the stable project id). The per-session archived
+/** Deletes a project (mirrors `af projects delete`): regular live sessions are
+ *  archived (restorable), in-place sessions are torn down, and any durable
+ *  project registration is removed. The real git repo is untouched. `root` is
+ *  the repo path (worktree.repo_path, the stable project id). The per-session
  *  events + the projects.changed event trigger a rail/projects resync. */
 export async function deleteProject(root: string, token: string): Promise<DeleteProjectResult> {
   return af("DeleteProject", { repo_path: root, repo_id: "" }, token);

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -730,8 +730,9 @@ function openConfirm(action: "kill" | "archive" | "restore", session: Actionable
   );
 }
 
-/** Opens the reversible delete-project confirm for a project row (#1735). On
- *  confirm it archives the repo's live sessions via DeleteProject; the archived
+/** Opens the delete-project confirm for a project row (#1735). On confirm it
+ *  archives the repo's regular live sessions, tears down in-place ones, and
+ *  removes any durable project registration via DeleteProject; the lifecycle
  *  events + projects.changed resync the rail and drop the project from the view. */
 function openDeleteProject(root: string, label: string, sessionCount: number): void {
   openModal(

--- a/web/src/modals.ts
+++ b/web/src/modals.ts
@@ -543,9 +543,9 @@ export function confirmModal(
   return handle;
 }
 
-/** A reversible delete-project confirm modal (#1735): a normal confirm (NOT a
- *  typed-name gate) because the action is reversible — the project's live
- *  sessions are archived (restorable) and its real git repo is untouched. */
+/** Delete-project confirmation (#1735): archived sessions remain restorable and
+ *  the real git repo is untouched, while the durable project registration is
+ *  removed. */
 export function confirmDeleteProjectModal(
   opts: { projectLabel: string; sessionCount: number; onConfirm: () => void; onCancel: () => void },
 ): ModalHandle {

--- a/web/src/project.ts
+++ b/web/src/project.ts
@@ -61,9 +61,9 @@ export function projectName(root: string): string {
  * Two deliberate consequences:
  *  - An ARCHIVED-only repo (no live session, no task) is NOT a project — it drops out
  *    the moment its last session is archived, exactly as the daemon's DeleteProject
- *    reversible contract intends (deleting a project archives its live sessions, and
- *    the project disappears). So the switcher never shows a stale archived-only entry
- *    whose delete would be a silent no-op.
+ *    contract intends (deleting a project archives its regular live sessions, removes
+ *    its durable registration, and the project disappears). So the switcher never
+ *    shows a stale archived-only entry whose delete would be a silent no-op.
  *  - A TASK-only repo (a task but no session) IS a project, so its tasks stay
  *    reachable (the Tasks view scopes to it); its rail is the empty state.
  *

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -278,8 +278,9 @@ export interface Actions {
   triggerTask(task: TaskData): void;
   /** Removes a task via RemoveTask. */
   removeTask(task: TaskData): void;
-  /** Opens the reversible delete-project confirm for a project row (#1735); on
-   *  confirm index.ts calls DeleteProject, which archives its live sessions. */
+  /** Opens the delete-project confirm for a project row (#1735); on confirm
+   *  index.ts calls DeleteProject, which removes the project registration and
+   *  archives each restorable live session. */
   deleteProject(root: string, label: string, sessionCount: number): void;
   /** Opens the add-project modal (#2456): register a git checkout by path via
    *  RegisterProject so it appears as an empty project you can create into. */
@@ -1481,8 +1482,8 @@ export class AppShell {
 
     // Footer actions. Add-project is ALWAYS present (#2456): it is the empty
     // state's coherent action and a convenience when projects already exist. The
-    // reversible delete-project control (#1735) rides alongside it, but only for
-    // the CURRENT project (single-project IA).
+    // delete-project control (#1735) rides alongside it, but only for the CURRENT
+    // project (single-project IA).
     const footChildren: HTMLElement[] = [];
 
     const add = h("button", { type: "button", class: "af-ghost af-project-add" }, "+ Add project");
@@ -1498,7 +1499,7 @@ export class AppShell {
     if (currentSummary) {
       const del = h("button", { type: "button", class: "af-ghost af-project-delete" }, "Delete project");
       const isRegistered = state.registeredProjects.includes(currentSummary.root);
-      // Delete-project ARCHIVES the project's live sessions (#1735, reversible) AND, for
+      // Delete-project ARCHIVES the project's regular live sessions (#1735) AND, for
       // a registered project, removes its durable registry record (#2456) so it leaves
       // the switcher. It is a silent no-op ONLY for a project with neither: a task-only,
       // UNregistered repo (its tasks are cleared from the Tasks view, not here), so it is


### PR DESCRIPTION
## Summary

- Correct `af projects delete` help: the command removes a durable project registration even when the project has no live sessions.
- Distinguish the restorable archived-session state from the registration and root-agent opt-in that restore does not recreate.
- Align the directly related daemon, TUI, and web explanatory comments, then regenerate `docs/reference/cli.md` from the Cobra tree.

## Code evidence

- [`daemon.DeleteProject` removes the registry record after every session settles](https://github.com/sachiniyer/agent-factory/blob/b5325f5bc25d56624e9c335ece197790a21c26d0/daemon/deleteproject.go#L262-L275).
- [`DeleteProjectResult.Deregistered` records that removal](https://github.com/sachiniyer/agent-factory/blob/b5325f5bc25d56624e9c335ece197790a21c26d0/daemon/deleteproject.go#L54-L69).
- [The sessionless-project test requires the registry to be empty after delete](https://github.com/sachiniyer/agent-factory/blob/b5325f5bc25d56624e9c335ece197790a21c26d0/daemon/register_project_test.go#L176-L203).

Addresses #2645 (documentation scope only; the separately proposed JSON response field is unchanged).

## Test Plan

All required gates ran after the final commit was pushed, against `53a6d18cc0a166ef7df2188abb1fa04383b5b01d`:

- [x] `golangci-lint run --timeout=3m --fast` passes
- [x] `gofmt -l .` produces no output
- [x] `go build ./...` passes
- [x] `make test-container` passes
- [x] `deadcode -test ./...` produces no output
- [x] `scripts/lint-file-length.sh` passes
- [x] `mkdocs build --strict` passes
- [x] `scripts/gen-docs.sh` leaves every generated artifact unchanged

— Captain Claude