### PR TITLE
Redact access_token values from dial errors and logs

### DIFF
--- a/agentproto/auth.go
+++ b/agentproto/auth.go
@@ -1,6 +1,7 @@
 package agentproto
 
 import (
+	"errors"
 	"net/http"
 	"net/url"
 	"strings"
@@ -21,7 +22,87 @@ const (
 	// request headers on a WebSocket handshake, so the token rides the URL for the
 	// web client (§4.4); it must be part of the design now, not retrofitted.
 	AccessTokenQueryParam = "access_token"
+	accessTokenRedaction  = "REDACTED"
 )
+
+// RedactAccessTokenURL replaces every access_token query value in raw while
+// preserving the rest of the URL for diagnostics. url.URL.Redacted is not a
+// substitute: it redacts userinfo only and leaves query parameters untouched.
+func RedactAccessTokenURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		// An unparseable URL cannot be safely separated from its credential.
+		return "[url redacted]"
+	}
+	q := parsed.Query()
+	if _, ok := q[AccessTokenQueryParam]; !ok {
+		// URL.Query discards malformed query pairs. The text pass still catches
+		// an exact access_token field without trusting a partially parsed query.
+		return RedactAccessTokenText(raw)
+	}
+	q.Set(AccessTokenQueryParam, accessTokenRedaction)
+	parsed.RawQuery = q.Encode()
+	return parsed.String()
+}
+
+// RedactAccessTokenError strips an access_token from a failed request while
+// retaining the original error chain whenever structured redaction is enough.
+// net/http and WebSocket dial failures commonly contain a *url.Error whose URL
+// includes the full query string.
+func RedactAccessTokenError(err error, token string) error {
+	if err == nil {
+		return nil
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		urlErr.URL = RedactAccessTokenURL(urlErr.URL)
+	}
+
+	message := RedactAccessTokenText(err.Error())
+	if token != "" {
+		message = strings.ReplaceAll(message, token, accessTokenRedaction)
+	}
+	if message != err.Error() {
+		// A non-URL error carried the credential somewhere the structured pass
+		// could not reach. Drop its type rather than retain the secret.
+		return errors.New(message)
+	}
+	return err
+}
+
+// RedactAccessTokenText is the logging-boundary backstop for an access_token
+// query embedded in otherwise unstructured text. Call sites that know they are
+// handling a URL or request error must still use the structured helpers above.
+func RedactAccessTokenText(text string) string {
+	needle := AccessTokenQueryParam + "="
+	if !strings.Contains(text, needle) {
+		return text
+	}
+
+	var redacted strings.Builder
+	rest := text
+	for {
+		i := strings.Index(rest, needle)
+		if i < 0 {
+			redacted.WriteString(rest)
+			return redacted.String()
+		}
+		valueStart := i + len(needle)
+		if i > 0 && rest[i-1] != '?' && rest[i-1] != '&' {
+			redacted.WriteString(rest[:valueStart])
+			rest = rest[valueStart:]
+			continue
+		}
+
+		valueEnd := valueStart
+		for valueEnd < len(rest) && !strings.ContainsRune("& \t\r\n#\"'", rune(rest[valueEnd])) {
+			valueEnd++
+		}
+		redacted.WriteString(rest[:valueStart])
+		redacted.WriteString(accessTokenRedaction)
+		rest = rest[valueEnd:]
+	}
+}
 
 // BearerToken extracts the token from an Authorization header value, matching the
 // scheme case-insensitively. It returns "" when the value is absent or not a

--- a/agentproto/auth_test.go
+++ b/agentproto/auth_test.go
@@ -1,10 +1,119 @@
 package agentproto
 
 import (
+	"errors"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 )
+
+func TestURLRedactedLeavesAccessTokenQueryUntouched(t *testing.T) {
+	const token = "af-sentinel-url-redacted-trap"
+	u, err := url.Parse("ws://box.test/stream?access_token=" + token)
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	if got := u.Redacted(); !strings.Contains(got, token) {
+		t.Fatalf("url.URL.Redacted unexpectedly removed the query token: %q", got)
+	}
+}
+
+func TestRedactAccessTokenURL(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		raw         string
+		wantAbsent  []string
+		wantPresent []string
+	}{
+		{
+			name:        "token value replaced, everything else kept",
+			raw:         "http://box:8080/v1/sessions/s/stream?tab=2&access_token=sekrit",
+			wantAbsent:  []string{"sekrit"},
+			wantPresent: []string{"box:8080", "/v1/sessions/s/stream", "tab=2", "REDACTED"},
+		},
+		{
+			name:        "duplicate token values all replaced",
+			raw:         "http://box:8080/stream?access_token=one&access_token=two",
+			wantAbsent:  []string{"access_token=one", "access_token=two"},
+			wantPresent: []string{"box:8080", "access_token=REDACTED"},
+		},
+		{
+			name:        "no token untouched",
+			raw:         "http://box:8080/v1/sessions/s/stream?tab=2",
+			wantAbsent:  []string{"REDACTED"},
+			wantPresent: []string{"box:8080", "tab=2"},
+		},
+		{
+			name:        "unparseable url says nothing",
+			raw:         "http://box:8080/\x7f?access_token=sekrit",
+			wantAbsent:  []string{"sekrit"},
+			wantPresent: []string{"redacted"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RedactAccessTokenURL(tc.raw)
+			for _, absent := range tc.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("RedactAccessTokenURL(%q) = %q, must not contain %q", tc.raw, got, absent)
+				}
+			}
+			for _, want := range tc.wantPresent {
+				if !strings.Contains(got, want) {
+					t.Errorf("RedactAccessTokenURL(%q) = %q, want it to contain %q", tc.raw, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestRedactAccessTokenError(t *testing.T) {
+	const token = "af-sentinel-error-redaction"
+	cause := errors.New("connection refused")
+	dialErr := &url.Error{
+		Op:  "Get",
+		URL: "ws://box:8080/stream?tab=2&access_token=" + token,
+		Err: cause,
+	}
+
+	got := RedactAccessTokenError(dialErr, token)
+	if strings.Contains(got.Error(), token) {
+		t.Fatalf("structured dial error retained token: %s", got)
+	}
+	if !strings.Contains(got.Error(), "box:8080") || !strings.Contains(got.Error(), "REDACTED") {
+		t.Fatalf("structured dial error lost useful URL context: %s", got)
+	}
+	if !errors.Is(got, cause) {
+		t.Fatalf("structured redaction lost the original error chain: %v", got)
+	}
+
+	plain := errors.New("transport failure carrying token " + token)
+	got = RedactAccessTokenError(plain, token)
+	if strings.Contains(got.Error(), token) || !strings.Contains(got.Error(), "REDACTED") {
+		t.Fatalf("unstructured error was not safely redacted: %s", got)
+	}
+	clean := errors.New("connection refused")
+	if got := RedactAccessTokenError(clean, token); got != clean {
+		t.Fatalf("clean error identity changed: %v", got)
+	}
+	if RedactAccessTokenError(nil, token) != nil {
+		t.Fatal("nil error must remain nil")
+	}
+}
+
+func TestRedactAccessTokenText(t *testing.T) {
+	const token = "af-sentinel-log-redaction"
+	in := "access_token=first Get \"ws://box/stream?tab=2&access_token=" + token + "\": dial failed"
+	got := RedactAccessTokenText(in)
+	if strings.Contains(got, token) || strings.Contains(got, "first") {
+		t.Fatalf("text redactor retained token: %s", got)
+	}
+	for _, want := range []string{"box", "tab=2", "access_token=REDACTED", "dial failed"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("text redactor lost %q: %s", want, got)
+		}
+	}
+}
 
 func TestBearerToken(t *testing.T) {
 	cases := []struct {

--- a/apiclient/stream.go
+++ b/apiclient/stream.go
@@ -89,7 +89,8 @@ func (c *Client) DialStream(ctx context.Context, title, repoID, tabID string, ta
 	}
 	conn, resp, err := websocket.Dial(dialCtx, u, &opts)
 	if err != nil {
-		return nil, &TransportError{Err: fmt.Errorf("apiclient: dial pty stream: %w", err)}
+		return nil, &TransportError{Err: fmt.Errorf("apiclient: dial pty stream: %w",
+			agentproto.RedactAccessTokenError(err, c.token))}
 	}
 	// Raise the read limit off the 32 KiB default: a full-screen repaint of a wide
 	// pane, or a ?since replay of the whole ring, is a single large binary frame.

--- a/apiclient/stream_test.go
+++ b/apiclient/stream_test.go
@@ -19,6 +19,34 @@ import (
 	"github.com/sachiniyer/agent-factory/terminal"
 )
 
+func TestDialStreamErrorDoesNotExposeAccessToken(t *testing.T) {
+	const token = "af-sentinel-2644-do-not-log"
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+
+	c, err := NewRemote("http://"+addr, token)
+	if err != nil {
+		t.Fatalf("NewRemote: %v", err)
+	}
+	_, err = c.DialStream(context.Background(), "probe", "", "", 0, 0)
+	if err == nil {
+		t.Fatal("dial against a closed port returned nil error")
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Fatalf("failed remote WebSocket dial exposed its access_token query value: %s", err)
+	}
+	if !strings.Contains(err.Error(), addr) {
+		t.Fatalf("redaction removed the failed endpoint needed for diagnosis: %s", err)
+	}
+}
+
 // previewServer stands up a Unix-socket HTTP server answering POST /v1/Preview
 // like the daemon does, and returns a Client dialing it plus a pointer to the
 // last request it saw (so a test can assert the tab/full/title were carried).

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"runtime"
 
+	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
@@ -842,7 +843,8 @@ func webTabAttachGuard(inst *session.Instance, tabIdx int) error {
 	}
 	switch tabs[tabIdx].Kind {
 	case session.TabKindWeb:
-		return fmt.Errorf("this is a web tab (%s) — view it in the web UI or open the URL in a browser", tabs[tabIdx].URL)
+		return fmt.Errorf("this is a web tab (%s) — view it in the web UI or open the URL in a browser",
+			agentproto.RedactAccessTokenURL(tabs[tabIdx].URL))
 	case session.TabKindVSCode:
 		return fmt.Errorf("this is a VS Code tab — view it in the web UI; a terminal can't render the editor")
 	default:

--- a/app/interactive_test.go
+++ b/app/interactive_test.go
@@ -709,6 +709,18 @@ func TestClickCommittingWebTabPreviewShowsGuardNotAttach(t *testing.T) {
 	assert.False(t, h.interactive, "a web tab cannot embed either")
 }
 
+func TestWebTabAttachGuardDoesNotExposeAccessToken(t *testing.T) {
+	const token = "af-sentinel-webtab-guard"
+	inst := startedLocalInstance(t, "web-host")
+	_, err := inst.AddWebTab("http://localhost:3000/app?access_token="+token+"&view=2", "")
+	require.NoError(t, err)
+
+	err = webTabAttachGuard(inst, len(inst.GetTabs())-1)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), token)
+	assert.Contains(t, err.Error(), "access_token=REDACTED")
+}
+
 // TestAttachFocusedBrowserOnlyPaneShowsGuardNotAttach pins webTabAttachGuard on
 // the FOCUSED-PANE attach path (handleEnterPane, #1817) — the one path into
 // attachInstanceTab that nothing else fences.

--- a/daemon/configassistant_routes.go
+++ b/daemon/configassistant_routes.go
@@ -30,8 +30,8 @@ import (
 // Authorization header on a WS handshake, so the token rides ?access_token= exactly
 // as /v1/sessions/{id}/stream does. Neither handler logs the request URL, so the
 // token never reaches a log (#2461). If a future error path must log a URL here, it
-// MUST scrub it with redactAccessTokenInURL — url.Redacted() leaves a query token
-// intact (see session/agentserver_remote.go). Known, accepted limitation (per the
+// MUST scrub it with agentproto.RedactAccessTokenURL — url.Redacted() leaves a query token
+// intact (see agentproto/auth.go). Known, accepted limitation (per the
 // #2467 decision): the durable token still rides every stream URL repo-wide, which
 // is fine behind the tailnet-only listener; a repo-wide move to WS tickets is not
 // in scope.

--- a/daemon/webtab_error_marker_test.go
+++ b/daemon/webtab_error_marker_test.go
@@ -1,10 +1,42 @@
 package daemon
 
 import (
+	"bytes"
+	stdlog "log"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	aflog "github.com/sachiniyer/agent-factory/log"
 )
+
+func TestWebTabProxyFailureDoesNotLogTargetAccessToken(t *testing.T) {
+	const token = "af-sentinel-webtab-target"
+	dead := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	targetURL := dead.URL + "/app?view=2&access_token=" + token
+	dead.Close()
+
+	var warnings bytes.Buffer
+	previous := aflog.WarningLog
+	aflog.WarningLog = stdlog.New(&warnings, "", 0)
+	t.Cleanup(func() { aflog.WarningLog = previous })
+
+	mux, sessionID, tabID := newWebTabProxyFixture(t, targetURL)
+	rec := proxyGet(t, mux, sessionID, tabID, "app?view=2")
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadGateway)
+	}
+	if strings.Contains(warnings.String(), token) {
+		t.Fatalf("web-tab proxy log exposed the target access_token: %s", warnings.String())
+	}
+	if !strings.Contains(warnings.String(), "access_token=REDACTED") {
+		t.Fatalf("web-tab proxy log lost its redaction marker: %s", warnings.String())
+	}
+	if strings.Contains(rec.Body.String(), token) {
+		t.Fatalf("web-tab proxy error response exposed the target access_token: %s", rec.Body.String())
+	}
+}
 
 // The #1909 gate: an af-GENERATED proxy failure must be distinguishable from an
 // upstream-generated one that happens to carry the same status.

--- a/daemon/webtab_proxy.go
+++ b/daemon/webtab_proxy.go
@@ -470,12 +470,14 @@ func (cs *controlServer) webTabProxyHandler(w http.ResponseWriter, r *http.Reque
 	// confused-deputy hole this transport closes.
 	if !target.isUnixSocket() && !session.IsLoopbackWebTarget(target.URL) {
 		writeHTTPError(w, r, http.StatusBadRequest,
-			fmt.Errorf("web tab target %q is not loopback; external URLs are iframed directly, not proxied", target.URL))
+			fmt.Errorf("web tab target %q is not loopback; external URLs are iframed directly, not proxied",
+				agentproto.RedactAccessTokenURL(target.URL)))
 		return
 	}
 	targetURL, err := url.Parse(target.URL)
 	if err != nil {
-		writeHTTPError(w, r, http.StatusInternalServerError, fmt.Errorf("invalid web tab target: %w", err))
+		writeHTTPError(w, r, http.StatusInternalServerError, fmt.Errorf("invalid web tab target: %w",
+			agentproto.RedactAccessTokenError(err, "")))
 		return
 	}
 
@@ -628,7 +630,10 @@ func (cs *controlServer) webTabProxyHandler(w http.ResponseWriter, r *http.Reque
 			return nil
 		},
 		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
-			log.WarningLog.Printf("web tab proxy to %s failed: %v", targetURL.Redacted(), err)
+			safeErr := agentproto.RedactAccessTokenError(err,
+				agentproto.AccessTokenFromQuery(targetURL.Query()))
+			log.WarningLog.Printf("web tab proxy to %s failed: %v",
+				agentproto.RedactAccessTokenURL(targetURL.String()), safeErr)
 			// Mark this 502 as AF's OWN before writing it (#1909). Reaching here means
 			// the upstream never answered — the transport failed, or ModifyResponse
 			// rejected the response — so no upstream header has been copied to w and
@@ -640,7 +645,7 @@ func (cs *controlServer) webTabProxyHandler(w http.ResponseWriter, r *http.Reque
 			// no longer reach the client.
 			w.Header().Set(webtabErrorHeader, webtabErrorUpstreamUnreachable)
 			writeHTTPError(w, r, http.StatusBadGateway,
-				fmt.Errorf("web tab dev server at %s is unreachable: %w", targetURL.Host, err))
+				fmt.Errorf("web tab dev server at %s is unreachable: %w", targetURL.Host, safeErr))
 		},
 	}
 	proxy.ServeHTTP(w, r)

--- a/log/log.go
+++ b/log/log.go
@@ -55,9 +55,9 @@ func (d dirtyWriter) Write(p []byte) (int, error) {
 // real file/stderr loggers. Without this, code paths like `af upgrade` that
 // forget to call Initialize crash inside the SIGTERM fallback (#514).
 func init() {
-	InfoLog = log.New(io.Discard, "", 0)
-	WarningLog = log.New(io.Discard, "", 0)
-	ErrorLog = log.New(io.Discard, "", 0)
+	InfoLog = log.New(redactedLogSink(io.Discard), "", 0)
+	WarningLog = log.New(redactedLogSink(io.Discard), "", 0)
+	ErrorLog = log.New(redactedLogSink(io.Discard), "", 0)
 }
 
 // mu guards writes to globalLogFile and the exported *log.Logger pointers
@@ -428,13 +428,13 @@ func Initialize(daemon bool) {
 	// through to stderr instead of being dropped.
 	if globalLogFile != nil {
 		if InfoLog != nil {
-			InfoLog.SetOutput(os.Stderr)
+			InfoLog.SetOutput(redactedLogSink(os.Stderr))
 		}
 		if WarningLog != nil {
-			WarningLog.SetOutput(os.Stderr)
+			WarningLog.SetOutput(redactedLogSink(os.Stderr))
 		}
 		if ErrorLog != nil {
-			ErrorLog.SetOutput(os.Stderr)
+			ErrorLog.SetOutput(redactedLogSink(os.Stderr))
 		}
 		_ = globalLogFile.Close()
 		globalLogFile = nil
@@ -456,9 +456,9 @@ func Initialize(daemon bool) {
 		if daemon {
 			fmtS = "[DAEMON] %s"
 		}
-		InfoLog = log.New(os.Stderr, fmt.Sprintf(fmtS, "INFO:"), log.Ldate|log.Ltime|log.Lshortfile)
-		WarningLog = log.New(dirtyWriter{os.Stderr}, fmt.Sprintf(fmtS, "WARNING:"), log.Ldate|log.Ltime|log.Lshortfile)
-		ErrorLog = log.New(dirtyWriter{os.Stderr}, fmt.Sprintf(fmtS, "ERROR:"), log.Ldate|log.Ltime|log.Lshortfile)
+		InfoLog = log.New(redactedLogSink(os.Stderr), fmt.Sprintf(fmtS, "INFO:"), log.Ldate|log.Ltime|log.Lshortfile)
+		WarningLog = log.New(dirtyWriter{redactedLogSink(os.Stderr)}, fmt.Sprintf(fmtS, "WARNING:"), log.Ldate|log.Ltime|log.Lshortfile)
+		ErrorLog = log.New(dirtyWriter{redactedLogSink(os.Stderr)}, fmt.Sprintf(fmtS, "ERROR:"), log.Ldate|log.Ltime|log.Lshortfile)
 		return
 	}
 
@@ -474,9 +474,9 @@ func Initialize(daemon bool) {
 	if daemon {
 		fmtS = "[DAEMON] %s"
 	}
-	InfoLog = log.New(w, fmt.Sprintf(fmtS, "INFO:"), log.Ldate|log.Ltime|log.Lshortfile)
-	WarningLog = log.New(dirtyWriter{w}, fmt.Sprintf(fmtS, "WARNING:"), log.Ldate|log.Ltime|log.Lshortfile)
-	ErrorLog = log.New(dirtyWriter{w}, fmt.Sprintf(fmtS, "ERROR:"), log.Ldate|log.Ltime|log.Lshortfile)
+	InfoLog = log.New(redactedLogSink(w), fmt.Sprintf(fmtS, "INFO:"), log.Ldate|log.Ltime|log.Lshortfile)
+	WarningLog = log.New(dirtyWriter{redactedLogSink(w)}, fmt.Sprintf(fmtS, "WARNING:"), log.Ldate|log.Ltime|log.Lshortfile)
+	ErrorLog = log.New(dirtyWriter{redactedLogSink(w)}, fmt.Sprintf(fmtS, "ERROR:"), log.Ldate|log.Ltime|log.Lshortfile)
 
 	globalLogFile = w
 }
@@ -527,13 +527,13 @@ func closeWithReport(report bool) {
 	// guarantees no Printf ever lands on a closed fd. Reversing this order
 	// loses messages logged in the gap between Close and SetOutput (#642).
 	if InfoLog != nil {
-		InfoLog.SetOutput(os.Stderr)
+		InfoLog.SetOutput(redactedLogSink(os.Stderr))
 	}
 	if WarningLog != nil {
-		WarningLog.SetOutput(os.Stderr)
+		WarningLog.SetOutput(redactedLogSink(os.Stderr))
 	}
 	if ErrorLog != nil {
-		ErrorLog.SetOutput(os.Stderr)
+		ErrorLog.SetOutput(redactedLogSink(os.Stderr))
 	}
 	// Only claim a file was written when one was actually opened. When
 	// Initialize fell back to stderr (or was never called), globalLogFile is

--- a/log/redact.go
+++ b/log/redact.go
@@ -1,0 +1,28 @@
+package log
+
+import (
+	"io"
+
+	"github.com/sachiniyer/agent-factory/agentproto"
+)
+
+// accessTokenRedactingWriter is a last-line defense for agent-factory.log and
+// its stderr fallback. URL-producing call sites still redact structurally so
+// returned errors and non-log surfaces are safe too.
+type accessTokenRedactingWriter struct{ writer io.Writer }
+
+func (w accessTokenRedactingWriter) Write(p []byte) (int, error) {
+	redacted := []byte(agentproto.RedactAccessTokenText(string(p)))
+	n, err := w.writer.Write(redacted)
+	if err != nil {
+		return 0, err
+	}
+	if n != len(redacted) {
+		return 0, io.ErrShortWrite
+	}
+	return len(p), nil
+}
+
+func redactedLogSink(writer io.Writer) io.Writer {
+	return accessTokenRedactingWriter{writer: writer}
+}

--- a/log/redact_test.go
+++ b/log/redact_test.go
@@ -1,0 +1,34 @@
+package log
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInitializedLoggerRedactsAccessTokenQuery(t *testing.T) {
+	const token = "af-sentinel-logger-boundary"
+	logPathOverride = filepath.Join(t.TempDir(), "agent-factory.log")
+	t.Cleanup(func() {
+		CloseQuiet()
+		logPathOverride = ""
+	})
+
+	Initialize(false)
+	ErrorLog.Printf("attach failed: Get %q: connection refused",
+		"ws://daemon.test/stream?tab=2&access_token="+token)
+	CloseQuiet()
+
+	contents, err := os.ReadFile(logPathOverride)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	got := string(contents)
+	if strings.Contains(got, token) {
+		t.Fatalf("logging boundary persisted the access token: %s", got)
+	}
+	if !strings.Contains(got, "access_token=REDACTED") || !strings.Contains(got, "daemon.test") {
+		t.Fatalf("logging boundary lost useful redacted context: %s", got)
+	}
+}

--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -619,61 +619,6 @@ func (c *remoteAgentClient) preview(tab int, full bool) (PreviewSnapshot, error)
 	}, nil
 }
 
-// accessTokenRedaction replaces the sandbox bearer token wherever a URL carrying
-// it would otherwise reach a log or an error surface.
-const accessTokenRedaction = "REDACTED"
-
-// redactAccessTokenInURL returns raw with the ?access_token= VALUE replaced.
-//
-// url.Redacted() is not a substitute and must not be reached for here: it
-// redacts USERINFO (the user:pass@ form) and leaves the query string untouched,
-// so an access_token query survives it completely.
-func redactAccessTokenInURL(raw string) string {
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		// Unparseable: say nothing rather than risk echoing the credential.
-		return "[url redacted]"
-	}
-	q := parsed.Query()
-	if q.Get(agentproto.AccessTokenQueryParam) == "" {
-		return raw
-	}
-	q.Set(agentproto.AccessTokenQueryParam, accessTokenRedaction)
-	parsed.RawQuery = q.Encode()
-	return parsed.String()
-}
-
-// redactDialError strips the sandbox bearer token from a failed dial's error.
-//
-// The token rides the URL as ?access_token= (the browser-WS fallback the
-// agent-server also honours), and a failed dial surfaces as a *url.Error
-// carrying that whole URL — so wrapping the raw error puts the credential in
-// whatever renders it. That was survivable while the only failed-dial path was
-// subscribe(), whose error goes to an HTTP response; #2450 made the daemon retry
-// on a timer and LOG each failure, which would write the token to
-// agent-factory.log once per backoff for as long as a tab stays open.
-//
-// The *url.Error is mutated in place rather than replaced: it is freshly created
-// by this dial and unshared, and fixing it there cleans every wrapper that
-// renders it through %w, so errors.Is/As keep working on the chain.
-//
-// The substring check afterwards is a deliberate backstop, not redundancy: it
-// catches any failure shape that carried the credential somewhere other than a
-// *url.Error. If one ever does, the structure is dropped and the secret is not.
-func redactDialError(err error, token string) error {
-	if err == nil {
-		return nil
-	}
-	var uerr *url.Error
-	if errors.As(err, &uerr) {
-		uerr.URL = redactAccessTokenInURL(uerr.URL)
-	}
-	if token != "" && strings.Contains(err.Error(), token) {
-		return errors.New(strings.ReplaceAll(err.Error(), token, accessTokenRedaction))
-	}
-	return err
-}
-
 // dialStream opens the WS PTY subscription to tab `tab` (from the live tail). The
 // token rides both the Authorization header and the ?access_token= query — the
 // agent-server honors either, and the query mirrors the browser WS path Phase 5
@@ -699,7 +644,8 @@ func (c *remoteAgentClient) dialStream(ctx context.Context, tab int) (*websocket
 	defer cancel()
 	conn, _, err := websocket.Dial(dialCtx, u, opts)
 	if err != nil {
-		return nil, fmt.Errorf("remote agent-server: dial pty stream: %w", redactDialError(err, c.token))
+		return nil, fmt.Errorf("remote agent-server: dial pty stream: %w",
+			agentproto.RedactAccessTokenError(err, c.token))
 	}
 	conn.SetReadLimit(4 << 20)
 	return conn, nil

--- a/session/agentserver_remote_token_redaction_test.go
+++ b/session/agentserver_remote_token_redaction_test.go
@@ -2,7 +2,6 @@ package session
 
 import (
 	"context"
-	"errors"
 	"net"
 	"strings"
 	"testing"
@@ -65,75 +64,5 @@ func TestRemoteAgentDialStream_ErrorCarriesNoToken(t *testing.T) {
 	if !strings.Contains(derr.Error(), addr) {
 		t.Fatalf("the dial error no longer names the endpoint it failed to reach: %s\n\n"+
 			"redaction must remove the credential, not the diagnosis", derr.Error())
-	}
-}
-
-// TestRedactAccessTokenInURL pins the redaction itself, including the two ways
-// it could quietly stop working: leaving the value in place, or destroying the
-// rest of the URL along with it.
-func TestRedactAccessTokenInURL(t *testing.T) {
-	for _, tc := range []struct {
-		name        string
-		raw         string
-		wantAbsent  string
-		wantPresent []string
-	}{
-		{
-			name:        "token value replaced, everything else kept",
-			raw:         "http://box:8080/v1/sessions/s/stream?tab=2&access_token=sekrit",
-			wantAbsent:  "sekrit",
-			wantPresent: []string{"box:8080", "/v1/sessions/s/stream", "tab=2", accessTokenRedaction},
-		},
-		{
-			name:        "no token, untouched",
-			raw:         "http://box:8080/v1/sessions/s/stream?tab=2",
-			wantAbsent:  accessTokenRedaction,
-			wantPresent: []string{"box:8080", "tab=2"},
-		},
-		{
-			name: "unparseable url says nothing rather than risk echoing it",
-			// A control character makes url.Parse fail.
-			raw:         "http://box:8080/\x7f?access_token=sekrit",
-			wantAbsent:  "sekrit",
-			wantPresent: []string{"redacted"},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			got := redactAccessTokenInURL(tc.raw)
-			if tc.wantAbsent != "" && strings.Contains(got, tc.wantAbsent) {
-				t.Errorf("redactAccessTokenInURL(%q) = %q, must not contain %q", tc.raw, got, tc.wantAbsent)
-			}
-			for _, want := range tc.wantPresent {
-				if !strings.Contains(got, want) {
-					t.Errorf("redactAccessTokenInURL(%q) = %q, want it to contain %q", tc.raw, got, want)
-				}
-			}
-		})
-	}
-}
-
-// TestRedactDialErrorBackstop covers the defence that does not depend on the
-// error being a *url.Error: if some other failure shape ever carries the
-// credential, the structure is dropped rather than the secret.
-func TestRedactDialErrorBackstop(t *testing.T) {
-	const token = "tok-abc123"
-
-	plain := errors.New("some transport failure carrying access_token=" + token + " inline")
-	got := redactDialError(plain, token)
-	if strings.Contains(got.Error(), token) {
-		t.Fatalf("redactDialError left the token in a non-url.Error: %s", got.Error())
-	}
-	if !strings.Contains(got.Error(), accessTokenRedaction) {
-		t.Fatalf("redactDialError scrubbed the token but left no marker: %s", got.Error())
-	}
-
-	// An error with no credential in it must survive untouched, identity included,
-	// so ordinary failures keep their type for errors.Is/As.
-	clean := errors.New("connection refused")
-	if got := redactDialError(clean, token); got != clean {
-		t.Fatalf("redactDialError replaced a clean error (%v); it must pass it through unchanged", got)
-	}
-	if redactDialError(nil, token) != nil {
-		t.Fatal("redactDialError(nil) must stay nil")
 	}
 }


### PR DESCRIPTION
## Summary

- move the existing query-token URL/error redactor from `session` into the shared `agentproto` transport package and use it from both WebSocket dialers
- redact every audited Go error/log surface that can carry an `access_token` URL, including the web-tab proxy and TUI web-tab guard
- add a lightweight redacting writer at the main log boundary as defense in depth; structured call-site redaction remains the primary defense
- add distinctive sentinel regressions for dial errors, proxy logs/responses, TUI errors, the shared primitive, and the logging boundary

## Root cause

`apiclient.DialStream` appended the remote daemon bearer token as `?access_token=<token>`, then wrapped the failed `websocket.Dial` error verbatim. The underlying `*url.Error` rendered the full request URL, and `app/home_attach.go` persisted that string with `%v`.

The repo already handled the same failure shape in `session/agentserver_remote.go`, but its redactor was package-local. This change extracts that security primitive so both dialers use one implementation.

Go's `url.URL.Redacted()` is not used as a fix: the regression suite verifies that it leaves the `access_token` query value untouched because it redacts userinfo only.

## Audit

- `apiclient.DialStream`: token-bearing daemon WebSocket URL; now redacts before wrapping
- `session.remoteAgentClient.dialStream`: token-bearing agent-server WebSocket URL; now calls the same shared helper as apiclient
- remote REST clients: bearer travels only in the Authorization header, so their `*url.Error` URLs contain no token
- web-tab proxy: a target application may itself use `?access_token=`; its rejection, parse, proxy-log, and proxy-error paths now redact while preserving host/path/other query context
- TUI web-tab attach guard: its user-visible/logged URL error now redacts the target query token
- browser WebSocket constructors: the token reaches the wire, but those TypeScript paths do not feed a Go error string or `agent-factory.log`
- main log sinks: use the shared text backstop so a future missed URL-formatting call does not persist an `access_token` query value

## Validation

Fail-first proof on the pre-fix tree:

`GOTOOLCHAIN=go1.25.0 go test ./apiclient -run '^TestDialStreamErrorDoesNotExposeAccessToken$' -count=1`

This failed with the distinctive sentinel visible in the full URL.

Passed on pushed head `7b6ba758969f6edbf87c1bbaf02c930cd22104a4`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container`

Closes #2644