### PR TITLE
fix(auth): redact semicolon-delimited access tokens

### DIFF
--- a/agentproto/auth.go
+++ b/agentproto/auth.go
@@ -88,14 +88,14 @@ func RedactAccessTokenText(text string) string {
 			return redacted.String()
 		}
 		valueStart := i + len(needle)
-		if i > 0 && rest[i-1] != '?' && rest[i-1] != '&' {
+		if i > 0 && rest[i-1] != '?' && rest[i-1] != '&' && rest[i-1] != ';' {
 			redacted.WriteString(rest[:valueStart])
 			rest = rest[valueStart:]
 			continue
 		}
 
 		valueEnd := valueStart
-		for valueEnd < len(rest) && !strings.ContainsRune("& \t\r\n#\"'", rune(rest[valueEnd])) {
+		for valueEnd < len(rest) && !strings.ContainsRune("&; \t\r\n#\"'", rune(rest[valueEnd])) {
 			valueEnd++
 		}
 		redacted.WriteString(rest[:valueStart])

--- a/agentproto/auth_test.go
+++ b/agentproto/auth_test.go
@@ -39,6 +39,12 @@ func TestRedactAccessTokenURL(t *testing.T) {
 			wantPresent: []string{"box:8080", "access_token=REDACTED"},
 		},
 		{
+			name:        "semicolon query separator",
+			raw:         "http://box:8080/stream?view=2;access_token=sekrit;mode=full",
+			wantAbsent:  []string{"sekrit"},
+			wantPresent: []string{"box:8080", "view=2", "access_token=REDACTED", "mode=full"},
+		},
+		{
 			name:        "no token untouched",
 			raw:         "http://box:8080/v1/sessions/s/stream?tab=2",
 			wantAbsent:  []string{"REDACTED"},


### PR DESCRIPTION
## What changed

- Treat legacy semicolon query separators as access-token field boundaries in the shared text redactor.
- Preserve following query fields while replacing only the credential value.
- Add regression coverage for a persisted web-tab URL shaped like `?view=2;access_token=sekrit;mode=full`.

## Why

A late P1 Codex finding on merged PR #2684 showed that Go's URL query parser drops semicolon-delimited fields. The URL redactor then falls back to the text redactor, which previously recognized only `?` and `&`; the secret could therefore survive and reach `WarningLog` on a proxy failure.

Finding: https://github.com/sachiniyer/agent-factory/pull/2684#discussion_r3683288136

## Impact

Failed web-tab proxy requests and other logging paths now redact `access_token` values even when legacy URLs use semicolons as query separators, without discarding useful endpoint or neighboring-field context.

## Reproduction

Before the fix, `TestRedactAccessTokenURL/semicolon_query_separator` failed because the returned URL still contained `sekrit` and no `access_token=REDACTED` marker.

## Validation

Exact head: `c1961fa4f3a9ed3a6d88f83a90244c8b613d869e`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `make test-container`
