### PR TITLE
Fail reset when tmux ownership is unknown

### DIFF
--- a/session/tmux/capture_wedge_test.go
+++ b/session/tmux/capture_wedge_test.go
@@ -280,10 +280,9 @@ func TestCleanupSessionsDoesNotHangOnWedgedServer(t *testing.T) {
 }
 
 // TestSessionHomeMarkerDoesNotHangOnWedgedServer covers the ownership probe the
-// sweep runs once PER discovered session. It is best-effort (no error to return),
-// so the contract is simply that it returns — and returns "no marker", since a
-// wedged server proves nothing about ownership and the sweep's safe direction is
-// to leave a session it cannot prove it owns (#1122).
+// sweep runs once PER discovered session. A wedged server proves nothing about
+// ownership, so it must return UNKNOWN as ErrTmuxTimeout rather than laundering
+// the missing answer into "no marker" (#1122/#2633).
 func TestSessionHomeMarkerDoesNotHangOnWedgedServer(t *testing.T) {
 	stallingTmuxOnPath(t)
 	shortTmuxTimeout(t, 200*time.Millisecond)
@@ -291,17 +290,21 @@ func TestSessionHomeMarkerDoesNotHangOnWedgedServer(t *testing.T) {
 	type result struct {
 		home string
 		ok   bool
+		err  error
 	}
 	done := make(chan result, 1)
 	go func() {
-		home, ok := sessionHomeMarker(cmd.MakeExecutor(), "af_wedged")
-		done <- result{home, ok}
+		home, ok, err := sessionHomeMarker(cmd.MakeExecutor(), "af_wedged")
+		done <- result{home, ok, err}
 	}()
 
 	select {
 	case got := <-done:
 		if got.ok {
 			t.Fatalf("a wedged server must not be read as proof of ownership, got home %q", got.home)
+		}
+		if !errors.Is(got.err, ErrTmuxTimeout) {
+			t.Fatalf("a wedged ownership probe must remain unknown as ErrTmuxTimeout, got %v", got.err)
 		}
 	case <-time.After(30 * time.Second):
 		t.Fatal("sessionHomeMarker hung against a stalled tmux: CleanupSessions calls it once " +

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -179,7 +179,10 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 	}
 	matches := make([]string, 0, len(prefixed))
 	for _, match := range prefixed {
-		home, ok := sessionHomeMarker(cmdExec, match)
+		home, ok, markerErr := sessionHomeMarker(cmdExec, match)
+		if markerErr != nil {
+			return fmt.Errorf("cannot determine tmux session %s ownership; refusing to continue cleanup: %w", match, markerErr)
+		}
 		switch {
 		case !ok:
 			log.InfoLog.Printf("leaving tmux session %s: no AF_HOME ownership marker (pre-marker build or tmux <3.2); kill manually with: %s", match,

--- a/session/tmux/cleanup_bug_test.go
+++ b/session/tmux/cleanup_bug_test.go
@@ -112,8 +112,9 @@ af_legacy: 1 windows (created Wed May 20 12:02:00 2026) [179x47]`
 				case strings.Contains(strings.Join(cmd.Args, " "), "af_theirs"):
 					return []byte("AF_HOME=/another-home\n"), nil
 				default:
-					// tmux exits non-zero when the variable is unset.
-					return nil, errExit1
+					// Unfiltered show-environment authoritatively represents a
+					// missing marker by succeeding without an AF_HOME line.
+					return []byte("PATH=/usr/bin\n"), nil
 				}
 			}
 			return []byte(tmuxOutput), nil

--- a/session/tmux/cleanup_unknown_test.go
+++ b/session/tmux/cleanup_unknown_test.go
@@ -1,0 +1,78 @@
+package tmux
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd"
+)
+
+// TestCleanupSessionsOwnershipCheckTimeoutIsUnknown guards #2633: listing a
+// session does not make its ownership known. If the per-session AF_HOME probe
+// times out, reset must stop instead of treating UNKNOWN as "no marker" and
+// continuing on to worktree deletion.
+func TestCleanupSessionsOwnershipCheckTimeoutIsUnknown(t *testing.T) {
+	dir := t.TempDir()
+	script := `#!/bin/sh
+case "$1" in
+ls)
+  echo 'af_owned: 1 windows (created Thu Jan 1 00:00:00 1970)'
+  ;;
+show-environment)
+  sleep 300 &
+  wait
+  ;;
+*)
+  exit 97
+  ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	shortTmuxTimeout(t, 200*time.Millisecond)
+
+	err := CleanupSessions(cmd.MakeExecutor())
+	if !errors.Is(err, ErrTmuxTimeout) {
+		t.Fatalf("CleanupSessions error = %v, want ErrTmuxTimeout when AF_HOME ownership probe does not answer", err)
+	}
+}
+
+// TestCleanupSessionsOwnershipCheckFailureIsUnknown covers the adjacent
+// non-timeout case. Unfiltered show-environment reports a genuinely absent
+// marker with successful output, so a command failure means ownership was not
+// determined and must stop the sweep too.
+func TestCleanupSessionsOwnershipCheckFailureIsUnknown(t *testing.T) {
+	dir := t.TempDir()
+	script := `#!/bin/sh
+case "$1" in
+ls)
+  echo 'af_owned: 1 windows (created Thu Jan 1 00:00:00 1970)'
+  ;;
+show-environment)
+  exit 97
+  ;;
+*)
+  exit 98
+  ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	err := CleanupSessions(cmd.MakeExecutor())
+	if err == nil {
+		t.Fatal("CleanupSessions error = nil, want ownership probe failure to stop the sweep")
+	}
+	if errors.Is(err, ErrTmuxTimeout) {
+		t.Fatalf("non-timeout ownership probe failure was misclassified as ErrTmuxTimeout: %v", err)
+	}
+}

--- a/session/tmux/envmarker.go
+++ b/session/tmux/envmarker.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -51,27 +52,37 @@ func sessionEnvFlags(sanitizedName string) []string {
 }
 
 // sessionHomeMarker reads the AF_HOME ancestry marker from a tmux session's
-// environment (stamped via `new-session -e` at creation). Returns ("", false)
-// when the session carries no marker — created by a pre-marker build or by a
-// tmux older than 3.2, which cannot set session environment at creation.
+// environment (stamped via `new-session -e` at creation). A false present value
+// means tmux answered and the session carries no marker — created by a pre-marker
+// build or by a tmux older than 3.2, which cannot set session environment at
+// creation. A non-nil error means tmux did not answer authoritatively, so the
+// caller must keep ownership UNKNOWN rather than treating the marker as absent.
 //
 // Bounded by tmuxCommandTimeout (#2099): CleanupSessions calls this once per
 // discovered session, so an unbounded stall on any one of them wedges the whole
 // sweep — and `af reset` runs that sweep synchronously in a short-lived CLI
-// process, where the only way out is ^C. A tripped deadline reports "no marker",
-// which is the safe direction: the sweep leaves any session it cannot PROVE this
-// home owns (#1122), and a wedged server proves nothing.
-func sessionHomeMarker(cmdExec cmd.Executor, sanitizedName string) (string, bool) {
+// process, where the only way out is ^C. The unfiltered form is deliberate:
+// `show-environment AF_HOME` reports an absent variable as a generic command
+// failure, while unfiltered `show-environment` succeeds and simply omits it.
+// That preserves absent separately from a timeout or other probe failure.
+func sessionHomeMarker(cmdExec cmd.Executor, sanitizedName string) (home string, present bool, err error) {
 	ctx, cancel := tmuxTimeoutContext()
 	defer cancel()
-	out, err := outputTmuxBoundedWith(ctx, cmdExec, "show-environment", "-t", exactTarget(sanitizedName), EnvMarkerHome)
+	out, err := outputTmuxBoundedWith(ctx, cmdExec, "show-environment", "-t", exactTarget(sanitizedName))
 	if err != nil {
-		// show-environment exits non-zero when the variable is unset.
-		return "", false
+		if ctx.Err() != nil {
+			return "", false, fmt.Errorf("%w: show-environment %s after %s", ErrTmuxTimeout, sanitizedName, tmuxCommandTimeout)
+		}
+		return "", false, fmt.Errorf("read %s ownership marker for tmux session %s: %w", EnvMarkerHome, sanitizedName, err)
 	}
-	// One line of the form AF_HOME=/path; a leading '-' (variable marked for
-	// removal) or any other shape counts as no marker.
-	return strings.CutPrefix(strings.TrimSpace(string(out)), EnvMarkerHome+"=")
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if home, ok := strings.CutPrefix(strings.TrimSuffix(line, "\r"), EnvMarkerHome+"="); ok {
+			return home, true, nil
+		}
+	}
+	// A leading '-' (variable marked for removal), unrelated environment
+	// entries, or empty output all authoritatively mean no active marker.
+	return "", false, nil
 }
 
 var (


### PR DESCRIPTION
## Summary

- preserve three-valued tmux ownership results during reset cleanup
- treat ownership-probe timeouts and other probe failures as unknown and abort before destructive reset work
- keep a confirmed missing `AF_HOME` marker as a distinct, non-error result

## Root cause

`sessionHomeMarker` collapsed every `show-environment` error into `present=false`. `CleanupSessions` interpreted that result as a confirmed missing marker and returned success, allowing factory reset to continue to worktree deletion while tmux session ownership was unknown.

The probe now reads the unfiltered environment, where an absent marker is represented by successful output without `AF_HOME`; command failures remain errors, and timeouts wrap `ErrTmuxTimeout`.

## Red-first evidence

Before the implementation change, the containerized regressions failed with:

- `CleanupSessions error = <nil>, want ErrTmuxTimeout when AF_HOME ownership probe does not answer`
- `CleanupSessions error = nil, want ownership probe failure to stop the sweep`

## Validation

Validated pushed SHA `97ea33fbcd9aa9b72387250fc255202b4f3a1698`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container` (full suite, run last)

Closes #2633