### PR TITLE
fix archive hangs on cross-filesystem FIFOs

### DIFF
--- a/session/git/worktree_archive.go
+++ b/session/git/worktree_archive.go
@@ -279,8 +279,8 @@ func (e *copiedWorktreeSourceCleanupError) Unwrap() error {
 // copyTree recursively copies the directory rooted at src to dest, preserving
 // regular files (contents + permission bits), subdirectories, and symlinks
 // (copied as links, never followed). It is only reached on the cross-device
-// fallback; a git worktree contains exactly these node kinds (including the
-// `.git` pointer file, which `git worktree repair` rewrites afterwards).
+// fallback. Other node kinds are rejected before opening them: in particular,
+// opening a FIFO for reading would wait indefinitely for a writer (#2654).
 func copyTree(src, dest string) error {
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -300,8 +300,10 @@ func copyTree(src, dest string) error {
 				return err
 			}
 			return os.Symlink(link, target)
-		default:
+		case info.Mode().IsRegular():
 			return copyFile(path, target, info.Mode().Perm())
+		default:
+			return fmt.Errorf("cannot move worktree across filesystems: unsupported file type at %s (%s)", path, info.Mode().Type())
 		}
 	})
 }

--- a/session/git/worktree_archive_test.go
+++ b/session/git/worktree_archive_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -586,4 +587,37 @@ func TestCopyTree_PreservesModesAndSymlinks(t *testing.T) {
 	linkTarget, err := os.Readlink(filepath.Join(dest, "link"))
 	require.NoError(t, err, "symlink must be copied as a link, not followed")
 	assert.Equal(t, "a.txt", linkTarget)
+}
+
+// TestCopyTree_RejectsNamedPipeWithoutBlocking is the #2654 regression. The
+// cross-device move fallback copies a worktree node by node; opening a FIFO as
+// though it were a regular file waits for a writer forever. Special files must
+// instead fail promptly so ArchiveSession can release its operation/kill guards.
+//
+// PRE-FIX: copyTree does not return before the deadline. The writer below then
+// unblocks it solely so the test process can finish and report the hang cleanly.
+func TestCopyTree_RejectsNamedPipeWithoutBlocking(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "src")
+	require.NoError(t, os.MkdirAll(src, 0755))
+	fifo := filepath.Join(src, "events.fifo")
+	require.NoError(t, syscall.Mkfifo(fifo, 0600))
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	done := make(chan error, 1)
+	go func() {
+		done <- copyTree(src, dest)
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "a FIFO cannot be copied as a regular file")
+		assert.Contains(t, err.Error(), "unsupported file type")
+		assert.Contains(t, err.Error(), fifo)
+	case <-time.After(500 * time.Millisecond):
+		writer, err := os.OpenFile(fifo, os.O_WRONLY, 0)
+		require.NoError(t, err, "open a writer only to release the pre-fix blocked reader")
+		require.NoError(t, writer.Close())
+		eventualErr := <-done
+		t.Fatalf("HUNG: copyTree blocked opening named pipe %s; after a writer released it, copyTree returned %v", fifo, eventualErr)
+	}
 }


### PR DESCRIPTION
## Summary

- reject FIFOs and every other non-regular special file before the cross-filesystem copy engine opens them
- preserve the existing directory, regular-file, and symlink behavior
- add a deadline-based regression proving a named pipe fails promptly instead of hanging archive/restore

## Root cause and issue relationship

`copyTree` treated every non-directory, non-symlink node as a regular file. Opening a FIFO for reading blocks until a writer appears, so an archive or restore could remain inside the cross-device move forever while holding the session operation lock and `killsInFlight`. That is a concrete trigger for the undeletable-session symptom in #2641.

It is not the whole of #2641: the archive and restore entry points can also wait indefinitely while acquiring an operation lock held by some other wedged operation. That lock-bound fix is intentionally separate.

## Red-first proof

Observed against the untouched tree:

```
=== RUN   TestCopyTree_RejectsNamedPipeWithoutBlocking
worktree_archive_test.go:621: HUNG: copyTree blocked opening named pipe .../src/events.fifo; after a writer released it, copyTree returned <nil>
--- FAIL: TestCopyTree_RejectsNamedPipeWithoutBlocking (0.50s)
```

The same focused test now passes immediately.

## Validation

Validated on pushed head `8643dd0d34bf5187bf134155029f794018941582`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- focused container regression and existing copy-tree test
- `make test-container`

Closes #2654