### PR TITLE
fix(auth): redact ambiguous semicolon token suffixes

### DIFF
--- a/agentproto/auth.go
+++ b/agentproto/auth.go
@@ -94,8 +94,11 @@ func RedactAccessTokenText(text string) string {
 			continue
 		}
 
+		// A preceding semicolon can introduce a legacy query field, but a semicolon
+		// inside the value is ambiguous. Redact through the next unambiguous boundary
+		// rather than risk preserving credential material after it.
 		valueEnd := valueStart
-		for valueEnd < len(rest) && !strings.ContainsRune("&; \t\r\n#\"'", rune(rest[valueEnd])) {
+		for valueEnd < len(rest) && !strings.ContainsRune("& \t\r\n#\"'", rune(rest[valueEnd])) {
 			valueEnd++
 		}
 		redacted.WriteString(rest[:valueStart])

--- a/agentproto/auth_test.go
+++ b/agentproto/auth_test.go
@@ -39,10 +39,16 @@ func TestRedactAccessTokenURL(t *testing.T) {
 			wantPresent: []string{"box:8080", "access_token=REDACTED"},
 		},
 		{
-			name:        "semicolon query separator",
+			name:        "semicolon separator redacts ambiguous suffix",
 			raw:         "http://box:8080/stream?view=2;access_token=sekrit;mode=full",
-			wantAbsent:  []string{"sekrit"},
-			wantPresent: []string{"box:8080", "view=2", "access_token=REDACTED", "mode=full"},
+			wantAbsent:  []string{"sekrit", "mode=full"},
+			wantPresent: []string{"box:8080", "view=2", "access_token=REDACTED"},
+		},
+		{
+			name:        "semicolon inside token value",
+			raw:         "http://box:8080/stream?access_token=;sekrit",
+			wantAbsent:  []string{";sekrit"},
+			wantPresent: []string{"box:8080", "access_token=REDACTED"},
 		},
 		{
 			name:        "no token untouched",


### PR DESCRIPTION
## What changed

- Keep `;` as a recognized legacy boundary before an `access_token` field.
- Stop treating `;` as an unambiguous end of the token value.
- Conservatively redact an ambiguous semicolon suffix through the next safe boundary.
- Cover both `?view=2;access_token=sekrit;mode=full` and `?access_token=;sekrit`.

## Why

Codex found a P1 on exact head `c1961fa4f3a9ed3a6d88f83a90244c8b613d869e` of merged PR #2687: a valid raw semicolon inside the credential was preserved as `;sekrit` after the redaction marker. PR #2687 merged while the follow-up fix was being validated, so this is a forward fix from current master.

Finding: https://github.com/sachiniyer/agent-factory/pull/2687#discussion_r3685726192

## Security behavior

Semicolons are ambiguous: some upstream parsers treat them as query-field separators, while others keep them in the value. The safe rule is asymmetric:

- before `access_token=`, `;` can identify the legacy field boundary;
- after the token starts, `;` remains credential material and is redacted rather than preserved.

This may redact neighboring legacy-semicolon text after the credential, but it cannot expose a credential suffix.

## Reproduction

Before this fix, `TestRedactAccessTokenURL/semicolon_inside_token_value` failed because `?access_token=;sekrit` became `?access_token=REDACTED;sekrit`.

## Validation

Exact head: `00170105b97eea5e52cf3d0de4116727b6beac60`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `make test-container`
