### PR TITLE
fix(session): restore reaped local tombstones

### DIFF
--- a/session/instance_data.go
+++ b/session/instance_data.go
@@ -193,6 +193,7 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 		userKilled:            data.UserKilled,
 		startupStateUnknown:   data.StartupStateUnknown,
 	}
+	worktreeReaped := false
 
 	// Pick backend based on persisted BackendType.
 	switch {
@@ -258,7 +259,7 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 		// delete. Accept only that exact terminal shape: a live row or a partially
 		// populated worktree remains unknown/corrupt and must not be treated as
 		// proof that no worktree exists.
-		worktreeReaped := data.UserKilled && data.Worktree.RepoPath == "" && data.Worktree.WorktreePath == ""
+		worktreeReaped = data.UserKilled && data.Worktree.RepoPath == "" && data.Worktree.WorktreePath == ""
 		if !worktreeReaped {
 			gw, err := git.NewGitWorktreeFromStorage(
 				data.Worktree.RepoPath,
@@ -290,6 +291,14 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 			State:  data.PRInfo.State,
 			Branch: data.PRInfo.Branch,
 		}
+	}
+
+	// The local runtime and worktree are already gone. Keep this terminal row
+	// inert until the daemon retries only the failed record deletion; starting it
+	// would synthesize a fresh conventional tmux name and make the retry target a
+	// session that never belonged to this tombstone.
+	if worktreeReaped {
+		return instance, nil
 	}
 
 	// An uncertain startup loads INERT. Re-running Start(false) would probe or

--- a/session/instance_data.go
+++ b/session/instance_data.go
@@ -252,19 +252,28 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 			branchCreatedByUs = *data.Worktree.BranchCreatedByUs
 		}
 
-		gw, err := git.NewGitWorktreeFromStorage(
-			data.Worktree.RepoPath,
-			data.Worktree.WorktreePath,
-			data.Worktree.SessionName,
-			data.Worktree.BranchName,
-			data.Worktree.BaseCommitSHA,
-			data.Worktree.ExternalWorktree,
-			branchCreatedByUs,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to restore git worktree: %w", err)
+		// A completed local kill clears gitWorktree before deleting its durable
+		// tombstone. If that delete fails, the shutdown checkpoint writes both
+		// paths empty and the next daemon still needs the row so it can finish the
+		// delete. Accept only that exact terminal shape: a live row or a partially
+		// populated worktree remains unknown/corrupt and must not be treated as
+		// proof that no worktree exists.
+		worktreeReaped := data.UserKilled && data.Worktree.RepoPath == "" && data.Worktree.WorktreePath == ""
+		if !worktreeReaped {
+			gw, err := git.NewGitWorktreeFromStorage(
+				data.Worktree.RepoPath,
+				data.Worktree.WorktreePath,
+				data.Worktree.SessionName,
+				data.Worktree.BranchName,
+				data.Worktree.BaseCommitSHA,
+				data.Worktree.ExternalWorktree,
+				branchCreatedByUs,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to restore git worktree: %w", err)
+			}
+			instance.gitWorktree = gw
 		}
-		instance.gitWorktree = gw
 
 		// Rebuild the instance's tab list from disk so every tab (agent + shell)
 		// reconnects to its exact tmux session across an af/daemon restart — the

--- a/session/storage_retain_test.go
+++ b/session/storage_retain_test.go
@@ -116,6 +116,9 @@ func TestSaveInstances_RestoresReapedLocalTombstone(t *testing.T) {
 	if !restored[0].UserKilled() {
 		t.Fatal("restored local session lost its kill tombstone")
 	}
+	if restored[0].Started() {
+		t.Fatal("reaped tombstone was started and synthesized a new tmux teardown target")
+	}
 	if got := restored[0].GetWorktreePath(); got != "" {
 		t.Fatalf("restored reaped tombstone worktree path = %q, want empty", got)
 	}

--- a/session/storage_retain_test.go
+++ b/session/storage_retain_test.go
@@ -68,6 +68,59 @@ func TestSaveInstances_KeepsTombstonedRowAlongsideStartedSibling(t *testing.T) {
 	}
 }
 
+// TestSaveInstances_RestoresReapedLocalTombstone covers the crash window after
+// a local kill has successfully torn down its tmux sessions and worktree, but
+// deleting the durable kill record fails. teardownKill has cleared the
+// gitWorktree pointer, so the shutdown checkpoint legitimately writes an empty
+// Worktree payload. The next daemon must still load that tombstone so its poll
+// can finish deleting the record; dropping it turns a retryable record-delete
+// failure into a permanent ghost.
+func TestSaveInstances_RestoresReapedLocalTombstone(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := t.TempDir()
+	state := newMockStorage()
+
+	doomed := &Instance{
+		ID:       "reaped-local-id",
+		Title:    "reaped-local",
+		Path:     repoPath,
+		Program:  "claude",
+		liveness: LiveLost,
+		backend:  &LocalBackend{},
+		started:  false,
+	}
+	doomed.MarkUserKilled()
+
+	storage, err := NewStorage(state, "")
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	if err := storage.SaveInstances([]*Instance{doomed}); err != nil {
+		t.Fatalf("SaveInstances: %v", err)
+	}
+	rows := readDisk(t, state, repoPath)
+	if len(rows) != 1 {
+		t.Fatalf("SaveInstances persisted %d sessions, want the tombstone", len(rows))
+	}
+	if rows[0].Worktree.RepoPath != "" || rows[0].Worktree.WorktreePath != "" {
+		t.Fatalf("reaped tombstone persisted a worktree: %+v", rows[0].Worktree)
+	}
+
+	restored, err := storage.LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances: %v", err)
+	}
+	if len(restored) != 1 {
+		t.Fatalf("LoadInstances restored %d sessions, want the retained tombstone", len(restored))
+	}
+	if !restored[0].UserKilled() {
+		t.Fatal("restored local session lost its kill tombstone")
+	}
+	if got := restored[0].GetWorktreePath(); got != "" {
+		t.Fatalf("restored reaped tombstone worktree path = %q, want empty", got)
+	}
+}
+
 // TestSaveInstances_KeepsStartupUnknownRowAlongsideStartedSibling applies the
 // same retention rule to #2207's inert startup record. It has no kill tombstone
 // by design, so StartupStateUnknown must independently keep a wholesale storage


### PR DESCRIPTION
## Summary

- preserve a reaped local-session tombstone when its serialized worktree is empty
- restrict the exception to `UserKilled` records with both worktree paths empty
- keep that already-reaped tombstone inert so retrying the record deletion cannot synthesize a new tmux target
- cover the complete `SaveInstances` -> `LoadInstances` daemon-restart path

## Verified root cause

A successful local teardown clears `gitWorktree` before the durable record is deleted. If that final delete fails, `SaveInstances` retains the `UserKilled` row and serializes an empty `Worktree`. On restart, `FromInstanceData` unconditionally called `NewGitWorktreeFromStorage`, rejected the empty path, and `LoadInstances` skipped the tombstone.

The exception intentionally does not accept live rows or partially populated worktree data: those remain unknown/corrupt rather than being collapsed into proof that teardown completed. The valid reaped shape returns inert; starting it would bind a newly synthesized conventional tmux name even though its original resources are already gone.

## Regressions observed red

Against `origin/master` before the initial fix:

```
--- FAIL: TestSaveInstances_RestoresReapedLocalTombstone (0.00s)
    storage_retain_test.go:107: LoadInstances restored 0 sessions, want the retained tombstone
FAIL
```

Against the initial PR head before addressing the inline Codex P1:

```
--- FAIL: TestSaveInstances_RestoresReapedLocalTombstone (1.31s)
    storage_retain_test.go:120: reaped tombstone was started and synthesized a new tmux teardown target
FAIL
```

## Adjacent audit

Audited every production call to `NewGitWorktreeFromStorage`. `daemon/manager_persist.go` already has an explicit no-worktree cleanup path; the remaining production restore call is this constructor. Test and application setup call sites supply concrete paths. The new guard requires both paths to be empty, so a one-sided path remains an error.

The inline Codex finding on the initial head was read and addressed by keeping the reaped tombstone inert.

## Validation

Pushed head: `1dbf21bf5e0a2563dc96a3f6c4cf3aed47df37e1`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container` (full suite, run last against the pushed head)

Closes #2667