### PR TITLE
fix(daemon): rebind listeners after listener death

### DIFF
--- a/daemon/listener_reload.go
+++ b/daemon/listener_reload.go
@@ -49,7 +49,8 @@ type webListeners struct {
 	webConfigAddr string
 	// webGen distinguishes listener generations so a superseded listener's Serve
 	// returning cannot clear the lifecycle bound-state the NEW listener just set. A
-	// done-watcher clears only while its own generation is still current.
+	// done-watcher clears health and binding state only while its own generation is
+	// still current, allowing an unchanged configured address to be rebound.
 	webGen uint64
 
 	previewClose      func() error
@@ -129,15 +130,19 @@ func (wl *webListeners) bindWebLocked(addr string) error {
 	gen := wl.webGen
 	if wl.manager.lifecycle != nil {
 		wl.manager.lifecycle.setTCPBound(info.Addr)
-		go func() {
-			<-info.done
-			wl.mu.Lock()
-			if wl.webGen == gen {
+	}
+	go func() {
+		<-info.done
+		wl.mu.Lock()
+		if wl.webGen == gen {
+			if wl.manager.lifecycle != nil {
 				wl.manager.lifecycle.clearTCPBound()
 			}
-			wl.mu.Unlock()
-		}()
-	}
+			wl.webClose = nil
+			wl.webConfigAddr = ""
+		}
+		wl.mu.Unlock()
+	}()
 	if old != nil {
 		_ = old()
 	}
@@ -196,15 +201,19 @@ func (wl *webListeners) bindPreviewLocked(addr string) error {
 	gen := wl.previewGen
 	if wl.manager.lifecycle != nil {
 		wl.manager.lifecycle.setPreviewBound(info.Addr)
-		go func() {
-			<-info.done
-			wl.mu.Lock()
-			if wl.previewGen == gen {
+	}
+	go func() {
+		<-info.done
+		wl.mu.Lock()
+		if wl.previewGen == gen {
+			if wl.manager.lifecycle != nil {
 				wl.manager.lifecycle.clearPreviewBound()
 			}
-			wl.mu.Unlock()
-		}()
-	}
+			wl.previewClose = nil
+			wl.previewConfigAddr = ""
+		}
+		wl.mu.Unlock()
+	}()
 	if old != nil {
 		_ = old()
 	}

--- a/daemon/listener_reload_test.go
+++ b/daemon/listener_reload_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -152,6 +153,56 @@ func TestWebListenerRebindFailureKeepsOldListenerServing(t *testing.T) {
 		"bind-new-before-close: a failed rebind must keep the old listener serving")
 	require.Equal(t, oldAddr, m.lifecycle.snapshot().listeners.TCPBoundAddr,
 		"lifecycle must still report the old address after a failed rebind")
+}
+
+func TestWebListenersRebindSameAddressAfterListenerDeath(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.ListenAddr = "127.0.0.1:0"
+	cfg.PreviewListenAddr = "127.0.0.1:0"
+	m, wl, _ := boundWebListeners(t, cfg)
+
+	tests := []struct {
+		name      string
+		getCloser func() func() error
+		isBound   func() bool
+	}{
+		{
+			name: "control",
+			getCloser: func() func() error {
+				wl.mu.Lock()
+				defer wl.mu.Unlock()
+				closer := wl.webClose
+				return closer
+			},
+			isBound: func() bool { return m.lifecycle.snapshot().listeners.TCPBound },
+		},
+		{
+			name: "preview",
+			getCloser: func() func() error {
+				wl.mu.Lock()
+				defer wl.mu.Unlock()
+				closer := wl.previewClose
+				return closer
+			},
+			isBound: func() bool { return m.lifecycle.snapshot().listeners.PreviewBound },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			closer := tt.getCloser()
+			require.NotNil(t, closer)
+			require.NoError(t, closer())
+			require.Eventually(t, func() bool { return !tt.isBound() }, time.Second, 10*time.Millisecond,
+				"the done watcher must observe listener death")
+
+			failed, err := wl.reconcile(m.Config())
+			require.NoError(t, err)
+			require.Empty(t, failed)
+			require.Eventually(t, tt.isBound, time.Second, 10*time.Millisecond,
+				"reconciling the unchanged configured address must replace the dead listener")
+		})
+	}
 }
 
 // TestApplyConfigTokenlessNetworkWarnsAndBinds: a tokenless non-loopback address is


### PR DESCRIPTION
## Summary
- clear the complete control and preview binding state when the current listener generation dies
- preserve generation checks so a superseded listener cannot clear replacement state
- let unchanged configured addresses reconcile onto fresh listeners

## Diagnosis and adjacent audit
Verified the report against the current implementation: each done-watcher cleared lifecycle health but retained its closer and configured-address sentinel, so reconcile treated a dead same-address listener as current. The preview done-watcher used the same anti-pattern and is fixed and tested alongside the control listener. No other restartable-listener done-watchers use this state pair.

## Regression evidence
Before the implementation change, the new container regression failed for both listener types:

```
--- FAIL: TestWebListenersRebindSameAddressAfterListenerDeath/control (1.01s)
    listener_reload_test.go:202: Condition never satisfied
    Messages: reconciling the unchanged configured address must replace the dead listener
--- FAIL: TestWebListenersRebindSameAddressAfterListenerDeath/preview (1.01s)
    listener_reload_test.go:202: Condition never satisfied
    Messages: reconciling the unchanged configured address must replace the dead listener
```

After the fix:

```
ok github.com/sachiniyer/agent-factory/daemon 0.087s
```

## Validation
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container`

The full container suite passed last against pushed SHA `22ff1282e251908962c8e76b938ad893a38fb66e`.

Closes #2606