### PR TITLE
fix: broadcast successful limit resumes

### DIFF
--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -509,7 +509,18 @@ func (m *Manager) resumeFromLimitLockedOutcome(repoID, key string, instance *ses
 	// The cleared limit is itself durable state worth a checkpoint. On the respawn
 	// arm this is the second write; that is deliberate — the first one records the
 	// rebuilt worktree of a session still parked at the wall, this one records the
-	// resume that actually landed.
-	m.persistInstance(repoID, instance)
+	// resume that actually landed. Publish the same snapshot while still holding
+	// the repo ordering lock: session.updated replaces the client's whole session
+	// projection, so letting this event race a newer tab mutation could put the
+	// client back on an older roster.
+	repoStartLock := m.startLockForRepo(repoID)
+	repoStartLock.Lock()
+	data := instance.ToInstanceData()
+	persistErr := persistInstanceData(repoID, data)
+	m.publishEvent(agentproto.EventSessionUpdated, data)
+	repoStartLock.Unlock()
+	if persistErr != nil {
+		log.WarningLog.Printf("failed to persist instance %q: %v", instance.Title, persistErr)
+	}
 	return resumePerformed, nil
 }

--- a/daemon/limit_resume_test.go
+++ b/daemon/limit_resume_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/session"
 	sessiongit "github.com/sachiniyer/agent-factory/session/git"
 )
@@ -280,6 +281,33 @@ func TestResumeFromLimit_RespawnArm_ClearsLimitDurablyOnSuccess(t *testing.T) {
 	}
 	if !rec.LimitResetAt.IsZero() {
 		t.Fatalf("persisted reset time = %v, want zero (a cleared limit must not carry a stale window to disk)", rec.LimitResetAt)
+	}
+}
+
+// TestResumeFromLimit_PublishesRunningTransition pins the event-plane half of a
+// successful limit resume. The resume mutates and persists the session directly,
+// so the next status poll snapshots LiveRunning as its "before" state and cannot
+// reconstruct the missing LimitReached -> Running transition for other clients.
+func TestResumeFromLimit_PublishesRunningTransition(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &limitResumeBackend{FakeBackend: session.NewFakeBackend(), alive: true}
+	inst := registerStarted(t, manager, repoID, repoPath, "resume-event", backend, true, session.Running)
+	inst.SetLimitReached(time.Now().Add(30 * time.Minute).UTC())
+
+	_, events := manager.events.subscribe()
+	if err := manager.resumeFromLimit(ResumeFromLimitRequest{Title: "resume-event", RepoID: repoID}); err != nil {
+		t.Fatalf("resumeFromLimit returned %v, want nil", err)
+	}
+
+	updated := drainNextSessionEvent(t, events, agentproto.EventSessionUpdated)
+	if updated.Liveness != session.LiveRunning {
+		t.Fatalf("session.updated liveness = %v, want LiveRunning", updated.Liveness)
+	}
+	if updated.ID != inst.ID || updated.Title != inst.Title {
+		t.Fatalf("session.updated identity = (%q, %q), want (%q, %q)", updated.ID, updated.Title, inst.ID, inst.Title)
+	}
+	if rec := recordFor(t, repoID, "resume-event"); rec == nil || rec.Liveness != session.LiveRunning {
+		t.Fatalf("persisted resumed session = %+v, want LiveRunning", rec)
 	}
 }
 


### PR DESCRIPTION
## Summary

- publish the successful LimitReached -> Running transition immediately from the shared daemon resume path
- persist and publish one InstanceData snapshot under the repo ordering lock so whole-session events cannot race newer tab projections
- cover the live-agent resume path with a regression that checks the event payload and durable state

## Diagnosis

Confirmed on current master: `resumeFromLimitLockedOutcome` cleared and persisted the limit state, but returned without publishing `session.updated`. The next poll snapshots the already-resumed `LiveRunning` state as its baseline, so it cannot recreate the missed transition.

Adjacent call-site audit: the TUI `ClearLimitReached` is only an optimistic local mirror after the daemon succeeds. Handoff's clear is an intermediate outgoing-provider cleanup inside the separate `OpReplacing` transaction, not a committed limit-resume outcome, so neither call site belongs in this fix.

## Red regression

Observed before the production change on `b320e24cbe57750756fe76fc7740f6ef40ff5694`:

```
--- FAIL: TestResumeFromLimit_PublishesRunningTransition (3.05s)
    limit_resume_test.go:302: no session.updated event published within the deadline
FAIL
```

## Validation

Validated pushed head `525ecd5b6c054ba70a9c3a58d1aa161bb83a32f2`:

- `GOTOOLCHAIN=go1.25.0 golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `GOTOOLCHAIN=go1.25.0 go build ./...`
- `GOTOOLCHAIN=go1.25.0 deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container GOTESTARGS="./daemon -run TestResumeFromLimit -count=1"`
- `make test-container`

Closes #2642