### PR TITLE
fix: reject ignored explicit tab fields

### DIFF
--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -276,10 +276,13 @@ type DeliverPromptResponse struct {
 //   - Process tab (Shell=false, the #930 PR 5 default): runs Command in the
 //     worktree. Name is the optional display name (a default is derived from
 //     Command's basename when empty). Command must be non-empty.
-//   - Shell tab (Shell=true): runs $SHELL in the worktree, exactly like the TUI's
-//     `t` key (Instance.AddShellTab). Command/Name are ignored; the name is the
-//     auto-derived unique "shell"/"shell-2"/… The TUI routes its `t` mutation
-//     here so the daemon — not the TUI — owns the tab write (#960 PR 2).
+//   - Shell tab (Shell=true, with an empty Kind): runs $SHELL in the worktree,
+//     exactly like the TUI's `t` key (Instance.AddShellTab). This legacy shape
+//     remains permissive of unused fields for compatibility; the canonical
+//     Kind="shell" shape rejects Command/Name/URL/Port instead of silently
+//     discarding them. The name is the auto-derived unique
+//     "shell"/"shell-2"/… The TUI routes its `t` mutation here so the daemon —
+//     not the TUI — owns the tab write (#960 PR 2).
 //   - Web tab (Kind="web"): an iframe/URL tab with no PTY. URL is the target
 //     (or Port as a localhost:<port> convenience). See the Kind/URL/Port fields.
 //   - VS Code tab (Kind="vscode"): a code-server editor on the session's
@@ -297,7 +300,8 @@ type CreateTabRequest struct {
 	Shell   bool   `json:"shell"`
 	// Kind selects the tab type. Empty (the default) means a process tab (or a
 	// shell tab when Shell is set); "shell" is the canonical explicit spelling
-	// for that same shell path; "web" creates a URL/iframe tab with no PTY,
+	// for that same shell path and rejects fields AddShellTab cannot honor; "web"
+	// creates a URL/iframe tab with no PTY,
 	// targeting URL (or Port as a localhost:<port> convenience); "vscode" creates
 	// a VS Code editor tab on the session's worktree, which takes no target. The
 	// vocabulary is session.ParseTabKindName — shared with the CLI, so the two

--- a/daemon/create_tab_test.go
+++ b/daemon/create_tab_test.go
@@ -316,6 +316,66 @@ func TestCreateTab_ShellSpawnsPersistsAndReturnsName(t *testing.T) {
 	}
 }
 
+// TestCreateTab_ExplicitShellRejectsIncompatibleFields pins the direct daemon
+// contract for the canonical Kind=shell shape. These fields cannot affect an
+// AddShellTab call, so accepting them would report success after silently
+// discarding part of the request. Each rejection must happen before session
+// lookup: the deliberately missing title would otherwise produce a lookup error.
+func TestCreateTab_ExplicitShellRejectsIncompatibleFields(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		req  CreateTabRequest
+		want string
+	}{
+		{"command", CreateTabRequest{Command: "bash -lc true"}, "--command is not valid for a shell tab"},
+		{"name", CreateTabRequest{Name: "terminal"}, "--name is not valid for a shell tab"},
+		{"url", CreateTabRequest{URL: "http://localhost:3000"}, "--url/--port are not valid for a shell tab"},
+		{"port", CreateTabRequest{Port: 3000}, "--url/--port are not valid for a shell tab"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := tc.req
+			req.Title = "missing"
+			req.Kind = "shell"
+			_, err := manager.CreateTab(req)
+			if err == nil {
+				t.Fatalf("CreateTab(%+v) succeeded; want a rejection", req)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want one containing %q before session lookup", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestCreateTab_ExplicitKindRejectsConflictingLegacyShellFlag covers the other
+// selector-level silent discard: an explicit non-shell Kind wins dispatch over
+// Shell today, so accepting both would ignore a true legacy selector. The empty
+// Kind + Shell=true compatibility shape remains valid and is covered by the
+// shell creation tests above.
+func TestCreateTab_ExplicitKindRejectsConflictingLegacyShellFlag(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	for _, tc := range []CreateTabRequest{
+		{Title: "missing", Kind: "web", URL: "http://localhost:3000", Shell: true},
+		{Title: "missing", Kind: "vscode", Shell: true},
+	} {
+		_, err := manager.CreateTab(tc)
+		if err == nil || !strings.Contains(err.Error(), "shell=true") {
+			t.Errorf("CreateTab(%+v) err = %v, want conflicting-selector rejection before session lookup", tc, err)
+		}
+	}
+}
+
 // TestCreateTab_ShellRejectsRemoteInstance verifies the shell path also refuses
 // remote sessions (no local worktree), matching the process path and the TUI's
 // `t` rule.

--- a/daemon/create_tab_web_test.go
+++ b/daemon/create_tab_web_test.go
@@ -115,6 +115,25 @@ func TestCreateTab_WebRejectsMissingTarget(t *testing.T) {
 	}
 }
 
+// TestCreateTab_WebRejectsCommandBeforeLookup closes the adjacent direct-client
+// silent-discard path: AddWebTab consumes URL/Port and Name, but never Command.
+// The CLI already rejects this combination; the daemon contract must do the
+// same before looking up or mutating a session.
+func TestCreateTab_WebRejectsCommandBeforeLookup(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	_, err = manager.CreateTab(CreateTabRequest{
+		Title: "missing", Kind: "web", URL: "http://localhost:3000", Command: "npm run dev",
+	})
+	if err == nil || !strings.Contains(err.Error(), "--command is not valid for a web tab") {
+		t.Fatalf("err = %v, want command rejection before session lookup", err)
+	}
+}
+
 // TestCreateTab_WebRejectsUnknownKind verifies an unrecognized --kind is refused.
 func TestCreateTab_WebRejectsUnknownKind(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))

--- a/daemon/manager_tabs.go
+++ b/daemon/manager_tabs.go
@@ -35,7 +35,26 @@ func (m *Manager) CreateTab(req CreateTabRequest) (CreateTabResponse, error) {
 		return CreateTabResponse{}, fmt.Errorf("unknown tab kind %q (expected one of %s, or empty)",
 			req.Kind, strings.Join(session.TabKindNameList(), ", "))
 	}
-	isShell := req.Shell || explicitKind && kind == session.TabKindShell
+	isExplicitShell := explicitKind && kind == session.TabKindShell
+	if req.Shell && explicitKind && !isExplicitShell {
+		return CreateTabResponse{}, fmt.Errorf("shell=true conflicts with explicit tab kind %q", req.Kind)
+	}
+	// Kind=shell is the strict daemon/API spelling. AddShellTab cannot consume
+	// any of these fields, so reject them before session lookup rather than
+	// returning success after silently discarding part of the request. Keep the
+	// historical empty-Kind + Shell=true shape permissive for compatibility.
+	if isExplicitShell {
+		if strings.TrimSpace(req.Command) != "" {
+			return CreateTabResponse{}, fmt.Errorf("--command is not valid for a shell tab (--kind shell): it runs $SHELL")
+		}
+		if strings.TrimSpace(req.Name) != "" {
+			return CreateTabResponse{}, fmt.Errorf("--name is not valid for a shell tab (--kind shell): its canonical name is \"shell\"")
+		}
+		if strings.TrimSpace(req.URL) != "" || req.Port != 0 {
+			return CreateTabResponse{}, fmt.Errorf("--url/--port are not valid for a shell tab (--kind shell)")
+		}
+	}
+	isShell := req.Shell || isExplicitShell
 	isWeb := explicitKind && kind == session.TabKindWeb
 	isVSCode := explicitKind && kind == session.TabKindVSCode
 	if !explicitKind && !isShell && strings.TrimSpace(req.Command) == "" {
@@ -67,6 +86,9 @@ func (m *Manager) CreateTab(req CreateTabRequest) (CreateTabResponse, error) {
 				return CreateTabResponse{}, perr
 			}
 			target = portURL
+		}
+		if strings.TrimSpace(req.Command) != "" {
+			return CreateTabResponse{}, fmt.Errorf("--command is not valid for a web tab (--kind web); use --url or --port")
 		}
 		normalized, nerr := session.NormalizeWebTabURL(target)
 		if nerr != nil {


### PR DESCRIPTION
## Summary

- reject Command, Name, URL, and Port on the explicit `Kind: "shell"` daemon/API form before session lookup or mutation
- preserve the permissive legacy empty-`Kind`, `Shell: true` form used by existing TUI/web callers
- close adjacent silent-discard paths for web + Command and conflicting `Shell: true` plus an explicit non-shell kind
- document the strict explicit-shell versus compatible legacy-shell contract

## Root cause

`Manager.CreateTab` selected `AddShellTab()` for an explicit shell kind without validating fields that method cannot consume. The CLI rejected the combinations, but direct control-socket and HTTP callers received success after their fields were ignored.

The adjacent audit found VS Code already rejects fields it cannot consume. Web consumes Name and documents Port as a URL fallback, but its direct daemon path did not reject Command. A true legacy Shell selector could also be silently overridden by an explicit web or VS Code kind. Both are fixed here.

## Red evidence

The daemon regression was run against today's tree before the fix:

```
--- FAIL: TestCreateTab_ExplicitShellRejectsIncompatibleFields/command
err = instance "missing" not found, want one containing "--command is not valid for a shell tab" before session lookup
--- FAIL: TestCreateTab_ExplicitShellRejectsIncompatibleFields/name
err = instance "missing" not found, want one containing "--name is not valid for a shell tab" before session lookup
--- FAIL: TestCreateTab_ExplicitShellRejectsIncompatibleFields/url
err = instance "missing" not found, want one containing "--url/--port are not valid for a shell tab" before session lookup
--- FAIL: TestCreateTab_ExplicitShellRejectsIncompatibleFields/port
err = instance "missing" not found, want one containing "--url/--port are not valid for a shell tab" before session lookup
```

Adjacent cases also failed red with `instance "missing" not found` rather than an early incompatible-field/selector rejection.

## Validation

Focused regressions passed in the isolated container, including the unchanged legacy shell creation path.

Pre-push gates:

- `GOTOOLCHAIN=go1.25.0 golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `GOTOOLCHAIN=go1.25.0 go build ./...`
- `GOTOOLCHAIN=go1.25.0 deadcode -test ./...`
- `scripts/lint-file-length.sh`

The full `make test-container` suite was the final code gate and passed against pushed head `8b19fbaf8dc12f4538485ea42944b6f9b9aec21b`.

Closes #2686