### PR TITLE
fix(remote): separate WebSocket dial and handshake timeouts

### DIFF
--- a/apiclient/client.go
+++ b/apiclient/client.go
@@ -117,7 +117,8 @@ const localWSBase = "ws://unix"
 // bearer token on every call (#1592 Phase 3 PR4); httpBase/wsBase then carry the
 // real http://host:port / ws://host:port authority. A zero Client is not usable.
 type Client struct {
-	httpClient *http.Client
+	httpClient      *http.Client
+	remoteTransport *http.Transport
 	// token is the bearer credential threaded on every REST call (Authorization
 	// header) and WS dial (header + ?access_token=) for a REMOTE target. It is
 	// empty for the local unix socket, whose peer is trusted (0600 perms are the
@@ -138,8 +139,8 @@ type Client struct {
 	// socket, which keeps its blocking-read semantics (the socket is either there
 	// or not, bounded by dialTimeout, and the in-memory snapshot returns promptly).
 	// WS stream dials never consult this field — they are bounded only by the
-	// transport's dial + handshake timeouts, so a long-lived stream is never
-	// severed by an overall deadline.
+	// transport's independent dial + handshake timeouts, so a long-lived stream
+	// is never severed by an overall deadline.
 	requestTimeout time.Duration
 }
 

--- a/apiclient/remote.go
+++ b/apiclient/remote.go
@@ -54,12 +54,14 @@ import (
 //     provisioning; a truly wedged connection is still bounded (just not
 //     instantly), and the fast-fail case is already covered by the dial above.
 //
-// Notably there is NO transport-level ResponseHeaderTimeout and NO
-// http.Client.Timeout: a shared ResponseHeaderTimeout would fire mid-provision on
-// a slow synchronous create (Greptile #1734), and http.Client.Timeout would
-// additionally kill an established WS stream (coder/websocket warns against it).
-// WS/stream dials are EXEMPT from the overall deadline entirely — they carry only
-// the dial bound, so a long-lived PTY subscription is never severed.
+// Notably there is NO SHARED transport-level ResponseHeaderTimeout and NO
+// http.Client.Timeout: a ResponseHeaderTimeout on the REST transport would fire
+// mid-provision on a slow synchronous create (Greptile #1734), and
+// http.Client.Timeout would additionally kill an established WS stream
+// (coder/websocket warns against it). DialStream clones the remote transport and
+// puts ResponseHeaderTimeout only on that one WS handshake. WS/stream dials are
+// EXEMPT from the overall REST deadline entirely, so a long-lived PTY
+// subscription is never severed.
 //
 // They are vars (not consts) only so a test can shrink them to prove the bound
 // fires without waiting the full budget — the same pattern attach.go's
@@ -81,6 +83,7 @@ func NewRemote(daemonURL, token string) (*Client, error) {
 		return nil, err
 	}
 	dialer := &net.Dialer{Timeout: remoteDialTimeout}
+	transport := &http.Transport{DialContext: dialer.DialContext}
 	return &Client{
 		httpClient: &http.Client{
 			// No http.Client.Timeout: it fires on the whole request lifetime, which
@@ -88,14 +91,13 @@ func NewRemote(daemonURL, token string) (*Client, error) {
 			// (coder/websocket warns against it). The overall REST bound is applied
 			// per-call as a request-context deadline instead (call(), remote-only),
 			// so WS/stream dials stay exempt.
-			Transport: &http.Transport{
-				DialContext: dialer.DialContext,
-			},
+			Transport: transport,
 		},
-		token:          token,
-		httpBase:       httpBase,
-		wsBase:         wsBase,
-		requestTimeout: remoteRequestTimeout,
+		remoteTransport: transport,
+		token:           token,
+		httpBase:        httpBase,
+		wsBase:          wsBase,
+		requestTimeout:  remoteRequestTimeout,
 	}, nil
 }
 

--- a/apiclient/remote_test.go
+++ b/apiclient/remote_test.go
@@ -297,6 +297,45 @@ func TestDialStream_StalledHandshakeTimesOut(t *testing.T) {
 	}
 }
 
+// TestDialStream_StalledRequestWriteTimesOut covers the pre-header half of the
+// handshake. ResponseHeaderTimeout has not started while net/http is still
+// writing the upgrade request, so the dial also needs an overall backstop.
+func TestDialStream_StalledRequestWriteTimesOut(t *testing.T) {
+	origDial, origHandshake := remoteDialTimeout, remoteWSHandshakeTimeout
+	remoteDialTimeout = 250 * time.Millisecond
+	remoteWSHandshakeTimeout = 250 * time.Millisecond
+	t.Cleanup(func() {
+		remoteDialTimeout, remoteWSHandshakeTimeout = origDial, origHandshake
+	})
+
+	c, err := NewRemote("http://pipe.invalid", "tok")
+	if err != nil {
+		t.Fatalf("NewRemote: %v", err)
+	}
+	client, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = peer.Close()
+	})
+	c.remoteTransport.DialContext = func(context.Context, string, string) (net.Conn, error) {
+		return client, nil
+	}
+
+	errc := make(chan error, 1)
+	go func() {
+		_, err := c.DialStream(context.Background(), "alpha", "", "", 0, 0)
+		errc <- err
+	}()
+	select {
+	case err := <-errc:
+		if err == nil {
+			t.Fatal("stalled WebSocket request write unexpectedly succeeded")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("HANG: DialStream did not return while the peer stopped reading the upgrade request")
+	}
+}
+
 // TestDialStream_SlowTCPDialKeepsFullHandshakeBudget is the #2670 regression:
 // the remote TCP connect and WebSocket upgrade have independent budgets. A TCP
 // connect that consumes more than the upgrade budget but less than the dial

--- a/apiclient/remote_test.go
+++ b/apiclient/remote_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -339,6 +340,49 @@ func TestDialStream_SlowTCPDialKeepsFullHandshakeBudget(t *testing.T) {
 		t.Fatalf("TCP dial used the WebSocket handshake budget: %v", err)
 	}
 	_ = sc.Conn.Close(websocket.StatusNormalClosure, "")
+}
+
+type closeNotifyConn struct {
+	net.Conn
+	closed chan struct{}
+	once   sync.Once
+}
+
+func (c *closeNotifyConn) Close() error {
+	c.once.Do(func() { close(c.closed) })
+	return c.Conn.Close()
+}
+
+func TestDialStream_RejectedUpgradeClosesPerDialTransport(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/sessions/{id}/stream", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "upgrade rejected", http.StatusServiceUnavailable)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c, err := NewRemote(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewRemote: %v", err)
+	}
+	closed := make(chan struct{})
+	dial := c.remoteTransport.DialContext
+	c.remoteTransport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		conn, err := dial(ctx, network, address)
+		if err != nil {
+			return nil, err
+		}
+		return &closeNotifyConn{Conn: conn, closed: closed}, nil
+	}
+
+	if _, err := c.DialStream(context.Background(), "alpha", "", "", 0, 0); err == nil {
+		t.Fatal("rejected WebSocket upgrade unexpectedly succeeded")
+	}
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("rejected WebSocket upgrade left the per-dial transport connection idle")
+	}
 }
 
 // TestNewRemote_SlowButProgressingResponseNotKilled is the Greptile correctness

--- a/apiclient/remote_test.go
+++ b/apiclient/remote_test.go
@@ -296,6 +296,51 @@ func TestDialStream_StalledHandshakeTimesOut(t *testing.T) {
 	}
 }
 
+// TestDialStream_SlowTCPDialKeepsFullHandshakeBudget is the #2670 regression:
+// the remote TCP connect and WebSocket upgrade have independent budgets. A TCP
+// connect that consumes more than the upgrade budget but less than the dial
+// budget must not make an otherwise immediate upgrade time out.
+func TestDialStream_SlowTCPDialKeepsFullHandshakeBudget(t *testing.T) {
+	origHandshake := remoteWSHandshakeTimeout
+	remoteWSHandshakeTimeout = 250 * time.Millisecond
+	t.Cleanup(func() { remoteWSHandshakeTimeout = origHandshake })
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/sessions/{id}/stream", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			return
+		}
+		_ = conn.Close(websocket.StatusNormalClosure, "")
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c, err := NewRemote(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewRemote: %v", err)
+	}
+	transport := c.httpClient.Transport.(*http.Transport)
+	dial := transport.DialContext
+	dialDelay := 2 * remoteWSHandshakeTimeout
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		timer := time.NewTimer(dialDelay)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			return dial(ctx, network, address)
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	sc, err := c.DialStream(context.Background(), "alpha", "", "", 0, 0)
+	if err != nil {
+		t.Fatalf("TCP dial used the WebSocket handshake budget: %v", err)
+	}
+	_ = sc.Conn.Close(websocket.StatusNormalClosure, "")
+}
+
 // TestNewRemote_SlowButProgressingResponseNotKilled is the Greptile correctness
 // guard for a slow SYNCHRONOUS create: a valid RPC whose server does real work for
 // a while and answers JUST UNDER the overall deadline (like a remote docker/ssh

--- a/apiclient/stream.go
+++ b/apiclient/stream.go
@@ -83,6 +83,7 @@ func (c *Client) DialStream(ctx context.Context, title, repoID, tabID string, ta
 	if c.remoteTransport != nil {
 		wsTransport := c.remoteTransport.Clone()
 		wsTransport.ResponseHeaderTimeout = remoteWSHandshakeTimeout
+		defer wsTransport.CloseIdleConnections()
 		wsClient := *c.httpClient
 		wsClient.Transport = wsTransport
 		opts.HTTPClient = &wsClient

--- a/apiclient/stream.go
+++ b/apiclient/stream.go
@@ -80,6 +80,7 @@ func (c *Client) DialStream(ctx context.Context, title, repoID, tabID string, ta
 	// clone is WS-only: putting this bound on the shared REST transport would sever
 	// a slow synchronous CreateSession before provisioning finishes. The local Unix
 	// socket keeps its existing transport unchanged.
+	dialCtx := ctx
 	if c.remoteTransport != nil {
 		wsTransport := c.remoteTransport.Clone()
 		wsTransport.ResponseHeaderTimeout = remoteWSHandshakeTimeout
@@ -87,8 +88,15 @@ func (c *Client) DialStream(ctx context.Context, title, repoID, tabID string, ta
 		wsClient := *c.httpClient
 		wsClient.Transport = wsTransport
 		opts.HTTPClient = &wsClient
+		// ResponseHeaderTimeout starts only after net/http finishes writing the
+		// upgrade request. Keep a larger overall backstop for a peer that connects
+		// but stops reading: dial + upgrade may each consume their full independent
+		// budgets, while request writing can never hang forever.
+		var cancel context.CancelFunc
+		dialCtx, cancel = context.WithTimeout(ctx, remoteDialTimeout+remoteWSHandshakeTimeout)
+		defer cancel()
 	}
-	conn, resp, err := websocket.Dial(ctx, u, &opts)
+	conn, resp, err := websocket.Dial(dialCtx, u, &opts)
 	if err != nil {
 		return nil, &TransportError{Err: fmt.Errorf("apiclient: dial pty stream: %w",
 			agentproto.RedactAccessTokenError(err, c.token))}

--- a/apiclient/stream.go
+++ b/apiclient/stream.go
@@ -74,20 +74,20 @@ func (c *Client) DialStream(ctx context.Context, title, repoID, tabID string, ta
 	if enc := q.Encode(); enc != "" {
 		u += "?" + enc
 	}
-	// A REMOTE target bounds the UPGRADE handshake so a peer that accepts the TCP
-	// connection but never answers the 101 can't hang the attach path (which dials
-	// with context.Background()) — plain HTTP has no TLS handshake timeout to lean
-	// on. The deadline governs ONLY the handshake: coder/websocket's Dial does not
-	// use the context for the established stream, so cancelling it after Dial
-	// returns never severs the live subscription. The local unix socket keeps
-	// context.Background() (the socket is local — there or not, bounded by dial).
-	dialCtx := ctx
-	if c.requestTimeout > 0 {
-		var cancel context.CancelFunc
-		dialCtx, cancel = context.WithTimeout(ctx, remoteWSHandshakeTimeout)
-		defer cancel()
+	// A REMOTE target bounds the UPGRADE response separately from the TCP connect.
+	// ResponseHeaderTimeout starts only after the request has been written, so a
+	// slow-but-valid connect cannot consume the 101 exchange's budget (#2670). The
+	// clone is WS-only: putting this bound on the shared REST transport would sever
+	// a slow synchronous CreateSession before provisioning finishes. The local Unix
+	// socket keeps its existing transport unchanged.
+	if c.remoteTransport != nil {
+		wsTransport := c.remoteTransport.Clone()
+		wsTransport.ResponseHeaderTimeout = remoteWSHandshakeTimeout
+		wsClient := *c.httpClient
+		wsClient.Transport = wsTransport
+		opts.HTTPClient = &wsClient
 	}
-	conn, resp, err := websocket.Dial(dialCtx, u, &opts)
+	conn, resp, err := websocket.Dial(ctx, u, &opts)
 	if err != nil {
 		return nil, &TransportError{Err: fmt.Errorf("apiclient: dial pty stream: %w",
 			agentproto.RedactAccessTokenError(err, c.token))}

--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -523,6 +523,7 @@ var remoteAgentWSHandshakeTimeout = 10 * time.Second
 // pieces that define the contract through the agentproto/apiproto leaves.
 type remoteAgentClient struct {
 	httpClient *http.Client
+	transport  *http.Transport
 	httpBase   string // http://host:port
 	wsBase     string // ws://host:port
 	token      string
@@ -542,16 +543,16 @@ func newRemoteAgentClient(ep AgentServerEndpoint, title string) (*remoteAgentCli
 		return nil, err
 	}
 	dialer := &net.Dialer{Timeout: remoteAgentDialTimeout}
+	transport := &http.Transport{DialContext: dialer.DialContext}
 	return &remoteAgentClient{
 		httpClient: &http.Client{
-			Transport: &http.Transport{
-				DialContext: dialer.DialContext,
-			},
+			Transport: transport,
 		},
-		httpBase: httpBase,
-		wsBase:   wsBase,
-		token:    ep.Token,
-		title:    title,
+		transport: transport,
+		httpBase:  httpBase,
+		wsBase:    wsBase,
+		token:     ep.Token,
+		title:     title,
 	}, nil
 }
 
@@ -636,13 +637,15 @@ func (c *remoteAgentClient) dialStream(ctx context.Context, tab int) (*websocket
 		HTTPClient: c.httpClient,
 		HTTPHeader: http.Header{agentproto.AuthHeader: []string{agentproto.BearerScheme + c.token}},
 	}
-	// Bound the UPGRADE handshake so a wedged agent-server (TCP accepted, 101 never
-	// sent) can't hang this dial forever. coder/websocket's Dial context bounds only
-	// the handshake — the established stream reads use the parent ctx (passed into
-	// readLoop), so cancelling this after Dial returns never severs the live stream.
-	dialCtx, cancel := context.WithTimeout(ctx, remoteAgentWSHandshakeTimeout)
-	defer cancel()
-	conn, _, err := websocket.Dial(dialCtx, u, opts)
+	// Bound the UPGRADE response independently of the TCP connect (#2670). The
+	// WebSocket-only clone starts ResponseHeaderTimeout after the request is
+	// written; the shared REST transport remains free of a response-header bound.
+	wsTransport := c.transport.Clone()
+	wsTransport.ResponseHeaderTimeout = remoteAgentWSHandshakeTimeout
+	wsClient := *c.httpClient
+	wsClient.Transport = wsTransport
+	opts.HTTPClient = &wsClient
+	conn, _, err := websocket.Dial(ctx, u, opts)
 	if err != nil {
 		return nil, fmt.Errorf("remote agent-server: dial pty stream: %w",
 			agentproto.RedactAccessTokenError(err, c.token))

--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -642,6 +642,7 @@ func (c *remoteAgentClient) dialStream(ctx context.Context, tab int) (*websocket
 	// written; the shared REST transport remains free of a response-header bound.
 	wsTransport := c.transport.Clone()
 	wsTransport.ResponseHeaderTimeout = remoteAgentWSHandshakeTimeout
+	defer wsTransport.CloseIdleConnections()
 	wsClient := *c.httpClient
 	wsClient.Transport = wsTransport
 	opts.HTTPClient = &wsClient

--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -501,10 +501,10 @@ const remoteWSWriteTimeout = 10 * time.Second
 
 // remoteAgentDialTimeout bounds the TCP connect to the sandbox (a real network
 // hop), and remoteAgentCallTimeout bounds a whole control REST round-trip.
-const (
-	remoteAgentDialTimeout = 10 * time.Second
-	remoteAgentCallTimeout = 30 * time.Second
-)
+const remoteAgentCallTimeout = 30 * time.Second
+
+// var, not const, so transport phase-bound tests can shrink the dial budget.
+var remoteAgentDialTimeout = 10 * time.Second
 
 // remoteAgentWSHandshakeTimeout bounds the WS UPGRADE handshake on the internal
 // daemon→agent-server stream dial — the 101 exchange after the TCP connect. Plain
@@ -646,7 +646,12 @@ func (c *remoteAgentClient) dialStream(ctx context.Context, tab int) (*websocket
 	wsClient := *c.httpClient
 	wsClient.Transport = wsTransport
 	opts.HTTPClient = &wsClient
-	conn, _, err := websocket.Dial(ctx, u, opts)
+	// ResponseHeaderTimeout does not cover a blocked request write. The larger
+	// overall backstop lets TCP connect and the 101 response each use their full
+	// independent budget while still bounding a peer that stops reading.
+	dialCtx, cancel := context.WithTimeout(ctx, remoteAgentDialTimeout+remoteAgentWSHandshakeTimeout)
+	defer cancel()
+	conn, _, err := websocket.Dial(dialCtx, u, opts)
 	if err != nil {
 		return nil, fmt.Errorf("remote agent-server: dial pty stream: %w",
 			agentproto.RedactAccessTokenError(err, c.token))

--- a/session/agentserver_remote_ws_timeout_test.go
+++ b/session/agentserver_remote_ws_timeout_test.go
@@ -72,6 +72,42 @@ func TestRemoteAgentDialStream_StalledHandshakeTimesOut(t *testing.T) {
 	}
 }
 
+func TestRemoteAgentDialStream_StalledRequestWriteTimesOut(t *testing.T) {
+	origDial, origHandshake := remoteAgentDialTimeout, remoteAgentWSHandshakeTimeout
+	remoteAgentDialTimeout = 250 * time.Millisecond
+	remoteAgentWSHandshakeTimeout = 250 * time.Millisecond
+	t.Cleanup(func() {
+		remoteAgentDialTimeout, remoteAgentWSHandshakeTimeout = origDial, origHandshake
+	})
+
+	rc, err := newRemoteAgentClient(AgentServerEndpoint{URL: "http://pipe.invalid", Token: "tok"}, "probe")
+	if err != nil {
+		t.Fatalf("newRemoteAgentClient: %v", err)
+	}
+	client, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = peer.Close()
+	})
+	rc.transport.DialContext = func(context.Context, string, string) (net.Conn, error) {
+		return client, nil
+	}
+
+	errc := make(chan error, 1)
+	go func() {
+		_, err := rc.dialStream(context.Background(), 0)
+		errc <- err
+	}()
+	select {
+	case err := <-errc:
+		if err == nil {
+			t.Fatal("stalled agent-server WebSocket request write unexpectedly succeeded")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("HANG: agent-server dial did not return while the peer stopped reading the upgrade request")
+	}
+}
+
 // TestRemoteAgentDialStream_SlowTCPDialKeepsFullHandshakeBudget audits #2670's
 // adjacent daemon-to-agent-server stream dial. Its TCP connect and WebSocket
 // upgrade must receive independent timeout budgets too.

--- a/session/agentserver_remote_ws_timeout_test.go
+++ b/session/agentserver_remote_ws_timeout_test.go
@@ -3,8 +3,12 @@ package session
 import (
 	"context"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/coder/websocket"
 )
 
 // TestRemoteAgentDialStream_StalledHandshakeTimesOut is the #1730 guard on the
@@ -65,4 +69,48 @@ func TestRemoteAgentDialStream_StalledHandshakeTimesOut(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("HANG: dialStream did not return on a stalled agent-server upgrade (#1730 regression on the internal hop)")
 	}
+}
+
+// TestRemoteAgentDialStream_SlowTCPDialKeepsFullHandshakeBudget audits #2670's
+// adjacent daemon-to-agent-server stream dial. Its TCP connect and WebSocket
+// upgrade must receive independent timeout budgets too.
+func TestRemoteAgentDialStream_SlowTCPDialKeepsFullHandshakeBudget(t *testing.T) {
+	orig := remoteAgentWSHandshakeTimeout
+	remoteAgentWSHandshakeTimeout = 250 * time.Millisecond
+	t.Cleanup(func() { remoteAgentWSHandshakeTimeout = orig })
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/sessions/{id}/stream", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			return
+		}
+		_ = conn.Close(websocket.StatusNormalClosure, "")
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	rc, err := newRemoteAgentClient(AgentServerEndpoint{URL: srv.URL, Token: "tok"}, "probe")
+	if err != nil {
+		t.Fatalf("newRemoteAgentClient: %v", err)
+	}
+	transport := rc.httpClient.Transport.(*http.Transport)
+	dial := transport.DialContext
+	dialDelay := 2 * remoteAgentWSHandshakeTimeout
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		timer := time.NewTimer(dialDelay)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			return dial(ctx, network, address)
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	conn, err := rc.dialStream(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("TCP dial used the WebSocket handshake budget: %v", err)
+	}
+	_ = conn.Close(websocket.StatusNormalClosure, "")
 }

--- a/session/agentserver_remote_ws_timeout_test.go
+++ b/session/agentserver_remote_ws_timeout_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -113,4 +114,47 @@ func TestRemoteAgentDialStream_SlowTCPDialKeepsFullHandshakeBudget(t *testing.T)
 		t.Fatalf("TCP dial used the WebSocket handshake budget: %v", err)
 	}
 	_ = conn.Close(websocket.StatusNormalClosure, "")
+}
+
+type closeNotifyAgentConn struct {
+	net.Conn
+	closed chan struct{}
+	once   sync.Once
+}
+
+func (c *closeNotifyAgentConn) Close() error {
+	c.once.Do(func() { close(c.closed) })
+	return c.Conn.Close()
+}
+
+func TestRemoteAgentDialStream_RejectedUpgradeClosesPerDialTransport(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/sessions/{id}/stream", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "upgrade rejected", http.StatusServiceUnavailable)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	rc, err := newRemoteAgentClient(AgentServerEndpoint{URL: srv.URL, Token: "tok"}, "probe")
+	if err != nil {
+		t.Fatalf("newRemoteAgentClient: %v", err)
+	}
+	closed := make(chan struct{})
+	dial := rc.transport.DialContext
+	rc.transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		conn, err := dial(ctx, network, address)
+		if err != nil {
+			return nil, err
+		}
+		return &closeNotifyAgentConn{Conn: conn, closed: closed}, nil
+	}
+
+	if _, err := rc.dialStream(context.Background(), 0); err == nil {
+		t.Fatal("rejected agent-server WebSocket upgrade unexpectedly succeeded")
+	}
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("rejected agent-server upgrade left the per-dial transport connection idle")
+	}
 }


### PR DESCRIPTION
## Summary

- give remote daemon WebSocket TCP dialing and HTTP 101 upgrade independent timeout budgets
- apply the same correction to the adjacent daemon-to-agent-server stream transport
- bound a connected peer that stops reading the WebSocket upgrade request
- close idle connections retained by each short-lived WebSocket transport clone after rejected upgrades
- keep the REST transport free of a response-header timeout so slow synchronous provisioning remains supported

## Root cause

Both remote stream clients started `remote*WSHandshakeTimeout` before calling `websocket.Dial`. That context governed TCP dialing as well as the HTTP upgrade, so a slow TCP connect consumed or exhausted the handshake budget.

Each WebSocket dial now uses a transport clone with `ResponseHeaderTimeout`, which starts after the upgrade request is written, while the original `net.Dialer.Timeout` continues to bound TCP connect independently. A larger dial-plus-handshake context also bounds a connected peer that stops reading before `ResponseHeaderTimeout` begins. The clone closes only idle connections after the attempt; a successfully upgraded WebSocket is active and remains open.

## Red first

The two delayed-dial regressions failed against `b320e24cbe57750756fe76fc7740f6ef40ff5694`:

```text
--- FAIL: TestDialStream_SlowTCPDialKeepsFullHandshakeBudget (0.25s)
    remote_test.go:339: TCP dial used the WebSocket handshake budget: ... context deadline exceeded
--- FAIL: TestRemoteAgentDialStream_SlowTCPDialKeepsFullHandshakeBudget (0.25s)
    agentserver_remote_ws_timeout_test.go:113: TCP dial used the WebSocket handshake budget: ... context deadline exceeded
```

The rejected-upgrade review regressions then failed against `04afba20843918aa8264f16dc4680db83080ce4c`:

```text
--- FAIL: TestDialStream_RejectedUpgradeClosesPerDialTransport (1.00s)
    remote_test.go:384: rejected WebSocket upgrade left the per-dial transport connection idle
--- FAIL: TestRemoteAgentDialStream_RejectedUpgradeClosesPerDialTransport (1.00s)
    agentserver_remote_ws_timeout_test.go:158: rejected agent-server upgrade left the per-dial transport connection idle
```

The blocked-request-write review regressions then failed against `cdcf0b38b90d1414a28fdf0460944d1bf7624ede`:

```text
--- FAIL: TestDialStream_StalledRequestWriteTimesOut (2.00s)
    remote_test.go:335: HANG: DialStream did not return while the peer stopped reading the upgrade request
--- FAIL: TestRemoteAgentDialStream_StalledRequestWriteTimesOut (2.00s)
    agentserver_remote_ws_timeout_test.go:107: HANG: agent-server dial did not return while the peer stopped reading the upgrade request
```

## Validation

Validated pushed head `e087ad1a7099ecdd1e27262d6ab0d8c4e68f95a6`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container`

Closes #2670