### PR TITLE
fix: bind project deletion archives to stable session IDs

### DIFF
--- a/daemon/deleteproject.go
+++ b/daemon/deleteproject.go
@@ -213,7 +213,20 @@ func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 			result.Killed = append(result.Killed, session.InstanceData{ID: killed.ID, Title: killed.Title})
 			continue
 		}
-		_, archived, err := m.ArchiveSession(ArchiveSessionRequest{Title: t.title, RepoID: repoID})
+		// Carry the same snapshotted stable identity into archive that the
+		// external-session kill path above carries into KillSession. A title-only
+		// lookup here can resolve a NEW same-title session created after the
+		// snapshot and archive work the user never confirmed deleting.
+		_, archived, err := m.ArchiveSession(ArchiveSessionRequest{ID: t.id, Title: t.title, RepoID: repoID})
+		if errors.Is(err, errSessionNotFound) {
+			// Snapshot-gated idempotency, exactly like the kill path: this target
+			// existed under m.mu and is now authoritatively absent by stable ID, so
+			// the original is already gone. Do not infer anything about a possible
+			// replacement; the live-session re-check below observes it separately
+			// and keeps the project registered for a fresh delete decision.
+			archived = session.InstanceData{ID: t.id, Title: t.title}
+			err = nil
+		}
 		// A target that is ALREADY archived is idempotent SUCCESS, not a failure
 		// (#2108). The snapshot above is a point-in-time read taken under m.mu and
 		// then acted on with the lock released, so a concurrent ArchiveSession can

--- a/daemon/deleteproject_test.go
+++ b/daemon/deleteproject_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -308,6 +309,67 @@ func TestDeleteProject_ConcurrentlyArchivedTargetIsSuccess(t *testing.T) {
 	assert.Equal(t, session.Archived, beta.GetStatus())
 	assert.True(t, exists(betaSrc), "the seam only flipped liveness; this delete must not re-move an archived worktree")
 	assert.Empty(t, liveProjectRoots(manager.Snapshot(repoID)), "no live session ⇒ the project drops out of the active list")
+}
+
+// TestDeleteProject_DoesNotArchiveSameTitleReplacement covers the stable-ID
+// half of the snapshot contract. DeleteProject captures beta, then releases
+// m.mu while it archives alpha. If beta is killed and recreated in that window,
+// the replacement is a new session that was never part of the user's confirmed
+// delete. It must survive; the final concurrent-create guard must then keep the
+// project registered so a retry can make a fresh decision about that session.
+func TestDeleteProject_DoesNotArchiveSameTitleReplacement(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerArchivable(t, manager, repoID, repoPath, "alpha")
+	beta, _ := registerArchivable(t, manager, repoID, repoPath, "beta")
+	require.NoError(t, manager.SaveInstances())
+
+	originalBetaID := beta.ID
+	var replacement *session.Instance
+	var replacementPath string
+	recreated := false
+	orig := archivePersist
+	t.Cleanup(func() { archivePersist = orig })
+	archivePersist = func(m *Manager, rid string, inst *session.Instance) error {
+		if inst.Title == "alpha" && !recreated {
+			recreated = true
+			_, err := m.KillSession(KillSessionRequest{ID: originalBetaID, Title: "beta", RepoID: repoID})
+			require.NoError(t, err)
+
+			replacementPath = filepath.Join(filepath.Dir(repoPath), "wt-beta-replacement")
+			const replacementBranch = "af/beta-replacement"
+			out, err := exec.Command("git", "-C", repoPath, "worktree", "add", "-b", replacementBranch, replacementPath).CombinedOutput()
+			require.NoError(t, err, string(out))
+			gw, err := sessiongit.NewGitWorktreeFromStorage(repoPath, replacementPath, "beta", replacementBranch, "", false, true)
+			require.NoError(t, err)
+			replacement, err = session.NewInstance(session.InstanceOptions{Title: "beta", Path: repoPath, Program: "claude"})
+			require.NoError(t, err)
+			replacement.SetBackend(session.NewFakeBackend())
+			replacement.SetGitWorktreeForTest(gw)
+			replacement.SetStartedForTest(true)
+			replacement.SetStatusForTest(session.Ready)
+			m.mu.Lock()
+			m.instances[daemonInstanceKey(repoID, "beta")] = replacement
+			m.mu.Unlock()
+			require.NotEqual(t, originalBetaID, replacement.ID)
+			require.NoError(t, appendInstanceData(repoID, replacement.ToInstanceData()),
+				"a completed recreation durably records the replacement identity")
+		}
+		return orig(m, rid, inst)
+	}
+
+	result, err := manager.DeleteProject(DeleteProjectRequest{RepoID: repoID, RepoPath: repoPath})
+	require.Error(t, err, "a replacement session must keep the project registered for a fresh delete decision")
+	assert.Contains(t, err.Error(), "a session started for this project meanwhile")
+	require.NotNil(t, replacement)
+	assert.NotEqual(t, session.Archived, replacement.GetStatus(), "the recreated session must not be archived for the old target")
+	assert.True(t, exists(replacementPath), "the recreated session's worktree must stay in place")
+
+	archivedIDs := make(map[string]bool, len(result.Archived))
+	for _, data := range result.Archived {
+		archivedIDs[data.ID] = true
+	}
+	assert.True(t, archivedIDs[originalBetaID], "the already-gone snapshotted beta counts as completed")
+	assert.False(t, archivedIDs[replacement.ID], "the replacement identity was never in the delete snapshot")
 }
 
 // TestDeleteProject_GenuineArchiveFailureStillReportsPartialFailure is the


### PR DESCRIPTION
Closes #2656

## Root cause

`DeleteProject` snapshots each live session under `m.mu`, including its stable ID, then releases the lock before acting. The external-session kill path forwarded that ID, but the regular archive path resolved by `{title, repoID}` only. If the snapshotted session was killed and a new session reused its title before the archive loop reached it, the archive could target the replacement.

## Fix

- Pass the snapshotted stable ID to `ArchiveSession`, matching the adjacent `KillSession` path.
- Treat an authoritative stable-ID miss as idempotent success only inside `DeleteProject`, whose own snapshot proves the original target existed.
- Leave a same-title replacement live so the existing final live-session re-check preserves the project registration and asks the user to retry with a fresh decision.

## Adjacent call-site audit

The other destructive verb in the loop, `KillSession`, already carries the snapshotted ID and has the same snapshot-gated not-found handling. Retained TUI kill/archive/close-tab actions already capture stable session and tab IDs. One-shot CLI title arguments remain deliberately scoped title lookups because they do not retain a previously selected object across a confirmation/race window.

## Fail-first regression

On unmodified master `b320e24c`, the deterministic kill-and-recreate test failed because the newly created same-title session was archived and project deletion incorrectly succeeded:

```text
Error:      An error is expected but got nil.
Test:       TestDeleteProject_DoesNotArchiveSameTitleReplacement
Messages:   a replacement session must keep the project registered for a fresh delete decision
```

The fixed test verifies that the replacement keeps its new stable ID, stays unarchived, keeps its worktree in place, and is excluded from the snapshotted result.

## Validation

All required gates are green on pushed head `052799f2a11fce93a927bd6dbf9a8835b1028352`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container` (full suite; daemon 224.199s, integration 73.326s, tmux 98.177s)

No host daemon suite, daemon restart, dev install, real daemon mutation, or unisolated tmux teardown was used.