### PR TITLE
fix(daemon): gate creates behind orphan sweep

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -23,7 +23,9 @@ import (
 // restoreManagerForStartup is the warm-up restore entry point RunDaemon uses.
 // Package-level so tests can inject a slow or gated restore and prove the
 // control socket binds and serves before the restore completes (#829).
-var restoreManagerForStartup = func(m *Manager) error { return m.RestoreInstances() }
+// RunDaemon opens the manager's readiness barrier itself, after the startup
+// orphan sweep, so a concurrent create cannot manufacture a sweep candidate.
+var restoreManagerForStartup = func(m *Manager) error { return m.restoreInstances() }
 
 // sweepOrphanContainers reaps docker session containers this daemon leaked, at
 // startup (#2194 slice 4). Package-level so a test can assert startup passes the
@@ -263,6 +265,12 @@ func runDaemon(cfg *config.Config, upgradeTransactionID string) error {
 		log.InfoLog.Printf("received shutdown request via control socket during instance restore; exiting")
 		return nil
 	}
+	// Upgrade candidates deliberately park before the orphan sweep. Preserve the
+	// pre-existing probation contract: restored state is readable while every
+	// mutation remains blocked by the lifecycle gate.
+	if manager.lifecycle.snapshot().transactionID != "" {
+		manager.finishInstanceRestore()
+	}
 	if manager.lifecycle.isUpgradeProbation() {
 		log.InfoLog.Printf("instance restore complete; daemon is in upgrade probation")
 		select {
@@ -281,15 +289,18 @@ func runDaemon(cfg *config.Config, upgradeTransactionID string) error {
 
 	// Reap docker session containers this daemon leaked — a container that outlived
 	// its session because a previous daemon died without reaping, its record is
-	// gone, or a reap raced a create. Runs after the restore above so the live
-	// roster (and its pending-create window) is authoritative. Best-effort and
-	// non-fatal like sweepLegacyTaskUnits: a sweep problem must never block
-	// startup, and it no-ops when docker is not installed (#2194 slice 4).
+	// gone, or a reap raced a create. Runs after the restore above, but BEFORE the
+	// manager readiness barrier opens. Therefore every af.home-scoped container the
+	// sweep can see predates create admission; containers from a new CreateSession
+	// cannot appear midway through the destructive pass (#2632). Best-effort and
+	// non-fatal like sweepLegacyTaskUnits: a sweep problem must never block startup,
+	// and it no-ops when docker is not installed (#2194 slice 4).
 	if homeID, err := configDirForReap(); err != nil {
 		log.WarningLog.Printf("orphan sweep: cannot resolve the AF home; skipping: %v", err)
 	} else {
 		sweepOrphanContainers(homeID, manager.dockerReapProtectedSlugs())
 	}
+	manager.finishInstanceRestore()
 
 	// Start schedule evaluation only after the control server is up and the
 	// restore has finished: a task firing immediately goes through the

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -27,16 +27,6 @@ import (
 // orphan sweep, so a concurrent create cannot manufacture a sweep candidate.
 var restoreManagerForStartup = func(m *Manager) error { return m.restoreInstances() }
 
-// sweepOrphanContainers reaps docker session containers this daemon leaked, at
-// startup (#2194 slice 4). Package-level so a test can assert startup passes the
-// live-plus-pending protected slugs and can stub out the docker work.
-var sweepOrphanContainers = session.SweepOrphanContainers
-
-// configDirForReap resolves the AF home the orphan sweep scopes its container
-// query to (it must match the af.home label runContainer stamps). A seam, mirroring
-// the above, so a test can supply a deterministic home.
-var configDirForReap = config.GetConfigDir
-
 // RunDaemon runs the daemon process: it serves the local control plane,
 // evaluates task cron schedules in-process, supervises watch-task scripts,
 // and iterates over all sessions each poll to compute their authoritative
@@ -287,19 +277,7 @@ func runDaemon(cfg *config.Config, upgradeTransactionID string) error {
 	// in-process scheduler below replaces them.
 	sweepLegacyTaskUnits()
 
-	// Reap docker session containers this daemon leaked — a container that outlived
-	// its session because a previous daemon died without reaping, its record is
-	// gone, or a reap raced a create. Runs after the restore above, but BEFORE the
-	// manager readiness barrier opens. Therefore every af.home-scoped container the
-	// sweep can see predates create admission; containers from a new CreateSession
-	// cannot appear midway through the destructive pass (#2632). Best-effort and
-	// non-fatal like sweepLegacyTaskUnits: a sweep problem must never block startup,
-	// and it no-ops when docker is not installed (#2194 slice 4).
-	if homeID, err := configDirForReap(); err != nil {
-		log.WarningLog.Printf("orphan sweep: cannot resolve the AF home; skipping: %v", err)
-	} else {
-		sweepOrphanContainers(homeID, manager.dockerReapProtectedSlugs())
-	}
+	sweepStartupOrphanContainers(manager)
 	manager.finishInstanceRestore()
 
 	// Start schedule evaluation only after the control server is up and the

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -64,9 +64,11 @@ type Manager struct {
 	// Load().
 	limitDetector atomic.Pointer[task.LimitDetector]
 
-	// ready is closed once the initial instance restore has completed. Until
-	// then the daemon is "warming up": the control socket is already bound
-	// (#829) but state-dependent RPCs return errDaemonStarting.
+	// ready is closed once restored state is safe for state-dependent RPCs. For
+	// RunDaemon that includes the startup orphan sweep as well as instance restore,
+	// so a create cannot race the destructive sweep (#2632). Until then the daemon
+	// is "warming up": the control socket is already bound (#829), but
+	// state-dependent RPCs return errDaemonStarting.
 	ready     chan struct{}
 	readyOnce sync.Once
 	// lifecycle is the daemon-wide health/admission state. Manager readiness
@@ -376,13 +378,21 @@ func newManagerShellForDaemon(cfg *config.Config, transactionID string) (*Manage
 	return mgr, nil
 }
 
-// RestoreInstances loads every repo's persisted instances into the manager
-// and marks it ready. RunDaemon does this only after the control socket is bound
-// (#829), keeping Ping and Shutdown available while persisted state is
-// rehydrated. Replacing the instance map wholesale is safe: every RPC that
-// mutates it is gated on Ready, and the refresh poll loop starts after the
-// restore completes.
+// RestoreInstances loads every repo's persisted instances into a standalone
+// manager and marks it ready. RunDaemon uses restoreInstances directly and opens
+// readiness only after its startup orphan sweep (#2632).
 func (m *Manager) RestoreInstances() error {
+	if err := m.restoreInstances(); err != nil {
+		return err
+	}
+	m.finishInstanceRestore()
+	return nil
+}
+
+// restoreInstances loads persisted state without opening the readiness barrier.
+// RunDaemon binds its control socket first (#829), performs this load, then keeps
+// state RPCs gated until the startup orphan sweep is complete (#2632).
+func (m *Manager) restoreInstances() error {
 	instances, ghosts, err := refreshDaemonInstances(nil)
 	if err != nil {
 		return err
@@ -391,6 +401,10 @@ func (m *Manager) RestoreInstances() error {
 	m.instances = instances
 	m.ghostTaskRuns = ghosts
 	m.mu.Unlock()
+	return nil
+}
+
+func (m *Manager) finishInstanceRestore() {
 	m.readyOnce.Do(func() { close(m.ready) })
 	// Publish the lifecycle phase only after the Manager readiness barrier is
 	// open. A Ping that says upgrade_probation must never race a Snapshot that
@@ -399,7 +413,6 @@ func (m *Manager) RestoreInstances() error {
 	if m.lifecycle != nil {
 		m.lifecycle.markRestoreComplete()
 	}
-	return nil
 }
 
 // Ready reports whether the initial instance restore has completed.

--- a/daemon/orphan_reaper.go
+++ b/daemon/orphan_reaper.go
@@ -1,0 +1,28 @@
+package daemon
+
+import (
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// sweepOrphanContainers reaps docker session containers this daemon leaked, at
+// startup (#2194 slice 4). Package-level so tests can stub out the docker work.
+var sweepOrphanContainers = session.SweepOrphanContainers
+
+// configDirForReap resolves the AF home the orphan sweep scopes its container
+// query to. It must match the af.home label runContainer stamps.
+var configDirForReap = config.GetConfigDir
+
+// sweepStartupOrphanContainers runs after instance restore, but before the
+// manager readiness barrier opens. Therefore every af.home-scoped container the
+// sweep can see predates create admission; a new CreateSession cannot manufacture
+// a candidate midway through the destructive pass (#2632).
+func sweepStartupOrphanContainers(manager *Manager) {
+	homeID, err := configDirForReap()
+	if err != nil {
+		log.WarningLog.Printf("orphan sweep: cannot resolve the AF home; skipping: %v", err)
+		return
+	}
+	sweepOrphanContainers(homeID, manager.dockerReapProtectedSlugs())
+}

--- a/daemon/orphan_reaper_test.go
+++ b/daemon/orphan_reaper_test.go
@@ -1,12 +1,66 @@
 package daemon
 
 import (
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/session"
 )
+
+// TestRunDaemonKeepsManagerWarmingUntilOrphanSweepCompletes pins the startup
+// ordering that makes the sweep's candidate set a true pre-admission boundary:
+// no state-dependent RPC can start a new container while the sweep is running.
+func TestRunDaemonKeepsManagerWarmingUntilOrphanSweepCompletes(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+
+	sweepStarted := make(chan struct{})
+	sweepGate := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseSweep := func() { releaseOnce.Do(func() { close(sweepGate) }) }
+	t.Cleanup(releaseSweep)
+
+	previousSweep := sweepOrphanContainers
+	sweepOrphanContainers = func(string, map[string]bool) session.OrphanSweepResult {
+		close(sweepStarted)
+		<-sweepGate
+		return session.OrphanSweepResult{}
+	}
+	t.Cleanup(func() { sweepOrphanContainers = previousSweep })
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- RunDaemon(config.DefaultConfig()) }()
+
+	select {
+	case <-sweepStarted:
+	case err := <-runDone:
+		t.Fatalf("RunDaemon exited before the orphan sweep: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunDaemon did not start the orphan sweep")
+	}
+
+	var resp SendPromptResponse
+	err := callDaemonNoEnsure("SendPrompt", SendPromptRequest{Title: "created-during-sweep", Prompt: "hi"}, &resp)
+	require.Error(t, err)
+	assert.True(t, IsDaemonStartingErr(err),
+		"state RPC reached the ready manager while the orphan sweep was still running: %v", err)
+
+	releaseSweep()
+	result, err := RequestShutdown()
+	require.NoError(t, err)
+	assert.Equal(t, ShutdownViaRPC, result)
+	select {
+	case err := <-runDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunDaemon did not exit after shutdown")
+	}
+}
 
 // TestDockerReapProtectedSlugs: the orphan sweep's protected set covers live
 // instances AND still-provisioning pending creates (the #2549 window where a


### PR DESCRIPTION
## What

Keep the daemon's session-state readiness barrier closed until the startup Docker orphan sweep finishes. The control socket still serves Ping and Shutdown during this interval, but CreateSession and every other state-dependent RPC receive the typed daemon-starting outcome.

The sweep wiring now lives in `daemon/orphan_reaper.go` so the startup file remains within the repository file-length limit.

## Root cause

`RestoreInstances` closed `Manager.ready` before `runDaemon` invoked the orphan sweep. That admitted a concurrent CreateSession after the protected-slug snapshot and allowed its new `af.home`-scoped container to appear in the sweep's destructive candidate list.

Opening readiness only after the sweep creates a hard boundary: every container the startup sweep can see predates create admission, so a container created by this daemon during the sweep is impossible. Upgrade-probation daemons preserve their existing behavior and do not run the sweep.

Adjacent call sites were audited: control and HTTP session mutations share `requireStateMutationAdmission`; scheduler, watcher, delivery, and root-agent create paths start only after this new barrier.

## Fail-first regression

The new startup-ordering test was first run against today's tree and failed:

```
Error: Should be true
Messages: state RPC reached the ready manager while the orphan sweep was still running: instance "created-during-sweep" not found; prompt not delivered
--- FAIL: TestRunDaemonKeepsManagerWarmingUntilOrphanSweepCompletes
```

After the fix, the same test passes and the existing warm-up, readiness, probation, and protected-slug tests pass.

## Validation

Validated on pushed SHA `46eec6d183431c67394bffcb8f14490a9204d9f7`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container` (full suite, run last)

Closes #2632