### PR TITLE
fix(tui): cancel attach input before terminal restore

### DIFF
--- a/apiclient/attach.go
+++ b/apiclient/attach.go
@@ -2,6 +2,7 @@ package apiclient
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/signal"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+	"github.com/muesli/cancelreader"
 	"golang.org/x/term"
 
 	"github.com/sachiniyer/agent-factory/agentproto"
@@ -66,6 +68,11 @@ func (c *Client) AttachStream(ctx context.Context, title, repoID, tabID string, 
 	if err != nil {
 		return nil, err
 	}
+	in, err := newAttachInputReader(attachStdin)
+	if err != nil {
+		_ = sc.Conn.Close(websocket.StatusInternalError, "stdin cancellation")
+		return nil, fmt.Errorf("prepare cancellable stdin: %w", err)
+	}
 	// The tmux/ssh client used to own local terminal setup; the clientless proxy
 	// must do it itself so arrow keys, Ctrl sequences and the detach key arrive
 	// byte-for-byte and nothing echoes locally. For the CLI (no bubbletea) this is
@@ -73,15 +80,26 @@ func (c *Client) AttachStream(ctx context.Context, title, repoID, tabID string, 
 	// bubbletea's termios so Restore hands it back exactly.
 	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
 	if err != nil {
+		_ = in.Close()
 		_ = sc.Conn.Close(websocket.StatusInternalError, "raw mode")
 		return nil, err
 	}
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		driveAttachStream(sc.Conn, oldState)
+		driveAttachStream(sc.Conn, oldState, in)
 	}()
 	return done, nil
+}
+
+// newAttachInputReader gives the attach exclusive, cancellable ownership of
+// stdin. Tests may provide their own CancelReader to model terminal FIFO order;
+// production wraps os.Stdin with the same cancelreader Bubble Tea uses.
+func newAttachInputReader(in io.Reader) (cancelreader.CancelReader, error) {
+	if cancellable, ok := in.(cancelreader.CancelReader); ok {
+		return cancellable, nil
+	}
+	return cancelreader.NewReader(in)
 }
 
 // attachWriteTimeout bounds a single WS write so a wedged server can't pin the
@@ -90,7 +108,9 @@ var attachWriteTimeout = 10 * time.Second
 
 // driveAttachStream runs the loops of a full-screen attach — WS→stdout, stdin→WS
 // (with detach-key detection), and SIGWINCH→RESIZE — until the stream ends, then
-// restores the terminal. It owns the terminal for its lifetime.
+// restores the terminal. It owns the terminal for its lifetime. The caller
+// supplies a cancellable stdin reader so a server-side exit can unblock the
+// input pump before Bubble Tea starts its replacement reader (#2671).
 //
 // Concurrency: THREE goroutines can write the WS conn (INPUT from stdin, RESIZE
 // from SIGWINCH, the detach control frame), but coder/websocket permits only ONE
@@ -98,16 +118,16 @@ var attachWriteTimeout = 10 * time.Second
 // writer, not one-lock-per-anything. The reader runs independently (one reader +
 // one writer is allowed). conn.Close is idempotent via closeOnce (both the drain
 // timer and the drain-complete path close it). The io seams are captured as
-// locals up front so the (deliberately leaked-until-next-keystroke) stdin
-// goroutine never reads the package-level seam vars a test swaps back in Cleanup.
-func driveAttachStream(conn *websocket.Conn, oldState *term.State) {
+// locals up front so no goroutine re-reads package-level vars a test swaps back
+// in Cleanup.
+func driveAttachStream(conn *websocket.Conn, oldState *term.State, in cancelreader.CancelReader) {
+	defer in.Close()
 	// Snapshot EVERY package-level seam/tunable once, here, before any goroutine
 	// spawns. The goroutines then read only these locals — never the package vars
-	// a test swaps and restores in Cleanup — so a driver goroutine (notably the
-	// stdin reader, which stays blocked on in.Read until the next keystroke) can
-	// never race that restore. This single entry read is sequenced before the
-	// workers and before `done`, so it is ordered against the test's restore.
-	in, out, termSize := attachStdin, attachStdout, attachTermSize
+	// a test swaps and restores in Cleanup. This single entry read is sequenced
+	// before the workers and before `done`, so it is ordered against the test's
+	// restore.
+	out, termSize := attachStdout, attachTermSize
 	drainTimeout, writeTimeout := attachDrainTimeout, attachWriteTimeout
 
 	// The read context is deliberately NOT cancelled on detach: after MsgDetach we
@@ -183,7 +203,9 @@ func driveAttachStream(conn *websocket.Conn, oldState *term.State) {
 	// CLI that turns on the kitty keyboard protocol or modifyOtherKeys makes the
 	// terminal report ctrl+<key> as an escape sequence, and matching 0x17 alone
 	// left the user unable to detach at all (#1832). See detachkey.go.
+	stdinDone := make(chan struct{})
 	go func() {
+		defer close(stdinDone)
 		buf := make([]byte, 32)
 		for {
 			n, err := in.Read(buf)
@@ -231,7 +253,12 @@ func driveAttachStream(conn *websocket.Conn, oldState *term.State) {
 	}()
 
 	<-copyDone
+	// A server close/MsgExit can end copyDone while stdin is still blocked. Cancel
+	// that read and wait for the pump to prove it has exited before restoring the
+	// terminal; requesting cancellation alone is not proof the reader is gone.
+	_ = in.Cancel()
 	closeConn()
+	<-stdinDone
 	// The stream is fully drained (copyDone), so this lands strictly after any
 	// modes the pane program set — neutralize the terminal (#845, local edition),
 	// then hand the termios back to whatever owned it before attach (bubbletea for

--- a/apiclient/attach_test.go
+++ b/apiclient/attach_test.go
@@ -6,12 +6,14 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/coder/websocket"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
@@ -36,6 +38,89 @@ func (s *syncBuffer) String() string {
 	defer s.mu.Unlock()
 	return s.buf.String()
 }
+
+// sharedAttachInput models the FIFO ownership of a terminal input queue. A byte
+// is delivered to exactly one blocked reader, oldest first; cancelling a reader
+// wakes it without consuming input. This is the property that makes a stale
+// attach reader steal the first post-attach keystroke from Bubble Tea (#2671).
+type sharedAttachInput struct {
+	mu        sync.Mutex
+	cond      *sync.Cond
+	buf       []byte
+	queue     []int
+	cancelled map[int]bool
+}
+
+type sharedAttachReader struct {
+	input *sharedAttachInput
+	id    int
+}
+
+func newSharedAttachInput() *sharedAttachInput {
+	in := &sharedAttachInput{cancelled: make(map[int]bool)}
+	in.cond = sync.NewCond(&in.mu)
+	return in
+}
+
+func (in *sharedAttachInput) reader(id int) *sharedAttachReader {
+	return &sharedAttachReader{input: in, id: id}
+}
+
+func (in *sharedAttachInput) typed(p []byte) {
+	in.mu.Lock()
+	defer in.mu.Unlock()
+	in.buf = append(in.buf, p...)
+	in.cond.Broadcast()
+}
+
+func (in *sharedAttachInput) blocked(id int) bool {
+	in.mu.Lock()
+	defer in.mu.Unlock()
+	for _, queued := range in.queue {
+		if queued == id {
+			return true
+		}
+	}
+	return false
+}
+
+func (in *sharedAttachInput) cancel(id int) bool {
+	in.mu.Lock()
+	defer in.mu.Unlock()
+	in.cancelled[id] = true
+	in.cond.Broadcast()
+	return true
+}
+
+func (r *sharedAttachReader) Read(p []byte) (int, error) {
+	in := r.input
+	in.mu.Lock()
+	defer in.mu.Unlock()
+	in.queue = append(in.queue, r.id)
+	defer func() {
+		for i, queued := range in.queue {
+			if queued == r.id {
+				in.queue = append(in.queue[:i], in.queue[i+1:]...)
+				break
+			}
+		}
+		in.cond.Broadcast()
+	}()
+	for {
+		if in.cancelled[r.id] {
+			return 0, context.Canceled
+		}
+		if len(in.buf) > 0 && in.queue[0] == r.id {
+			n := copy(p, in.buf)
+			in.buf = in.buf[n:]
+			return n, nil
+		}
+		in.cond.Wait()
+	}
+}
+
+func (r *sharedAttachReader) Cancel() bool { return r.input.cancel(r.id) }
+func (r *sharedAttachReader) Close() error { r.input.cancel(r.id); return nil }
 
 // attachWSServer stands up a Unix-socket WS server that hands the accepted
 // server-side conn to the test over connCh so the test can play the daemon's
@@ -75,7 +160,19 @@ func attachWSServer(t *testing.T) (*Client, <-chan *websocket.Conn) {
 // exercise the RESIZE writer. Read only on the main (sequential) test goroutine.
 var driverTermSize = func() (uint16, uint16, bool) { return 0, 0, false }
 
-func startDriver(t *testing.T) (srvConn *websocket.Conn, stdinW *io.PipeWriter, stdout *syncBuffer, done <-chan struct{}) {
+func startDriver(t *testing.T) (srvConn *websocket.Conn, stdinW *os.File, stdout *syncBuffer, done <-chan struct{}) {
+	t.Helper()
+	inR, inW, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = inR.Close()
+		_ = inW.Close()
+	})
+	server, out, driverDone := startDriverWithInput(t, inR)
+	return server, inW, out, driverDone
+}
+
+func startDriverWithInput(t *testing.T, in io.Reader) (srvConn *websocket.Conn, stdout *syncBuffer, done <-chan struct{}) {
 	t.Helper()
 	// Fast drain so a detach that the server doesn't promptly close still ends the
 	// test quickly.
@@ -92,19 +189,20 @@ func startDriver(t *testing.T) (srvConn *websocket.Conn, stdinW *io.PipeWriter, 
 	}
 	server := <-connCh
 
-	inR, inW := io.Pipe()
 	out := &syncBuffer{}
 	prevIn, prevOut := attachStdin, attachStdout
-	attachStdin, attachStdout = inR, out
+	attachStdin, attachStdout = in, out
 	// driverTermSize defaults to a non-TTY (no resize frames); a test can set it
 	// before startDriver to make the driver's initial sendResize actually fire.
 	prevSize := attachTermSize
 	attachTermSize = driverTermSize
 	t.Cleanup(func() { attachStdin, attachStdout, attachTermSize = prevIn, prevOut, prevSize })
 
+	input, err := newAttachInputReader(in)
+	require.NoError(t, err)
 	d := make(chan struct{})
-	go func() { defer close(d); driveAttachStream(sc.Conn, nil) }()
-	return server, inW, out, d
+	go func() { defer close(d); driveAttachStream(sc.Conn, nil, input) }()
+	return server, out, d
 }
 
 func readServerMsg(t *testing.T, conn *websocket.Conn) agentproto.Message {
@@ -356,6 +454,53 @@ func TestAttachStream_ServerExitClosesAttach(t *testing.T) {
 		t.Fatalf("write exit: %v", err)
 	}
 	waitClosed(t, done)
+}
+
+// TestAttachStream_ServerExitCancelsStdinBeforeReturning is the terminal
+// hand-back invariant for #2671. A server-side exit must remove the attach's
+// already-blocked stdin reader before Bubble Tea starts its replacement reader;
+// otherwise the old reader is first in the terminal's FIFO and consumes the
+// user's first post-attach keystroke.
+func TestAttachStream_ServerExitCancelsStdinBeforeReturning(t *testing.T) {
+	const attachReaderID, tuiReaderID = 1, 2
+	in := newSharedAttachInput()
+	t.Cleanup(func() {
+		in.cancel(attachReaderID)
+		in.cancel(tuiReaderID)
+	})
+	server, _, done := startDriverWithInput(t, in.reader(attachReaderID))
+	require.Eventually(t, func() bool { return in.blocked(attachReaderID) },
+		time.Second, time.Millisecond, "attach reader must be blocked on terminal input")
+
+	// Let the client's close handshake complete after it receives MsgExit.
+	go func() {
+		for {
+			if _, _, err := server.Read(context.Background()); err != nil {
+				return
+			}
+		}
+	}()
+	require.NoError(t, agentproto.WriteControl(context.Background(), server, agentproto.NewExitMessage(0)))
+	waitClosed(t, done)
+
+	firstKey := make(chan byte, 1)
+	go func() {
+		buf := make([]byte, 1)
+		n, err := in.reader(tuiReaderID).Read(buf)
+		if err == nil && n == 1 {
+			firstKey <- buf[0]
+		}
+	}()
+	require.Eventually(t, func() bool { return in.blocked(tuiReaderID) },
+		time.Second, time.Millisecond, "replacement TUI reader must be blocked")
+	in.typed([]byte{'?'})
+
+	select {
+	case got := <-firstKey:
+		require.Equal(t, byte('?'), got)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("first post-attach keystroke was consumed by the stale attach stdin reader")
+	}
 }
 
 func waitFor(t *testing.T, cond func() bool, msg string) {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/coder/websocket v1.8.15
 	github.com/creack/pty v1.1.24
 	github.com/mattn/go-runewidth v0.0.23
+	github.com/muesli/cancelreader v0.2.2
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6
 	github.com/muesli/reflow v0.3.0
 	github.com/muesli/termenv v0.16.0
@@ -47,7 +48,6 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
-	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/scripts/tui-2671-scenario.sh
+++ b/scripts/tui-2671-scenario.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Real-TUI regression for #2671, via:
+#
+#   scripts/testbox.sh scenario scripts/tui-2671-scenario.sh
+#
+# A server-side pane exit ends the full-screen WS attach without a detach key.
+# The first key after Bubble Tea reclaims the terminal must reach the TUI rather
+# than the attach's old stdin reader. The test sends exactly one `?` and expects
+# the help screen; retrying would hide the bug.
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source /src/scripts/tui-driver.sh
+
+export AF_DRIVER_COLS=120 AF_DRIVER_ROWS=30
+export AF_DRIVER_REPO="$HOME/sandbox/mock-repo"
+
+af_reset_sandbox
+af_boot
+af_new_instance disconnect-me
+af_select disconnect-me
+af_attach
+
+# Stop only this disposable sandbox's serving daemon, forcing the real WS attach
+# connection to end without a detach key. Resolve and verify the exact pid first;
+# the host daemon is outside the container and cannot be reached from here.
+daemon_pid="$("$HOME/bin/af" daemon status --json | jq -er '.data.serving_pid')"
+daemon_cmd="$(tr '\0' ' ' <"/proc/$daemon_pid/cmdline")"
+if ! printf '%s\n' "$daemon_cmd" | grep -qE '/af --daemon([[:space:]]|$)'; then
+    _af_fail "#2671: refusing to signal unverified sandbox daemon pid $daemon_pid: $daemon_cmd"
+    exit 1
+fi
+kill -TERM "$daemon_pid"
+af_wait_for 'Agent Factory' "$AF_DRIVER_TIMEOUT" 'server disconnect returns to TUI'
+
+# One keypress, no retry: the leaked attach reader wins the terminal FIFO on the
+# unfixed tree and consumes this byte before Bubble Tea can see it.
+af_send '?'
+af_wait_for 'Agent Factory v' 5 'first post-disconnect keystroke opens help'
+
+echo 'PASS: #2671 first post-disconnect keystroke reaches the TUI'


### PR DESCRIPTION
## Summary

- wrap full-screen attach stdin in the same cancellable reader primitive Bubble Tea uses
- cancel the reader and wait for the input goroutine to exit before restoring terminal ownership
- add a FIFO terminal regression and an isolated real-TUI server-disconnect scenario

## Root cause

A server-side WebSocket exit closed the output loop and returned from `driveAttachStream`, but its stdin goroutine remained blocked on the terminal. Bubble Tea then restored its own input reader, leaving the stale attach reader first in the terminal FIFO to consume the next keypress.

Adjacent raw-input paths were audited. The local WebSocket attach is the only in-process raw stdin pump; remote hook attachment is process-owned and does not leave this goroutine pattern behind.

## Fail-first evidence

The focused regression failed on the unfixed tree with:

```text
attach_test.go:494: first post-attach keystroke was consumed by the stale attach stdin reader
--- FAIL: TestAttachStream_ServerExitCancelsStdinBeforeReturning (0.51s)
```

The real TUI scenario terminated only its disposable sandbox daemon, sent one `?`, and failed before the fix with:

```text
TIMEOUT 5s waiting for: first post-disconnect keystroke opens help
```

The captured screen remained on the normal sidebar, proving the single keypress never reached Bubble Tea.

## Validation

- `scripts/testbox.sh scenario scripts/tui-2671-scenario.sh`
- focused attach tests including normal detach and server exit
- `scripts/testbox.sh test ./apiclient -count=1`
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container` — full suite passed last against pushed SHA `5a9cdac7646f3489ebf5673677e8946a95182c03`

Closes #2671