### PR TITLE
bound archive and restore operation locks

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -101,8 +101,10 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, session.Ins
 		m.mu.Unlock()
 	}()
 
-	opLock := m.opLockFor(key)
-	opLock.Lock()
+	opLock, err := m.lockSessionOperationWithin(key, "archive", req.Title)
+	if err != nil {
+		return "", session.InstanceData{}, err
+	}
 	defer opLock.Unlock()
 
 	// Re-verify under the op-lock: findSession released m.mu, so a racing kill
@@ -360,8 +362,10 @@ func (m *Manager) restoreArchivedInstance(instance *session.Instance, repoID, ti
 		m.mu.Unlock()
 	}()
 
-	opLock := m.opLockFor(key)
-	opLock.Lock()
+	opLock, err := m.lockSessionOperationWithin(key, "restore", req.Title)
+	if err != nil {
+		return "", err
+	}
 	defer opLock.Unlock()
 
 	// Re-verify under the op-lock (findSession released m.mu).

--- a/daemon/archive_test.go
+++ b/daemon/archive_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/session"
 	sessiongit "github.com/sachiniyer/agent-factory/session/git"
@@ -216,6 +217,98 @@ func TestArchiveSession_RejectsWhenOperationInFlight(t *testing.T) {
 	_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "in progress")
+}
+
+// TestArchiveRestore_StuckPeerOperation_DoesNotHoldKillGuardIndefinitely is the
+// #2641 regression across every archive/restore path that registers in
+// killsInFlight before acquiring the per-session operation lock. A wedged peer
+// may delay these operations, but it must not make the session undeletable for
+// the daemon's lifetime.
+//
+// PRE-FIX: each case misses the deadline below because it waits in opLock.Lock.
+func TestArchiveRestore_StuckPeerOperation_DoesNotHoldKillGuardIndefinitely(t *testing.T) {
+	prev := opLockTimeout
+	opLockTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { opLockTimeout = prev })
+
+	t.Run("archive", func(t *testing.T) {
+		manager, repoID, repoPath := newStatusTestManager(t)
+		inst, _ := registerArchivable(t, manager, repoID, repoPath, "archive-wait")
+		key := daemonInstanceKey(repoID, inst.Title)
+
+		assertGuardedOperationLockWaitBounded(t, manager, key, func() error {
+			_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: inst.Title, RepoID: repoID})
+			return err
+		})
+		assert.Equal(t, session.Ready, inst.GetStatus(), "a timed-out archive must not change session state")
+	})
+
+	t.Run("archived restore", func(t *testing.T) {
+		manager, repoID, repoPath := newStatusTestManager(t)
+		inst, _ := registerArchivable(t, manager, repoID, repoPath, "archived-restore-wait")
+		inst.SetBackend(&recoverFakeBackend{FakeBackend: session.NewFakeBackend()})
+		_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: inst.Title, RepoID: repoID})
+		require.NoError(t, err)
+		key := daemonInstanceKey(repoID, inst.Title)
+
+		assertGuardedOperationLockWaitBounded(t, manager, key, func() error {
+			_, _, err := manager.RestoreArchived(RestoreArchivedRequest{Title: inst.Title, RepoID: repoID})
+			return err
+		})
+		assert.Equal(t, session.Archived, inst.GetStatus(), "a timed-out restore must leave the session archived")
+	})
+
+	t.Run("lost restore", func(t *testing.T) {
+		manager, repoID, repoPath := newStatusTestManager(t)
+		backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
+		inst := registerStarted(t, manager, repoID, repoPath, "lost-restore-wait", backend, true, session.Lost)
+		key := daemonInstanceKey(repoID, inst.Title)
+
+		assertGuardedOperationLockWaitBounded(t, manager, key, func() error {
+			_, _, err := manager.RestoreSession(RestoreSessionRequest{Title: inst.Title, RepoID: repoID})
+			return err
+		})
+		assert.Equal(t, session.Lost, inst.GetStatus(), "a timed-out restore must leave the session lost")
+	})
+}
+
+func assertGuardedOperationLockWaitBounded(t *testing.T, manager *Manager, key string, operation func() error) {
+	t.Helper()
+	opLock := manager.opLockFor(key)
+	opLock.Lock()
+	locked := true
+	t.Cleanup(func() {
+		if locked {
+			opLock.Unlock()
+		}
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- operation()
+	}()
+	require.Eventually(t, func() bool { return killGuardHeld(manager, key) }, time.Second, 5*time.Millisecond,
+		"operation never registered its killsInFlight guard")
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "operation cannot succeed without acquiring its lock")
+		assert.Contains(t, err.Error(), "timed out")
+		assert.Contains(t, err.Error(), "retry")
+		assert.False(t, killGuardHeld(manager, key), "timed-out operation left the session undeletable")
+		opLock.Unlock()
+		locked = false
+	case <-time.After(2 * time.Second):
+		// Prevent the pre-fix operation from mutating the instance after the test
+		// releases the lock solely to let its goroutine return.
+		manager.mu.Lock()
+		delete(manager.instances, key)
+		manager.mu.Unlock()
+		opLock.Unlock()
+		locked = false
+		eventualErr := <-done
+		t.Fatalf("HUNG: operation did not return while a peer held its operation lock; after the lock was released it returned %v", eventualErr)
+	}
 }
 
 // TestArchiveSession_RejectsExternalWorktree (#1028 Greptile P1): an

--- a/daemon/killbound.go
+++ b/daemon/killbound.go
@@ -40,13 +40,13 @@ import (
 // finishes the kill with no daemon restart. Bounding the wait is what re-arms
 // the self-heal; the two are the same fix.
 
-// opLockTimeout bounds how long KillSession waits for a session's operation lock
-// before giving up. The lock serializes a kill against an in-flight Recover
-// (#1108) and that exclusion is load-bearing — a kill must never interleave with
-// a respawn — so this stays a real mutual exclusion and NOT a race. What changes
-// is only the failure mode: an unbounded Lock() turns a peer's slow operation
-// into a permanent wedge of this session, while a bounded wait turns it into a
-// retryable error the user can act on.
+// opLockTimeout bounds how long a kill, archive, or manual restore waits for a
+// session's operation lock before giving up. The lock serializes these actions
+// against an in-flight Recover (#1108) and that exclusion is load-bearing — they
+// must never interleave with a respawn — so this stays a real mutual exclusion
+// and NOT a race. What changes is only the failure mode: an unbounded Lock()
+// inside killsInFlight turns a peer's slow operation into a permanent wedge of
+// this session, while a bounded wait releases the guard with a retryable error.
 //
 // Generous on purpose: a healthy Recover holds this lock for as long as a tmux
 // respawn takes, and a kill that waits a few seconds behind one is CORRECT
@@ -66,9 +66,9 @@ var opLockPollInterval = 5 * time.Millisecond
 // every opLockPollInterval while contended, and the loss of the mutex's
 // starvation-avoidance fairness (TryLock never queues), so a caller can in
 // principle lose several races to a lock that is handed off rapidly. That is
-// acceptable here and nowhere near the hot path: the only bounded acquirer is a
-// user-initiated kill, the poll cost lasts only as long as the contention, and
-// the alternative it replaces is waiting forever.
+// acceptable here and nowhere near the hot path: the bounded acquirers are
+// user-initiated lifecycle operations, the poll cost lasts only as long as the
+// contention, and the alternative it replaces is waiting forever.
 func lockWithin(mu *sync.Mutex, d time.Duration) bool {
 	if mu.TryLock() {
 		return true
@@ -89,6 +89,20 @@ func lockWithin(mu *sync.Mutex, d time.Duration) bool {
 			return false
 		}
 	}
+}
+
+// lockSessionOperationWithin takes the per-session operation lock with the same
+// bound for archive and both manual restore paths. Each caller has registered in
+// killsInFlight but has not mutated the session yet, so timeout is a known no-op:
+// the requested action did not start, the deferred guard cleanup can run, and a
+// later kill or retry remains possible (#2641).
+func (m *Manager) lockSessionOperationWithin(key, operation, title string) (*sync.Mutex, error) {
+	opLock := m.opLockFor(key)
+	if !lockWithin(opLock, opLockTimeout) {
+		log.WarningLog.Printf("%s of session %q could not acquire its operation lock within %s; another operation on this session is not releasing it", operation, title, opLockTimeout)
+		return nil, fmt.Errorf("%s of session %q timed out after %s waiting for another operation on it to finish; the requested %s did not start and made no changes — retry", operation, title, opLockTimeout, operation)
+	}
+	return opLock, nil
 }
 
 // killWatchdogDelay is how long a kill may run before the watchdog reports the

--- a/daemon/restore.go
+++ b/daemon/restore.go
@@ -62,8 +62,10 @@ func (m *Manager) restoreLostOrDeadSession(repoID, title string, instance *sessi
 		m.mu.Unlock()
 	}()
 
-	opLock := m.opLockFor(key)
-	opLock.Lock()
+	opLock, err := m.lockSessionOperationWithin(key, "restore", title)
+	if err != nil {
+		return "", err
+	}
 	defer opLock.Unlock()
 
 	m.mu.Lock()


### PR DESCRIPTION
## Summary

- bound every archive/manual-restore operation-lock acquisition made while `killsInFlight` is held
- share one timed-acquire path across archive, archived restore, and lost/dead restore
- return an actionable timeout that states only the known result: this requested operation did not start or make changes
- add one regression covering all three guarded call sites and proving the guard is released

## Diagnosis and relationship to #2654

The report is correct. These three paths registered `killsInFlight` and then called `opLock.Lock()` without a deadline. If any peer held that lock indefinitely, the blocked caller retained `killsInFlight`, so kill was rejected until daemon restart.

#2654 is one concrete way to create the same user-visible symptom: a cross-filesystem archive could block on a FIFO while already holding the operation lock and kill guard. PR #2689 addresses that specific copy-engine cause. It does not eliminate these independent unbounded lock waits, so this PR keeps the general bound separate.

## Red-first proof

Observed against the untouched tree:

```
archive_test.go:239: HUNG: operation did not return while a peer held its operation lock; after the lock was released it returned session "archive-wait" changed state before archive could start
archive_test.go:254: HUNG: operation did not return while a peer held its operation lock; after the lock was released it returned session "archived-restore-wait" changed state before restore could start
archive_test.go:267: HUNG: operation did not return while a peer held its operation lock; after the lock was released it returned session "lost-restore-wait" changed state before restore could start
--- FAIL: TestArchiveRestore_StuckPeerOperation_DoesNotHoldKillGuardIndefinitely (6.20s)
```

The same three cases now return after the shortened test timeout, release `killsInFlight`, and leave the requested operation unstarted. The existing bounded-kill regression remains green.

## Adjacent audit

The only production paths that both register `killsInFlight` and then acquire `opLock` were:

- `ArchiveSession`
- archived-session restore
- lost/dead-session restore

All three now use the shared bound. Automatic restore and interrupted-kill recovery already use `TryLock` and never wait. Other prompt/tab callers do not retain `killsInFlight`, so they cannot create this undeletable-session failure shape.

## Validation

Validated on pushed head `85466fa72cb3064c3c99d4757aa401d640ab5539`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- focused container regression plus the existing bounded-kill regression
- `make test-container`

Closes #2641