### PR TITLE
fix: report committed task mutations

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -3,9 +3,11 @@ package api
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/apiclient"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/log"
@@ -36,6 +38,15 @@ var (
 	daemonRestartTask      = daemon.RestartTask
 	daemonTriggerTask      = daemon.TriggerTask
 )
+
+// warnCommittedTaskMutation keeps a post-commit schedule failure visible while
+// the command returns success for the durable task change. In particular, the
+// warning says not to retry: AddTask generates a fresh ID on every invocation,
+// so treating this definite outcome as an ordinary failure can create a
+// duplicate scheduled task.
+func warnCommittedTaskMutation(err error) {
+	fmt.Fprintf(os.Stderr, "warning: %v; the task change is saved and must not be retried\n", err)
+}
 
 // strPtr / boolPtr build the pointer fields of a task.TaskUpdate patch. The CLI
 // sends a field-level patch (#1700): only the flags the user actually passed
@@ -240,7 +251,10 @@ var tasksAddCmd = &cobra.Command{
 		// own scheduler/watchers in-process, so no separate reload poke is needed
 		// (#1029 PR 3). The on-disk tasks.json format is unchanged.
 		if err := daemonAddTask(s); err != nil {
-			return jsonError(fmt.Errorf("failed to add task: %w", err))
+			if !apiclient.IsMutationCommitted(err) {
+				return jsonError(fmt.Errorf("failed to add task: %w", err))
+			}
+			warnCommittedTaskMutation(err)
 		}
 
 		// Echo the resolved binding, not just the id (#1891). The id alone left
@@ -281,7 +295,10 @@ var tasksRemoveCmd = &cobra.Command{
 		// it was a moment ago, and only the daemon can re-verify it atomically
 		// with the delete.
 		if err := daemonRemoveTask(args[0], expect); err != nil {
-			return jsonError(fmt.Errorf("failed to remove task: %w", err))
+			if !apiclient.IsMutationCommitted(err) {
+				return jsonError(fmt.Errorf("failed to remove task: %w", err))
+			}
+			warnCommittedTaskMutation(err)
 		}
 
 		return jsonOut(map[string]bool{"ok": true})
@@ -550,7 +567,19 @@ var tasksUpdateCmd = &cobra.Command{
 
 		updated, err := daemonUpdateTask(args[0], patch, expect)
 		if err != nil {
-			return jsonError(fmt.Errorf("failed to update task: %w", err))
+			if !apiclient.IsMutationCommitted(err) {
+				return jsonError(fmt.Errorf("failed to update task: %w", err))
+			}
+			warnCommittedTaskMutation(err)
+			// net/rpc discards the response body whenever the server returns an
+			// error, even for this definite committed outcome. Read the durable
+			// record back so the update command preserves its normal output.
+			stored, readErr := task.GetTask(args[0])
+			if readErr != nil {
+				return jsonError(fmt.Errorf(
+					"task update committed, but its durable value could not be read back: %w", readErr))
+			}
+			updated = *stored
 		}
 
 		return jsonOut(updated)

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -271,6 +271,30 @@ func TestTasksAdd_DaemonWriteFailureFailsAdd(t *testing.T) {
 	assert.Zero(t, calls.writes, "no successful write is recorded when the RPC fails")
 }
 
+func TestTasksAdd_CommittedReloadFailureIsNotRetryable(t *testing.T) {
+	useTempConfig(t)
+	resetAddFlags(t)
+	stubDaemon(t)
+	repo := setupAddRepo(t)
+
+	daemonAddTask = func(tk task.Task) error {
+		require.NoError(t, task.AddTask(tk))
+		return committedTaskMutationTestError{}
+	}
+	taskAddNameFlag = "committed-add"
+	taskAddPromptFlag = "p"
+	taskAddCronFlag = "0 9 * * *"
+	taskAddProgramFlag = "claude"
+
+	err := tasksAddCmd.RunE(tasksAddCmd, nil)
+	require.NoError(t, err, "a durable add must not be reported as a retryable command failure")
+	tasks, err := task.LoadTasks()
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, "committed-add", tasks[0].Name)
+	assert.Equal(t, repo, tasks[0].ProjectPath)
+}
+
 // TestTasksAdd_RejectsEmptyPrompt is the regression guard for #517: Cobra's
 // MarkFlagRequired only checks flag presence, so --prompt "" (or
 // whitespace-only) used to slip through and create a task that no-ops when
@@ -590,6 +614,27 @@ func TestTasksRemove_RemovesTaskViaDaemon(t *testing.T) {
 	assert.Empty(t, tasks)
 	assert.Equal(t, 1, calls.writes, "remove must dispatch the write to the daemon")
 }
+
+func TestTasksRemove_CommittedReloadFailureIsNotRetryable(t *testing.T) {
+	useTempConfig(t)
+	stubDaemon(t)
+	seedTask(t, task.Task{ID: "committed-remove", Prompt: "p", CronExpr: "0 9 * * *", Enabled: true})
+
+	daemonRemoveTask = func(id string, expect task.ProjectExpectation) error {
+		require.NoError(t, task.RemoveTask(id, expect))
+		return committedTaskMutationTestError{}
+	}
+	err := tasksRemoveCmd.RunE(tasksRemoveCmd, []string{"committed-remove"})
+	require.NoError(t, err, "a durable removal must not be reported as a retryable command failure")
+	tasks, err := task.LoadTasks()
+	require.NoError(t, err)
+	assert.Empty(t, tasks)
+}
+
+type committedTaskMutationTestError struct{}
+
+func (committedTaskMutationTestError) Error() string           { return "scheduler reload failed after commit" }
+func (committedTaskMutationTestError) MutationCommitted() bool { return true }
 
 func TestTasksRemove_MissingTaskErrors(t *testing.T) {
 	useTempConfig(t)

--- a/app/content_persistence.go
+++ b/app/content_persistence.go
@@ -124,6 +124,15 @@ func (m *home) saveContentPaneState() error {
 	}
 	for _, tsk := range sp.ConsumeDeleted() {
 		if err := removeTaskThroughDaemon(tsk.ID); err != nil {
+			if apiclient.IsMutationCommitted(err) {
+				// The durable removal landed and the reload below will project
+				// it. Keep the schedule failure visible without telling the user
+				// to retry a deletion that already happened.
+				log.WarningLog.Printf("task removal committed but schedule refresh failed: %v", err)
+				saveErr = errors.Join(saveErr, fmt.Errorf(
+					"task %q was removed, but the daemon could not refresh its schedules: %w", tsk.Name, err))
+				continue
+			}
 			log.ErrorLog.Printf("failed to remove task: %v", err)
 			saveErr = errors.Join(saveErr, fmt.Errorf("failed to remove task %q: %w", tsk.Name, err))
 		}

--- a/app/handle_overlay_test.go
+++ b/app/handle_overlay_test.go
@@ -616,6 +616,87 @@ func TestHandleTaskCreate_RoutesThroughDaemonRPC(t *testing.T) {
 	assert.Empty(t, disk, "TUI must not write tasks.json directly (#960 sole writer)")
 }
 
+// TestHandleTaskCreate_CommittedReloadFailureRefreshesAndWarns covers the
+// three-valued AddTask outcome: the durable write succeeded, but the daemon's
+// scheduler/watcher refresh did not. The TUI must accept and reload the created
+// task instead of leaving the form looking retryable and inviting a duplicate.
+func TestHandleTaskCreate_CommittedReloadFailureRefreshesAndWarns(t *testing.T) {
+	h := newTestHome(t)
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+	repo, err := config.CurrentRepo()
+	require.NoError(t, err)
+	h.repoID = repo.ID
+
+	t.Cleanup(SetTaskAdderForTest(func(tk task.Task) error {
+		require.NoError(t, task.AddTask(tk))
+		return committedTaskMutationTestError{}
+	}))
+
+	tp := h.automations.TaskPane()
+	tp.SetTasks(nil)
+	_, _ = h.showTasksOverlay()
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("committed-task")})
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // trigger selector
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // schedule picker
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // prompt
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("do a thing")})
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // target session
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // path
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // program
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // save
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyEnter})
+
+	require.Len(t, h.store.GetTasks(), 1,
+		"a committed add must refresh the TUI instead of leaving a retryable form")
+	assert.Equal(t, "committed-task", h.store.GetTasks()[0].Name)
+	assert.False(t, tp.IsCreating(), "the committed task must leave create mode")
+	assert.Contains(t, h.errBox.FullError(), "scheduler reload failed after commit",
+		"the post-commit refresh failure must still be visible")
+	assert.NotContains(t, h.errBox.FullError(), "failed to save task",
+		"a committed add must not be presented as a failed save")
+}
+
+func TestSaveContentPaneState_CommittedRemovalRefreshesAndWarns(t *testing.T) {
+	h := newTestHome(t)
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+	repo, err := config.CurrentRepo()
+	require.NoError(t, err)
+	h.repoID = repo.ID
+
+	removed := task.Task{
+		ID: "committed-remove", Name: "remove me", Prompt: "p", CronExpr: "0 9 * * *",
+		ProjectPath: repo.Root, Program: "claude", Enabled: true, CreatedAt: time.Now(),
+	}
+	require.NoError(t, task.AddTask(removed))
+	loaded, err := task.LoadTasksForCurrentRepo()
+	require.NoError(t, err)
+	h.store.SetTasks(loaded)
+	tp := h.automations.TaskPane()
+	tp.SetTasks(loaded)
+	_, _ = h.showTasksOverlay()
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyEsc})
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")})
+
+	t.Cleanup(SetTaskRemoverForTest(func(id string) error {
+		require.NoError(t, task.RemoveTask(id, task.ProjectExpectation{}))
+		return committedTaskMutationTestError{}
+	}))
+	err = h.saveContentPaneState()
+	require.Error(t, err, "the post-commit schedule failure must remain visible")
+	assert.Contains(t, err.Error(), "was removed, but the daemon could not refresh its schedules")
+	assert.NotContains(t, err.Error(), "failed to remove task",
+		"a committed removal must not be presented as retryable")
+	assert.Empty(t, h.store.GetTasks(), "the TUI projection must refresh to the durable removal")
+}
+
+type committedTaskMutationTestError struct{}
+
+func (committedTaskMutationTestError) Error() string           { return "scheduler reload failed after commit" }
+func (committedTaskMutationTestError) MutationCommitted() bool { return true }
+
 // TestSaveContentPaneState_RoutesThroughDaemonRPC is the #1029 PR 6 guard for
 // the edit/delete path: closing the task manager with dirty edits must persist
 // them through the daemon RPCs (update + remove), not by writing tasks.json

--- a/app/home_tasks.go
+++ b/app/home_tasks.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/apiclient"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/task"
 	"github.com/sachiniyer/agent-factory/ui/layout"
@@ -63,10 +64,12 @@ func (m *home) handleTaskCreate() tea.Cmd {
 	}
 	// Route the create through the daemon (#1029 PR 6): it is the sole writer of
 	// tasks.json among clients (#960) and re-arms its own scheduler/watchers in
-	// the same RPC, so there is no separate ReloadTasks poke — the write and its
-	// schedule refresh are one atomic daemon call.
-	if err := addTaskThroughDaemon(t); err != nil {
-		return m.handleError(fmt.Errorf("failed to save task: %v", err))
+	// the same RPC, so there is no separate ReloadTasks poke. The task-file write
+	// is the durable commit; a later refresh failure is classified so this caller
+	// can accept the saved task without presenting a retryable create form.
+	addErr := addTaskThroughDaemon(t)
+	if addErr != nil && !apiclient.IsMutationCommitted(addErr) {
+		return m.handleError(fmt.Errorf("failed to save task: %v", addErr))
 	}
 	// Refresh sidebar and task pane
 	tasks, err := task.LoadTasksForCurrentRepo()
@@ -75,6 +78,9 @@ func (m *home) handleTaskCreate() tea.Cmd {
 		sp.SetTasks(tasks)
 		// Reflow so the new automation grows the rail's section (#1126).
 		m.relayout()
+	}
+	if addErr != nil {
+		return m.handleError(fmt.Errorf("task was saved, but the daemon could not refresh its schedules: %w", addErr))
 	}
 	return nil
 }

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -296,8 +296,41 @@ func callDaemonNoEnsure(method string, req any, resp any) error {
 	}
 	client := rpc.NewClient(conn)
 	defer client.Close()
-	return client.Call(controlServiceName+"."+method, req, resp)
+	return classifyTaskMutationRPCError(method, client.Call(controlServiceName+"."+method, req, resp))
 }
+
+// classifyTaskMutationRPCError restores the one machine-readable outcome that
+// net/rpc drops: rpc.ServerError carries only Error(), not the concrete server
+// type. Classification is deliberately narrow — both the RPC method and the
+// exact server-owned prefix must match — so a transport failure or an arbitrary
+// application error remains unknown rather than being promoted to committed.
+func classifyTaskMutationRPCError(method string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var prefix string
+	switch method {
+	case "AddTask":
+		prefix = taskAddCommittedErrorPrefix
+	case "UpdateTask":
+		prefix = taskUpdateCommittedErrorPrefix
+	case "RemoveTask":
+		prefix = taskRemoveCommittedErrorPrefix
+	default:
+		return err
+	}
+	var serverErr rpc.ServerError
+	if !errors.As(err, &serverErr) || !strings.HasPrefix(serverErr.Error(), prefix+" ") {
+		return err
+	}
+	return &rpcMutationCommittedError{err: err}
+}
+
+type rpcMutationCommittedError struct{ err error }
+
+func (e *rpcMutationCommittedError) Error() string           { return e.err.Error() }
+func (e *rpcMutationCommittedError) Unwrap() error           { return e.err }
+func (e *rpcMutationCommittedError) MutationCommitted() bool { return true }
 
 // RequestApplyConfig asks a RUNNING daemon to apply the on-disk global config to
 // itself in place (#2480). It deliberately never STARTS a daemon: a config write

--- a/daemon/control_expect_gob_test.go
+++ b/daemon/control_expect_gob_test.go
@@ -3,13 +3,73 @@ package daemon
 import (
 	"bytes"
 	"encoding/gob"
+	"errors"
+	"net"
+	"net/rpc"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/task"
 )
+
+type committedTaskRPC struct{}
+
+func (committedTaskRPC) AddTask(_ AddTaskRequest, resp *AddTaskResponse) error {
+	resp.OK = true
+	return &mutationCommittedError{err: errors.New(taskAddCommittedErrorPrefix + " simulated")}
+}
+
+// TestControlClientPreservesMutationCommittedOutcome crosses a real isolated
+// net/rpc socket. net/rpc normally flattens the server error to rpc.ServerError;
+// the client must restore the definite committed outcome without classifying
+// unrelated transport or application failures as committed.
+func TestControlClientPreservesMutationCommittedOutcome(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	socketPath, err := DaemonSocketPath()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(socketPath), 0o755))
+
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+	server := rpc.NewServer()
+	require.NoError(t, server.RegisterName(controlServiceName, committedTaskRPC{}))
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr == nil {
+			server.ServeConn(conn)
+		}
+	}()
+
+	err = callDaemonNoEnsure("AddTask", AddTaskRequest{}, &AddTaskResponse{})
+	require.Error(t, err)
+	type committedOutcome interface{ MutationCommitted() bool }
+	var outcome committedOutcome
+	require.True(t, errors.As(err, &outcome) && outcome.MutationCommitted(),
+		"the control client must preserve the server's definite committed outcome: %T: %v", err, err)
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		err    error
+	}{
+		{"wrong method", "UpdateTask", rpc.ServerError(taskAddCommittedErrorPrefix + " simulated")},
+		{"wrong prefix", "AddTask", rpc.ServerError("task add failed before commit")},
+		{"non-server error", "AddTask", errors.New(taskAddCommittedErrorPrefix + " simulated")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyTaskMutationRPCError(tc.method, tc.err)
+			var classified committedOutcome
+			assert.False(t, errors.As(got, &classified),
+				"an unknown outcome must not be promoted to committed: %T: %v", got, got)
+		})
+	}
+}
 
 // The control socket is net/rpc with gob encoding, and gob ELIDES zero-valued
 // fields. That is what made *T optional fields silently arrive as nil in #1700,

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -28,13 +28,21 @@ type controlServer struct {
 
 // mutationCommittedError preserves the otherwise-ambiguous outcome of a
 // durable mutation whose non-transactional follow-up failed. HTTP exposes its
-// code additively; net/rpc clients retain the same human-readable error text.
+// code additively; net/rpc carries the server-owned prefix that the control
+// client narrowly restores to the same three-valued marker.
 type mutationCommittedError struct {
 	err error
 }
 
-func (e *mutationCommittedError) Error() string { return e.err.Error() }
-func (e *mutationCommittedError) Unwrap() error { return e.err }
+const (
+	taskAddCommittedErrorPrefix    = "task add committed, but failed to reload task schedules:"
+	taskUpdateCommittedErrorPrefix = "task update committed, but failed to reload task schedules:"
+	taskRemoveCommittedErrorPrefix = "task removal committed, but failed to reload task schedules:"
+)
+
+func (e *mutationCommittedError) Error() string           { return e.err.Error() }
+func (e *mutationCommittedError) Unwrap() error           { return e.err }
+func (e *mutationCommittedError) MutationCommitted() bool { return true }
 func (e *mutationCommittedError) APIErrorCode() string {
 	return apiproto.ErrorCodeMutationCommitted
 }
@@ -297,11 +305,15 @@ func (s *controlServer) AddTask(req AddTaskRequest, resp *AddTaskResponse) error
 	if err := task.AddTask(req.Task); err != nil {
 		return err
 	}
-	if err := s.reloadTaskSchedulesLocked(); err != nil {
-		return err
-	}
 	resp.OK = true
+	// The task-file write is the durable commit. Publish it before the
+	// non-transactional scheduler/watch reload so other clients never remain
+	// stale when that follow-up fails.
 	s.manager.publishEvent(agentproto.EventTaskCreated, req.Task)
+	if reloadErr := s.reloadTaskSchedulesLocked(); reloadErr != nil {
+		return &mutationCommittedError{err: fmt.Errorf(
+			"%s %w", taskAddCommittedErrorPrefix, reloadErr)}
+	}
 	return nil
 }
 
@@ -330,7 +342,7 @@ func (s *controlServer) UpdateTask(req UpdateTaskRequest, resp *UpdateTaskRespon
 		return nil
 	}
 	return &mutationCommittedError{err: fmt.Errorf(
-		"task update committed, but failed to reload task schedules: %w", reloadErr)}
+		"%s %w", taskUpdateCommittedErrorPrefix, reloadErr)}
 }
 
 func (s *controlServer) RemoveTask(req RemoveTaskRequest, resp *RemoveTaskResponse) error {
@@ -345,11 +357,14 @@ func (s *controlServer) RemoveTask(req RemoveTaskRequest, resp *RemoveTaskRespon
 	if err := task.RemoveTask(req.ID, req.Expect); err != nil {
 		return err
 	}
-	if err := s.reloadTaskSchedulesLocked(); err != nil {
-		return err
-	}
 	resp.OK = true
+	// Removal is already durable at this point. Announce that commit even when
+	// the scheduler/watch reload cannot apply it in-process.
 	s.manager.publishEvent(agentproto.EventTaskRemoved, task.Task{ID: req.ID})
+	if reloadErr := s.reloadTaskSchedulesLocked(); reloadErr != nil {
+		return &mutationCommittedError{err: fmt.Errorf(
+			"%s %w", taskRemoveCommittedErrorPrefix, reloadErr)}
+	}
 	return nil
 }
 

--- a/daemon/task_rpc_test.go
+++ b/daemon/task_rpc_test.go
@@ -135,6 +135,72 @@ func TestControlUpdateTask_PostCommitFailureStillPublishes(t *testing.T) {
 	}
 }
 
+func TestControlAddTask_PostCommitFailureStillPublishes(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	ready := make(chan struct{})
+	close(ready)
+	manager := &Manager{events: newEventsHub(), ready: ready}
+	_, events := manager.events.subscribe()
+	srv := &controlServer{
+		manager:   manager,
+		scheduler: failingReloadTaskScheduler(),
+	}
+	created := enabledCronTask("bbbb0099", "")
+
+	var resp AddTaskResponse
+	err := srv.AddTask(AddTaskRequest{Task: created}, &resp)
+	stored, getErr := task.GetTask(created.ID)
+	require.NoError(t, getErr)
+	assert.Equal(t, created.ID, stored.ID)
+
+	select {
+	case event := <-events:
+		require.Equal(t, agentproto.EventTaskCreated, event.Type)
+		var got task.Task
+		require.NoError(t, json.Unmarshal(event.Data, &got))
+		assert.Equal(t, created.ID, got.ID)
+	default:
+		t.Fatal("committed task create was not published before the post-commit error returned")
+	}
+	require.ErrorContains(t, err, "task add committed")
+	var committed *mutationCommittedError
+	require.ErrorAs(t, err, &committed)
+	assert.True(t, resp.OK, "the response must acknowledge the durable commit")
+}
+
+func TestControlRemoveTask_PostCommitFailureStillPublishes(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	removed := enabledCronTask("dddd0099", "")
+	require.NoError(t, task.AddTask(removed))
+	ready := make(chan struct{})
+	close(ready)
+	manager := &Manager{events: newEventsHub(), ready: ready}
+	_, events := manager.events.subscribe()
+	srv := &controlServer{
+		manager:   manager,
+		scheduler: failingReloadTaskScheduler(),
+	}
+
+	var resp RemoveTaskResponse
+	err := srv.RemoveTask(RemoveTaskRequest{ID: removed.ID}, &resp)
+	_, getErr := task.GetTask(removed.ID)
+	require.Error(t, getErr, "the task must remain durably removed")
+
+	select {
+	case event := <-events:
+		require.Equal(t, agentproto.EventTaskRemoved, event.Type)
+		var got task.Task
+		require.NoError(t, json.Unmarshal(event.Data, &got))
+		assert.Equal(t, removed.ID, got.ID)
+	default:
+		t.Fatal("committed task removal was not published before the post-commit error returned")
+	}
+	require.ErrorContains(t, err, "task removal committed")
+	var committed *mutationCommittedError
+	require.ErrorAs(t, err, &committed)
+	assert.True(t, resp.OK, "the response must acknowledge the durable commit")
+}
+
 // TestControlRemoveTask_WritesAndDisarms pins that RemoveTask deletes the task
 // and drops it from the scheduler in the same call.
 func TestControlRemoveTask_WritesAndDisarms(t *testing.T) {

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -13228,6 +13228,12 @@ function openAddTask() {
           closeModal();
           refreshTasks();
         }).catch((e) => {
+          if (isMutationCommittedError(e)) {
+            closeModal();
+            refreshTasks();
+            surfaceTabError(e);
+            return;
+          }
           m.setBusy(false);
           m.setError(errorText(e));
         });

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "210be27a4eaa";
+const VERSION = "1d42b52a2fde";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -2889,6 +2889,46 @@ test("#2381: the manual-trigger fixture cannot also fire from its cron during th
   }
 });
 
+test("#2588: a committed add refreshes and warns instead of inviting a duplicate", REAL_FIXTURE, async () => {
+  let listCalls = 0;
+  await page.route("**/v1/ListTasks", async (route) => {
+    listCalls += 1;
+    await route.continue();
+  });
+  await page.route("**/v1/AddTask", async (route) => {
+    await route.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: null,
+        error: { message: "task was saved, but scheduler reload failed", code: "mutation_committed" },
+      }),
+    });
+  });
+
+  try {
+    await page.locator('.af-viewtab[data-view="tasks"]').click();
+    const tasks = page.locator(".af-tasks");
+    await tasks.locator(".af-tasks-add").click();
+    const modal = page.locator(".af-modal-card");
+    await modal.locator('input[aria-label="Task name"]').fill("committed-add-probe");
+    await setCustomCron(modal, manualTriggerFixtureCron(new Date()));
+    await modal.locator('textarea[aria-label="Prompt"]').fill("echo committed");
+
+    const beforeSubmit = listCalls;
+    await modal.locator("button.af-primary").click();
+
+    await expect(modal, "a committed add must leave the retryable create form").toBeHidden();
+    await expect.poll(() => listCalls, { message: "a committed add must refresh the task projection" }).toBeGreaterThan(
+      beforeSubmit,
+    );
+    await expect(page.locator(".af-toast")).toContainText("scheduler reload failed");
+  } finally {
+    await page.unroute("**/v1/AddTask");
+    await page.unroute("**/v1/ListTasks");
+  }
+});
+
 test("tasks view (#1592 PR8): list the seeded task; add / trigger / remove round-trips", REAL_FIXTURE, async () => {
   // Capture the task-mutation request bodies so we can prove every mutation carries
   // the STABLE task id — the add mints it client-side, and trigger/remove must send

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -1304,6 +1304,12 @@ function openAddTask(): void {
             refreshTasks();
           })
           .catch((e) => {
+            if (isMutationCommittedError(e)) {
+              closeModal();
+              refreshTasks();
+              surfaceTabError(e);
+              return;
+            }
             m.setBusy(false);
             m.setError(errorText(e));
           });


### PR DESCRIPTION
## Summary

- publish `task.created` and `task.removed` at the durable task-file commit boundary
- classify a later scheduler/watcher reload failure as a machine-readable committed outcome across net/rpc
- make web, TUI, and CLI callers accept and refresh committed Add/Update/Remove changes while separately surfacing the reload warning
- add regressions at the daemon, transport, API, TUI, and browser boundaries

## Design decision

The durable task-file commit and the schedule notification cannot be made genuinely atomic with the current architecture. Scheduler and watcher reloads mutate in-process/external runtime state and can partially succeed; rolling the task file back afterward would be another fallible mutation and could make the result unknowable.

This change therefore applies the established UpdateTask contract consistently: once disk commits, publish the durable value, mark the RPC response committed, and return a typed committed outcome if refresh fails. The change is reported as successful-but-degraded, never as a retryable failed mutation.

## Adjacent call-site audit

- Daemon AddTask, UpdateTask, and RemoveTask now share the same durable-commit/event/reload ordering.
- The net/rpc client only reclassifies exact server-owned method/error-prefix pairs; wrong methods, wrong prefixes, and non-server errors remain unknown.
- Web Add now joins the already committed-aware update/toggle/remove paths.
- TUI create and remove now join its committed-aware update path.
- CLI add, update, and remove all accept committed outcomes; update reads the durable task back because net/rpc discards response bodies on errors.
- ReloadTasks does not mutate storage; RestartTask and TriggerTask have different commit boundaries.

## Red regressions

Observed before the production changes:

```
--- FAIL: TestControlAddTask_PostCommitFailureStillPublishes (0.00s)
    task_rpc_test.go:163: committed task create was not published before the post-commit error returned
--- FAIL: TestControlRemoveTask_PostCommitFailureStillPublishes (0.01s)
    task_rpc_test.go:196: committed task removal was not published before the post-commit error returned
FAIL
```

Caller and transport regressions were also watched red before their fixes:

```
--- FAIL: TestHandleTaskCreate_CommittedReloadFailureRefreshesAndWarns
    handle_overlay_test.go:651: "[]" should have 1 item(s), but has 0
    ... a committed add must refresh the TUI instead of leaving a retryable form
--- FAIL: TestTasksAdd_CommittedReloadFailureIsNotRetryable
    Received unexpected error:
      failed to add task: scheduler reload failed after commit
--- FAIL: TestTasksRemove_CommittedReloadFailureIsNotRetryable
    Received unexpected error:
      failed to remove task: scheduler reload failed after commit
--- FAIL: TestControlClientPreservesMutationCommittedOutcome
    ... must preserve ...: rpc.ServerError: task add committed, but failed to reload task schedules: simulated
--- FAIL: TestSaveContentPaneState_CommittedRemovalRefreshesAndWarns
    "failed to remove task \"remove me\": scheduler reload failed after commit"
    does not contain "was removed, but the daemon could not refresh its schedules"
```

The browser regression likewise failed before the source and committed bundle were fixed:

```
Error: a committed add must leave the retryable create form
expect(locator).toBeHidden() failed
Locator: .af-modal-card
Expected: hidden
Received: visible
Timeout: 15000ms
```

## Validation

Validated pushed head `8a59e89827df63d5b982e4545c992b2621b3e600`:

- `GOTOOLCHAIN=go1.25.0 golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (empty)
- `GOTOOLCHAIN=go1.25.0 go build ./...`
- `GOTOOLCHAIN=go1.25.0 deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `GOTOOLCHAIN=go1.25.0 make web-build` (committed bundle byte-clean afterward)
- `GOTOOLCHAIN=go1.25.0 make web-test` (455 tests)
- `GOTOOLCHAIN=go1.25.0 make web-selftest-container` (126/126)
- focused daemon, transport, API, and TUI regressions in isolated `make test-container` runs
- `GOTOOLCHAIN=go1.25.0 make test-container` (full suite, run last against the pushed head)

GitHub CI is also terminal green on this head (16 checks; Deploy is expected-skipped).

Closes #2588