### PR TITLE
fix(config): validate lock file identity after flock

### DIFF
--- a/config/filelock.go
+++ b/config/filelock.go
@@ -40,6 +40,13 @@ func TryWithFileLock(path string, fn func() error) (acquired bool, err error) {
 		return false, fmt.Errorf("failed to acquire file lock on %s: %w", lockPath, err)
 	}
 	defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	current, err := lockFileIsCurrent(f, lockPath)
+	if err != nil {
+		return false, fmt.Errorf("failed to validate file lock on %s: %w", lockPath, err)
+	}
+	if !current {
+		return false, fmt.Errorf("file lock on %s was replaced while acquiring it", lockPath)
+	}
 
 	return true, fn()
 }
@@ -65,8 +72,10 @@ var ErrLockTimeout = errors.New("timed out waiting for file lock")
 // no timed acquire: a blocking Flock cannot be interrupted or given a deadline.
 // Polling costs a wakeup every lockPollInterval while contended and trades away
 // flock's (already unspecified) queueing fairness; the caller's budget bounds how
-// long that lasts. The fd is opened ONCE and reused across attempts so a
-// contended retry does not churn the lock file.
+// long that lasts. A contended fd is reused across polling attempts, then its
+// identity is compared with the lock path after acquisition. If the path was
+// replaced while waiting, the stale inode is unlocked and the current path is
+// opened before retrying.
 func WithFileLockTimeout(path string, timeout time.Duration, fn func() error) error {
 	lockPath := path + ".lock"
 
@@ -74,32 +83,49 @@ func WithFileLockTimeout(path string, timeout time.Duration, fn func() error) er
 		return fmt.Errorf("failed to create lock directory: %w", err)
 	}
 
-	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
-	if err != nil {
-		return fmt.Errorf("failed to open lock file %s: %w", lockPath, err)
-	}
-	defer f.Close()
-
 	deadline := time.Now().Add(timeout)
 	for {
-		err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
-		if err == nil {
-			defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
-			return fn()
+		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+		if err != nil {
+			return fmt.Errorf("failed to open lock file %s: %w", lockPath, err)
 		}
-		if !errors.Is(err, syscall.EWOULDBLOCK) {
-			return fmt.Errorf("failed to acquire file lock on %s: %w", lockPath, err)
+		for {
+			err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+			if err == nil {
+				current, validateErr := lockFileIsCurrent(f, lockPath)
+				if validateErr != nil {
+					_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+					_ = f.Close()
+					return fmt.Errorf("failed to validate file lock on %s: %w", lockPath, validateErr)
+				}
+				if current {
+					defer f.Close()
+					defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+					return fn()
+				}
+				_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+				_ = f.Close()
+				if !time.Now().Before(deadline) {
+					return fmt.Errorf("%w on %s after %s (lock file was replaced while waiting)", ErrLockTimeout, lockPath, timeout)
+				}
+				break
+			}
+			if !errors.Is(err, syscall.EWOULDBLOCK) {
+				_ = f.Close()
+				return fmt.Errorf("failed to acquire file lock on %s: %w", lockPath, err)
+			}
+			if !time.Now().Before(deadline) {
+				_ = f.Close()
+				return fmt.Errorf("%w on %s after %s (another agent-factory process is holding it)", ErrLockTimeout, lockPath, timeout)
+			}
+			// Sleep no longer than the remaining budget, so the effective wait
+			// matches the caller's timeout instead of overshooting by up to a poll.
+			wait := lockPollInterval
+			if remaining := time.Until(deadline); remaining < wait {
+				wait = remaining
+			}
+			time.Sleep(wait)
 		}
-		if !time.Now().Before(deadline) {
-			return fmt.Errorf("%w on %s after %s (another agent-factory process is holding it)", ErrLockTimeout, lockPath, timeout)
-		}
-		// Sleep no longer than the remaining budget, so the effective wait
-		// matches the caller's timeout instead of overshooting by up to a poll.
-		wait := lockPollInterval
-		if remaining := time.Until(deadline); remaining < wait {
-			wait = remaining
-		}
-		time.Sleep(wait)
 	}
 }
 
@@ -120,18 +146,44 @@ func WithFileLock(path string, fn func() error) error {
 		return fmt.Errorf("failed to create lock directory: %w", err)
 	}
 
-	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	for {
+		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+		if err != nil {
+			return fmt.Errorf("failed to open lock file %s: %w", lockPath, err)
+		}
+		if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+			_ = f.Close()
+			return fmt.Errorf("failed to acquire file lock on %s: %w", lockPath, err)
+		}
+		current, validateErr := lockFileIsCurrent(f, lockPath)
+		if validateErr != nil {
+			_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+			_ = f.Close()
+			return fmt.Errorf("failed to validate file lock on %s: %w", lockPath, validateErr)
+		}
+		if current {
+			defer f.Close()
+			defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+			return fn()
+		}
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}
+}
+
+func lockFileIsCurrent(f *os.File, lockPath string) (bool, error) {
+	openedInfo, err := f.Stat()
 	if err != nil {
-		return fmt.Errorf("failed to open lock file %s: %w", lockPath, err)
+		return false, err
 	}
-	defer f.Close()
-
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
-		return fmt.Errorf("failed to acquire file lock on %s: %w", lockPath, err)
+	pathInfo, err := os.Stat(lockPath)
+	if os.IsNotExist(err) {
+		return false, nil
 	}
-	defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
-
-	return fn()
+	if err != nil {
+		return false, err
+	}
+	return os.SameFile(openedInfo, pathInfo), nil
 }
 
 // AtomicWriteFile writes data to a temporary file in the same directory as path

--- a/config/filelock_replacement_linux_test.go
+++ b/config/filelock_replacement_linux_test.go
@@ -1,0 +1,117 @@
+//go:build linux
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileLockWaitersDoNotEnterThroughReplacedLockFile(t *testing.T) {
+	tests := []struct {
+		name string
+		wait func(string, func() error) error
+	}{
+		{
+			name: "blocking",
+			wait: WithFileLock,
+		},
+		{
+			name: "timeout",
+			wait: func(path string, fn func() error) error {
+				return WithFileLockTimeout(path, 2*time.Second, fn)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "state.json")
+			lockPath := path + ".lock"
+			oldLock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+			require.NoError(t, err)
+			require.NoError(t, syscall.Flock(int(oldLock.Fd()), syscall.LOCK_EX))
+			var releaseOld sync.Once
+			releaseOldLock := func() {
+				releaseOld.Do(func() {
+					_ = syscall.Flock(int(oldLock.Fd()), syscall.LOCK_UN)
+					_ = oldLock.Close()
+				})
+			}
+			t.Cleanup(releaseOldLock)
+
+			oldInfo, err := oldLock.Stat()
+			require.NoError(t, err)
+			waiterEntered := make(chan struct{})
+			waiterDone := make(chan error, 1)
+			go func() {
+				waiterDone <- tt.wait(path, func() error {
+					close(waiterEntered)
+					return nil
+				})
+			}()
+
+			require.Eventually(t, func() bool {
+				return openFileDescriptions(t, oldInfo) >= 2
+			}, time.Second, 10*time.Millisecond,
+				"the waiter must have opened the old lock inode before it is replaced")
+
+			require.NoError(t, os.Remove(lockPath))
+			currentEntered := make(chan struct{})
+			releaseCurrent := make(chan struct{})
+			var releaseCurrentOnce sync.Once
+			releaseCurrentLock := func() { releaseCurrentOnce.Do(func() { close(releaseCurrent) }) }
+			t.Cleanup(releaseCurrentLock)
+			currentDone := make(chan error, 1)
+			go func() {
+				currentDone <- WithFileLock(path, func() error {
+					close(currentEntered)
+					<-releaseCurrent
+					return nil
+				})
+			}()
+
+			select {
+			case <-currentEntered:
+			case <-time.After(time.Second):
+				t.Fatal("replacement lock holder did not enter its critical section")
+			}
+			releaseOldLock()
+
+			select {
+			case <-waiterEntered:
+				t.Error("waiter entered through the stale inode while the replacement lock was held")
+			case <-time.After(100 * time.Millisecond):
+			}
+
+			releaseCurrentLock()
+			select {
+			case <-waiterEntered:
+			case <-time.After(time.Second):
+				t.Fatal("waiter did not acquire the current lock after it was released")
+			}
+			require.NoError(t, <-currentDone)
+			require.NoError(t, <-waiterDone)
+		})
+	}
+}
+
+func openFileDescriptions(t *testing.T, want os.FileInfo) int {
+	t.Helper()
+	entries, err := os.ReadDir("/proc/self/fd")
+	require.NoError(t, err)
+	count := 0
+	for _, entry := range entries {
+		info, err := os.Stat(filepath.Join("/proc/self/fd", entry.Name()))
+		if err == nil && os.SameFile(info, want) {
+			count++
+		}
+	}
+	return count
+}


### PR DESCRIPTION
## Summary
- validate that the flocked file handle still matches the lock path before entering a critical section
- reopen and retry the current inode for blocking and timed locks when replacement is detected
- return an explicit error from the nonblocking try-lock when identity changes, preserving the indeterminate outcome
- keep replacement retries within the timed acquisition budget

## Diagnosis and adjacent audit
Verified the report against the current implementation: a timed waiter reused one descriptor while polling and entered its critical section after that inode had been unlinked and replaced. The blocking lock has the same queued-stale-descriptor path, and the nonblocking lock has a smaller open-to-flock replacement window. All three config lock APIs now validate identity after acquisition. The existing upgrade transaction lock already performs equivalent post-flock identity validation and needed no change.

## Regression evidence
The regression waits until `/proc/self/fd` proves each waiter has opened the old inode, replaces the path, acquires the replacement lock, and then releases the old inode. Before the fix both waiters entered concurrently:

```
--- FAIL: TestFileLockWaitersDoNotEnterThroughReplacedLockFile/blocking (0.01s)
    filelock_replacement_linux_test.go:89: waiter entered through the stale inode while the replacement lock was held
--- FAIL: TestFileLockWaitersDoNotEnterThroughReplacedLockFile/timeout (0.02s)
    filelock_replacement_linux_test.go:89: waiter entered through the stale inode while the replacement lock was held
```

After the fix:

```
ok github.com/sachiniyer/agent-factory/config 0.244s
```

## Validation
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container`

The full container suite passed last against pushed SHA `22218bcc59fb5804cdf381703fde5d4e14e0a943`.

Closes #2593