### PR TITLE
fix: anchor Amp readiness on its frame prefix

### DIFF
--- a/task/amp_ready_test.go
+++ b/task/amp_ready_test.go
@@ -19,8 +19,8 @@ import (
 // escape wraps the repo/branch on the bottom rule. Those escapes sit between the
 // box-drawing glyphs, so the old box regex never matched in the wild — amp creates
 // spun the full readiness timeout. The fix strips escapes first, then requires the
-// labeled top rule AND the closing bottom rule, so the real ready frame matches and
-// the blank loading pane / "Welcome to Amp" banner do not.
+// frame's invariant top prefix AND closing bottom rule, so the real ready frame
+// matches and the blank loading pane / "Welcome to Amp" banner do not.
 func TestIsAmpPromptFrameRealCapture(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -55,7 +55,7 @@ func TestIsAmpPromptFrameRealCapture(t *testing.T) {
 }
 
 // TestIsAmpPromptFrameRequiresBothRules guards the strictness the old comment
-// asked for: a labeled top rule alone (a partial redraw, or the box top scrolled
+// asked for: a top rule alone (a partial redraw, or the box top scrolled
 // into stale scrollback) is not "accepting input" until the closing bottom rule is
 // also present. Built from the real capture so the ANSI handling is exercised too.
 func TestIsAmpPromptFrameRequiresBothRules(t *testing.T) {
@@ -76,14 +76,14 @@ func TestIsAmpPromptFrameRequiresBothRules(t *testing.T) {
 	}
 
 	if isAmpPromptFrame(joinLines(topOnly)) {
-		t.Error("labeled top rule without the bottom rule must not count as ready")
+		t.Error("top rule without the bottom rule must not count as ready")
 	}
 	if isAmpPromptFrame(joinLines(bottomOnly)) {
-		t.Error("bottom rule without the labeled top rule must not count as ready")
+		t.Error("bottom rule without the top rule must not count as ready")
 	}
 }
 
-// TestIsAmpPromptFrameRequiresContiguousBox pins Greptile P2: the labeled top rule
+// TestIsAmpPromptFrameRequiresContiguousBox pins Greptile P2: the top rule
 // and the closing bottom rule must belong to ONE adjacent box. Separated fragments
 // — an old frame's top border left in scrollback, unrelated output, then a bottom
 // border — must not read as ready; one contiguous current box must.
@@ -102,6 +102,27 @@ func TestIsAmpPromptFrameRequiresContiguousBox(t *testing.T) {
 		"╰──────── /tmp/repo (main) ────────╯\n"
 	if !isAmpPromptFrame(live) {
 		t.Error("a contiguous current amp prompt box must count as ready")
+	}
+}
+
+// TestIsAmpPromptFrameIgnoresModeLabel pins the rendered protocol boundary:
+// Amp owns the text embedded in the prompt frame's top rule and can add, rename,
+// or override modes independently of af. Readiness therefore anchors on the
+// invariant frame prefix and contiguous box shape, never a mode vocabulary.
+func TestIsAmpPromptFrameIgnoresModeLabel(t *testing.T) {
+	for _, label := range []string{"ultra", "backend-defined-mode"} {
+		t.Run(label, func(t *testing.T) {
+			content := "╭──────── " + label + " ────────╮\n" +
+				"│ >                                        │\n" +
+				"│                                          │\n" +
+				"╰──────── /tmp/repo (main) ────────╯\n"
+			if !isAmpPromptFrame(content) {
+				t.Fatalf("a contiguous Amp prompt frame with label %q must count as ready", label)
+			}
+			if !isReadyContent(content, "amp") {
+				t.Fatalf("WaitForReady seam rejected Amp prompt frame label %q", label)
+			}
+		})
 	}
 }
 

--- a/task/runner.go
+++ b/task/runner.go
@@ -42,16 +42,16 @@ var (
 	// indicator strings are NOT contiguous in a raw capture either and must be
 	// matched on the stripped skeleton for the same reason.
 	paneAnsiEscape = regexp.MustCompile("\x1b\\[[0-9;?]*[ -/]*[@-~]|\x1b\\][^\x07\x1b]*(?:\x07|\x1b\\\\)")
-	// ampPromptFrameTop matches the top rule of amp's input-prompt frame: a
-	// box-drawing top run carrying the mode label near its right end, e.g.
-	// "╭──── medium ────╮" (matched after ANSI stripping). The left side is
-	// tolerant of decorations amp interleaves into the rule (e.g. a "$0.06" cost
-	// indicator once a turn has spent tokens: "╭──── $0.06 ─ medium ─╮"), so the
-	// match keeps working across those format variants; the mode label followed
-	// by the closing "─╮" is the stable anchor.
-	ampPromptFrameTop = regexp.MustCompile(`╭[─ ].*[─ ](low|medium|high|deep)[─ ]+╮`)
+	// ampPromptFrameTop matches the invariant rendered prefix of amp's
+	// input-prompt frame (after ANSI stripping): a top-left corner immediately
+	// followed by its horizontal rule. Text embedded later in that rule is owned
+	// by amp — mode names and decorations have both changed — so it is deliberately
+	// NOT part of the protocol. The contiguous interior + bottom-rule walk below
+	// supplies the strictness that excludes banners, loading panes, and stale
+	// fragments.
+	ampPromptFrameTop = regexp.MustCompile(`^\s*╭─`)
 	// ampPromptFrameBottom matches the bottom rule of the same frame, which carries
-	// the repo/branch, e.g. "╰──── repo (branch) ────╯". Requiring BOTH the labeled
+	// the repo/branch, e.g. "╰──── repo (branch) ────╯". Requiring BOTH the anchored
 	// top and the closing bottom confirms the input box fully rendered and is
 	// accepting input — it excludes amp's blank loading pane and its "Welcome to
 	// Amp" banner, neither of which draws the box (the reason the match is strict).
@@ -241,7 +241,7 @@ func isReadyContent(content, agent string) bool {
 // accepting-input state. amp colorizes the frame, so the ANSI escapes are stripped
 // first (see ampAnsiEscape).
 //
-// Readiness requires a CONTIGUOUS frame: a labeled top rule, immediately followed
+// Readiness requires a CONTIGUOUS frame: the anchored top rule, immediately followed
 // by the box-interior rows (each a "│ … │" line) and then the closing bottom rule,
 // with no other line in between. Matching the top and bottom rules independently
 // anywhere in the pane would let an old top border in scrollback pair with a newer
@@ -272,7 +272,7 @@ func isAmpPromptFrame(content string) bool {
 // questions: "is opencode accepting input?" is whether the frame exists at all,
 // and "is opencode mid-turn?" is what the status bar BELOW that frame says.
 //
-// opencode's composer has no labeled top rule (unlike amp's "╭──── medium ────╮"),
+// opencode's composer has no top rule (unlike amp's "╭──── medium ────╮"),
 // so the walk anchors on the distinctive bottom rule and steps UP one line: a real
 // composer always has a "┃" box-interior row directly above its rule. Requiring
 // that pairing rather than matching a lone "╹" anywhere excludes stray glyphs.
@@ -321,13 +321,13 @@ func ampFrameBottomRule(content string) (string, bool) {
 		if !ampPromptFrameTop.MatchString(line) {
 			continue
 		}
-		// Walk downward from the labeled top rule: box-interior rows begin with
+		// Walk downward from the anchored top rule: box-interior rows begin with
 		// the "│" border, and a bottom rule closes a contiguous box. Any other line
 		// before the bottom rule means these borders are not one box, so this top
 		// rule is stale scrollback — keep scanning.
 		//
 		// Keep the LAST such frame, not the first: agent output can quote a
-		// complete frame (labeled top rule, "│" interior, bottom rule) above the
+		// complete frame (top rule, "│" interior, bottom rule) above the
 		// live one, so the CURRENT frame is the bottom-most complete pairing, never
 		// the first — returning the first pinned an idle session at Running when the
 		// quoted rule read as working (#2439). opencodeFrameLines tracks its last


### PR DESCRIPTION
Closes #2657

## Root cause

Amp readiness detection treated the mode label embedded in the prompt-frame border as part of af's protocol. The matcher enumerated `low|medium|high|deep`, so current `ultra` frames—and any future or backend-defined label—never reached ready and waited for the 60-second timeout.

## Fix

Anchor readiness on Amp's invariant rendered frame prefix, `╭─`, after ANSI stripping. Keep the existing contiguous box walk (top rule, interior rows, bottom rule) as the structural proof that the current prompt is fully rendered and accepting input.

The embedded mode/decorative text is deliberately ignored because Amp owns and can override that vocabulary.

## Adjacent detector audit

Amp's working-state detector already keys on the structural presence of a status segment rather than enumerating verbs. OpenCode readiness/working detection likewise uses invariant frame glyphs and status anchors. No adjacent detector repeats this backend-label enumeration.

## Fail-first regression

On unmodified master `b320e24c`, the new protocol-boundary test failed for both current `ultra` and a backend-defined label:

```text
--- FAIL: TestIsAmpPromptFrameIgnoresModeLabel/ultra
    a contiguous Amp prompt frame with label "ultra" must count as ready
--- FAIL: TestIsAmpPromptFrameIgnoresModeLabel/backend-defined-mode
    a contiguous Amp prompt frame with label "backend-defined-mode" must count as ready
```

The existing real ANSI captures, cost-decorated frame, loading pane, welcome banner, partial-frame, and stale-fragment cases remain green.

## Validation

All required gates are green on pushed head `8a454702f36f50ad94ca58368552dca2d437ee54`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container` (full suite; daemon 240.162s, integration 77.568s, tmux 99.397s, task 4.540s)

No host daemon suite, daemon restart, dev install, real daemon mutation, or unisolated tmux teardown was used.