### PR TITLE
fix(ssh): preserve host-key posture for restart cleanup

### DIFF
--- a/session/backend_ssh.go
+++ b/session/backend_ssh.go
@@ -268,9 +268,10 @@ func (p *sshProvisioner) provision() (ProvisionResult, error) {
 			remoteAgentBackend: remoteAgentBackend{reap: teardown},
 			provisioner:        p,
 			cleanup: &SSHRuntimeCleanupData{
-				Config:     p.cfg,
-				SessionDir: p.sessionDir,
-				RemotePID:  p.remotePID,
+				Config:              p.cfg,
+				SessionDir:          p.sessionDir,
+				RemotePID:           p.remotePID,
+				HostKeyVerification: p.hostKeyVerification,
 			},
 		},
 		Endpoint: endpoint,

--- a/session/runtime_cleanup.go
+++ b/session/runtime_cleanup.go
@@ -32,9 +32,10 @@ type DockerRuntimeCleanupData struct {
 }
 
 type SSHRuntimeCleanupData struct {
-	Config     config.SSHConfig `json:"config"`
-	SessionDir string           `json:"session_dir"`
-	RemotePID  string           `json:"remote_pid,omitempty"`
+	Config              config.SSHConfig `json:"config"`
+	SessionDir          string           `json:"session_dir"`
+	RemotePID           string           `json:"remote_pid,omitempty"`
+	HostKeyVerification string           `json:"host_key_verification,omitempty"`
 }
 
 type HookRuntimeCleanupData struct {
@@ -164,10 +165,11 @@ func restoreRuntimeCleanup(title, backendType string, data *RuntimeCleanupData) 
 		}
 		cleanup := *data.SSH
 		p := &sshProvisioner{
-			spec:       ProvisionSpec{Title: title},
-			cfg:        data.SSH.Config,
-			sessionDir: data.SSH.SessionDir,
-			remotePID:  data.SSH.RemotePID,
+			spec:                ProvisionSpec{Title: title},
+			cfg:                 data.SSH.Config,
+			hostKeyVerification: data.SSH.HostKeyVerification,
+			sessionDir:          data.SSH.SessionDir,
+			remotePID:           data.SSH.RemotePID,
 		}
 		teardown := p.reap
 		return &sshBackend{

--- a/session/runtime_cleanup_test.go
+++ b/session/runtime_cleanup_test.go
@@ -183,10 +183,11 @@ func TestHookCleanupHandlePreservesResolvedNoAgent(t *testing.T) {
 // the retained row while leaving its remote process and directory behind.
 func TestSSHCleanupHandleSurvivesTombstoneRoundTrip(t *testing.T) {
 	p := &sshProvisioner{
-		spec:       ProvisionSpec{Title: "restart-reap"},
-		cfg:        config.SSHConfig{Host: "cleanup.example.test", User: "remote"},
-		sessionDir: "/home/remote/.af-sessions/restart-reap.1234",
-		remotePID:  "4242",
+		spec:                ProvisionSpec{Title: "restart-reap"},
+		cfg:                 config.SSHConfig{Host: "cleanup.example.test", User: "remote"},
+		hostKeyVerification: config.SSHHostKeyAcceptNew,
+		sessionDir:          "/home/remote/.af-sessions/restart-reap.1234",
+		remotePID:           "4242",
 	}
 	teardown := p.reap
 	inst := &Instance{
@@ -197,9 +198,10 @@ func TestSSHCleanupHandleSurvivesTombstoneRoundTrip(t *testing.T) {
 			remoteAgentBackend: remoteAgentBackend{reap: teardown},
 			provisioner:        p,
 			cleanup: &SSHRuntimeCleanupData{
-				Config:     p.cfg,
-				SessionDir: p.sessionDir,
-				RemotePID:  p.remotePID,
+				Config:              p.cfg,
+				SessionDir:          p.sessionDir,
+				RemotePID:           p.remotePID,
+				HostKeyVerification: p.hostKeyVerification,
 			},
 		},
 		runtimeTeardown: teardown,
@@ -226,6 +228,9 @@ func TestSSHCleanupHandleSurvivesTombstoneRoundTrip(t *testing.T) {
 	}
 	if !strings.Contains(string(raw), "runtime_cleanup") {
 		t.Fatalf("kill tombstone omitted its durable cleanup handle: %s", raw)
+	}
+	if !strings.Contains(string(raw), `"host_key_verification":"accept-new"`) {
+		t.Fatalf("kill tombstone omitted the SSH host-key posture needed to reuse the af-owned known_hosts store after restart: %s", raw)
 	}
 	// The live attempt sends the identity-guarded kill, then loses certainty while
 	// removing the directory. The raw tombstone above is what a daemon restart
@@ -261,6 +266,9 @@ func TestSSHCleanupHandleSurvivesTombstoneRoundTrip(t *testing.T) {
 		t.Fatalf("restored backend has no SSH reaper: %T", restored.backend)
 	}
 	restoredP := restoredBackend.provisioner
+	if restoredP.hostKeyVerification != config.SSHHostKeyAcceptNew {
+		t.Fatalf("restored SSH cleanup posture = %q, want %q", restoredP.hostKeyVerification, config.SSHHostKeyAcceptNew)
+	}
 	restoredP.client = &ssh.Client{}
 	var killCalls, rmCalls int
 	restoredP.reapRunKill = func(_ time.Duration, script string) (bool, error) {
@@ -283,6 +291,29 @@ func TestSSHCleanupHandleSurvivesTombstoneRoundTrip(t *testing.T) {
 	}
 	if killCalls != 1 || rmCalls != 1 {
 		t.Fatalf("restored cleanup work: kill=%d rm=%d, want 1/1", killCalls, rmCalls)
+	}
+}
+
+func TestLegacySSHCleanupHandleDefaultsHostKeyVerificationToStrict(t *testing.T) {
+	missingKnownHosts := filepath.Join(t.TempDir(), "missing-known-hosts")
+	backend, _, err := restoreRuntimeCleanup("legacy-ssh-cleanup", "ssh", &RuntimeCleanupData{
+		SSH: &SSHRuntimeCleanupData{
+			Config:     config.SSHConfig{Host: "legacy.example.test", KnownHosts: missingKnownHosts},
+			SessionDir: "/srv/af/legacy",
+		},
+	})
+	if err != nil {
+		t.Fatalf("restore legacy SSH cleanup: %v", err)
+	}
+	sshBackend, ok := backend.(*sshBackend)
+	if !ok || sshBackend.provisioner == nil {
+		t.Fatalf("restored backend has no SSH provisioner: %T", backend)
+	}
+	if _, err := sshBackend.provisioner.hostKeyCallback(); err == nil {
+		t.Fatal("legacy cleanup without a stored posture did not default to strict; strict must refuse a missing known_hosts file")
+	}
+	if _, err := os.Stat(missingKnownHosts); !os.IsNotExist(err) {
+		t.Fatalf("legacy strict fallback created an accept-new host-key store: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- persist the provision-time SSH host-key verification posture in kill tombstones
- restore that posture into the SSH reaper after a daemon restart
- retain strict fail-closed behavior for legacy tombstones without the new field

## Root cause

#2565 made `ssh_host_key_verification=accept-new` learn keys in an af-owned store, but the durable SSH cleanup handle stored only SSH config, remote directory, and PID. After restart, the restored `sshProvisioner` therefore had an empty posture and fell through to strict mode, which consulted a different default known_hosts path and could retry the tombstone forever.

## Legacy records

Pre-fix tombstones still have no stored posture and deliberately remain strict; the code does not infer the weaker `accept-new` policy from an absent field. If the host key is available only in the af-owned accept-new store, cleanup cannot determine that the remote workspace was reaped, so it retains the record and retries on every daemon status poll (1s by default), logging the failed reconnect and the retained-record retry. This PR fixes tombstones created after the patch; an already-stuck legacy tombstone is not migrated automatically.

## Red first

The restart round-trip regression failed against `b320e24cbe57750756fe76fc7740f6ef40ff5694`:

```text
--- FAIL: TestSSHCleanupHandleSurvivesTombstoneRoundTrip (0.00s)
    runtime_cleanup_test.go:232: kill tombstone omitted the SSH host-key posture needed to reuse the af-owned known_hosts store after restart: { ... "runtime_cleanup":{"ssh":{"config":{"host":"cleanup.example.test","user":"remote"},"session_dir":"/home/remote/.af-sessions/restart-reap.1234","remote_pid":"4242"}}}
```

## Validation

Validated pushed head `bb6537fd71f0dc69bea3cbdc0b1a8c065214f5ff`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container`

Closes #2658