### PR TITLE
Secure tmux ownership marker parsing

### DIFF
--- a/session/tmux/cleanup_bug_test.go
+++ b/session/tmux/cleanup_bug_test.go
@@ -95,6 +95,7 @@ af_theirs: 1 windows (created Wed May 20 12:01:00 2026) [179x47]
 af_legacy: 1 windows (created Wed May 20 12:02:00 2026) [179x47]`
 
 	var killedSessions []string
+	missingMarkerErr := tmuxMissingEnvironmentError(t)
 	cmdExec := cmd_test.MockCmdExec{
 		RunFunc: func(cmd *exec.Cmd) error {
 			for i, arg := range cmd.Args {
@@ -112,8 +113,11 @@ af_legacy: 1 windows (created Wed May 20 12:02:00 2026) [179x47]`
 				case strings.Contains(strings.Join(cmd.Args, " "), "af_theirs"):
 					return []byte("AF_HOME=/another-home\n"), nil
 				default:
-					// Unfiltered show-environment authoritatively represents a
-					// missing marker by succeeding without an AF_HOME line.
+					if cmd.Args[len(cmd.Args)-1] == EnvMarkerHome {
+						return nil, missingMarkerErr
+					}
+					// The unfiltered fallback authoritatively represents a missing
+					// marker by succeeding; its contents are never authorization.
 					return []byte("PATH=/usr/bin\n"), nil
 				}
 			}
@@ -125,4 +129,14 @@ af_legacy: 1 windows (created Wed May 20 12:02:00 2026) [179x47]`
 	require.NoError(t, err)
 	require.Equal(t, []string{"=af_mine:"}, killedSessions,
 		"only the session carrying this home's AF_HOME marker may be killed; foreign-home and marker-less sessions must survive (#1122)")
+}
+
+func tmuxMissingEnvironmentError(t *testing.T) error {
+	t.Helper()
+	cmd := exec.Command("sh", "-c", "printf 'unknown variable: AF_HOME\\n' >&2; exit 1")
+	_, err := cmd.Output()
+	if err == nil {
+		t.Fatal("missing-variable command unexpectedly succeeded")
+	}
+	return err
 }

--- a/session/tmux/cleanup_unknown_test.go
+++ b/session/tmux/cleanup_unknown_test.go
@@ -76,3 +76,80 @@ esac
 		t.Fatalf("non-timeout ownership probe failure was misclassified as ErrTmuxTimeout: %v", err)
 	}
 }
+
+// TestCleanupSessionsDoesNotTrustInjectedMarkerLine guards the ownership
+// authorization boundary: tmux renders newlines inside an unrelated environment
+// value as new output lines. Such a continuation must never impersonate the
+// session's actual AF_HOME marker and authorize a kill.
+func TestCleanupSessionsDoesNotTrustInjectedMarkerLine(t *testing.T) {
+	dir := t.TempDir()
+	killMarker := filepath.Join(dir, "killed")
+	script := `#!/bin/sh
+case "$1" in
+ls)
+  echo 'af_unowned: 1 windows (created Thu Jan 1 00:00:00 1970)'
+  ;;
+show-environment)
+  if [ "${4-}" = "AF_HOME" ]; then
+	printf 'unknown variable: AF_HOME\n' >&2
+    exit 1
+  fi
+  printf 'OTHER=first\nAF_HOME=%s\n' "$AGENT_FACTORY_HOME"
+  ;;
+list-panes)
+  ;;
+kill-session)
+  : > "$KILL_MARKER"
+  ;;
+*)
+  exit 97
+  ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	t.Setenv("KILL_MARKER", killMarker)
+
+	if err := CleanupSessions(cmd.MakeExecutor()); err != nil {
+		t.Fatalf("CleanupSessions returned an error for a confirmed missing marker: %v", err)
+	}
+	if _, err := os.Stat(killMarker); !os.IsNotExist(err) {
+		t.Fatalf("injected AF_HOME continuation authorized a session kill, stat error = %v", err)
+	}
+}
+
+// TestCleanupSessionsTargetedMarkerFailureRemainsUnknown guards the two-query
+// boundary: a later unfiltered success proves only that the second command
+// answered. It must not rewrite a transient targeted failure into a confirmed
+// missing marker and let reset continue to worktree deletion.
+func TestCleanupSessionsTargetedMarkerFailureRemainsUnknown(t *testing.T) {
+	dir := t.TempDir()
+	script := `#!/bin/sh
+case "$1" in
+ls)
+  echo 'af_unknown: 1 windows (created Thu Jan 1 00:00:00 1970)'
+  ;;
+show-environment)
+  if [ "${4-}" = "AF_HOME" ]; then
+    exit 97
+  fi
+  echo 'PATH=/usr/bin'
+  ;;
+*)
+  exit 98
+  ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	if err := CleanupSessions(cmd.MakeExecutor()); err == nil {
+		t.Fatal("CleanupSessions error = nil, want transient targeted marker failure to remain unknown")
+	}
+}

--- a/session/tmux/envmarker.go
+++ b/session/tmux/envmarker.go
@@ -1,8 +1,10 @@
 package tmux
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -61,28 +63,65 @@ func sessionEnvFlags(sanitizedName string) []string {
 // Bounded by tmuxCommandTimeout (#2099): CleanupSessions calls this once per
 // discovered session, so an unbounded stall on any one of them wedges the whole
 // sweep — and `af reset` runs that sweep synchronously in a short-lived CLI
-// process, where the only way out is ^C. The unfiltered form is deliberate:
-// `show-environment AF_HOME` reports an absent variable as a generic command
-// failure, while unfiltered `show-environment` succeeds and simply omits it.
-// That preserves absent separately from a timeout or other probe failure.
+// process, where the only way out is ^C. The targeted query is the only output
+// trusted as the marker: unfiltered environment output can render a newline in
+// an unrelated value as a forged-looking AF_HOME line. If the targeted query
+// fails, an unfiltered query is used only to prove that the session answered and
+// the named variable was absent. If neither query answers, ownership remains
+// unknown and cleanup stops before destructive reset work.
 func sessionHomeMarker(cmdExec cmd.Executor, sanitizedName string) (home string, present bool, err error) {
 	ctx, cancel := tmuxTimeoutContext()
-	defer cancel()
-	out, err := outputTmuxBoundedWith(ctx, cmdExec, "show-environment", "-t", exactTarget(sanitizedName))
-	if err != nil {
-		if ctx.Err() != nil {
-			return "", false, fmt.Errorf("%w: show-environment %s after %s", ErrTmuxTimeout, sanitizedName, tmuxCommandTimeout)
+	out, markerErr := outputTmuxBoundedWith(ctx, cmdExec, "show-environment", "-t", exactTarget(sanitizedName), EnvMarkerHome)
+	markerTimedOut := ctx.Err() != nil
+	cancel()
+	if markerErr == nil {
+		line := strings.TrimSuffix(strings.TrimSuffix(string(out), "\n"), "\r")
+		if line == "-"+EnvMarkerHome {
+			return "", false, nil
 		}
-		return "", false, fmt.Errorf("read %s ownership marker for tmux session %s: %w", EnvMarkerHome, sanitizedName, err)
-	}
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		if home, ok := strings.CutPrefix(strings.TrimSuffix(line, "\r"), EnvMarkerHome+"="); ok {
-			return home, true, nil
+		if strings.ContainsAny(line, "\r\n") {
+			return "", false, fmt.Errorf("read %s ownership marker for tmux session %s: malformed multiline response", EnvMarkerHome, sanitizedName)
 		}
+		home, ok := strings.CutPrefix(line, EnvMarkerHome+"=")
+		if !ok {
+			return "", false, fmt.Errorf("read %s ownership marker for tmux session %s: malformed response %q", EnvMarkerHome, sanitizedName, line)
+		}
+		return home, true, nil
 	}
-	// A leading '-' (variable marked for removal), unrelated environment
-	// entries, or empty output all authoritatively mean no active marker.
-	return "", false, nil
+	if markerTimedOut {
+		return "", false, fmt.Errorf("%w: show-environment %s after %s", ErrTmuxTimeout, sanitizedName, tmuxCommandTimeout)
+	}
+	if !missingSessionEnvMarker(markerErr) {
+		return "", false, fmt.Errorf("read %s ownership marker for tmux session %s: %w", EnvMarkerHome, sanitizedName, markerErr)
+	}
+
+	// The targeted result itself identified an absent variable. Ask for the
+	// environment without consuming its ambiguous contents: success confirms the
+	// session answered and the marker alone was absent. A generic targeted error
+	// never reaches this fallback, even if this second command would succeed.
+	allCtx, allCancel := tmuxTimeoutContext()
+	_, allErr := outputTmuxBoundedWith(allCtx, cmdExec, "show-environment", "-t", exactTarget(sanitizedName))
+	allTimedOut := allCtx.Err() != nil
+	allCancel()
+	if allErr == nil {
+		return "", false, nil
+	}
+	if allTimedOut {
+		return "", false, fmt.Errorf("%w: show-environment %s after %s", ErrTmuxTimeout, sanitizedName, tmuxCommandTimeout)
+	}
+
+	return "", false, fmt.Errorf("read %s ownership marker for tmux session %s: targeted query: %v; environment query: %w",
+		EnvMarkerHome, sanitizedName, markerErr, allErr)
+}
+
+// missingSessionEnvMarker recognizes tmux's explicit absent-variable answer
+// from the TARGETED query. Exit status alone is insufficient: a transient
+// wrapper/server failure may also be nonzero, and a later command succeeding
+// cannot retroactively determine why the first failed.
+func missingSessionEnvMarker(err error) bool {
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr) &&
+		strings.TrimSpace(string(exitErr.Stderr)) == "unknown variable: "+EnvMarkerHome
 }
 
 var (


### PR DESCRIPTION
## Summary

- keep targeted `show-environment AF_HOME` as the sole authority for the ownership value
- use unfiltered `show-environment` only after the targeted query explicitly reports `unknown variable: AF_HOME`
- reject malformed targeted responses and keep transient named-query failures unknown
- preserve #2688's fail-closed timeout and command-failure behavior

## Root cause

The #2688 fix parsed every `AF_HOME=` line from unfiltered session-environment output. tmux renders embedded newlines in unrelated values as new output lines, so a foreign session could forge a matching marker continuation and be classified as owned. The first #2705 revision also let a later successful unfiltered query rewrite a transient targeted failure into a confirmed missing marker.

## Red-first evidence

Against current `master`, the hostile-newline regression failed with:

`injected AF_HOME continuation authorized a session kill, stat error = <nil>`

The adjacent transient-failure regression failed against the first #2705 revision with:

`CleanupSessions error = nil, want transient targeted marker failure to remain unknown`

## Validation

Validated pushed SHA `20663bb1826001f75ae8849006f49dad7c96b840`:

- hostile-newline, timeout, transient-failure, confirmed-absent-marker, and existing wedge regressions
- `make test-container GOTESTARGS='./session/tmux'`
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container` (full suite, run last)

Closes #2705