### PR TITLE
fix(docker): surface failed provision cleanup

### DIFF
--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -632,8 +632,10 @@ func (p *dockerProvisioner) reap() error {
 	// success (err == nil) never reaches here.
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		// Unknown-state, and NOT latched: RETAIN the row now and re-run on the next
-		// reap. (#2049 classification + #2063-review retry.)
-		reapErr = fmt.Errorf("%w: %w", ErrWorkspaceStateUnknown, reapErr)
+		// reap. exec.CommandContext reports the killed process, not the context
+		// sentinel, so join ctx.Err explicitly and keep the deadline classifiable by
+		// callers (#2049 classification + #2063 review + #2590 review).
+		reapErr = fmt.Errorf("%w: %w", ErrWorkspaceStateUnknown, errors.Join(reapErr, ctx.Err()))
 		log.WarningLog.Printf("%v", reapErr)
 		return reapErr
 	}

--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -241,14 +241,24 @@ func (dockerRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 	}
 	res, err := p.provision()
 	if err != nil {
-		// Reap anything the failed provision left running so a container never
-		// leaks on a partial failure.
-		if p.containerID != "" {
-			p.reap()
-		}
-		return ProvisionResult{}, err
+		return ProvisionResult{}, p.reapProvisionFailure(err)
 	}
 	return res, nil
+}
+
+// reapProvisionFailure cleans up a container created by a failed provision. No
+// Instance record exists to carry a future retry, so a reap that does not succeed
+// must remain visible to the caller with both causes and the orphan risk (#2590).
+func (p *dockerProvisioner) reapProvisionFailure(provisionErr error) error {
+	if p.containerID == "" {
+		return provisionErr
+	}
+	reapErr := p.reap()
+	if reapErr == nil {
+		return provisionErr
+	}
+	return fmt.Errorf("backend=docker: provisioning failed and cleanup of container %s for session %q did not complete; a container may still be running; inspect it before retrying: %w",
+		p.shortID(), p.spec.Title, errors.Join(provisionErr, reapErr))
 }
 
 // dockerProvisioner holds the state of one container provisioning so its steps

--- a/session/backend_docker_reap_unknown_test.go
+++ b/session/backend_docker_reap_unknown_test.go
@@ -61,7 +61,9 @@ func TestDockerProvisionFailureSurfacesUnknownReap(t *testing.T) {
 		case "rm":
 			reapCalls.Add(1)
 			<-ctx.Done()
-			return nil, ctx.Err()
+			// exec.CommandContext reports the killed process (for example,
+			// "signal: killed"), not ctx.Err(); reap must add the deadline.
+			return nil, errors.New("signal: killed")
 		default:
 			return nil, fmt.Errorf("unexpected docker command: %v", args)
 		}
@@ -91,9 +93,9 @@ func TestDockerProvisionFailureSurfacesUnknownReap(t *testing.T) {
 // so TeardownStateUnknown returns true and the daemon RETAINS the row.
 //
 // The injected dockerExec faithfully models a deadline kill: it blocks until the
-// caller's context is cancelled and returns ctx.Err() (context.DeadlineExceeded),
-// exactly as exec.CommandContext's kill surfaces to reap via ctx.Err(). Before the
-// fix reap returned a plain error and TeardownStateUnknown was false.
+// caller's context is cancelled, then returns the killed process error rather
+// than ctx.Err(), exactly as exec.CommandContext does. reap must add the context
+// deadline itself. Before the fix it returned only a plain process error.
 func TestDockerReapTimeoutIsWorkspaceStateUnknown(t *testing.T) {
 	withShortDockerReapTimeout(t, 150*time.Millisecond)
 	restore := SetDockerExecForTest(func(ctx context.Context, _ []string, args ...string) ([]byte, error) {
@@ -101,7 +103,7 @@ func TestDockerReapTimeoutIsWorkspaceStateUnknown(t *testing.T) {
 			return []byte(dockerReapTestEngineID + "\n"), nil
 		}
 		<-ctx.Done()
-		return nil, ctx.Err()
+		return nil, errors.New("signal: killed")
 	})
 	defer restore()
 
@@ -122,6 +124,9 @@ func TestDockerReapTimeoutIsWorkspaceStateUnknown(t *testing.T) {
 	}
 	if !errors.Is(err, ErrWorkspaceStateUnknown) {
 		t.Fatalf("a wedged/timed-out reap must wrap ErrWorkspaceStateUnknown so the row is retained (#2049); got a plain error: %v", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("a timed-out reap must preserve the actual context deadline, got %v", err)
 	}
 	if !TeardownStateUnknown(err) {
 		t.Fatalf("TeardownStateUnknown must be true for a timed-out reap so KillSession/deleteSessionRecord RETAIN the row instead of orphaning the leaked container; got false for: %v", err)
@@ -206,7 +211,7 @@ func TestDockerReapTimeoutIsReRunnable(t *testing.T) {
 		}
 		atomic.AddInt32(&calls, 1)
 		<-ctx.Done()
-		return nil, ctx.Err()
+		return nil, errors.New("signal: killed")
 	})
 	defer restore()
 
@@ -255,7 +260,7 @@ func TestDockerReapTimeoutThenSuccessClears(t *testing.T) {
 		atomic.AddInt32(&calls, 1)
 		if wedged.Load() {
 			<-ctx.Done()
-			return nil, ctx.Err()
+			return nil, errors.New("signal: killed")
 		}
 		return []byte("deadbeefcafe0000\n"), nil
 	})

--- a/session/backend_docker_reap_unknown_test.go
+++ b/session/backend_docker_reap_unknown_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -30,6 +32,57 @@ func withShortDockerReapTimeout(t *testing.T, d time.Duration) {
 	prev := dockerReapTimeout
 	dockerReapTimeout = d
 	t.Cleanup(func() { dockerReapTimeout = prev })
+}
+
+// TestDockerProvisionFailureSurfacesUnknownReap covers the no-record failure
+// path: if provisioning fails after creating a container and its immediate reap
+// times out, both causes and the orphan risk must reach the session creator.
+func TestDockerProvisionFailureSurfacesUnknownReap(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoRoot := initTempGitRepo(t)
+	writeInRepoConfig(t, repoRoot, map[string]any{
+		"backend": "docker",
+		"docker":  map[string]any{"image": "img:latest"},
+	})
+	defer SetLookPathForTest(func(string) (string, error) { return "/usr/bin/docker", nil })()
+	defer SetDockerSelfBinaryForTest(filepath.Join(t.TempDir(), "af"))()
+	withShortDockerReapTimeout(t, 50*time.Millisecond)
+
+	provisionErr := errors.New("permission denied")
+	var reapCalls atomic.Int32
+	defer SetDockerExecForTest(func(ctx context.Context, _ []string, args ...string) ([]byte, error) {
+		switch args[0] {
+		case "info":
+			return []byte(dockerReapTestEngineID + "\n"), nil
+		case "run":
+			return []byte(dockerCreatedID + "\n"), nil
+		case "exec":
+			return nil, provisionErr
+		case "rm":
+			reapCalls.Add(1)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		default:
+			return nil, fmt.Errorf("unexpected docker command: %v", args)
+		}
+	})()
+
+	_, err := dockerRuntime{}.Provision(ProvisionSpec{
+		RepoRoot: repoRoot,
+		Title:    "partial-container",
+		CloneURL: "file:///repo",
+	})
+	if !errors.Is(err, provisionErr) || !errors.Is(err, ErrWorkspaceStateUnknown) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("provision and unknown cleanup causes must all survive, got %v", err)
+	}
+	if reapCalls.Load() != 1 {
+		t.Fatalf("failed provision attempted container cleanup %d times, want 1", reapCalls.Load())
+	}
+	for _, detail := range []string{shortContainerID(dockerCreatedID), "partial-container", "may still be running", "inspect it before retrying"} {
+		if !strings.Contains(err.Error(), detail) {
+			t.Fatalf("provision cleanup error omitted %q: %v", detail, err)
+		}
+	}
 }
 
 // TestDockerReapTimeoutIsWorkspaceStateUnknown is the #2049 regression: a reap


### PR DESCRIPTION
## What

Surface Docker cleanup failures when container provisioning has already failed. The returned error now preserves the original provisioning cause, the cleanup cause, and any `ErrWorkspaceStateUnknown`/deadline sentinels, while naming the partial container and warning that it may still be running.

Successful cleanup still returns only the original provisioning error. A failure before Docker creates a container does not attempt cleanup.

## Root cause

`dockerRuntime.Provision` called `p.reap()` as a bare statement and discarded its result. If `docker rm -f` timed out, there was no Instance record to carry a later retry, but the caller saw only the provisioning error and was falsely led to believe cleanup had completed.

Hook and SSH already preserve both causes. The adjacent-call audit found no other discarded production Docker reap result: the startup sweeper explicitly classifies success, unknown, and known failure.

## Fail-first regressions

The initial failure-path test was first run against today's tree and failed:

```
backend_docker_reap_unknown_test.go:76: provision and unknown cleanup causes must all survive, got backend=docker: git config in container failed: : permission denied
--- FAIL: TestDockerProvisionFailureSurfacesUnknownReap
```

Codex then identified that the fake returned `context.DeadlineExceeded` directly, unlike production `exec.CommandContext`. After changing the fake to return `signal: killed`, the corrected test failed against the first PR head:

```
provision and unknown cleanup causes must all survive, got backend=docker: provisioning failed and cleanup of container abcdef012345 for session "partial-container" did not complete...
the worktree action was cut off by its deadline; the workspace may be partially removed: backend=docker: `docker rm -f abcdef012345` failed: : signal: killed
--- FAIL: TestDockerProvisionFailureSurfacesUnknownReap
```

`dockerProvisioner.reap` now joins its expired context explicitly, so the production-shaped error preserves `context.DeadlineExceeded`. All Docker timeout tests now use process-error fakes and retain the success/known/unknown polarity.

## Validation

Validated on pushed SHA `dfa22980d5a2f4c2912e72907047a940c39e9d4c`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container` (full suite, run last)

Closes #2590