### PR TITLE
fix: honor RepoID-only project deletion

### DIFF
--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -153,9 +153,11 @@ type RestoreSessionResponse struct {
 // registration or root opt-in.
 //
 // RepoPath is the repo root (the stable project id clients group by:
-// worktree.repo_path). RepoID is the precomputed id; when empty the daemon
-// derives it from RepoPath. At least one must be set. Deleting an unknown project
-// is a clean no-op; a registered project with no live sessions is deregistered.
+// worktree.repo_path). RepoID is the precomputed id; when either is omitted the
+// daemon derives it from RepoPath or its durable registry record, respectively.
+// When both are set they must identify the same project. At least one must be
+// set. Deleting an unknown project is a clean no-op; a registered project with no
+// live sessions is deregistered.
 type DeleteProjectRequest struct {
 	RepoPath string `json:"repo_path"`
 	RepoID   string `json:"repo_id"`

--- a/daemon/deleteproject.go
+++ b/daemon/deleteproject.go
@@ -69,6 +69,41 @@ type DeleteProjectResult struct {
 	Deregistered bool
 }
 
+// normalizeDeleteProjectPath resolves an existing path to its canonical main
+// repo root and identity. A stale/missing path falls back to its cleaned spelling
+// so deleting an unknown or moved project remains an idempotent no-op.
+func normalizeDeleteProjectPath(path string) (string, string) {
+	root := config.ExpandTilde(strings.TrimSpace(path))
+	if repo, err := config.RepoFromPath(root); err == nil {
+		return repo.Root, repo.ID
+	}
+	root = filepath.Clean(root)
+	return root, config.RepoIDFromRoot(root)
+}
+
+// registeredProjectRootForRepoID resolves the path needed by
+// config.DeregisterProject when a direct client supplies only the daemon's
+// repo identity. Registry read failure is an unknown outcome, not evidence that
+// no matching registration exists, so callers must treat an error as fatal
+// before mutating sessions or root-agent state.
+func registeredProjectRootForRepoID(repoID string) (string, error) {
+	projects, err := config.ListProjects()
+	if err != nil {
+		return "", fmt.Errorf("read durable project registry: %w", err)
+	}
+	var root string
+	for _, project := range projects {
+		if config.RepoIDFromRoot(project.Root) != repoID {
+			continue
+		}
+		if root != "" && filepath.Clean(root) != filepath.Clean(project.Root) {
+			return "", fmt.Errorf("repo id %s matches multiple registered roots %q and %q; cannot determine which project to deregister", repoID, root, project.Root)
+		}
+		root = project.Root
+	}
+	return root, nil
+}
+
 // DeleteProject deletes a project — a repo grouping of sessions (#1735) — with
 // archive-then-remove semantics under the single-writer daemon:
 //
@@ -83,9 +118,9 @@ type DeleteProjectResult struct {
 //   - The repo's root_agents opt-in is dropped (in-memory suppression for this
 //     daemon's life + removed from config on disk) so the project does not linger
 //     empty in the picker and no always-on root respawns.
-//   - A durable project registration whose root matches req.RepoPath is removed
-//     after every session settles, so a registered-but-sessionless project also
-//     disappears.
+//   - A durable project registration whose root matches RepoPath — or whose root
+//     the daemon resolves from a RepoID-only request — is removed after every
+//     session settles, so a registered-but-sessionless project also disappears.
 //
 // The user's real git repository is never touched. Because the active-projects
 // list is derived from LIVE sessions, archiving them all removes the project from
@@ -95,16 +130,15 @@ type DeleteProjectResult struct {
 // a zero-count success; a registered project with no sessions is deregistered.
 func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, error) {
 	repoID := strings.TrimSpace(req.RepoID)
+	repoPath := strings.TrimSpace(req.RepoPath)
 	if repoID == "" {
-		root := strings.TrimSpace(req.RepoPath)
-		if root == "" {
+		if repoPath == "" {
 			return DeleteProjectResult{}, fmt.Errorf("delete project: repo_id or repo_path is required")
 		}
 		// Expand a leading ~ BEFORE canonicalizing: git (RepoFromPath) does not do
 		// tilde expansion — the shell normally would — so a literal "~/repo" request
 		// (a root_agents key spelling, or a hand-typed CLI arg) must be expanded here
 		// or it resolves to nothing and silently misses (#1740 review).
-		root = config.ExpandTilde(root)
 		// Canonicalize the path the SAME way the daemon keys repos everywhere:
 		// resolve it to the main-repo root (git toplevel) and hash THAT, so a
 		// symlinked / trailing-slash / relative / subdirectory / ".."-laden form of
@@ -113,10 +147,21 @@ func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 		// typo'd project) fall back to hashing the cleaned path: that yields no
 		// match, which is the clean idempotent no-op deleting an unknown project
 		// must be (Sachin's locked semantics), not a wrong-project hit.
-		if repo, rerr := config.RepoFromPath(root); rerr == nil {
-			repoID = repo.ID
-		} else {
-			repoID = config.RepoIDFromRoot(filepath.Clean(root))
+		repoPath, repoID = normalizeDeleteProjectPath(repoPath)
+	} else if repoPath == "" {
+		var err error
+		repoPath, err = registeredProjectRootForRepoID(repoID)
+		if err != nil {
+			return DeleteProjectResult{RepoID: repoID}, fmt.Errorf("delete project %s: could not determine its registered root from repo_id; nothing was changed: %w", repoID, err)
+		}
+	} else {
+		// Both selectors must describe one project. Otherwise RepoID chooses the
+		// sessions/root-agent state while RepoPath chooses a potentially different
+		// registry row — a split-target partial delete hidden behind success.
+		var pathRepoID string
+		repoPath, pathRepoID = normalizeDeleteProjectPath(repoPath)
+		if pathRepoID != repoID {
+			return DeleteProjectResult{RepoID: repoID}, fmt.Errorf("delete project: repo_id %s does not match repo_path %q (repo id %s); nothing was changed", repoID, repoPath, pathRepoID)
 		}
 	}
 	result := DeleteProjectResult{RepoID: repoID}
@@ -266,17 +311,23 @@ func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 	// Every session for the repo is archived and none is starting — NOW drop the durable
 	// #2355 registry record (after the archive, #2549): the deregister must never land
 	// while a session survives, or the delete leaves a live orphan in a repo no longer in
-	// the registry. req.RepoPath is the project's root (both the web and TUI send it); a
-	// project that was never registered is a false no-op. Recorded so the projects-changed
-	// publish fires even when no session was archived (a registered, sessionless project).
-	if deregistered, regErr := config.DeregisterProject(config.ExpandTilde(strings.TrimSpace(req.RepoPath))); regErr != nil {
-		// SYMMETRIC to an archive failure, and NOT "nothing changed": the sessions are
-		// already archived here, so a retry re-archives nothing and finishes the deregister
-		// — at worst an empty-but-registered project, never a live orphan.
-		return result, fmt.Errorf("delete project %s: archived %d session(s) but could not remove its durable registry record — the project still lists; retry to finish, a retry re-archives nothing: %w", repoID, len(result.Archived), regErr)
-	} else if deregistered {
-		result.Deregistered = true
-		log.InfoLog.Printf("delete project %s: removed its durable registry record", repoID)
+	// the registry. repoPath is either caller-provided and canonicalized, or resolved from
+	// the daemon's durable registry for the documented RepoID-only form. An empty root
+	// means no matching registration existed at resolution time, so there is nothing to
+	// deregister. Recorded so the projects-changed publish fires even when no session was
+	// archived (a registered, sessionless project).
+	if repoPath != "" {
+		deregistered, regErr := config.DeregisterProject(repoPath)
+		if regErr != nil {
+			// SYMMETRIC to an archive failure, and NOT "nothing changed": the sessions are
+			// already archived here, so a retry re-archives nothing and finishes the deregister
+			// — at worst an empty-but-registered project, never a live orphan.
+			return result, fmt.Errorf("delete project %s: archived %d session(s) but could not remove its durable registry record — the project still lists; retry to finish, a retry re-archives nothing: %w", repoID, len(result.Archived), regErr)
+		}
+		if deregistered {
+			result.Deregistered = true
+			log.InfoLog.Printf("delete project %s: removed its durable registry record", repoID)
+		}
 	}
 
 	log.InfoLog.Printf("deleted project %s: archived %d session(s), tore down %d in-place session(s)", repoID, len(result.Archived), len(result.Killed))

--- a/daemon/deleteproject_test.go
+++ b/daemon/deleteproject_test.go
@@ -191,6 +191,47 @@ func TestDeleteProject_DerivesRepoIDFromPath(t *testing.T) {
 	assert.Empty(t, liveProjectRoots(manager.Snapshot(repoID)))
 }
 
+// TestDeleteProject_RepoIDOnlyRegistryReadFailureLeavesProjectIntact pins the
+// unknown outcome while resolving the omitted RepoPath. A corrupt registry is
+// not evidence that no matching registration exists: fail before archiving or
+// suppressing anything so the caller can repair and retry atomically.
+func TestDeleteProject_RepoIDOnlyRegistryReadFailureLeavesProjectIntact(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, source := registerArchivable(t, manager, repoID, repoPath, "worker")
+
+	registered, err := config.RegisterProject(repoPath)
+	require.NoError(t, err)
+	metadata := filepath.Join(os.Getenv("AGENT_FACTORY_HOME"), config.ProjectRegistryDirName, registered.ID, "project.json")
+	require.NoError(t, os.WriteFile(metadata, []byte("{ not json"), 0o600))
+
+	result, err := manager.DeleteProject(DeleteProjectRequest{RepoID: repoID})
+	require.Error(t, err, "an unreadable registry makes RepoID-only resolution unknown")
+	assert.Contains(t, err.Error(), "registered root")
+	assert.Empty(t, result.Archived, "resolution failure must happen before any session mutation")
+	assert.Equal(t, session.LiveReady, inst.GetLiveness())
+	_, statErr := os.Stat(source)
+	assert.NoError(t, statErr, "the live worktree must remain in place")
+}
+
+// TestDeleteProject_RejectsMismatchedRepoIDAndPath prevents a split-target
+// delete: RepoID selects the sessions/root-agent state, while RepoPath selects
+// the durable registry row. If they describe different projects, fail before
+// either half is mutated instead of reporting success for a partial request.
+func TestDeleteProject_RejectsMismatchedRepoIDAndPath(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, source := registerArchivable(t, manager, repoID, repoPath, "worker")
+	other := filepath.Join(t.TempDir(), "different-project")
+	require.NotEqual(t, repoID, config.RepoIDFromRoot(other))
+
+	result, err := manager.DeleteProject(DeleteProjectRequest{RepoID: repoID, RepoPath: other})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match")
+	assert.Empty(t, result.Archived)
+	assert.Equal(t, session.LiveReady, inst.GetLiveness())
+	_, statErr := os.Stat(source)
+	assert.NoError(t, statErr, "a mismatched request must not move the worktree")
+}
+
 // TestDeleteProject_NonCanonicalPathStillMatches: a path-only request whose path
 // is NOT the canonical repo root (here a subdirectory of the repo — hashing it
 // raw would miss) still targets the right project, because the daemon resolves it

--- a/daemon/register_project_test.go
+++ b/daemon/register_project_test.go
@@ -203,6 +203,37 @@ func TestControlServer_DeleteProject_RemovesRegistryRecordAndPublishes(t *testin
 	assert.Empty(t, projects, "the deleted project's registry record is gone, so the switcher drops it")
 }
 
+// TestControlServer_DeleteProject_RepoIDOnlyRemovesRegistryRecord pins the
+// documented direct-client shape that omits RepoPath. Success is not evidence of
+// deletion here: the bug returned OK while passing an empty path to
+// DeregisterProject, so assert the durable registry state itself.
+func TestControlServer_DeleteProject_RepoIDOnlyRemovesRegistryRecord(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	require.NoError(t, err)
+
+	manager, err := NewManager(config.DefaultConfig())
+	require.NoError(t, err)
+	cs := &controlServer{manager: manager}
+
+	var reg RegisterProjectResponse
+	require.NoError(t, cs.RegisterProject(RegisterProjectRequest{Path: repoPath}, &reg))
+	projects, err := config.ListProjects()
+	require.NoError(t, err)
+	require.Len(t, projects, 1, "precondition: the sessionless project is registered")
+
+	var del DeleteProjectResponse
+	require.NoError(t, cs.DeleteProject(DeleteProjectRequest{RepoID: repo.ID}, &del))
+	require.True(t, del.OK)
+	assert.Equal(t, 0, del.ArchivedCount)
+	assert.Equal(t, 0, del.KilledCount)
+
+	projects, err = config.ListProjects()
+	require.NoError(t, err)
+	assert.Empty(t, projects, "RepoID-only success must remove the durable registry record")
+}
+
 // TestControlServer_RegisterProject_GatedWhenWarming: like every state mutation,
 // RegisterProject is refused while the manager is still warming up, with the
 // daemon-starting error clients retry on.


### PR DESCRIPTION
## Summary

- resolve a missing DeleteProject RepoPath from the daemon's durable project registry when a direct caller supplies only RepoID
- fail before any session or root-agent mutation when the registry cannot be read or the RepoID maps ambiguously
- reject mismatched RepoID + RepoPath selectors before they can archive one project and deregister another
- preserve path-only canonicalization and idempotent deletion of unregistered/session-derived projects

## Root cause

Manager.DeleteProject accepted the documented RepoID-only shape, but its final deregistration call still used the empty request RepoPath. config.DeregisterProject therefore returned (false, nil), DeleteProject returned success, and a registered sessionless project remained durable.

The fix reads the daemon's own registry records and matches their canonical roots with config.RepoIDFromRoot before any mutation. A registry read error remains unknown and is returned as an error rather than collapsed into "no registration".

## Red evidence

The RepoID-only control-server regression failed against today's tree after an OK response:

```
Should be empty, but was [{prj_... chk_... /tmp/.../repo . true}]
Messages: RepoID-only success must remove the durable registry record
```

The unknown-outcome regression also failed red: with corrupt registry metadata, the old path archived one session before reporting the late deregistration error; result.Archived had one row, liveness changed from Ready to Archived, and the source worktree was gone.

The adjacent mismatched-selector regression failed red with:

```
An error is expected but got nil.
```

## Adjacent audit

CLI and TUI call sites already send both canonical RepoPath and RepoID. The uncovered RepoID-only shape is direct control/HTTP. Path-only, subdirectory, tilde, and existing projects.changed coverage remains green. URL/path normalization is shared through one helper so the two selector shapes cannot drift.

## Validation

Focused regressions passed in the isolated container.

Pre-push gates:

- `GOTOOLCHAIN=go1.25.0 golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `GOTOOLCHAIN=go1.25.0 go build ./...`
- `GOTOOLCHAIN=go1.25.0 deadcode -test ./...`
- `scripts/lint-file-length.sh`

The full `make test-container` suite was the final code gate and passed against pushed head `7ecbe60184ab4302a2b05c72521f46c4f29830c7`.

Closes #2685