### PR TITLE
fix: reset replay backoff after delivery

### DIFF
--- a/daemon/eventqueue_test.go
+++ b/daemon/eventqueue_test.go
@@ -853,6 +853,76 @@ func TestWatcherDrainLogsExpiryCountWhenStoppedMidBackoff(t *testing.T) {
 	}
 }
 
+// TestWatcherDrain_StaleCursorSuccessResetsBackoff proves delivery health is
+// independent of queue-head ownership. A concurrent queue mutation can move the
+// head while deliver is in flight, making this drainer's cursor stale even though
+// the target accepted the event. The next failure must restart at base backoff.
+func TestWatcherDrain_StaleCursorSuccessResetsBackoff(t *testing.T) {
+	const taskID = "ab265501"
+	var w *taskWatcher
+	attempts := 0
+	hookErr := make(chan error, 1)
+	postSuccessFailure := make(chan struct{})
+	w = newRateSlotWatcher(t, taskID, func(_, _ string) error {
+		attempts++
+		switch attempts {
+		case 1, 2:
+			return errors.New("initial outage")
+		case 3:
+			// Move the queue head between the drain loop's peek and advance,
+			// reproducing the stale cursor an overflow race can create.
+			_, cursor, ok, err := w.queue.peek()
+			if err != nil || !ok {
+				hookErr <- fmt.Errorf("peek queued event for stale-cursor hook: ok=%v err=%v", ok, err)
+				return nil
+			}
+			advanced, err := w.queue.advance(cursor)
+			if err != nil || !advanced {
+				hookErr <- fmt.Errorf("advance queued event for stale-cursor hook: advanced=%v err=%v", advanced, err)
+			}
+			return nil
+		default:
+			select {
+			case <-postSuccessFailure:
+			default:
+				close(postSuccessFailure)
+			}
+			return errors.New("outage after successful stale-cursor delivery")
+		}
+	})
+	w.sup.drainBaseBackoff = 40 * time.Millisecond
+	w.sup.drainMaxBackoff = 160 * time.Millisecond
+	for _, line := range []string{"first", "second"} {
+		if err := w.queue.enqueue(line); err != nil {
+			t.Fatalf("enqueue %q: %v", line, err)
+		}
+	}
+
+	warn, _ := captureWatcherLogs(t)
+	w.wg.Add(1)
+	go w.drainLoop()
+	select {
+	case <-postSuccessFailure:
+	case <-time.After(5 * time.Second):
+		t.Fatal("drainer never reached the post-success failure")
+	}
+	waitUntil(t, 5*time.Second, "post-success retry log", func() bool {
+		return strings.Contains(warn.String(), "outage after successful stale-cursor delivery")
+	})
+	w.stopOnce.Do(func() { close(w.stopCh) })
+	w.wg.Wait()
+
+	select {
+	case err := <-hookErr:
+		t.Fatal(err)
+	default:
+	}
+	if got := warn.String(); !strings.Contains(got,
+		"retrying in 40ms: outage after successful stale-cursor delivery") {
+		t.Fatalf("post-success retry did not restart at base backoff:\n%s", got)
+	}
+}
+
 // flakyDeliver fails every delivery until healed, then records successes. It
 // drives the outage→recovery shape end to end through a real watcher.
 type flakyDeliver struct {

--- a/daemon/watcher_drain.go
+++ b/daemon/watcher_drain.go
@@ -194,6 +194,10 @@ func (w *taskWatcher) drainLoop() {
 		// The park is over — re-arm the notice so the NEXT episode logs on entry
 		// instead of being silently swallowed by the previous one's throttle window.
 		parkLog.reset()
+		// Backoff tracks consecutive delivery failures, not queue cursor ownership.
+		// A successful delivery resets it even if a concurrent head move makes this
+		// drainer's cursor stale and advance asks us to re-peek.
+		backoff = w.sup.drainBaseBackoff
 		advanced, err := w.queue.advance(cursor)
 		if err != nil {
 			log.ErrorLog.Printf("watch task %s: failed to advance the event queue; replay parked until the next reload: %v", w.taskID, err)
@@ -204,6 +208,5 @@ func (w *taskWatcher) drainLoop() {
 			continue
 		}
 		replayed++
-		backoff = w.sup.drainBaseBackoff
 	}
 }


### PR DESCRIPTION
## Summary

- reset replay backoff immediately after a successful delivery, before queue cursor advancement
- keep stale-cursor re-peek behavior unchanged while separating it from delivery-health state
- add a deterministic drain-loop regression that inflates backoff, moves the head during a successful delivery, and checks the next failure uses base backoff

## Diagnosis

Confirmed on current master: drainLoop reset backoff only after queue.advance(cursor) returned true. A concurrent overflow/head move can make that cursor stale after the target accepted the event, so the continue path retained an inflated failure backoff even though delivery had recovered.

Adjacent call-site audit: the only other queue.advance(cursor) in drainLoop expires aged records and performs no delivery, so it must not reset delivery-failure backoff. Live delivery does not carry this replay-local backoff variable.

## Red regression

Observed before the production change on `183e8b76fec0e09e823ba49c500dda39a4210a44`:

```
--- FAIL: TestWatcherDrain_StaleCursorSuccessResetsBackoff (0.13s)
    eventqueue_test.go:922: post-success retry did not restart at base backoff:
        ... retrying in 40ms: initial outage
        ... retrying in 80ms: initial outage
        ... retrying in 160ms: outage after successful stale-cursor delivery
FAIL
```

The successful delivery should have reset that final retry to the 40ms test base.

## Validation

Validated pushed head `d5a17c384d14bfc6eb1af9a7a61474fa2023cc18` after rebasing onto current `master`:

- `GOTOOLCHAIN=go1.25.0 golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `GOTOOLCHAIN=go1.25.0 go build ./...`
- `GOTOOLCHAIN=go1.25.0 deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container GOTESTARGS="./daemon -run TestWatcherDrain_StaleCursorSuccessResetsBackoff -count=1"`
- `make test-container GOTESTARGS="./daemon -run TestWatcherDrain -count=1"`
- `GOTOOLCHAIN=go1.25.0 make test-container`

Closes #2655