### PR TITLE
fix(tui): keep session titles single-line

### DIFF
--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/sachiniyer/agent-factory/internal/namegen"
 	"github.com/sachiniyer/agent-factory/log"
@@ -219,7 +220,16 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// openBackendPicker.
 		return m.openBackendPicker()
 	case tea.KeyRunes:
-		newTitle := instance.Title + string(msg.Runes)
+		// Bracketed paste arrives as ONE KeyRunes message and may contain
+		// newlines or other control runes. Titles are sidebar rows, so keep only
+		// printable content from the whole payload before measuring it (#2640).
+		cleanRunes := make([]rune, 0, len(msg.Runes))
+		for _, r := range msg.Runes {
+			if !unicode.IsControl(r) {
+				cleanRunes = append(cleanRunes, r)
+			}
+		}
+		newTitle := instance.Title + string(cleanRunes)
 		if runewidth.StringWidth(newTitle) > 32 {
 			return m, m.handleError(fmt.Errorf("title cannot be longer than 32 characters"))
 		}

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -76,6 +76,33 @@ func TestHandleStateNewKeySpaceUnderLimit(t *testing.T) {
 	assert.Equal(t, "hello ", homeModel.namingInstance.Title)
 }
 
+// TestHandleStateNewMultiLinePasteKeepsTitleSingleLine reproduces #2640 at the
+// Bubble Tea boundary: bracketed paste is ONE KeyRunes message, not a sequence
+// of per-character key events. Control runes in that one payload must not enter
+// the title and turn a single sidebar row into several terminal lines.
+func TestHandleStateNewMultiLinePasteKeepsTitleSingleLine(t *testing.T) {
+	h := &home{
+		ctx:       context.Background(),
+		state:     stateNew,
+		appConfig: config.DefaultConfig(),
+		errBox:    ui.NewErrBox(),
+	}
+	instance, err := session.NewInstance(session.InstanceOptions{
+		Path: t.TempDir(), Program: "claude",
+	})
+	require.NoError(t, err)
+	h.namingInstance = instance
+
+	_, _ = h.handleStateNew(tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Paste: true,
+		Runes: []rune("alpha\nbeta\r\t\x1b"),
+	})
+
+	assert.Equal(t, "alphabeta", instance.Title,
+		"a single pasted KeyRunes payload must not retain layout-breaking control characters")
+}
+
 func TestHandleMenuHighlightingDoesNotInterceptNamingText(t *testing.T) {
 	h := newTestHome(t)
 	h.state = stateNew

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -366,6 +366,30 @@ func TestValidateTitleAvailableLockedRejectsWhitespace(t *testing.T) {
 	}
 }
 
+// TestValidateTitleAvailableLockedRejectsControlCharacters keeps the daemon's
+// title admission authoritative for every client. The TUI strips controls from
+// pasted titles, but CLI/API callers must not be able to create the same
+// multi-line sidebar corruption by sending them directly (#2640).
+func TestValidateTitleAvailableLockedRejectsControlCharacters(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	manager, err := newManagerShell(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("newManagerShell: %v", err)
+	}
+
+	for _, title := range []string{"alpha\nbeta", "alpha\rbeta", "alpha\tbeta", "alpha\x1bbeta"} {
+		manager.mu.Lock()
+		err := manager.validateTitleAvailableLocked("repo-id", "/tmp/repo", title, "claude", runtimeNamespaceLocalTmux, false, nil)
+		manager.mu.Unlock()
+		if err == nil {
+			t.Fatalf("expected title containing controls %q to be rejected", title)
+		}
+		if !strings.Contains(err.Error(), "single line") || !strings.Contains(err.Error(), "control") {
+			t.Fatalf("title %q: expected a single-line control-character error, got: %v", title, err)
+		}
+	}
+}
+
 // TestManagerCreateSessionRejectsCaseVariantTitleFromDisk covers the disk-side
 // branch of the #605 fix: a case-variant title persisted to disk from a prior
 // daemon run must still be rejected when the manager loads fresh and a new

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -390,6 +390,46 @@ func TestValidateTitleAvailableLockedRejectsControlCharacters(t *testing.T) {
 	}
 }
 
+// TestNextAvailableTitleRejectsMalformedBaseBeforeSuffixing covers the derived
+// title path used by web and task creates. A malformed base is not a collision:
+// suffixing cannot remove its controls, and whitespace must not turn into a
+// punctuation-only candidate. Reject the base once with the canonical shape
+// error instead of walking 10,000 candidates and reporting exhaustion.
+func TestNextAvailableTitleRejectsMalformedBaseBeforeSuffixing(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	manager, err := newManagerShell(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("newManagerShell: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		base    string
+		wantErr string
+	}{
+		{name: "control", base: "alpha\nbeta", wantErr: "single line"},
+		{name: "whitespace", base: "   ", wantErr: "session title is required"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			manager.mu.Lock()
+			got, err := manager.nextAvailableTitleLocked(
+				"repo-id", "/tmp/repo", tc.base, "claude", runtimeNamespaceLocalTmux, nil,
+			)
+			manager.mu.Unlock()
+
+			if err == nil {
+				t.Fatalf("malformed title base %q resolved to %q", tc.base, got)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("malformed title base %q: expected %q, got: %v", tc.base, tc.wantErr, err)
+			}
+			if strings.Contains(err.Error(), "could not find an available title") {
+				t.Fatalf("malformed title base %q was misreported as collision exhaustion: %v", tc.base, err)
+			}
+		})
+	}
+}
+
 // TestManagerCreateSessionRejectsCaseVariantTitleFromDisk covers the disk-side
 // branch of the #605 fix: a case-variant title persisted to disk from a prior
 // daemon run must still be rejected when the manager loads fresh and a new

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -804,6 +804,14 @@ func (m *Manager) uniqueArchivedTitleLocked(repoID, repoPath, base, program stri
 }
 
 func (m *Manager) nextAvailableTitleLocked(repoID, repoPath, baseTitle, program string, namespace runtimeNameNamespace, diskData []session.InstanceData) (string, error) {
+	// Shape errors belong to the base, not to any candidate's availability.
+	// Validate once before the suffix walk so controls do not burn all 10,000
+	// rungs and whitespace cannot turn into a punctuation-only "   -2" title.
+	// allowReserved stays true here because a base of "root" deliberately skips
+	// the reserved bare candidate and resolves to "root-2" below.
+	if err := m.validateTitleShapeLocked(baseTitle, true); err != nil {
+		return "", err
+	}
 	// Session records are not the only thing that can make a candidate unusable
 	// (#2091). A branch already CHECKED OUT by some worktree cannot be checked
 	// out again, and archiving relocates a worktree rather than removing it

--- a/daemon/manager_create_names.go
+++ b/daemon/manager_create_names.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
@@ -172,6 +173,12 @@ func (m *Manager) validateTitleShapeLocked(title string, allowReserved bool) err
 	// before the emptiness gate; the TUI naming flow applies the same check.
 	if strings.TrimSpace(title) == "" {
 		return fmt.Errorf("session title is required")
+	}
+	// Titles render as one sidebar row in every TUI client. Reject control
+	// characters at the authoritative create boundary so CLI/API callers cannot
+	// bypass the TUI's pasted-rune sanitization and create multi-line rows (#2640).
+	if strings.IndexFunc(title, unicode.IsControl) >= 0 {
+		return fmt.Errorf("session title must be a single line and contain no control characters")
 	}
 	// The "root" title belongs to the daemon-managed root agent (#1106).
 	// Every creation path lands here — TUI, `af sessions create`, task

--- a/scripts/tui-2640-scenario.sh
+++ b/scripts/tui-2640-scenario.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Real-TUI regression for #2640, via:
+#
+#   scripts/testbox.sh scenario scripts/tui-2640-scenario.sh
+#
+# Bubble Tea emits bracketed paste as ONE KeyRunes message. Inject the actual
+# bracketed-paste protocol around a multi-line payload so this cannot
+# accidentally pass by testing one ordinary key event per character.
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source /src/scripts/tui-driver.sh
+
+export AF_DRIVER_COLS=120 AF_DRIVER_ROWS=30
+export AF_DRIVER_REPO="$HOME/sandbox/mock-repo"
+
+af_reset_sandbox
+af_boot
+af_ensure_nav
+af_focus_tree
+af_send n
+af_wait_for 'submit name' "$AF_DRIVER_TIMEOUT" 'naming form opens'
+
+# One bracketed paste: embedded newline plus carriage-return, tab, and escape.
+# The title row must remain one line and concatenate the printable runes.
+af_send_literal $'\e[200~alpha\nbeta\r\t\e[201~'
+af_wait_for 'alphabeta' 5 'multi-line paste renders as one title row'
+
+af_send Enter
+af_wait_for 'alphabeta.*●' "$AF_DRIVER_TIMEOUT" 'sanitized pasted title creates successfully'
+
+echo 'PASS: #2640 bracketed multi-line paste keeps the title and sidebar single-line'


### PR DESCRIPTION
## Summary

- strip Unicode control characters from the complete `KeyRunes` payload before appending a TUI session title
- reject control characters at the daemon's authoritative create-title shape gate for CLI/API parity
- validate derived title bases once before suffix search, preserving `root` → `root-2`
- add an isolated real-TUI scenario that injects one actual bracketed multi-line paste

## Root cause

Bubble Tea delivers a bracketed paste as one `KeyRunes{Paste:true}` message. The naming handler appended that complete rune slice and checked only display width; newline, carriage-return, tab, and escape controls therefore entered `Instance.Title` despite contributing no useful width, splitting one sidebar row across terminal lines.

The adjacent title-creation paths were audited. `SetTitle` is only used by this naming flow, but daemon create admission also accepted controls from CLI/API clients. The daemon gate now rejects new control-bearing titles while persisted legacy records remain loadable. After Codex identified the derived `TitleBase` path, that path was fixed at its entry: malformed bases are shape-validated once, rather than treating their errors as 10,000 candidate collisions. Reserved `root` remains allowed as a base so its established `root-2` derivation is unchanged.

## Fail-first evidence

The one-message unit reproduction failed on the unfixed tree with:

```text
expected: "alphabeta"
actual  : "alpha\nbeta\r\t\x1b"
--- FAIL: TestHandleStateNewMultiLinePasteKeepsTitleSingleLine
```

The authoritative daemon test separately failed with:

```text
expected title containing controls "alpha\nbeta" to be rejected
--- FAIL: TestValidateTitleAvailableLockedRejectsControlCharacters
```

Codex's P2 follow-up regression also failed first on the pushed implementation:

```text
malformed title base "alpha\\nbeta": expected "single line", got: could not find an available title for "alpha\\nbeta"
malformed title base "   " resolved to "   -2"
--- FAIL: TestNextAvailableTitleRejectsMalformedBaseBeforeSuffixing
```

The real TUI scenario injected `ESC[200~alpha\nbeta...ESC[201~` as one paste and failed with:

```text
TIMEOUT 5s waiting for: multi-line paste renders as one title row
```

Its captured sidebar showed `alpha` on one row and the remaining paste shifting the layout/border.

## Validation

- `scripts/testbox.sh scenario scripts/tui-2640-scenario.sh`
- focused app and daemon regressions, including the existing whitespace-title gate
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container` — full suite passed last against pushed SHA `17fbe55ae9b3a2959a1698775ac5fe6300b8bbda` (`app` 177.585s, `daemon` 251.201s)

Closes #2640