### PR TITLE
fix(tmux): anchor doc trust prompt on renderer chrome

### DIFF
--- a/session/tmux/doc_trust_prompt_test.go
+++ b/session/tmux/doc_trust_prompt_test.go
@@ -564,6 +564,18 @@ func TestCheckAndHandleTrustPrompt_RealDocDialogIsDismissed(t *testing.T) {
 	}
 }
 
+func TestCheckAndHandleTrustPrompt_OverriddenDocMessageIsDismissed(t *testing.T) {
+	content := `https://aider.chat/docs/faq.html
+Review these docs before continuing? (Y)es/(N)o/(D)on't ask again [Yes]:`
+	for _, program := range []string{ProgramAider, ProgramGemini} {
+		t.Run(program, func(t *testing.T) {
+			handled, cmds := runTrustPromptCheck(t, program, content)
+			require.True(t, handled, "the renderer invariant must identify the active URL prompt")
+			require.Contains(t, sentKeystrokes(cmds), "tmux send-keys -t =af_trust: D Enter")
+		})
+	}
+}
+
 // The dialog marker alone is not the doc-trust dialog: aider renders
 // "(D)on't ask again" on every confirmation prompt it asks. Dismissing an
 // arbitrary confirmation with 'D' ("don't ask again") is exactly the unbidden
@@ -605,6 +617,29 @@ Add src/main.go to the chat?
 					"renders is not evidence the doc dialog is up — tapping 'D' here answers an "+
 					"unrelated question; got %v", cmds)
 			require.False(t, handled)
+		})
+	}
+}
+
+func TestCheckAndHandleTrustPrompt_DocMatcherSourceCommentInjectsNothing(t *testing.T) {
+	content := `// DocTrustPromptPresent reports whether content shows the documentation-link
+// trust dialog shared by aider/gemini:
+//
+//	Open documentation url for more info? (Y)es/(N)o/(D)on't ask again [Yes]:
+//
+// ACTION HERE REQUIRES POSITIVE EVIDENCE.
+func DocTrustPromptPresent(content string) bool {
+	return strings.Contains(content, "Open documentation url for more info") &&
+		strings.Contains(content, "(D)on't ask again")
+}`
+
+	for _, program := range []string{ProgramAider, ProgramGemini} {
+		t.Run(program, func(t *testing.T) {
+			handled, cmds := runTrustPromptCheck(t, program, content)
+			require.False(t, handled,
+				"source text describing the prompt is not evidence that the prompt is active")
+			require.Empty(t, sentKeystrokes(cmds),
+				"repo-controlled source visible in the pane must not trigger daemon input; got %v", cmds)
 		})
 	}
 }

--- a/session/tmux/doc_trust_prompt_test.go
+++ b/session/tmux/doc_trust_prompt_test.go
@@ -28,11 +28,11 @@ import (
 // that gate and prove nothing about the path that actually types into the pane
 // (#1952).
 
-// Real aider doc-trust dialog: the prose line co-occurs with the dialog-only
-// "(D)on't ask again" affordance.
-const aiderDocTrustDialog = `Add https://aider.chat/docs/faq.html to the chat?
-Open documentation url for more info
-(Y)es/(N)o/(D)on't ask again [Yes]:`
+// Real aider doc-trust dialog: offer_url renders its URL subject in reverse
+// video before the caller-controlled question and confirmation suffix.
+const aiderDocTrustDialog = "\x1b[7mhttps://aider.chat/docs/faq.html\n" +
+	"\x1b[0m\x1b[38;5;21mOpen documentation url for more info? " +
+	"(Y)es/(N)o/(D)on't ask again [Yes]:  \x1b[39m\n\x1b[38;5;21m   \x1b[39m"
 
 // The SAME prose line as ordinary agent output — no dialog, nothing to dismiss.
 // This is the #1952 repro: an agent that merely mentions the phrase must not be
@@ -565,13 +565,26 @@ func TestCheckAndHandleTrustPrompt_RealDocDialogIsDismissed(t *testing.T) {
 }
 
 func TestCheckAndHandleTrustPrompt_OverriddenDocMessageIsDismissed(t *testing.T) {
-	content := `https://aider.chat/docs/faq.html
-Review these docs before continuing? (Y)es/(N)o/(D)on't ask again [Yes]:`
+	content := "\x1b[7mhttps://aider.chat/docs/faq.html\x1b[0m\n" +
+		"Review these docs before continuing? (Y)es/(N)o/(D)on't ask again [Yes]:"
 	for _, program := range []string{ProgramAider, ProgramGemini} {
 		t.Run(program, func(t *testing.T) {
 			handled, cmds := runTrustPromptCheck(t, program, content)
 			require.True(t, handled, "the renderer invariant must identify the active URL prompt")
 			require.Contains(t, sentKeystrokes(cmds), "tmux send-keys -t =af_trust: D Enter")
+		})
+	}
+}
+
+func TestCheckAndHandleTrustPrompt_PrintedURLThenUnrelatedConfirmInjectsNothing(t *testing.T) {
+	content := `See https://aider.chat/docs/faq.html for the details.
+Add src/main.go to the chat? (Y)es/(N)o/(D)on't ask again [Yes]:`
+	for _, program := range []string{ProgramAider, ProgramGemini} {
+		t.Run(program, func(t *testing.T) {
+			handled, cmds := runTrustPromptCheck(t, program, content)
+			require.False(t, handled,
+				"a recently printed URL does not turn the next generic confirmation into a URL-offer prompt")
+			require.Empty(t, sentKeystrokes(cmds), "got %v", cmds)
 		})
 	}
 }

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -301,57 +301,26 @@ func CodexTrustPromptPresent(content string) bool {
 		noOption < affordance && affordance == last
 }
 
-// DocTrustPromptPresent reports whether content shows the documentation-link
-// trust dialog shared by aider/gemini:
+// DocTrustPromptPresent reports whether content ends at the documentation-link
+// confirmation prompt shared by aider/gemini:
 //
-//	Open documentation url for more info? (Y)es/(N)o/(D)on't ask again [Yes]:
+//	https://aider.chat/docs/...
+//	<question text> (Y)es/(N)o/(D)on't ask again [Yes]:
 //
-// BOTH the full prose question and the "(D)on't ask again" affordance are
-// required, and NEITHER is redundant:
+// aider's InputOutput.confirm_ask accepts caller-controlled question text, then
+// appends the confirmation prefix above. InputOutput.offer_url separately renders
+// the URL subject before asking. Match those renderer invariants: the final
+// non-empty line must end at the full confirmation prefix, and a URL must be in
+// its immediate prompt context. Do not key daemon input on the overridable prose.
+// In particular, this source file contains the old prose and affordance together;
+// a strings.Contains matcher lets repo-controlled text inject D+Enter (#2638).
 //
-//   - The affordance is not a discriminator. aider renders "(D)on't ask again"
-//     on EVERY confirmation it asks ("Add src/main.go to the chat?", …). It only
-//     tells us some prompt is up — not which one. It is the weaker anchor.
-//   - The prose is the discriminator, and only at FULL length. Do not shorten it
-//     to a prefix like "Open documentation url": the prefix plus an affordance
-//     that is nearly always present means an unrelated confirmation gets answered
-//     'D' whenever that string is anywhere on screen — including in a source file
-//     the agent has open. This repo is self-hosted, so that is not hypothetical.
-//
-// The full prose is also the ORIGINAL observed string (2b23c52); the shorter form
-// was a later paraphrase introduced for readiness detection (7d78ee6), not an
-// observation of the dialog. Match what the dialog actually renders.
-//
-// ACTION HERE REQUIRES POSITIVE EVIDENCE, because the two ways to be wrong do not
-// cost the same:
-//
-//   - A MISS costs one keypress. The dialog stays up, the user presses D — or the
-//     next tick of the daemon's 1-second poll catches it, since this re-runs
-//     continuously and the real dialog does not go away on its own.
-//   - A FALSE POSITIVE types 'D'+Enter into a RUNNING agent that never asked
-//     anything (TapDAndEnter, via CheckAndHandleTrustPrompt above). That is
-//     unbidden input into someone's live session: it can answer a different
-//     question than the one we think is on screen, or land in an agent's prompt
-//     box and modify their files. The poll's caller discards the bool, so nothing
-//     breaks the loop — it re-fires every tick the phrase stays on screen (#1952).
-//
-// So this is deliberately conservative BY CONSTRUCTION, and the asymmetry above is
-// the reason. When the match is ambiguous the answer is DO NOTHING. If you are here
-// to "loosen this so it catches more cases": that trade buys back a keypress the
-// user can supply themselves, and pays for it in keystrokes injected into live
-// agents. Prefer adding a NEW anchored predicate for a specific dialog you can
-// identify over widening this one.
-//
-// Before changing this predicate, answer: what does the new one ADMIT that the old
-// one did not? Not what it rejects — what it lets through. Adding a conjunct while
-// quietly weakening another term reads as tightening and is not; that is how the
-// #1952 fix itself first shipped a NEW false-positive path. The tests only exercise
-// the real dialogs, so they will not catch it for you.
-//
-// The match runs against a visible-only capture (CapturePaneContent), so content
-// is whatever is on screen right now — including the agent's own output, a log
-// line, or a file it printed. Requiring a marker only the real dialog renders is
-// what keeps ordinary output from being mistaken for a question.
+// The immediate-context and final-line requirements both matter. The affordance
+// appears on unrelated aider confirmations, while a URL or a copied fixture can
+// appear in ordinary output. Together they describe the rendered URL prompt, not
+// merely strings that appeared somewhere in the visible pane. Ambiguity is a
+// negative here: a miss costs one manual keypress, while a false positive types
+// into a running agent on every daemon poll (#1952).
 //
 // This is the single copy, shared with task's readiness check (task/runner.go
 // isReadyContent) so the dismissal and the readiness signal can never drift apart
@@ -359,8 +328,26 @@ func CodexTrustPromptPresent(content string) bool {
 // #1952 happened. It lives here because task already imports session/tmux; the
 // reverse edge would be an import cycle.
 func DocTrustPromptPresent(content string) bool {
-	return strings.Contains(content, "Open documentation url for more info") &&
-		strings.Contains(content, "(D)on't ask again")
+	const confirmPrefix = "(Y)es/(N)o/(D)on't ask again [Yes]:"
+	content = ansiCSISequence.ReplaceAllString(strings.ReplaceAll(content, "\r\n", "\n"), "")
+	lines := strings.Split(content, "\n")
+	last := len(lines) - 1
+	for last >= 0 && strings.TrimSpace(lines[last]) == "" {
+		last--
+	}
+	if last < 0 || !strings.HasSuffix(strings.TrimSpace(lines[last]), confirmPrefix) {
+		return false
+	}
+	first := last - 2
+	if first < 0 {
+		first = 0
+	}
+	for _, line := range lines[first : last+1] {
+		if strings.Contains(line, "https://") || strings.Contains(line, "http://") {
+			return true
+		}
+	}
+	return false
 }
 
 // claudeTrustPromptPresent reports whether the captured pane content is showing

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -304,23 +304,28 @@ func CodexTrustPromptPresent(content string) bool {
 // DocTrustPromptPresent reports whether content ends at the documentation-link
 // confirmation prompt shared by aider/gemini:
 //
-//	https://aider.chat/docs/...
+//	<reverse-video>https://aider.chat/docs/...
 //	<question text> (Y)es/(N)o/(D)on't ask again [Yes]:
 //
 // aider's InputOutput.confirm_ask accepts caller-controlled question text, then
-// appends the confirmation prefix above. InputOutput.offer_url separately renders
-// the URL subject before asking. Match those renderer invariants: the final
-// non-empty line must end at the full confirmation prefix, and a URL must be in
-// its immediate prompt context. Do not key daemon input on the overridable prose.
-// In particular, this source file contains the old prose and affordance together;
-// a strings.Contains matcher lets repo-controlled text inject D+Enter (#2638).
+// appends the confirmation suffix above. InputOutput.offer_url separately renders
+// its URL subject in reverse video before asking. Match that renderer-owned SGR
+// prefix immediately before the final prompt line. Do not key daemon input on the
+// overridable prose. In particular, this source file contains the old prose and
+// affordance together; a strings.Contains matcher lets repo-controlled text inject
+// D+Enter (#2638).
 //
-// The immediate-context and final-line requirements both matter. The affordance
-// appears on unrelated aider confirmations, while a URL or a copied fixture can
-// appear in ordinary output. Together they describe the rendered URL prompt, not
-// merely strings that appeared somewhere in the visible pane. Ambiguity is a
-// negative here: a miss costs one manual keypress, while a false positive types
-// into a running agent on every daemon poll (#1952).
+// The reverse-video URL subject and final-line requirements both matter. The
+// affordance appears on unrelated aider confirmations, while an ordinary URL can
+// appear immediately before one. Without the renderer prefix those two unrelated
+// lines compose a false positive. A no-color or otherwise ambiguous capture is not
+// proof of a prompt and stays false.
+//
+// This is deliberately conservative because the two errors are asymmetric. A miss
+// costs one manual keypress, and the real dialog remains visible for the next poll
+// to retry. A false positive types D+Enter into a live agent that asked nothing; it
+// can answer a different question or modify the agent's input, and the daemon's
+// continuous poll repeats it while the text remains visible (#1952).
 //
 // This is the single copy, shared with task's readiness check (task/runner.go
 // isReadyContent) so the dismissal and the readiness signal can never drift apart
@@ -329,25 +334,41 @@ func CodexTrustPromptPresent(content string) bool {
 // reverse edge would be an import cycle.
 func DocTrustPromptPresent(content string) bool {
 	const confirmPrefix = "(Y)es/(N)o/(D)on't ask again [Yes]:"
-	content = ansiCSISequence.ReplaceAllString(strings.ReplaceAll(content, "\r\n", "\n"), "")
+	content = strings.ReplaceAll(content, "\r\n", "\n")
 	lines := strings.Split(content, "\n")
 	last := len(lines) - 1
-	for last >= 0 && strings.TrimSpace(lines[last]) == "" {
+	for last >= 0 && strings.TrimSpace(ansiCSISequence.ReplaceAllString(lines[last], "")) == "" {
 		last--
 	}
-	if last < 0 || !strings.HasSuffix(strings.TrimSpace(lines[last]), confirmPrefix) {
+	if last < 1 || !strings.HasSuffix(
+		strings.TrimSpace(ansiCSISequence.ReplaceAllString(lines[last], "")), confirmPrefix,
+	) {
 		return false
 	}
-	first := last - 2
-	if first < 0 {
-		first = 0
-	}
-	for _, line := range lines[first : last+1] {
-		if strings.Contains(line, "https://") || strings.Contains(line, "http://") {
-			return true
+	return reverseVideoURLSubject(lines[last-1])
+}
+
+func reverseVideoURLSubject(line string) bool {
+	reverse := false
+	remaining := line
+	for strings.HasPrefix(remaining, "\x1b[") {
+		end := strings.IndexByte(remaining, 'm')
+		if end < 2 {
+			return false
 		}
+		for _, code := range strings.Split(remaining[2:end], ";") {
+			switch code {
+			case "", "0", "27":
+				reverse = false
+			case "7":
+				reverse = true
+			}
+		}
+		remaining = remaining[end+1:]
 	}
-	return false
+	visible := strings.TrimSpace(ansiCSISequence.ReplaceAllString(remaining, ""))
+	return reverse && !strings.ContainsAny(visible, " \t") &&
+		(strings.HasPrefix(visible, "https://") || strings.HasPrefix(visible, "http://"))
 }
 
 // claudeTrustPromptPresent reports whether the captured pane content is showing

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -62,8 +62,8 @@ func TestIsReadyContent(t *testing.T) {
 		{
 			name:  "claude doc trust prompt",
 			agent: "claude",
-			content: "Open documentation url for more info: https://docs/\n" +
-				"(Y)es/(N)o/(D)on't ask again [Yes]:",
+			content: "\x1b[7mhttps://docs/\x1b[0m\n" +
+				"Review docs? (Y)es/(N)o/(D)on't ask again [Yes]:",
 			want: true,
 		},
 		{"claude not ready", "claude", "installing dependencies...\nready soon", false},
@@ -103,8 +103,8 @@ func TestIsReadyContent(t *testing.T) {
 		{
 			name:  "aider doc trust prompt",
 			agent: "aider",
-			content: "Open documentation url for more info: https://aider.chat/docs/\n" +
-				"(Y)es/(N)o/(D)on't ask again [Yes]:",
+			content: "\x1b[7mhttps://aider.chat/docs/\x1b[0m\n" +
+				"Review docs? (Y)es/(N)o/(D)on't ask again [Yes]:",
 			want: true,
 		},
 		{"aider not ready", "aider", "loading model weights…", false},
@@ -112,10 +112,11 @@ func TestIsReadyContent(t *testing.T) {
 		// gemini (best-guess box-border signal — see #714)
 		{"gemini box frame", "gemini", "╭──╮\n│ Gemini │\n╰──╯", true},
 		{
-			name:    "gemini doc trust prompt",
-			agent:   "gemini",
-			content: "Gemini CLI\nhttps://docs.example.test/\nReview docs? (Y)es/(N)o/(D)on't ask again [Yes]:",
-			want:    true,
+			name:  "gemini doc trust prompt",
+			agent: "gemini",
+			content: "Gemini CLI\n\x1b[7mhttps://docs.example.test/\x1b[0m\n" +
+				"Review docs? (Y)es/(N)o/(D)on't ask again [Yes]:",
+			want: true,
 		},
 		{"gemini not ready", "gemini", "starting gemini-cli…", false},
 
@@ -125,7 +126,7 @@ func TestIsReadyContent(t *testing.T) {
 		{"amp high-mode input box", "amp", "╭──────── high ────────╮\n│ > \n╰──────── /tmp/repo ─────╯", true},
 		{"amp box without prompt anchor", "amp", "╭ downloading tools ╮\n╰ please wait ─────╯", false},
 		{"amp prompt top without input line", "amp", "╭──────── medium ────────╮\nloading plugins", false},
-		{"amp doc trust prompt", "amp", "https://docs.example.test/\nReview docs? (Y)es/(N)o/(D)on't ask again [Yes]:", true},
+		{"amp doc trust prompt", "amp", "\x1b[7mhttps://docs.example.test/\x1b[0m\nReview docs? (Y)es/(N)o/(D)on't ask again [Yes]:", true},
 		{"amp not ready on arbitrary output", "amp", "loading settings", false},
 
 		// opencode — the composer frame is the ready signal. The real-capture

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -114,7 +114,7 @@ func TestIsReadyContent(t *testing.T) {
 		{
 			name:    "gemini doc trust prompt",
 			agent:   "gemini",
-			content: "Gemini CLI\nOpen documentation url for more info.\n(D)on't ask again",
+			content: "Gemini CLI\nhttps://docs.example.test/\nReview docs? (Y)es/(N)o/(D)on't ask again [Yes]:",
 			want:    true,
 		},
 		{"gemini not ready", "gemini", "starting gemini-cli…", false},
@@ -125,7 +125,7 @@ func TestIsReadyContent(t *testing.T) {
 		{"amp high-mode input box", "amp", "╭──────── high ────────╮\n│ > \n╰──────── /tmp/repo ─────╯", true},
 		{"amp box without prompt anchor", "amp", "╭ downloading tools ╮\n╰ please wait ─────╯", false},
 		{"amp prompt top without input line", "amp", "╭──────── medium ────────╮\nloading plugins", false},
-		{"amp doc trust prompt", "amp", "Open documentation url for more info.\n(D)on't ask again", true},
+		{"amp doc trust prompt", "amp", "https://docs.example.test/\nReview docs? (Y)es/(N)o/(D)on't ask again [Yes]:", true},
 		{"amp not ready on arbitrary output", "amp", "loading settings", false},
 
 		// opencode — the composer frame is the ready signal. The real-capture

--- a/task/trust_readiness_parity_test.go
+++ b/task/trust_readiness_parity_test.go
@@ -15,9 +15,8 @@ import (
 // disjunction of a trust predicate and some other ready signal, so a second
 // signal hiding in here would satisfy a label check for the wrong reason.
 // TestTrustDialogFixtureCarriesOnlyATrustSignal guards that, via nonTrustTwin.
-const docTrustDialogFixture = `Add https://aider.chat/docs/faq.html to the chat?
-Open documentation url for more info
-(Y)es/(N)o/(D)on't ask again [Yes]:`
+const docTrustDialogFixture = "\x1b[7mhttps://aider.chat/docs/faq.html\x1b[0m\n" +
+	"Open documentation url for more info? (Y)es/(N)o/(D)on't ask again [Yes]:"
 
 // Which predicate isReadyContent's arm for an agent uses to decide a trust
 // dialog means "ready". This is a fact about AF's code, greppable in runner.go —


### PR DESCRIPTION
Closes #2638

## What was wrong
`DocTrustPromptPresent` searched the entire visible pane with `strings.Contains` for the documentation prompt prose and the generic "(D)on't ask again" affordance. The predicate's own justification comment in `session/tmux/start.go` contained both strings, so merely displaying that repository source made the daemon believe a live prompt existed and inject `D` plus Enter.

That was a repository-content-to-daemon-behavior path: text that only appeared in the pane was treated as proof that the prompt renderer was currently waiting for input.

## What changed
The matcher now keys on Aider's renderer-owned structure, not caller-provided prose:

- the line immediately before the active prompt must be an HTTP(S) URL whose captured cells begin in reverse-video SGR, as `InputOutput.offer_url` renders its subject;
- the final non-empty visible line must end in the full rendered confirmation suffix;
- the question between those anchors remains fully overridable.

The regression uses the actual `tmux capture-pane -p -e -J` shape, including the reverse-video URL subject, the colored prompt line, and trailing styled blank cells. The shared predicate still drives both active dismissal and task readiness, so those paths cannot drift.

## Why the alternatives were rejected
The issue report suggested distinguishing punctuation after the old prose. That still makes daemon input depend on overridable natural-language message text and can still match copied source or output. A whole-pane substring check is unsafe for the same reason.

The first pushed head required the generic confirmation suffix plus any URL in the preceding two lines. Review correctly found that an ordinary printed URL followed by an unrelated confirmation composes the same condition. That alternative is rejected: the URL must carry the reverse-video subject prefix produced by the URL-offer renderer. An unstyled/no-color capture remains ambiguous and does not trigger input.

The matcher is deliberately conservative because the errors are asymmetric. A miss costs one manual keypress, and the real dialog remains visible for the next daemon poll to retry. A false positive types `D` plus Enter into a live agent that asked nothing, can answer a different prompt or modify its input, and repeats on every poll while the text remains visible. Ambiguous content is therefore "could not determine," not permission to type.

## Red first
The original source-comment regression failed against the pre-fix tree:

```
--- FAIL: TestCheckAndHandleTrustPrompt_DocMatcherSourceCommentInjectsNothing (0.00s)
    --- FAIL: TestCheckAndHandleTrustPrompt_DocMatcherSourceCommentInjectsNothing/aider
        doc_trust_prompt_test.go:627: Should be false
        Messages: source text describing the prompt is not evidence that the prompt is active
    --- FAIL: TestCheckAndHandleTrustPrompt_DocMatcherSourceCommentInjectsNothing/gemini
        doc_trust_prompt_test.go:627: Should be false
        Messages: source text describing the prompt is not evidence that the prompt is active
```

The review regression also failed against the first pushed head:

```
--- FAIL: TestCheckAndHandleTrustPrompt_PrintedURLThenUnrelatedConfirmInjectsNothing (0.00s)
    --- FAIL: TestCheckAndHandleTrustPrompt_PrintedURLThenUnrelatedConfirmInjectsNothing/aider
        doc_trust_prompt_test.go:585: Should be false
        Messages: a recently printed URL does not turn the next generic confirmation into a URL-offer prompt
    --- FAIL: TestCheckAndHandleTrustPrompt_PrintedURLThenUnrelatedConfirmInjectsNothing/gemini
        doc_trust_prompt_test.go:585: Should be false
        Messages: a recently printed URL does not turn the next generic confirmation into a URL-offer prompt
```

Both regressions exercise the production handler and assert that no keystrokes are injected. A positive test verifies that an overridden question is still dismissed when the renderer prefix is present.

## Validation
Pushed head: `6926e7bef2027b8700fe6d2e99f8b7e0100bdb75`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- full `session/tmux` and `task` package tests in the test container
- `make test-container` (full suite, last, on the pushed head)
