### PR TITLE
fix: clear auto-hide notices after preview commits

### DIFF
--- a/app/pane_autohide_status_test.go
+++ b/app/pane_autohide_status_test.go
@@ -93,6 +93,49 @@ func TestPane_AutoHideViaPreviewFocusStartsClearTimer(t *testing.T) {
 		"updatePanePreview returns the clear-timer cmd so the notice auto-clears after 3s (#1685)")
 }
 
+// TestPane_AutoHideViaPreviewCommitToOpenTabStartsClearTimer is the #2639
+// regression: a preview target can become open in another pane before Enter
+// commits it. commitPanePreviewReplace then focuses that already-open pane,
+// whose relayout hides the preview owner at narrow widths. The notice must be
+// consumed and its clear timer returned just like every other focus relayout.
+func TestPane_AutoHideViaPreviewCommitToOpenTabStartsClearTimer(t *testing.T) {
+	h := paneTestHome(t)
+	resizeHome(h, layout.MultiPaneMinWidth-1, 24) // only one pane fits
+
+	visible, hidden := openPanesForBothAndReturnHidden(t, h)
+	owner := h.store.FindOpenPane(visible, 0)
+	target := h.store.FindOpenPane(hidden, 0)
+	require.NotNil(t, owner)
+	require.NotNil(t, target)
+	require.NotSame(t, owner, target)
+
+	w := h.paneWindows[owner.ID()]
+	require.NotNil(t, w)
+	original := paneBinding{instance: visible, tab: 0}
+	preview := paneBinding{instance: hidden, tab: 0}
+	seq := w.SetPreview(preview.instance, preview.tab, paneBindingLabel(original))
+	h.panePreviewTxn = &panePreviewTxn{
+		ownerPaneID: owner.ID(),
+		original:    original,
+		target:      preview,
+		seq:         seq,
+	}
+
+	// Reset the notice left by setup so only the commit relayout is measured.
+	h.errBox.Clear()
+	h.pendingPaneAutoHideStatus = ""
+	h.paneAutoHideNoticeID = 0
+
+	committed, cmd := h.commitPanePreviewReplace()
+
+	require.Same(t, target, committed, "the preview commits to the pane that already owns the target tab")
+	require.NotEmpty(t, h.errBox.FullError(), "the commit relayout reports the newly hidden preview owner")
+	assert.Equal(t, "", h.pendingPaneAutoHideStatus,
+		"the preview-commit path consumes the pending status instead of leaving it forever (#2639)")
+	require.NotNil(t, cmd,
+		"preview commit returns the clear-timer cmd so the notice auto-clears after 3s (#2639)")
+}
+
 // TestPane_OpenFocusRefreshProducedStatusStillClears guards the Greptile edge on
 // PR #1771: a status produced by the SUBSEQUENT selectionChanged refresh during
 // an open-or-focus must still be drained + timed. Here focusOpenPane on the

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -384,7 +384,10 @@ func (m *home) commitPanePreviewReplace() (*store.OpenPane, tea.Cmd) {
 		m.store.TouchOpenPane(existing)
 		m.relayout()
 		m.focusRegion(layout.PaneRegion(existing.ID()))
-		return existing, m.panesRefresh(m.attached.Load())
+		return existing, tea.Batch(
+			m.panesRefresh(m.attached.Load()),
+			m.consumePaneAutoHideStatus(),
+		)
 	}
 	w := m.paneWindows[owner.ID()]
 	m.panePreviewTxn = nil
@@ -399,7 +402,13 @@ func (m *home) commitPanePreviewReplace() (*store.OpenPane, tea.Cmd) {
 	m.lastPaneCapture[owner.ID()] = time.Time{}
 	m.relayout()
 	m.focusRegion(layout.PaneRegion(owner.ID()))
-	return owner, m.panesRefresh(m.attached.Load())
+	// Both successful commit branches relayout directly rather than through
+	// focusOpenPane/openOrFocusPane. Drain any auto-hide status here so neither
+	// branch can leave a notice without its clear timer (#2639).
+	return owner, tea.Batch(
+		m.panesRefresh(m.attached.Load()),
+		m.consumePaneAutoHideStatus(),
+	)
 }
 
 func (m *home) commitPanePreviewAlongside() tea.Cmd {


### PR DESCRIPTION
Closes #2639

## Diagnosis

`commitPanePreviewReplace` directly relaid out the workspace when a preview committed to a tab that was already open in another pane. At a narrow width that relayout correctly queued the "pane hidden" notice, but this return path skipped `consumePaneAutoHideStatus`, so no three-second clear command was ever scheduled.

The report's diagnosis is confirmed. The adjacent successful rebind branch also performs a direct relayout, so both successful commit exits now drain the pending status and batch its clear timer with the pane refresh. The other focus paths already consume the status through `openOrFocusPane` or `updatePanePreview`.

## Fail first

The regression test was added and run against today's unmodified implementation:

```
expected: ""
actual  : "alpha · ◆ Agent hidden — too narrow for 2 panes; resize wider or use `s` open pane"
--- FAIL: TestPane_AutoHideViaPreviewCommitToOpenTabStartsClearTimer
```

## Validation

Focused container tests:
- `scripts/testbox.sh test ./app -run 'TestPane_(AutoHideViaPreviewCommitToOpenTabStartsClearTimer|AutoHideViaPreviewFocusStartsClearTimer|OpenFocusRefreshProducedStatusStillClears)$' -count=1 -v`

Required gates:
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container`

The full container suite was run last and passed against pushed head `5494619dd913193102a891c2ec0d5a183c6354d6` (`app` 166.689s, `daemon` 231.813s).

Real-TUI validation on that unchanged head used an ephemeral `scripts/testbox.sh scenario` drive (the temporary scenario was removed after the run): open alpha/beta panes wide, select gamma to create a live preview, press Enter to commit/rebind the preview, resize narrow to trigger auto-hide, observe the notice clear on its timer, then resize wide and verify both committed panes return. Result:

```text
PASS: #2639 real TUI preview commit and auto-hide lifecycle
```

The exact already-open-target race remains pinned by the fail-first unit regression above; the real drive deliberately uses only deterministic user input through the production TUI/backend.