### PR TITLE
fix: persist tab closes before teardown

### DIFF
--- a/daemon/close_tab_cleanup_test.go
+++ b/daemon/close_tab_cleanup_test.go
@@ -1,0 +1,295 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The daemon-side disk contract for #2669's review follow-up. The session
+// package proves the retention mechanism; these prove the two things only the
+// daemon can: that an unconfirmed teardown's cleanup handle actually reaches
+// instances.json (the point of it being durable), and that the wedge the finding
+// describes — a same-named tab re-deriving the survivor's tmux name — is gone.
+
+// unkillableTabExec models a tmux server that refuses kill-session for the named
+// sessions and leaves them running, the shape close.go reports as a real
+// teardown error rather than a timeout.
+func unkillableTabExec(alive map[string]bool, unkillable map[string]bool) (cmd_test.MockCmdExec, func(string) bool) {
+	var mu sync.Mutex
+	existing := map[string]bool{}
+	for name, ok := range alive {
+		existing[name] = ok
+	}
+	nameOf := func(cmd *exec.Cmd) string {
+		for i, a := range cmd.Args {
+			switch {
+			case (a == "-t" || a == "-s") && i+1 < len(cmd.Args):
+				return strings.TrimSuffix(strings.TrimPrefix(cmd.Args[i+1], "="), ":")
+			case strings.HasPrefix(a, "-t="):
+				return strings.TrimPrefix(a, "-t=")
+			case strings.HasPrefix(a, "-s="):
+				return strings.TrimPrefix(a, "-s=")
+			}
+		}
+		return ""
+	}
+	mockExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			s := cmd.String()
+			name := nameOf(cmd)
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case strings.Contains(s, "has-session"):
+				if existing[name] {
+					return nil
+				}
+				return &tabNoSessionErr{}
+			case strings.Contains(s, "new-session"):
+				existing[name] = true
+			case strings.Contains(s, "kill-session"):
+				if unkillable[name] {
+					return errors.New("kill-session refused")
+				}
+				delete(existing, name)
+			}
+			return nil
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) { return []byte("content"), nil },
+	}
+	return mockExec, func(name string) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return existing[name]
+	}
+}
+
+// persistedInstance reads back the one persisted record for repoID.
+func persistedInstance(t *testing.T, repoID string) session.InstanceData {
+	t.Helper()
+	raw, err := config.LoadRepoInstances(repoID)
+	if err != nil {
+		t.Fatalf("LoadRepoInstances: %v", err)
+	}
+	var data []session.InstanceData
+	if err := json.Unmarshal(raw, &data); err != nil {
+		t.Fatalf("unmarshal instances: %v", err)
+	}
+	if len(data) != 1 {
+		t.Fatalf("expected 1 persisted instance, got %d", len(data))
+	}
+	return data[0]
+}
+
+// TestCloseTab_UnconfirmedTeardownPersistsCleanupHandle is the #2669 review
+// regression at the storage boundary. CloseTab commits the shrunken roster
+// before it kills tmux, so a kill that answers with the session still alive used
+// to leave the persisted record naming that tmux session NOWHERE: the process
+// was untracked across every future daemon restart. The close must still
+// succeed — it is durably committed — while the record retains a cleanup handle.
+func TestCloseTab_UnconfirmedTeardownPersistsCleanupHandle(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const title = "worker"
+	agentName := "af_" + title + "_agent"
+	// The tab's tmux name is derived at spawn, so refuse every kill except the
+	// agent's: the process tab's session is whichever one CreateTab lands on.
+	mockExec, aliveFn := unkillableTabExec(
+		map[string]bool{agentName: true},
+		map[string]bool{agentName + "__btop": true})
+	inst := startedLocalTabInstanceWithExec(t, manager, repo.ID, repoPath, title, agentName, mockExec)
+	created, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Command: "btop -t"})
+	if err != nil {
+		t.Fatalf("CreateTab: %v", err)
+	}
+	if created.TmuxName != agentName+"__btop" {
+		t.Fatalf("precondition: process tab tmux = %q, want %q", created.TmuxName, agentName+"__btop")
+	}
+
+	name, err := manager.CloseTab(CloseTabRequest{Title: title, RepoID: repo.ID, TabID: created.ID})
+	if err != nil {
+		t.Fatalf("CloseTab must succeed on an unconfirmed teardown: the roster decision is durable: %v", err)
+	}
+	if name != "btop" {
+		t.Fatalf("closed tab name = %q, want btop", name)
+	}
+	if !aliveFn(created.TmuxName) {
+		t.Fatal("precondition: the fixture's kill must leave the session alive; the test's premise is wrong")
+	}
+	if got := inst.TabCount(); got != 1 {
+		t.Fatalf("tab count = %d, want 1: the close is committed regardless of teardown", got)
+	}
+
+	data := persistedInstance(t, repo.ID)
+	for _, tab := range data.Tabs {
+		if tab.TmuxName == created.TmuxName {
+			t.Fatal("the persisted record still carries the closed tab; a restart would respawn it")
+		}
+	}
+	if len(data.PendingTabCleanup) != 1 {
+		t.Fatalf("persisted cleanup handles = %d, want 1: the leaked tmux session %q is now untracked "+
+			"across daemon restarts", len(data.PendingTabCleanup), created.TmuxName)
+	}
+	if got := data.PendingTabCleanup[0].TmuxName; got != created.TmuxName {
+		t.Fatalf("persisted cleanup handle names %q, want the closed tab's session %q", got, created.TmuxName)
+	}
+	if data.PendingTabCleanup[0].TabID != created.ID {
+		t.Fatalf("cleanup handle tab id = %q, want %q", data.PendingTabCleanup[0].TabID, created.ID)
+	}
+}
+
+// TestCloseTab_ConfirmedTeardownPersistsNoCleanupHandle keeps the retention from
+// becoming a leak of its own: an ordinary close proves the session is gone, so
+// the record must carry no handle for a future daemon to retry.
+func TestCloseTab_ConfirmedTeardownPersistsNoCleanupHandle(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const title = "worker"
+	agentName := "af_" + title + "_agent"
+	mockExec, aliveFn := unkillableTabExec(map[string]bool{agentName: true}, nil)
+	startedLocalTabInstanceWithExec(t, manager, repo.ID, repoPath, title, agentName, mockExec)
+	created, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Command: "btop -t"})
+	if err != nil {
+		t.Fatalf("CreateTab: %v", err)
+	}
+
+	if _, err := manager.CloseTab(CloseTabRequest{Title: title, RepoID: repo.ID, TabID: created.ID}); err != nil {
+		t.Fatalf("CloseTab: %v", err)
+	}
+	if aliveFn(created.TmuxName) {
+		t.Fatal("precondition: a confirmed close must actually kill the session")
+	}
+
+	if got := persistedInstance(t, repo.ID).PendingTabCleanup; len(got) != 0 {
+		t.Fatalf("a confirmed teardown left %d cleanup handle(s) on disk; every future daemon start "+
+			"would retry a kill that already succeeded", len(got))
+	}
+}
+
+// TestCreateTab_AvoidsTmuxNameRetainedByUnconfirmedClose is the user-visible half
+// of the finding. After a close whose kill failed, nothing on the roster holds
+// the "btop" token, so the next `tab-create` re-derived the survivor's exact tmux
+// name and TmuxSession.Start rejected it as already existing — a wedge no retry
+// clears, because every retry derives the same name. The retained handle
+// reserves the token, so the spawn walks to "btop-2" and succeeds.
+func TestCreateTab_AvoidsTmuxNameRetainedByUnconfirmedClose(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const title = "worker"
+	agentName := "af_" + title + "_agent"
+	mockExec, aliveFn := unkillableTabExec(
+		map[string]bool{agentName: true},
+		map[string]bool{agentName + "__btop": true})
+	startedLocalTabInstanceWithExec(t, manager, repo.ID, repoPath, title, agentName, mockExec)
+	first, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Command: "btop -t"})
+	if err != nil {
+		t.Fatalf("CreateTab: %v", err)
+	}
+	if _, err := manager.CloseTab(CloseTabRequest{Title: title, RepoID: repo.ID, TabID: first.ID}); err != nil {
+		t.Fatalf("CloseTab: %v", err)
+	}
+	if !aliveFn(first.TmuxName) {
+		t.Fatal("precondition: the first tab's session must survive the failed kill")
+	}
+
+	second, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Command: "btop -t"})
+	if err != nil {
+		t.Fatalf("recreating the tab must not collide with the un-reaped session: %v", err)
+	}
+	if second.TmuxName == first.TmuxName {
+		t.Fatalf("the new tab re-derived the surviving session's tmux name %q; Start would reject it "+
+			"as already existing and no retry could ever clear it", second.TmuxName)
+	}
+	// The user still gets the name they asked for — only the tmux namespace walks
+	// (#1957): the reservation must not charge the display namespace for a
+	// collision in tmux's.
+	if second.Name != "btop" {
+		t.Fatalf("recreated tab name = %q, want btop: the cleanup handle must not take the user's name", second.Name)
+	}
+}
+
+// TestSweepStartupTabCleanup_RetiresConfirmedHandlesOnDisk covers the wiring the
+// session-package retry test cannot: that the daemon's startup pass records the
+// retirement through the targeted per-repo writer, so the next start does not
+// retry a finished teardown forever.
+//
+// The seeded handle names a tmux session that does not exist, which Close treats
+// as a confirmed absence (#967 idempotent teardown). That keeps the test's only
+// real tmux contact to a kill and a probe against a name nothing owns.
+func TestSweepStartupTabCleanup_RetiresConfirmedHandlesOnDisk(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed; the startup sweep drives a real teardown")
+	}
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const title = "worker"
+	agentName := "af_" + title + "_agent"
+	mockExec, _ := unkillableTabExec(map[string]bool{agentName: true}, nil)
+	inst := startedLocalTabInstanceWithExec(t, manager, repo.ID, repoPath, title, agentName, mockExec)
+	// A handle left by a previous daemon whose close committed but whose kill was
+	// never confirmed. The session it names is long gone.
+	inst.SetPendingTabCleanupForTest([]session.TabCleanupData{
+		{TabID: "closed-tab", TmuxName: agentName + "__reaped-by-a-crash"},
+	})
+	if err := persistInstanceData(repo.ID, inst.ToInstanceData()); err != nil {
+		t.Fatalf("seeding the pending handle: %v", err)
+	}
+	if len(persistedInstance(t, repo.ID).PendingTabCleanup) != 1 {
+		t.Fatal("precondition: the seeded handle must be on disk")
+	}
+
+	sweepStartupTabCleanup(manager)
+
+	if got := inst.PendingTabCleanup(); len(got) != 0 {
+		t.Fatalf("the sweep left %d handle(s) in memory for a session that is positively gone", len(got))
+	}
+	if got := persistedInstance(t, repo.ID).PendingTabCleanup; len(got) != 0 {
+		t.Fatalf("the sweep reaped the session but did not record it; every future start would "+
+			"retry the finished teardown (%d handle(s) still on disk)", len(got))
+	}
+}

--- a/daemon/close_tab_commit_order_test.go
+++ b/daemon/close_tab_commit_order_test.go
@@ -1,0 +1,103 @@
+package daemon
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+func TestCloseTab_PublishesCommittedRosterBeforeTmuxTeardownCompletes(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const title, agentName = "worker", "af_worker_agent"
+	processTmuxName := agentName + "__btop"
+	killStarted := make(chan struct{}, 1)
+	releaseKill := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(releaseKill) }) })
+	mockExec, _ := closeBlockingTabExec(
+		map[string]bool{agentName: true}, processTmuxName, killStarted, releaseKill)
+	startedLocalTabInstanceWithExec(t, manager, repo.ID, repoPath, title, agentName, mockExec)
+	created, err := manager.CreateTab(CreateTabRequest{
+		Title: title, RepoID: repo.ID, Command: "btop",
+	})
+	if err != nil {
+		t.Fatalf("CreateTab: %v", err)
+	}
+
+	_, events := manager.events.subscribe()
+	done := make(chan error, 1)
+	go func() {
+		_, closeErr := manager.CloseTab(CloseTabRequest{
+			Title: title, RepoID: repo.ID, TabID: created.ID,
+		})
+		done <- closeErr
+	}()
+
+	select {
+	case <-killStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("CloseTab never reached tmux teardown")
+	}
+
+	// Reaching tmux teardown proves the commit callback returned. Pin that the
+	// smaller roster really is durable before checking its client notification.
+	raw, err := config.LoadRepoInstances(repo.ID)
+	if err != nil {
+		t.Fatalf("LoadRepoInstances during teardown: %v", err)
+	}
+	var persisted []session.InstanceData
+	if err := json.Unmarshal(raw, &persisted); err != nil {
+		t.Fatalf("unmarshal committed instances: %v", err)
+	}
+	if len(persisted) != 1 {
+		t.Fatalf("committed instance count = %d, want 1", len(persisted))
+	}
+	for _, tab := range persisted[0].Tabs {
+		if tab.ID == created.ID {
+			t.Fatalf("tab %q was not durably removed before tmux teardown", created.ID)
+		}
+	}
+
+	publishedBeforeTeardown := false
+	select {
+	case event := <-events:
+		if event.Type != agentproto.EventSessionUpdated {
+			t.Fatalf("event type = %q, want %q", event.Type, agentproto.EventSessionUpdated)
+		}
+		var update session.InstanceData
+		if err := json.Unmarshal(event.Data, &update); err != nil {
+			t.Fatalf("unmarshal session.updated: %v", err)
+		}
+		publishedBeforeTeardown = true
+		for _, tab := range update.Tabs {
+			if tab.ID == created.ID {
+				t.Fatalf("session.updated still carries closed tab %q", created.ID)
+			}
+		}
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	releaseOnce.Do(func() { close(releaseKill) })
+	if err := <-done; err != nil {
+		t.Fatalf("CloseTab: %v", err)
+	}
+	if !publishedBeforeTeardown {
+		t.Fatal("CloseTab waited for tmux teardown before publishing the durably committed roster")
+	}
+}

--- a/daemon/close_tab_test.go
+++ b/daemon/close_tab_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -76,6 +77,64 @@ func TestCloseTab_RemovesNonAgentTabAndPersists(t *testing.T) {
 		if tab.Kind == session.TabKindProcess {
 			t.Fatalf("persisted record still carries process tab %q after close", tab.Name)
 		}
+	}
+}
+
+// TestCloseTab_PersistFailureKeepsTmuxTabForRetry is the #2669 durability
+// regression. A close is not committed until the shrunken roster reaches disk:
+// if that write fails, the live roster and its tmux session must remain intact
+// so the user can retry. Killing first leaves the old row on disk, and a daemon
+// restart then respawns the supposedly closed tab from that stale row.
+func TestCloseTab_PersistFailureKeepsTmuxTabForRetry(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const title = "worker"
+	agentName := "af_" + title + "_agent"
+	mockExec, tmuxAlive := closeBlockingTabExec(
+		map[string]bool{agentName: true}, "never-block", nil, nil)
+	inst := startedLocalTabInstanceWithExec(t, manager, repo.ID, repoPath, title, agentName, mockExec)
+	created, err := manager.CreateTab(CreateTabRequest{
+		Title: title, RepoID: repo.ID, Command: "btop -t",
+	})
+	if err != nil {
+		t.Fatalf("CreateTab: %v", err)
+	}
+	if !tmuxAlive(created.TmuxName) {
+		t.Fatalf("precondition: process tmux %q was not started", created.TmuxName)
+	}
+
+	// Corrupt validly located storage so persistInstanceData fails deterministically
+	// even in the root-running container suite. The manager has already resolved
+	// the live instance, so the failure lands at the commit boundary under test.
+	path, err := config.RepoInstancesPath(repo.ID)
+	if err != nil {
+		t.Fatalf("RepoInstancesPath: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{ not json"), 0o600); err != nil {
+		t.Fatalf("corrupting the instances file: %v", err)
+	}
+
+	_, err = manager.CloseTab(CloseTabRequest{
+		Title: title, RepoID: repo.ID, TabID: created.ID,
+	})
+	if err == nil {
+		t.Fatal("CloseTab succeeded despite a persist failure; the test's premise is wrong")
+	}
+	if got := inst.TabCount(); got != 2 {
+		t.Fatalf("persist failure left %d tabs, want 2: the close must remain retryable", got)
+	}
+	if !tmuxAlive(created.TmuxName) {
+		t.Fatalf("persist failure killed process tmux %q; stale disk state can resurrect it on restart", created.TmuxName)
 	}
 }
 

--- a/daemon/create_tab_vscode_test.go
+++ b/daemon/create_tab_vscode_test.go
@@ -236,11 +236,10 @@ func TestCloseTab_ShellTabLeavesEditorAlone(t *testing.T) {
 	}
 }
 
-// TestCloseTab_StopsEditorEvenWhenPersistFails is the codex P2 fix. CloseTab
-// removes the tab from the live instance BEFORE persisting, so a persist failure
-// (disk full, permissions) leaves a session with no reachable vscode tab — and,
-// without this, an editor running until daemon shutdown that nothing can ever
-// reach again or clean up.
+// TestCloseTab_StopsEditorEvenWhenPersistFails keeps #2669's rollback compatible
+// with #2668's retry-handle rule. The last VS Code tab is restored if persistence
+// fails, but only after its editor has been confirmed stopped; a later access can
+// start a fresh editor without leaking the old process.
 func TestCloseTab_StopsEditorEvenWhenPersistFails(t *testing.T) {
 	manager, repoID, title := newVSCodeCreateFixture(t)
 	key := daemonInstanceKey(repoID, title)
@@ -269,6 +268,9 @@ func TestCloseTab_StopsEditorEvenWhenPersistFails(t *testing.T) {
 		t.Fatal("CloseTab succeeded despite a persist failure; the test's premise is wrong")
 	}
 	if _, ok := manager.vscode.servers[key]; ok {
-		t.Fatal("the editor is still running after its last vscode tab was closed and the persist failed; nothing can reach or reap it until daemon shutdown")
+		t.Fatal("the editor is still running after its last VS Code tab was staged and the persist failed")
+	}
+	if !instanceHasVSCodeTab(manager.instances[key]) {
+		t.Fatal("persist failure did not restore the vscode tab for retry")
 	}
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -278,6 +278,7 @@ func runDaemon(cfg *config.Config, upgradeTransactionID string) error {
 	sweepLegacyTaskUnits()
 
 	sweepStartupOrphanContainers(manager)
+	sweepStartupTabCleanup(manager)
 	manager.finishInstanceRestore()
 
 	// Start schedule evaluation only after the control server is up and the

--- a/daemon/manager_tabs.go
+++ b/daemon/manager_tabs.go
@@ -295,12 +295,24 @@ func (m *Manager) CloseTab(req CloseTabRequest) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if committed.TeardownErr != nil {
+	switch {
+	case committed.TeardownErr != nil:
 		// The durable decision succeeded, but teardown did not provide evidence
 		// that the tmux process is gone. Report that third state in diagnostics
 		// without presenting the committed close as retryable: a restart reads the
-		// shrunken roster and will not resurrect this tab.
-		log.WarningLog.Printf("CloseTab %q committed, but runtime teardown could not be confirmed: %v", name, committed.TeardownErr)
+		// shrunken roster and will not resurrect this tab. The tmux session is not
+		// abandoned either — the commit persisted a cleanup handle for it, which the
+		// next daemon start sweeps and which reserves its name against a colliding
+		// spawn in the meantime (#2669).
+		log.WarningLog.Printf("CloseTab %q committed, but runtime teardown could not be confirmed; its tmux session is retained for cleanup: %v", name, committed.TeardownErr)
+	case committed.Settled != nil:
+		// Teardown confirmed the session is gone, so retire its cleanup handle on
+		// disk. Best-effort by design: a failed write only leaves a handle whose
+		// retry harmlessly re-kills an absent session, and turning that into a
+		// CloseTab error would report a fully completed close as failed.
+		if err := persistInstanceData(repoID, *committed.Settled); err != nil {
+			log.WarningLog.Printf("CloseTab %q completed, but clearing its tmux cleanup handle failed; the next daemon start will retry the (already finished) teardown: %v", name, err)
+		}
 	}
 	return name, nil
 }

--- a/daemon/manager_tabs.go
+++ b/daemon/manager_tabs.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -229,10 +228,10 @@ func tabTmuxNameByID(tabs []session.TabData, id string) string {
 // resolve onto a reused name doesn't mislabel a tab, it kills the wrong tmux
 // session. The agent tab (index 0) is unclosable — KillSession tears down the
 // whole session instead — matching the TUI's `w` rule (handleCloseTab). Returns
-// the resolved name of the closed tab. Unlike CreateTab there is no rollback on persist failure: CloseTab
-// has already killed the tab's tmux session, so there is nothing live left to
-// orphan — the in-memory list (tab removed) is the more accurate state, and the
-// stale disk record is harmless (its session is dead and won't reconnect).
+// the resolved name of the closed tab. The roster removal is committed to disk
+// before irreversible stream/tmux teardown. A persist failure restores the exact
+// live tab for retry; otherwise stale disk state could respawn a killed tab on a
+// daemon restart (#2669).
 func (m *Manager) CloseTab(req CloseTabRequest) (string, error) {
 	instance, repoID, title, release, err := m.tabMutationTarget(req.ID, req.Title, req.RepoID,
 		tabMutationLabels{action: "close a tab", op: "tab close"})
@@ -264,8 +263,6 @@ func (m *Manager) CloseTab(req CloseTabRequest) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	closedTab := tabs[idx]
-
 	var vscodeKey string
 	if lastVSCode {
 		// Stop before removing the last durable UI retry handle. An unknown result
@@ -276,28 +273,32 @@ func (m *Manager) CloseTab(req CloseTabRequest) (string, error) {
 		}
 	}
 
-	if err := instance.CloseTabByID(targetID); err != nil {
+	var data session.InstanceData
+	committed, err := instance.CloseTabByIDWithCommit(targetID, func(staged session.InstanceData) error {
+		// A proxy that resolved the tab before the first stop can still reach
+		// editor admission without the session op-lock. Sweep again while the
+		// roster is staged but before committing it. An unknown result makes the
+		// transaction restore the exact tab, preserving its durable retry handle.
+		if lastVSCode {
+			if err := m.stopVSCodeForInstance(vscodeKey, instance.ID); err != nil {
+				return fmt.Errorf("final editor teardown stayed unknown: %w", err)
+			}
+		}
+		if err := persistInstanceData(repoID, staged); err != nil {
+			return fmt.Errorf("failed to persist tab close: %w", err)
+		}
+		data = staged
+		return nil
+	})
+	if err != nil {
 		return "", err
 	}
-
-	// A proxy that resolved the tab before the first stop can still reach editor
-	// admission without the session op-lock. Sweep again after the roster change,
-	// and propagate uncertainty before persisting the close. A persist failure is
-	// still safe: the live roster has no tab and this final sweep stopped its
-	// editor; a restart restores the old tab and lazily starts a new one.
-	if lastVSCode {
-		if err := m.stopVSCodeForInstance(vscodeKey, instance.ID); err != nil {
-			stopErr := fmt.Errorf("could not confirm final editor teardown after closing the VS Code tab: %w", err)
-			if restoreErr := instance.RestoreClosedVSCodeTab(closedTab, idx); restoreErr != nil {
-				return "", errors.Join(stopErr, fmt.Errorf("restoring the VS Code retry tab: %w", restoreErr))
-			}
-			return "", fmt.Errorf("restored the VS Code tab because final editor teardown stayed unknown: %w", stopErr)
-		}
-	}
-
-	data := instance.ToInstanceData()
-	if err := persistInstanceData(repoID, data); err != nil {
-		return "", fmt.Errorf("failed to persist tab close: %w", err)
+	if committed.TeardownErr != nil {
+		// The durable decision succeeded, but teardown did not provide evidence
+		// that the tmux process is gone. Report that third state in diagnostics
+		// without presenting the committed close as retryable: a restart reads the
+		// shrunken roster and will not resurrect this tab.
+		log.WarningLog.Printf("CloseTab %q committed, but runtime teardown could not be confirmed: %v", name, committed.TeardownErr)
 	}
 
 	// Announce the shrunk roster (#1812) — the close-side counterpart of

--- a/daemon/manager_tabs.go
+++ b/daemon/manager_tabs.go
@@ -273,7 +273,6 @@ func (m *Manager) CloseTab(req CloseTabRequest) (string, error) {
 		}
 	}
 
-	var data session.InstanceData
 	committed, err := instance.CloseTabByIDWithCommit(targetID, func(staged session.InstanceData) error {
 		// A proxy that resolved the tab before the first stop can still reach
 		// editor admission without the session op-lock. Sweep again while the
@@ -287,7 +286,10 @@ func (m *Manager) CloseTab(req CloseTabRequest) (string, error) {
 		if err := persistInstanceData(repoID, staged); err != nil {
 			return fmt.Errorf("failed to persist tab close: %w", err)
 		}
-		data = staged
+		// Announce the shrunk roster (#1812) as soon as it is durable. Runtime
+		// stream/tmux teardown follows the commit and may block or remain unknown;
+		// neither changes the committed roster clients should render.
+		m.publishEvent(agentproto.EventSessionUpdated, staged)
 		return nil
 	})
 	if err != nil {
@@ -300,12 +302,6 @@ func (m *Manager) CloseTab(req CloseTabRequest) (string, error) {
 		// shrunken roster and will not resurrect this tab.
 		log.WarningLog.Printf("CloseTab %q committed, but runtime teardown could not be confirmed: %v", name, committed.TeardownErr)
 	}
-
-	// Announce the shrunk roster (#1812) — the close-side counterpart of
-	// CreateTab's publish; see there for why this rides on session.updated. A tab
-	// closed out-of-band must disappear from every open client, not just the one
-	// that closed it.
-	m.publishEvent(agentproto.EventSessionUpdated, data)
 	return name, nil
 }
 

--- a/daemon/manager_tabs_arrange.go
+++ b/daemon/manager_tabs_arrange.go
@@ -191,17 +191,16 @@ func stableTabTargetID(tab *session.Tab, title string) (string, error) {
 	return tab.ID, nil
 }
 
-// Rollback on persist failure: rename and reorder DO roll back, CloseTab
-// deliberately does not, and CreateTab does. Since the existing verbs resolve
-// this in opposite directions, a new tab verb has to decide rather than copy.
+// Rollback on persist failure: every tab verb keeps memory/runtime aligned with
+// the last durable roster, but the mechanism depends on its side effects. A new
+// tab verb has to choose its commit boundary deliberately rather than copy.
 //
 // The rule is what the mutation left OUTSIDE memory. CreateTab rolls back
 // because it has already spawned a live tmux session: keeping it after a failed
 // persist would orphan a process that vanishes from the roster on restart.
-// CloseTab does NOT roll back because it has already killed the tab's tmux
-// session — that is irreversible, so the in-memory list (tab gone) is the more
-// accurate state and the stale disk record is harmless (its session is dead and
-// won't reconnect).
+// CloseTab instead stages the removal, persists that smaller roster, and only
+// then ends the stream/tmux session. A failed persist restores the still-live tab;
+// killing first would leave a stale disk row that Restore can respawn (#2669).
 //
 // Rename and reorder are the third case: pure in-memory metadata, no tmux, no
 // side effect, and exactly reversible. So memory can and should be put back —

--- a/daemon/tab_cleanup_sweep.go
+++ b/daemon/tab_cleanup_sweep.go
@@ -1,0 +1,49 @@
+package daemon
+
+import (
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// sweepStartupTabCleanup retries the tmux teardown of tabs whose close was
+// durably committed by a previous daemon but never confirmed (#2669), and
+// persists each record whose handles it managed to retire.
+//
+// It runs in the same window as the orphan-container sweep: after instance
+// restore, before the readiness barrier opens. That placement is what makes the
+// pass safe to run without per-session op-locks — no RPC can be closing a tab,
+// spawning a sibling, or killing a session concurrently, so every handle the
+// sweep sees belongs to the previous daemon's unfinished work rather than to an
+// in-flight close of this one.
+//
+// Failures are logged and never fatal. An unconfirmed retry keeps its handle for
+// the next start, which is strictly better than the pre-#2669 behavior of
+// forgetting the session existed; a failed persist keeps a handle whose retry is
+// idempotent. Neither justifies refusing to open the daemon.
+func sweepStartupTabCleanup(manager *Manager) {
+	for _, instance := range manager.InstancesSnapshot() {
+		if len(instance.PendingTabCleanup()) == 0 {
+			continue
+		}
+		retired, remaining := instance.RetryPendingTabCleanup()
+		if retired == 0 {
+			continue
+		}
+		// Persist through the targeted per-repo writer, the single-writer direction
+		// of #960 — a whole-list SaveInstances here would rewrite every sibling
+		// record to retire one session's handles.
+		root := instance.GetRepoPath()
+		if root == "" {
+			root = instance.Path
+		}
+		data := instance.ToInstanceData()
+		if err := persistInstanceData(config.RepoIDFromRoot(root), data); err != nil {
+			log.WarningLog.Printf(
+				"tab cleanup sweep: reaped %d leftover tmux session(s) of session %q but could not record it; the next start will retry the finished teardown: %v",
+				retired, instance.Title, err)
+			continue
+		}
+		log.InfoLog.Printf("tab cleanup sweep: session %q reaped %d leftover tmux session(s), %d still unconfirmed",
+			instance.Title, retired, remaining)
+	}
+}

--- a/session/instance.go
+++ b/session/instance.go
@@ -289,6 +289,12 @@ type Instance struct {
 	// replacement is provisioned. It is independent of userKilled: restore
 	// failures retain wanted sessions, not kill tombstones.
 	runtimeCleanupStateUnknown bool
+	// pendingTabCleanup holds the tmux cleanup handles of tabs already durably
+	// removed from Tabs whose teardown was never confirmed (#2669). Guarded by
+	// i.mu like Tabs, because a close stages both under one acquisition and a
+	// spawn must reserve against both in the same critical section. It is
+	// deliberately NOT part of the roster: nothing renders or respawns from it.
+	pendingTabCleanup []TabCleanupData
 }
 
 // tmuxLocked returns the agent tab's tmux session, or nil when the instance has

--- a/session/instance_accessors.go
+++ b/session/instance_accessors.go
@@ -382,6 +382,17 @@ func (i *Instance) SetStartedForTest(started bool) {
 	i.started = started
 }
 
+// SetPendingTabCleanupForTest seeds the unconfirmed tab-teardown handles a
+// previous daemon would have left behind (#2669). Test-only: the real flow
+// writes them from CloseTab's commit and reads them back through
+// FromInstanceData, neither of which a daemon-package test can reach without
+// staging a whole crashed close.
+func (i *Instance) SetPendingTabCleanupForTest(pending []TabCleanupData) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.pendingTabCleanup = append([]TabCleanupData(nil), pending...)
+}
+
 // SetGitWorktreeForTest assigns a git worktree to this instance. Test-only:
 // the real flow sets this inside LocalBackend.Start, which isn't available
 // in unit tests that use FakeBackend.

--- a/session/instance_data.go
+++ b/session/instance_data.go
@@ -102,6 +102,15 @@ func (i *Instance) toInstanceDataLocked() InstanceData {
 		data.Tabs = append(data.Tabs, td)
 	}
 
+	// Cleanup handles for tabs whose roster removal is durable but whose tmux
+	// teardown was never confirmed (#2669). Projected alongside Tabs, and from the
+	// same critical section, so a snapshot can never show a tab as both gone and
+	// untracked: whichever side of the close the read lands on, exactly one of the
+	// two lists names the tmux session.
+	if len(i.pendingTabCleanup) > 0 {
+		data.PendingTabCleanup = append([]TabCleanupData(nil), i.pendingTabCleanup...)
+	}
+
 	// Keep writing the legacy single TmuxName field (set from the agent tab) for
 	// one release: a binary rolled back to before #930 PR 2 still finds the
 	// agent session by its exact name, and old readers ignore the new Tabs list.
@@ -298,6 +307,11 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 		// load-bearing #930 requirement. LocalBackend.Start(false) then restores
 		// each tab's session.
 		restoreLocalTabs(instance, data)
+		// Carry unconfirmed tab-teardown handles across the restart (#2669). They
+		// are restored NEXT TO the roster, never into it: the daemon's startup sweep
+		// retries the kill, and a spawn reserves against them, but no tab is
+		// rebuilt from a tombstone.
+		instance.pendingTabCleanup = restoredTabCleanup(data.PendingTabCleanup)
 	}
 
 	if data.PRInfo.Number != 0 {

--- a/session/storage.go
+++ b/session/storage.go
@@ -134,6 +134,17 @@ type InstanceData struct {
 	StartupStateUnknown bool      `json:"startup_state_unknown,omitempty"`
 	TmuxName            string    `json:"tmux_name,omitempty"`
 	Tabs                []TabData `json:"tabs,omitempty"`
+	// PendingTabCleanup retains the tmux identity of tabs whose removal from Tabs
+	// is already durable but whose teardown could not be confirmed (#2669). It is
+	// the tab-scoped analogue of RuntimeCleanup, and it exists because CloseTab
+	// commits the shrunken roster BEFORE killing tmux: without it, a kill-session
+	// that times out (or answers while the session still exists) would drop the
+	// closed tab's only tmux identity, leaking that process untracked forever and
+	// letting a later same-named tab derive the same tmux name and collide with
+	// the survivor. Entries are cleanup handles, never tabs — nothing renders or
+	// respawns from them. Additive + omitempty on the TabData.ID rollforward
+	// precedent: records written before this field simply have none.
+	PendingTabCleanup []TabCleanupData `json:"pending_tab_cleanup,omitempty"`
 	// AgentConversation mirrors the Agent tab's provider conversation id for
 	// API/CLI consumers. The per-tab source of truth is TabData.Conversation.
 	AgentConversation *AgentConversationData `json:"agent_conversation,omitempty"`
@@ -240,6 +251,22 @@ type TabData struct {
 	// indistinguishable from a session that was never handed off — and those two
 	// deserve the same treatment, so nothing has to be backfilled.
 	Handoffs []AgentHandoff `json:"handoffs,omitempty"`
+}
+
+// TabCleanupData is one durable cleanup handle for a closed tab whose tmux
+// teardown was never confirmed. It deliberately carries only what a retry needs
+// — no Kind, Command, or URL — so it cannot be mistaken for, or restored as, a
+// TabData: a tombstone that could round-trip into a tab would resurrect exactly
+// the closed tab #2669 exists to keep buried.
+type TabCleanupData struct {
+	// TabID is the closed tab's stable id (#1738). Ids are never reused, so it
+	// names the exact close this handle belongs to and keeps the retry's logs and
+	// deduplication honest across restarts.
+	TabID string `json:"tab_id,omitempty"`
+	// TmuxName is the cleanup handle proper: the EXACT tmux session name the retry
+	// must kill, and the token a later spawn must not re-derive. An entry with no
+	// name would be untargetable, so CloseTab never records one.
+	TmuxName string `json:"tmux_name"`
 }
 
 // PRInfoData represents the serializable data of a PRInfo

--- a/session/tab_cleanup_retry.go
+++ b/session/tab_cleanup_retry.go
@@ -1,0 +1,89 @@
+package session
+
+import (
+	"fmt"
+
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// Retrying an unconfirmed tab teardown (#2669).
+//
+// CloseTab commits the shrunken roster before it kills tmux, so the kill can
+// still time out (or answer while the session survives) after the tab is gone
+// for good. tab_close.go records a TabCleanupData handle for exactly that case.
+// This file is what eventually spends it: the daemon sweeps every restored
+// instance once at startup, before readiness, which is the moment the previous
+// daemon's unfinished kills are both discoverable and unraced.
+//
+// Startup is the ONLY retry trigger, deliberately. An immediate in-process retry
+// would re-run the command that just timed out against the same wedged server,
+// and a periodic one would keep doing so forever; neither adds information. The
+// other half of the problem — a new tab deriving the survivor's name — is not
+// solved by killing at all but by uniqueTabTmuxName reserving the pending token,
+// so a spawn stays correct whether or not the retry has succeeded yet.
+
+// PendingTabCleanup returns a copy of the instance's unconfirmed tab-teardown
+// handles. Copied because the caller iterates outside i.mu while a concurrent
+// close may append.
+func (i *Instance) PendingTabCleanup() []TabCleanupData {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	if len(i.pendingTabCleanup) == 0 {
+		return nil
+	}
+	return append([]TabCleanupData(nil), i.pendingTabCleanup...)
+}
+
+// RetryPendingTabCleanup re-attempts the tmux teardown of every tab whose close
+// was durably committed but never confirmed, and retires each handle whose
+// session is now positively gone. It reports how many handles were retired and
+// how many remain unconfirmed.
+//
+// Retiring only on a CONFIRMED kill is the whole discipline. tmux Close is
+// idempotent — killing an already-absent session succeeds (#967) — so a nil
+// error genuinely means "no such session remains", which is the one answer that
+// justifies dropping the last durable pointer to it. A timeout keeps the handle:
+// an unanswered server is not evidence of absence, and #2669 is precisely the
+// bug where an unknown outcome was read as a finished one.
+//
+// A zero retired count means no handle was retired and therefore nothing needs
+// persisting, so the caller can skip the write entirely.
+func (i *Instance) RetryPendingTabCleanup() (retired, remaining int) {
+	for _, handle := range i.PendingTabCleanup() {
+		if err := killTabCleanupSession(handle); err != nil {
+			log.WarningLog.Printf(
+				"session %q: tab cleanup for tmux session %q is still unconfirmed and will be retried on the next daemon start: %v",
+				i.Title, handle.TmuxName, err)
+			remaining++
+			continue
+		}
+		i.mu.Lock()
+		i.pendingTabCleanup = dropTabCleanup(i.pendingTabCleanup, &handle)
+		i.mu.Unlock()
+		log.InfoLog.Printf("session %q: reaped the leftover tmux session %q of a closed tab", i.Title, handle.TmuxName)
+		retired++
+	}
+	return retired, remaining
+}
+
+// killTabCleanupSession tears down one leftover session by its EXACT persisted
+// name — the same exact-name binding restoreLocalTabs uses, never a name
+// re-derived from a tab, which after a rename or a suffix walk would target the
+// wrong session.
+//
+// It goes through the same package var restore does so tests can stay hermetic;
+// production builds a real tmux session. Pane state is ignored for the reason
+// closeRemovedTab ignores it: reaping one tab's session touches no worktree, so
+// nothing destructive follows an unknown.
+func killTabCleanupSession(handle TabCleanupData) error {
+	if handle.TmuxName == "" {
+		return fmt.Errorf("tab cleanup handle has no tmux session name")
+	}
+	// The program is irrelevant to a kill and this session is never started from
+	// here, so an empty one keeps the handle honest about carrying no command.
+	ts := restoreTmuxSession(handle.TmuxName, "")
+	if _, err := ts.Close(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/session/tab_cleanup_retry_test.go
+++ b/session/tab_cleanup_retry_test.go
@@ -1,0 +1,315 @@
+package session
+
+import (
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// The #2669 review follow-up. Persisting the close before teardown fixed the
+// resurrection half of the bug and opened its mirror image: teardown now runs
+// AFTER the tab is durably gone, so a kill-session that times out (or answers
+// while the session survives) used to drop the closed tab's only tmux identity.
+// The process then leaked untracked forever, and a later tab with the same name
+// re-derived the same tmux name and could not start at all.
+//
+// These cover the retention contract end to end: a handle is written when
+// teardown is unconfirmed, retired when it is confirmed, retried across a
+// restart, and reserved against by a spawn in the meantime — while never
+// reappearing as a tab.
+
+// cleanupExec models a tmux server where kill-session FAILS for the named
+// sessions and leaves them alive, which is the exact shape close.go turns into
+// an "error killing tmux session" (kill answered, the follow-up has-session
+// probe still sees it). Every other session kills normally.
+func cleanupExec(alive map[string]bool, unkillable map[string]bool) (cmd_test.MockCmdExec, func(string) bool, func() int) {
+	var mu sync.Mutex
+	existing := map[string]bool{}
+	for name, ok := range alive {
+		existing[name] = ok
+	}
+	kills := 0
+	nameOf := func(cmd *exec.Cmd) string {
+		for i, a := range cmd.Args {
+			switch {
+			case (a == "-t" || a == "-s") && i+1 < len(cmd.Args):
+				return strings.TrimSuffix(strings.TrimPrefix(cmd.Args[i+1], "="), ":")
+			case strings.HasPrefix(a, "-t="):
+				return strings.TrimPrefix(a, "-t=")
+			case strings.HasPrefix(a, "-s="):
+				return strings.TrimPrefix(a, "-s=")
+			}
+		}
+		return ""
+	}
+	mockExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			s := cmd.String()
+			name := nameOf(cmd)
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case strings.Contains(s, "has-session"):
+				if existing[name] {
+					return nil
+				}
+				return errors.New("can't find session")
+			case strings.Contains(s, "new-session"):
+				existing[name] = true
+			case strings.Contains(s, "kill-session"):
+				kills++
+				if unkillable[name] {
+					// Answers with a failure and the session stays up: Close probes,
+					// sees it, and reports a real teardown error rather than a timeout.
+					return errors.New("kill-session refused")
+				}
+				delete(existing, name)
+			}
+			return nil
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) { return []byte("content"), nil },
+	}
+	return mockExec, func(name string) bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return existing[name]
+		}, func() int {
+			mu.Lock()
+			defer mu.Unlock()
+			return kills
+		}
+}
+
+// cleanupInstanceData is a normal live local session with one closable shell tab.
+func cleanupInstanceData(t *testing.T, agentName, shellName string) InstanceData {
+	t.Helper()
+	const repoPath = "/tmp/tab-cleanup-repo"
+	return InstanceData{
+		Title:    "tab-cleanup",
+		Path:     repoPath,
+		Program:  "claude",
+		Status:   Running,
+		TmuxName: agentName,
+		Tabs: []TabData{
+			{ID: "tab-agent", Name: agentTabName, Kind: TabKindAgent, TmuxName: agentName},
+			{ID: "tab-shell", Name: shellTabName, Kind: TabKindShell, TmuxName: shellName},
+		},
+		Worktree: GitWorktreeData{
+			RepoPath:     repoPath,
+			WorktreePath: filepath.Join(t.TempDir(), "wt"),
+			SessionName:  "tab-cleanup",
+			BranchName:   "tab-cleanup-branch",
+		},
+	}
+}
+
+// TestCloseTabByIDWithCommit_UnconfirmedTeardownRetainsCleanupHandle is the
+// headline regression. The close commits, so the tab is durably gone — but the
+// kill failed with the session still up, so the projection handed to commit must
+// already carry a cleanup handle naming that session. Without it the persisted
+// record is the last thing that ever mentioned the tmux name.
+func TestCloseTabByIDWithCommit_UnconfirmedTeardownRetainsCleanupHandle(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const agentName = "af_tab-cleanup_agent"
+	shellName := agentName + "__shell"
+	mockExec, aliveFn, _ := cleanupExec(
+		map[string]bool{agentName: true, shellName: true},
+		map[string]bool{shellName: true})
+	pty := persistPtyFactory{t: t, cmdExec: mockExec}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, mockExec)
+	}
+	defer func() { restoreTmuxSession = prev }()
+
+	inst, err := FromInstanceData(cleanupInstanceData(t, agentName, shellName))
+	require.NoError(t, err)
+
+	var committed InstanceData
+	result, err := inst.CloseTabByIDWithCommit("tab-shell", func(staged InstanceData) error {
+		committed = staged
+		return nil
+	})
+	require.NoError(t, err, "the close itself must succeed: only the teardown was unconfirmed")
+	require.Error(t, result.TeardownErr, "the fixture's kill-session must fail; the test's premise is wrong")
+	assert.Nil(t, result.Settled, "an unconfirmed teardown has nothing to settle")
+
+	// The durable decision: the tab is gone from the roster...
+	for _, td := range committed.Tabs {
+		assert.NotEqual(t, shellName, td.TmuxName,
+			"the committed roster still carries the closed tab; a restart would respawn it (#2669)")
+	}
+	// ...and its tmux session is still named by something durable.
+	require.Len(t, committed.PendingTabCleanup, 1,
+		"an unconfirmed teardown dropped the closed tab's only tmux identity: the session is now untracked forever")
+	assert.Equal(t, shellName, committed.PendingTabCleanup[0].TmuxName)
+	assert.Equal(t, "tab-shell", committed.PendingTabCleanup[0].TabID)
+
+	// The handle is live state too, not just a one-shot projection: a later
+	// snapshot (the daemon's checkpoint) must keep carrying it.
+	assert.True(t, aliveFn(shellName), "fixture: the unkillable session must still be up")
+	assert.Equal(t, []TabCleanupData{{TabID: "tab-shell", TmuxName: shellName}}, inst.PendingTabCleanup())
+	assert.Len(t, inst.ToInstanceData().PendingTabCleanup, 1)
+}
+
+// TestCloseTabByIDWithCommit_ConfirmedTeardownRetiresCleanupHandle is the other
+// half of the contract, and the one that keeps the mechanism from becoming a
+// permanent leak of its own: the ordinary close must leave NO handle behind, so
+// no daemon start ever retries a teardown that already finished.
+func TestCloseTabByIDWithCommit_ConfirmedTeardownRetiresCleanupHandle(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const agentName = "af_tab-cleanup_agent"
+	shellName := agentName + "__shell"
+	mockExec, aliveFn, _ := cleanupExec(
+		map[string]bool{agentName: true, shellName: true}, nil)
+	pty := persistPtyFactory{t: t, cmdExec: mockExec}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, mockExec)
+	}
+	defer func() { restoreTmuxSession = prev }()
+
+	inst, err := FromInstanceData(cleanupInstanceData(t, agentName, shellName))
+	require.NoError(t, err)
+
+	var committed InstanceData
+	result, err := inst.CloseTabByIDWithCommit("tab-shell", func(staged InstanceData) error {
+		committed = staged
+		return nil
+	})
+	require.NoError(t, err)
+	require.NoError(t, result.TeardownErr)
+	assert.False(t, aliveFn(shellName), "fixture: a confirmed close must actually kill the session")
+
+	// The handle is staged for the commit — the write has to precede the kill, or
+	// a crash between them loses the identity...
+	require.Len(t, committed.PendingTabCleanup, 1,
+		"the handle must be durable BEFORE teardown: a crash in between would lose the tmux identity")
+	// ...and retired once the kill is confirmed, with a projection that says so.
+	assert.Empty(t, inst.PendingTabCleanup(), "a confirmed teardown must retire its handle")
+	require.NotNil(t, result.Settled, "a confirmed teardown must hand back the retirement to persist")
+	assert.Empty(t, result.Settled.PendingTabCleanup)
+}
+
+// TestCloseTabByIDWithCommit_CommitFailureDropsStagedCleanupHandle guards the
+// rollback. The tab is put back because it still owns its tmux session, so a
+// handle for that same session must NOT survive: it would double-count a live
+// tab as awaiting cleanup and let the startup sweep kill the session out from
+// under it.
+func TestCloseTabByIDWithCommit_CommitFailureDropsStagedCleanupHandle(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const agentName = "af_tab-cleanup_agent"
+	shellName := agentName + "__shell"
+	mockExec, aliveFn, _ := cleanupExec(
+		map[string]bool{agentName: true, shellName: true}, nil)
+	pty := persistPtyFactory{t: t, cmdExec: mockExec}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, mockExec)
+	}
+	defer func() { restoreTmuxSession = prev }()
+
+	inst, err := FromInstanceData(cleanupInstanceData(t, agentName, shellName))
+	require.NoError(t, err)
+
+	_, err = inst.CloseTabByIDWithCommit("tab-shell", func(InstanceData) error {
+		return errors.New("persist failed")
+	})
+	require.Error(t, err)
+
+	assert.Equal(t, 2, inst.TabCount(), "the rollback must restore the tab")
+	assert.True(t, aliveFn(shellName), "the rollback must leave the tab's session alive")
+	assert.Empty(t, inst.PendingTabCleanup(),
+		"a rolled-back close left a cleanup handle for a tab that is still on the roster; the sweep would kill its live session")
+	assert.Empty(t, inst.ToInstanceData().PendingTabCleanup)
+}
+
+// TestRetryPendingTabCleanup_RetiresOnlyConfirmedKills is the across-restart
+// half of the finding: a handle persisted by a previous daemon must be retried,
+// and retired ONLY on a confirmed kill. tmux Close is idempotent (#967), so a
+// nil error genuinely means no such session remains — which is the one answer
+// that justifies dropping the last durable pointer to it. An unconfirmed retry
+// keeps its handle for the next start.
+func TestRetryPendingTabCleanup_RetiresOnlyConfirmedKills(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const agentName = "af_tab-cleanup_agent"
+	reapable := agentName + "__gone"
+	stuck := agentName + "__stuck"
+	mockExec, aliveFn, killCount := cleanupExec(
+		map[string]bool{agentName: true, reapable: true, stuck: true},
+		map[string]bool{stuck: true})
+	pty := persistPtyFactory{t: t, cmdExec: mockExec}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, mockExec)
+	}
+	defer func() { restoreTmuxSession = prev }()
+
+	data := cleanupInstanceData(t, agentName, agentName+"__shell")
+	data.PendingTabCleanup = []TabCleanupData{
+		{TabID: "closed-1", TmuxName: reapable},
+		{TabID: "closed-2", TmuxName: stuck},
+	}
+	inst, err := FromInstanceData(data)
+	require.NoError(t, err)
+
+	// A tombstone must never load as a tab: the whole point is that these are
+	// CLOSED. Two tabs is the fixture's roster, unchanged by the two handles.
+	assert.Equal(t, 2, inst.TabCount(), "a cleanup handle was restored as a tab; the closed tab is back")
+	require.Len(t, inst.PendingTabCleanup(), 2, "both handles must survive the restart")
+
+	before := killCount()
+	retired, remaining := inst.RetryPendingTabCleanup()
+	assert.Greater(t, killCount(), before, "the sweep must actually re-issue kill-session")
+	assert.Equal(t, 1, retired)
+	assert.Equal(t, 1, remaining)
+	assert.False(t, aliveFn(reapable), "the reapable leftover session must be gone")
+	assert.Equal(t, []TabCleanupData{{TabID: "closed-2", TmuxName: stuck}}, inst.PendingTabCleanup(),
+		"only the confirmed kill may be retired; an unconfirmed one keeps its handle for the next start")
+}
+
+// TestUniqueTabTmuxName_ReservesPendingCleanupTokens covers the user-visible
+// half of the finding. After an unconfirmed close of "fresh" nothing on the
+// roster holds that token, so the next spawn re-derived the survivor's exact
+// name and TmuxSession.Start rejected it as already existing — a wedge no retry
+// clears, because every retry derives the same name. Reserving the pending token
+// walks the spawn to "fresh-2" instead, exactly as it does around a renamed
+// sibling (#1957).
+func TestUniqueTabTmuxName_ReservesPendingCleanupTokens(t *testing.T) {
+	const agentName = "af_tab-cleanup_agent"
+	tabs := []*Tab{{Name: agentTabName, Kind: TabKindAgent}}
+
+	assert.Equal(t, agentName+"__fresh", uniqueTabTmuxName(tabs, nil, agentName, "fresh"),
+		"with nothing pending the spawn keeps the requested token")
+
+	pending := []TabCleanupData{{TabID: "closed", TmuxName: agentName + "__fresh"}}
+	assert.Equal(t, agentName+"__fresh-2", uniqueTabTmuxName(tabs, pending, agentName, "fresh"),
+		"a spawn re-derived the tmux name of a session whose teardown was never confirmed; Start would reject it as already existing")
+
+	// A handle from some other prefix reserves nothing here — the same honesty
+	// tabTmuxToken applies rather than deriving a token it cannot trust.
+	foreign := []TabCleanupData{{TabID: "closed", TmuxName: "af_other_agent__fresh"}}
+	assert.Equal(t, agentName+"__fresh", uniqueTabTmuxName(tabs, foreign, agentName, "fresh"))
+}

--- a/session/tab_close.go
+++ b/session/tab_close.go
@@ -25,7 +25,7 @@ func (i *Instance) CloseTab(idx int) error {
 	}
 	tab := i.removeTabLocked(idx)
 	i.mu.Unlock()
-	return i.closeRemovedTab(tab)
+	return i.closeRemovedTabRetainingCleanup(tab)
 }
 
 // CloseTabByID removes the tab with stable id, selecting and removing it in the
@@ -44,7 +44,31 @@ func (i *Instance) CloseTabByID(tabID string) error {
 	}
 	tab := i.removeTabLocked(idx)
 	i.mu.Unlock()
-	return i.closeRemovedTab(tab)
+	return i.closeRemovedTabRetainingCleanup(tab)
+}
+
+// closeRemovedTabRetainingCleanup is closeRemovedTab for the two variants with
+// no commit boundary of their own: it records a cleanup handle when teardown
+// leaves the tmux session unaccounted for.
+//
+// These variants cannot pre-stage the handle the way CloseTabByIDWithCommit
+// does, because they never persist — CreateTab's rollback reaches CloseTabByID
+// precisely BECAUSE its write just failed, so no handle could reach disk at that
+// moment anyway. Retaining it in memory is still strictly better than dropping
+// it: this daemon stops re-deriving the surviving session's name for a new tab,
+// and the next successful persist of the session carries the handle to disk
+// where the startup sweep can spend it.
+func (i *Instance) closeRemovedTabRetainingCleanup(tab *Tab) error {
+	err := i.closeRemovedTab(tab)
+	if err == nil {
+		return nil
+	}
+	if handle, _ := stageTabCleanup(nil, tab); handle != nil {
+		i.mu.Lock()
+		i.pendingTabCleanup = append(i.pendingTabCleanup, *handle)
+		i.mu.Unlock()
+	}
+	return err
 }
 
 // CommittedTabClose separates the durable roster decision from the best-effort
@@ -53,8 +77,19 @@ func (i *Instance) CloseTabByID(tabID string) error {
 // absent but runtime teardown could not be confirmed. Callers must not turn the
 // latter into a failed commit and retry the state mutation as though it never
 // happened.
+//
+// The unconfirmed case is not merely reported, it is RETAINED: the commit
+// persists a TabCleanupData handle for the tab's tmux session, and only a
+// confirmed teardown retires it. Settled is that retirement — the projection
+// with the handle already dropped, which the caller should persist so the next
+// daemon does not retry a kill that already succeeded. It is nil when there was
+// nothing to retire (a tmux-less tab, or a teardown left unconfirmed), and
+// persisting it is best-effort: losing that write only costs one idempotent
+// re-kill of an absent session, whereas losing the handle itself is the leak
+// this whole mechanism exists to prevent.
 type CommittedTabClose struct {
 	TeardownErr error
+	Settled     *InstanceData
 }
 
 // CloseTabByIDWithCommit stages removal of the stable tab, calls commit with the
@@ -62,6 +97,14 @@ type CommittedTabClose struct {
 // teardown. If commit fails, the exact tab is restored at its original position
 // before the error is returned, leaving both the roster and runtime available
 // for a safe retry (#2669).
+//
+// The projection commit receives has the tab off Tabs AND its tmux identity on
+// PendingTabCleanup, so the durable record never describes a state where the
+// session is neither a tab nor a tracked cleanup. That handoff is the point: the
+// roster shrinks irrevocably at the commit, but teardown runs afterwards and may
+// time out, so something durable has to keep naming the tmux session until a
+// kill is confirmed. A tombstone rather than a retained tab, because the tab is
+// genuinely closed — it must not render, and a restore must not respawn it.
 //
 // Selection, staging, snapshotting, and commit run under the same instance lock.
 // Besides keeping the rollback exact, this prevents another tab mutation from
@@ -84,19 +127,94 @@ func (i *Instance) CloseTabByIDWithCommit(
 	}
 
 	tab := i.removeTabLocked(idx)
+	handle, staged := stageTabCleanup(i.pendingTabCleanup, tab)
+	i.pendingTabCleanup = staged
 	data := i.toInstanceDataLocked()
 	if err := commit(data); err != nil {
 		// Nothing can change the roster while i.mu is held, so reinserting at idx
-		// restores the precise pre-close order and the same live tab object.
+		// restores the precise pre-close order and the same live tab object. The
+		// staged handle goes back too: the tab still owns its tmux session, so a
+		// tombstone for it would double-count a live tab as awaiting cleanup and
+		// could get its session killed under it by the startup sweep.
 		i.Tabs = append(i.Tabs, nil)
 		copy(i.Tabs[idx+1:], i.Tabs[idx:])
 		i.Tabs[idx] = tab
+		i.pendingTabCleanup = dropTabCleanup(i.pendingTabCleanup, handle)
 		i.mu.Unlock()
 		return CommittedTabClose{}, err
 	}
 	i.mu.Unlock()
 
-	return CommittedTabClose{TeardownErr: i.closeRemovedTab(tab)}, nil
+	teardownErr := i.closeRemovedTab(tab)
+	if teardownErr != nil || handle == nil {
+		// Unconfirmed: the handle stays, and the daemon's startup sweep owns the
+		// retry. Nothing to settle for a tmux-less tab either — it never staged one.
+		return CommittedTabClose{TeardownErr: teardownErr}, nil
+	}
+	// Confirmed dead. Retire the handle and hand the caller the projection that
+	// records the retirement.
+	i.mu.Lock()
+	i.pendingTabCleanup = dropTabCleanup(i.pendingTabCleanup, handle)
+	settled := i.toInstanceDataLocked()
+	i.mu.Unlock()
+	return CommittedTabClose{Settled: &settled}, nil
+}
+
+// stageTabCleanup returns the cleanup handle a just-removed tab needs, plus the
+// pending list with it appended. The handle is nil — and the list unchanged —
+// for a tab with no tmux session of its own (web, VS Code, or never started):
+// there is no process to leak and no token a later spawn could collide with, so
+// recording one would only manufacture a retry against a name that never
+// existed.
+func stageTabCleanup(pending []TabCleanupData, tab *Tab) (*TabCleanupData, []TabCleanupData) {
+	if tab == nil || tab.tmux == nil {
+		return nil, pending
+	}
+	name := tab.tmux.SanitizedName()
+	if name == "" {
+		return nil, pending
+	}
+	handle := TabCleanupData{TabID: tab.ID, TmuxName: name}
+	return &handle, append(pending, handle)
+}
+
+// dropTabCleanup removes handle from pending, matching on the tmux name — the
+// field that identifies the session a retry would target. Matching on TabID
+// would miss a legacy tab that was backfilled an id only on the load AFTER its
+// tombstone was written, leaving an entry nothing can ever retire. Returns nil
+// for an emptied list so the projection omits the field entirely rather than
+// persisting an empty array.
+func dropTabCleanup(pending []TabCleanupData, handle *TabCleanupData) []TabCleanupData {
+	if handle == nil || len(pending) == 0 {
+		return pending
+	}
+	// Build a fresh slice rather than filtering in place: the staged list can share
+	// a backing array with the caller's, and a projection built between the two
+	// points holds its own copy only because it was copied eagerly. Rewriting
+	// shared storage here would be a silent aliasing bug for one allocation saved.
+	var kept []TabCleanupData
+	for _, entry := range pending {
+		if entry.TmuxName == handle.TmuxName {
+			continue
+		}
+		kept = append(kept, entry)
+	}
+	return kept
+}
+
+// restoredTabCleanup rebuilds the pending-cleanup list from a persisted record,
+// dropping entries with no tmux name. Such an entry cannot be targeted by a
+// retry or reserved against by a spawn, so keeping it would only make the
+// session look permanently un-swept.
+func restoredTabCleanup(data []TabCleanupData) []TabCleanupData {
+	var pending []TabCleanupData
+	for _, entry := range data {
+		if entry.TmuxName == "" {
+			continue
+		}
+		pending = append(pending, entry)
+	}
+	return pending
 }
 
 // removeTabLocked detaches idx from the roster and returns the exact tab object

--- a/session/tab_close.go
+++ b/session/tab_close.go
@@ -47,30 +47,56 @@ func (i *Instance) CloseTabByID(tabID string) error {
 	return i.closeRemovedTab(tab)
 }
 
-// RestoreClosedVSCodeTab reinserts the exact metadata-only tab removed by a
-// CloseTabByID whose final editor sweep stayed unknown. VS Code tabs own no tmux
-// process or PTY, so restoring the roster entry restores the durable retry
-// handle without reviving anything already torn down. The daemon holds its
-// per-instance operation lock across close and rollback; this lock still guards
-// the slice for readers and rejects any inconsistent insertion.
-func (i *Instance) RestoreClosedVSCodeTab(tab *Tab, idx int) error {
-	if tab == nil || tab.Kind != TabKindVSCode || tab.tmux != nil {
-		return fmt.Errorf("only a metadata-only VS Code tab can be restored after close")
-	}
+// CommittedTabClose separates the durable roster decision from the best-effort
+// runtime teardown that follows it. A nil TeardownErr confirms both the PTY
+// stream and tmux close completed; a non-nil value means the tab is durably
+// absent but runtime teardown could not be confirmed. Callers must not turn the
+// latter into a failed commit and retry the state mutation as though it never
+// happened.
+type CommittedTabClose struct {
+	TeardownErr error
+}
+
+// CloseTabByIDWithCommit stages removal of the stable tab, calls commit with the
+// resulting InstanceData, and only then performs irreversible stream/tmux
+// teardown. If commit fails, the exact tab is restored at its original position
+// before the error is returned, leaving both the roster and runtime available
+// for a safe retry (#2669).
+//
+// Selection, staging, snapshotting, and commit run under the same instance lock.
+// Besides keeping the rollback exact, this prevents another tab mutation from
+// producing a projection between the staged roster and the one commit receives.
+// commit must not call back into Instance: it receives the already-built
+// projection for that reason.
+func (i *Instance) CloseTabByIDWithCommit(
+	tabID string,
+	commit func(InstanceData) error,
+) (CommittedTabClose, error) {
 	i.mu.Lock()
-	defer i.mu.Unlock()
-	if idx <= 0 || idx > len(i.Tabs) {
-		return fmt.Errorf("cannot restore VS Code tab %q at index %d", tab.Name, idx)
+	idx, exists := i.tabIndexByIDLocked(tabID)
+	if !exists {
+		i.mu.Unlock()
+		return CommittedTabClose{}, fmt.Errorf("session %q tab id %q: %w", i.Title, tabID, ErrTabGone)
 	}
-	for _, current := range i.Tabs {
-		if current.ID == tab.ID || current.Name == tab.Name {
-			return fmt.Errorf("cannot restore VS Code tab %q: its identity or name is already present", tab.Name)
-		}
+	if idx == 0 {
+		i.mu.Unlock()
+		return CommittedTabClose{}, fmt.Errorf("tab cannot be closed")
 	}
-	i.Tabs = append(i.Tabs, nil)
-	copy(i.Tabs[idx+1:], i.Tabs[idx:])
-	i.Tabs[idx] = tab
-	return nil
+
+	tab := i.removeTabLocked(idx)
+	data := i.toInstanceDataLocked()
+	if err := commit(data); err != nil {
+		// Nothing can change the roster while i.mu is held, so reinserting at idx
+		// restores the precise pre-close order and the same live tab object.
+		i.Tabs = append(i.Tabs, nil)
+		copy(i.Tabs[idx+1:], i.Tabs[idx:])
+		i.Tabs[idx] = tab
+		i.mu.Unlock()
+		return CommittedTabClose{}, err
+	}
+	i.mu.Unlock()
+
+	return CommittedTabClose{TeardownErr: i.closeRemovedTab(tab)}, nil
 }
 
 // removeTabLocked detaches idx from the roster and returns the exact tab object

--- a/session/tab_close.go
+++ b/session/tab_close.go
@@ -178,12 +178,14 @@ func stageTabCleanup(pending []TabCleanupData, tab *Tab) (*TabCleanupData, []Tab
 	return &handle, append(pending, handle)
 }
 
-// dropTabCleanup removes handle from pending, matching on the tmux name — the
-// field that identifies the session a retry would target. Matching on TabID
-// would miss a legacy tab that was backfilled an id only on the load AFTER its
-// tombstone was written, leaving an entry nothing can ever retire. Returns nil
-// for an emptied list so the projection omits the field entirely rather than
-// persisting an empty array.
+// dropTabCleanup removes handle from pending, matching on the tmux name rather
+// than the TabID. The name is what a retry actually targets, and it is the field
+// guaranteed unique across the list: uniqueTabTmuxName reserves pending tokens,
+// so no live tab and no other handle can hold the same session name. TabID is
+// carried for diagnostics and can be empty on a hand-edited or pre-#1738 record,
+// which would leave such an entry unretirable. Returns nil for an emptied list
+// so the projection omits the field entirely rather than persisting an empty
+// array.
 func dropTabCleanup(pending []TabCleanupData, handle *TabCleanupData) []TabCleanupData {
 	if handle == nil || len(pending) == 0 {
 		return pending

--- a/session/tab_names.go
+++ b/session/tab_names.go
@@ -79,15 +79,31 @@ func uniqueTabNameExcluding(tabs []*Tab, base string, exclude *Tab) string {
 // the #1957 sequence — and then it is the spawned session, not the user's
 // requested name, that takes the "-2".
 //
+// pending is the instance's unconfirmed tab-cleanup list (#2669), and it is
+// reserved against for the same reason the roster is: those sessions may still
+// be alive. A close whose kill-session timed out leaves no tab holding the
+// token, so without this a `tab-create --name fresh` would re-derive the
+// survivor's exact name and Start would reject it as already existing — a wedge
+// no retry clears, because every retry derives the same name. Reserving instead
+// walks the spawn to "fresh-2", exactly as it does around a renamed sibling.
+//
 // agentSanitized is passed in rather than read off tabs[0] because the caller
 // (tab_spawn.go) already holds the agent session it is spawning a sibling of,
 // and an instance with no agent session cannot spawn a sibling at all.
-func uniqueTabTmuxName(tabs []*Tab, agentSanitized, base string) string {
+func uniqueTabTmuxName(tabs []*Tab, pending []TabCleanupData, agentSanitized, base string) string {
 	prefix := agentSanitized + tmuxTabSeparator
-	used := make(map[string]bool, len(tabs))
+	used := make(map[string]bool, len(tabs)+len(pending))
 	for _, t := range tabs {
 		if token := tabTmuxToken(prefix, t); token != "" {
 			used[token] = true
+		}
+	}
+	for _, entry := range pending {
+		// Same HasPrefix honesty as tabTmuxToken: a handle for some other prefix
+		// (a legacy or hand-edited record) reserves nothing here rather than
+		// reserving a token derived wrongly.
+		if strings.HasPrefix(entry.TmuxName, prefix) {
+			used[strings.TrimPrefix(entry.TmuxName, prefix)] = true
 		}
 	}
 	return prefix + firstFreeName(used, base)

--- a/session/tab_names.go
+++ b/session/tab_names.go
@@ -92,7 +92,11 @@ func uniqueTabNameExcluding(tabs []*Tab, base string, exclude *Tab) string {
 // and an instance with no agent session cannot spawn a sibling at all.
 func uniqueTabTmuxName(tabs []*Tab, pending []TabCleanupData, agentSanitized, base string) string {
 	prefix := agentSanitized + tmuxTabSeparator
-	used := make(map[string]bool, len(tabs)+len(pending))
+	// Sized off the roster alone rather than len(tabs)+len(pending): a map grows
+	// on its own, pending is empty on every close that confirmed its teardown, and
+	// summing two lengths is an allocation size CodeQL cannot bound (it does not
+	// know maxTabs caps both).
+	used := make(map[string]bool, len(tabs))
 	for _, t := range tabs {
 		if token := tabTmuxToken(prefix, t); token != "" {
 			used[token] = true

--- a/session/tab_spawn.go
+++ b/session/tab_spawn.go
@@ -55,7 +55,7 @@ func (i *Instance) AddShellTab() (*Tab, error) {
 	// session to spawn a sibling of — the precondition check below rejects it.
 	tmuxName := ""
 	if agentTmux != nil {
-		tmuxName = uniqueTabTmuxName(i.Tabs, agentTmux.SanitizedName(), displayName)
+		tmuxName = uniqueTabTmuxName(i.Tabs, i.pendingTabCleanup, agentTmux.SanitizedName(), displayName)
 	}
 	nTabs := len(i.Tabs)
 	i.mu.RUnlock()
@@ -140,7 +140,7 @@ func (i *Instance) AddProcessTab(command, requestedName string) (*Tab, error) {
 	// Both namespaces resolved under the one read lock; see AddShellTab.
 	tmuxName := ""
 	if agentTmux != nil {
-		tmuxName = uniqueTabTmuxName(i.Tabs, agentTmux.SanitizedName(), displayName)
+		tmuxName = uniqueTabTmuxName(i.Tabs, i.pendingTabCleanup, agentTmux.SanitizedName(), displayName)
 	}
 	nTabs := len(i.Tabs)
 	i.mu.RUnlock()

--- a/session/teardown.go
+++ b/session/teardown.go
@@ -54,6 +54,22 @@ type teardownMode interface {
 	// it true and fences with OpArchiving instead, so a failed move self-heals
 	// via the Lost-restore loop.
 	clearsStarted() bool
+	// reapsPendingTabCleanup reports whether this mode must also tear down the
+	// session's unconfirmed tab-close handles (#2669) — the tmux sessions of tabs
+	// already off the roster whose kill was never confirmed.
+	//
+	// True for the two DESTRUCTIVE modes, and load-bearing for both. They touch the
+	// workspace, and a pending process is cwd'd in that workspace exactly like a
+	// live tab's: archive would otherwise relocate a worktree out from under it,
+	// and kill would delete the record — the handle's only home — while the process
+	// ran on, permanently untracked. Routing them through the same closeTab gives
+	// them the same pane-exit wait and the same unknown-blocks-the-worktree gate.
+	//
+	// False for release-PTY, and that is not an omission: it runs no kill-session
+	// at all. Reaping there would retire durable handles on the strength of a
+	// teardown that never killed anything — the precise "unknown read as finished"
+	// mistake #2669 is about.
+	reapsPendingTabCleanup() bool
 	// finalize reconciles the instance's tab list and worktree pointer under a
 	// held i.mu after teardown. closed pairs each torn-down tab with the tmux it
 	// closed (for identity-guarded ref clearing); gw is the worktree captured
@@ -205,6 +221,23 @@ func (i *Instance) teardownTabs(mode teardownMode) error {
 			closed = append(closed, closedTab{id: tab.ID, name: tab.Name, ts: tab.tmux})
 		}
 	}
+	// The roster is not the whole runtime. A close that committed but could not
+	// confirm its kill left a tmux session running in this same worktree with only
+	// a durable handle naming it (#2669), and a destructive teardown has to account
+	// for it or it will move/delete the workspace around a live process — or drop
+	// the record that is the handle's only home. Captured here so the retirement
+	// below removes exactly what this pass tore down.
+	var reaped []TabCleanupData
+	if mode.reapsPendingTabCleanup() && len(i.pendingTabCleanup) > 0 {
+		reaped = append([]TabCleanupData(nil), i.pendingTabCleanup...)
+		for _, handle := range reaped {
+			// Bound by its EXACT persisted name, the same binding restoreLocalTabs
+			// uses. The program is irrelevant to a kill and nothing is started here.
+			closed = append(closed, closedTab{
+				id: handle.TabID, name: handle.TmuxName, ts: restoreTmuxSession(handle.TmuxName, ""),
+			})
+		}
+	}
 	gw := i.gitWorktree
 	title := i.Title
 	if mode.clearsStarted() {
@@ -252,6 +285,14 @@ func (i *Instance) teardownTabs(mode teardownMode) error {
 
 	i.mu.Lock()
 	mode.finalize(i, closed, gw)
+	// Every pane above — live tabs and pending handles alike — is CONFIRMED dead by
+	// the gate, so the handles this pass reaped have nothing left to name. Retire
+	// exactly those rather than clearing the list: a handle appended after the
+	// snapshot above was never torn down here, and dropping it would lose the only
+	// pointer to a session nothing killed.
+	for idx := range reaped {
+		i.pendingTabCleanup = dropTabCleanup(i.pendingTabCleanup, &reaped[idx])
+	}
 	i.mu.Unlock()
 
 	return errors.Join(errs...)
@@ -332,6 +373,10 @@ func (teardownKill) handleWorktree(gw *git.GitWorktree, title string) (teardownS
 
 func (teardownKill) clearsStarted() bool { return true }
 
+// reapsPendingTabCleanup: kill deletes the record, which is the cleanup handle's
+// only home. A pending session not killed here is untracked forever.
+func (teardownKill) reapsPendingTabCleanup() bool { return true }
+
 func (teardownKill) finalize(i *Instance, closed []closedTab, gw *git.GitWorktree) {
 	clearClosedTmuxRefs(i, closed)
 	if i.gitWorktree == gw {
@@ -364,6 +409,11 @@ func (teardownReleasePTY) handleWorktree(_ *git.GitWorktree, _ string) (teardown
 }
 
 func (teardownReleasePTY) clearsStarted() bool { return true }
+
+// reapsPendingTabCleanup: false. This mode runs no kill-session, so it can never
+// confirm a pending session dead — and it shares its tmux with the canonical
+// instance, which still needs those handles.
+func (teardownReleasePTY) reapsPendingTabCleanup() bool { return false }
 
 func (teardownReleasePTY) finalize(i *Instance, closed []closedTab, _ *git.GitWorktree) {
 	clearClosedTmuxRefs(i, closed)
@@ -423,6 +473,11 @@ func (m teardownArchive) handleWorktree(gw *git.GitWorktree, title string) (tear
 }
 
 func (teardownArchive) clearsStarted() bool { return false }
+
+// reapsPendingTabCleanup: archive MOVES the worktree a pending process is still
+// cwd'd in, so it must confirm that process dead first — the #802 ordering the
+// live tabs already get.
+func (teardownArchive) reapsPendingTabCleanup() bool { return true }
 
 func (teardownArchive) finalize(i *Instance, _ []closedTab, _ *git.GitWorktree) {
 	// Reduce to the tabs an un-archive can actually bring back: the agent tab

--- a/session/teardown_gate_test.go
+++ b/session/teardown_gate_test.go
@@ -29,11 +29,22 @@ type gateStubMode struct {
 	worktreeCalled   bool
 	finalizeCalled   bool
 	clearStartedFlag bool
+	reapPendingFlag  bool
+	closedNames      []string
+	stateByName      map[string]teardownState
 }
 
-func (m *gateStubMode) closeTab(_ *tmux.TmuxSession, _, _ string) (teardownState, error) {
+func (m *gateStubMode) closeTab(_ *tmux.TmuxSession, _, tabName string) (teardownState, error) {
+	m.closedNames = append(m.closedNames, tabName)
+	// stateByName lets a test make ONE named session the unknown one, so a gate
+	// firing can be attributed to that session rather than to any tab in the pass.
+	if state, ok := m.stateByName[tabName]; ok {
+		return state, m.closeErr
+	}
 	return m.closeState, m.closeErr
 }
+
+func (m *gateStubMode) reapsPendingTabCleanup() bool { return m.reapPendingFlag }
 
 func (m *gateStubMode) handleWorktree(_ *git.GitWorktree, _ string) (teardownState, error) {
 	m.worktreeCalled = true

--- a/session/teardown_pending_cleanup_test.go
+++ b/session/teardown_pending_cleanup_test.go
@@ -1,0 +1,140 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// The #2669 round-2 review finding. A startup-only retry policy leaves a window
+// the daemon never reopens: an unconfirmed CloseTab followed by KillSession or
+// archive BEFORE the next restart. teardownTabs enumerated only i.Tabs, so the
+// pending tmux session escaped session-wide teardown entirely — archive would
+// relocate the worktree while that process was still cwd'd in it, and a kill
+// would delete the record, and with it the handle that was the session's only
+// remaining pointer, while the process ran on.
+//
+// The fix routes pending handles through the SAME closeTab the live tabs use, so
+// they inherit the pane-exit wait and the unknown-blocks-the-worktree gate, and
+// retires them only when that gate confirms them dead.
+
+// pendingTeardownInstance is a started local instance with one agent tab and the
+// given unconfirmed tab-cleanup handles.
+func pendingTeardownInstance(t *testing.T, handles ...TabCleanupData) *Instance {
+	t.Helper()
+	inst, err := NewInstance(InstanceOptions{Title: "reap", Path: "/tmp/reap-repo", Program: "claude"})
+	require.NoError(t, err)
+	inst.SetTmuxSession(tmux.NewTmuxSessionFromSanitizedName("af_reap_agent", "claude"))
+	inst.SetStartedForTest(true)
+	inst.SetPendingTabCleanupForTest(handles)
+	return inst
+}
+
+// TestTeardownTabs_DestructiveModeTearsDownPendingHandles is the headline: a
+// destructive teardown must present the pending session to closeTab, exactly
+// like a live tab, so the same #802 pane-exit ordering runs before the worktree
+// is moved or deleted.
+func TestTeardownTabs_DestructiveModeTearsDownPendingHandles(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedName(name, program)
+	}
+	defer func() { restoreTmuxSession = prev }()
+
+	const leaked = "af_reap_agent__btop"
+	inst := pendingTeardownInstance(t, TabCleanupData{TabID: "closed-1", TmuxName: leaked})
+	mode := &gateStubMode{
+		closeState: stateKnown, worktreeState: stateKnown, reapPendingFlag: true,
+	}
+
+	require.NoError(t, inst.teardownTabs(mode))
+
+	assert.Contains(t, mode.closedNames, leaked,
+		"a destructive teardown skipped the pending tmux session; archive would move the worktree "+
+			"out from under it and kill would delete the record that is its only handle")
+	assert.True(t, mode.worktreeCalled, "every pane was confirmed dead, so the worktree step must run")
+	assert.Empty(t, inst.PendingTabCleanup(), "a confirmed teardown must retire the handle it reaped")
+}
+
+// TestTeardownTabs_UnconfirmedPendingKillBlocksWorktreeAndKeepsRecord is the
+// safety half. A pending session whose kill cannot be confirmed must stop the
+// destructive step and report ErrPaneMayBeLive, so the caller RETAINS the record
+// instead of deleting the handle while the process may still be running.
+func TestTeardownTabs_UnconfirmedPendingKillBlocksWorktreeAndKeepsRecord(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedName(name, program)
+	}
+	defer func() { restoreTmuxSession = prev }()
+
+	const leaked = "af_reap_agent__btop"
+	inst := pendingTeardownInstance(t, TabCleanupData{TabID: "closed-1", TmuxName: leaked})
+	// ONLY the pending session is unknown; the live agent tab answers cleanly. So a
+	// blocked worktree step is attributable to the pending handle alone, not to any
+	// tab in the pass.
+	mode := &gateStubMode{
+		closeState: stateKnown, worktreeState: stateKnown, reapPendingFlag: true,
+		stateByName: map[string]teardownState{leaked: stateUnknown},
+	}
+
+	err := inst.teardownTabs(mode)
+	require.Error(t, err)
+	assert.True(t, TeardownStateUnknown(err),
+		"an unconfirmed pending kill must report an unknown so the caller RETAINS the record; "+
+			"deleting it would strand the tmux session with nothing naming it")
+	assert.False(t, mode.worktreeCalled,
+		"the worktree must not be moved or deleted while a pending pane may still be running in it")
+	assert.False(t, mode.finalizeCalled, "finalize would clear the state a retry needs")
+	assert.Equal(t, []TabCleanupData{{TabID: "closed-1", TmuxName: leaked}}, inst.PendingTabCleanup(),
+		"an unconfirmed kill must keep its handle for the retry")
+}
+
+// TestTeardownTabs_ReleasePTYLeavesPendingHandlesAlone guards the non-destructive
+// mode. Release-PTY runs no kill-session at all, so it can never confirm a
+// pending session dead — retiring handles there would drop a durable pointer on
+// the strength of a teardown that killed nothing, which is the exact
+// unknown-read-as-finished mistake this whole mechanism exists to prevent. It
+// also shares its tmux with the canonical instance (#867), which still needs them.
+func TestTeardownTabs_ReleasePTYLeavesPendingHandlesAlone(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const leaked = "af_reap_agent__btop"
+	handle := TabCleanupData{TabID: "closed-1", TmuxName: leaked}
+	inst := pendingTeardownInstance(t, handle)
+	mode := &gateStubMode{
+		closeState: stateKnown, worktreeState: stateKnown, reapPendingFlag: false,
+	}
+
+	require.NoError(t, inst.teardownTabs(mode))
+
+	assert.NotContains(t, mode.closedNames, leaked,
+		"release-PTY must not touch a pending session: it shares tmux with the canonical instance")
+	assert.Equal(t, []TabCleanupData{handle}, inst.PendingTabCleanup(),
+		"release-PTY killed nothing, so it must not retire a handle")
+}
+
+// TestTeardownModes_DeclarePendingReapByDestructiveness pins the policy itself.
+// The two modes that touch the workspace reap; the one that does not, does not.
+// A future mode has to make this choice explicitly rather than inherit it.
+func TestTeardownModes_DeclarePendingReapByDestructiveness(t *testing.T) {
+	assert.True(t, teardownKill{}.reapsPendingTabCleanup(),
+		"kill deletes the record, which is the handle's only home")
+	assert.True(t, teardownArchive{}.reapsPendingTabCleanup(),
+		"archive moves the worktree a pending process is still cwd'd in")
+	assert.False(t, teardownReleasePTY{}.reapsPendingTabCleanup(),
+		"release-PTY runs no kill-session, so it can confirm nothing dead")
+}


### PR DESCRIPTION
Closes #2669

## Root cause

`Manager.CloseTab` irreversibly removed the tab, ended its PTY stream, and killed its tmux session before persisting the smaller roster. If `persistInstanceData` failed, the stale on-disk tab survived; a later daemon restore could respawn that supposedly closed tmux-backed tab.

Committing the roster first fixes that and opens its mirror image, which the exact-head review caught: teardown now runs AFTER the tab is durably gone, so a `kill-session` that times out — or answers while the session is still up — dropped the closed tab's only tmux identity. The process leaked untracked across every future daemon restart, and a later tab with the same name re-derived the same tmux name, which `TmuxSession.Start` rejects as already existing: a wedge no retry clears, because every retry derives the same name.

## Implemented on this head

**The durable commit (#2669 proper)**

- stage stable-ID tab removal and build the exact shrunken projection under the instance lock
- persist that projection before ending the stream or closing tmux
- restore the exact live tab at its original position if persistence fails
- publish `session.updated` immediately after the durable commit, before potentially slow tmux teardown
- preserve #2716's final-VS-Code invariant: editor teardown must be confirmed before committing removal of its last durable retry handle

**The cleanup tombstone (review follow-up)**

- new `InstanceData.PendingTabCleanup []TabCleanupData` (`{tab_id, tmux_name}`) — the tab-scoped analogue of the existing `RuntimeCleanup`, additive + omitempty on the `TabData.ID` rollforward precedent
- the handle is staged and committed in the **same projection** that removes the tab, so the persisted record never describes a state where the tmux session is neither a tab nor a tracked cleanup
- a confirmed teardown retires the handle and returns a `Settled` projection for the caller to persist; an unconfirmed one keeps it; a rolled-back commit drops the staged handle with the tab it restores, so a live tab is never double-counted as awaiting cleanup
- entries are cleanup handles, **never tabs**: `TabCleanupData` carries no Kind/Command/URL, restore loads them beside the roster rather than into it, and nothing renders or respawns from one
- `daemon.sweepStartupTabCleanup` retries the kill once per daemon start, in the same pre-readiness window as the orphan-container sweep (#2632) so no RPC can race it. It retires **only confirmed kills** — tmux `Close` is idempotent (#967), so a nil error genuinely means no such session remains, while a timeout keeps its handle for the next start
- `uniqueTabTmuxName` reserves pending tokens as well as live ones, so a recreated tab walks the spawn to `…__btop-2` instead of colliding. Only the tmux namespace walks; the user still gets the display name they asked for (#1957)

**Session-wide teardown (round-2 review P1)**

A startup-only retry left a window the daemon never reopens: an unconfirmed close followed by `KillSession` or archive BEFORE the next restart. `teardownTabs` enumerated `i.Tabs` only, so the pending session escaped session-wide teardown — archive would relocate the worktree while that process was cwd'd in it, and kill would delete the record, and with it the handle that was the session's only remaining pointer.

- pending handles now go through the SAME `closeTab` the live tabs use, inheriting the #802 pane-exit wait and the #1917 unknown-blocks-the-worktree gate
- retention needed no new rule: the gate raises `ErrPaneMayBeLive`, and `deleteSessionRecord` already refuses to delete a record on `TeardownStateUnknown`
- the mode DECLARES whether it reaps — kill and archive yes (they touch the workspace), release-PTY **no**: it runs no `kill-session`, so it can confirm nothing dead, and it shares its tmux with the canonical instance (#867). Reaping there would retire a durable handle on a teardown that killed nothing
- only the handles the pass actually tore down are retired; one appended after the snapshot was never killed here

Adjacent audit: `CreateTab` already closes an unpersisted spawn — it reaches `CloseTabByID` precisely because its persist just failed, so no handle can reach disk there; it now retains one in memory anyway, so this daemon stops re-deriving the leaked name and the next successful persist carries it to disk. Rename, reorder, and `SetPRInfo` already roll back metadata on persistence errors. The TUI's `DropClosedTab` is a client-side reconciliation path and intentionally does not own daemon tmux teardown.

## Regression proof

Observed red on the pre-fix tree:

```
--- FAIL: TestCloseTab_PersistFailureKeepsTmuxTabForRetry (0.08s)
    close_tab_test.go:134: persist failure left 1 tabs, want 2: the close must remain retryable
FAIL
```

Observed red for the first review follow-up before moving the event into the commit boundary:

```
--- FAIL: TestCloseTab_PublishesCommittedRosterBeforeTmuxTeardownCompletes (5.18s)
    close_tab_commit_order_test.go:98: CloseTab waited for tmux teardown before publishing the durably committed roster
FAIL
```

Each new test was watched failing first, by defeating the fix three separate ways — never stage a handle, ignore pending tokens in the reservation, drop the tombstone on restore. Every one produced the exact assertion it claims, and the restored tree is green. The collision test reproduces the reviewer's predicted error verbatim:

```
--- FAIL: TestCloseTab_UnconfirmedTeardownPersistsCleanupHandle (1.43s)
    close_tab_cleanup_test.go:148: persisted cleanup handles = 0, want 1: the leaked tmux
    session "af_worker_agent__btop" is now untracked across daemon restarts
--- FAIL: TestCreateTab_AvoidsTmuxNameRetainedByUnconfirmedClose (0.11s)
    close_tab_cleanup_test.go:233: recreating the tab must not collide with the un-reaped
    session: failed to start process tab: tmux session definitely did not start:
    tmux session already exists: af_worker_agent__btop
```

## Validation

Exact pushed head: `231acb75d083fc690a857aa53556c32600f4754c` (rebased onto master `b6e310a8`)

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (empty)
- `go build ./...`
- `deadcode -test ./...` (empty)
- `scripts/lint-file-length.sh` (1120 Go files, 0 grandfathered)
- focused coverage for #2669 close ordering, rollback, events, tombstone retention/retirement/retry/reservation, destructive-teardown reaping, and #2716 editor safety
- full suite last against the exact pushed head: `make test-container` — 43 packages ok, 0 failures (app 153.3s, daemon 221.5s, session 42.2s, session/tmux 95.6s, integration 55.3s)

`Test (macOS)` went red once on this head with `TestPersistedVSCodeStop_DoesNotHoldSupervisorLockWhileWaiting` — an EPERM from `waitForProcessGroupExit` in `daemon/vscode_owner.go`. Not from this PR: that file and its test are byte-identical to master here (`git diff origin/master...HEAD` → 0 lines), the test builds a `vscodeSupervisor` directly and never reaches `teardownTabs`, and master has its own recent macOS failure. Green on re-run. The EPERM handling looks worth a real fix, but it is #2716-adjacent code and out of scope for this PR.
