### PR TITLE
fix(daemon): reject tabs on killed sessions

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -451,11 +451,16 @@ func (m *Manager) restoreArchivedInstance(instance *session.Instance, repoID, ti
 // returns an error: an archive/kill that beat us to the op-lock has fully
 // completed by the time we acquire it (it held the lock across its entire
 // teardown+move), so a mid-archive Deleting is never observed — only the terminal
-// Archived. A completed kill leaves the stale instance started=false, which
-// AddShellTab/AddProcessTab reject downstream.
+// Archived. A restored kill tombstone has no in-flight op-lock state and may
+// still be started, so UserKilled must be checked explicitly under this newly
+// acquired lock rather than left to the instance-level started guard.
 func (m *Manager) archiveExclusiveTabLock(key string, instance *session.Instance) (*sync.Mutex, error) {
 	opLock := m.opLockFor(key)
 	opLock.Lock()
+	if instance.UserKilled() {
+		opLock.Unlock()
+		return nil, fmt.Errorf("cannot create a tab on killed session %q", instance.Title)
+	}
 	if err := instance.TabSpawnBlocked(); err != nil {
 		opLock.Unlock()
 		return nil, err

--- a/daemon/create_tab_archive_test.go
+++ b/daemon/create_tab_archive_test.go
@@ -208,3 +208,27 @@ func TestCreateTab_ShellRejectedAfterArchive(t *testing.T) {
 	assert.Contains(t, err.Error(), "archived")
 	assert.False(t, isAlive(agentName+"__shell"), "no shell tmux session may be spawned into the moved-away worktree")
 }
+
+// TestCreateTab_RejectedForRestoredKillTombstone covers the restart window
+// after kill intent was persisted but before teardown completed. A restored
+// local tombstone is started so the daemon can display and finish it, while its
+// durable UserKilled marker is the only terminal fence: the pre-crash op-lock
+// and transient OpKilling value are gone. CreateTab must honor that marker and
+// never create a sibling tmux session that the next status poll immediately
+// tears down.
+func TestCreateTab_RejectedForRestoredKillTombstone(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	const title, agentName = "worker", "af_worker_agent"
+	inst, _, isAlive := registerArchivableWithTmux(t, manager, repoID, repoPath, title, agentName)
+
+	// Exact post-restart lifecycle shape: FromInstanceData + Start(false) keeps a
+	// tombstoned local row started, but disk persistence scrubbed its in-flight op.
+	inst.MarkUserKilled()
+	require.True(t, inst.Started())
+	require.Equal(t, session.OpNone, inst.GetInFlightOp())
+
+	_, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Command: "btop"})
+	require.Error(t, err, "CreateTab on a restored kill tombstone must be rejected")
+	assert.Contains(t, err.Error(), "killed")
+	assert.False(t, isAlive(agentName+"__btop"), "no process tmux session may be spawned for a killed session")
+}


### PR DESCRIPTION
## Summary

- reject `CreateTab` when the resolved session carries a durable `UserKilled` tombstone
- perform the tombstone check under the per-session operation lock
- cover the post-restart shape where the row is started, its transient operation was scrubbed, and only `UserKilled` fences mutation

## Verified root cause

A kill tombstone can reload with `started=true` and `OpNone`: persistence intentionally scrubs the transient `OpKilling` value, while `LocalBackend.Start(false)` returns early for `UserKilled` after marking the row started. `CreateTab` then acquires the session op-lock, but `archiveExclusiveTabLock` checked only `TabSpawnBlocked`, which does not include the durable tombstone. The new process tab was therefore spawned and persisted before the next poll finished the kill.

## Regression observed red

Against current `origin/master` before the fix:

```
--- FAIL: TestCreateTab_RejectedForRestoredKillTombstone (1.59s)
    create_tab_archive_test.go:231:
        Error:       An error is expected but got nil.
        Messages:    CreateTab on a restored kill tombstone must be rejected
FAIL
```

## Adjacent audit

The other in-place tab mutations share `tabMutationTarget`, which already re-checks `UserKilled` after acquiring the op-lock. Web-tab proxy creation/serving also checks `UserKilled` after `TabSpawnBlocked`; PR-info mutation and conversation capture have their own tombstone guards. `archiveExclusiveTabLock` is the only production `CreateTab` gate missing it.

## Validation

Pushed head: `6ef152ed0dd6d2e5dbefa05b164169cbad848f93`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container` (full suite, run last against the pushed head)

Closes #2636