### PR TITLE
fix(daemon): retain closer after listener failure

### DIFF
--- a/daemon/listener_reload.go
+++ b/daemon/listener_reload.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"sync"
 
@@ -39,18 +40,25 @@ type webListeners struct {
 	// webMux is the shared control-plane mux (also served on the unix socket). The
 	// preview listener builds its own mux fresh per bind (newPreviewMux is stateless).
 	webMux http.Handler
+	// listenTCP is the bind boundary for both restartable listeners. Keeping it
+	// on the owner lets lifecycle tests distinguish an underlying listener death
+	// from the owner's server-close path while exercising the real HTTP server.
+	listenTCP func(network, address string) (net.Listener, error)
 
 	mu sync.Mutex
-	// webClose/webConfigAddr describe the currently-bound web listener. webConfigAddr
-	// is the CONFIG value that produced it (not the resolved bound address), so
-	// reconcile compares like-for-like and does not rebind on an unchanged setting.
-	// "" ⇒ not serving (the listen_addr="" opt-out).
+	// webClose owns all accepted connections for the latest generation, so an
+	// unexpected Serve exit does not make it stale. webConfigAddr describes only
+	// the live binding: it is the CONFIG value that produced the listener (not the
+	// resolved bound address), so reconcile compares like-for-like. "" means not
+	// accepting (or the listen_addr="" opt-out).
 	webClose      func() error
 	webConfigAddr string
 	// webGen distinguishes listener generations so a superseded listener's Serve
 	// returning cannot clear the lifecycle bound-state the NEW listener just set. A
 	// done-watcher clears health and binding state only while its own generation is
-	// still current, allowing an unchanged configured address to be rebound.
+	// still current, allowing an unchanged configured address to be rebound. It
+	// clears the closer only after our Close initiated the exit; after listener
+	// failure the closer remains the handle to accepted connections.
 	webGen uint64
 
 	previewClose      func() error
@@ -61,7 +69,7 @@ type webListeners struct {
 // newWebListeners builds the manager (never binds — startHTTPServer's initial
 // bind and ApplyConfig's rebinds both go through reconcileFromLocked/bind* below).
 func newWebListeners(manager *Manager, webMux http.Handler) *webListeners {
-	return &webListeners{manager: manager, webMux: webMux}
+	return &webListeners{manager: manager, webMux: webMux, listenTCP: net.Listen}
 }
 
 // reconcile brings the two socket listeners in line with newCfg, rebinding only
@@ -116,8 +124,8 @@ func (wl *webListeners) bindWebLocked(addr string) error {
 	// require_loopback_token live per request, so this value never enforces auth.
 	policy := webListenerPolicy(cfg)
 	notice := config.ListenerExposureNotice(cfg)
-	closer, info, err := startTCPListener(wl.webMux, addr, cfg, policy, withWebShell, nil,
-		&livePosture{snapshot: wl.manager.Config, policyFromConfig: true})
+	closer, info, err := startTCPListenerWithListen(wl.webMux, addr, cfg, policy, withWebShell, nil,
+		&livePosture{snapshot: wl.manager.Config, policyFromConfig: true}, wl.listenTCP)
 	if err != nil {
 		return fmt.Errorf("apply listen_addr %q: %w — daemon still serving on %s", addr, err, servingOn(wl.webConfigAddr))
 	}
@@ -138,7 +146,9 @@ func (wl *webListeners) bindWebLocked(addr string) error {
 			if wl.manager.lifecycle != nil {
 				wl.manager.lifecycle.clearTCPBound()
 			}
-			wl.webClose = nil
+			if info.closeRequested() {
+				wl.webClose = nil
+			}
 			wl.webConfigAddr = ""
 		}
 		wl.mu.Unlock()
@@ -189,8 +199,8 @@ func (wl *webListeners) bindPreviewLocked(addr string) error {
 	cfg := wl.manager.Config()
 	policy := previewListenerPolicy(cfg)
 	notice := config.PreviewListenerExposureNotice(cfg)
-	closer, info, err := startTCPListener(newPreviewMux(), addr, cfg, policy, previewShell, previewListenerAuth(wl.manager),
-		&livePosture{snapshot: wl.manager.Config, policyFromConfig: false})
+	closer, info, err := startTCPListenerWithListen(newPreviewMux(), addr, cfg, policy, previewShell, previewListenerAuth(wl.manager),
+		&livePosture{snapshot: wl.manager.Config, policyFromConfig: false}, wl.listenTCP)
 	if err != nil {
 		return fmt.Errorf("apply preview_listen_addr %q: %w — daemon still serving preview on %s", addr, err, servingOn(wl.previewConfigAddr))
 	}
@@ -209,7 +219,9 @@ func (wl *webListeners) bindPreviewLocked(addr string) error {
 			if wl.manager.lifecycle != nil {
 				wl.manager.lifecycle.clearPreviewBound()
 			}
-			wl.previewClose = nil
+			if info.closeRequested() {
+				wl.previewClose = nil
+			}
 			wl.previewConfigAddr = ""
 		}
 		wl.mu.Unlock()

--- a/daemon/listener_reload.go
+++ b/daemon/listener_reload.go
@@ -82,13 +82,18 @@ func (wl *webListeners) reconcile(newCfg *config.Config) (failed []string, err e
 	wl.mu.Lock()
 	defer wl.mu.Unlock()
 	var errs []error
-	if newCfg.ListenAddr != wl.webConfigAddr {
+	// A closer retained after unexpected listener death outlives the empty
+	// binding sentinel. Disabling that listener must still enter bindWebLocked's
+	// teardown path so accepted connections do not survive reconciliation.
+	if newCfg.ListenAddr != wl.webConfigAddr ||
+		(newCfg.ListenAddr == "" && wl.webClose != nil) {
 		if e := wl.bindWebLocked(newCfg.ListenAddr); e != nil {
 			errs = append(errs, e)
 			failed = append(failed, "listen_addr")
 		}
 	}
-	if newCfg.PreviewListenAddr != wl.previewConfigAddr {
+	if newCfg.PreviewListenAddr != wl.previewConfigAddr ||
+		(newCfg.PreviewListenAddr == "" && wl.previewClose != nil) {
 		if e := wl.bindPreviewLocked(newCfg.PreviewListenAddr); e != nil {
 			errs = append(errs, e)
 			failed = append(failed, "preview_listen_addr")

--- a/daemon/listener_reload_test.go
+++ b/daemon/listener_reload_test.go
@@ -309,6 +309,88 @@ func TestWebListenersRetainCloserAfterUnexpectedListenerDeath(t *testing.T) {
 	}
 }
 
+func TestWebListenersDisableClosesRetainedServerAfterUnexpectedListenerDeath(t *testing.T) {
+	for _, kind := range []string{"control", "preview"} {
+		t.Run(kind, func(t *testing.T) {
+			t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+			cfg := config.DefaultConfig()
+			cfg.ListenAddr = ""
+			cfg.PreviewListenAddr = ""
+			if kind == "control" {
+				cfg.ListenAddr = "127.0.0.1:0"
+			} else {
+				cfg.PreviewListenAddr = "127.0.0.1:0"
+			}
+
+			m, err := NewManager(cfg)
+			require.NoError(t, err)
+			wl := newWebListeners(m, newHTTPMux(&controlServer{manager: m}))
+			m.webListeners = wl
+
+			var listener *readObservedListener
+			wl.listenTCP = func(network, address string) (net.Listener, error) {
+				bound, listenErr := net.Listen(network, address)
+				if listenErr != nil {
+					return nil, listenErr
+				}
+				listener = &readObservedListener{Listener: bound, readStarted: make(chan struct{})}
+				return listener, nil
+			}
+			failed, err := wl.reconcile(m.Config())
+			require.NoError(t, err)
+			require.Empty(t, failed)
+			t.Cleanup(func() { _ = wl.close() })
+
+			state := m.lifecycle.snapshot().listeners
+			addr := state.TCPBoundAddr
+			if kind == "preview" {
+				addr = state.PreviewBoundAddr
+			}
+			conn, err := net.Dial("tcp", addr)
+			require.NoError(t, err)
+			defer conn.Close()
+			_, err = io.WriteString(conn, "GET / HTTP/1.1\r\nHost: localhost\r\n")
+			require.NoError(t, err)
+			require.Eventually(t, func() bool {
+				select {
+				case <-listener.readStarted:
+					return true
+				default:
+					return false
+				}
+			}, time.Second, 10*time.Millisecond, "the server must accept and begin reading the connection")
+
+			require.NoError(t, listener.Close(), "fail the listener without calling the server closer")
+			require.Eventually(t, func() bool {
+				wl.mu.Lock()
+				defer wl.mu.Unlock()
+				if kind == "control" {
+					return wl.webConfigAddr == "" && wl.webClose != nil
+				}
+				return wl.previewConfigAddr == "" && wl.previewClose != nil
+			}, time.Second, 10*time.Millisecond, "listener death must leave only the accepted-connection closer")
+
+			disabled := *m.Config()
+			if kind == "control" {
+				disabled.ListenAddr = ""
+			} else {
+				disabled.PreviewListenAddr = ""
+			}
+			m.live.Store(&disabled)
+			failed, err = wl.reconcile(&disabled)
+			require.NoError(t, err)
+			require.Empty(t, failed)
+
+			require.NoError(t, conn.SetReadDeadline(time.Now().Add(time.Second)))
+			_, err = conn.Read(make([]byte, 1))
+			var netErr net.Error
+			require.Error(t, err)
+			require.False(t, errors.As(err, &netErr) && netErr.Timeout(),
+				"disabling a dead listener must close its retained accepted connections")
+		})
+	}
+}
+
 // TestApplyConfigTokenlessNetworkWarnsAndBinds: a tokenless non-loopback address is
 // WARNED about at save time and BINDS — never refused (#2168 Phase 0; the #2556
 // correction the plan called out). ApplyConfig surfaces the exposure notice as a

--- a/daemon/listener_reload_test.go
+++ b/daemon/listener_reload_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -201,6 +202,109 @@ func TestWebListenersRebindSameAddressAfterListenerDeath(t *testing.T) {
 			require.Empty(t, failed)
 			require.Eventually(t, tt.isBound, time.Second, 10*time.Millisecond,
 				"reconciling the unchanged configured address must replace the dead listener")
+		})
+	}
+}
+
+type readObservedListener struct {
+	net.Listener
+	readStarted chan struct{}
+}
+
+func (l *readObservedListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	return &readObservedConn{Conn: conn, readStarted: l.readStarted}, nil
+}
+
+type readObservedConn struct {
+	net.Conn
+	readStarted chan struct{}
+	started     atomic.Bool
+}
+
+func (c *readObservedConn) Read(p []byte) (int, error) {
+	if c.started.CompareAndSwap(false, true) {
+		close(c.readStarted)
+	}
+	return c.Conn.Read(p)
+}
+
+func TestWebListenersRetainCloserAfterUnexpectedListenerDeath(t *testing.T) {
+	for _, kind := range []string{"control", "preview"} {
+		t.Run(kind, func(t *testing.T) {
+			t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+			cfg := config.DefaultConfig()
+			cfg.ListenAddr = ""
+			cfg.PreviewListenAddr = ""
+			if kind == "control" {
+				cfg.ListenAddr = "127.0.0.1:0"
+			} else {
+				cfg.PreviewListenAddr = "127.0.0.1:0"
+			}
+
+			m, err := NewManager(cfg)
+			require.NoError(t, err)
+			wl := newWebListeners(m, newHTTPMux(&controlServer{manager: m}))
+			m.webListeners = wl
+
+			var listener *readObservedListener
+			wl.listenTCP = func(network, address string) (net.Listener, error) {
+				bound, listenErr := net.Listen(network, address)
+				if listenErr != nil {
+					return nil, listenErr
+				}
+				listener = &readObservedListener{Listener: bound, readStarted: make(chan struct{})}
+				return listener, nil
+			}
+			failed, err := wl.reconcile(m.Config())
+			require.NoError(t, err)
+			require.Empty(t, failed)
+			t.Cleanup(func() { _ = wl.close() })
+
+			state := m.lifecycle.snapshot().listeners
+			addr := state.TCPBoundAddr
+			if kind == "preview" {
+				addr = state.PreviewBoundAddr
+			}
+			conn, err := net.Dial("tcp", addr)
+			require.NoError(t, err)
+			defer conn.Close()
+			_, err = io.WriteString(conn, "GET / HTTP/1.1\r\nHost: localhost\r\n")
+			require.NoError(t, err)
+			require.Eventually(t, func() bool {
+				select {
+				case <-listener.readStarted:
+					return true
+				default:
+					return false
+				}
+			}, time.Second, 10*time.Millisecond, "the server must accept and begin reading the connection")
+
+			require.NoError(t, listener.Close(), "fail the listener without calling the server closer")
+			require.Eventually(t, func() bool {
+				wl.mu.Lock()
+				defer wl.mu.Unlock()
+				if kind == "control" {
+					return wl.webConfigAddr == ""
+				}
+				return wl.previewConfigAddr == ""
+			}, time.Second, 10*time.Millisecond, "the done watcher must observe listener death")
+
+			require.NoError(t, conn.SetReadDeadline(time.Now().Add(100*time.Millisecond)))
+			_, err = conn.Read(make([]byte, 1))
+			var netErr net.Error
+			require.ErrorAs(t, err, &netErr)
+			require.True(t, netErr.Timeout(), "the accepted connection must survive listener death before shutdown")
+
+			require.NoError(t, wl.close())
+			require.NoError(t, conn.SetReadDeadline(time.Now().Add(time.Second)))
+			_, err = conn.Read(make([]byte, 1))
+			require.Error(t, err)
+			require.False(t, errors.As(err, &netErr) && netErr.Timeout(),
+				"daemon shutdown must still reach and close the accepted connection")
 		})
 	}
 }

--- a/daemon/tcpserver.go
+++ b/daemon/tcpserver.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"sync/atomic"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
@@ -35,9 +36,10 @@ import (
 // documented log-file-readability consideration, gated behind the explicit
 // listen_addr opt-in.
 type tcpListenerInfo struct {
-	Addr  string // the resolved bound address (host:port, port filled in for :0)
-	Token string // the bearer token clients must present
-	done  <-chan struct{}
+	Addr           string // the resolved bound address (host:port, port filled in for :0)
+	Token          string // the bearer token clients must present
+	done           <-chan struct{}
+	closeRequested func() bool
 }
 
 // tokenGatePolicy is how a TCP listener's bearer-token gate treats peers. Its
@@ -191,6 +193,14 @@ type livePosture struct {
 // token rotate` takes effect for new connections without a daemon restart. An
 // override supplies its own already-minted credential and is compared as-is.
 func startTCPListener(mux http.Handler, addr string, cfg *config.Config, policy tokenGatePolicy, shell webShell, auth *tcpListenerAuth, live *livePosture) (func() error, tcpListenerInfo, error) {
+	return startTCPListenerWithListen(mux, addr, cfg, policy, shell, auth, live, net.Listen)
+}
+
+// startTCPListenerWithListen is startTCPListener with the socket constructor
+// supplied by the restartable-listener owner. Production uses net.Listen; the
+// seam lets lifecycle tests fail the listener underneath http.Server without
+// conflating that path with calling the returned server closer.
+func startTCPListenerWithListen(mux http.Handler, addr string, cfg *config.Config, policy tokenGatePolicy, shell webShell, auth *tcpListenerAuth, live *livePosture, listen func(network, address string) (net.Listener, error)) (func() error, tcpListenerInfo, error) {
 	var token string
 	var expectedToken func() (string, error)
 	var expectedForRequest func(*http.Request) (string, error)
@@ -219,7 +229,7 @@ func startTCPListener(mux http.Handler, addr string, cfg *config.Config, policy 
 	}
 	// A plain TCP listener — net.Listen (not tls.Listen). Addr() reports the
 	// concrete port even when addr requests :0 (used by the integration test).
-	listener, err := net.Listen("tcp", addr)
+	listener, err := listen("tcp", addr)
 	if err != nil {
 		return nil, tcpListenerInfo{}, fmt.Errorf("bind TCP listener on %q: %w", addr, err)
 	}
@@ -282,6 +292,7 @@ func startTCPListener(mux http.Handler, addr string, cfg *config.Config, policy 
 		ReadHeaderTimeout: httpReadHeaderTimeout,
 	}
 	done := make(chan struct{})
+	var closeRequested atomic.Bool
 	go func() {
 		defer close(done)
 		if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
@@ -290,9 +301,16 @@ func startTCPListener(mux http.Handler, addr string, cfg *config.Config, policy 
 	}()
 
 	info := tcpListenerInfo{
-		Addr:  listener.Addr().String(),
-		Token: token,
-		done:  done,
+		Addr:           listener.Addr().String(),
+		Token:          token,
+		done:           done,
+		closeRequested: closeRequested.Load,
 	}
-	return srv.Close, info, nil
+	closeServer := func() error {
+		// Set before Close so the Serve watcher can distinguish our teardown from
+		// an underlying listener failure even when Serve returns immediately.
+		closeRequested.Store(true)
+		return srv.Close()
+	}
+	return closeServer, info, nil
 }


### PR DESCRIPTION
Closes #2710

## What was wrong
`http.Server.Serve` returning has two causes with opposite cleanup requirements:

- If the daemon called `Server.Close`, accepted connections are already terminated and clearing the closer is correct.
- If the underlying listener died, `Serve` only stopped accepting. Already-accepted connections can remain active, and `Server.Close` is still the only handle that can reach them.

The control and preview done-watchers treated both cases as "generation finished" and cleared both the configured-address sentinel and the closer. That fixed same-address rebinding but discarded the only shutdown/reconcile handle for surviving connections.

## What changed
Each TCP listener generation records whether its owner invoked the returned closer. The current-generation watcher always clears lifecycle state and the dead configured-address sentinel so the same address can be rebound. It clears the closer only after an owner-requested close; after unexpected listener failure, the closer remains available for the next reconcile or daemon shutdown.

Both control and preview watchers use the same rule. The existing generation guards are unchanged, so a superseded generation still cannot clear its replacement's state.

## Why the alternative was rejected
Clearing every field when `Serve` returns conflates "not accepting" with "no live connections." Invoking the closer immediately from the watcher would terminate in-flight work merely because the accept loop failed. Retaining the closer separates the address sentinel's lifetime from the connection owner's lifetime: rebinding is allowed immediately, while accepted connections remain reachable for deliberate reconcile or shutdown cleanup.

The non-restartable agent-server caller does not keep generation watcher state and needs no corresponding change.

## Red first
Against master, the regression opened a real HTTP connection, waited until the server began reading it, killed only the underlying listener, verified the accepted connection remained alive, and then invoked daemon shutdown:

```
--- FAIL: TestWebListenersRetainCloserAfterUnexpectedListenerDeath (2.27s)
    --- FAIL: TestWebListenersRetainCloserAfterUnexpectedListenerDeath/control (1.14s)
        listener_reload_test.go:306: Should be false
        Messages: daemon shutdown must still reach and close the accepted connection
    --- FAIL: TestWebListenersRetainCloserAfterUnexpectedListenerDeath/preview (1.13s)
        listener_reload_test.go:306: Should be false
        Messages: daemon shutdown must still reach and close the accepted connection
```

Both subtests now observe shutdown closing the accepted connection. The original same-address recovery regression remains green.

## Validation
Pushed head: `97df3467109fb60f2b214fda3c757b6da468b941`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- focused listener lifecycle tests in the test container
- full daemon package in the test container
- `make test-container` (full suite, last, on the pushed head)


## Codex follow-up: disable after listener death
The exact-head review found one remaining lifetime edge: after unexpected listener death the address sentinel is already empty, so reconciling a newly disabled address could return early even though the retained closer still owned accepted connections. The new real-connection regression failed against the reviewed head for both listeners:

```
--- FAIL: TestWebListenersDisableClosesRetainedServerAfterUnexpectedListenerDeath (2.34s)
    --- FAIL: .../control
        Should be false
        Messages: disabling a dead listener must close its retained accepted connections
    --- FAIL: .../preview
        Should be false
        Messages: disabling a dead listener must close its retained accepted connections
```

Reconciliation now enters the existing teardown path whenever the desired address is empty and a retained closer exists. The binding sentinel and closer remain separate: same-address recovery still keys on the dead binding, while disable/reconcile and shutdown can both reach accepted connections. The original same-address, shutdown-after-death, and generation-guard behavior remains intact. The full container suite passed last on the pushed head above.
