### PR TITLE
fix: recover queue tails when load truncate fails

### DIFF
--- a/daemon/eventqueue.go
+++ b/daemon/eventqueue.go
@@ -88,12 +88,13 @@ type eventQueue struct {
 	curPath string // <dir>/<taskID>.cursor
 	remove  func(string) error
 
-	// appendRecord/truncate are the append and truncate seams. Production wires
-	// them to os.Truncate and a real O_APPEND write; tests inject them to
-	// simulate the partial-write + truncate-failure path that #1634 wedged on
-	// (a real short write is otherwise impossible to force on a local FS).
-	appendRecord func(path string, rec []byte) (int, error)
-	truncate     func(path string, size int64) error
+	// appendRecord/appendBoundary/truncate are the write seams. Production wires
+	// both appends to a real O_APPEND write and truncate to os.Truncate; tests
+	// inject them to simulate short writes, truncate failures, and deferred close
+	// errors that a local filesystem cannot force deterministically.
+	appendRecord   func(path string, rec []byte) (int, error)
+	appendBoundary func(path string, rec []byte) (int, error)
+	truncate       func(path string, size int64) error
 
 	mu      sync.Mutex
 	offset  int64 // byte offset of the first undelivered event
@@ -128,13 +129,14 @@ func eventQueueDir() (string, error) {
 // which is what lets a backlog survive a daemon restart or reload.
 func newEventQueue(dir, taskID string) *eventQueue {
 	q := &eventQueue{
-		taskID:       taskID,
-		path:         filepath.Join(dir, taskID+".jsonl"),
-		curPath:      filepath.Join(dir, taskID+".cursor"),
-		remove:       os.Remove,
-		appendRecord: appendRecordToFile,
-		truncate:     os.Truncate,
-		now:          time.Now,
+		taskID:         taskID,
+		path:           filepath.Join(dir, taskID+".jsonl"),
+		curPath:        filepath.Join(dir, taskID+".cursor"),
+		remove:         os.Remove,
+		appendRecord:   appendRecordToFile,
+		appendBoundary: appendRecordToFile,
+		truncate:       os.Truncate,
+		now:            time.Now,
 	}
 	q.load()
 	return q
@@ -198,8 +200,10 @@ func (q *eventQueue) load() {
 				// away so the next append starts on a record boundary instead
 				// of gluing two records into one corrupt line.
 				log.WarningLog.Printf("watch task %s: discarding %d bytes of torn trailing event-queue record", q.taskID, len(raw))
-				if terr := os.Truncate(q.path, scanned); terr != nil {
-					log.WarningLog.Printf("watch task %s: failed to truncate torn event-queue tail: %v", q.taskID, terr)
+				if terr := q.truncate(q.path, scanned); terr != nil {
+					// q.size already includes the torn bytes discovered during load;
+					// recoverTornRecordLocked accounts only for the new boundary byte.
+					q.recoverTornRecordLocked(len(raw), terr, true)
 				} else {
 					q.size = scanned
 				}
@@ -268,7 +272,7 @@ func (q *eventQueue) enqueue(line string) error {
 		// — same degradation as enqueue failing outright).
 		if n > 0 {
 			if terr := q.truncate(q.path, q.size); terr != nil {
-				q.recoverTornRecordLocked(n, terr)
+				q.recoverTornRecordLocked(n, terr, false)
 			}
 		}
 		return err
@@ -294,10 +298,10 @@ func appendRecordToFile(path string, rec []byte) (int, error) {
 	return n, err
 }
 
-// recoverTornRecordLocked salvages a short write whose truncate ALSO failed, so
-// the torn bytes (n of them, no trailing newline) are stuck on disk. Left as-is
-// they would permanently wedge the queue (#1634): the next O_APPEND merges its
-// record onto the torn bytes into one invalid line that no restart could clear.
+// recoverTornRecordLocked salvages torn bytes whose truncate ALSO failed. This
+// handles both a short write in enqueue and a torn tail found by load after a
+// restart. Left as-is, the next O_APPEND merges its record onto the torn bytes
+// into one invalid line that no restart could clear.
 // Best-effort recovery: append a single newline to force a record boundary, so
 // the torn fragment becomes its own (unparseable) line that peek() drops and
 // skips past instead of merging into the next event. The fragment is counted as
@@ -305,24 +309,32 @@ func appendRecordToFile(path string, rec []byte) (int, error) {
 // later good event would be miscounted and silently lost when the head is
 // skipped. If even the newline append fails, the reader's skip path is the final
 // backstop (a merged line is skippable too, only losing the following event).
-// Callers hold q.mu.
-func (q *eventQueue) recoverTornRecordLocked(n int, truncErr error) {
-	f, ferr := os.OpenFile(q.path, os.O_WRONLY|os.O_APPEND, 0644)
-	if ferr != nil {
-		log.WarningLog.Printf("watch task %s: failed to truncate short-written event record (%v); could not reopen to re-align it: %v", q.taskID, truncErr, ferr)
+// sizeIncludesTorn distinguishes load (q.size came from stat and already counts
+// the fragment) from enqueue (q.size is still the last good boundary). Callers
+// hold q.mu.
+func (q *eventQueue) recoverTornRecordLocked(n int, truncErr error, sizeIncludesTorn bool) {
+	written, werr := q.appendBoundary(q.path, []byte{'\n'})
+	if written < 1 {
+		if werr == nil {
+			werr = io.ErrShortWrite
+		}
+		log.WarningLog.Printf("watch task %s: failed to truncate torn event-queue record (%v); could not re-align it with a newline: %v", q.taskID, truncErr, werr)
 		return
 	}
-	_, werr := f.Write([]byte{'\n'})
-	if closeErr := f.Close(); werr == nil {
-		werr = closeErr
+	if !sizeIncludesTorn {
+		q.size += int64(n)
 	}
-	if werr != nil {
-		log.WarningLog.Printf("watch task %s: failed to truncate short-written event record (%v); could not re-align it with a newline: %v", q.taskID, truncErr, werr)
-		return
-	}
-	q.size += int64(n) + 1
+	q.size++ // the recovery newline
 	q.pending++
-	log.WarningLog.Printf("watch task %s: failed to truncate short-written event record (%v); re-aligned the torn %d bytes with a trailing newline so the queue stays readable", q.taskID, truncErr, n)
+	if werr != nil {
+		// The full boundary byte is visible and must be counted, just like a
+		// fully-written event record whose Close reports deferred writeback
+		// failure. Its crash durability is unknown, so keep that warning explicit;
+		// a restart will inspect and recover the tail again if it did not persist.
+		log.WarningLog.Printf("watch task %s: failed to truncate torn event-queue record (%v); re-aligned the torn %d bytes, but could not confirm the recovery newline on close: %v", q.taskID, truncErr, n, werr)
+		return
+	}
+	log.WarningLog.Printf("watch task %s: failed to truncate torn event-queue record (%v); re-aligned the torn %d bytes with a trailing newline so the queue stays readable", q.taskID, truncErr, n)
 }
 
 // resetCursorBeforeFreshAppendLocked removes or zeroes any leftover cursor

--- a/daemon/eventqueue_test.go
+++ b/daemon/eventqueue_test.go
@@ -315,6 +315,131 @@ func TestEventQueue_TornTrailingRecordTruncated(t *testing.T) {
 	}
 }
 
+// TestEventQueue_LoadTruncateFailurePreservesNextEvent covers restart recovery
+// when a torn tail cannot be truncated. The recovery boundary must be appended
+// and counted before a later enqueue, or peek will consume the new event as part
+// of one corrupt merged line while decrementing its only pending count.
+func TestEventQueue_LoadTruncateFailurePreservesNextEvent(t *testing.T) {
+	dir := t.TempDir()
+	const taskID = "ab265901"
+	seed := newEventQueue(dir, taskID)
+	if err := seed.enqueue("whole"); err != nil {
+		t.Fatalf("enqueue whole: %v", err)
+	}
+	f, err := os.OpenFile(seed.path, os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		t.Fatalf("open queue tail: %v", err)
+	}
+	const torn = `{"seq":2,"ts":"2026-07-28T`
+	if _, err := f.WriteString(torn); err != nil {
+		_ = f.Close()
+		t.Fatalf("write torn tail: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close torn tail: %v", err)
+	}
+
+	truncateCalls := 0
+	reopened := &eventQueue{
+		taskID:         taskID,
+		path:           seed.path,
+		curPath:        seed.curPath,
+		remove:         os.Remove,
+		appendRecord:   appendRecordToFile,
+		appendBoundary: appendRecordToFile,
+		truncate: func(string, int64) error {
+			truncateCalls++
+			return errors.New("simulated load truncate failure")
+		},
+		now: time.Now,
+	}
+	reopened.load()
+	if got := reopened.pendingCount(); got != 2 {
+		t.Fatalf("pending after injected load truncate failure = %d, want 2 (whole record plus recovered torn fragment); truncate seam calls = %d", got, truncateCalls)
+	}
+	if truncateCalls != 1 {
+		t.Fatalf("load truncate seam calls = %d, want 1", truncateCalls)
+	}
+	if info, err := os.Stat(reopened.path); err != nil {
+		t.Fatalf("stat recovered queue: %v", err)
+	} else if reopened.size != info.Size() {
+		t.Fatalf("recovered in-memory size = %d, on-disk size = %d", reopened.size, info.Size())
+	}
+
+	if err := reopened.enqueue("after"); err != nil {
+		t.Fatalf("enqueue after failed load truncate: %v", err)
+	}
+	got := drainAllEvents(t, reopened)
+	want := []string{"whole", "after"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("drained after load truncate failure %v, want %v", got, want)
+	}
+}
+
+// TestEventQueue_LoadRecoveryCloseFailurePreservesNextEvent covers the second
+// failure in the restart recovery itself: the one-byte boundary write completes,
+// but Close reports a deferred writeback error. The newline is visible in the
+// file and must be counted, or the corrupt-head skip spends the next real event's
+// pending count and removes it without delivery.
+func TestEventQueue_LoadRecoveryCloseFailurePreservesNextEvent(t *testing.T) {
+	dir := t.TempDir()
+	const taskID = "ab265902"
+	seed := newEventQueue(dir, taskID)
+	if err := seed.enqueue("whole"); err != nil {
+		t.Fatalf("enqueue whole: %v", err)
+	}
+	f, err := os.OpenFile(seed.path, os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		t.Fatalf("open queue tail: %v", err)
+	}
+	const torn = `{"seq":2,"ts":"2026-07-28T`
+	if _, err := f.WriteString(torn); err != nil {
+		_ = f.Close()
+		t.Fatalf("write torn tail: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close torn tail: %v", err)
+	}
+
+	closeErr := errors.New("simulated recovery close failure")
+	reopened := &eventQueue{
+		taskID:       taskID,
+		path:         seed.path,
+		curPath:      seed.curPath,
+		remove:       os.Remove,
+		appendRecord: appendRecordToFile,
+		appendBoundary: func(path string, rec []byte) (int, error) {
+			n, err := appendRecordToFile(path, rec)
+			if err != nil {
+				return n, err
+			}
+			return n, closeErr
+		},
+		truncate: func(string, int64) error {
+			return errors.New("simulated load truncate failure")
+		},
+		now: time.Now,
+	}
+	reopened.load()
+	if got := reopened.pendingCount(); got != 2 {
+		t.Fatalf("pending after full recovery boundary write + close failure = %d, want 2", got)
+	}
+	if info, err := os.Stat(reopened.path); err != nil {
+		t.Fatalf("stat recovered queue: %v", err)
+	} else if reopened.size != info.Size() {
+		t.Fatalf("recovered in-memory size = %d, on-disk size = %d", reopened.size, info.Size())
+	}
+
+	if err := reopened.enqueue("after"); err != nil {
+		t.Fatalf("enqueue after recovery close failure: %v", err)
+	}
+	got := drainAllEvents(t, reopened)
+	want := []string{"whole", "after"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("drained after recovery close failure %v, want %v", got, want)
+	}
+}
+
 // drainAllEvents peeks+advances until the queue is empty, returning the lines
 // of every event delivered in order. peek self-heals corrupt head records
 // (#1634), so a wedged queue would surface here as a peek error, not a hang.


### PR DESCRIPTION
## Summary

- route restart-time torn-tail truncation through the queue's injectable truncate seam
- recover a failed load-time truncation by appending and accounting for a record boundary
- preserve exact queue size accounting: load already counted the torn bytes, while enqueue has not
- account a fully written recovery newline even when Close reports a deferred writeback error
- keep close durability unknown in the warning while preventing the next real event from losing its pending count

## Diagnosis

Confirmed on current `master`: `eventQueue.load` called `os.Truncate` directly. If that truncation failed, load kept only the complete-record pending count and returned. The next append then joined the torn fragment to a valid event; the corrupt-head skip consumed the merged line while decrementing the valid event's count, silently losing that next event.

The issue's proposed recovery direction was right, but the helper could not be called unchanged: load initializes `q.size` from `stat`, so it already includes the torn bytes. Enqueue's short-write path does not. The shared helper now takes that accounting fact explicitly and only adds the recovery newline on the load path.

The review found a second three-valued case in that recovery: a one-byte boundary write can complete while Close reports a deferred writeback error. The byte is visible and must be counted in the live queue, while its crash durability remains unknown and is reported as such. A restart will inspect the tail again if it did not persist.

Adjacent call-site audit: these are the only two queue truncation paths. Both now use the injectable seam and the same torn-record recovery, with explicit size accounting for their different preconditions. The main event append already retained and counted full writes with close errors; recovery now follows the same rule.

## Red regressions

Observed before the original production change on `183e8b76fec0e09e823ba49c500dda39a4210a44`:

```
--- FAIL: TestEventQueue_LoadTruncateFailurePreservesNextEvent (0.00s)
    eventqueue_test.go:357: pending after injected load truncate failure = 1, want 2 (whole record plus recovered torn fragment); truncate seam calls = 0
FAIL
```

Observed after adding the close-error seam but before accounting a full recovery write on `006e48c8bc8bc2f0a0ba925df99be36795dc80cf`:

```
--- FAIL: TestEventQueue_LoadRecoveryCloseFailurePreservesNextEvent (0.00s)
    eventqueue_test.go:425: pending after full recovery boundary write + close failure = 1, want 2
FAIL
```

## Validation

Validated pushed head `eb4251e402e226d70871e96a35bbbcb4892ae3be` after rebasing onto current `master`:

- `GOTOOLCHAIN=go1.25.0 golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `GOTOOLCHAIN=go1.25.0 go build ./...`
- `GOTOOLCHAIN=go1.25.0 deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `GOTOOLCHAIN=go1.25.0 make test-container GOTESTARGS="./daemon -run 'TestEventQueue_(LoadTruncateFailurePreservesNextEvent|LoadRecoveryCloseFailurePreservesNextEvent|FullWriteCloseFailureKeepsEvent)' -count=1"`
- `GOTOOLCHAIN=go1.25.0 make test-container`

Closes #2659