### PR TITLE
fix(remote): require evidence before declaring loss

### DIFF
--- a/app/dead_session_test.go
+++ b/app/dead_session_test.go
@@ -191,6 +191,10 @@ func TestHandleEnter_RemoteLostRowConfirmsBeforeReprovision(t *testing.T) {
 
 			rendered := strings.Join(strings.Fields(h.confirmationOverlay.Render()), " ")
 			require.Contains(t, rendered, "never pushed", "the confirmation names the unpushed-work risk")
+			require.Contains(t, rendered, "can't be reached", "the confirmation names the unknown-connectivity case")
+			require.Contains(t, rendered, "refuses", "the confirmation says unknown connectivity blocks replacement")
+			require.NotContains(t, rendered, "can't be reached, restore provisions",
+				"the confirmation must not promise replacement from mere unreachability")
 
 			// Confirming raises the optimistic op and dispatches the restore off the
 			// event loop via startRestoreMsg (mirrors handleStateConfirm forwarding).

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -432,10 +432,11 @@ func (m *home) handleRestore() (tea.Model, tea.Cmd) {
 // A restore is dispatched IMMEDIATELY (no confirmation) only where it is provably
 // safe: a local session re-spawns its tmux in place, and an archived session
 // restores from the branch the archive already pushed. But a Lost/Dead REMOTE
-// session's restore re-provisions a fresh sandbox when the old one can't be reached,
-// discarding any unpushed work on it (#1794) — so that one is gated behind a
-// confirmation that names the risk. Enter, `o`, and a mouse double-click all funnel
-// here, so none can silently discard work.
+// session's restore may re-provision a fresh sandbox after session-specific dead
+// evidence, discarding any unpushed work on the old one (#1794) — so that one is
+// gated behind a confirmation that names the risk. Mere unreachability blocks the
+// replacement. Enter, `o`, and a mouse double-click all funnel here, so none can
+// silently discard work.
 //
 // Scope: the tree ROW verbs and the pane-preview commit reached from them. The
 // focused-pane guards (activateInteractive, handleEnterPane) are a distinct, rarer
@@ -464,7 +465,7 @@ func (m *home) restoreIfResting(selected *session.Instance) (tea.Cmd, bool) {
 func (m *home) confirmReprovisioningRestore(selected *session.Instance) tea.Cmd {
 	title := selected.Title
 	target := captureSessionActionTarget(selected, m.repoID)
-	message := fmt.Sprintf("[!] Restore remote session '%s'?\n\nIf its sandbox can't be reached, restore provisions a fresh one from the last pushed commit and discards any changes on the old sandbox that were never pushed. A reachable sandbox just reconnects, losing nothing.", title)
+	message := fmt.Sprintf("[!] Restore remote session '%s'?\n\nIf its sandbox can't be reached, restore refuses to replace it because unreachability is not proof that it is gone. If the sandbox answers that its agent is gone, restore provisions a fresh one from the last pushed commit and discards any changes on the old sandbox that were never pushed. A reachable live sandbox just reconnects, losing nothing.", title)
 	return m.confirmAction(message, func() tea.Msg {
 		inst := m.resolveSessionActionTarget(target)
 		if inst == nil {

--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -89,6 +89,9 @@ type lostRestoreState struct {
 	// remoteLogged dedupes the "not restoring a remote session" note to once
 	// per Lost episode.
 	remoteLogged bool
+	// remoteUnknownLogged dedupes the safety note while a Lost remote sandbox
+	// remains unreachable. Unknown never authorizes destructive re-provisioning.
+	remoteUnknownLogged bool
 	// vanishedWorktreesLogged dedupes the high-visibility #1303 diagnostic to
 	// one ERROR per distinct missing worktree path during a Lost episode.
 	vanishedWorktreesLogged map[string]struct{}
@@ -319,10 +322,11 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 	// row may have gone Lost many ticks ago (restore is backoff-throttled out to
 	// 5 minutes) and the transport may have healed since. Re-probe NOW, against
 	// live state, rather than trusting a stale verdict: an agent-server that
-	// answers proves the sandbox is there, so heal the row and let the next poll
-	// settle its real liveness. Bounded, so a genuinely wedged remote cannot
-	// stall the poll loop here either.
-	if m.remoteSandboxAnswersAlive(inst) {
+	// answers alive proves the sandbox is there, while an answer of dead permits
+	// recovery. An unanswerable probe permits neither. Bounded, so a genuinely
+	// wedged remote cannot stall the poll loop here either.
+	switch m.remoteSandboxLiveness(inst) {
+	case probeAlive:
 		log.InfoLog.Printf("not re-provisioning lost remote session %q: its sandbox answers as alive (re-provisioning would orphan it and lose unpushed work) — clearing the Lost mark", inst.Title)
 		_ = inst.Transition(session.ObserveLiveness(session.LiveRunning))
 		// Clear before the persist, same ordering rule as the recovery path below:
@@ -335,6 +339,18 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 		delete(m.lostRestoreStates, key)
 		m.mu.Unlock()
 		return
+	case probeUnknown:
+		m.mu.Lock()
+		logIt := !st.remoteUnknownLogged
+		st.remoteUnknownLogged = true
+		m.mu.Unlock()
+		if logIt {
+			log.WarningLog.Printf("not re-provisioning lost remote session %q: could not determine whether its existing sandbox is gone; unreachable is not dead, and replacement could discard unpushed work", inst.Title)
+		}
+		return
+	case probeDead:
+		// The sandbox answered that its agent is gone. This session-specific
+		// evidence, unlike a transport failure, permits recovery.
 	}
 
 	if err := inst.Recover(); err != nil {

--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -92,6 +92,10 @@ type lostRestoreState struct {
 	// remoteUnknownLogged dedupes the safety note while a Lost remote sandbox
 	// remains unreachable. Unknown never authorizes destructive re-provisioning.
 	remoteUnknownLogged bool
+	// remoteUnknownAttempts backs off repeated safety probes independently from
+	// actual Recover failures. An unanswered liveness check did not attempt a
+	// restore and must not inflate the restore failure/escalation diagnostics.
+	remoteUnknownAttempts int
 	// vanishedWorktreesLogged dedupes the high-visibility #1303 diagnostic to
 	// one ERROR per distinct missing worktree path during a Lost episode.
 	vanishedWorktreesLogged map[string]struct{}
@@ -343,6 +347,8 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 		m.mu.Lock()
 		logIt := !st.remoteUnknownLogged
 		st.remoteUnknownLogged = true
+		st.remoteUnknownAttempts++
+		st.nextAttempt = time.Now().Add(lostRestoreBackoff(st.remoteUnknownAttempts))
 		m.mu.Unlock()
 		if logIt {
 			log.WarningLog.Printf("not re-provisioning lost remote session %q: could not determine whether its existing sandbox is gone; unreachable is not dead, and replacement could discard unpushed work", inst.Title)
@@ -350,7 +356,12 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 		return
 	case probeDead:
 		// The sandbox answered that its agent is gone. This session-specific
-		// evidence, unlike a transport failure, permits recovery.
+		// evidence, unlike a transport failure, permits recovery. An explicit
+		// not-provisioned sentinel reaches the same arm for inert records.
+		m.mu.Lock()
+		st.remoteUnknownAttempts = 0
+		st.nextAttempt = time.Time{}
+		m.mu.Unlock()
 	}
 
 	if err := inst.Recover(); err != nil {
@@ -443,14 +454,7 @@ func (m *Manager) lostRestoreFailed(key string, st *lostRestoreState, title stri
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	st.consecutiveFailures++
-	backoff := lostRestoreBackoffMax
-	// Guard the shift: past ~16 doublings the exponential form has no meaning
-	// and would overflow.
-	if shift := st.consecutiveFailures - 1; shift < 16 {
-		if b := lostRestoreBackoffBase << shift; b < backoff {
-			backoff = b
-		}
-	}
+	backoff := lostRestoreBackoff(st.consecutiveFailures)
 	st.nextAttempt = time.Now().Add(backoff)
 	if st.consecutiveFailures == lostRestoreEscalationThreshold {
 		if path, ok := missingWorktreePath(err); ok && st.vanishedWorktreeWasLogged(path) {
@@ -461,6 +465,18 @@ func (m *Manager) lostRestoreFailed(key string, st *lostRestoreState, title stri
 		return
 	}
 	log.WarningLog.Printf("restore of lost session %q failed (attempt %d), retrying in %s: %v", title, st.consecutiveFailures, backoff, err)
+}
+
+func lostRestoreBackoff(attempt int) time.Duration {
+	backoff := lostRestoreBackoffMax
+	// Guard the shift: past ~16 doublings the exponential form has no meaning
+	// and would overflow.
+	if shift := attempt - 1; shift >= 0 && shift < 16 {
+		if b := lostRestoreBackoffBase << shift; b < backoff {
+			backoff = b
+		}
+	}
+	return backoff
 }
 
 // recordLostRestoreFailure is the single failure-accounting path for automatic

--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -753,13 +753,10 @@ func TestRestoreLostSessions_AliveRemoteSandboxIsNotReprovisioned(t *testing.T) 
 	}
 }
 
-// TestRestoreLostSessions_UnreachableRemoteSandboxIsReprovisioned is the
-// companion that keeps the #1794 recheck from becoming a blanket "never restore
-// remote sessions". A genuinely gone sandbox (nothing listening, so the probe is
-// refused outright) must still be re-provisioned — that recovery IS the feature
-// (#1108/#1782), and the recheck only exists to veto it when the sandbox proves
-// it is still there.
-func TestRestoreLostSessions_UnreachableRemoteSandboxIsReprovisioned(t *testing.T) {
+// TestRestoreLostSessions_UnreachableRemoteSandboxIsNotReprovisioned is the
+// #2589 last gate: an unreachable sandbox has not answered whether it is alive or
+// dead, so automatic recovery must preserve it and retry observation later.
+func TestRestoreLostSessions_UnreachableRemoteSandboxIsNotReprovisioned(t *testing.T) {
 	withRemoteLossThresholds(t, 3, time.Minute, time.Second)
 	zeroRestoreBackoff(t)
 
@@ -768,7 +765,7 @@ func TestRestoreLostSessions_UnreachableRemoteSandboxIsReprovisioned(t *testing.
 
 	manager.RestoreLostSessions()
 
-	if got := backend.recoverCalls(); got != 1 {
-		t.Fatalf("Recover calls = %d, want 1 — an unreachable sandbox must still be recovered; the recheck is a veto on live sandboxes, not a block on remote restore", got)
+	if got := backend.recoverCalls(); got != 0 {
+		t.Fatalf("Recover calls = %d, want 0 — unreachable is not dead, so automatic restore must not discard the existing sandbox's unpushed work", got)
 	}
 }

--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -767,5 +768,75 @@ func TestRestoreLostSessions_UnreachableRemoteSandboxIsNotReprovisioned(t *testi
 
 	if got := backend.recoverCalls(); got != 0 {
 		t.Fatalf("Recover calls = %d, want 0 — unreachable is not dead, so automatic restore must not discard the existing sandbox's unpushed work", got)
+	}
+}
+
+func registerKnownUnprovisionedRemote(t *testing.T, manager *Manager, repoID, repoPath, title string) (*session.Instance, *remoteWorkspaceBackend) {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: repoPath, Program: "claude"})
+	if err != nil {
+		t.Fatalf("NewInstance: %v", err)
+	}
+	backend := &remoteWorkspaceBackend{FakeBackend: session.NewFakeBackend()}
+	inst.SetBackend(backend)
+	inst.SetStartedForTest(true)
+	inst.SetStatusForTest(session.Lost)
+	seedDiskInstance(t, repoID, title, repoPath)
+	manager.mu.Lock()
+	manager.instances[daemonInstanceKey(repoID, title)] = inst
+	manager.mu.Unlock()
+	return inst, backend
+}
+
+func TestRestoreLostSessions_KnownUnprovisionedRemoteIsReprovisioned(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	_, backend := registerKnownUnprovisionedRemote(t, manager, repoID, repoPath, "inert-auto")
+
+	manager.RestoreLostSessions()
+
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("Recover calls = %d, want 1 for a remote runtime explicitly known to be unprovisioned", got)
+	}
+}
+
+func TestRestoreSession_KnownUnprovisionedRemoteIsReprovisioned(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	_, backend := registerKnownUnprovisionedRemote(t, manager, repoID, repoPath, "inert-manual")
+
+	if _, _, err := manager.RestoreSession(RestoreSessionRequest{Title: "inert-manual", RepoID: repoID}); err != nil {
+		t.Fatalf("RestoreSession: %v", err)
+	}
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("Recover calls = %d, want 1 for a remote runtime explicitly known to be unprovisioned", got)
+	}
+}
+
+func TestRestoreLostSessions_UnreachableRemoteProbeBacksOff(t *testing.T) {
+	prevBase, prevMax := lostRestoreBackoffBase, lostRestoreBackoffMax
+	lostRestoreBackoffBase, lostRestoreBackoffMax = time.Hour, time.Hour
+	t.Cleanup(func() { lostRestoreBackoffBase, lostRestoreBackoffMax = prevBase, prevMax })
+
+	var aliveCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/agent/alive" {
+			aliveCalls.Add(1)
+			http.Error(w, "temporarily unreachable", http.StatusServiceUnavailable)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	manager, repoID, repoPath := newStatusTestManager(t)
+	_, backend := registerStartedRemote(t, manager, repoID, repoPath, "remote-blackhole", srv.URL, session.Lost)
+
+	manager.RestoreLostSessions()
+	manager.RestoreLostSessions()
+
+	if got := aliveCalls.Load(); got != 1 {
+		t.Fatalf("Alive calls = %d, want 1 while the unknown observation is in backoff", got)
+	}
+	if got := backend.recoverCalls(); got != 0 {
+		t.Fatalf("Recover calls = %d, want 0 because the sandbox never answered", got)
 	}
 }

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -458,15 +458,16 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		// a healthy sandbox errors identically, and acting on one is destructive —
 		// Lost feeds RestoreLostSessions in this same tick, whose remote Recover
 		// RE-PROVISIONS a fresh sandbox and orphans the running one along with its
-		// unpushed commits (#1794). So require DURABLE failure (see remoteloss.go)
-		// before even considering Lost.
+		// unpushed commits (#1794). So require durable failures before paying for
+		// a separate confirmation, and require that confirmation to ANSWER dead
+		// before considering Lost (#2589).
 		//
 		// Lost, not Dead (#1108): no kill intent is on record, so the session
 		// vanished out from under a live record and stays recovery-eligible.
-		// Without this the remote session kept its last-known liveness
-		// (Running/Ready) forever while its agent-server was gone, so the TUI
-		// showed a healthy row for a dead session (#1782).
-		m.settleRemoteProbeFailure(repoID, key, instance, before, beforeReset)
+		// If both probes are unanswerable, the last-known liveness is deliberately
+		// retained: connectivity alone cannot distinguish a dead sandbox from a
+		// live one holding unpushed work.
+		m.settleRemoteProbeFailure(repoID, key, instance, before, beforeReset, epoch)
 		return
 	}
 	projectionChanged := instance.SetAgentModelChangeAtEpoch(obs.ModelChange, epoch)
@@ -521,23 +522,10 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 			// bad, not absent. #935's immediacy is unchanged for both runtimes.
 			_ = instance.Transition(session.ObserveLiveness(session.LiveLost).AtEpoch(epoch))
 		case probeUnknown:
-			// A REMOTE probe that never answered. It says nothing about the agent,
-			// and Lost here feeds a re-provision that orphans a possibly-live
-			// sandbox, so it only counts toward the debounce (#1794) — never
-			// settles anything by itself.
-			//
-			// Reaching this means the Snapshot answered on this same tick while the
-			// Alive probe did not: the transport worked a moment ago, so this is a
-			// blip between two calls, and the clear above has already reset the
-			// episode. The count therefore cannot climb here on its own — by
-			// design. A real outage takes Snapshot down too, and that path
-			// (settleRemoteProbeFailure) is where an episode accumulates. Recording
-			// it anyway keeps one honest definition of the counter — "probes that
-			// could not be answered" — so a degrading transport starts its episode
-			// at the first unanswered probe rather than the first failed Snapshot.
-			if m.noteRemoteProbeFailure(key, instance.Title) {
-				_ = instance.Transition(session.ObserveLiveness(session.LiveLost).AtEpoch(epoch))
-			}
+			// Snapshot answered on this tick but Alive did not. That is inconsistent
+			// transport evidence, not evidence that this specific sandbox is gone.
+			// Preserve the last-known liveness; Lost would authorize destructive
+			// remote re-provisioning from pushed state (#2589).
 		case probeAlive:
 			// The agent-server was asked and reports its agent RUNNING — the
 			// codebase's own affirmative signal, sitting one file away the whole time.

--- a/daemon/remoteloss.go
+++ b/daemon/remoteloss.go
@@ -34,10 +34,10 @@ import (
 //     no amount of debouncing rescues a caller that cannot tell the two apart,
 //     which is why the limit-resume path needed the distinction rather than a
 //     debounce of its own.
-//  2. DEBOUNCE what remains. A run of probeUnknown could still be a real outage,
-//     so it must eventually settle Lost (that is #1782's guarantee). This is the
-//     only thing the counter tracks — consecutive UNANSWERABLE probes, never
-//     "looks dead" observations. Any answered probe clears it.
+//  2. DEBOUNCE before a second probe. A run of failed Snapshots earns one bounded
+//     Alive confirmation, but never manufactures death from silence. Only an
+//     ANSWERED probeDead may settle Lost; probeUnknown preserves last-known state
+//     because unreachable is not dead (#2589).
 //
 // The debounce demands the failure be DURABLE on two independent axes:
 //
@@ -49,20 +49,16 @@ import (
 //     N ticks in a couple of seconds, which is exactly the blip this is meant
 //     to survive.
 //
-// Both axes must be satisfied, so whichever is slower under the operator's
-// daemon_poll_interval governs — which is the point of having both. At the 1s
-// default the grace period dominates (a durably dead remote surfaces as Lost
-// after ~60s rather than ~3s); at a coarse interval the count does. Either way
-// the ceiling on how long a genuinely dead remote reads healthy is bounded and
-// small, which is the #1782 guarantee — 60s of stale green is a fair price for
-// never re-provisioning over a live sandbox.
+// Both axes must be satisfied before the confirmation call. If that call is also
+// unanswerable, the episode resets and later failures may try again; no number of
+// connectivity failures can authorize replacing a possibly-live sandbox.
 var (
-	// remoteLostFailureThreshold is the consecutive failed-probe count required
-	// before a remote session may be marked Lost. var, not const, so tests can
-	// drive the threshold directly.
+	// remoteLostFailureThreshold is the consecutive failed-Snapshot count required
+	// before the daemon pays for a separate Alive confirmation. var, not const, so
+	// tests can drive the threshold directly.
 	remoteLostFailureThreshold = 3
 	// remoteLostGracePeriod is the minimum wall-clock span the failures must
-	// persist before Lost is allowed, independent of how many ticks fit in it.
+	// persist before the confirmation, independent of how many ticks fit in it.
 	remoteLostGracePeriod = 60 * time.Second
 	// remoteLostConfirmTimeout bounds the confirmation Alive() probe. It is
 	// deliberately SHORT and unrelated to remoteAgentCallTimeout (30s): the
@@ -147,8 +143,7 @@ func (m *Manager) clearRemoteLoss(key string) {
 	m.mu.Unlock()
 }
 
-// remoteSandboxAnswersAlive reports whether a remote session's sandbox answers
-// as alive right now — the veto every re-provision must clear first.
+// remoteSandboxLiveness keeps all three outcomes of the final pre-recovery probe.
 //
 // A Lost mark is a claim about the past, and it can be minutes stale: restore
 // backs off to 5 minutes, and a user can hit restore by hand at any moment.
@@ -156,18 +151,17 @@ func (m *Manager) clearRemoteLoss(key string) {
 // sandbox never pushed, so the question that matters is not "was it lost?" but
 // "is it gone NOW?" — asked against live state, immediately before acting.
 //
-// probeAlive, specifically: an ANSWERED alive is proof the sandbox is there and
-// a re-provision would orphan it. probeDead and probeUnknown both fall through
-// to recovery — a sandbox that answers "my agent is gone", and one that answers
-// nothing at all after the debounce already judged it durably unreachable, are
-// both cases where recovery is what the user wants (#1108/#1782).
+// probeAlive proves the sandbox is there and heals the stale Lost row. probeDead
+// is session-specific evidence that replacement is safe. probeUnknown authorizes
+// nothing: unreachable is not dead, and collapsing it into probeDead is exactly
+// how a connectivity failure can discard unpushed work (#2589).
 //
 // Bounded, so a wedged remote cannot stall the poll goroutine here either.
-func (m *Manager) remoteSandboxAnswersAlive(instance *session.Instance) bool {
+func (m *Manager) remoteSandboxLiveness(instance *session.Instance) livenessProbe {
 	if !isRemoteWorkspace(instance) {
-		return false // a local session has no sandbox to orphan
+		return probeDead // a local session has no remote sandbox to preserve
 	}
-	return aliveWithin(instance.AgentServer(), remoteLostConfirmTimeout) == probeAlive
+	return aliveWithin(instance.AgentServer(), remoteLostConfirmTimeout)
 }
 
 // noteRuntimeReplaced retires observations owned by the prior runtime after a
@@ -259,7 +253,7 @@ func (m *Manager) sweepRemoteLossStates() {
 // rather than once per tick. That is also what keeps a wedged sandbox from
 // double-stalling the serial poll: it can no longer spend a full 30s Snapshot
 // AND a full 30s Alive on every single tick (#1794).
-func (m *Manager) settleRemoteProbeFailure(repoID, key string, instance *session.Instance, before session.Liveness, beforeReset time.Time) {
+func (m *Manager) settleRemoteProbeFailure(repoID, key string, instance *session.Instance, before session.Liveness, beforeReset time.Time, epoch uint64) {
 	if !isRemoteWorkspace(instance) {
 		// A local agent-server's Snapshot never errors; if that ever changes,
 		// an unexplained local error is not evidence of death. Leave it be.
@@ -291,9 +285,11 @@ func (m *Manager) settleRemoteProbeFailure(repoID, key string, instance *session
 		log.WarningLog.Printf("remote session %q: agent-server reports its agent is gone — marking it Lost", instance.Title)
 		m.clearRemoteLoss(key)
 	case probeUnknown:
-		log.WarningLog.Printf("remote session %q: agent-server unreachable and still unanswerable after %s — marking it Lost", instance.Title, remoteLostGracePeriod)
+		log.WarningLog.Printf("remote session %q: agent-server unreachable and still unanswerable after %s — leaving its last-known status unchanged; unreachable is not evidence that this sandbox is gone", instance.Title, remoteLostGracePeriod)
+		m.clearRemoteLoss(key)
+		return
 	}
-	_ = instance.Transition(session.ObserveLiveness(session.LiveLost))
+	_ = instance.Transition(session.ObserveLiveness(session.LiveLost).AtEpoch(epoch))
 	m.persistPollChange(repoID, instance, before, beforeReset, false)
 }
 

--- a/daemon/remoteloss.go
+++ b/daemon/remoteloss.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"errors"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/log"
@@ -152,9 +153,11 @@ func (m *Manager) clearRemoteLoss(key string) {
 // "is it gone NOW?" — asked against live state, immediately before acting.
 //
 // probeAlive proves the sandbox is there and heals the stale Lost row. probeDead
-// is session-specific evidence that replacement is safe. probeUnknown authorizes
-// nothing: unreachable is not dead, and collapsing it into probeDead is exactly
-// how a connectivity failure can discard unpushed work (#2589).
+// is session-specific evidence that replacement is safe: either the server
+// answered false or af's clientless sentinel says this runtime is explicitly not
+// provisioned. probeUnknown authorizes nothing: unreachable is not dead, and
+// collapsing it into probeDead is exactly how a connectivity failure can discard
+// unpushed work (#2589).
 //
 // Bounded, so a wedged remote cannot stall the poll goroutine here either.
 func (m *Manager) remoteSandboxLiveness(instance *session.Instance) livenessProbe {
@@ -302,9 +305,9 @@ type livenessProbe int
 const (
 	// probeAlive: the agent answered and is running.
 	probeAlive livenessProbe = iota
-	// probeDead: the agent-server answered and reports its agent gone. This is
-	// AUTHORITATIVE — the sandbox is reachable, it looked, and the agent is not
-	// there. Callers may act on it immediately.
+	// probeDead: session-specific evidence says the runtime is absent. Either the
+	// agent-server answered and reports its agent gone, or af has an explicit
+	// not-provisioned sentinel for this session. Callers may act on it immediately.
 	probeDead
 	// probeUnknown: the probe could not be answered — a transport failure or a
 	// timeout. NOT evidence of death. Only repetition over time (the debounce)
@@ -358,6 +361,8 @@ func aliveWithin(as session.AgentServer, timeout time.Duration) livenessProbe {
 	select {
 	case r := <-done:
 		switch {
+		case errors.Is(r.err, session.ErrRemoteSandboxNotProvisioned):
+			return probeDead
 		case r.err != nil:
 			return probeUnknown
 		case r.alive:

--- a/daemon/restore.go
+++ b/daemon/restore.go
@@ -107,7 +107,7 @@ func (m *Manager) restoreLostOrDeadSession(repoID, title string, instance *sessi
 		m.mu.Unlock()
 		return instance.GetWorktreePath(), nil
 	case probeUnknown:
-		return "", fmt.Errorf("cannot restore remote session %q: could not determine whether its existing sandbox is gone; refusing to re-provision while it is unreachable because that could discard unpushed work", title)
+		return "", fmt.Errorf("cannot restore remote session %q: could not determine whether its existing sandbox is gone; refusing to re-provision while it is unreachable because that could discard unpushed work (if you know it is permanently gone, explicitly kill this session and create a replacement)", title)
 	case probeDead:
 		// The sandbox answered that its agent is gone, so replacement is safe.
 	}

--- a/daemon/restore.go
+++ b/daemon/restore.go
@@ -96,7 +96,8 @@ func (m *Manager) restoreLostOrDeadSession(repoID, title string, instance *sessi
 	// really lost and healing the row delivers exactly what was asked for, without
 	// the destruction. A user who genuinely wants a new sandbox kills and
 	// recreates (#1794).
-	if m.remoteSandboxAnswersAlive(instance) {
+	switch m.remoteSandboxLiveness(instance) {
+	case probeAlive:
 		log.InfoLog.Printf("not re-provisioning session %q: its sandbox answers as alive, so it was never lost — clearing the Lost mark instead (re-provisioning would orphan it and discard unpushed work)", title)
 		_ = instance.Transition(session.ObserveLiveness(session.LiveRunning))
 		m.clearRemoteLoss(remoteLossKey(repoID, instance))
@@ -105,6 +106,10 @@ func (m *Manager) restoreLostOrDeadSession(repoID, title string, instance *sessi
 		delete(m.lostRestoreStates, key)
 		m.mu.Unlock()
 		return instance.GetWorktreePath(), nil
+	case probeUnknown:
+		return "", fmt.Errorf("cannot restore remote session %q: could not determine whether its existing sandbox is gone; refusing to re-provision while it is unreachable because that could discard unpushed work", title)
+	case probeDead:
+		// The sandbox answered that its agent is gone, so replacement is safe.
 	}
 
 	if err := instance.Recover(); err != nil {

--- a/daemon/status_remote_test.go
+++ b/daemon/status_remote_test.go
@@ -95,8 +95,8 @@ func withRemoteLossThresholds(t *testing.T, count int, grace, confirm time.Durat
 }
 
 // driveDurableRemoteLoss runs enough failing ticks, spread over enough fake
-// wall-clock, to satisfy BOTH debounce axes — the "the sandbox really is gone"
-// signal.
+// wall-clock, to satisfy both axes and earn a separate Alive confirmation. The
+// confirmation's answer — never the failures themselves — decides liveness.
 func driveDurableRemoteLoss(m *Manager, advance func(time.Duration)) {
 	for i := 0; i < remoteLostFailureThreshold; i++ {
 		m.RefreshStatuses()
@@ -105,18 +105,41 @@ func driveDurableRemoteLoss(m *Manager, advance func(time.Duration)) {
 	m.RefreshStatuses()
 }
 
-// TestRefreshStatuses_UnreachableRemoteMarkedLost is the #1782 regression, held
-// intact across the #1794 debounce. A remote session's agent-server dies
-// (container killed, ssh forward dropped), so every REST probe fails with
-// ECONNREFUSED. The poll used to return on the first Snapshot error before any
-// liveness check ran, leaving the session pinned at its last-known Running/Ready
-// forever — the TUI showed a healthy row for a session that was gone. A DURABLE
-// unreachability must still settle to Lost; #1794 only changed how much evidence
-// that takes, never the destination.
+// confirmedDeadThenUnknownRemote returns an agent-server that initially answers
+// alive=false after each failed Snapshot, then can be switched to an unanswerable
+// posture to model a transport blip against a replacement runtime.
+func confirmedDeadThenUnknownRemote(t *testing.T) (string, func()) {
+	t.Helper()
+	var unknown atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/agent/snapshot":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"message": "capture failed"},
+			})
+		case "/v1/agent/alive":
+			if unknown.Load() {
+				http.Error(w, "transport unavailable", http.StatusServiceUnavailable)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"alive": false}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL, func() { unknown.Store(true) }
+}
+
+// TestRefreshStatuses_UnreachableRemoteDoesNotMarkLost is the #2589 safety
+// boundary: even durable transport failure cannot say whether this particular
+// sandbox is gone. Lost authorizes destructive re-provisioning from pushed state,
+// so silence must preserve the last-known state rather than discard unpushed work.
 //
 // Port 1 on loopback has no listener, so every probe is refused immediately —
 // the "agent-server is unreachable" shape, with no timeout to wait out.
-func TestRefreshStatuses_UnreachableRemoteMarkedLost(t *testing.T) {
+func TestRefreshStatuses_UnreachableRemoteDoesNotMarkLost(t *testing.T) {
 	withRemoteLossThresholds(t, 3, time.Minute, time.Second)
 	advance := withFrozenClock(t)
 	manager, repoID, repoPath := newStatusTestManager(t)
@@ -127,13 +150,78 @@ func TestRefreshStatuses_UnreachableRemoteMarkedLost(t *testing.T) {
 	driveDurableRemoteLoss(manager, advance)
 
 	inst := manager.instances[daemonInstanceKey(repoID, "remote-gone")]
-	if got := inst.GetLiveness(); got != session.LiveLost {
-		t.Fatalf("in-memory liveness = %v, want LiveLost (a durably unreachable agent-server must not keep reading as Running)", got)
+	if got := inst.GetLiveness(); got != session.LiveRunning {
+		t.Fatalf("in-memory liveness = %v, want LiveRunning left unchanged — unreachable is not evidence that this sandbox is gone", got)
 	}
-	// Persisted too, so the status survives a daemon reload and the restore loop
-	// can find it — Lost, not Dead: no kill intent, still recovery-eligible (#1108).
-	if got := persistedStatus(t, repoID, "remote-gone"); got != session.Lost {
-		t.Fatalf("persisted status = %v, want Lost", got)
+	if got := persistedStatus(t, repoID, "remote-gone"); got != session.Running {
+		t.Fatalf("persisted status = %v, want Running left unchanged", got)
+	}
+}
+
+func TestRefreshStatuses_IdleSnapshotWithUnanswerableAliveDoesNotMarkLost(t *testing.T) {
+	withRemoteLossThresholds(t, 1, 0, time.Second)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/agent/snapshot":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"updated": false, "has_prompt": false, "content": ""},
+			})
+		case "/v1/agent/alive":
+			http.Error(w, "transport unavailable", http.StatusServiceUnavailable)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, _ := registerStartedRemote(t, manager, repoID, repoPath, "remote-idle-unknown", srv.URL, session.Running)
+	manager.RefreshStatuses()
+
+	if got := inst.GetLiveness(); got != session.LiveRunning {
+		t.Fatalf("liveness = %v, want LiveRunning left unchanged — an unanswerable Alive probe is not evidence of death", got)
+	}
+}
+
+func TestRefreshStatuses_StaleRemoteDeadConfirmationDoesNotCrossEpoch(t *testing.T) {
+	withRemoteLossThresholds(t, 1, 0, 5*time.Second)
+	aliveStarted := make(chan struct{})
+	releaseAlive := make(chan struct{})
+	var once sync.Once
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/agent/snapshot":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"message": "capture failed"},
+			})
+		case "/v1/agent/alive":
+			once.Do(func() { close(aliveStarted) })
+			<-releaseAlive
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"alive": false}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, _ := registerStartedRemote(t, manager, repoID, repoPath, "remote-stale-loss", srv.URL, session.Running)
+	done := make(chan struct{})
+	go func() {
+		manager.RefreshStatuses()
+		close(done)
+	}()
+	<-aliveStarted
+	if err := inst.Transition(session.BeginArchive()); err != nil {
+		t.Fatalf("authoritative transition while probe was blocked: %v", err)
+	}
+	close(releaseAlive)
+	<-done
+
+	if got := inst.GetLiveness(); got == session.LiveLost {
+		t.Fatal("stale remote-dead confirmation crossed a newer state epoch and marked the session Lost")
 	}
 }
 
@@ -360,12 +448,10 @@ func TestRefreshStatuses_ConfirmationProbeIsBounded(t *testing.T) {
 	if elapsed >= remoteCallTimeout {
 		t.Fatalf("threshold tick took %s — it waited out the full %s call timeout instead of the short confirmation bound", elapsed, remoteCallTimeout)
 	}
-	// A wedged agent-server that cannot answer a liveness ping on top of durable
-	// snapshot failure is unreachable by any useful definition — the bound must
-	// resolve it, not just abandon it.
+	// The timeout is an unknown result, not evidence that this sandbox is gone.
 	inst := manager.instances[daemonInstanceKey(repoID, "remote-wedged")]
-	if got := inst.GetLiveness(); got != session.LiveLost {
-		t.Fatalf("liveness = %v, want LiveLost — a bounded confirmation that times out still has to settle the session", got)
+	if got := inst.GetLiveness(); got != session.LiveRunning {
+		t.Fatalf("liveness = %v, want LiveRunning left unchanged — a bounded confirmation timeout is not evidence of death", got)
 	}
 }
 
@@ -384,6 +470,7 @@ func TestRefreshStatuses_ConfirmationProbeIsBounded(t *testing.T) {
 // One tick, Lost. The debounce is for absent evidence, not bad evidence.
 func TestRefreshStatuses_ReachableRemoteWithDeadAgentGoesLostImmediately(t *testing.T) {
 	withRemoteLossThresholds(t, 3, time.Minute, time.Second)
+	zeroRestoreBackoff(t)
 
 	// The sandbox is healthy and answering. The agent inside it is not.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -404,13 +491,16 @@ func TestRefreshStatuses_ReachableRemoteWithDeadAgentGoesLostImmediately(t *test
 	defer srv.Close()
 
 	manager, repoID, repoPath := newStatusTestManager(t)
-	registerStartedRemote(t, manager, repoID, repoPath, "remote-agent-dead", srv.URL, session.Running)
+	inst, backend := registerStartedRemote(t, manager, repoID, repoPath, "remote-agent-dead", srv.URL, session.Running)
 
 	manager.RefreshStatuses() // exactly one tick
 
-	inst := manager.instances[daemonInstanceKey(repoID, "remote-agent-dead")]
 	if got := inst.GetLiveness(); got != session.LiveLost {
 		t.Fatalf("liveness after one tick = %v, want LiveLost — the sandbox ANSWERED that its agent is gone, which is authoritative; the debounce is for probes that could not be answered, not for answers we dislike", got)
+	}
+	manager.RestoreLostSessions()
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("Recover calls = %d, want 1 — the final pre-recovery probe answered that this specific agent is gone", got)
 	}
 }
 
@@ -434,8 +524,8 @@ func TestRestoreLostSessions_PostRecoverBlipDoesNotReprovisionAgain(t *testing.T
 	advance := withFrozenClock(t)
 
 	manager, repoID, repoPath := newStatusTestManager(t)
-	// Nothing listening: every probe is refused, so the loss is real and durable.
-	inst, backend := registerStartedRemote(t, manager, repoID, repoPath, "remote-recovered", "http://127.0.0.1:1", session.Running)
+	url, makeUnknown := confirmedDeadThenUnknownRemote(t)
+	inst, backend := registerStartedRemote(t, manager, repoID, repoPath, "remote-recovered", url, session.Running)
 
 	// Durable loss -> Lost -> the restore loop re-provisions once. That part is
 	// the #1108/#1782 feature working correctly.
@@ -449,6 +539,7 @@ func TestRestoreLostSessions_PostRecoverBlipDoesNotReprovisionAgain(t *testing.T
 	}
 
 	// The fresh sandbox now takes ONE transport blip.
+	makeUnknown()
 	advance(time.Second)
 	manager.RefreshStatuses()
 	manager.RestoreLostSessions()
@@ -478,10 +569,13 @@ func TestRefreshStatuses_NewSessionDoesNotInheritDebounceState(t *testing.T) {
 	const title = "reused-title"
 	old, _ := registerStartedRemote(t, manager, repoID, repoPath, title, "http://127.0.0.1:1", session.Running)
 
-	// The doomed predecessor accumulates a threshold-satisfying failure history.
-	driveDurableRemoteLoss(manager, advance)
-	if got := old.GetLiveness(); got != session.LiveLost {
-		t.Fatalf("setup: predecessor liveness = %v, want LiveLost", got)
+	// The predecessor accumulates failures just below the confirmation threshold.
+	for i := 0; i < remoteLostFailureThreshold-1; i++ {
+		manager.RefreshStatuses()
+		advance(remoteLostGracePeriod)
+	}
+	if got := old.GetLiveness(); got == session.LiveLost {
+		t.Fatalf("setup: predecessor liveness = %v before any answered-dead confirmation", got)
 	}
 	manager.mu.Lock()
 	stale := len(manager.remoteLossStates)
@@ -500,7 +594,12 @@ func TestRefreshStatuses_NewSessionDoesNotInheritDebounceState(t *testing.T) {
 	// One blip against the newcomer.
 	advance(time.Second)
 	manager.RefreshStatuses()
-	manager.RestoreLostSessions()
+	manager.mu.Lock()
+	freshState := manager.remoteLossStates[remoteLossKey(repoID, fresh)]
+	manager.mu.Unlock()
+	if freshState == nil || freshState.consecutiveFailures != 1 {
+		t.Fatalf("new session failure state = %#v, want a fresh one-failure episode", freshState)
+	}
 
 	if got := fresh.GetLiveness(); got != session.LiveRunning {
 		t.Fatalf("new session's liveness = %v, want LiveRunning — it inherited the killed session's failure count through the repo/title key, so its FIRST blip marked it Lost (#1794)", got)
@@ -526,7 +625,8 @@ func TestRestoreSession_PostManualRecoverBlipDoesNotReprovision(t *testing.T) {
 	advance := withFrozenClock(t)
 
 	manager, repoID, repoPath := newStatusTestManager(t)
-	inst, backend := registerStartedRemote(t, manager, repoID, repoPath, "remote-manual", "http://127.0.0.1:1", session.Running)
+	url, makeUnknown := confirmedDeadThenUnknownRemote(t)
+	inst, backend := registerStartedRemote(t, manager, repoID, repoPath, "remote-manual", url, session.Running)
 
 	// A durable outage parks it at Lost with a threshold-satisfying history.
 	driveDurableRemoteLoss(manager, advance)
@@ -543,6 +643,7 @@ func TestRestoreSession_PostManualRecoverBlipDoesNotReprovision(t *testing.T) {
 	}
 
 	// One blip against the sandbox that restore just built.
+	makeUnknown()
 	advance(time.Second)
 	manager.RefreshStatuses()
 	manager.RestoreLostSessions()
@@ -572,8 +673,11 @@ func TestRestoreArchived_RemoteReprovisionClearsDebounce(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	inst, backend := registerStartedRemote(t, manager, repoID, repoPath, "remote-archived", "http://127.0.0.1:1", session.Running)
 
-	// A durable outage leaves a threshold-satisfying history on the record.
-	driveDurableRemoteLoss(manager, advance)
+	// Leave a live, below-threshold failure episode on the record.
+	for i := 0; i < remoteLostFailureThreshold-1; i++ {
+		manager.RefreshStatuses()
+		advance(remoteLostGracePeriod)
+	}
 	manager.mu.Lock()
 	stale := len(manager.remoteLossStates)
 	manager.mu.Unlock()
@@ -643,6 +747,19 @@ func TestRestoreSession_AliveRemoteSandboxIsNotReprovisioned(t *testing.T) {
 	}
 }
 
+func TestRestoreSession_UnreachableRemoteSandboxIsNotReprovisioned(t *testing.T) {
+	withRemoteLossThresholds(t, 3, time.Minute, time.Second)
+	manager, repoID, repoPath := newStatusTestManager(t)
+	_, backend := registerStartedRemote(t, manager, repoID, repoPath, "remote-restore-unknown", "http://127.0.0.1:1", session.Lost)
+
+	if _, _, err := manager.RestoreSession(RestoreSessionRequest{Title: "remote-restore-unknown", RepoID: repoID}); err == nil {
+		t.Fatal("manual restore re-provisioned without evidence that the existing remote sandbox is gone")
+	}
+	if got := backend.recoverCalls(); got != 0 {
+		t.Fatalf("Recover calls = %d, want 0 — unreachable is not dead, so manual restore must not discard the existing sandbox's unpushed work", got)
+	}
+}
+
 // TestSweepRemoteLossStates_DropsArchivedRows is codex's P3 on 2ec7b52.
 //
 // The sweep took presence in m.instances as proof of liveness, but an archived
@@ -658,7 +775,10 @@ func TestSweepRemoteLossStates_DropsArchivedRows(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	inst, _ := registerStartedRemote(t, manager, repoID, repoPath, "remote-shelved", "http://127.0.0.1:1", session.Running)
 
-	driveDurableRemoteLoss(manager, advance)
+	for i := 0; i < remoteLostFailureThreshold-1; i++ {
+		manager.RefreshStatuses()
+		advance(remoteLostGracePeriod)
+	}
 	manager.mu.Lock()
 	before := len(manager.remoteLossStates)
 	manager.mu.Unlock()

--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -289,8 +289,14 @@ type deadRemoteAgentServer struct {
 
 var _ AgentServer = (*deadRemoteAgentServer)(nil)
 
+// ErrRemoteSandboxNotProvisioned marks the clientless AgentServer sentinel used
+// when af knows this session has no provisioned runtime to contact. It is
+// session-specific absence evidence, unlike a transport error from an endpoint
+// that may still be alive behind a broken network path.
+var ErrRemoteSandboxNotProvisioned = errors.New("remote sandbox is not provisioned")
+
 func (s *deadRemoteAgentServer) err() error {
-	return fmt.Errorf("session %q has no live agent-server: its sandbox is not provisioned", s.title)
+	return fmt.Errorf("%w for session %q", ErrRemoteSandboxNotProvisioned, s.title)
 }
 
 func (s *deadRemoteAgentServer) Provision(bool) error            { return s.err() }
@@ -304,11 +310,9 @@ func (s *deadRemoteAgentServer) PreviewByID(string, bool) (PreviewSnapshot, erro
 	return PreviewSnapshot{}, s.err()
 }
 
-// Alive returns (false, err) = UNKNOWN, never an authoritative "the agent is gone":
-// there is no sandbox to answer, so a caller must not treat this false as proof of
-// death and act destructively on it (#1794). remoteSandboxAnswersAlive reads it as
-// "did not answer alive", so the restore loop keeps re-provisioning rather than
-// declaring the row un-recoverable.
+// Alive returns the typed not-provisioned error rather than an ordinary transport
+// error. Restore must re-provision an inert record after restart or a failed
+// recovery, while a real endpoint that merely cannot answer remains unknown.
 func (s *deadRemoteAgentServer) Alive() (bool, error) { return false, s.err() }
 
 func (s *deadRemoteAgentServer) SendPrompt(string) error { return s.err() }


### PR DESCRIPTION
## Summary

- require session-specific dead evidence before a remote session can transition to Lost
- preserve the captured lifecycle epoch through the confirmation probe so stale evidence cannot cross an archive/recovery boundary
- keep unknown connectivity as last-known state in both active status refresh and Lost-session restore
- refuse automatic and manual re-provisioning when a real remote endpoint cannot answer
- distinguish af's explicit per-session not-provisioned sentinel so inert/retryable runtimes still recover
- back off repeated unknown restore observations without counting them as failed Recover attempts

## Root cause

The debounced remote-loss path treated a failed confirmation probe as sufficient to mark the session Lost, and its final transition was not scoped to the lifecycle epoch that produced the evidence. A general outage could therefore be mistaken for proof that a specific remote session was gone; delayed confirmation could also cross a concurrent lifecycle transition.

Restore contained the same three-valued collapse: a boolean helper mapped both confirmed-dead and unknown to "not alive", allowing an unreachable sandbox to be re-provisioned. That risks abandoning work that still exists remotely.

The status and restore paths now retain `alive`, `dead`, and `unknown` distinctly. Dead requires session-specific evidence: either an authoritative per-session `alive=false` response or af's typed not-provisioned sentinel for an inert runtime. Network errors and timeouts remain unknown, leave status unchanged, and block re-provisioning. The Lost write is guarded by the epoch captured before confirmation.

## Red first

These initial regressions failed against the pre-fix tree:

```text
--- FAIL: TestRestoreLostSessions_UnreachableRemoteSandboxIsNotReprovisioned (0.00s)
    Recover calls = 1
--- FAIL: TestRefreshStatuses_UnreachableRemoteDoesNotMarkLost (0.00s)
    liveness = Lost
--- FAIL: TestRefreshStatuses_IdleSnapshotWithUnanswerableAliveDoesNotMarkLost (0.00s)
    liveness = Lost
--- FAIL: TestRefreshStatuses_StaleRemoteDeadConfirmationDoesNotCrossEpoch (0.00s)
    stale confirmation marked Lost
--- FAIL: TestRefreshStatuses_ConfirmationProbeIsBounded (0.00s)
    timeout marked Lost
--- FAIL: TestRestoreSession_UnreachableRemoteSandboxIsNotReprovisioned (0.00s)
    manual restore re-provisioned
```

The Codex review regressions then failed against `3a1d65ebffe9e7cc2c8626897726c239f605b021`:

```text
--- FAIL: TestRestoreLostSessions_KnownUnprovisionedRemoteIsReprovisioned (4.70s)
    Recover calls = 0, want 1 for a remote runtime explicitly known to be unprovisioned
--- FAIL: TestRestoreSession_KnownUnprovisionedRemoteIsReprovisioned (0.15s)
    cannot restore remote session "inert-manual": could not determine whether its existing sandbox is gone
--- FAIL: TestRestoreLostSessions_UnreachableRemoteProbeBacksOff (0.12s)
    Alive calls = 2, want 1 while the unknown observation is in backoff
--- FAIL: TestHandleEnter_RemoteLostRowConfirmsBeforeReprovision
    confirmation does not contain "refuses"
```

## Adjacent audit

The audit covered every `probeUnknown` consumer and both automatic and manual restore entry points. The concurrency-limit path already preserved unknown and was left unchanged. Existing tests that used connection refusal as a stand-in for death were changed to return explicit `alive=false`; connection refusal is connectivity evidence, not death evidence.

Unknown automatic restore probes use the existing exponential cadence but a separate counter, so an unanswered observation neither stalls every poll nor falsely escalates as a failed Recover.

## Manual escape hatch

There is deliberately no new `restore --force` wire/API option in this issue. If an operator knows an unreachable sandbox is permanently gone, the existing explicit destructive path is to kill the session record and create a replacement. That workflow already carries the repository's deletion and unpushed-work warnings; the unknown-restore error now names it. Ordinary manual restore stays fail-closed, and automatic restore can never override unknown connectivity.

## Validation

Validated pushed head `8b4ab00fe7a46cfe4629bb253c49af914a95fd29`:

- focused daemon remote-status, restore, backoff, sentinel, and TUI confirmation regressions
- `go test ./session ./daemon ./app -count=1`
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container`

Closes #2589