### PR TITLE
Report only completed factory reset removals

### DIFF
--- a/commands/reset.go
+++ b/commands/reset.go
@@ -96,6 +96,9 @@ type resetPlan struct {
 	worktrees               int                 // AF-managed worktrees (excludes external --here trees)
 	repoRoots               map[string]struct{} // distinct repos with AF records (display only)
 	branches                map[string][]string // repoRoot -> AF-created branch names to prune
+	// sessionCountsByRepo lets execution count only records whose repo-level
+	// delete/retain write completed, instead of echoing the planned totals.
+	sessionCountsByRepo map[string]resetSessionCounts
 
 	// worktreeTargets are the SPECIFIC worktree dirs AF created for its sessions
 	// (from the records), each paired with its repo root. Reset removes exactly
@@ -117,9 +120,15 @@ type resetPlan struct {
 // root git needs to operate on it and the repoID whose record set describes it
 // (the record is retained when the removal is blocked — see #2110).
 type worktreeTarget struct {
-	repoID string
-	root   string
-	path   string
+	repoID   string
+	root     string
+	path     string
+	archived bool // category of the owning record, for blocked-result accounting
+}
+
+type resetSessionCounts struct {
+	sessions int
+	archived int
 }
 
 func (p *resetPlan) branchCount() int {
@@ -466,10 +475,11 @@ func planFactoryReset() (*resetPlan, error) {
 	}
 
 	plan := &resetPlan{
-		configDir: dir,
-		storage:   storage,
-		repoRoots: make(map[string]struct{}),
-		branches:  make(map[string][]string),
+		configDir:           dir,
+		storage:             storage,
+		repoRoots:           make(map[string]struct{}),
+		branches:            make(map[string][]string),
+		sessionCountsByRepo: make(map[string]resetSessionCounts),
 	}
 
 	all, err := state.GetAllInstances()
@@ -502,11 +512,16 @@ func planFactoryReset() (*resetPlan, error) {
 			if root == "" {
 				root = r.Path
 			}
-			if session.IsArchivedData(r) {
+			archived := session.IsArchivedData(r)
+			counts := plan.sessionCountsByRepo[repoID]
+			if archived {
 				plan.archived++
+				counts.archived++
 			} else {
 				plan.sessions++
+				counts.sessions++
 			}
+			plan.sessionCountsByRepo[repoID] = counts
 			// Target ONLY the worktree dirs AF created for its sessions. An
 			// external (--here) session IS the user's live tree, so it is never a
 			// target. This record-driven list is why reset never removes the
@@ -514,7 +529,7 @@ func planFactoryReset() (*resetPlan, error) {
 			if r.Worktree.WorktreePath != "" && !r.Worktree.ExternalWorktree && root != "" {
 				plan.worktrees++
 				plan.worktreeTargets = append(plan.worktreeTargets,
-					worktreeTarget{repoID: repoID, root: root, path: r.Worktree.WorktreePath})
+					worktreeTarget{repoID: repoID, root: root, path: r.Worktree.WorktreePath, archived: archived})
 			}
 			if root == "" {
 				continue
@@ -627,16 +642,15 @@ func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 		projectsRemoved = plan.projects
 	}
 
-	// Snapshot which AF-created branches exist up front, so the final count is
-	// accurate even though branch deletion happens AFTER worktree removal.
+	// Collect the AF-created branch targets before worktree removal. The deletion
+	// primitive reports whether each branch was actually removed, which is the
+	// only result included in the final summary.
 	type branchRef struct{ root, name string }
 	var planned []branchRef
-	existedBefore := make(map[branchRef]bool)
 	for root, names := range plan.branches {
 		for _, b := range names {
 			ref := branchRef{root, b}
 			planned = append(planned, ref)
-			existedBefore[ref] = git.LocalBranchExists(root, b)
 		}
 	}
 
@@ -652,11 +666,24 @@ func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 	// the record here is what made the old "re-run to finish" guidance a lie — the
 	// re-run planned nothing and the branch stayed blocked forever.
 	blockedWorktrees := make(map[string][]string) // repoID -> worktree paths still registered
+	blockedSessions := make(map[string]resetSessionCounts)
+	worktreesRemoved := 0
 	for _, wt := range plan.worktreeTargets {
-		if _, err := git.RemoveWorktreeDir(wt.root, wt.path); err != nil {
+		removed, err := git.RemoveWorktreeDir(wt.root, wt.path)
+		if removed {
+			worktreesRemoved++
+		}
+		if err != nil {
 			errs = append(errs, fmt.Errorf("remove worktree %s: %w", wt.path, err))
 			if errors.Is(err, git.ErrWorktreeStillRegistered) {
 				blockedWorktrees[wt.repoID] = append(blockedWorktrees[wt.repoID], wt.path)
+				counts := blockedSessions[wt.repoID]
+				if wt.archived {
+					counts.archived++
+				} else {
+					counts.sessions++
+				}
+				blockedSessions[wt.repoID] = counts
 			}
 		}
 	}
@@ -665,19 +692,15 @@ func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 	// archived), gated on BranchCreatedByUs at plan time. After worktree removal
 	// + prune above, a live session's branch is no longer checked out, so
 	// `git branch -D` succeeds. Best-effort per branch.
-	for _, ref := range planned {
-		if _, err := git.DeleteLocalBranch(ref.root, ref.name); err != nil {
-			log.WarningLog.Printf("reset: %v", err)
-			errs = append(errs, fmt.Errorf("delete branch %s in %s: %w", ref.name, ref.root, err))
-		}
-	}
-
-	// A planned branch that existed before and is gone now was removed by this
-	// reset.
 	branchesDeleted := 0
 	for _, ref := range planned {
-		if existedBefore[ref] && !git.LocalBranchExists(ref.root, ref.name) {
+		removed, err := git.DeleteLocalBranch(ref.root, ref.name)
+		if removed {
 			branchesDeleted++
+		}
+		if err != nil {
+			log.WarningLog.Printf("reset: %v", err)
+			errs = append(errs, fmt.Errorf("delete branch %s in %s: %w", ref.name, ref.root, err))
 		}
 	}
 
@@ -695,20 +718,33 @@ func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 	for rid := range blockedWorktrees {
 		preserveRepoIDs = append(preserveRepoIDs, rid)
 	}
+	removedSessions := resetSessionCounts{}
 	if len(preserveRepoIDs) == 0 {
 		if err := plan.storage.DeleteAllInstances(); err != nil {
 			errs = append(errs, fmt.Errorf("reset session storage: %w", err))
+		} else {
+			removedSessions.sessions = plan.sessions
+			removedSessions.archived = plan.archived
 		}
 	} else {
 		for _, rid := range plan.processedRepoIDs {
 			if paths, blocked := blockedWorktrees[rid]; blocked {
 				if err := retainBlockedInstances(rid, paths); err != nil {
 					errs = append(errs, fmt.Errorf("retain blocked session records for repo %s: %w", rid, err))
+				} else {
+					plannedCounts := plan.sessionCountsByRepo[rid]
+					blockedCounts := blockedSessions[rid]
+					removedSessions.sessions += max(0, plannedCounts.sessions-blockedCounts.sessions)
+					removedSessions.archived += max(0, plannedCounts.archived-blockedCounts.archived)
 				}
 				continue
 			}
 			if err := config.DeleteRepoInstances(rid); err != nil {
 				errs = append(errs, fmt.Errorf("delete instances for repo %s: %w", rid, err))
+			} else {
+				counts := plan.sessionCountsByRepo[rid]
+				removedSessions.sessions += counts.sessions
+				removedSessions.archived += counts.archived
 			}
 		}
 	}
@@ -727,8 +763,11 @@ func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 	errs = append(errs, removeArchivedDirs(plan.configDir, preserveRepoIDs)...)
 
 	// Delete the task store (removes <AF_HOME>/tasks.json).
+	tasksRemoved := 0
 	if err := task.DeleteAllTasks(); err != nil {
 		errs = append(errs, fmt.Errorf("reset tasks: %w", err))
+	} else {
+		tasksRemoved = plan.tasks
 	}
 
 	// Remove the remaining AF state trees/files, leaving config (config.toml,
@@ -757,11 +796,11 @@ func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 		blockedCount += len(paths)
 	}
 	summary := &resetSummary{
-		sessions:  plan.sessions,
-		archived:  plan.archived,
-		tasks:     plan.tasks,
+		sessions:  removedSessions.sessions,
+		archived:  removedSessions.archived,
+		tasks:     tasksRemoved,
 		projects:  projectsRemoved,
-		worktrees: plan.worktrees,
+		worktrees: worktreesRemoved,
 		branches:  branchesDeleted,
 		corrupt:   len(plan.corruptRepoIDs),
 		blocked:   blockedCount,

--- a/commands/reset_locked_worktree_test.go
+++ b/commands/reset_locked_worktree_test.go
@@ -57,6 +57,10 @@ func TestFactoryReset_LockedWorktreeIsRecoverable(t *testing.T) {
 	if summary.blocked != 1 {
 		t.Errorf("summary.blocked = %d, want 1", summary.blocked)
 	}
+	if summary.sessions != 2 || summary.archived != 1 || summary.worktrees != 2 {
+		t.Errorf("summary removed sessions/archived/worktrees = %d/%d/%d, want 2/1/2; the blocked live session and worktree were retained",
+			summary.sessions, summary.archived, summary.worktrees)
+	}
 
 	// --- Ownership safety: git still owns that path, so AF left it alone ---
 	if _, statErr := os.Stat(liveWT); statErr != nil {
@@ -130,5 +134,48 @@ func TestFactoryReset_LockedWorktreeIsRecoverable(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(home, "archived")); !os.IsNotExist(statErr) {
 		t.Errorf("archived/ should be gone after the recovery re-run, stat: %v", statErr)
+	}
+}
+
+// TestFactoryReset_LockedArchivedWorktreeIsNotReportedRemoved guards #2605:
+// a blocked archive keeps both its session record and its worktree, so neither
+// may be included in the summary's completed-removal counts.
+func TestFactoryReset_LockedArchivedWorktreeIsNotReportedRemoved(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	t.Chdir(t.TempDir())
+
+	repo, liveWT, reusedWT := seedMockRepo(t, home)
+	repoID := config.RepoIDFromRoot(repo)
+	archivedWT := filepath.Join(home, "archived", repoID, "arch")
+	runGit(t, repo, "worktree", "add", "-q", archivedWT, "af-session-2")
+	seedAFState(t, home, repo, liveWT, reusedWT)
+	runGit(t, repo, "worktree", "lock", archivedWT, "--reason", "still in use")
+
+	plan, err := planFactoryReset()
+	if err != nil {
+		t.Fatalf("planFactoryReset: %v", err)
+	}
+	summary, err := executeFactoryReset(plan)
+	if !errors.Is(err, git.ErrWorktreeStillRegistered) {
+		t.Fatalf("executeFactoryReset error = %v, want ErrWorktreeStillRegistered", err)
+	}
+	if summary.sessions != 3 || summary.archived != 0 || summary.worktrees != 2 || summary.blocked != 1 {
+		t.Errorf("summary = %+v, want 3 sessions, 0 archived, 2 worktrees, and 1 blocked; the archived record and worktree remain", *summary)
+	}
+
+	if _, statErr := os.Stat(archivedWT); statErr != nil {
+		t.Errorf("locked archived worktree must survive, stat: %v", statErr)
+	}
+	raw, loadErr := config.LoadRepoInstances(repoID)
+	if loadErr != nil {
+		t.Fatalf("LoadRepoInstances: %v", loadErr)
+	}
+	var kept []session.InstanceData
+	if unmarshalErr := json.Unmarshal(raw, &kept); unmarshalErr != nil {
+		t.Fatalf("unmarshal retained records: %v", unmarshalErr)
+	}
+	if len(kept) != 1 || !session.IsArchivedData(kept[0]) {
+		t.Fatalf("retained records = %+v, want exactly the blocked archived session", kept)
 	}
 }

--- a/commands/reset_test.go
+++ b/commands/reset_test.go
@@ -620,6 +620,9 @@ func TestFactoryReset_ResilientPartialFailure(t *testing.T) {
 	if summary.branches != 2 {
 		t.Errorf("branches = %d, want 2", summary.branches)
 	}
+	if summary.tasks != 0 {
+		t.Errorf("tasks = %d, want 0 because the task-store removal did not complete", summary.tasks)
+	}
 
 	// Clear the injected failure and re-run: a clean run completes.
 	if err := os.RemoveAll(tasksPath); err != nil {


### PR DESCRIPTION
## Summary

- count live and archived session records only when their repo-level deletion or blocked-record retention write completes
- count worktrees and branches from the removal primitives' positive `removed` results
- report zero task removals when deleting the task store fails
- retain blocked live/archive categories in the summary instead of echoing planned totals

## Root cause

The reset summary copied planned session, archive, task, and worktree counts even when execution retained or failed to remove those resources. That collapsed an unsuccessful or undetermined outcome into a claimed removal.

## Red-first evidence

Against current `master`:

`summary removed sessions/archived/worktrees = 3/1/3, want 2/1/2; the blocked live session and worktree were retained`

`summary = {sessions:3 archived:1 tasks:2 projects:0 worktrees:3 branches:1 corrupt:0 blocked:1}, want 3 sessions, 0 archived, 2 worktrees, and 1 blocked; the archived record and worktree remain`

`tasks = 2, want 0 because the task-store removal did not complete`

## Validation

Validated pushed SHA `be4ba102b8ec9cba82c1587e1b0cf87626174f61`:

- focused blocked-live, blocked-archived, and task-failure regressions
- `make test-container GOTESTARGS='./commands'`
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container` (full suite, run last)

Closes #2605