### PR TITLE
fix(session): preserve restore state on limit detection

### DIFF
--- a/session/limit_test.go
+++ b/session/limit_test.go
@@ -47,6 +47,24 @@ func TestSetLimitReached_SkipsTransient(t *testing.T) {
 	}
 }
 
+// TestSetLimitReached_SkipsRestore: a usage-limit observation must not destroy
+// the OpRestoring fence or its LiveLost liveness while a restore is in flight.
+func TestSetLimitReached_SkipsRestore(t *testing.T) {
+	i, err := NewInstance(InstanceOptions{Title: "restoring", Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+	require.NoError(t, i.Transition(BeginArchive()))
+	require.NoError(t, i.Transition(CommitArchive()))
+	require.NoError(t, i.Transition(BeginRestore()))
+	require.Equal(t, LiveLost, i.GetLiveness())
+	require.Equal(t, OpRestoring, i.GetInFlightOp())
+
+	i.SetLimitReached(time.Now().Add(time.Hour))
+
+	require.Equal(t, OpRestoring, i.GetInFlightOp(), "SetLimitReached must preserve an active restore fence")
+	require.Equal(t, LiveLost, i.GetLiveness(), "SetLimitReached must preserve restore liveness")
+	require.False(t, i.LimitReached(), "an in-flight restore must not be marked limit-reached")
+}
+
 // TestClearLimitReached moves a limit-blocked instance back to Running and drops
 // the reset time; it is a no-op on a non-limit instance.
 func TestClearLimitReached(t *testing.T) {

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -463,8 +463,7 @@ func (i *Instance) TabSpawnBlocked() error {
 // the banner carried none) for the sidebar badge and PR3's auto-resume
 // scheduler. There is no legacy Status value for SetStatus to decompose onto, so
 // the daemon single-writer (#960) sets the liveness axis directly here. Skips a
-// row mid create/kill teardown so it never clobbers an in-flight op, mirroring
-// SetStatusIfNotDeleting.
+// row with any operation in flight so it never clobbers that operation's fence.
 func (i *Instance) SetLimitReached(resetAt time.Time) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
@@ -492,14 +491,13 @@ func (i *Instance) SetLimitReachedAtEpoch(resetAt time.Time, epoch uint64) bool 
 }
 
 // setLimitReachedLocked is the shared body: mark the instance limit-blocked and
-// record its reset time, skipping a row mid create/kill teardown so it never
-// clobbers an in-flight op. Reports whether it applied. Caller holds i.mu.
+// record its reset time, skipping a row with any operation in flight so it never
+// clobbers that operation's fence. Reports whether it applied. Caller holds i.mu.
 func (i *Instance) setLimitReachedLocked(resetAt time.Time) bool {
-	if s := i.statusLocked(); s == Loading || s == Deleting {
+	if i.inFlightOp != OpNone {
 		return false
 	}
 	lv, op, prevReset := i.lifecycleStateLocked()
-	i.inFlightOp = OpNone
 	i.liveness = LiveLimitReached
 	i.limitResetAt = resetAt
 	i.noteStateChangeLocked(lv, op, prevReset)


### PR DESCRIPTION
## Summary
- guard usage-limit state updates on the direct in-flight operation axis
- preserve both `OpRestoring` and `LiveLost` when limit detection races a restore
- remove the redundant write that cleared `inFlightOp`

## Verified diagnosis
`setLimitReachedLocked` used composed legacy status as a proxy for an active operation. `OpRestoring` composes to `Lost`, so it passed the `Loading`/`Deleting` guard and was then cleared. The production archive -> restore transition reproduces the corruption.

Adjacent audit: this was the only `session` call site using composed `Loading`/`Deleting` as the "any operation in flight" predicate. Both public setters share the corrected helper, and neighboring lifecycle guards use `inFlightOp` directly.

## Red first
Observed against the unmodified branch base:

```
--- FAIL: TestSetLimitReached_SkipsRestore (0.00s)
    limit_test.go:63:
        Error:       Not equal:
                     expected: 4
                     actual  : 0
        Messages:    SetLimitReached must preserve an active restore fence
FAIL
```

## Validation
Validated exact pushed head `cc35862fec59dcfddd046a629ee40d778938ad25`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `go test ./session -count=1`
- `make test-container` (full suite, run last against the pushed head)
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`

Closes #2635