### PR TITLE
fix(remote): reject generic hook title fallbacks

### DIFF
--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -106,10 +106,19 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			Backend:     session.BackendKind(m.pendingBackend),
 			ForceRemote: m.pendingForceRemote,
 		}, instance.Path)
-		if backendKindErr == nil && backendKind != session.BackendLocal {
+		if backendKindErr == nil && backendKind == session.BackendHook {
+			if !session.RemoteHookTitleHasASCIIAlnum(title) {
+				return m, m.handleError(fmt.Errorf(
+					"remote hook session title %q must contain at least one ASCII letter or digit (A-Z, a-z, or 0-9)",
+					title,
+				))
+			}
 			existing := make([]*session.Instance, 0, m.store.NumInstances())
 			for _, other := range m.store.GetInstances() {
-				if other == instance || other.Capabilities().Workspace != session.WorkspaceRemote {
+				// Only hook sessions own this global slug namespace. Docker and
+				// SSH are remote workspaces too, but their same-looking slugs are
+				// repo-scoped paths or labels and cannot collide with --name.
+				if other == instance || !other.ToInstanceData().IsRemoteHook() {
 					continue
 				}
 				existing = append(existing, other)

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -107,9 +107,9 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			ForceRemote: m.pendingForceRemote,
 		}, instance.Path)
 		if backendKindErr == nil && backendKind == session.BackendHook {
-			if !session.RemoteHookTitleHasASCIIAlnum(title) {
+			if !session.RemoteHookTitleHasSpecificSlug(title) {
 				return m, m.handleError(fmt.Errorf(
-					"remote hook session title %q must contain at least one ASCII letter or digit (A-Z, a-z, or 0-9)",
+					"remote hook session title %q must retain at least one ASCII letter or digit after hook-name sanitization",
 					title,
 				))
 			}

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -540,6 +540,98 @@ func TestHandleStateNewRejectsRemoteSlugCollision(t *testing.T) {
 	assert.Contains(t, h.errBox.String(), "myapp")
 }
 
+type remoteNonHookNamingBackend struct {
+	*session.FakeBackend
+	typeName string
+}
+
+func (b *remoteNonHookNamingBackend) Type() string { return b.typeName }
+
+func (b *remoteNonHookNamingBackend) Capabilities() session.Capabilities {
+	return (&session.HookBackend{}).Capabilities()
+}
+
+func TestHandleStateNewHookSlugIgnoresNonHookRemoteSessions(t *testing.T) {
+	for _, backendType := range []string{"docker", "ssh"} {
+		t.Run(backendType, func(t *testing.T) {
+			h := newTestHome(t)
+			h.state = stateNew
+			h.errBox.SetSize(120, 1)
+
+			existing, err := session.NewInstance(session.InstanceOptions{
+				Title:   "myapp",
+				Path:    t.TempDir(),
+				Program: "claude",
+			})
+			require.NoError(t, err)
+			existing.SetBackend(&remoteNonHookNamingBackend{
+				FakeBackend: session.NewFakeBackend(),
+				typeName:    backendType,
+			})
+			h.store.AddInstance(existing)
+
+			naming, err := session.NewInstance(session.InstanceOptions{
+				Title:   "my_app",
+				Path:    t.TempDir(),
+				Program: "claude",
+				Backend: session.BackendLocal,
+			})
+			require.NoError(t, err)
+			h.namingInstance = naming
+			h.pendingForceRemote = true
+
+			_, cmd := h.handleStateNew(tea.KeyMsg{Type: tea.KeyEnter})
+
+			assert.Equal(t, stateDefault, h.state)
+			assert.Nil(t, h.namingInstance, "a non-hook sandbox does not own a hook slug")
+			assert.NotNil(t, cmd, "a free hook name should submit the create")
+		})
+	}
+}
+
+func TestHandleStateNewRejectsRemoteHookTitleWithoutASCIIAlphanumeric(t *testing.T) {
+	h := newTestHome(t)
+	h.state = stateNew
+	h.errBox.SetSize(120, 1)
+
+	naming, err := session.NewInstance(session.InstanceOptions{
+		Title:   "日本語",
+		Path:    t.TempDir(),
+		Program: "claude",
+		Backend: session.BackendLocal,
+	})
+	require.NoError(t, err)
+	h.namingInstance = naming
+	h.pendingForceRemote = true
+
+	_, _ = h.handleStateNew(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Equal(t, stateNew, h.state)
+	require.Same(t, naming, h.namingInstance, "a rejected title must remain editable")
+	assert.Contains(t, h.errBox.String(), "ASCII letter or digit")
+}
+
+func TestHandleStateNewAllowsNonASCIITitleForNonHookSandbox(t *testing.T) {
+	h := newTestHome(t)
+	h.state = stateNew
+
+	naming, err := session.NewInstance(session.InstanceOptions{
+		Title:   "日本語",
+		Path:    t.TempDir(),
+		Program: "claude",
+		Backend: session.BackendLocal,
+	})
+	require.NoError(t, err)
+	h.namingInstance = naming
+	h.pendingBackend = string(session.BackendDocker)
+
+	_, cmd := h.handleStateNew(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Equal(t, stateDefault, h.state)
+	assert.Nil(t, h.namingInstance, "a Docker title does not claim the global hook namespace")
+	assert.NotNil(t, cmd, "an accepted title should submit the create")
+}
+
 // TestNamingCreateFlow_NoDoubleTransition guards the #1350 regression: the
 // naming→create flow must raise the optimistic OpCreating exactly once. When the
 // naming flow began, startNewInstance already raised BeginCreate; the Enter

--- a/daemon/create_remote_slug_test.go
+++ b/daemon/create_remote_slug_test.go
@@ -77,3 +77,40 @@ func TestCreateSessionRejectsRemoteSlugCollisionWithInMemoryInstance(t *testing.
 		t.Fatalf("rejection must name the remote hook-name collision, got: %v", err)
 	}
 }
+
+// TestValidateTitleRejectsRemoteHookWithoutASCIIAlphanumeric is the daemon-side
+// #2594 regression. Hook names are global and Slugify falls back to "session"
+// when no ASCII letter or digit survives, so admitting two such titles makes
+// unrelated sandboxes claim the same external name.
+func TestValidateTitleRejectsRemoteHookWithoutASCIIAlphanumeric(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	for _, title := range []string{"日本語", "مرحبا", "!!!"} {
+		manager.mu.Lock()
+		err := manager.validateTitleAvailableLocked(repoID, repoPath, title, "claude", runtimeNamespaceRemoteHook, false, nil)
+		manager.mu.Unlock()
+		if err == nil {
+			t.Errorf("remote hook title %q contains no ASCII letter or digit but was accepted", title)
+			continue
+		}
+		if !strings.Contains(err.Error(), "ASCII letter or digit") {
+			t.Errorf("remote hook title %q returned an unclear error: %v", title, err)
+		}
+	}
+
+	for _, title := range []string{"SESSION!", "日本語-2"} {
+		manager.mu.Lock()
+		err := manager.validateTitleAvailableLocked(repoID, repoPath, title, "claude", runtimeNamespaceRemoteHook, false, nil)
+		manager.mu.Unlock()
+		if err != nil {
+			t.Errorf("remote hook title %q has an ASCII component and must remain valid: %v", title, err)
+		}
+	}
+
+	manager.mu.Lock()
+	err := manager.validateTitleAvailableLocked(repoID, repoPath, "日本語", "claude", runtimeNamespaceSandbox, false, nil)
+	manager.mu.Unlock()
+	if err != nil {
+		t.Fatalf("non-hook sandbox titles do not claim the global hook namespace: %v", err)
+	}
+}

--- a/daemon/create_remote_slug_test.go
+++ b/daemon/create_remote_slug_test.go
@@ -85,12 +85,17 @@ func TestCreateSessionRejectsRemoteSlugCollisionWithInMemoryInstance(t *testing.
 func TestValidateTitleRejectsRemoteHookWithoutASCIIAlphanumeric(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 
-	for _, title := range []string{"日本語", "مرحبا", "!!!"} {
+	for _, title := range []string{
+		"日本語",
+		"مرحبا",
+		"!!!",
+		strings.Repeat("-", 200) + "a", // the only alphanumeric is truncated before fallback
+	} {
 		manager.mu.Lock()
 		err := manager.validateTitleAvailableLocked(repoID, repoPath, title, "claude", runtimeNamespaceRemoteHook, false, nil)
 		manager.mu.Unlock()
 		if err == nil {
-			t.Errorf("remote hook title %q contains no ASCII letter or digit but was accepted", title)
+			t.Errorf("remote hook title %q retains no ASCII letter or digit in its bounded slug but was accepted", title)
 			continue
 		}
 		if !strings.Contains(err.Error(), "ASCII letter or digit") {
@@ -98,7 +103,7 @@ func TestValidateTitleRejectsRemoteHookWithoutASCIIAlphanumeric(t *testing.T) {
 		}
 	}
 
-	for _, title := range []string{"SESSION!", "日本語-2"} {
+	for _, title := range []string{"SESSION!", "日本語-2", strings.Repeat("-", 199) + "a"} {
 		manager.mu.Lock()
 		err := manager.validateTitleAvailableLocked(repoID, repoPath, title, "claude", runtimeNamespaceRemoteHook, false, nil)
 		manager.mu.Unlock()

--- a/daemon/create_remote_slug_test.go
+++ b/daemon/create_remote_slug_test.go
@@ -119,3 +119,22 @@ func TestValidateTitleRejectsRemoteHookWithoutASCIIAlphanumeric(t *testing.T) {
 		t.Fatalf("non-hook sandbox titles do not claim the global hook namespace: %v", err)
 	}
 }
+
+// TestNextAvailableTitleRejectsGenericRemoteHookSlug covers TitleBase creates,
+// which validate the unsuffixed base before walking collision suffixes. That
+// early shape check must use the caller's runtime namespace too: suffixing a
+// generic fallback would silently turn an invalid hook title into a different
+// externally visible name.
+func TestNextAvailableTitleRejectsGenericRemoteHookSlug(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	manager.mu.Lock()
+	got, err := manager.nextAvailableTitleLocked(repoID, repoPath, "日本語", "claude", runtimeNamespaceRemoteHook, nil)
+	manager.mu.Unlock()
+	if err == nil {
+		t.Fatalf("remote hook TitleBase without a specific slug resolved to %q", got)
+	}
+	if !strings.Contains(err.Error(), "ASCII letter or digit") {
+		t.Fatalf("remote hook TitleBase returned an unclear error: %v", err)
+	}
+}

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -809,7 +809,7 @@ func (m *Manager) nextAvailableTitleLocked(repoID, repoPath, baseTitle, program 
 	// rungs and whitespace cannot turn into a punctuation-only "   -2" title.
 	// allowReserved stays true here because a base of "root" deliberately skips
 	// the reserved bare candidate and resolves to "root-2" below.
-	if err := m.validateTitleShapeLocked(baseTitle, true); err != nil {
+	if err := m.validateTitleShapeLocked(baseTitle, namespace, true); err != nil {
 		return "", err
 	}
 	// Session records are not the only thing that can make a candidate unusable

--- a/daemon/manager_create_names.go
+++ b/daemon/manager_create_names.go
@@ -139,7 +139,7 @@ func (m *Manager) titlesCollide(a, b string) bool {
 // inline here, so the pre-rename path picks it up automatically — a check added
 // only to this function is exactly how #2415 happened.
 func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program string, namespace runtimeNameNamespace, allowReserved bool, diskData []session.InstanceData) error {
-	if err := m.validateTitleShapeLocked(title, allowReserved); err != nil {
+	if err := m.validateTitleShapeLocked(title, namespace, allowReserved); err != nil {
 		return err
 	}
 	if err := m.findTitleRecordConflictLocked(repoID, repoPath, title, namespace, diskData); err != nil {
@@ -159,15 +159,15 @@ func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program 
 // an archived row never owns a live tmux name, and anything the probe finds is a
 // genuine orphan the rename has no effect on.
 func (m *Manager) validateTitleClaimableLocked(repoID, repoPath, title, program string, namespace runtimeNameNamespace, allowReserved bool, diskData []session.InstanceData, ignore *session.Instance) error {
-	if err := m.validateTitleShapeLocked(title, allowReserved); err != nil {
+	if err := m.validateTitleShapeLocked(title, namespace, allowReserved); err != nil {
 		return err
 	}
 	return m.validateTitleNamespacesLocked(repoID, repoPath, title, program, namespace, diskData, ignore)
 }
 
-// validateTitleShapeLocked rejects titles that are malformed or reserved,
-// independent of any existing session.
-func (m *Manager) validateTitleShapeLocked(title string, allowReserved bool) error {
+// validateTitleShapeLocked rejects titles that are malformed for the selected
+// runtime namespace or reserved, independent of any existing session.
+func (m *Manager) validateTitleShapeLocked(title string, namespace runtimeNameNamespace, allowReserved bool) error {
 	// Whitespace-only titles (e.g. "   ") are non-empty and so slip past a bare
 	// == "" check, creating sessions with effectively blank names (#973). Trim
 	// before the emptiness gate; the TUI naming flow applies the same check.
@@ -179,6 +179,14 @@ func (m *Manager) validateTitleShapeLocked(title string, allowReserved bool) err
 	// bypass the TUI's pasted-rune sanitization and create multi-line rows (#2640).
 	if strings.IndexFunc(title, unicode.IsControl) >= 0 {
 		return fmt.Errorf("session title must be a single line and contain no control characters")
+	}
+	// Hook scripts receive one globally shared --name derived by Slugify. A title
+	// with no ASCII alphanumeric content collapses to the generic "session"
+	// fallback, so reject it before collision checks or provisioning. Docker and
+	// SSH may use the same slug helper for repo-scoped paths or labels, but do not
+	// claim this global hook namespace and therefore keep accepting Unicode titles.
+	if namespace == runtimeNamespaceRemoteHook && !session.RemoteHookTitleHasASCIIAlnum(title) {
+		return fmt.Errorf("remote hook session title %q must contain at least one ASCII letter or digit (A-Z, a-z, or 0-9); add an ASCII component so it derives a specific hook name", title)
 	}
 	// The "root" title belongs to the daemon-managed root agent (#1106).
 	// Every creation path lands here — TUI, `af sessions create`, task

--- a/daemon/manager_create_names.go
+++ b/daemon/manager_create_names.go
@@ -181,12 +181,13 @@ func (m *Manager) validateTitleShapeLocked(title string, namespace runtimeNameNa
 		return fmt.Errorf("session title must be a single line and contain no control characters")
 	}
 	// Hook scripts receive one globally shared --name derived by Slugify. A title
-	// with no ASCII alphanumeric content collapses to the generic "session"
-	// fallback, so reject it before collision checks or provisioning. Docker and
-	// SSH may use the same slug helper for repo-scoped paths or labels, but do not
-	// claim this global hook namespace and therefore keep accepting Unicode titles.
-	if namespace == runtimeNamespaceRemoteHook && !session.RemoteHookTitleHasASCIIAlnum(title) {
-		return fmt.Errorf("remote hook session title %q must contain at least one ASCII letter or digit (A-Z, a-z, or 0-9); add an ASCII component so it derives a specific hook name", title)
+	// whose bounded sanitized form retains no ASCII alphanumeric content collapses
+	// to the generic "session" fallback, so reject it before collision checks or
+	// provisioning. Docker and SSH may use the same slug helper for repo-scoped
+	// paths or labels, but do not claim this global hook namespace and therefore
+	// keep accepting Unicode titles.
+	if namespace == runtimeNamespaceRemoteHook && !session.RemoteHookTitleHasSpecificSlug(title) {
+		return fmt.Errorf("remote hook session title %q must retain at least one ASCII letter or digit after hook-name sanitization and truncation; add an ASCII component so it derives a specific hook name", title)
 	}
 	// The "root" title belongs to the daemon-managed root agent (#1106).
 	// Every creation path lands here — TUI, `af sessions create`, task

--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -51,9 +51,17 @@ The `<name>` passed to hooks via `--name` is a slug derived from the session tit
 3. drop every character that is not `[a-z0-9-]`
 4. truncate to 200 bytes (so the slug stays a legal filesystem component for `mktemp`/`mkdir`)
 5. trim leading/trailing `-`
-6. if empty, use `session`
+6. reject the remote-hook title if the result is empty
 
 Examples: `"Fix Auth Bug"` → `fix-auth-bug`, `"my_app"` → `myapp`, `"af-test"` stays `af-test`. Two titles that slugify to the same value are rejected at create time, since `delete_cmd` keys on the slug. There is no hidden hash suffix.
+
+A remote-hook title must therefore retain at least one ASCII letter or digit in
+the bounded result. Titles such as `日本語` and `!!!` are rejected before
+`launch_cmd` runs instead of receiving the generic name `session`. The check is
+applied after the 200-byte bound too: a title made of 200 hyphens followed by
+`a` is rejected because truncation removes its only letter. Add an ASCII
+component that survives the bound (for example, `日本語-2`) to derive a specific
+hook name.
 
 **Hook names are global across projects.** Session titles are otherwise unique only *within* a project — the same title may exist in several repos at once (see [cli.md](cli.md#af-sessions)). Remote hook names are the deliberate exception: the slug reaches your scripts verbatim, with no repo component, and they tag and reap real sandboxes by it. Two projects using one name would let a second `launch_cmd` clobber the first sandbox, and either `delete_cmd` reap the survivor. So a remote-hook session's title must not collide with a remote-hook session in *any* project; af refuses the create and names the project already using it. Local sessions are unaffected — only hook-backed remote sessions share this namespace.
 

--- a/session/backend_hook_remote.go
+++ b/session/backend_hook_remote.go
@@ -17,6 +17,23 @@ var slugRegexp = regexp.MustCompile(`[^a-z0-9-]`)
 // (#2528). The slug is ASCII ([a-z0-9-]), so a byte truncation is rune-safe.
 const maxSlugLen = 200
 
+// RemoteHookTitleHasASCIIAlnum reports whether a title can derive a hook name
+// from its own content. Hook names accept ASCII only; without a letter or digit,
+// Slugify has to use its compatibility fallback "session", which is not unique
+// enough for the hook backend's global namespace.
+//
+// Do not infer this from Slugify(title) == "session": valid titles such as
+// "SESSION!" deliberately derive that same slug.
+func RemoteHookTitleHasASCIIAlnum(title string) bool {
+	for i := 0; i < len(title); i++ {
+		c := title[i]
+		if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' {
+			return true
+		}
+	}
+	return false
+}
+
 // Slugify converts a title to a slug-safe string for the remote hook scripts.
 // The slug is the stable identifier launch_cmd and delete_cmd receive via
 // --name (docs/remote-hooks.md): launch_cmd tags the provisioned sandbox with

--- a/session/backend_hook_remote.go
+++ b/session/backend_hook_remote.go
@@ -17,21 +17,15 @@ var slugRegexp = regexp.MustCompile(`[^a-z0-9-]`)
 // (#2528). The slug is ASCII ([a-z0-9-]), so a byte truncation is rune-safe.
 const maxSlugLen = 200
 
-// RemoteHookTitleHasASCIIAlnum reports whether a title can derive a hook name
-// from its own content. Hook names accept ASCII only; without a letter or digit,
-// Slugify has to use its compatibility fallback "session", which is not unique
-// enough for the hook backend's global namespace.
+// RemoteHookTitleHasSpecificSlug reports whether the exact sanitization and
+// truncation Slugify applies retains a title-derived name. A raw title may have
+// ASCII content only after the bounded slug prefix (for example, 200 hyphens
+// followed by "a"), so scanning the unbounded input is not equivalent.
 //
 // Do not infer this from Slugify(title) == "session": valid titles such as
 // "SESSION!" deliberately derive that same slug.
-func RemoteHookTitleHasASCIIAlnum(title string) bool {
-	for i := 0; i < len(title); i++ {
-		c := title[i]
-		if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' {
-			return true
-		}
-	}
-	return false
+func RemoteHookTitleHasSpecificSlug(title string) bool {
+	return slugWithoutFallback(title) != ""
 }
 
 // Slugify converts a title to a slug-safe string for the remote hook scripts.
@@ -41,6 +35,14 @@ func RemoteHookTitleHasASCIIAlnum(title string) bool {
 // must not coexist (FindSlugCollision guards that at create time — including two
 // long titles that truncate to the same slug).
 func Slugify(title string) string {
+	s := slugWithoutFallback(title)
+	if s == "" {
+		s = "session"
+	}
+	return s
+}
+
+func slugWithoutFallback(title string) string {
 	s := strings.ToLower(title)
 	s = strings.ReplaceAll(s, " ", "-")
 	s = slugRegexp.ReplaceAllString(s, "")
@@ -48,9 +50,6 @@ func Slugify(title string) string {
 		s = s[:maxSlugLen]
 	}
 	s = strings.Trim(s, "-")
-	if s == "" {
-		s = "session"
-	}
 	return s
 }
 


### PR DESCRIPTION
## Summary

- reject remote-hook titles whose sanitized, truncated form collapses to the generic hook name `session`
- keep daemon admission authoritative and mirror the same error in the TUI naming flow
- scope the TUI hook-name collision precheck to actual hook sessions, not Docker/SSH workspaces
- preserve valid title-derived slugs such as `SESSION!`, `日本語-2`, and a letter at the bounded slug edge, plus Unicode-only Docker/SSH titles
- carry the same namespace-aware shape check through `TitleBase` auto-suffixing after rebasing over master
- document the rejection and its post-truncation behavior in the public remote-hook contract

## Root cause

`Slugify` intentionally accepts only `[a-z0-9-]`, bounds the result, trims hyphens, and falls back to `session` when nothing remains. That fallback is safe for repo-scoped sandbox paths, but remote hook scripts receive the bare slug as a global `--name`. Distinct hook titles whose bounded sanitized forms are empty therefore claim the same external name.

The report's diagnosis is correct, but checking `Slugify(title) == "session"` would reject valid titles such as `SESSION!` that deliberately derive that slug. Scanning the raw title for ASCII is also insufficient: 200 hyphens followed by `a` contains ASCII, but truncation removes the only letter before hyphen trimming. Validation and `Slugify` now share the exact pre-fallback normalization pipeline.

The adjacent TUI precheck also treated every remote workspace as a hook-name owner. Docker and SSH sessions do not claim the hook backend's global namespace, so the mirror now compares only serialized remote-hook records, matching daemon admission.

After rebasing, master had added an early `TitleBase` shape check. It must receive the requested runtime namespace too; otherwise a Unicode-only hook base would evade the hook rule and silently become `日本語-2`.

## Red first

The daemon and TUI regressions failed before the initial fix:

```text
--- FAIL: TestValidateTitleRejectsRemoteHookWithoutASCIIAlphanumeric (2.44s)
    create_remote_slug_test.go:93: remote hook title "日本語" contains no ASCII letter or digit but was accepted
    create_remote_slug_test.go:93: remote hook title "مرحبا" contains no ASCII letter or digit but was accepted
    create_remote_slug_test.go:93: remote hook title "!!!" contains no ASCII letter or digit but was accepted
--- FAIL: TestHandleStateNewRejectsRemoteHookTitleWithoutASCIIAlphanumeric (2.41s)
    expected stateNew, actual stateDefault
    a rejected title must remain editable: namingInstance was nil
```

The adjacent backend-scope regressions then failed before narrowing the existing-session scan:

```text
--- FAIL: TestHandleStateNewHookSlugIgnoresNonHookRemoteSessions (3.31s)
    --- FAIL: TestHandleStateNewHookSlugIgnoresNonHookRemoteSessions/docker
        expected stateDefault, actual stateNew
        a non-hook sandbox does not own a hook slug: namingInstance was non-nil
    --- FAIL: TestHandleStateNewHookSlugIgnoresNonHookRemoteSessions/ssh
        expected stateDefault, actual stateNew
        a non-hook sandbox does not own a hook slug: namingInstance was non-nil
```

The Codex truncation regression failed against `2098b13a6fb2ff0b96f484798457f04740e4bb36`:

```text
--- FAIL: TestValidateTitleRejectsRemoteHookWithoutASCIIAlphanumeric (1.79s)
    create_remote_slug_test.go:98: remote hook title "--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------a" retains no ASCII letter or digit in its bounded slug but was accepted
```

The rebased `TitleBase` path was also observed red before passing the runtime namespace:

```text
--- FAIL: TestNextAvailableTitleRejectsGenericRemoteHookSlug (0.09s)
    create_remote_slug_test.go:135: remote hook TitleBase without a specific slug resolved to "日本語-2"
```

## Validation

Validated pushed head `1f058ecfc4fdaf20a8dee1680e56869aacfc6cff`:

- focused container packages: `make test-container GOTESTARGS='./session ./daemon ./app'`
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- real TUI through an isolated `tmux -L af-2594-...` server and real hook-backed `af agent-server`:
  - `日本語` was rejected before `launch_cmd`
  - `日本語-2` provisioned exactly once as hook name `2`
  - the remote row was Ready/actionable and its live pane rendered the agent prompt
- full suite last: `make test-container`

Closes #2594