### PR TITLE
Report the actual orphan tmux session name

### DIFF
--- a/daemon/create_reuse_archived_claimable_test.go
+++ b/daemon/create_reuse_archived_claimable_test.go
@@ -140,17 +140,19 @@ func TestReserveCreate_ReservedHookNameRefusesBeforeArchivedRename(t *testing.T)
 func TestReserveCreate_UnclaimableGuardStaysOutOfTheWay(t *testing.T) {
 	manager, _, repoPath := newStatusTestManager(t)
 
-	orphan := tmux.SanitizedNameForRepo("solo", repoPath)
+	const title = "My Session"
+	orphan := tmux.SanitizedNameForRepo(title, repoPath)
 	out, err := exec.Command("tmux", "new-session", "-d", "-s", orphan, "sh").CombinedOutput()
 	require.NoError(t, err, string(out))
 	t.Cleanup(func() { _ = exec.Command("tmux", "kill-session", "-t", "="+orphan).Run() })
 
-	_, _, release, renamed, err := manager.reserveCreate(CreateSessionRequest{RepoPath: repoPath, Title: "solo", Program: "claude"})
+	_, _, release, renamed, err := manager.reserveCreate(CreateSessionRequest{RepoPath: repoPath, Title: title, Program: "claude"})
 	if release != nil {
 		release()
 	}
 	require.Error(t, err, "an orphan tmux session still blocks a create with no archived collision")
-	assert.Contains(t, err.Error(), "conflicting tmux session")
+	assert.Contains(t, err.Error(), "conflicting tmux session \""+orphan+"\" is already running",
+		"the descriptive session name must be the real tmux target, not the unsanitized title")
 	assert.Nil(t, renamed)
 }
 

--- a/daemon/manager_create_names.go
+++ b/daemon/manager_create_names.go
@@ -304,7 +304,8 @@ func (m *Manager) validateTitleNamespacesLocked(repoID, repoPath, title, program
 		// No creator will ever finish it, so this stays a plain error (not
 		// errConcurrentCreate): DeliverPrompt must fail fast with cleanup
 		// guidance rather than wait out waitForTargetSession's timeout (#916).
-		return fmt.Errorf("conflicting tmux session %q is already running; no agent-factory session owns it. Clean it up with: %s", title, shellsuggest.Command("tmux", "kill-session", "-t", tmuxSession.SanitizedName()))
+		tmuxName := tmuxSession.SanitizedName()
+		return fmt.Errorf("conflicting tmux session %q is already running; no agent-factory session owns it. Clean it up with: %s", tmuxName, shellsuggest.Command("tmux", "kill-session", "-t", tmuxName))
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- report the real repo-scoped sanitized tmux session name in orphan-collision prose
- reuse that same resolved name in the suggested cleanup command
- cover a title containing spaces so the raw title and tmux target cannot be confused

## Root cause

The orphan collision message labeled the raw title as a tmux session name, even though title sanitization and the repo hash produce a different tmux target.

## Red-first evidence

Against current `master`:

`"conflicting tmux session \\"My Session\\" ... tmux kill-session -t af_94f2a973_MySession" does not contain "conflicting tmux session \\"af_94f2a973_MySession\\" is already running"`

## Validation

Validated pushed SHA `17bef69ee27660716e0d6d959ae703c8cb2c86b7`:

- orphan collision regression for a title with spaces
- adjacent archived-reuse and DeliverPrompt orphan paths
- `make test-container GOTESTARGS='./daemon'`
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container` (full suite, run last)

Closes #2672