### PR TITLE
fix(session): reap sandbox before reprovision

### DIFF
--- a/session/archive_sandbox.go
+++ b/session/archive_sandbox.go
@@ -1,7 +1,10 @@
 package session
 
 import (
+	"errors"
 	"fmt"
+
+	"github.com/sachiniyer/agent-factory/log"
 )
 
 // Archive/restore for the disposable sandbox backends (#1592 Phase 4 PR6),
@@ -105,7 +108,10 @@ func (i *Instance) RestoreSandbox() error {
 		// The sandbox is up but the agent failed to launch on it — reap the
 		// freshly provisioned sandbox and clear its wiring so a retry re-provisions
 		// from a clean state instead of stranding a container/remote (#1726).
-		i.teardownAfterStartFailure()
+		if cleanupErr := i.teardownAfterStartFailure(); cleanupErr != nil {
+			return fmt.Errorf("agent start failed and the replacement sandbox's cleanup state is unknown: %w",
+				errors.Join(err, cleanupErr))
+		}
 		return err
 	}
 	return nil
@@ -128,7 +134,10 @@ func recoverSandbox(i *Instance) error {
 		// remote wiring on a Start failure so the Lost-restore loop's next retry
 		// re-provisions cleanly rather than stacking a second sandbox on the first
 		// still-running one (#1726).
-		i.teardownAfterStartFailure()
+		if cleanupErr := i.teardownAfterStartFailure(); cleanupErr != nil {
+			return fmt.Errorf("agent start failed and the replacement sandbox's cleanup state is unknown: %w",
+				errors.Join(err, cleanupErr))
+		}
 		return err
 	}
 	_ = i.Transition(ConfirmLive())
@@ -163,15 +172,31 @@ func (i *Instance) reprovisionRemote() error {
 	if err != nil {
 		return fmt.Errorf("cannot re-provision session %q: %w", i.Title, err)
 	}
+	// A failed archive/recovery can leave the old sandbox wiring live. Reap it
+	// before provisioning a replacement so bindProvisionResult never discards its
+	// only cleanup handle. An unknown outcome keeps the old wiring installed for a
+	// real retry instead of provisioning a second sandbox on a guess.
+	if err := i.reapRemoteRuntimeForReplacement(); err != nil {
+		return fmt.Errorf("cannot re-provision session %q: previous sandbox cleanup state is unknown: %w", i.Title, err)
+	}
 	res, err := rt.Provision(spec)
 	if err != nil {
 		return fmt.Errorf("failed to re-provision sandbox for session %q: %w", i.Title, err)
 	}
 	if err := i.bindProvisionResult(res); err != nil {
 		// The sandbox is up but its endpoint could not be wired — reap it so a
-		// bad restore never leaks a container/remote.
+		// bad restore never leaks a container/remote. An unknown reap keeps the
+		// new backend + cleanup handle installed (without its invalid client) so
+		// the next restore retries that cleanup before provisioning again.
 		if res.Teardown != nil {
-			_ = res.Teardown()
+			if cleanupErr := res.Teardown(); cleanupErr != nil {
+				if TeardownStateUnknown(cleanupErr) {
+					i.retainProvisionResultCleanup(res)
+					return fmt.Errorf("failed to bind re-provisioned sandbox for session %q and its cleanup state is unknown: %w",
+						i.Title, errors.Join(err, cleanupErr))
+				}
+				log.WarningLog.Printf("session %q: unbound replacement sandbox teardown reported a completed error: %v", i.Title, cleanupErr)
+			}
 		}
 		return fmt.Errorf("failed to bind re-provisioned sandbox for session %q: %w", i.Title, err)
 	}
@@ -205,6 +230,19 @@ func (i *Instance) bindProvisionResult(res ProvisionResult) error {
 	return nil
 }
 
+// retainProvisionResultCleanup installs only the identity and cleanup handle of
+// a provisioned sandbox whose endpoint could not be bound and whose teardown
+// outcome was unknown. The invalid client is deliberately omitted; AgentServer
+// rebuilds as a deadRemoteAgentServer whose Kill can retry this exact cleanup.
+func (i *Instance) retainProvisionResultCleanup(res ProvisionResult) {
+	i.mu.Lock()
+	i.agentSrv = nil
+	i.backend = res.Backend
+	i.remoteClient = nil
+	i.runtimeTeardown = res.Teardown
+	i.mu.Unlock()
+}
+
 // resetRemoteRuntime clears the instance's remote-runtime wiring after its
 // sandbox has been reaped (archive), leaving an inert record whose backend still
 // classifies it as a remote sandbox (#1592 Phase 4 PR6). A subsequent restore
@@ -219,25 +257,36 @@ func (i *Instance) resetRemoteRuntime() {
 	i.mu.Unlock()
 }
 
-// teardownAfterStartFailure reaps a freshly re-provisioned sandbox after the
-// agent Start failed on the restore/recover path, then clears the remote-runtime
-// wiring (#1726). It mirrors reprovisionRemote's bind-failure discipline —
-// run the stored Teardown so the container/remote is reclaimed — and reuses the
-// SAME i.mu ownership as bindProvisionResult/resetRemoteRuntime (#1729): the
-// teardown is read under i.mu.RLock and invoked OUTSIDE the lock (it may block on
-// docker/ssh I/O), then resetRemoteRuntime clears remoteClient/runtimeTeardown/
-// agentSrv together so a retry starts from a clean, unbound state and never
-// stacks a second sandbox on the first. Each runtime serializes teardown, so a
-// later Kill cannot overlap it; docker/SSH latch completed outcomes and leave an
-// outcome whose completion was unknown deliberately retryable.
-func (i *Instance) teardownAfterStartFailure() {
+// reapRemoteRuntimeForReplacement reaps the currently bound sandbox before its
+// wiring is replaced. Teardown has three outcomes: success and a completed,
+// known-state error both follow the runtimes' existing best-effort contract and
+// clear the binding; an unknown-state error preserves the binding and handle so
+// the next restore can retry instead of stacking another sandbox on it.
+//
+// The teardown is read under i.mu and invoked outside the lock because docker/SSH
+// I/O may block. Each runtime serializes and conditionally latches its own reap.
+func (i *Instance) reapRemoteRuntimeForReplacement() error {
 	i.mu.RLock()
 	teardown := i.runtimeTeardown
 	i.mu.RUnlock()
-	if teardown != nil {
-		_ = teardown()
+	if teardown == nil {
+		return nil
+	}
+	if err := teardown(); err != nil {
+		if TeardownStateUnknown(err) {
+			return err
+		}
+		log.WarningLog.Printf("session %q: previous sandbox teardown reported a completed error; continuing with replacement: %v", i.Title, err)
 	}
 	i.resetRemoteRuntime()
+	return nil
+}
+
+// teardownAfterStartFailure applies the same replacement rule to a freshly
+// provisioned sandbox whose agent failed to start: clear it after a known
+// teardown outcome, but retain an unknown cleanup handle for the next retry.
+func (i *Instance) teardownAfterStartFailure() error {
+	return i.reapRemoteRuntimeForReplacement()
 }
 
 // isSandboxBackendType reports whether a persisted backend Type() names a

--- a/session/archive_sandbox.go
+++ b/session/archive_sandbox.go
@@ -82,6 +82,9 @@ func (i *Instance) ArchiveSandbox() (string, error) {
 	//    (container rm / remote dir cleanup + tunnel close) — the branch is durable,
 	//    the sandbox is disposable.
 	if err := as.Kill(); err != nil {
+		if TeardownStateUnknown(err) {
+			i.markRuntimeCleanupStateUnknown()
+		}
 		return branch, fmt.Errorf("pushed branch %q but failed to tear the sandbox down for session %q: %w", branch, i.Title, err)
 	}
 	// 4. Drop the dead remote wiring so the instance is an inert archived record
@@ -226,6 +229,7 @@ func (i *Instance) bindProvisionResult(res ProvisionResult) error {
 	i.backend = res.Backend
 	i.remoteClient = rc
 	i.runtimeTeardown = res.Teardown
+	i.runtimeCleanupStateUnknown = false
 	i.mu.Unlock()
 	return nil
 }
@@ -240,6 +244,7 @@ func (i *Instance) retainProvisionResultCleanup(res ProvisionResult) {
 	i.backend = res.Backend
 	i.remoteClient = nil
 	i.runtimeTeardown = res.Teardown
+	i.runtimeCleanupStateUnknown = true
 	i.mu.Unlock()
 }
 
@@ -254,6 +259,17 @@ func (i *Instance) resetRemoteRuntime() {
 	i.agentSrv = nil
 	i.remoteClient = nil
 	i.runtimeTeardown = nil
+	i.runtimeCleanupStateUnknown = false
+	i.mu.Unlock()
+}
+
+// markRuntimeCleanupStateUnknown makes an indeterminate reap durable without
+// changing the session's wanted/kill intent. The exact backend identity staged
+// by ToInstanceData then crosses storage so a restart must retry this cleanup
+// before provisioning a replacement.
+func (i *Instance) markRuntimeCleanupStateUnknown() {
+	i.mu.Lock()
+	i.runtimeCleanupStateUnknown = true
 	i.mu.Unlock()
 }
 
@@ -274,6 +290,7 @@ func (i *Instance) reapRemoteRuntimeForReplacement() error {
 	}
 	if err := teardown(); err != nil {
 		if TeardownStateUnknown(err) {
+			i.markRuntimeCleanupStateUnknown()
 			return err
 		}
 		log.WarningLog.Printf("session %q: previous sandbox teardown reported a completed error; continuing with replacement: %v", i.Title, err)

--- a/session/archive_sandbox_reprovision_test.go
+++ b/session/archive_sandbox_reprovision_test.go
@@ -14,6 +14,14 @@ type orderedReprovisionRuntime struct {
 	res    ProvisionResult
 }
 
+type cleanupFailingStartBackend struct {
+	*dockerBackend
+}
+
+func (b *cleanupFailingStartBackend) Start(*Instance, bool) error {
+	return fmt.Errorf("start failed")
+}
+
 func (r *orderedReprovisionRuntime) Provision(ProvisionSpec) (ProvisionResult, error) {
 	*r.events = append(*r.events, "provision")
 	return r.res, nil
@@ -71,7 +79,13 @@ func TestReprovisionRemote_RetainsPreviousRuntimeWhenTeardownUnknown(t *testing.
 	restoreRuntime := SetRuntimeForTest(BackendDocker, func() Runtime { return rt })
 	defer restoreRuntime()
 
-	oldBackend := newInertSandboxBackend("docker")
+	oldBackend := &dockerBackend{
+		containerID: "old",
+		cleanup: &DockerRuntimeCleanupData{
+			ContainerID: "old",
+			EngineID:    "engine-id",
+		},
+	}
 	oldClient := &remoteAgentClient{title: "old"}
 	oldTeardown := func() error {
 		return fmt.Errorf("%w: cleanup timed out", ErrWorkspaceStateUnknown)
@@ -94,13 +108,20 @@ func TestReprovisionRemote_RetainsPreviousRuntimeWhenTeardownUnknown(t *testing.
 	assert.Same(t, oldBackend, i.backend)
 	assert.Same(t, oldClient, i.remoteClient)
 	assert.NotNil(t, i.runtimeTeardown, "the retryable cleanup handle must remain installed")
+	assertUnknownCleanupSurvivesRestart(t, i)
 }
 
 // TestRecoverSandbox_RetainsRuntimeWhenStartFailureCleanupUnknown covers the
 // adjacent replacement path: if the freshly provisioned sandbox cannot be
 // confirmed reaped after Start fails, retain its wiring instead of orphaning it.
 func TestRecoverSandbox_RetainsRuntimeWhenStartFailureCleanupUnknown(t *testing.T) {
-	freshBackend := &failingStartBackend{FakeBackend: NewFakeBackend(), typ: "docker"}
+	freshBackend := &cleanupFailingStartBackend{dockerBackend: &dockerBackend{
+		containerID: "fresh",
+		cleanup: &DockerRuntimeCleanupData{
+			ContainerID: "fresh",
+			EngineID:    "engine-id",
+		},
+	}}
 	ep := &AgentServerEndpoint{URL: "http://127.0.0.1:9", Token: "tok"}
 	rt := fakeRuntime{res: ProvisionResult{
 		Backend:  freshBackend,
@@ -129,6 +150,7 @@ func TestRecoverSandbox_RetainsRuntimeWhenStartFailureCleanupUnknown(t *testing.
 	assert.Same(t, freshBackend, i.backend)
 	assert.NotNil(t, i.remoteClient)
 	assert.NotNil(t, i.runtimeTeardown, "unknown cleanup must keep the handle available for retry")
+	assertUnknownCleanupSurvivesRestart(t, i)
 }
 
 // TestReprovisionRemote_RetainsNewRuntimeWhenBindFailureCleanupUnknown covers
@@ -136,7 +158,13 @@ func TestRecoverSandbox_RetainsRuntimeWhenStartFailureCleanupUnknown(t *testing.
 // validation failed, and cleanup could not establish whether the new sandbox
 // was reaped. Its handle must become the instance's next retry target.
 func TestReprovisionRemote_RetainsNewRuntimeWhenBindFailureCleanupUnknown(t *testing.T) {
-	freshBackend := &dockerBackend{containerID: "fresh"}
+	freshBackend := &dockerBackend{
+		containerID: "fresh",
+		cleanup: &DockerRuntimeCleanupData{
+			ContainerID: "fresh",
+			EngineID:    "engine-id",
+		},
+	}
 	rt := fakeRuntime{res: ProvisionResult{
 		Backend:  freshBackend,
 		Endpoint: &AgentServerEndpoint{URL: "://invalid", Token: "tok"},
@@ -163,4 +191,19 @@ func TestReprovisionRemote_RetainsNewRuntimeWhenBindFailureCleanupUnknown(t *tes
 	assert.Same(t, freshBackend, i.backend)
 	assert.Nil(t, i.remoteClient)
 	assert.NotNil(t, i.runtimeTeardown, "unknown cleanup must keep the new sandbox's handle")
+	assertUnknownCleanupSurvivesRestart(t, i)
+}
+
+// assertUnknownCleanupSurvivesRestart exercises the production storage
+// round-trip used by both automatic and manual restore failure paths. A cleanup
+// outcome that could not be determined must keep its exact teardown identity;
+// otherwise the next daemon provisions over a sandbox that may still exist.
+func assertUnknownCleanupSurvivesRestart(t *testing.T, i *Instance) {
+	t.Helper()
+	stored := i.ToInstanceData().ForStorage()
+	require.True(t, stored.RuntimeCleanupStateUnknown, "unknown cleanup lost its durable state marker")
+	require.NotNil(t, stored.RuntimeCleanup, "unknown cleanup lost its teardown identity at the storage boundary")
+	restored, err := FromInstanceData(stored)
+	require.NoError(t, err)
+	require.NotNil(t, restored.runtimeTeardown, "unknown cleanup restored without a retryable teardown")
 }

--- a/session/archive_sandbox_reprovision_test.go
+++ b/session/archive_sandbox_reprovision_test.go
@@ -1,0 +1,166 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type orderedReprovisionRuntime struct {
+	events *[]string
+	res    ProvisionResult
+}
+
+func (r *orderedReprovisionRuntime) Provision(ProvisionSpec) (ProvisionResult, error) {
+	*r.events = append(*r.events, "provision")
+	return r.res, nil
+}
+
+// TestReprovisionRemote_ReapsPreviousRuntimeBeforeProvision proves replacement
+// never discards the previous sandbox's teardown handle. A completed teardown
+// error follows the established best-effort contract, but is still attempted
+// before the replacement is provisioned.
+func TestReprovisionRemote_ReapsPreviousRuntimeBeforeProvision(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		teardownErr error
+	}{
+		{name: "success"},
+		{name: "known failure", teardownErr: errors.New("runtime answered with a cleanup failure")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var events []string
+			freshBackend := &dockerBackend{containerID: "fresh"}
+			rt := &orderedReprovisionRuntime{
+				events: &events,
+				res: ProvisionResult{
+					Backend:  freshBackend,
+					Teardown: func() error { return nil },
+				},
+			}
+			restoreRuntime := SetRuntimeForTest(BackendDocker, func() Runtime { return rt })
+			defer restoreRuntime()
+
+			i := &Instance{
+				Title:   "s",
+				Path:    t.TempDir(),
+				Branch:  "root/s",
+				backend: newInertSandboxBackend("docker"),
+				runtimeTeardown: func() error {
+					events = append(events, "old teardown")
+					return tc.teardownErr
+				},
+			}
+
+			require.NoError(t, i.reprovisionRemote())
+			assert.Equal(t, []string{"old teardown", "provision"}, events)
+			assert.Same(t, freshBackend, i.GetBackend())
+		})
+	}
+}
+
+// TestReprovisionRemote_RetainsPreviousRuntimeWhenTeardownUnknown proves an
+// unanswerable cleanup is not treated as success or as a completed failure. No
+// replacement is provisioned, and the old wiring remains available to retry.
+func TestReprovisionRemote_RetainsPreviousRuntimeWhenTeardownUnknown(t *testing.T) {
+	var events []string
+	rt := &orderedReprovisionRuntime{events: &events, res: ProvisionResult{Backend: &dockerBackend{containerID: "fresh"}}}
+	restoreRuntime := SetRuntimeForTest(BackendDocker, func() Runtime { return rt })
+	defer restoreRuntime()
+
+	oldBackend := newInertSandboxBackend("docker")
+	oldClient := &remoteAgentClient{title: "old"}
+	oldTeardown := func() error {
+		return fmt.Errorf("%w: cleanup timed out", ErrWorkspaceStateUnknown)
+	}
+	i := &Instance{
+		Title:           "s",
+		Path:            t.TempDir(),
+		Branch:          "root/s",
+		backend:         oldBackend,
+		remoteClient:    oldClient,
+		runtimeTeardown: oldTeardown,
+	}
+
+	err := i.reprovisionRemote()
+	require.ErrorIs(t, err, ErrWorkspaceStateUnknown)
+	assert.Empty(t, events, "unknown old-sandbox cleanup must stop before provisioning")
+
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	assert.Same(t, oldBackend, i.backend)
+	assert.Same(t, oldClient, i.remoteClient)
+	assert.NotNil(t, i.runtimeTeardown, "the retryable cleanup handle must remain installed")
+}
+
+// TestRecoverSandbox_RetainsRuntimeWhenStartFailureCleanupUnknown covers the
+// adjacent replacement path: if the freshly provisioned sandbox cannot be
+// confirmed reaped after Start fails, retain its wiring instead of orphaning it.
+func TestRecoverSandbox_RetainsRuntimeWhenStartFailureCleanupUnknown(t *testing.T) {
+	freshBackend := &failingStartBackend{FakeBackend: NewFakeBackend(), typ: "docker"}
+	ep := &AgentServerEndpoint{URL: "http://127.0.0.1:9", Token: "tok"}
+	rt := fakeRuntime{res: ProvisionResult{
+		Backend:  freshBackend,
+		Endpoint: ep,
+		Teardown: func() error {
+			return fmt.Errorf("%w: cleanup timed out", ErrWorkspaceStateUnknown)
+		},
+	}}
+	restoreRuntime := SetRuntimeForTest(BackendDocker, func() Runtime { return rt })
+	defer restoreRuntime()
+
+	i := &Instance{
+		Title:    "s",
+		Path:     t.TempDir(),
+		Branch:   "root/s",
+		backend:  newInertSandboxBackend("docker"),
+		liveness: LiveLost,
+	}
+
+	err := recoverSandbox(i)
+	require.ErrorContains(t, err, "start failed")
+	require.ErrorIs(t, err, ErrWorkspaceStateUnknown)
+
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	assert.Same(t, freshBackend, i.backend)
+	assert.NotNil(t, i.remoteClient)
+	assert.NotNil(t, i.runtimeTeardown, "unknown cleanup must keep the handle available for retry")
+}
+
+// TestReprovisionRemote_RetainsNewRuntimeWhenBindFailureCleanupUnknown covers
+// the remaining replacement failure window: provisioning succeeded, endpoint
+// validation failed, and cleanup could not establish whether the new sandbox
+// was reaped. Its handle must become the instance's next retry target.
+func TestReprovisionRemote_RetainsNewRuntimeWhenBindFailureCleanupUnknown(t *testing.T) {
+	freshBackend := &dockerBackend{containerID: "fresh"}
+	rt := fakeRuntime{res: ProvisionResult{
+		Backend:  freshBackend,
+		Endpoint: &AgentServerEndpoint{URL: "://invalid", Token: "tok"},
+		Teardown: func() error {
+			return fmt.Errorf("%w: cleanup timed out", ErrWorkspaceStateUnknown)
+		},
+	}}
+	restoreRuntime := SetRuntimeForTest(BackendDocker, func() Runtime { return rt })
+	defer restoreRuntime()
+
+	i := &Instance{
+		Title:   "s",
+		Path:    t.TempDir(),
+		Branch:  "root/s",
+		backend: newInertSandboxBackend("docker"),
+	}
+
+	err := i.reprovisionRemote()
+	require.ErrorContains(t, err, "failed to bind re-provisioned sandbox")
+	require.ErrorIs(t, err, ErrWorkspaceStateUnknown)
+
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	assert.Same(t, freshBackend, i.backend)
+	assert.Nil(t, i.remoteClient)
+	assert.NotNil(t, i.runtimeTeardown, "unknown cleanup must keep the new sandbox's handle")
+}

--- a/session/archive_sandbox_test.go
+++ b/session/archive_sandbox_test.go
@@ -53,6 +53,7 @@ func assertRemoteRuntimeReset(t *testing.T, i *Instance) {
 	defer i.mu.RUnlock()
 	assert.Nil(t, i.remoteClient, "remoteClient cleared after Start-failure teardown")
 	assert.Nil(t, i.runtimeTeardown, "runtimeTeardown cleared after Start-failure teardown")
+	assert.False(t, i.runtimeCleanupStateUnknown, "completed teardown clears the unknown-cleanup marker")
 	assert.Nil(t, i.agentSrv, "cached agent-server cleared after Start-failure teardown")
 }
 
@@ -312,11 +313,37 @@ func TestArchiveSandbox_RecordsBranchOnKillFailure(t *testing.T) {
 	assert.Contains(t, err.Error(), `pushed branch "root/s"`, "error names the branch that IS durable")
 	assert.Contains(t, err.Error(), "failed to tear the sandbox down", "error names the half that failed")
 	assert.Equal(t, 1, as.killCalls, "the teardown was attempted")
+	assert.False(t, i.ToInstanceData().RuntimeCleanupStateUnknown,
+		"an answered cleanup failure must not be collapsed into unknown state")
 
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 	assert.Equal(t, "root/s", i.Branch,
 		"the durable branch must be recorded despite the teardown failure — Lost-restore re-provisions from i.Branch (#1781)")
+}
+
+// TestArchiveSandbox_UnknownKillCleanupSurvivesRestart covers the failure that
+// precedes restore: branch push succeeded, but sandbox teardown could not report
+// whether the old runtime still exists. The daemon persists the resulting Lost
+// session, so the cleanup identity must cross that restart before any restore
+// provisions a replacement.
+func TestArchiveSandbox_UnknownKillCleanupSurvivesRestart(t *testing.T) {
+	as := &stubAgentServer{
+		branch:  "root/s",
+		killErr: fmt.Errorf("%w: sandbox teardown timed out", ErrWorkspaceStateUnknown),
+	}
+	i := newStubbedSandboxInstance(as)
+	i.backend = &dockerBackend{
+		containerID: "possibly-live-container",
+		cleanup: &DockerRuntimeCleanupData{
+			ContainerID: "possibly-live-container",
+			EngineID:    "engine-id",
+		},
+	}
+
+	_, err := i.ArchiveSandbox()
+	require.ErrorIs(t, err, ErrWorkspaceStateUnknown)
+	assertUnknownCleanupSurvivesRestart(t, i)
 }
 
 // TestArchiveSandbox_RecordsBranchOnSuccess pins that moving the assignment earlier

--- a/session/instance.go
+++ b/session/instance.go
@@ -269,6 +269,12 @@ type Instance struct {
 	// over REST. nil only for local sessions. Each runtime serializes repeated
 	// calls; docker/SSH deliberately retry outcomes whose completion is unknown.
 	runtimeTeardown func() error
+	// runtimeCleanupStateUnknown is the durable third outcome of a sandbox reap:
+	// teardown neither confirmed success nor reported a completed failure, so the
+	// exact runtime identity above must survive storage and be retried before any
+	// replacement is provisioned. It is independent of userKilled: restore
+	// failures retain wanted sessions, not kill tombstones.
+	runtimeCleanupStateUnknown bool
 }
 
 // tmuxLocked returns the agent tab's tmux session, or nil when the instance has

--- a/session/instance_backend_guard_test.go
+++ b/session/instance_backend_guard_test.go
@@ -18,7 +18,8 @@ import (
 // goroutine.
 //
 //   - currentBackend / capabilitiesLocked — the synchronized accessors themselves.
-//   - SetBackend / bindProvisionResult — the writers; both take i.mu.Lock.
+//   - SetBackend / bindProvisionResult / retainProvisionResultCleanup — the
+//     writers; all take i.mu.Lock.
 //   - AgentServer / reprovisionRemote / toInstanceDataLocked — read inside an
 //     i.mu section their callers established.
 //   - PreviewTabSnapshotByID — snapshots the backend while its stable tab target
@@ -27,15 +28,16 @@ import (
 //   - FromInstanceData — a constructor. It populates a local *Instance that no
 //     other goroutine can observe yet, so there is nothing to synchronize with.
 var backendReadersUnderLock = map[string]bool{
-	"currentBackend":         true,
-	"capabilitiesLocked":     true,
-	"SetBackend":             true,
-	"bindProvisionResult":    true,
-	"AgentServer":            true,
-	"reprovisionRemote":      true,
-	"toInstanceDataLocked":   true,
-	"PreviewTabSnapshotByID": true,
-	"FromInstanceData":       true,
+	"currentBackend":               true,
+	"capabilitiesLocked":           true,
+	"SetBackend":                   true,
+	"bindProvisionResult":          true,
+	"retainProvisionResultCleanup": true,
+	"AgentServer":                  true,
+	"reprovisionRemote":            true,
+	"toInstanceDataLocked":         true,
+	"PreviewTabSnapshotByID":       true,
+	"FromInstanceData":             true,
 }
 
 // TestBackendFieldIsOnlyReadUnderLock is a source-level guard for #2096/#2165.

--- a/session/instance_data.go
+++ b/session/instance_data.go
@@ -58,13 +58,15 @@ func (i *Instance) toInstanceDataLocked() InstanceData {
 		UserKilled:            i.userKilled,
 		StartupStateUnknown:   i.startupStateUnknown,
 	}
+	data.RuntimeCleanupStateUnknown = i.runtimeCleanupStateUnknown
 
 	if i.backend != nil {
 		data.BackendType = i.backend.Type()
 		if provider, ok := i.backend.(runtimeCleanupProvider); ok {
 			// Stage the exact off-box teardown identity privately on every snapshot.
-			// ForStorage publishes it only when UserKilled is true, including the
-			// persistKillTombstone copy that flips the flag after this read.
+			// ForStorage publishes it only when UserKilled or an unknown cleanup
+			// outcome makes it durable, including the persistKillTombstone copy that
+			// flips the kill flag after this read.
 			data.runtimeCleanup = provider.runtimeCleanupData()
 		}
 	}
@@ -193,6 +195,7 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 		userKilled:            data.UserKilled,
 		startupStateUnknown:   data.StartupStateUnknown,
 	}
+	instance.runtimeCleanupStateUnknown = data.RuntimeCleanupStateUnknown
 	worktreeReaped := false
 
 	// Pick backend based on persisted BackendType.
@@ -207,15 +210,16 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 		// re-provisioned on restore (re-running launch_cmd for hook), never
 		// reconstructed here.
 		instance.backend = newInertSandboxBackend(data.BackendType)
-		// A kill tombstone is a durable promise to FINISH teardown after a
-		// restart. Rebuild only that teardown handle — no endpoint, tunnel, or
-		// live sandbox client is dialled during load. Archived sandboxes were
-		// already reaped before becoming Archived, so deleting their record needs
-		// no remote cleanup handle.
-		if data.UserKilled && liveness != LiveArchived {
+		// A kill tombstone is a durable promise to FINISH teardown after a restart;
+		// an unknown cleanup outcome is the same obligation without terminal kill
+		// intent. Rebuild only that teardown handle — no endpoint, tunnel, or live
+		// sandbox client is dialled during load. Archived sandboxes were already
+		// reaped before becoming Archived, so deleting their record needs no remote
+		// cleanup handle.
+		if (data.UserKilled || data.RuntimeCleanupStateUnknown) && liveness != LiveArchived {
 			backend, teardown, cleanupErr := restoreRuntimeCleanup(data.Title, data.BackendType, data.RuntimeCleanup)
 			if cleanupErr != nil {
-				// Legacy/malformed tombstones fail closed. Keeping the inert backend
+				// Legacy/malformed retention records fail closed. Keeping the inert backend
 				// preserves classification while this closure makes Kill return the
 				// unknown-state sentinel, so finishUserKill retains the only record
 				// instead of laundering a missing handle into no-op success.

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -292,9 +293,18 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 		if err != nil {
 			// The sandbox is already up (backendFactory provisioned it); a bad
 			// endpoint here would strand it, so reap it before failing rather than
-			// leaking a container/remote workspace.
+			// leaking a container/remote workspace. No Instance exists to retain a
+			// retry handle, so preserve every cleanup failure in the returned chain
+			// and call out an unknown outcome as a possible orphan.
 			if res.Teardown != nil {
-				_ = res.Teardown()
+				if cleanupErr := res.Teardown(); cleanupErr != nil {
+					if TeardownStateUnknown(cleanupErr) {
+						return nil, fmt.Errorf("failed to build remote agent-server client and sandbox cleanup state is unknown; a sandbox may still be running: %w",
+							errors.Join(err, cleanupErr))
+					}
+					return nil, fmt.Errorf("failed to build remote agent-server client and sandbox cleanup failed: %w",
+						errors.Join(err, cleanupErr))
+				}
 			}
 			return nil, fmt.Errorf("failed to build remote agent-server client: %w", err)
 		}

--- a/session/instance_factory_cleanup_test.go
+++ b/session/instance_factory_cleanup_test.go
@@ -1,0 +1,42 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewInstance_BindFailureSurfacesCleanupOutcome covers the create-time twin
+// of restore binding failure. No Instance exists to retain a retry handle here,
+// so every cleanup error must remain in the returned chain, including the
+// distinct unknown-state sentinel.
+func TestNewInstance_BindFailureSurfacesCleanupOutcome(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		cleanupErr error
+	}{
+		{name: "known failure", cleanupErr: errors.New("runtime answered with a cleanup failure")},
+		{name: "unknown", cleanupErr: fmt.Errorf("%w: cleanup timed out", ErrWorkspaceStateUnknown)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			previousFactory := backendFactory
+			backendFactory = func(InstanceOptions, string) (ProvisionResult, error) {
+				return ProvisionResult{
+					Backend:  newInertSandboxBackend("docker"),
+					Endpoint: &AgentServerEndpoint{URL: "://invalid", Token: "tok"},
+					Teardown: func() error { return tc.cleanupErr },
+				}, nil
+			}
+			defer func() { backendFactory = previousFactory }()
+
+			_, err := NewInstance(InstanceOptions{Title: "s", Path: t.TempDir(), Program: "claude"})
+			require.ErrorContains(t, err, "failed to build remote agent-server client")
+			require.ErrorIs(t, err, tc.cleanupErr, "cleanup outcome must not disappear from the create error")
+			if TeardownStateUnknown(tc.cleanupErr) {
+				require.ErrorIs(t, err, ErrWorkspaceStateUnknown)
+			}
+		})
+	}
+}

--- a/session/runtime_cleanup.go
+++ b/session/runtime_cleanup.go
@@ -11,13 +11,15 @@ import (
 )
 
 // RuntimeCleanupData is the storage-only teardown identity committed alongside a
-// remote session's kill tombstone. It is deliberately a tagged union rather than
-// a bag of shared strings: each backend restores only its own exact handle, and a
-// malformed record carrying two variants is refused instead of guessed at.
+// remote session's kill tombstone or an unknown cleanup outcome. It is
+// deliberately a tagged union rather than a bag of shared strings: each backend
+// restores only its own exact handle, and a malformed record carrying two
+// variants is refused instead of guessed at.
 //
 // InstanceData uses a private staging field to keep this out of daemon snapshots;
-// ForStorage publishes it only for UserKilled records. Bug reports drop it in
-// full because host names, command paths, and container ids are operator-private.
+// ForStorage publishes it only at those two retention boundaries. Bug reports
+// drop it in full because host names, command paths, and container ids are
+// operator-private.
 type RuntimeCleanupData struct {
 	Docker *DockerRuntimeCleanupData `json:"docker,omitempty"`
 	SSH    *SSHRuntimeCleanupData    `json:"ssh,omitempty"`

--- a/session/storage.go
+++ b/session/storage.go
@@ -140,10 +140,16 @@ type InstanceData struct {
 	Worktree          GitWorktreeData        `json:"worktree"`
 	PRInfo            PRInfoData             `json:"pr_info,omitempty"`
 	BackendType       string                 `json:"backend_type,omitempty"`
-	// RuntimeCleanup is written only for a committed UserKilled tombstone. It is
-	// the durable identity finishUserKill needs to resume off-box teardown after a
-	// daemon restart; normal snapshots keep it nil and stage the live handle in the
-	// private field below until ForStorage sees the tombstone.
+	// RuntimeCleanupStateUnknown is the independent retention marker for a sandbox
+	// teardown whose completion could not be determined. The next restore must
+	// retry RuntimeCleanup before it can safely provision a replacement. It is not
+	// a UserKilled tombstone: the session remains wanted after cleanup is settled.
+	RuntimeCleanupStateUnknown bool `json:"runtime_cleanup_state_unknown,omitempty"`
+	// RuntimeCleanup is written for a committed UserKilled tombstone or the
+	// unknown-cleanup state above. It is the durable identity needed to resume
+	// off-box teardown after a daemon restart; ordinary snapshots keep it nil and
+	// stage the live handle in the private field below until ForStorage reaches a
+	// retention boundary.
 	RuntimeCleanup *RuntimeCleanupData `json:"runtime_cleanup,omitempty"`
 	runtimeCleanup *RuntimeCleanupData
 }
@@ -186,10 +192,12 @@ func (d InstanceData) ForStorage() InstanceData {
 	case lv == LiveArchived:
 		// Archived rows have already reaped their runtime, so retaining a teardown
 		// identity here would only preserve unused credentials until row deletion.
+		d.RuntimeCleanupStateUnknown = false
 		d.RuntimeCleanup = nil
-	case !d.UserKilled:
+	case !d.UserKilled && !d.RuntimeCleanupStateUnknown:
 		// Cleanup credentials/identities have no reason to live in ordinary session
-		// records. The kill tombstone is their only persistence boundary.
+		// records. Kill intent and an unknown teardown outcome are the two durable
+		// retention boundaries.
 		d.RuntimeCleanup = nil
 	case d.runtimeCleanup != nil:
 		d.RuntimeCleanup = d.runtimeCleanup.clone()
@@ -340,11 +348,12 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 		data := inst.ToInstanceData()
 		status := data.Status
 		pendingHandoff := data.PendingHandoffMission != ""
+		unknownRuntimeCleanup := data.RuntimeCleanupStateUnknown
 		// A pending mission is a durable recovery obligation and therefore a
 		// retention claim, not generic transient UI state. OpReplacing composes to
 		// Loading, but dropping that row would erase the only handle to a live
 		// incoming runtime. The explicit marker outranks the lossy legacy status.
-		if (status == Loading || status == Deleting) && !pendingHandoff {
+		if (status == Loading || status == Deleting) && !pendingHandoff && !unknownRuntimeCleanup {
 			continue
 		}
 		// The !Started() skip drops transient never-started junk (a create that
@@ -356,17 +365,18 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 		// the same repo is saved — would silently orphan the archived worktree.
 		// (Lost is unaffected: it loads started=true, so it already survives.)
 		//
-		// TOMBSTONED and startup-unknown instances are also kept (#1917/#2207).
-		// Both are started=false and not Archived while their workspace may still be
-		// live: one because teardown could not confirm the pane dead or finish a
-		// worktree removal, the other because startup never established the runtime's
-		// identity. The record is deliberately RETAINED as that workspace's only
+		// TOMBSTONED, startup-unknown, and runtime-cleanup-unknown instances are
+		// also kept (#1917/#2207). They are started=false and not Archived while
+		// their workspace may still be live: teardown could not confirm the pane
+		// dead or finish a worktree removal, startup never established the runtime's
+		// identity, or an off-box teardown did not establish whether its sandbox was
+		// reaped. The record is deliberately RETAINED as that workspace's only
 		// handle. Without this clause the next checkpoint triggered by any other
 		// started session in the repo would silently drop it, undoing the retention
 		// in a layer that never heard of it, and orphaning the very workspace the
 		// retention exists to protect. Retention is a claim on this writer too.
 		if !inst.Started() && status != Archived && !data.UserKilled &&
-			!data.StartupStateUnknown && !pendingHandoff {
+			!data.StartupStateUnknown && !pendingHandoff && !unknownRuntimeCleanup {
 			continue
 		}
 		root := inst.GetRepoPath()

--- a/session/storage_retain_test.go
+++ b/session/storage_retain_test.go
@@ -1,10 +1,69 @@
 package session
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/config"
 )
+
+// TestSaveInstances_KeepsUnknownRuntimeCleanupAlongsideStartedSibling makes an
+// unanswerable sandbox teardown a durable retention claim. The row is inert and
+// not user-killed, but dropping it from a wholesale checkpoint also drops the
+// only identity that can prove the old sandbox gone before reprovisioning.
+func TestSaveInstances_KeepsUnknownRuntimeCleanupAlongsideStartedSibling(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := t.TempDir()
+	state := newMockStorage()
+
+	alive := &Instance{Title: "alive", Path: repoPath, started: true, liveness: LiveRunning}
+	uncertain := &Instance{
+		ID:       "unknown-cleanup-id",
+		Title:    "unknown-cleanup",
+		Path:     repoPath,
+		Program:  "claude",
+		started:  false,
+		liveness: LiveLost,
+		backend: &dockerBackend{
+			containerID: "possibly-live-container",
+			cleanup: &DockerRuntimeCleanupData{
+				ContainerID: "possibly-live-container",
+				EngineID:    "engine-id",
+			},
+		},
+		runtimeTeardown: func() error {
+			return fmt.Errorf("%w: teardown timed out", ErrWorkspaceStateUnknown)
+		},
+	}
+	if err := uncertain.teardownAfterStartFailure(); !TeardownStateUnknown(err) {
+		t.Fatalf("teardown outcome = %v, want unknown", err)
+	}
+
+	storage, err := NewStorage(state, "")
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	if err := storage.SaveInstances([]*Instance{alive, uncertain}); err != nil {
+		t.Fatalf("SaveInstances: %v", err)
+	}
+
+	for _, row := range readDisk(t, state, repoPath) {
+		if row.Title != uncertain.Title {
+			continue
+		}
+		if row.RuntimeCleanup == nil {
+			t.Fatal("retained unknown-cleanup row lost its teardown identity")
+		}
+		if !row.RuntimeCleanupStateUnknown {
+			t.Fatal("retained unknown-cleanup row lost its durable state marker")
+		}
+		if row.UserKilled {
+			t.Fatal("unknown cleanup was collapsed into a user-kill tombstone")
+		}
+		return
+	}
+	t.Fatal("daemon checkpoint dropped the unknown-cleanup row and orphaned its possible sandbox")
+}
 
 // TestSaveInstances_KeepsTombstonedRowAlongsideStartedSibling is #1917 round-5
 // finding (1): the retain is undone by a writer in another layer.


### PR DESCRIPTION
## Summary

- reap the previously bound sandbox before provisioning a restore replacement
- preserve the old or newly provisioned cleanup handle whenever teardown state is unknown
- persist that distinct unknown-cleanup state and exact teardown identity across daemon restarts
- apply the same three-valued cleanup rule after archive, Start, and endpoint-bind failures
- surface create-time cleanup failures when no Instance exists to retain a retry handle

## Verified diagnosis

`reprovisionRemote` provisioned a fresh sandbox and then `bindProvisionResult` overwrote `runtimeTeardown` without invoking the old handle. This can happen after a partial archive/restore failure, leaving the prior container or remote directory orphaned.

The fix follows the existing teardown taxonomy:

- success: clear the old binding and provision
- completed/known error: log it and follow the runtimes' established best-effort contract
- unknown state: stop, preserve the exact cleanup handle, and retry it before any later provision

Adjacent audit found the same handle-discard pattern after Start failure and after a provision succeeded but endpoint binding failed; both are fixed here. New-instance endpoint binding has no persisted Instance on which to retain a handle, so its cleanup outcome is joined into the returned error instead of being discarded.

## Codex P1 follow-up

Codex correctly found that the retained in-memory handle was still scrubbed by `InstanceData.ForStorage` whenever `UserKilled` was false. The fix adds a separate `RuntimeCleanupStateUnknown` marker: it is not kill intent and never collapses “could not determine” into success or failure. At this boundary only, `ForStorage` persists the exact cleanup identity; `FromInstanceData` rebuilds a teardown-only backend, and the next restore must settle that cleanup before provisioning.

The adjacent persistence audit also fixed the wholesale `SaveInstances` retention filter and the earlier archive-teardown entry point. User-kill cleanup was already durable. Known-completed cleanup errors remain unmarked and do not retain credentials.

## Red first

Observed against the unmodified branch base:

```
TestReprovisionRemote_ReapsPreviousRuntimeBeforeProvision:
expected: []string{"old teardown", "provision"}
actual  : []string{"provision"}
```

```
TestReprovisionRemote_RetainsPreviousRuntimeWhenTeardownUnknown:
expected ErrWorkspaceStateUnknown in chain
in chain:
```

```
TestRecoverSandbox_RetainsRuntimeWhenStartFailureCleanupUnknown:
expected ErrWorkspaceStateUnknown in chain
in chain: "start failed"
```

```
TestReprovisionRemote_RetainsNewRuntimeWhenBindFailureCleanupUnknown:
expected ErrWorkspaceStateUnknown in chain
in chain: "failed to bind re-provisioned sandbox ..."
```

The adjacent create-time regression also failed red because both known and unknown cleanup errors disappeared from the returned error chain.

The review follow-up restart assertions failed red in all three retained-handle paths:

```
Expected value not to be nil.
unknown cleanup lost its teardown identity at the storage boundary
```

The archive-side unknown outcome failed independently:

```
TestArchiveSandbox_UnknownKillCleanupSurvivesRestart:
Should be true
unknown cleanup lost its durable state marker
```

The whole-repo checkpoint writer also dropped the retained row:

```
TestSaveInstances_KeepsUnknownRuntimeCleanupAlongsideStartedSibling:
daemon checkpoint dropped the unknown-cleanup row and orphaned its possible sandbox
```

## Validation

Validated exact pushed head `8239fbdfec24feb0564b6e93bdcf46852096931c`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- complete `go test ./session -count=1`
- focused old-runtime, archive, Start, bind, restart-roundtrip, and checkpoint regressions
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container` full suite, run last against the pushed head

Closes #2634