### PR TITLE
fix(probes): prefer completed answers over cleanup deadlines

### DIFF
--- a/daemon/autostart_inspect.go
+++ b/daemon/autostart_inspect.go
@@ -661,26 +661,27 @@ func runAutostartProbeCommand(name string, args ...string) probeResult {
 		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL) // reap stragglers
 	}
 
-	// Killed on the deadline: whatever it managed to print is not an answer.
-	if ctx.Err() != nil {
-		return probeResult{cause: fmt.Errorf("%s %s timed out after %s: %w",
-			name, strings.Join(args, " "), autostartProbeTimeout, ctx.Err())}
-	}
-	// Never ran, or died on a signal: also not an answer. Only an ExitError
-	// means the command itself decided how to end.
 	var exitErr *exec.ExitError
 	switch {
 	case err == nil, errors.Is(err, exec.ErrWaitDelay):
-		// ErrWaitDelay: the command finished and its answer is in out; only a
-		// straggler held the pipe, and the reap above killed it (#676/#914).
+		// The command finished and its answer is in out. ErrWaitDelay means only
+		// a straggler held the pipe; a deadline racing that cleanup cannot turn
+		// the completed answer into an unknown timeout (#676/#914).
 		return probeResult{completed: true, output: string(out), exitCode: 0}
-	case errors.As(err, &exitErr):
-		if exitErr.ExitCode() < 0 {
-			return probeResult{cause: fmt.Errorf("%s %s was killed before answering: %w",
-				name, strings.Join(args, " "), err)}
-		}
+	case errors.As(err, &exitErr) && exitErr.ExitCode() >= 0:
+		// A non-zero exit is still a completed service-manager answer. Preserve
+		// it even when inherited-pipe cleanup crosses the context deadline.
 		return probeResult{completed: true, output: string(out), exitCode: exitErr.ExitCode()}
+	case ctx.Err() != nil:
+		// The command itself did not complete before the deadline. Partial output
+		// is not an answer and remains structurally unreachable.
+		return probeResult{cause: fmt.Errorf("%s %s timed out after %s: %w",
+			name, strings.Join(args, " "), autostartProbeTimeout, ctx.Err())}
+	case errors.As(err, &exitErr):
+		return probeResult{cause: fmt.Errorf("%s %s was killed before answering: %w",
+			name, strings.Join(args, " "), err)}
 	default:
+		// Never ran or failed outside an ordinary process exit: no answer.
 		return probeResult{cause: fmt.Errorf("could not run %s %s: %w",
 			name, strings.Join(args, " "), err)}
 	}

--- a/daemon/autostart_inspect_test.go
+++ b/daemon/autostart_inspect_test.go
@@ -624,9 +624,12 @@ func TestAutostartProbe_WaitDelayStragglerIsStillAnAnswer(t *testing.T) {
 }
 
 func TestAutostartProbe_DeadlineDuringWaitDelayIsStillAnAnswer(t *testing.T) {
-	withProbeTimeout(t, 300*time.Millisecond)
+	// Leave ample time for the shell's successful exit to be observed before
+	// the context fires. The child explicitly retains both capture pipes, so the
+	// deadline still lands during WaitDelay cleanup on both Linux and macOS.
+	withProbeTimeout(t, time.Second)
 
-	res := runAutostartProbeCommand("sh", "-c", "sleep 0.2; echo active; sleep 30 &")
+	res := runAutostartProbeCommand("sh", "-c", "echo active; sleep 30 >&1 2>&1 &")
 
 	require.NoError(t, res.Cause(), "the probe answered before the deadline; only pipe cleanup crossed it")
 	out, ok := res.Output()

--- a/daemon/autostart_inspect_test.go
+++ b/daemon/autostart_inspect_test.go
@@ -623,6 +623,17 @@ func TestAutostartProbe_WaitDelayStragglerIsStillAnAnswer(t *testing.T) {
 	require.Contains(t, out, "active", "and its answer must survive")
 }
 
+func TestAutostartProbe_DeadlineDuringWaitDelayIsStillAnAnswer(t *testing.T) {
+	withProbeTimeout(t, 300*time.Millisecond)
+
+	res := runAutostartProbeCommand("sh", "-c", "sleep 0.2; echo active; sleep 30 &")
+
+	require.NoError(t, res.Cause(), "the probe answered before the deadline; only pipe cleanup crossed it")
+	out, ok := res.Output()
+	require.True(t, ok, "an answered probe must expose its output")
+	require.Contains(t, out, "active")
+}
+
 // The same shape, all the way through the classifier: a straggler must not turn
 // "active" into "inactive".
 func TestAutostartSupervision_WaitDelayStragglerDoesNotInvertTheAnswer(t *testing.T) {

--- a/daemon/control_client_supervision.go
+++ b/daemon/control_client_supervision.go
@@ -85,11 +85,13 @@ func runEnsureManagerCommand(deadline time.Time, name string, args ...string) er
 	if cmd.Process != nil {
 		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 	}
+	if err == nil || errors.Is(err, exec.ErrWaitDelay) {
+		// The manager exited zero. A deadline that fires while WaitDelay is
+		// cleaning inherited pipes cannot retroactively make the command time out.
+		return nil
+	}
 	if ctx.Err() != nil {
 		return fmt.Errorf("%s %s timed out: %w", name, strings.Join(args, " "), ctx.Err())
-	}
-	if err == nil || errors.Is(err, exec.ErrWaitDelay) {
-		return nil
 	}
 	return fmt.Errorf("%s %s failed: %w\n%s", name, strings.Join(args, " "), err, strings.TrimSpace(string(out)))
 }

--- a/daemon/control_client_supervision_test.go
+++ b/daemon/control_client_supervision_test.go
@@ -18,6 +18,17 @@ import (
 // fake systemctl binary. The AF home, unit file, socket, and manager process are
 // all private to the testbox; no host daemon or service manager is touched.
 
+func TestRunEnsureManagerCommand_DeadlineDuringWaitDelayStillSucceeds(t *testing.T) {
+	manager := filepath.Join(t.TempDir(), "manager")
+	if err := os.WriteFile(manager, []byte("#!/bin/sh\nsleep 1\nsleep 30 &\n"), 0o700); err != nil {
+		t.Fatalf("write fake manager: %v", err)
+	}
+
+	if err := runEnsureManagerCommand(time.Now().Add(1100*time.Millisecond), manager, "start"); err != nil {
+		t.Fatalf("the manager exited zero before the deadline; only pipe cleanup crossed it: %v", err)
+	}
+}
+
 func TestEnsureDaemonPrefersHomeServingUnit(t *testing.T) {
 	marker, home := installEnsureTestUnitAndManager(t, false)
 	pidPath := filepath.Join(home, "daemon.pid")

--- a/daemon/control_client_supervision_test.go
+++ b/daemon/control_client_supervision_test.go
@@ -20,11 +20,14 @@ import (
 
 func TestRunEnsureManagerCommand_DeadlineDuringWaitDelayStillSucceeds(t *testing.T) {
 	manager := filepath.Join(t.TempDir(), "manager")
-	if err := os.WriteFile(manager, []byte("#!/bin/sh\nsleep 1\nsleep 30 &\n"), 0o700); err != nil {
+	if err := os.WriteFile(manager, []byte("#!/bin/sh\nsleep 30 >&1 2>&1 &\n"), 0o700); err != nil {
 		t.Fatalf("write fake manager: %v", err)
 	}
 
-	if err := runEnsureManagerCommand(time.Now().Add(1100*time.Millisecond), manager, "start"); err != nil {
+	// The shell exits immediately; the child explicitly retains the capture
+	// pipes. This gives Wait ample time to observe the completed command before
+	// the deadline lands inside the 250ms WaitDelay cleanup window.
+	if err := runEnsureManagerCommand(time.Now().Add(200*time.Millisecond), manager, "start"); err != nil {
 		t.Fatalf("the manager exited zero before the deadline; only pipe cleanup crossed it: %v", err)
 	}
 }

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -709,6 +709,25 @@ func TestRemoteCoderWhoamiWarnsWithoutFailingDoctor(t *testing.T) {
 	require.Zero(t, report.UnresolvedCount(), "coder auth warnings must not fail doctor")
 }
 
+func TestRemoteCoderWhoami_WaitDelayStillUsesTheAnswer(t *testing.T) {
+	testguard.IsolateTmux(t)
+	dir := t.TempDir()
+	binDir := t.TempDir()
+	writeExecutable(t, binDir, "coder", "#!/bin/sh\necho 'alice'\nsleep 30 &\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	hook := writeHookScript(t, dir, "coder-hook.sh", "#!/bin/sh\necho '[]'\n")
+	report, err := Run(withRemote(testOptions(t, false),
+		&config.RemoteHooks{LaunchCmd: hook, DeleteCmd: hook}))
+	require.NoError(t, err)
+
+	checks := findCheckRows(report, "coder")
+	require.Len(t, checks, 1)
+	require.Equal(t, StatusPass, checks[0].Status,
+		"coder answered; a child holding the output pipe is cleanup, not probe failure")
+	require.Equal(t, "alice", checks[0].Detail)
+}
+
 // TestDaemonPingTimeoutIsAdvisoryNotFail is the #2040 fail-first: when the
 // control socket EXISTS but the ping DIAL times out — a live daemon momentarily
 // backlogged under heavy RPC load looks exactly like this — doctor must not read

--- a/doctor/remote.go
+++ b/doctor/remote.go
@@ -2,6 +2,7 @@ package doctor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -127,6 +128,11 @@ func checkCoderStatus(hooks *config.RemoteHooks, report *Report) {
 	cmd := exec.CommandContext(ctx, coderPath, "whoami")
 	cmd.WaitDelay = 500 * time.Millisecond
 	out, err := cmd.CombinedOutput()
+	if errors.Is(err, exec.ErrWaitDelay) {
+		// coder exited zero and answered; only a descendant held the capture
+		// pipe. The completed answer wins even if cleanup reaches the deadline.
+		err = nil
+	}
 	if err != nil {
 		detail := "coder whoami failed"
 		if ctx.Err() == context.DeadlineExceeded {

--- a/doctor/skew.go
+++ b/doctor/skew.go
@@ -930,16 +930,16 @@ func execBinaryVersion(path string) (string, error) {
 	if cmd.Process != nil {
 		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL) // reap stragglers
 	}
+	if err == nil || errors.Is(err, exec.ErrWaitDelay) {
+		// The binary exited zero and its answer is in out. ErrWaitDelay means
+		// only that inherited-pipe cleanup outlived the process; a context
+		// deadline racing that cleanup cannot turn the answer into a timeout.
+		return parseAFVersion(string(out)), nil
+	}
 	if ctx.Err() != nil {
 		return "", fmt.Errorf("%s version timed out after %s: %w", path, binaryProbeTimeout, ctx.Err())
 	}
-	if err != nil && !errors.Is(err, exec.ErrWaitDelay) {
-		// ErrWaitDelay alone means the binary answered and only a straggler held
-		// the pipe — the answer is in `out`, and the reap above killed the
-		// straggler. A real failure surfaces as an ExitError instead.
-		return "", err
-	}
-	return parseAFVersion(string(out)), nil
+	return "", err
 }
 
 // afVersionPattern is the exact shape `af version` prints. Requiring the full

--- a/doctor/skew_test.go
+++ b/doctor/skew_test.go
@@ -799,6 +799,17 @@ func TestExecBinaryVersion_StragglerStillYieldsTheAnswer(t *testing.T) {
 	require.Equal(t, "1.0.192", got)
 }
 
+func TestExecBinaryVersion_DeadlineDuringWaitDelayStillYieldsTheAnswer(t *testing.T) {
+	bin := fakeAFBinary(t, "sleep 4\necho 'agent-factory version 1.0.192'\nsleep 60 &\n")
+
+	start := time.Now()
+	got, err := execBinaryVersion(bin)
+
+	require.Less(t, time.Since(start), 8*time.Second)
+	require.NoError(t, err, "the binary answered before the deadline; only pipe cleanup crossed it")
+	require.Equal(t, "1.0.192", got)
+}
+
 func TestParseAFVersion_ShapeIsRequired(t *testing.T) {
 	// Accepted: our real output, including the released two-line form and an
 	// unreleased build.


### PR DESCRIPTION
Closes #2604

## What was wrong
`execBinaryVersion` checked `ctx.Err()` before interpreting `cmd.Output()`'s result. A PATH binary could print a valid version and exit before the five-second deadline, while a descendant kept stdout open long enough for `WaitDelay` cleanup to cross that deadline. The function then discarded the captured version and reported "timed out" even though execution had answered; only cleanup had not.

That collapses two different outcomes:

- execution did not complete before the deadline: no answer;
- execution completed, but inherited-pipe cleanup crossed the deadline: answered.

## What changed
Completed outcomes now win before deadline classification:

- `nil` and bare `exec.ErrWaitDelay` preserve captured successful output;
- a real deadline is reported only when the command result did not establish completion;
- nonzero service-manager exits with a nonnegative exit code remain completed answers, not unknown state.

The version probe still kills its process group and bounds pipe cleanup. A genuinely hanging binary remains a timeout and exposes no answer.

## Adjacent audit
The same ordering bug existed in three nearby bounded-command paths and is fixed with the same invariant:

- daemon autostart read probes no longer turn a completed service-manager answer into unknown when cleanup crosses the probe deadline;
- daemon service-manager start/kickstart commands no longer report a completed zero exit as timeout;
- doctor's `coder whoami` probe now treats bare `ErrWaitDelay` as an answered result.

Each has a real-process regression that failed before the change.

Other `WaitDelay` sites were audited. Git, Docker, tmux, config, and bug-report runners already normalize `ErrWaitDelay` before checking deadline state. The post-worktree hook's context-first branch is intentionally different: it is caller cancellation used to stop the remaining hook sequence, not an internal probe deadline being interpreted as an answer.

## Red first
The issue regression failed against master:

```
--- FAIL: TestExecBinaryVersion_DeadlineDuringWaitDelayStillYieldsTheAnswer (6.00s)
    skew_test.go:809:
        Error: Received unexpected error:
            /tmp/.../af version timed out after 5s: context deadline exceeded
        Messages: the binary answered before the deadline; only pipe cleanup crossed it
```

The adjacent regressions also failed before the fix:

```
--- FAIL: TestAutostartProbe_DeadlineDuringWaitDelayIsStillAnAnswer (2.21s)
    autostart_inspect_test.go:631: Received unexpected error:
        sh -c ... timed out after 300ms: context deadline exceeded
--- FAIL: TestRunEnsureManagerCommand_DeadlineDuringWaitDelayStillSucceeds (1.25s)
    control_client_supervision_test.go:28: ... manager start timed out: context deadline exceeded
--- FAIL: TestRemoteCoderWhoami_WaitDelayStillUsesTheAnswer (0.52s)
    doctor_test.go:726: expected PASS, actual WARN
```

## Validation
Pushed head: `c54d1df1e8ab9b264e7a0f04f4aaee97ee71fdb2`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- focused regressions in the test container
- full daemon and doctor package tests in the test container
- `make test-container` (full suite, last, on the pushed head)


## macOS CI follow-up
The first pushed test fixture gave the shell only 100ms to have its successful exit observed before the deadline. Under the macOS race run, that deadline genuinely killed the shell, so the test correctly received an unknown timeout instead of exercising WaitDelay cleanup. The portable fixture now exits immediately, explicitly keeps both capture pipes open in its child, and leaves a one-second observation margin before the deadline. The adjacent manager regression received the same hardening. Both passed 20 consecutive isolated-container iterations before the full suite passed on the pushed head above.
