### PR TITLE
Surface project deregistration in delete responses

### DIFF
--- a/api/projects.go
+++ b/api/projects.go
@@ -167,6 +167,7 @@ were archived.`,
 			"repo_path":      req.RepoPath,
 			"archived_count": resp.ArchivedCount,
 			"killed_count":   resp.KilledCount,
+			"deregistered":   resp.Deregistered,
 		})
 	},
 }

--- a/api/projects_delete_test.go
+++ b/api/projects_delete_test.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/daemon"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestProjectsDeleteJSONReportsDeregistration guards #2645's remaining CLI
+// contract: the daemon already reports whether it removed the durable project
+// record, so the command must not hide that outcome from JSON callers.
+func TestProjectsDeleteJSONReportsDeregistration(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	target := filepath.Join(t.TempDir(), "moved-project")
+
+	original := deleteProjectViaDaemon
+	deleteProjectViaDaemon = func(daemon.DeleteProjectRequest) (daemon.DeleteProjectResponse, error) {
+		return daemon.DeleteProjectResponse{OK: true, Deregistered: true}, nil
+	}
+	t.Cleanup(func() { deleteProjectViaDaemon = original })
+
+	out := captureStdout(t, func() {
+		require.NoError(t, projectsDeleteCmd.RunE(projectsDeleteCmd, []string{target}))
+	})
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &payload))
+	require.Equal(t, true, payload["deregistered"],
+		"projects delete JSON must expose the daemon's durable-registration outcome")
+}

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -708,6 +708,7 @@ func (s *controlServer) DeleteProject(req DeleteProjectRequest, resp *DeleteProj
 	resp.OK = true
 	resp.ArchivedCount = len(result.Archived)
 	resp.KilledCount = len(result.Killed)
+	resp.Deregistered = result.Deregistered
 	return nil
 }
 

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -171,6 +171,8 @@ type DeleteProjectResponse struct {
 	// down instead — only in-place/external worktrees (the root agent, `--here`
 	// sessions), whose kill never touches the user's tree or branch.
 	KilledCount int `json:"killed_count"`
+	// Deregistered reports whether the durable project record was removed.
+	Deregistered bool `json:"deregistered"`
 }
 
 // RegisterProjectRequest asks the daemon to register a git checkout as a durable,

--- a/daemon/register_project_test.go
+++ b/daemon/register_project_test.go
@@ -195,6 +195,7 @@ func TestControlServer_DeleteProject_RemovesRegistryRecordAndPublishes(t *testin
 	require.True(t, del.OK)
 	assert.Equal(t, 0, del.ArchivedCount, "a sessionless project archives nothing")
 	assert.Equal(t, 0, del.KilledCount)
+	assert.True(t, del.Deregistered, "the control response must report that the durable registration was removed")
 
 	waitForEvent(t, ch, agentproto.EventProjectsChanged)
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -472,11 +472,13 @@ export async function handoffSession(id: string, title: string, to: string, toke
 }
 
 /** The daemon's DeleteProject response: how many sessions it archived vs tore
- *  down (in-place ones that can't be archived). */
+ *  down (in-place ones that can't be archived), and whether it removed the
+ *  durable project registration. */
 export interface DeleteProjectResult {
   ok: boolean;
   archived_count: number;
   killed_count: number;
+  deregistered: boolean;
 }
 
 /** Deletes a project (mirrors `af projects delete`): regular live sessions are


### PR DESCRIPTION
## Summary

- carry the manager's `Deregistered` outcome through the DeleteProject control response
- expose `deregistered` in `af projects delete` JSON
- align the web response type with the additive daemon field

## Verified scope

PR #2676 already corrected the stale Cobra help and generated CLI reference on current master. This PR completes #2645's separately identified JSON-response gap; it does not duplicate the merged documentation change.

## Red-first evidence

The first contract test exposed the missing response shape:

`api/projects_delete_test.go:22:39: unknown field Deregistered in struct literal of type daemon.DeleteProjectResponse`

After adding only the response field, the two behavior tests failed independently:

`projects delete JSON must expose the daemon's durable-registration outcome: expected true, actual <nil>`

`the control response must report that the durable registration was removed: Should be true`

## Validation

Validated pushed SHA `19f0ba0138c2d049440327b09e6439736adcc8ef`:

- focused CLI JSON regression
- focused real control-server deregistration regression
- `make test-container GOTESTARGS='./api ./daemon'`
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container` (full suite, run last)

Closes #2645