### PR TITLE
Tolerate tmux sessions vanishing during reset ownership checks

### DIFF
--- a/internal/proctree/proctree.go
+++ b/internal/proctree/proctree.go
@@ -170,11 +170,28 @@ func SessionMembers(snap map[int]Process, sid int) []Process {
 // whether to keep WAITING, and waiting forever on a process we cannot see is
 // worse than stopping early on one that is somehow still there.
 func AliveSame(p Process) bool {
-	cur, err := readProc(p.PID)
+	same, _ := SameIdentity(p)
+	return same
+}
+
+// SameIdentity is AliveSame without its deliberate error collapse. It reports
+// a definitive false only when the process exited, became a zombie, or the PID
+// now names a different process instance. A denied or malformed identity read
+// remains an error so destructive callers never turn "could not check" into
+// permission to delete the process's workspace.
+func SameIdentity(p Process) (bool, error) {
+	return sameIdentity(p, readProc)
+}
+
+func sameIdentity(p Process, read func(int) (Process, error)) (bool, error) {
+	cur, err := read(p.PID)
 	if err != nil {
-		return false
+		if errors.Is(err, ErrProcessExited) || errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ESRCH) {
+			return false, nil
+		}
+		return false, fmt.Errorf("cannot revalidate pid %d identity: %w", p.PID, err)
 	}
-	return cur.StartID == p.StartID
+	return cur.StartID == p.StartID, nil
 }
 
 // ErrIdentityChanged is returned by Signal when the PID no longer names the

--- a/internal/proctree/proctree_darwin.go
+++ b/internal/proctree/proctree_darwin.go
@@ -73,10 +73,23 @@ const szomb = 5
 // readProc reads one process's kinfo_proc. Returns an error when the pid names
 // no live process, which is what makes it usable as an identity check.
 func readProc(pid int) (Process, error) {
-	kp, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	// The singular x/sys wrapper maps every response whose length differs from
+	// one kinfo_proc to EIO. For an exact PID that has exited, Darwin returns a
+	// successful zero-length response, so that wrapper erases authoritative
+	// absence into an undifferentiated error. The slice wrapper preserves the
+	// empty result while still surfacing actual sysctl failures and malformed
+	// response sizes.
+	kps, err := unix.SysctlKinfoProcSlice("kern.proc.pid", pid)
 	if err != nil {
 		return Process{}, err
 	}
+	if len(kps) == 0 {
+		return Process{}, ErrProcessExited
+	}
+	if len(kps) != 1 {
+		return Process{}, fmt.Errorf("kern.proc.pid returned %d entries for pid %d", len(kps), pid)
+	}
+	kp := &kps[0]
 	// kern.proc.pid answers for zombies too, with ppid, session and start time
 	// all intact — so without this the identity check matches a process that
 	// has already exited. Same defect as the Linux state field, same fix

--- a/internal/proctree/proctree_test.go
+++ b/internal/proctree/proctree_test.go
@@ -150,6 +150,23 @@ func TestSignalVerifiesIdentity(t *testing.T) {
 	}
 }
 
+// TestSameIdentityReadFailureIsUnknown distinguishes an unreadable identity
+// from a process that definitively exited or recycled its PID. Destructive
+// callers use this error-bearing form; AliveSame deliberately keeps collapsing
+// the same read failure to false for wait loops.
+func TestSameIdentityReadFailureIsUnknown(t *testing.T) {
+	readErr := errors.New("identity read denied")
+	same, err := sameIdentity(Process{PID: 42, StartID: 7}, func(int) (Process, error) {
+		return Process{}, readErr
+	})
+	if same {
+		t.Fatal("sameIdentity reported an unreadable process as the same identity")
+	}
+	if !errors.Is(err, readErr) {
+		t.Fatalf("sameIdentity error = %v, want read failure to remain reachable", err)
+	}
+}
+
 // TestSignalReapedInTOCTOUWindow simulates the process being reaped in the
 // unavoidable window between the identity check and the delivery of the
 // signal: AliveSame passes (the child is genuinely alive) but the kernel

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -348,18 +348,39 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 }
 
 func reapVanishedSessionProcesses(match, ownHome string, candidates []proctree.Process, captureErr error) error {
-	marked, inspectErr := markedOrphanProcesses(candidates, match, ownHome)
-	remaining := reapLeakedProcesses(match, marked, reapGraceWait, reapTermWait)
-	if len(remaining) > 0 {
-		pids := make([]string, 0, len(remaining))
-		for _, process := range remaining {
+	var sweepErr error
+	if captureErr != nil {
+		sweepErr = fmt.Errorf("could not establish the complete pane process tree before ownership lookup: %w", captureErr)
+	}
+	// Two refresh/reap passes cover a helper that appears after the pre-marker
+	// snapshot and a child it forks during the first bounded grace period. A
+	// final non-destructive refresh below is the evidence that cleanup finished.
+	for range 2 {
+		refreshed, refreshErr := refreshOrphanCandidates(candidates, match)
+		sweepErr = errors.Join(sweepErr, refreshErr)
+		marked, inspectErr := markedOrphanProcesses(refreshed, match, ownHome)
+		sweepErr = errors.Join(sweepErr, inspectErr)
+		remaining := reapLeakedProcesses(match, marked, reapGraceWait, reapTermWait)
+		if len(remaining) > 0 {
+			pids := make([]string, 0, len(remaining))
+			for _, process := range remaining {
+				pids = append(pids, fmt.Sprintf("%d", process.PID))
+			}
+			sweepErr = errors.Join(sweepErr, fmt.Errorf("marked processes %s are still alive after bounded teardown",
+				strings.Join(pids, ", ")))
+		}
+		candidates = refreshed
+	}
+	finalCandidates, refreshErr := refreshOrphanCandidates(candidates, match)
+	left, inspectErr := markedOrphanProcesses(finalCandidates, match, ownHome)
+	sweepErr = errors.Join(sweepErr, refreshErr, inspectErr)
+	if len(left) > 0 {
+		pids := make([]string, 0, len(left))
+		for _, process := range left {
 			pids = append(pids, fmt.Sprintf("%d", process.PID))
 		}
-		inspectErr = errors.Join(inspectErr, fmt.Errorf("marked processes %s are still alive after bounded teardown",
+		sweepErr = errors.Join(sweepErr, fmt.Errorf("marked processes %s appeared or remained after the orphan sweep",
 			strings.Join(pids, ", ")))
 	}
-	if captureErr != nil {
-		captureErr = fmt.Errorf("could not establish the complete pane process tree before ownership lookup: %w", captureErr)
-	}
-	return errors.Join(captureErr, inspectErr)
+	return sweepErr
 }

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -133,13 +133,20 @@ func probeSessionStrict(cmdExec cmd.Executor, name string) (exists bool, known b
 }
 
 // missingTmuxSession recognizes tmux's explicit exact-target absence answer.
-// Exit status 1 alone is ambiguous: a wrapper, policy failure, or unreachable
-// server can return the same status while the named session remains unknown.
+// Exit status 1 alone is ambiguous: wrapper, policy, and unclassified connection
+// failures can return the same status while the named session remains unknown.
+// An explicit no-server diagnostic is also definitive: no session can remain.
 func missingTmuxSession(err error, name string) bool {
 	var exitErr *exec.ExitError
-	return errors.As(err, &exitErr) &&
-		exitErr.ExitCode() == 1 &&
-		strings.TrimSpace(string(exitErr.Stderr)) == "can't find session: "+name
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+		return false
+	}
+	diagnostic := strings.TrimSpace(string(exitErr.Stderr))
+	if diagnostic == "can't find session: "+name {
+		return true
+	}
+	serverSocket, noServer := strings.CutPrefix(diagnostic, "no server running on ")
+	return noServer && strings.TrimSpace(serverSocket) != ""
 }
 
 // exactTarget builds an exact-match `-t` target spec for the named session.

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -209,6 +209,25 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 	for i, match := range prefixed {
 		prefixed[i] = match[:strings.Index(match, ":")]
 	}
+	// Capture every listed session's verified pane process tree before marker
+	// lookup. If the session vanishes during that lookup, tmux can no longer
+	// recover its pane ancestry; this is the last authoritative opportunity to
+	// bind any detached helper to the session. Capture errors are retained for
+	// the vanished-session branch; a live owned session is captured again just
+	// before kill, and a foreign session's unreadable panes never block this
+	// home's sweep.
+	preMarkerProcesses := make(map[string][]proctree.Process, len(prefixed))
+	preMarkerCaptureErrs := make(map[string]error, len(prefixed))
+	for _, match := range prefixed {
+		preMarkerProcesses[match], preMarkerCaptureErrs[match] = captureSessionProcessTrees(cmdExec, match)
+		if errors.Is(preMarkerCaptureErrs[match], ErrTmuxTimeout) {
+			// The server is already known to be wedged. Do not launch the
+			// ownership probe against it and pay another full timeout for an
+			// answer that still could not authorize deletion.
+			return fmt.Errorf("cannot capture tmux session %s processes before ownership lookup; refusing to continue cleanup: %w",
+				match, preMarkerCaptureErrs[match])
+		}
+	}
 
 	// Home-scope the sweep (#1122): the af_ prefix alone does not prove this
 	// home owns the session — another install or an escaped test process can
@@ -235,7 +254,7 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 			// reaper, so the absent branch performs an ownership-scoped process sweep.
 			exists, known, probeErr := probeSessionStrict(cmdExec, match)
 			if known && !exists {
-				if reapErr := reapVanishedSessionProcesses(match, ownHome); reapErr != nil {
+				if reapErr := reapVanishedSessionProcesses(match, ownHome, preMarkerProcesses[match], preMarkerCaptureErrs[match]); reapErr != nil {
 					return fmt.Errorf("tmux session %s vanished during ownership lookup, but its process cleanup is incomplete: %w",
 						match, reapErr)
 				}
@@ -328,8 +347,8 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 	return killErr
 }
 
-func reapVanishedSessionProcesses(match, ownHome string) error {
-	marked, inspectErr := markedOrphanProcesses(match, ownHome)
+func reapVanishedSessionProcesses(match, ownHome string, candidates []proctree.Process, captureErr error) error {
+	marked, inspectErr := markedOrphanProcesses(candidates, match, ownHome)
 	remaining := reapLeakedProcesses(match, marked, reapGraceWait, reapTermWait)
 	if len(remaining) > 0 {
 		pids := make([]string, 0, len(remaining))
@@ -339,17 +358,8 @@ func reapVanishedSessionProcesses(match, ownHome string) error {
 		inspectErr = errors.Join(inspectErr, fmt.Errorf("marked processes %s are still alive after bounded teardown",
 			strings.Join(pids, ", ")))
 	}
-	// Re-snapshot after signalling. A helper can fork between the first snapshot
-	// and SIGTERM; only a second affirmative empty result proves the sweep did
-	// not leave a newly detached marked child behind.
-	left, verifyErr := markedOrphanProcesses(match, ownHome)
-	if len(left) > 0 {
-		pids := make([]string, 0, len(left))
-		for _, process := range left {
-			pids = append(pids, fmt.Sprintf("%d", process.PID))
-		}
-		verifyErr = errors.Join(verifyErr, fmt.Errorf("marked processes %s appeared or remained after the orphan sweep",
-			strings.Join(pids, ", ")))
+	if captureErr != nil {
+		captureErr = fmt.Errorf("could not establish the complete pane process tree before ownership lookup: %w", captureErr)
 	}
-	return errors.Join(inspectErr, verifyErr)
+	return errors.Join(captureErr, inspectErr)
 }

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -263,8 +263,16 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 			}
 			// Idempotent teardown (#967): a session can vanish between the
 			// `tmux ls` above and this kill (TOCTOU). A gone session is the
-			// goal of cleanup, so only a survivor is a real failure.
-			if sessionExists(cmdExec, match) {
+			// goal of cleanup, but only an authoritative absence may turn the
+			// kill error into success. A failed re-probe leaves teardown unknown
+			// and must stop before process trees are reaped.
+			exists, known, probeErr := probeSessionStrict(cmdExec, match)
+			if !known {
+				killErr = fmt.Errorf("failed to kill tmux session %s and cannot determine whether it survived: %w",
+					match, errors.Join(killErrRaw, probeErr))
+				break
+			}
+			if exists {
 				killErr = fmt.Errorf("failed to kill tmux session %s: %v", match, killErrRaw)
 				break
 			}

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -112,24 +112,34 @@ func probeSession(cmdExec cmd.Executor, name string) (exists bool, known bool) {
 
 // probeSessionStrict is the non-lossy existence probe for CleanupSessions'
 // ownership gate. Unlike probeSession, it does not treat every non-timeout
-// execution failure as absence: only tmux's ordinary exit 1 is a determinate
-// "no such session" answer. Any other failure remains unknown and cannot
-// authorize reset to continue to worktree deletion.
+// execution failure as absence: only tmux's ordinary exit 1 paired with its
+// exact "can't find session" diagnostic is a determinate answer. Any other
+// failure remains unknown and cannot authorize reset to continue to worktree
+// deletion.
 func probeSessionStrict(cmdExec cmd.Executor, name string) (exists bool, known bool, err error) {
 	ctx, cancel := tmuxTimeoutContext()
 	defer cancel()
-	err = runTmuxBoundedWith(ctx, cmdExec, "has-session", fmt.Sprintf("-t=%s", name))
+	_, err = outputTmuxBoundedWith(ctx, cmdExec, "has-session", fmt.Sprintf("-t=%s", name))
 	if err == nil {
 		return true, true, nil
 	}
 	if ctx.Err() != nil {
 		return false, false, fmt.Errorf("%w: has-session %s after %s", ErrTmuxTimeout, name, tmuxCommandTimeout)
 	}
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+	if missingTmuxSession(err, name) {
 		return false, true, nil
 	}
 	return false, false, fmt.Errorf("has-session for %s did not return a usable answer: %w", name, err)
+}
+
+// missingTmuxSession recognizes tmux's explicit exact-target absence answer.
+// Exit status 1 alone is ambiguous: a wrapper, policy failure, or unreachable
+// server can return the same status while the named session remains unknown.
+func missingTmuxSession(err error, name string) bool {
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr) &&
+		exitErr.ExitCode() == 1 &&
+		strings.TrimSpace(string(exitErr.Stderr)) == "can't find session: "+name
 }
 
 // exactTarget builds an exact-match `-t` target spec for the named session.
@@ -204,8 +214,14 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 	for _, match := range prefixed {
 		home, ok, markerErr := sessionHomeMarker(cmdExec, match)
 		if markerErr != nil {
+			if errors.Is(markerErr, ErrTmuxTimeout) {
+				// The same server is already known to be wedged. A fallback
+				// probe would wait on it for another full timeout and still
+				// could not turn the ownership result into affirmative state.
+				return fmt.Errorf("cannot determine tmux session %s ownership; refusing to continue cleanup: %w", match, markerErr)
+			}
 			// The session may have disappeared after `tmux ls`. Re-probe the
-			// exact name after EVERY marker error: only an authoritative
+			// exact name after every non-timeout marker error: only an authoritative
 			// has-session absence turns this race into a successful no-op.
 			exists, known, probeErr := probeSessionStrict(cmdExec, match)
 			if known && !exists {

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -229,10 +229,17 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 			}
 			// The session may have disappeared after `tmux ls`. Re-probe the
 			// exact name after every non-timeout marker error: only an authoritative
-			// has-session absence turns this race into a successful no-op.
+			// has-session absence turns this race into a successful cleanup. Session
+			// absence is not process absence: a detached AF_SESSION-marked helper may
+			// have survived after tmux lost the pane ancestry used by the normal
+			// reaper, so the absent branch performs an ownership-scoped process sweep.
 			exists, known, probeErr := probeSessionStrict(cmdExec, match)
 			if known && !exists {
-				log.InfoLog.Printf("tmux session %s vanished during ownership lookup; nothing remains to clean", match)
+				if reapErr := reapVanishedSessionProcesses(match, ownHome); reapErr != nil {
+					return fmt.Errorf("tmux session %s vanished during ownership lookup, but its process cleanup is incomplete: %w",
+						match, reapErr)
+				}
+				log.InfoLog.Printf("tmux session %s vanished during ownership lookup; marked orphan process sweep completed", match)
 				continue
 			}
 			if !known {
@@ -319,4 +326,30 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 	}
 	wg.Wait()
 	return killErr
+}
+
+func reapVanishedSessionProcesses(match, ownHome string) error {
+	marked, inspectErr := markedOrphanProcesses(match, ownHome)
+	remaining := reapLeakedProcesses(match, marked, reapGraceWait, reapTermWait)
+	if len(remaining) > 0 {
+		pids := make([]string, 0, len(remaining))
+		for _, process := range remaining {
+			pids = append(pids, fmt.Sprintf("%d", process.PID))
+		}
+		inspectErr = errors.Join(inspectErr, fmt.Errorf("marked processes %s are still alive after bounded teardown",
+			strings.Join(pids, ", ")))
+	}
+	// Re-snapshot after signalling. A helper can fork between the first snapshot
+	// and SIGTERM; only a second affirmative empty result proves the sweep did
+	// not leave a newly detached marked child behind.
+	left, verifyErr := markedOrphanProcesses(match, ownHome)
+	if len(left) > 0 {
+		pids := make([]string, 0, len(left))
+		for _, process := range left {
+			pids = append(pids, fmt.Sprintf("%d", process.PID))
+		}
+		verifyErr = errors.Join(verifyErr, fmt.Errorf("marked processes %s appeared or remained after the orphan sweep",
+			strings.Join(pids, ", ")))
+	}
+	return errors.Join(inspectErr, verifyErr)
 }

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -109,6 +110,28 @@ func probeSession(cmdExec cmd.Executor, name string) (exists bool, known bool) {
 	return false, true
 }
 
+// probeSessionStrict is the non-lossy existence probe for CleanupSessions'
+// ownership gate. Unlike probeSession, it does not treat every non-timeout
+// execution failure as absence: only tmux's ordinary exit 1 is a determinate
+// "no such session" answer. Any other failure remains unknown and cannot
+// authorize reset to continue to worktree deletion.
+func probeSessionStrict(cmdExec cmd.Executor, name string) (exists bool, known bool, err error) {
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
+	err = runTmuxBoundedWith(ctx, cmdExec, "has-session", fmt.Sprintf("-t=%s", name))
+	if err == nil {
+		return true, true, nil
+	}
+	if ctx.Err() != nil {
+		return false, false, fmt.Errorf("%w: has-session %s after %s", ErrTmuxTimeout, name, tmuxCommandTimeout)
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false, true, nil
+	}
+	return false, false, fmt.Errorf("has-session for %s did not return a usable answer: %w", name, err)
+}
+
 // exactTarget builds an exact-match `-t` target spec for the named session.
 //
 // tmux resolves a bare `-t name` by exact match first and then PREFIX match, so
@@ -181,6 +204,18 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 	for _, match := range prefixed {
 		home, ok, markerErr := sessionHomeMarker(cmdExec, match)
 		if markerErr != nil {
+			// The session may have disappeared after `tmux ls`. Re-probe the
+			// exact name after EVERY marker error: only an authoritative
+			// has-session absence turns this race into a successful no-op.
+			exists, known, probeErr := probeSessionStrict(cmdExec, match)
+			if known && !exists {
+				log.InfoLog.Printf("tmux session %s vanished during ownership lookup; nothing remains to clean", match)
+				continue
+			}
+			if !known {
+				return fmt.Errorf("cannot determine tmux session %s ownership or whether it survived; refusing to continue cleanup: %w",
+					match, errors.Join(markerErr, probeErr))
+			}
 			return fmt.Errorf("cannot determine tmux session %s ownership; refusing to continue cleanup: %w", match, markerErr)
 		}
 		switch {

--- a/session/tmux/cleanup_unknown_test.go
+++ b/session/tmux/cleanup_unknown_test.go
@@ -16,6 +16,7 @@ import (
 // continuing on to worktree deletion.
 func TestCleanupSessionsOwnershipCheckTimeoutIsUnknown(t *testing.T) {
 	dir := t.TempDir()
+	probeMarker := filepath.Join(dir, "has-session-called")
 	script := `#!/bin/sh
 case "$1" in
 ls)
@@ -24,6 +25,10 @@ ls)
 show-environment)
   sleep 300 &
   wait
+  ;;
+has-session)
+  : > "$PROBE_MARKER"
+  exit 1
   ;;
 *)
   exit 97
@@ -35,11 +40,15 @@ esac
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	t.Setenv("PROBE_MARKER", probeMarker)
 	shortTmuxTimeout(t, 200*time.Millisecond)
 
 	err := CleanupSessions(cmd.MakeExecutor())
 	if !errors.Is(err, ErrTmuxTimeout) {
 		t.Fatalf("CleanupSessions error = %v, want ErrTmuxTimeout when AF_HOME ownership probe does not answer", err)
+	}
+	if _, err := os.Stat(probeMarker); !os.IsNotExist(err) {
+		t.Fatalf("marker timeout launched a second tmux probe, stat error = %v", err)
 	}
 }
 
@@ -170,6 +179,7 @@ show-environment)
   ;;
 has-session)
   [ "${2-}" = "-t=af_gone" ] || exit 98
+  printf "can't find session: af_gone\n" >&2
   exit 1
   ;;
 *)
@@ -220,6 +230,40 @@ esac
 	err := CleanupSessions(cmd.MakeExecutor())
 	if !errors.Is(err, ErrTmuxTimeout) {
 		t.Fatalf("CleanupSessions error = %v, want ErrTmuxTimeout when the exact session re-probe does not answer", err)
+	}
+}
+
+// TestCleanupSessionsMarkerErrorReprobeExit1FailureIsUnknown guards the exact
+// absence diagnostic. Exit 1 alone is ambiguous: a wrapper or policy failure
+// can use it too, so only tmux's named missing-session response may let reset
+// continue to destructive worktree cleanup.
+func TestCleanupSessionsMarkerErrorReprobeExit1FailureIsUnknown(t *testing.T) {
+	dir := t.TempDir()
+	script := `#!/bin/sh
+case "$1" in
+ls)
+  echo 'af_unknown: 1 windows (created Thu Jan 1 00:00:00 1970)'
+  ;;
+show-environment)
+  exit 97
+  ;;
+has-session)
+  printf 'policy denied\n' >&2
+  exit 1
+  ;;
+*)
+  exit 98
+  ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	if err := CleanupSessions(cmd.MakeExecutor()); err == nil {
+		t.Fatal("CleanupSessions error = nil, want exit 1 without tmux's absence diagnostic to remain unknown")
 	}
 }
 

--- a/session/tmux/cleanup_unknown_test.go
+++ b/session/tmux/cleanup_unknown_test.go
@@ -222,3 +222,42 @@ esac
 		t.Fatalf("CleanupSessions error = %v, want ErrTmuxTimeout when the exact session re-probe does not answer", err)
 	}
 }
+
+// TestCleanupSessionsKillFailureReprobeFailureIsUnknown covers the adjacent
+// destructive call site. A failed kill followed by a generic has-session
+// failure does not prove that the session disappeared, so cleanup must not
+// report success and continue to process-tree reaping.
+func TestCleanupSessionsKillFailureReprobeFailureIsUnknown(t *testing.T) {
+	dir := t.TempDir()
+	script := `#!/bin/sh
+case "$1" in
+ls)
+  echo 'af_owned: 1 windows (created Thu Jan 1 00:00:00 1970)'
+  ;;
+show-environment)
+  printf 'AF_HOME=%s\n' "$AGENT_FACTORY_HOME"
+  ;;
+list-panes)
+  ;;
+kill-session)
+  exit 97
+  ;;
+has-session)
+  [ "${2-}" = "-t=af_owned" ] || exit 99
+  exit 98
+  ;;
+*)
+  exit 96
+  ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	if err := CleanupSessions(cmd.MakeExecutor()); err == nil {
+		t.Fatal("CleanupSessions error = nil, want generic exact post-kill re-probe failure to remain unknown")
+	}
+}

--- a/session/tmux/cleanup_unknown_test.go
+++ b/session/tmux/cleanup_unknown_test.go
@@ -52,6 +52,49 @@ esac
 	}
 }
 
+// TestCleanupSessionsPreMarkerCaptureTimeoutStopsBeforeOwnershipProbe guards
+// the process-capture phase added for vanished-session helpers. A tripped
+// list-panes deadline already proves the server is wedged; launching the marker
+// lookup afterward would wait on the same server for a second full timeout and
+// still could not establish safe cleanup state.
+func TestCleanupSessionsPreMarkerCaptureTimeoutStopsBeforeOwnershipProbe(t *testing.T) {
+	dir := t.TempDir()
+	markerProbe := filepath.Join(dir, "show-environment-called")
+	script := `#!/bin/sh
+case "$1" in
+ls)
+  echo 'af_owned: 1 windows (created Thu Jan 1 00:00:00 1970)'
+  ;;
+list-panes)
+  sleep 300 &
+  wait
+  ;;
+show-environment)
+  : > "$MARKER_PROBE"
+  printf 'AF_HOME=%s\n' "$AGENT_FACTORY_HOME"
+  ;;
+*)
+  exit 97
+  ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	t.Setenv("MARKER_PROBE", markerProbe)
+	shortTmuxTimeout(t, 200*time.Millisecond)
+
+	err := CleanupSessions(cmd.MakeExecutor())
+	if !errors.Is(err, ErrTmuxTimeout) {
+		t.Fatalf("CleanupSessions error = %v, want ErrTmuxTimeout from pre-marker process capture", err)
+	}
+	if _, err := os.Stat(markerProbe); !os.IsNotExist(err) {
+		t.Fatalf("capture timeout launched ownership marker probe, stat error = %v", err)
+	}
+}
+
 // TestCleanupSessionsOwnershipCheckFailureIsUnknown covers the adjacent
 // non-timeout case. Unfiltered show-environment reports a genuinely absent
 // marker with successful output, so a command failure means ownership was not
@@ -174,6 +217,8 @@ case "$1" in
 ls)
   echo 'af_gone: 1 windows (created Thu Jan 1 00:00:00 1970)'
   ;;
+list-panes)
+  ;;
 show-environment)
   exit 1
   ;;
@@ -208,6 +253,8 @@ func TestCleanupSessionsToleratesLastSessionGoneDuringMarkerLookup(t *testing.T)
 case "$1" in
 ls)
   echo 'af_gone: 1 windows (created Thu Jan 1 00:00:00 1970)'
+  ;;
+list-panes)
   ;;
 show-environment)
   printf 'no server running on /tmp/tmux-1001/test\n' >&2

--- a/session/tmux/cleanup_unknown_test.go
+++ b/session/tmux/cleanup_unknown_test.go
@@ -198,6 +198,42 @@ esac
 	}
 }
 
+// TestCleanupSessionsToleratesLastSessionGoneDuringMarkerLookup covers the
+// same race when the disappearing session was the server's last one. tmux's
+// explicit no-server diagnostic authoritatively means no session can remain;
+// broader connection failures must still stay unknown.
+func TestCleanupSessionsToleratesLastSessionGoneDuringMarkerLookup(t *testing.T) {
+	dir := t.TempDir()
+	script := `#!/bin/sh
+case "$1" in
+ls)
+  echo 'af_gone: 1 windows (created Thu Jan 1 00:00:00 1970)'
+  ;;
+show-environment)
+  printf 'no server running on /tmp/tmux-1001/test\n' >&2
+  exit 1
+  ;;
+has-session)
+  [ "${2-}" = "-t=af_gone" ] || exit 98
+  printf 'no server running on /tmp/tmux-1001/test\n' >&2
+  exit 1
+  ;;
+*)
+  exit 97
+  ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	if err := CleanupSessions(cmd.MakeExecutor()); err != nil {
+		t.Fatalf("CleanupSessions error = %v, want an explicitly absent tmux server to prove the last session vanished", err)
+	}
+}
+
 // TestCleanupSessionsMarkerErrorReprobeTimeoutIsUnknown guards the second
 // half of #2706's tri-state: failure to answer the exact existence re-probe is
 // not evidence that the session vanished and must stop destructive reset work.

--- a/session/tmux/cleanup_unknown_test.go
+++ b/session/tmux/cleanup_unknown_test.go
@@ -153,3 +153,72 @@ esac
 		t.Fatal("CleanupSessions error = nil, want transient targeted marker failure to remain unknown")
 	}
 }
+
+// TestCleanupSessionsToleratesSessionGoneDuringMarkerLookup guards #2706's
+// ls-to-ownership-probe race. A session that definitively vanished is already
+// clean; only a surviving session or an unanswered existence probe should abort
+// reset.
+func TestCleanupSessionsToleratesSessionGoneDuringMarkerLookup(t *testing.T) {
+	dir := t.TempDir()
+	script := `#!/bin/sh
+case "$1" in
+ls)
+  echo 'af_gone: 1 windows (created Thu Jan 1 00:00:00 1970)'
+  ;;
+show-environment)
+  exit 1
+  ;;
+has-session)
+  [ "${2-}" = "-t=af_gone" ] || exit 98
+  exit 1
+  ;;
+*)
+  exit 97
+  ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	if err := CleanupSessions(cmd.MakeExecutor()); err != nil {
+		t.Fatalf("CleanupSessions error = %v, want a definitively vanished session to be tolerated", err)
+	}
+}
+
+// TestCleanupSessionsMarkerErrorReprobeTimeoutIsUnknown guards the second
+// half of #2706's tri-state: failure to answer the exact existence re-probe is
+// not evidence that the session vanished and must stop destructive reset work.
+func TestCleanupSessionsMarkerErrorReprobeTimeoutIsUnknown(t *testing.T) {
+	dir := t.TempDir()
+	script := `#!/bin/sh
+case "$1" in
+ls)
+  echo 'af_unknown: 1 windows (created Thu Jan 1 00:00:00 1970)'
+  ;;
+show-environment)
+  exit 97
+  ;;
+has-session)
+  sleep 300 &
+  wait
+  ;;
+*)
+  exit 98
+  ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	shortTmuxTimeout(t, 200*time.Millisecond)
+
+	err := CleanupSessions(cmd.MakeExecutor())
+	if !errors.Is(err, ErrTmuxTimeout) {
+		t.Fatalf("CleanupSessions error = %v, want ErrTmuxTimeout when the exact session re-probe does not answer", err)
+	}
+}

--- a/session/tmux/envmarker.go
+++ b/session/tmux/envmarker.go
@@ -68,7 +68,7 @@ func sessionEnvFlags(sanitizedName string) []string {
 // an unrelated value as a forged-looking AF_HOME line. If the targeted query
 // fails, an unfiltered query is used only to prove that the session answered and
 // the named variable was absent. If neither query answers, ownership remains
-// unknown and cleanup stops before destructive reset work.
+// unknown and cleanup decides whether the exact session has since vanished.
 func sessionHomeMarker(cmdExec cmd.Executor, sanitizedName string) (home string, present bool, err error) {
 	ctx, cancel := tmuxTimeoutContext()
 	out, markerErr := outputTmuxBoundedWith(ctx, cmdExec, "show-environment", "-t", exactTarget(sanitizedName), EnvMarkerHome)

--- a/session/tmux/idempotent_close_test.go
+++ b/session/tmux/idempotent_close_test.go
@@ -88,7 +88,7 @@ func TestCleanupSessions_ToleratesVanishedSession(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", "/owned-home")
 	const lsOutput = `af_gone: 1 windows (created Wed May 20 12:00:00 2026) [179x47]
 af_stuck: 1 windows (created Wed May 20 12:01:00 2026) [179x47]`
-	absentExit := exec.Command("sh", "-c", "exit 1").Run()
+	_, absentExit := exec.Command("sh", "-c", "printf \"can't find session: af_gone\\n\" >&2; exit 1").Output()
 	var tmuxExit *exec.ExitError
 	require.ErrorAs(t, absentExit, &tmuxExit)
 	require.Equal(t, 1, tmuxExit.ExitCode())
@@ -128,6 +128,12 @@ af_stuck: 1 windows (created Wed May 20 12:01:00 2026) [179x47]`
 				return nil
 			},
 			OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+				if strings.Contains(strings.Join(c.Args, " "), "has-session") {
+					if stillPresent[nameOf(c)] {
+						return []byte(""), nil
+					}
+					return nil, absentExit
+				}
 				if len(c.Args) > 1 && c.Args[1] == "show-environment" {
 					// Both sessions carry this home's marker (#1122).
 					return []byte("AF_HOME=/owned-home\n"), nil
@@ -158,6 +164,12 @@ af_stuck: 1 windows (created Wed May 20 12:01:00 2026) [179x47]`
 				return nil
 			},
 			OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+				if strings.Contains(strings.Join(c.Args, " "), "has-session") {
+					if stillPresent[nameOf(c)] {
+						return []byte(""), nil
+					}
+					return nil, absentExit
+				}
 				if len(c.Args) > 1 && c.Args[1] == "show-environment" {
 					// Both sessions carry this home's marker (#1122).
 					return []byte("AF_HOME=/owned-home\n"), nil

--- a/session/tmux/idempotent_close_test.go
+++ b/session/tmux/idempotent_close_test.go
@@ -88,6 +88,10 @@ func TestCleanupSessions_ToleratesVanishedSession(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", "/owned-home")
 	const lsOutput = `af_gone: 1 windows (created Wed May 20 12:00:00 2026) [179x47]
 af_stuck: 1 windows (created Wed May 20 12:01:00 2026) [179x47]`
+	absentExit := exec.Command("sh", "-c", "exit 1").Run()
+	var tmuxExit *exec.ExitError
+	require.ErrorAs(t, absentExit, &tmuxExit)
+	require.Equal(t, 1, tmuxExit.ExitCode())
 
 	// af_stuck survives its kill; af_gone vanished before we got to it.
 	stillPresent := map[string]bool{"af_stuck": true}
@@ -119,7 +123,7 @@ af_stuck: 1 windows (created Wed May 20 12:01:00 2026) [179x47]`
 					if stillPresent[nameOf(c)] {
 						return nil
 					}
-					return errExit1
+					return absentExit
 				}
 				return nil
 			},
@@ -149,7 +153,7 @@ af_stuck: 1 windows (created Wed May 20 12:01:00 2026) [179x47]`
 					if stillPresent[nameOf(c)] {
 						return nil
 					}
-					return errExit1
+					return absentExit
 				}
 				return nil
 			},

--- a/session/tmux/reap.go
+++ b/session/tmux/reap.go
@@ -246,13 +246,10 @@ func refreshOrphanCandidates(captured []proctree.Process, sanitizedName string) 
 	if err != nil {
 		return captured, fmt.Errorf("cannot refresh processes after tmux session %s vanished: %w", sanitizedName, err)
 	}
-	seen := make(map[int]bool, len(captured))
+	byPID := make(map[int]int, len(captured))
 	refreshed := make([]proctree.Process, 0, len(captured))
 	add := func(process proctree.Process) {
-		if !seen[process.PID] {
-			seen[process.PID] = true
-			refreshed = append(refreshed, process)
-		}
+		refreshed = addOrReplaceOrphanCandidate(refreshed, byPID, process)
 	}
 	for _, process := range captured {
 		add(process)
@@ -276,6 +273,21 @@ func refreshOrphanCandidates(captured []proctree.Process, sanitizedName string) 
 		}
 	}
 	return refreshed, nil
+}
+
+// addOrReplaceOrphanCandidate deduplicates by PID without confusing a PID
+// slot with a process identity. A current snapshot or marker scan must replace
+// an older entry when the same PID now carries another StartID; otherwise the
+// stale identity would be rejected later while the replacement escaped review.
+func addOrReplaceOrphanCandidate(candidates []proctree.Process, byPID map[int]int, process proctree.Process) []proctree.Process {
+	if index, exists := byPID[process.PID]; exists {
+		if candidates[index].StartID != process.StartID {
+			candidates[index] = process
+		}
+		return candidates
+	}
+	byPID[process.PID] = len(candidates)
+	return append(candidates, process)
 }
 
 func processEnvValue(environ []string, name string) (string, bool) {

--- a/session/tmux/reap.go
+++ b/session/tmux/reap.go
@@ -3,6 +3,8 @@ package tmux
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -125,6 +127,102 @@ func captureSessionProcessTrees(cmdExec cmd.Executor, sanitizedName string) ([]p
 		}
 	}
 	return procs, errors.Join(captureErrs...)
+}
+
+// markedOrphanProcesses finds same-user processes whose immutable launch
+// environment proves they belong to this exact tmux session and AF home. It is
+// the fallback after tmux authoritatively reports that a session vanished
+// before its pane tree could be captured: AF_SESSION recovers the lost session
+// identity, while AF_HOME keeps a same-named process from another install out
+// of the reap set.
+//
+// An unreadable environment on a live same-user process is UNKNOWN, not an
+// absent marker. Returning both the processes we did prove and an error lets
+// cleanup reap known-owned orphans while still refusing worktree deletion when
+// it could not rule out another one. Processes owned by another uid cannot have
+// been launched by this user's reset target and are skipped before reading
+// their environment.
+func markedOrphanProcesses(sanitizedName, ownHome string) ([]proctree.Process, error) {
+	snap, err := proctree.Snapshot()
+	if err != nil {
+		return nil, fmt.Errorf("cannot inspect processes after tmux session vanished: %w", err)
+	}
+	selfUID, selfUIDKnown := proctree.UID(os.Getpid())
+	if !selfUIDKnown {
+		return nil, fmt.Errorf("cannot determine reset process ownership while checking vanished tmux session %s", sanitizedName)
+	}
+	selfChain := selfAndAncestorProcesses(snap)
+	cleanHome := filepath.Clean(ownHome)
+	var owned []proctree.Process
+	var inspectErrs []error
+	for _, process := range snap {
+		uid, uidKnown := proctree.UID(process.PID)
+		if !uidKnown {
+			if proctree.AliveSame(process) {
+				inspectErrs = append(inspectErrs, fmt.Errorf("cannot determine owner of live pid %d", process.PID))
+			}
+			continue
+		}
+		if uid != selfUID {
+			continue
+		}
+
+		environ, envErr := proctree.Environ(process.PID)
+		if envErr != nil {
+			if proctree.AliveSame(process) {
+				inspectErrs = append(inspectErrs, fmt.Errorf("cannot determine whether live pid %d belongs to session %s: %w",
+					process.PID, sanitizedName, envErr))
+			}
+			continue
+		}
+		processSession, hasSession := processEnvValue(environ, EnvMarkerSession)
+		if !hasSession || processSession != sanitizedName {
+			continue
+		}
+		processHome, hasHome := processEnvValue(environ, EnvMarkerHome)
+		if !hasHome {
+			inspectErrs = append(inspectErrs, fmt.Errorf("live pid %d marks session %s but has no %s ownership marker",
+				process.PID, sanitizedName, EnvMarkerHome))
+			continue
+		}
+		if filepath.Clean(processHome) != cleanHome {
+			continue
+		}
+		if selfChain[process.PID] {
+			inspectErrs = append(inspectErrs, fmt.Errorf("refusing to reap reset process or ancestor pid %d for vanished session %s",
+				process.PID, sanitizedName))
+			continue
+		}
+		owned = append(owned, process)
+	}
+	return owned, errors.Join(inspectErrs...)
+}
+
+func processEnvValue(environ []string, name string) (string, bool) {
+	prefix := name + "="
+	for _, value := range environ {
+		if strings.HasPrefix(value, prefix) {
+			return value[len(prefix):], true
+		}
+	}
+	return "", false
+}
+
+func selfAndAncestorProcesses(snap map[int]proctree.Process) map[int]bool {
+	ancestors := make(map[int]bool)
+	pid := os.Getpid()
+	for range 128 {
+		if pid <= 0 || ancestors[pid] {
+			break
+		}
+		ancestors[pid] = true
+		process, ok := snap[pid]
+		if !ok {
+			break
+		}
+		pid = process.PPID
+	}
+	return ancestors
 }
 
 // reapLeakedProcesses waits for the captured processes to exit after

--- a/session/tmux/reap.go
+++ b/session/tmux/reap.go
@@ -160,12 +160,25 @@ func markedOrphanProcesses(candidates []proctree.Process, sanitizedName, ownHome
 	var owned []proctree.Process
 	var inspectErrs []error
 	for _, process := range candidates {
-		if !proctree.AliveSame(process) {
+		same, identityErr := proctree.SameIdentity(process)
+		if identityErr != nil {
+			inspectErrs = append(inspectErrs, fmt.Errorf("cannot determine whether captured pid %d is still the same process: %w",
+				process.PID, identityErr))
+			continue
+		}
+		if !same {
 			continue
 		}
 		uid, uidKnown := proctree.UID(process.PID)
 		if !uidKnown {
-			inspectErrs = append(inspectErrs, fmt.Errorf("cannot determine owner of captured live pid %d", process.PID))
+			sameAfter, recheckErr := proctree.SameIdentity(process)
+			switch {
+			case recheckErr != nil:
+				inspectErrs = append(inspectErrs, fmt.Errorf("cannot recheck captured pid %d after owner lookup failed: %w",
+					process.PID, recheckErr))
+			case sameAfter:
+				inspectErrs = append(inspectErrs, fmt.Errorf("cannot determine owner of captured live pid %d", process.PID))
+			}
 			continue
 		}
 		if uid != selfUID {
@@ -176,8 +189,15 @@ func markedOrphanProcesses(candidates []proctree.Process, sanitizedName, ownHome
 
 		environ, envErr := proctree.Environ(process.PID)
 		if envErr != nil {
-			inspectErrs = append(inspectErrs, fmt.Errorf("cannot determine whether captured live pid %d belongs to session %s: %w",
-				process.PID, sanitizedName, envErr))
+			sameAfter, recheckErr := proctree.SameIdentity(process)
+			switch {
+			case recheckErr != nil:
+				inspectErrs = append(inspectErrs, fmt.Errorf("cannot recheck captured pid %d after environment lookup failed: %w",
+					process.PID, errors.Join(envErr, recheckErr)))
+			case sameAfter:
+				inspectErrs = append(inspectErrs, fmt.Errorf("cannot determine whether captured live pid %d belongs to session %s: %w",
+					process.PID, sanitizedName, envErr))
+			}
 			continue
 		}
 		processSession, hasSession := processEnvValue(environ, EnvMarkerSession)
@@ -208,6 +228,54 @@ func markedOrphanProcesses(candidates []proctree.Process, sanitizedName, ownHome
 		owned = append(owned, process)
 	}
 	return owned, errors.Join(inspectErrs...)
+}
+
+// refreshOrphanCandidates closes the capture-to-marker TOCTOU window. A pane
+// can launch another helper after the pre-marker snapshot but before the marker
+// lookup observes that tmux removed the session. Once absence is authoritative,
+// no pane remains to launch more work, so a fresh process-table snapshot can add
+// every process still tied to the captured kernel sessions/trees plus any
+// readable process carrying the exact AF_SESSION marker.
+//
+// Environment failures on unrelated processes are deliberately ignored: they
+// are not evidence of membership. Failures on captured/SID/descendant
+// candidates remain visible when markedOrphanProcesses validates the bounded
+// set, preserving unknown without making hardened hosts globally unreadable.
+func refreshOrphanCandidates(captured []proctree.Process, sanitizedName string) ([]proctree.Process, error) {
+	snap, err := proctree.Snapshot()
+	if err != nil {
+		return captured, fmt.Errorf("cannot refresh processes after tmux session %s vanished: %w", sanitizedName, err)
+	}
+	seen := make(map[int]bool, len(captured))
+	refreshed := make([]proctree.Process, 0, len(captured))
+	add := func(process proctree.Process) {
+		if !seen[process.PID] {
+			seen[process.PID] = true
+			refreshed = append(refreshed, process)
+		}
+	}
+	for _, process := range captured {
+		add(process)
+		current, alive := snap[process.PID]
+		if alive && current.StartID == process.StartID {
+			for _, descendant := range proctree.TreeOf(snap, process.PID) {
+				add(descendant)
+			}
+		}
+		for _, member := range proctree.SessionMembers(snap, process.SID) {
+			add(member)
+		}
+	}
+	for _, process := range snap {
+		environ, envErr := proctree.Environ(process.PID)
+		if envErr != nil {
+			continue
+		}
+		if session, ok := processEnvValue(environ, EnvMarkerSession); ok && session == sanitizedName {
+			add(process)
+		}
+	}
+	return refreshed, nil
 }
 
 func processEnvValue(environ []string, name string) (string, bool) {

--- a/session/tmux/reap.go
+++ b/session/tmux/reap.go
@@ -81,6 +81,9 @@ func captureSessionProcessTrees(cmdExec cmd.Executor, sanitizedName string) ([]p
 	out, err := outputTmuxBoundedWith(ctx, cmdExec,
 		"list-panes", "-s", "-t", exactTarget(sanitizedName), "-F", "#{pane_pid}")
 	if err != nil {
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("%w: list-panes for %s after %s", ErrTmuxTimeout, sanitizedName, tmuxCommandTimeout)
+		}
 		return nil, fmt.Errorf("cannot list panes before teardown: %w", err)
 	}
 	snap, err := proctree.Snapshot()
@@ -129,23 +132,24 @@ func captureSessionProcessTrees(cmdExec cmd.Executor, sanitizedName string) ([]p
 	return procs, errors.Join(captureErrs...)
 }
 
-// markedOrphanProcesses finds same-user processes whose immutable launch
-// environment proves they belong to this exact tmux session and AF home. It is
-// the fallback after tmux authoritatively reports that a session vanished
-// before its pane tree could be captured: AF_SESSION recovers the lost session
-// identity, while AF_HOME keeps a same-named process from another install out
-// of the reap set.
+// markedOrphanProcesses filters a previously captured pane process tree down to
+// processes whose immutable launch environment proves they belong to this exact
+// tmux session and AF home. The capture happens while the listed session still
+// exists; if ownership lookup then loses the session, AF_SESSION and AF_HOME
+// provide the authority that the vanished tmux environment no longer can.
 //
-// An unreadable environment on a live same-user process is UNKNOWN, not an
-// absent marker. Returning both the processes we did prove and an error lets
-// cleanup reap known-owned orphans while still refusing worktree deletion when
-// it could not rule out another one. Processes owned by another uid cannot have
-// been launched by this user's reset target and are skipped before reading
-// their environment.
-func markedOrphanProcesses(sanitizedName, ownHome string) ([]proctree.Process, error) {
+// The candidate set is load-bearing. Scanning every same-user process would
+// turn an unrelated unreadable /proc environment into a possible helper and
+// make successful absence impossible on hardened hosts. Within the captured
+// tree, unreadable or mismatched provenance is genuinely UNKNOWN and blocks
+// worktree deletion rather than being collapsed into "not ours".
+func markedOrphanProcesses(candidates []proctree.Process, sanitizedName, ownHome string) ([]proctree.Process, error) {
+	if len(candidates) == 0 {
+		return nil, nil
+	}
 	snap, err := proctree.Snapshot()
 	if err != nil {
-		return nil, fmt.Errorf("cannot inspect processes after tmux session vanished: %w", err)
+		return nil, fmt.Errorf("cannot inspect captured processes after tmux session vanished: %w", err)
 	}
 	selfUID, selfUIDKnown := proctree.UID(os.Getpid())
 	if !selfUIDKnown {
@@ -155,33 +159,41 @@ func markedOrphanProcesses(sanitizedName, ownHome string) ([]proctree.Process, e
 	cleanHome := filepath.Clean(ownHome)
 	var owned []proctree.Process
 	var inspectErrs []error
-	for _, process := range snap {
+	for _, process := range candidates {
+		if !proctree.AliveSame(process) {
+			continue
+		}
 		uid, uidKnown := proctree.UID(process.PID)
 		if !uidKnown {
-			if proctree.AliveSame(process) {
-				inspectErrs = append(inspectErrs, fmt.Errorf("cannot determine owner of live pid %d", process.PID))
-			}
+			inspectErrs = append(inspectErrs, fmt.Errorf("cannot determine owner of captured live pid %d", process.PID))
 			continue
 		}
 		if uid != selfUID {
+			inspectErrs = append(inspectErrs, fmt.Errorf("captured live pid %d belongs to uid %d, not reset uid %d",
+				process.PID, uid, selfUID))
 			continue
 		}
 
 		environ, envErr := proctree.Environ(process.PID)
 		if envErr != nil {
-			if proctree.AliveSame(process) {
-				inspectErrs = append(inspectErrs, fmt.Errorf("cannot determine whether live pid %d belongs to session %s: %w",
-					process.PID, sanitizedName, envErr))
-			}
+			inspectErrs = append(inspectErrs, fmt.Errorf("cannot determine whether captured live pid %d belongs to session %s: %w",
+				process.PID, sanitizedName, envErr))
 			continue
 		}
 		processSession, hasSession := processEnvValue(environ, EnvMarkerSession)
-		if !hasSession || processSession != sanitizedName {
+		if !hasSession {
+			inspectErrs = append(inspectErrs, fmt.Errorf("captured live pid %d has no %s marker for vanished session %s",
+				process.PID, EnvMarkerSession, sanitizedName))
+			continue
+		}
+		if processSession != sanitizedName {
+			inspectErrs = append(inspectErrs, fmt.Errorf("captured live pid %d marks session %s instead of vanished session %s",
+				process.PID, processSession, sanitizedName))
 			continue
 		}
 		processHome, hasHome := processEnvValue(environ, EnvMarkerHome)
 		if !hasHome {
-			inspectErrs = append(inspectErrs, fmt.Errorf("live pid %d marks session %s but has no %s ownership marker",
+			inspectErrs = append(inspectErrs, fmt.Errorf("captured live pid %d marks session %s but has no %s ownership marker",
 				process.PID, sanitizedName, EnvMarkerHome))
 			continue
 		}

--- a/session/tmux/reap_test.go
+++ b/session/tmux/reap_test.go
@@ -244,6 +244,18 @@ func TestCleanupSessionsFailsClosedOnUnownedProcessForVanishedSession(t *testing
 		"a process with unknown home ownership must be left alone")
 }
 
+func TestAddOrReplaceOrphanCandidateReplacesRecycledPID(t *testing.T) {
+	stale := proctree.Process{PID: 42, StartID: 100}
+	current := proctree.Process{PID: 42, StartID: 200}
+	candidates := []proctree.Process{stale}
+	byPID := map[int]int{stale.PID: 0}
+
+	candidates = addOrReplaceOrphanCandidate(candidates, byPID, current)
+
+	require.Equal(t, []proctree.Process{current}, candidates,
+		"a current marked process must replace a stale identity that reused its PID")
+}
+
 func spawnMarkedSessionWithEscapee(t *testing.T, name, home string) proctree.Process {
 	t.Helper()
 	dir := t.TempDir()

--- a/session/tmux/reap_test.go
+++ b/session/tmux/reap_test.go
@@ -172,6 +172,46 @@ func TestCleanupSessionsReapsMarkedProcessWhenSessionVanishesDuringOwnership(t *
 		"AF_SESSION/AF_HOME-marked helper survived after its tmux session vanished")
 }
 
+// A pane can launch a helper after the pre-marker process snapshot and before
+// marker lookup loses the session. The post-absence refresh must find that
+// newly marked process rather than treating the older snapshot as final.
+func TestCleanupSessionsReapsHelperStartedAfterPreMarkerCapture(t *testing.T) {
+	testguard.IsolateTmux(t)
+	shrinkReapWaits(t)
+
+	const name = "af_vanished_late_helper"
+	home := t.TempDir()
+	trigger, pidFile := spawnSessionWaitingToStartHelper(t, name, home)
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	var marked proctree.Process
+	beforeKill := func() {
+		require.NoError(t, os.WriteFile(trigger, []byte("go"), 0o600))
+		var pid int
+		require.Eventually(t, func() bool {
+			data, err := os.ReadFile(pidFile)
+			if err != nil {
+				return false
+			}
+			pid, err = strconv.Atoi(strings.TrimSpace(string(data)))
+			if err != nil || pid <= 1 {
+				return false
+			}
+			snap, err := proctree.Snapshot()
+			if err != nil {
+				return false
+			}
+			var ok bool
+			marked, ok = snap[pid]
+			return ok
+		}, 5*time.Second, 20*time.Millisecond, "late helper never appeared")
+	}
+
+	require.NoError(t, CleanupSessions(vanishOnMarkerExecutorWith(t, name, beforeKill)))
+	require.False(t, proctree.AliveSame(marked),
+		"helper started after pre-marker capture survived vanished-session cleanup")
+}
+
 // The process sweep's AF_HOME check is an authorization boundary, not just a
 // filter: a same-named helper from another install must never be signalled.
 func TestCleanupSessionsDoesNotReapForeignHomeProcessForVanishedSession(t *testing.T) {
@@ -240,7 +280,35 @@ func spawnMarkedSessionWithEscapee(t *testing.T, name, home string) proctree.Pro
 	return marked
 }
 
+func spawnSessionWaitingToStartHelper(t *testing.T, name, home string) (trigger, pidFile string) {
+	t.Helper()
+	dir := t.TempDir()
+	trigger = filepath.Join(dir, "start-helper")
+	pidFile = filepath.Join(dir, "late-helper.pid")
+	script := fmt.Sprintf("while [ ! -f %s ]; do sleep 0.01; done; "+
+		"nohup sleep 300 >/dev/null 2>&1 & echo $! > %s; exec sleep 300", trigger, pidFile)
+	out, err := exec.Command("tmux", "new-session", "-d", "-s", name, "-c", dir,
+		"-e", EnvMarkerSession+"="+name, "-e", EnvMarkerHome+"="+home, script).CombinedOutput()
+	require.NoError(t, err, "tmux new-session: %s", out)
+	t.Cleanup(func() {
+		if data, readErr := os.ReadFile(pidFile); readErr == nil {
+			if pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data))); parseErr == nil {
+				if snap, snapErr := proctree.Snapshot(); snapErr == nil {
+					if process, ok := snap[pid]; ok {
+						_ = proctree.Signal(process, syscall.SIGKILL)
+					}
+				}
+			}
+		}
+	})
+	return trigger, pidFile
+}
+
 func vanishOnMarkerExecutor(t *testing.T, name string) cmd.Executor {
+	return vanishOnMarkerExecutorWith(t, name, nil)
+}
+
+func vanishOnMarkerExecutorWith(t *testing.T, name string, beforeKill func()) cmd.Executor {
 	t.Helper()
 	realExec := cmd.MakeExecutor()
 	vanished := false
@@ -249,6 +317,9 @@ func vanishOnMarkerExecutor(t *testing.T, name string) cmd.Executor {
 		OutputFunc: func(command *exec.Cmd) ([]byte, error) {
 			if len(command.Args) > 1 && command.Args[1] == "show-environment" && !vanished {
 				vanished = true
+				if beforeKill != nil {
+					beforeKill()
+				}
 				out, err := exec.Command("tmux", "kill-session", "-t", exactTarget(name)).CombinedOutput()
 				require.NoError(t, err, "kill session before marker lookup: %s", out)
 			}

--- a/session/tmux/reap_test.go
+++ b/session/tmux/reap_test.go
@@ -159,15 +159,15 @@ func TestCleanupSessionsReapsEscapedProcesses(t *testing.T) {
 // must not read "session absent" as "no process remains" and delete the
 // helper's worktree underneath it.
 func TestCleanupSessionsReapsMarkedProcessWhenSessionVanishesDuringOwnership(t *testing.T) {
+	testguard.IsolateTmux(t)
 	shrinkReapWaits(t)
 
 	const name = "af_vanished_with_helper"
 	home := t.TempDir()
-	marked := spawnAncestryMarkedHelper(t, name, home)
-	installVanishedSessionTmux(t, name)
+	marked := spawnMarkedSessionWithEscapee(t, name, home)
 	t.Setenv("AGENT_FACTORY_HOME", home)
 
-	require.NoError(t, CleanupSessions(cmd.MakeExecutor()))
+	require.NoError(t, CleanupSessions(vanishOnMarkerExecutor(t, name)))
 	require.False(t, proctree.AliveSame(marked),
 		"AF_SESSION/AF_HOME-marked helper survived after its tmux session vanished")
 }
@@ -175,14 +175,14 @@ func TestCleanupSessionsReapsMarkedProcessWhenSessionVanishesDuringOwnership(t *
 // The process sweep's AF_HOME check is an authorization boundary, not just a
 // filter: a same-named helper from another install must never be signalled.
 func TestCleanupSessionsDoesNotReapForeignHomeProcessForVanishedSession(t *testing.T) {
+	testguard.IsolateTmux(t)
 	shrinkReapWaits(t)
 
 	const name = "af_vanished_foreign_helper"
-	marked := spawnAncestryMarkedHelper(t, name, t.TempDir())
-	installVanishedSessionTmux(t, name)
+	marked := spawnMarkedSessionWithEscapee(t, name, t.TempDir())
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 
-	require.NoError(t, CleanupSessions(cmd.MakeExecutor()))
+	require.NoError(t, CleanupSessions(vanishOnMarkerExecutor(t, name)))
 	require.True(t, proctree.AliveSame(marked),
 		"a foreign-home helper with the same session name must not be reaped")
 }
@@ -191,72 +191,70 @@ func TestCleanupSessionsDoesNotReapForeignHomeProcessForVanishedSession(t *testi
 // not ours: it is unknown. Leave the process alive and stop reset before it can
 // delete a worktree the process may still be using.
 func TestCleanupSessionsFailsClosedOnUnownedProcessForVanishedSession(t *testing.T) {
+	testguard.IsolateTmux(t)
 	shrinkReapWaits(t)
 
 	const name = "af_vanished_unowned_helper"
-	marked := spawnAncestryMarkedHelper(t, name, "")
-	installVanishedSessionTmux(t, name)
+	marked := spawnMarkedSessionWithEscapee(t, name, "")
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 
-	err := CleanupSessions(cmd.MakeExecutor())
+	err := CleanupSessions(vanishOnMarkerExecutor(t, name))
 	require.ErrorContains(t, err, "has no AF_HOME ownership marker")
 	require.True(t, proctree.AliveSame(marked),
 		"a process with unknown home ownership must be left alone")
 }
 
-func spawnAncestryMarkedHelper(t *testing.T, name, home string) proctree.Process {
+func spawnMarkedSessionWithEscapee(t *testing.T, name, home string) proctree.Process {
 	t.Helper()
-	helper := exec.Command("sleep", "300")
-	helper.Env = append(os.Environ(), EnvMarkerSession+"="+name)
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "escapee.pid")
+	args := []string{"new-session", "-d", "-s", name, "-c", dir, "-e", EnvMarkerSession + "=" + name}
 	if home != "" {
-		helper.Env = append(helper.Env, EnvMarkerHome+"="+home)
+		args = append(args, "-e", EnvMarkerHome+"="+home)
 	}
-	require.NoError(t, helper.Start())
+	args = append(args, fmt.Sprintf("nohup sleep 300 >/dev/null 2>&1 & echo $! > %s; exec sleep 300", pidFile))
+	out, err := exec.Command("tmux", args...).CombinedOutput()
+	require.NoError(t, err, "tmux new-session: %s", out)
+
+	var pid int
+	require.Eventually(t, func() bool {
+		data, readErr := os.ReadFile(pidFile)
+		if readErr != nil {
+			return false
+		}
+		pid, readErr = strconv.Atoi(strings.TrimSpace(string(data)))
+		return readErr == nil && pid > 1
+	}, 5*time.Second, 20*time.Millisecond, "helper pid file never appeared")
 	t.Cleanup(func() {
-		_ = helper.Process.Kill()
-		_, _ = helper.Process.Wait()
+		if snap, snapErr := proctree.Snapshot(); snapErr == nil {
+			if process, ok := snap[pid]; ok {
+				_ = proctree.Signal(process, syscall.SIGKILL)
+			}
+		}
 	})
 
-	var marked proctree.Process
-	require.Eventually(t, func() bool {
-		snap, err := proctree.Snapshot()
-		if err != nil {
-			return false
-		}
-		var ok bool
-		marked, ok = snap[helper.Process.Pid]
-		if !ok {
-			return false
-		}
-		gotName, nameStatus := proctree.LookupEnv(marked.PID, EnvMarkerSession)
-		return nameStatus == proctree.EnvFound && gotName == name
-	}, 5*time.Second, 20*time.Millisecond, "helper ancestry marker never became readable")
+	snap, err := proctree.Snapshot()
+	require.NoError(t, err)
+	marked, ok := snap[pid]
+	require.True(t, ok, "helper %d not in process snapshot", pid)
 	return marked
 }
 
-func installVanishedSessionTmux(t *testing.T, name string) {
+func vanishOnMarkerExecutor(t *testing.T, name string) cmd.Executor {
 	t.Helper()
-	dir := t.TempDir()
-	script := fmt.Sprintf(`#!/bin/sh
-case "$1" in
-ls)
-  echo '%s: 1 windows (created Thu Jan 1 00:00:00 1970)'
-  ;;
-show-environment)
-  exit 97
-  ;;
-has-session)
-  [ "${2-}" = "-t=%s" ] || exit 98
-  printf "can't find session: %s\n" >&2
-  exit 1
-  ;;
-*)
-  exit 96
-  ;;
-esac
-`, name, name, name)
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755))
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	realExec := cmd.MakeExecutor()
+	vanished := false
+	return cmd_test.MockCmdExec{
+		RunFunc: realExec.Run,
+		OutputFunc: func(command *exec.Cmd) ([]byte, error) {
+			if len(command.Args) > 1 && command.Args[1] == "show-environment" && !vanished {
+				vanished = true
+				out, err := exec.Command("tmux", "kill-session", "-t", exactTarget(name)).CombinedOutput()
+				require.NoError(t, err, "kill session before marker lookup: %s", out)
+			}
+			return realExec.Output(command)
+		},
+	}
 }
 
 // TestCaptureRejectsNonTmuxPaneRoots is the safety property that keeps

--- a/session/tmux/reap_test.go
+++ b/session/tmux/reap_test.go
@@ -153,6 +153,112 @@ func TestCleanupSessionsReapsEscapedProcesses(t *testing.T) {
 		"SIGHUP-immune pane child survived CleanupSessions")
 }
 
+// TestCleanupSessionsReapsMarkedProcessWhenSessionVanishesDuringOwnership
+// covers the ls-to-marker race's process half. A detached helper can outlive
+// the tmux session that stamped its AF_SESSION/AF_HOME ancestry markers; reset
+// must not read "session absent" as "no process remains" and delete the
+// helper's worktree underneath it.
+func TestCleanupSessionsReapsMarkedProcessWhenSessionVanishesDuringOwnership(t *testing.T) {
+	shrinkReapWaits(t)
+
+	const name = "af_vanished_with_helper"
+	home := t.TempDir()
+	marked := spawnAncestryMarkedHelper(t, name, home)
+	installVanishedSessionTmux(t, name)
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	require.NoError(t, CleanupSessions(cmd.MakeExecutor()))
+	require.False(t, proctree.AliveSame(marked),
+		"AF_SESSION/AF_HOME-marked helper survived after its tmux session vanished")
+}
+
+// The process sweep's AF_HOME check is an authorization boundary, not just a
+// filter: a same-named helper from another install must never be signalled.
+func TestCleanupSessionsDoesNotReapForeignHomeProcessForVanishedSession(t *testing.T) {
+	shrinkReapWaits(t)
+
+	const name = "af_vanished_foreign_helper"
+	marked := spawnAncestryMarkedHelper(t, name, t.TempDir())
+	installVanishedSessionTmux(t, name)
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	require.NoError(t, CleanupSessions(cmd.MakeExecutor()))
+	require.True(t, proctree.AliveSame(marked),
+		"a foreign-home helper with the same session name must not be reaped")
+}
+
+// A matching AF_SESSION without readable home ownership is not foreign and is
+// not ours: it is unknown. Leave the process alive and stop reset before it can
+// delete a worktree the process may still be using.
+func TestCleanupSessionsFailsClosedOnUnownedProcessForVanishedSession(t *testing.T) {
+	shrinkReapWaits(t)
+
+	const name = "af_vanished_unowned_helper"
+	marked := spawnAncestryMarkedHelper(t, name, "")
+	installVanishedSessionTmux(t, name)
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	err := CleanupSessions(cmd.MakeExecutor())
+	require.ErrorContains(t, err, "has no AF_HOME ownership marker")
+	require.True(t, proctree.AliveSame(marked),
+		"a process with unknown home ownership must be left alone")
+}
+
+func spawnAncestryMarkedHelper(t *testing.T, name, home string) proctree.Process {
+	t.Helper()
+	helper := exec.Command("sleep", "300")
+	helper.Env = append(os.Environ(), EnvMarkerSession+"="+name)
+	if home != "" {
+		helper.Env = append(helper.Env, EnvMarkerHome+"="+home)
+	}
+	require.NoError(t, helper.Start())
+	t.Cleanup(func() {
+		_ = helper.Process.Kill()
+		_, _ = helper.Process.Wait()
+	})
+
+	var marked proctree.Process
+	require.Eventually(t, func() bool {
+		snap, err := proctree.Snapshot()
+		if err != nil {
+			return false
+		}
+		var ok bool
+		marked, ok = snap[helper.Process.Pid]
+		if !ok {
+			return false
+		}
+		gotName, nameStatus := proctree.LookupEnv(marked.PID, EnvMarkerSession)
+		return nameStatus == proctree.EnvFound && gotName == name
+	}, 5*time.Second, 20*time.Millisecond, "helper ancestry marker never became readable")
+	return marked
+}
+
+func installVanishedSessionTmux(t *testing.T, name string) {
+	t.Helper()
+	dir := t.TempDir()
+	script := fmt.Sprintf(`#!/bin/sh
+case "$1" in
+ls)
+  echo '%s: 1 windows (created Thu Jan 1 00:00:00 1970)'
+  ;;
+show-environment)
+  exit 97
+  ;;
+has-session)
+  [ "${2-}" = "-t=%s" ] || exit 98
+  printf "can't find session: %s\n" >&2
+  exit 1
+  ;;
+*)
+  exit 96
+  ;;
+esac
+`, name, name, name)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
 // TestCaptureRejectsNonTmuxPaneRoots is the safety property that keeps
 // mock-backed tests (and any confused tmux output) from ever capturing a
 // process tree that is not rooted in a real tmux pane: a claimed pane PID


### PR DESCRIPTION
## Summary

- re-probe the exact tmux session after a non-timeout ownership-marker error
- accept absence only from exit 1 plus tmux's exact named-session diagnostic or explicit `no server running on <socket>`
- keep timeout, wrapper/policy, and unclassified connection failures unknown
- return immediately after a marker timeout instead of launching a second doomed probe
- apply the same strict re-probe after a failed kill so reset never reaps process trees from an undetermined result

## Diagnosis

The report is correct. A session can disappear after `tmux ls` and before `show-environment`. The marker lookup then fails, even though the reset goal is already satisfied. This occurs in two authoritative forms: `can't find session: <name>` while a sibling keeps the server alive, or `no server running on <socket>` when the vanished session was the last one.

The adjacent probe audit found that the existing bool-like helper collapses generic command failures into absence. Cleanup therefore uses a strict three-valued re-probe: present, authoritatively absent, or unknown. The audit also found the same lossy helper after a failed kill; that call now uses the strict probe too.

## Red-first evidence

Original race:

> CleanupSessions error = cannot determine tmux session af_gone ownership; refusing to continue cleanup: read AF_HOME ownership marker for tmux session af_gone: exit status 1, want a definitively vanished session to be tolerated

Original fail-closed companion:

> CleanupSessions error = ... exit status 97, want ErrTmuxTimeout when the exact session re-probe does not answer

Adjacent failed-kill probe:

> CleanupSessions error = nil, want generic exact post-kill re-probe failure to remain unknown

Codex timeout finding:

> CleanupSessions error = <nil>, want ErrTmuxTimeout when AF_HOME ownership probe does not answer

Codex diagnostic finding:

> CleanupSessions error = nil, want exit 1 without tmux's absence diagnostic to remain unknown

Codex last-session finding:

> CleanupSessions error = cannot determine tmux session af_gone ownership or whether it survived; ... has-session for af_gone did not return a usable answer: exit status 1, want an explicitly absent tmux server to prove the last session vanished

## Verification

Pushed head: `35ad571d2a67717c20a92825207e8b7e51c107a8`

- `make test-container GOTESTARGS='./session/tmux -run TestCleanupSessions -count=1'`
- `make test-container GOTESTARGS='./session/tmux -count=1'` — `session/tmux 95.483s`
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- full `make test-container` last against the pushed head — green (`daemon 225.734s`, `session/tmux 96.549s`)

## Isolated tmux play-test

On exact head `35ad571d2a67717c20a92825207e8b7e51c107a8`:

- Dedicated `-L codex-af-2706-35ad-missing`: with a keeper alive, the vanished exact target returned exit 1 and `can't find session: af_vanish_probe`.
- Dedicated `-L codex-af-2706-35ad-last`: after the observed last session vanished, the exact target returned exit 1 and `no server running on /tmp/tmux-1001/codex-af-2706-35ad-last`.

Both isolated servers were removed afterward. No `af reset` or default tmux server was used.

Closes #2706

## Final exact-head verification after late finding

Final pushed head: `f92a2241a837e9be348c78128cf1270275bc40b5`

The late process-reaper regression failed first on `d06c1f3c`:

> AF_SESSION/AF_HOME-marked helper survived after its tmux session vanished

The first global-scan implementation then exposed a real CI defect on `d06c1f3c`:

> CleanupSessions error = tmux session af_gone vanished during ownership lookup, but its process cleanup is incomplete: cannot determine whether live pid 1275 belongs to session af_gone: ... permission denied

That scan was too broad: unrelated same-user processes with unreadable environments became possible helpers. The final implementation captures the listed session's verified pane tree before marker lookup and applies AF_SESSION/AF_HOME tri-state checks only to that bounded candidate set. A partial capture remains unknown and blocks deletion.

The adjacent capture-timeout regression also failed first:

> CleanupSessions error = failed to kill tmux session af_owned and cannot determine whether it survived: ... want ErrTmuxTimeout from pre-marker process capture

The final path returns ErrTmuxTimeout immediately and never launches the ownership probe after a capture deadline.

Final local gates on the pushed head:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container GOTESTARGS="./session/tmux -run TestCleanupSessions -count=1"`
- `make test-container GOTESTARGS="./session/tmux -count=1"` — `session/tmux 97.608s`
- full `make test-container` last — green (`daemon 298.800s`, `session/tmux 99.382s`)

Exact-head real-tmux play-test used only `-L codex-af-2706-f92a`: the pane tree was captured while `af_vanish_probe` existed, the session then vanished with a keeper alive, marker lookup returned `no such session`, exact `has-session` returned `can't find session`, and the detached marked helper remained alive for the cleanup path to handle. The helper and isolated server were removed; no `af reset` or default tmux server was used.

## Final exact-head verification after second review round

Final pushed head: \`af84e9f4cc8734d65b0cff4dcf1b5298c181164c\`

The late-helper race identified by Codex was reproduced red first:

> helper started after pre-marker capture survived vanished-session cleanup

Cleanup now refreshes the captured process tree only after tmux authoritatively reports the exact session absent. It expands candidates by captured descendants, kernel session IDs, and exact AF_SESSION markers; two reap passes and a final nondestructive verification cover processes launched or forked across the race. Any remaining marked process or candidate-scoped inspection error remains unknown and blocks deletion.

The liveness-collapse finding also received a red-first test:

> internal/proctree/proctree_test.go:159:15: undefined: sameIdentity

The resulting error-bearing \`proctree.SameIdentity\` API preserves identity read failures. Vanished-session cleanup treats those failures as unknown; the older bool helper remains only for wait loops where a later verification supplies authority.

Final local gates on the pushed head:

- \`GOTOOLCHAIN=go1.25.0 golangci-lint run --timeout=3m --fast\`
- \`GOTOOLCHAIN=go1.25.0 gofmt -l .\` — no output
- \`GOTOOLCHAIN=go1.25.0 go build ./...\`
- \`GOTOOLCHAIN=go1.25.0 deadcode -test ./...\`
- \`scripts/lint-file-length.sh\` — 1099 files, 0 grandfathered
- \`make test-container GOTESTARGS='./session/tmux -run TestCleanupSessionsReapsHelperStartedAfterPreMarkerCapture -count=1 -v'\` — green
- full \`make test-container\` last — green (\`daemon 258.113s\`, \`session/tmux 100.773s\`)

Exact-head race play-test used only \`-L codex-af-2706-af84e9f4\`. After the isolated session was removed, exact \`has-session\` authoritatively reported absence while its AF_SESSION/AF_HOME-marked helper was still alive, proving session absence is not process absence. The focused production cleanup test then proved this head reaps a helper launched after the pre-marker capture. The helper and isolated server were removed; no \`af reset\` or default tmux server was used.


## Final exact-head verification after PID-reuse finding

Final pushed head: \`7a86fd86e37a5f98ded5579ac9b06b5fbfa86a76\`

The PID-reuse regression failed first:

> session/tmux/reap_test.go:253:15: undefined: addOrReplaceOrphanCandidate

Candidate refresh now replaces the stored process when a newly discovered entry has the same PID but a different StartID. That preserves the current identity so marker validation and reaping cannot skip a helper merely because it reused a captured PID slot.

The preceding exact-head macOS CI run also failed red in the changed cleanup path:

> cannot determine whether captured pid 30811 is still the same process: cannot revalidate pid 30811 identity: input/output error

Darwin returns a successful zero-entry result for an exact PID that has exited, but x/sys's singular kinfo wrapper converts that response to EIO. The per-PID backend now uses the slice wrapper, which preserves zero entries as authoritative exit while still surfacing actual sysctl errors and malformed sizes as unknown.

Final local gates on the pushed head:

- \`GOTOOLCHAIN=go1.25.0 golangci-lint run --timeout=3m --fast\`
- \`GOTOOLCHAIN=go1.25.0 gofmt -l .\` — no output
- \`GOTOOLCHAIN=go1.25.0 go build ./...\`
- \`GOTOOLCHAIN=go1.25.0 deadcode -test ./...\`
- \`scripts/lint-file-length.sh\` — 1099 files, 0 grandfathered
- \`make test-container GOTESTARGS='./internal/proctree ./session/tmux -count=1'\` — green (\`session/tmux 97.674s\`)
- Darwin/arm64 proctree test cross-compile — green
- full \`make test-container\` last — green (\`daemon 249.278s\`, \`session/tmux 101.047s\`)

Exact-head play-test used only \`-L codex-af-2706-7a86fd86\`: after session removal, exact \`has-session\` authoritatively reported no server while the marked helper remained alive. The helper and isolated server were explicitly removed; no \`af reset\` or default tmux server was used.
