### PR TITLE
Keep killed handoffs terminal after restore

### DIFF
--- a/app/dead_session_test.go
+++ b/app/dead_session_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/daemon"
@@ -260,6 +261,44 @@ func TestInteractiveGuard_RestingRowsNameTheRestoreKey(t *testing.T) {
 				"the guard names the restore key, not a shell command")
 			require.NotContains(t, err.Error(), "af sessions restore",
 				"the guard must not send the user out to a CLI command (#2479)")
+		})
+	}
+}
+
+// TestInteractiveActionsBlockLiveUserKilledSession covers a retained kill whose
+// tmux binding survived teardown. Its live liveness and reachable pane must not
+// make tree Enter, tree attach, or focused-pane attach reopen a runtime already
+// committed for deletion.
+func TestInteractiveActionsBlockLiveUserKilledSession(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		act  func(*home, *session.Instance) (tea.Model, tea.Cmd)
+	}{
+		{name: "tree_enter", act: func(h *home, _ *session.Instance) (tea.Model, tea.Cmd) {
+			return h.handleEnter()
+		}},
+		{name: "tree_attach", act: func(h *home, _ *session.Instance) (tea.Model, tea.Cmd) {
+			return h.handleAttach()
+		}},
+		{name: "focused_pane_attach", act: func(h *home, inst *session.Instance) (tea.Model, tea.Cmd) {
+			return h.handleEnterPane(h.openPaneWindow(inst, 0))
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			inst := instanceWithFakeBackend(t, "killed-but-reachable")
+			inst.MarkUserKilled()
+			h.store.AddInstance(inst)
+			h.sidebar.SetSelectedInstance(0)
+
+			model, cmd := tc.act(h, inst)
+			h = model.(*home)
+
+			require.NotNil(t, cmd, "the rejected interaction must surface a transient error")
+			h.errBox.SetSize(200, 1)
+			require.Contains(t, h.errBox.String(), "was killed")
+			require.NotContains(t, h.errBox.String(), "restore",
+				"a kill tombstone has only a teardown off-ramp, never restore")
 		})
 	}
 }

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -764,6 +764,9 @@ func interactiveGuard(inst *session.Instance) error {
 	if inst.IsTearingDown() {
 		return fmt.Errorf("session '%s' is being deleted", inst.Title)
 	}
+	if inst.UserKilled() {
+		return fmt.Errorf("session '%s' was killed and is pending deletion", inst.Title)
+	}
 	if inst.GetInFlightOp() == session.OpRestoring {
 		// Restore in flight (#1210/#1300): archived rows are re-homed into
 		// Instances while the daemon moves/spawns, and Lost/Dead rows keep their

--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -1,8 +1,6 @@
 package app
 
 import (
-	"fmt"
-
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
@@ -615,21 +613,8 @@ func (m *home) handleEnterPane(p *store.OpenPane) (tea.Model, tea.Cmd) {
 	if instance == nil || instance.IsCreating() {
 		return m, nil
 	}
-	if instance.IsTearingDown() {
-		return m, m.handleError(fmt.Errorf("session '%s' is being deleted", instance.Title))
-	}
-	if instance.GetInFlightOp() == session.OpRestoring {
-		return m, m.handleError(fmt.Errorf("session '%s' is being restored", instance.Title))
-	}
-	if instance.GetLiveness() == session.LiveLost {
-		// Restore is a key IN this interface (#2479): name it, not a shell command.
-		return m, m.handleError(fmt.Errorf("session '%s' was lost — press %s to restore", instance.Title, restoreKeyHint()))
-	}
-	if instance.GetLiveness() == session.LiveDead {
-		return m, m.handleError(fmt.Errorf("session '%s' is no longer running — press %s to restore", instance.Title, restoreKeyHint()))
-	}
-	if !instance.TmuxAlive() {
-		return m, m.handleError(fmt.Errorf("session '%s' is no longer running", instance.Title))
+	if err := interactiveGuard(instance); err != nil {
+		return m, m.handleError(err)
 	}
 	// Fence attach off a browser-only tab HERE too. The tree-selection paths guard
 	// on the SELECTED tab, but a web/vscode tab already open as a focused pane

--- a/app/sync.go
+++ b/app/sync.go
@@ -635,10 +635,18 @@ func (m *home) updateInstanceFromSnapshot(inst *session.Instance, d session.Inst
 		changed = true
 	}
 	snapshotOp := d.InFlightOp
-	if d.UserKilled || inst.UserKilled() {
+	tombstoned := d.UserKilled || inst.UserKilled()
+	if tombstoned {
 		snapshotOp = session.OpNone
 	}
-	if reconcileSnapshotOp(inst, snapshotOp, lv) {
+	// A retained tombstone can already be Lost/Archived before the user retries
+	// its teardown. Those terminal liveness values therefore do not prove THIS
+	// retry completed: success removes the record, while the RPC completion
+	// clears the optimistic fence on failure. Preserve that local OpKilling until
+	// one of those determinate outcomes arrives; the snapshot op still stays
+	// scrubbed because no daemon process owns it after the tombstone commit.
+	preserveKillRetry := tombstoned && inst.GetInFlightOp() == session.OpKilling
+	if !preserveKillRetry && reconcileSnapshotOp(inst, snapshotOp, lv) {
 		changed = true
 	}
 	// Mirror the usage-limit reset time (#1146) alongside the liveness. It's

--- a/app/sync.go
+++ b/app/sync.go
@@ -627,7 +627,18 @@ func (m *home) updateInstanceFromSnapshot(inst *session.Instance, d session.Inst
 		_ = inst.Transition(session.ObserveLiveness(lv))
 		changed = true
 	}
-	if reconcileSnapshotOp(inst, d.InFlightOp, lv) {
+	// A kill tombstone is durable while an operation marker is process-local.
+	// Adopt it monotonically and clear any old marker under one session lock, so
+	// a same-session row cannot briefly project a killed handoff as Loading. An
+	// older snapshot with UserKilled=false cannot roll an adopted tombstone back.
+	if inst.ReconcileUserKilledSnapshot(d.UserKilled) {
+		changed = true
+	}
+	snapshotOp := d.InFlightOp
+	if d.UserKilled || inst.UserKilled() {
+		snapshotOp = session.OpNone
+	}
+	if reconcileSnapshotOp(inst, snapshotOp, lv) {
 		changed = true
 	}
 	// Mirror the usage-limit reset time (#1146) alongside the liveness. It's

--- a/app/sync_test.go
+++ b/app/sync_test.go
@@ -67,21 +67,32 @@ func TestSnapshotReconcilesUserKilledTombstone(t *testing.T) {
 // tombstone, its local OpKilling is still the only fence preventing a second
 // delete request while the first RPC is in flight.
 func TestSnapshotPreservesOptimisticKillForAdoptedTombstone(t *testing.T) {
-	h := newTestHome(t)
-	inst := instanceWithFakeBackend(t, "killed-retry")
-	inst.MarkUserKilled()
-	inst.SetInFlightOpForTest(session.OpKilling)
+	for _, tc := range []struct {
+		name     string
+		liveness session.Liveness
+	}{
+		{name: "running", liveness: session.LiveRunning},
+		{name: "lost", liveness: session.LiveLost},
+		{name: "archived", liveness: session.LiveArchived},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			inst := instanceWithFakeBackend(t, "killed-retry")
+			inst.MarkUserKilled()
+			inst.SetInFlightOpForTest(session.OpKilling)
 
-	data := inst.ToInstanceData()
-	data.UserKilled = true
-	data.InFlightOp = session.OpReplacing
-	data.Liveness = session.LiveRunning
+			data := inst.ToInstanceData()
+			data.UserKilled = true
+			data.InFlightOp = session.OpReplacing
+			data.Liveness = tc.liveness
 
-	h.updateInstanceFromSnapshot(inst, data)
+			h.updateInstanceFromSnapshot(inst, data)
 
-	require.Equal(t, session.OpKilling, inst.GetInFlightOp(),
-		"a non-terminal snapshot must preserve the retry's optimistic kill fence")
-	require.False(t, inst.CanKill(), "the active retry must not expose a duplicate kill action")
+			require.Equal(t, session.OpKilling, inst.GetInFlightOp(),
+				"a tombstone poll must preserve the retry's optimistic kill fence")
+			require.False(t, inst.CanKill(), "the active retry must not expose a duplicate kill action")
+		})
+	}
 }
 
 // instanceWithFakeBackend builds an instance backed by FakeBackend, marked

--- a/app/sync_test.go
+++ b/app/sync_test.go
@@ -68,17 +68,23 @@ func TestSnapshotReconcilesUserKilledTombstone(t *testing.T) {
 // delete request while the first RPC is in flight.
 func TestSnapshotPreservesOptimisticKillForAdoptedTombstone(t *testing.T) {
 	for _, tc := range []struct {
-		name     string
-		liveness session.Liveness
+		name        string
+		localKilled bool
+		liveness    session.Liveness
 	}{
-		{name: "running", liveness: session.LiveRunning},
-		{name: "lost", liveness: session.LiveLost},
-		{name: "archived", liveness: session.LiveArchived},
+		{name: "first adoption running", liveness: session.LiveRunning},
+		{name: "first adoption lost", liveness: session.LiveLost},
+		{name: "first adoption archived", liveness: session.LiveArchived},
+		{name: "already adopted running", localKilled: true, liveness: session.LiveRunning},
+		{name: "already adopted lost", localKilled: true, liveness: session.LiveLost},
+		{name: "already adopted archived", localKilled: true, liveness: session.LiveArchived},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			h := newTestHome(t)
 			inst := instanceWithFakeBackend(t, "killed-retry")
-			inst.MarkUserKilled()
+			if tc.localKilled {
+				inst.MarkUserKilled()
+			}
 			inst.SetInFlightOpForTest(session.OpKilling)
 
 			data := inst.ToInstanceData()

--- a/app/sync_test.go
+++ b/app/sync_test.go
@@ -24,6 +24,44 @@ func TestSnapshotReconcilesModelChangeWithoutLivenessChange(t *testing.T) {
 	require.Nil(t, inst.AgentModelChange())
 }
 
+// TestSnapshotReconcilesUserKilledTombstone pins the same-session half of the
+// durable precedence rule. Cold materialization already goes through
+// FromInstanceData; an open TUI instead mutates its existing row in place and
+// must not leave a killed handoff behind a stale replacement fence or expose a
+// restore action after the daemon has scrubbed that transient op.
+func TestSnapshotReconcilesUserKilledTombstone(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		liveness       session.Liveness
+		localKilled    bool
+		snapshotKilled bool
+		snapshotOp     session.InFlightOp
+	}{
+		{name: "live snapshot carrying replacement op", liveness: session.LiveRunning, snapshotKilled: true, snapshotOp: session.OpReplacing},
+		{name: "post-restart snapshot with scrubbed op", liveness: session.LiveLost, snapshotKilled: true, snapshotOp: session.OpNone},
+		{name: "older snapshot cannot rearm an adopted tombstone", liveness: session.LiveRunning, localKilled: true, snapshotOp: session.OpReplacing},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			inst := instanceWithFakeBackend(t, "killed-handoff")
+			if tc.localKilled {
+				inst.MarkUserKilled()
+			}
+			inst.SetInFlightOpForTest(tc.snapshotOp)
+			data := inst.ToInstanceData()
+			data.Liveness = tc.liveness
+			data.InFlightOp = tc.snapshotOp
+			data.UserKilled = tc.snapshotKilled
+
+			require.True(t, h.updateInstanceFromSnapshot(inst, data))
+			require.True(t, inst.UserKilled(), "same-session reconcile lost the daemon's durable tombstone")
+			require.Equal(t, session.OpNone, inst.GetInFlightOp(), "durable tombstone must clear every process-local operation")
+			require.True(t, inst.CanKill(), "tombstone lost its explicit teardown handle")
+			require.Equal(t, session.LifecycleActionNone, inst.LifecycleAction(), "tombstone exposed a competing archive/restore action")
+		})
+	}
+}
+
 // instanceWithFakeBackend builds an instance backed by FakeBackend, marked
 // Started and Running. Used by metadata-tick tests to exercise the loop body
 // without spinning up real tmux sessions.

--- a/app/sync_test.go
+++ b/app/sync_test.go
@@ -62,6 +62,28 @@ func TestSnapshotReconcilesUserKilledTombstone(t *testing.T) {
 	}
 }
 
+// TestSnapshotPreservesOptimisticKillForAdoptedTombstone distinguishes an old
+// daemon operation from the TUI's current retry. Once the row has adopted the
+// tombstone, its local OpKilling is still the only fence preventing a second
+// delete request while the first RPC is in flight.
+func TestSnapshotPreservesOptimisticKillForAdoptedTombstone(t *testing.T) {
+	h := newTestHome(t)
+	inst := instanceWithFakeBackend(t, "killed-retry")
+	inst.MarkUserKilled()
+	inst.SetInFlightOpForTest(session.OpKilling)
+
+	data := inst.ToInstanceData()
+	data.UserKilled = true
+	data.InFlightOp = session.OpReplacing
+	data.Liveness = session.LiveRunning
+
+	h.updateInstanceFromSnapshot(inst, data)
+
+	require.Equal(t, session.OpKilling, inst.GetInFlightOp(),
+		"a non-terminal snapshot must preserve the retry's optimistic kill fence")
+	require.False(t, inst.CanKill(), "the active retry must not expose a duplicate kill action")
+}
+
 // instanceWithFakeBackend builds an instance backed by FakeBackend, marked
 // Started and Running. Used by metadata-tick tests to exercise the loop body
 // without spinning up real tmux sessions.

--- a/daemon/handoff_recovery.go
+++ b/daemon/handoff_recovery.go
@@ -40,7 +40,7 @@ func (m *Manager) ResumePendingHandoffs() {
 
 	for _, entry := range entries {
 		mission := entry.instance.PendingHandoffMission()
-		if mission == "" || entry.instance.StartupStateUnknown() {
+		if mission == "" || entry.instance.UserKilled() || entry.instance.StartupStateUnknown() {
 			m.clearPendingHandoffRetry(entry.repoID, entry.instance)
 			continue
 		}
@@ -67,7 +67,7 @@ func (m *Manager) resumePendingHandoff(entry pendingHandoffEntry, mission string
 	op := entry.instance.GetInFlightOp()
 	if killing || current != entry.instance || entry.instance.IsTearingDown() ||
 		(op != session.OpNone && op != session.OpReplacing) ||
-		entry.instance.PendingHandoffMission() != mission || entry.instance.StartupStateUnknown() {
+		entry.instance.PendingHandoffMission() != mission || entry.instance.UserKilled() || entry.instance.StartupStateUnknown() {
 		return nil
 	}
 

--- a/daemon/handoff_test.go
+++ b/daemon/handoff_test.go
@@ -621,6 +621,29 @@ func TestResumePendingHandoffs_DeliversPostReadyFailure(t *testing.T) {
 	}
 }
 
+// TestResumePendingHandoffs_SkipsUserKilled makes the durable kill tombstone
+// terminal for the handoff recovery loop too. A retained teardown must never
+// receive the mission whose delivery lost the race with that kill.
+func TestResumePendingHandoffs_SkipsUserKilled(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &handoffBackend{FakeBackend: session.NewFakeBackend()}
+	inst := registerHandoffSubject(t, manager, repoID, repoPath, "killed-pending-handoff", backend)
+	inst.SetStatusForTest(session.Ready)
+	inst.SetPendingHandoffMission("continue inherited work")
+	inst.MarkUserKilled()
+
+	manager.ResumePendingHandoffs()
+
+	if got := inst.PendingHandoffMission(); got == "" {
+		t.Fatal("handoff recovery cleared a killed session's pending mission instead of leaving teardown authoritative")
+	}
+	events, previews, _ := backend.eventSnapshot()
+	_, prompts := backend.snapshot()
+	if previews != 0 || len(prompts) != 0 || len(events) != 0 {
+		t.Fatalf("handoff recovery touched a tombstoned runtime: previews=%d prompts=%q events=%q", previews, prompts, events)
+	}
+}
+
 func TestResumePendingHandoffs_PostReadyFailureClearsOutgoingLimit(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	sendErr := errors.New("paste transport failed")

--- a/scripts/tui-2591-scenario.sh
+++ b/scripts/tui-2591-scenario.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Real-TUI drive for #2591 and its exact-head review findings, via:
+#
+#   scripts/testbox.sh scenario scripts/tui-2591-scenario.sh
+#
+# It provisions a real local session on an explicitly named private tmux socket,
+# then makes only that af_* session's kill-session command fail. The daemon must
+# retain a durable UserKilled row while the real tmux binding remains reachable.
+# That is the state unit app tests cannot create: they replace the backend with a
+# fake before the interaction code runs.
+set -euo pipefail
+
+# Route the driver, the TUI, and the daemon through one explicitly isolated tmux
+# server. The wrapper also provides a deterministic unknown-state teardown: it
+# rejects kill-session only for af_* runtime targets, never the driver's session.
+real_tmux="$(command -v tmux)"
+# Agent Factory deliberately sanitizes PATH before it starts the daemon. Its
+# preserved prefix is $HOME/bin (where the sandbox binary also lives), so the
+# wrapper must live there or only the driver—not the daemon—would see it.
+wrapper="$HOME/bin/tmux"
+# The single-quoted lines are the wrapper's source; their variables must expand
+# when that generated script runs, not while this scenario writes it.
+# shellcheck disable=SC2016
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'set -euo pipefail' \
+    'printf "call %s\n" "$*" >>"$AGENT_FACTORY_HOME/tmux-wrapper.log"' \
+    'is_kill=0' \
+    'runtime_target=' \
+    'for arg in "$@"; do' \
+    '    case "$arg" in' \
+    '        kill-session) is_kill=1 ;;' \
+    '        =af_*|af_*) runtime_target="$arg" ;;' \
+    '    esac' \
+    'done' \
+    'if [ "$is_kill" = 1 ] && [ -n "$runtime_target" ]; then' \
+    '    printf "blocked %s\n" "$runtime_target" >>"$AGENT_FACTORY_HOME/tmux-wrapper.log"' \
+    '    exec sleep 30' \
+    'fi' \
+    "exec '$real_tmux' -L af-2591 \"\$@\"" >"$wrapper"
+chmod +x "$wrapper"
+export AF_DRIVER_SESSION=drive-2591
+
+# shellcheck source=/dev/null
+source /src/scripts/tui-driver.sh
+
+af_reset_sandbox
+af_boot
+af_new_instance killed-handoff
+af_select killed-handoff
+
+# Commit the kill through the real UI. The wrapper leaves the runtime present,
+# so the daemon retains the tombstone and reports the unknown teardown outcome.
+af_send D
+af_wait_for "Kill session 'killed-handoff'" "$AF_DRIVER_TIMEOUT" 'kill confirmation'
+af_send y
+af_wait_for "failed to kill session 'killed-handoff'" "$AF_DRIVER_TIMEOUT" \
+    'unknown teardown is surfaced to the user'
+grep -q '^blocked =af_' "$AGENT_FACTORY_HOME/tmux-wrapper.log" ||
+    _af_fail '#2591 fixture failed: the daemon did not execute the isolated tmux timeout wrapper'
+
+runtime_session="$(tmux list-sessions -F '#{session_name}' | grep '^af_' | head -1)"
+[ -n "$runtime_session" ] || _af_fail '#2591 fixture failed: the real runtime did not survive kill-session'
+tmux has-session -t "=$runtime_session"
+_af_log "assert OK: retained tombstone still has real tmux runtime $runtime_session on socket af-2591"
+
+# Restart the disposable container's real daemon from persisted state, then
+# replace only the named driver session. This is the actual cold-restore edge in
+# #2591; neither operation reaches the host daemon or the default tmux server.
+"$HOME/bin/af" daemon restart
+af_boot
+
+# The cold daemon projection must expose the retry. af_select requires the
+# row-scoped `D kill` menu item, so it fails if CanKill is false.
+af_select killed-handoff
+_af_log 'assert OK: retained live tombstone remains explicitly killable after reload'
+# af_select anchors with a burst of navigation keys. Let Bubble Tea drain their
+# highlight/replay messages before attributing the next edge-triggered key.
+sleep 2
+
+# Enter is the real-TUI proof from the cold-restored row. Without the guard it
+# opens/focuses the still-live runtime instead of producing the message below;
+# focused-pane and full-screen attach use the same guard and are covered at
+# their direct action funnels in app/dead_session_test.go.
+af_send Enter
+af_wait_for "session 'killed-handoff' was killed and is pending deletion" \
+    "$AF_DRIVER_TIMEOUT" 'Enter is fenced by durable kill intent'
+af_refute_screen 'nav mode' 'Enter did not enter the retained runtime'
+
+echo 'PASS: #2591 retained live tombstone stays killable and non-interactive'

--- a/scripts/tui-2591-scenario.sh
+++ b/scripts/tui-2591-scenario.sh
@@ -13,11 +13,42 @@ set -euo pipefail
 # Route the driver, the TUI, and the daemon through one explicitly isolated tmux
 # server. The wrapper also provides a deterministic unknown-state teardown: it
 # rejects kill-session only for af_* runtime targets, never the driver's session.
-real_tmux="$(command -v tmux)"
 # Agent Factory deliberately sanitizes PATH before it starts the daemon. Its
 # preserved prefix is $HOME/bin (where the sandbox binary also lives), so the
 # wrapper must live there or only the driver—not the daemon—would see it.
 wrapper="$HOME/bin/tmux"
+
+# A pinned AF_SELFTEST_NAME reuses its container. Resolve the underlying binary
+# past any pre-existing wrapper, preserve that path exactly, and restore it on
+# every exit so this scenario cannot poison a later driver run or recurse into
+# its own generated script.
+real_tmux=
+while IFS= read -r candidate; do
+    if [ "$candidate" != "$wrapper" ]; then
+        real_tmux="$candidate"
+        break
+    fi
+done < <(type -aP tmux)
+[ -n "$real_tmux" ] || {
+    printf '%s\n' '#2591 fixture failed: could not resolve the real tmux binary' >&2
+    exit 1
+}
+
+wrapper_backup_dir="$(mktemp -d)"
+wrapper_existed=0
+if [ -e "$wrapper" ] || [ -L "$wrapper" ]; then
+    cp -a -- "$wrapper" "$wrapper_backup_dir/tmux"
+    wrapper_existed=1
+fi
+cleanup_tmux_wrapper() {
+    rm -f -- "$wrapper"
+    if [ "$wrapper_existed" = 1 ]; then
+        cp -a -- "$wrapper_backup_dir/tmux" "$wrapper"
+    fi
+    rm -rf -- "$wrapper_backup_dir"
+}
+trap cleanup_tmux_wrapper EXIT
+
 # The single-quoted lines are the wrapper's source; their variables must expand
 # when that generated script runs, not while this scenario writes it.
 # shellcheck disable=SC2016

--- a/session/activity.go
+++ b/session/activity.go
@@ -50,6 +50,13 @@ const (
 // mid-create session as idle — releasing a concurrency slot it should hold, and
 // telling `sessions watch` a session is ready before it ever started.
 func ClassifyActivity(data InstanceData) (Activity, string) {
+	// A committed kill is terminal even while its teardown or an older operation
+	// marker remains visible. UserKilled means finish-this-kill, never resume work;
+	// treating a stale pending mission/op as active would keep watch and task slots
+	// alive for a run that can no longer continue.
+	if data.UserKilled {
+		return ActivityTerminal, "session was killed and its teardown is pending"
+	}
 	// A failed create whose runtime identity could not be confirmed is a settled
 	// blocked outcome, not an idle LiveReady session. It wins even over a stale
 	// OpCreating persisted by the failure path: no automatic operation may settle
@@ -184,6 +191,7 @@ func (v LifecycleView) Activity() Activity {
 	activity, _ := ClassifyActivity(InstanceData{
 		Liveness:            v.Liveness,
 		InFlightOp:          v.InFlightOp,
+		UserKilled:          v.UserKilled,
 		StartupStateUnknown: v.StartupStateUnknown,
 	})
 	return activity

--- a/session/activity_test.go
+++ b/session/activity_test.go
@@ -142,6 +142,30 @@ func TestLifecycleViewActivity(t *testing.T) {
 	require.Equal(t, ActivityIdle, i.LifecycleView().Activity(), "an idle agent releases its slot")
 }
 
+// TestActivity_UserKilledOutranksPendingHandoff keeps raw stored records and
+// live lifecycle views aligned: a committed kill is terminal even if the handoff
+// mission and its transient replacement op have not been cleared yet.
+func TestActivity_UserKilledOutranksPendingHandoff(t *testing.T) {
+	t.Run("record", func(t *testing.T) {
+		activity, _ := ClassifyActivity(InstanceData{
+			Liveness:              LiveRunning,
+			InFlightOp:            OpReplacing,
+			PendingHandoffMission: "continue inherited work",
+			UserKilled:            true,
+		})
+		require.Equal(t, ActivityTerminal, activity)
+	})
+
+	t.Run("lifecycle view", func(t *testing.T) {
+		activity := (LifecycleView{
+			Liveness:   LiveRunning,
+			InFlightOp: OpReplacing,
+			UserKilled: true,
+		}).Activity()
+		require.Equal(t, ActivityTerminal, activity)
+	})
+}
+
 // TestLifecycleViewIsInternallyConsistent: the whole point of the view is that
 // every field describes the SAME instant. A caller reaching a verdict from two
 // accessor calls can have a concurrent restore land between them and see a state

--- a/session/handoff_pending_test.go
+++ b/session/handoff_pending_test.go
@@ -50,3 +50,54 @@ func TestPendingHandoffMissionReconstructsDurableFence(t *testing.T) {
 		t.Fatal("startup-unknown pending record lost its explicit kill handle")
 	}
 }
+
+// TestPendingHandoffMissionWithUserKilledDoesNotReconstructFence proves the
+// durable kill tombstone outranks an undelivered handoff mission after storage
+// has scrubbed the process-local operation axis. The row must remain settled and
+// explicitly killable so the daemon can finish teardown after restart.
+func TestPendingHandoffMissionWithUserKilledDoesNotReconstructFence(t *testing.T) {
+	stored := (InstanceData{
+		ID:                    "killed-during-handoff-id",
+		Title:                 "killed-during-handoff",
+		Program:               "claude",
+		Status:                Running,
+		Liveness:              LiveRunning,
+		BackendType:           "docker",
+		PendingHandoffMission: "continue the inherited work",
+		UserKilled:            true,
+	}).ForStorage()
+
+	restored, err := FromInstanceData(stored)
+	if err != nil {
+		t.Fatalf("FromInstanceData: %v", err)
+	}
+	if got := restored.GetInFlightOp(); got != OpNone {
+		t.Fatalf("UserKilled pending-handoff record restored op %v, want OpNone", got)
+	}
+	if got := restored.GetStatus(); got == Loading {
+		t.Fatalf("UserKilled pending-handoff record restored as %v, want a settled teardown row", got)
+	}
+	if !restored.CanKill() {
+		t.Fatal("UserKilled pending-handoff record lost its explicit kill handle")
+	}
+	if got := restored.LifecycleAction(); got != LifecycleActionNone {
+		t.Fatalf("UserKilled pending-handoff record advertised lifecycle action %q, want none", got)
+	}
+
+	// A live daemon snapshot can still carry the pre-kill replacement op. The
+	// tombstone must override that carried transient just as it overrides the
+	// durable mission's reconstructed transient after a disk round-trip.
+	snapshot := stored
+	snapshot.Status = Loading
+	snapshot.InFlightOp = OpReplacing
+	restoredSnapshot, err := FromInstanceData(snapshot)
+	if err != nil {
+		t.Fatalf("FromInstanceData(snapshot): %v", err)
+	}
+	if got := restoredSnapshot.GetInFlightOp(); got != OpNone {
+		t.Fatalf("UserKilled pending-handoff snapshot restored op %v, want OpNone", got)
+	}
+	if !restoredSnapshot.CanKill() {
+		t.Fatal("UserKilled pending-handoff snapshot lost its explicit kill handle")
+	}
+}

--- a/session/instance_accessors.go
+++ b/session/instance_accessors.go
@@ -104,6 +104,30 @@ func (i *Instance) MarkUserKilled() {
 	i.userKilled = true
 }
 
+// ReconcileUserKilledSnapshot applies the durable tombstone carried by a
+// daemon snapshot to an already-materialized projection row. Tombstones are
+// monotonic: an older snapshot cannot make a killed row live again. Once the
+// tombstone is present, any reconstructed operation marker belongs to the old
+// process and must be cleared; only the daemon that owns an active teardown may
+// temporarily keep its live operation fence alongside MarkUserKilled.
+func (i *Instance) ReconcileUserKilledSnapshot(userKilled bool) bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	lv, op, resetAt := i.lifecycleStateLocked()
+	changed := false
+	if userKilled && !i.userKilled {
+		i.userKilled = true
+		changed = true
+	}
+	if i.userKilled && i.inFlightOp != OpNone {
+		i.inFlightOp = OpNone
+		changed = true
+	}
+	i.noteStateChangeLocked(lv, op, resetAt)
+	return changed
+}
+
 // UserKilled reports whether an explicit kill was recorded for this instance.
 func (i *Instance) UserKilled() bool {
 	i.mu.RLock()

--- a/session/instance_accessors.go
+++ b/session/instance_accessors.go
@@ -117,9 +117,10 @@ func (i *Instance) MarkUserKilled() {
 // ReconcileUserKilledSnapshot applies the durable tombstone carried by a
 // daemon snapshot to an already-materialized projection row. Tombstones are
 // monotonic: an older snapshot cannot make a killed row live again. When the
-// tombstone is first adopted, any existing operation marker belongs to the old
-// process and must be cleared with it. A later reconcile preserves an OpKilling
-// raised locally for the user's current teardown retry.
+// tombstone is first adopted, stale daemon operation markers must be cleared
+// with it. OpKilling is different: snapshot reconciliation runs on the TUI's
+// projection instance, so that marker belongs to the user's current teardown
+// request and must survive even the first tombstone snapshot.
 func (i *Instance) ReconcileUserKilledSnapshot(userKilled bool) bool {
 	i.mu.Lock()
 	defer i.mu.Unlock()
@@ -128,7 +129,9 @@ func (i *Instance) ReconcileUserKilledSnapshot(userKilled bool) bool {
 	changed := false
 	if userKilled && !i.userKilled {
 		i.userKilled = true
-		i.inFlightOp = OpNone
+		if i.inFlightOp != OpKilling {
+			i.inFlightOp = OpNone
+		}
 		changed = true
 	}
 	i.noteStateChangeLocked(lv, op, resetAt)

--- a/session/instance_accessors.go
+++ b/session/instance_accessors.go
@@ -98,18 +98,28 @@ func (i *Instance) GetWorktreeBranch() string {
 
 // MarkUserKilled records kill intent on the instance (#1108). Callers persist
 // the instance afterwards so the tombstone survives a daemon crash mid-kill.
+// Daemon callers reach this commit at serialized points: an explicit kill owns
+// the per-session operation lock, while failed-create retention still owns the
+// repo start lock and has not exposed the instance to another operation. Any
+// carried process-local operation therefore has no live owner and must not
+// outrank the durable tombstone or hide its retry action. A TUI retry owns its
+// OpKilling on a separate projection instance and is preserved by snapshot
+// reconciliation.
 func (i *Instance) MarkUserKilled() {
 	i.mu.Lock()
 	defer i.mu.Unlock()
+	lv, op, resetAt := i.lifecycleStateLocked()
 	i.userKilled = true
+	i.inFlightOp = OpNone
+	i.noteStateChangeLocked(lv, op, resetAt)
 }
 
 // ReconcileUserKilledSnapshot applies the durable tombstone carried by a
 // daemon snapshot to an already-materialized projection row. Tombstones are
-// monotonic: an older snapshot cannot make a killed row live again. Once the
-// tombstone is present, any reconstructed operation marker belongs to the old
-// process and must be cleared; only the daemon that owns an active teardown may
-// temporarily keep its live operation fence alongside MarkUserKilled.
+// monotonic: an older snapshot cannot make a killed row live again. When the
+// tombstone is first adopted, any existing operation marker belongs to the old
+// process and must be cleared with it. A later reconcile preserves an OpKilling
+// raised locally for the user's current teardown retry.
 func (i *Instance) ReconcileUserKilledSnapshot(userKilled bool) bool {
 	i.mu.Lock()
 	defer i.mu.Unlock()
@@ -118,9 +128,6 @@ func (i *Instance) ReconcileUserKilledSnapshot(userKilled bool) bool {
 	changed := false
 	if userKilled && !i.userKilled {
 		i.userKilled = true
-		changed = true
-	}
-	if i.userKilled && i.inFlightOp != OpNone {
 		i.inFlightOp = OpNone
 		changed = true
 	}

--- a/session/instance_data.go
+++ b/session/instance_data.go
@@ -42,7 +42,7 @@ func (i *Instance) toInstanceDataLocked() InstanceData {
 		Status:                i.statusLocked(),
 		Liveness:              i.liveness,
 		InFlightOp:            i.inFlightOp,
-		LifecycleAction:       lifecycleActionFor(i.ID, i.liveness, i.inFlightOp, i.startupStateUnknown),
+		LifecycleAction:       lifecycleActionFor(i.ID, i.liveness, i.inFlightOp, i.startupStateUnknown, i.userKilled),
 		CanKill:               canKillFor(i.ID, i.inFlightOp),
 		CanHandoff:            i.canHandoffLocked(),
 		CurrentAgent:          i.currentAgentNameLocked(),
@@ -166,8 +166,14 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 	// an irreversible runtime swap completed but its takeover brief did not. Disk
 	// still scrubs the generic op enum, then this specific proof reconstructs the
 	// replacement fence so status polling cannot call the idle incoming composer a
-	// completed task before recovery delivers its mission.
-	if data.PendingHandoffMission != "" && !data.StartupStateUnknown && inFlightOp == OpNone {
+	// completed task before recovery delivers its mission. A kill tombstone
+	// outranks every process-local op, including one carried by a live snapshot;
+	// startup-unknown likewise prevents synthesizing a replacement fence. Both
+	// terminal markers must retain an explicit teardown handle rather than load as
+	// an in-flight replacement.
+	if data.UserKilled {
+		inFlightOp = OpNone
+	} else if data.PendingHandoffMission != "" && !data.StartupStateUnknown && inFlightOp == OpNone {
 		inFlightOp = OpReplacing
 	}
 	instance := &Instance{

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -114,12 +114,13 @@ func opIsTeardown(op InFlightOp) bool {
 // already tearing down (OpKilling/OpArchiving) is inside the teardown fence, so
 // it offers no verb either — the action it would show (Archive on a live row,
 // Restore on the archived result) is precisely the mutation the fence exists to
-// refuse. Resting rows restore; every other settled row archives. Kill
-// addressability is intentionally independent (CanKill): a retained
-// startup-unknown row must remain removable without becoming attachable,
-// archivable, or restorable.
-func lifecycleActionFor(id string, liveness Liveness, op InFlightOp, startupStateUnknown bool) LifecycleAction {
-	if id == "" || op == OpCreating || op == OpReplacing || opIsTeardown(op) || startupStateUnknown {
+// refuse. A kill tombstone likewise admits no competing archive/restore action:
+// its only valid transition is finishing teardown. Resting rows restore; every
+// other settled row archives. Kill addressability is intentionally independent
+// (CanKill): a retained tombstone or startup-unknown row must remain removable
+// without becoming attachable, archivable, or restorable.
+func lifecycleActionFor(id string, liveness Liveness, op InFlightOp, startupStateUnknown, userKilled bool) LifecycleAction {
+	if id == "" || op == OpCreating || op == OpReplacing || opIsTeardown(op) || startupStateUnknown || userKilled {
 		return LifecycleActionNone
 	}
 	switch liveness {
@@ -147,7 +148,7 @@ func canKillFor(id string, op InFlightOp) bool {
 func (i *Instance) LifecycleAction() LifecycleAction {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
-	return lifecycleActionFor(i.ID, i.liveness, i.inFlightOp, i.startupStateUnknown)
+	return lifecycleActionFor(i.ID, i.liveness, i.inFlightOp, i.startupStateUnknown, i.userKilled)
 }
 
 // CanKill reports whether interactive clients may offer explicit teardown for

--- a/session/liveness_test.go
+++ b/session/liveness_test.go
@@ -129,11 +129,12 @@ func TestSnapshotInFlightOpRoundTrips(t *testing.T) {
 // the two non-actionable rows that triggered the regression.
 func TestLifecycleActionIsSharedAcrossInstanceAndProjection(t *testing.T) {
 	for _, tc := range []struct {
-		name string
-		id   string
-		live Liveness
-		op   InFlightOp
-		want LifecycleAction
+		name   string
+		id     string
+		live   Liveness
+		op     InFlightOp
+		killed bool
+		want   LifecycleAction
 	}{
 		{name: "ready archives", id: "ready-id", live: LiveReady, want: LifecycleActionArchive},
 		{name: "running archives", id: "running-id", live: LiveRunning, want: LifecycleActionArchive},
@@ -142,10 +143,11 @@ func TestLifecycleActionIsSharedAcrossInstanceAndProjection(t *testing.T) {
 		{name: "archived restores", id: "archived-id", live: LiveArchived, want: LifecycleActionRestore},
 		{name: "creating has no lifecycle action", id: "pending-id", live: LiveReady, op: OpCreating, want: LifecycleActionNone},
 		{name: "replacing admits no competing lifecycle action", id: "handoff-id", live: LiveReady, op: OpReplacing, want: LifecycleActionNone},
+		{name: "tombstone admits no lifecycle action", id: "killed-id", live: LiveLost, killed: true, want: LifecycleActionNone},
 		{name: "id-less has no lifecycle action", live: LiveReady, want: LifecycleActionNone},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			inst := &Instance{ID: tc.id, liveness: tc.live, inFlightOp: tc.op}
+			inst := &Instance{ID: tc.id, liveness: tc.live, inFlightOp: tc.op, userKilled: tc.killed}
 			require.Equal(t, tc.want, inst.LifecycleAction(), "TUI domain decision")
 			require.Equal(t, tc.want, inst.ToInstanceData().LifecycleAction, "web projection decision")
 		})

--- a/session/liveness_test.go
+++ b/session/liveness_test.go
@@ -215,6 +215,22 @@ func TestKillAddressabilityIsSharedAcrossInstanceAndProjection(t *testing.T) {
 	}
 }
 
+// TestMarkUserKilledClearsStaleOperationAndKeepsTeardownAddressable pins the
+// daemon commit point: the per-session operation lock proves a carried handoff
+// marker has no live owner by the time kill intent becomes durable. Leaving the
+// marker would hide the only retry action on a retained unknown-state teardown.
+func TestMarkUserKilledClearsStaleOperationAndKeepsTeardownAddressable(t *testing.T) {
+	inst := &Instance{ID: "killed-handoff-id", liveness: LiveRunning, inFlightOp: OpReplacing}
+
+	inst.MarkUserKilled()
+
+	require.Equal(t, OpNone, inst.GetInFlightOp(), "durable kill intent must discard the stale handoff fence")
+	require.True(t, inst.CanKill(), "a retained tombstone must keep its explicit teardown handle")
+	data := inst.ToInstanceData()
+	require.True(t, data.UserKilled)
+	require.True(t, data.CanKill, "daemon and web projections must expose the same teardown handle")
+}
+
 func TestInFlightOpStrippedFromStorageRecords(t *testing.T) {
 	data := InstanceData{Status: Deleting, Liveness: LiveRunning, InFlightOp: OpArchiving}
 	stored := data.ForStorage()


### PR DESCRIPTION
## Summary

- make `UserKilled` outrank both reconstructed and snapshot-carried handoff replacement operations
- reconcile the durable tombstone monotonically into already-open TUI rows and atomically discard their stale process-local operation
- classify killed retained handoffs as terminal and prevent the recovery loop from delivering their stale mission
- keep the explicit kill handle visible while suppressing competing archive/restore actions in both TUI and web projections

## Diagnosis verification

The issue diagnosis is correct: `FromInstanceData` reconstructed `OpReplacing` whenever `PendingHandoffMission` survived storage, without considering the durable `UserKilled` tombstone. That composed the row as `Loading` and made `CanKill` false.

The adjacent audit found the same precedence assumption in nearby paths and fixes them in this PR:

- a newly materialized live snapshot could carry `UserKilled + OpReplacing`
- an already-open TUI row never adopted `d.UserKilled`, so the same tombstone could remain behind `OpReplacing` or expose archive/restore after the daemon scrubbed the op
- `ClassifyActivity` / `LifecycleView.Activity` let the pending mission/op outrank `UserKilled`
- `ResumePendingHandoffs` could deliver and clear the old mission after the kill committed
- the lifecycle projection could advertise Restore for the now-settled tombstone even though runtime action validation rejects killed rows

Cold/add/swap materialization goes through `FromInstanceData`; `updateInstanceFromSnapshot` is the only same-session in-place projection path. The latter now uses `ReconcileUserKilledSnapshot`, which documents and atomically enforces the monotonic snapshot rule without changing `MarkUserKilled`: an active daemon teardown may legitimately retain its live operation fence.

Storage retention and task-slot accounting already handle `UserKilled` correctly, and `CanKill` intentionally remains a separate axis so teardown stays available.

## Red-first evidence

The storage round trip failed first:

```
--- FAIL: TestPendingHandoffMissionWithUserKilledDoesNotReconstructFence (0.00s)
    handoff_pending_test.go:75: UserKilled pending-handoff record restored op 5, want OpNone
FAIL
```

A newly materialized live snapshot carrying the stale operation failed separately:

```
handoff_pending_test.go:95: UserKilled pending-handoff snapshot restored op 5, want OpNone
```

The raw record and lifecycle projection both classified the tombstone as pending instead of terminal:

```
expected: 2
actual  : 0
Test: TestActivity_UserKilledOutranksPendingHandoff/record
Test: TestActivity_UserKilledOutranksPendingHandoff/lifecycle_view
```

Recovery touched the killed handoff:

```
handoff_test.go:638: handoff recovery cleared a killed session's pending mission instead of leaving teardown authoritative
```

The shared lifecycle policy exposed Restore:

```
expected: ""
actual  : "restore"
Test: TestLifecycleActionIsSharedAcrossInstanceAndProjection/tombstone_admits_no_lifecycle_action
```

The later inline-review regression for an existing TUI row was also observed red before its fix:

```
--- FAIL: TestSnapshotReconcilesUserKilledTombstone
    --- FAIL: TestSnapshotReconcilesUserKilledTombstone/live_snapshot_carrying_replacement_op
        sync_test.go:50: Error: Should be true
    --- FAIL: TestSnapshotReconcilesUserKilledTombstone/post-restart_snapshot_with_scrubbed_op
        sync_test.go:51: Error: Should be true
        same-session reconcile lost the daemon's durable tombstone
FAIL
```

The monotonic older-snapshot case failed independently:

```
--- FAIL: TestSnapshotReconcilesUserKilledTombstone
    --- FAIL: TestSnapshotReconcilesUserKilledTombstone/older_snapshot_cannot_rearm_an_adopted_tombstone
        sync_test.go:56: Error: Should be true
FAIL
```

## Verification

Pushed head: `a9f9363f8b9dc9d7f254ef00bf616266e20b5ed3`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- complete `app` package
- complete `session` package
- focused storage, activity, lifecycle-action, handoff-recovery, and same-session reconciliation regressions
- `make test-container` last against the pushed head

Closes #2591
## Exact-head review follow-up

The first Codex review on `809410bc53d9e94931a8ecf1980807d8f956c73b` found three adjacent lifecycle gaps. All three were reproduced before their fixes.

A repeated snapshot erased the TUI retry fence:

```
--- FAIL: TestSnapshotPreservesOptimisticKillForAdoptedTombstone
    expected: 2
    actual  : 0
    a non-terminal snapshot must preserve the retry's optimistic kill fence
```

The daemon tombstone commit retained the stale handoff operation:

```
--- FAIL: TestMarkUserKilledClearsStaleOperationAndKeepsTeardownAddressable
    expected: 0
    actual  : 5
    durable kill intent must discard the stale handoff fence
```

All three interaction funnels admitted the retained live runtime:

```
--- FAIL: TestInteractiveActionsBlockLiveUserKilledSession
    --- FAIL: .../tree_enter
    --- FAIL: .../tree_attach
    --- FAIL: .../focused_pane_attach
        Expected value not to be nil.
        the rejected interaction must surface a transient error
```

The fix distinguishes daemon state from the TUI projection: `MarkUserKilled` clears the stale daemon-owned operation at its serialized commit point, while `ReconcileUserKilledSnapshot` clears an operation only when the projection first adopts the tombstone and preserves a later local `OpKilling` retry. Every Enter/attach funnel now uses the shared `UserKilled` guard, including focused panes.

The real-TUI replay uses only tmux socket `-L af-2591`, retains a real `af_*` runtime after an unknown teardown, restarts the disposable container daemon from disk, and then proves the cold row is both explicitly killable and non-interactive:

```
[tui-driver] assert OK: retained tombstone still has real tmux runtime af_f5fff34b_killed-handoff on socket af-2591
daemon restarted
[tui-driver] assert OK: retained live tombstone remains explicitly killable after reload
[tui-driver] refute OK: Enter did not enter the retained runtime
PASS: #2591 retained live tombstone stays killable and non-interactive
```

### Final verification

Pushed head: `a9f9363f8b9dc9d7f254ef00bf616266e20b5ed3`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- complete `app`, `session`, and `daemon` packages
- `bash -n scripts/tui-2591-scenario.sh`
- `shellcheck scripts/tui-2591-scenario.sh`
- `scripts/testbox.sh scenario scripts/tui-2591-scenario.sh`
- `make test-container` last against the pushed head

## Second exact-head review follow-up

The Codex review of `1d5fc2bbb3ffb2b28ba25f080fdfa683db0d47df` found two more P2s. Both were reproduced before their fixes.

Terminal tombstone liveness incorrectly cleared the active retry fence:

```
--- FAIL: TestSnapshotPreservesOptimisticKillForAdoptedTombstone/lost
    expected: 2
    actual  : 0
    a tombstone poll must preserve the retry's optimistic kill fence
--- FAIL: TestSnapshotPreservesOptimisticKillForAdoptedTombstone/archived
    expected: 2
    actual  : 0
    a tombstone poll must preserve the retry's optimistic kill fence
```

The reusable scenario passed once, then the second invocation hung in the recursively generated tmux wrapper:

```
first invocation: PASS: #2591 retained live tombstone stays killable and non-interactive
second invocation: no output for 60 seconds; scoped test process remained alive
terminated scoped test process: exit 143
```

The reconcile now preserves a local `OpKilling` whenever the row is already tombstoned, regardless of its pre-existing liveness. A successful retry removes the record; a failed retry's RPC completion clears the local fence, so a Lost/Archived poll is no longer collapsed into false completion.

The TUI scenario now resolves the real tmux binary past `$HOME/bin/tmux`, saves any pre-existing wrapper, and restores/removes it in an EXIT trap. On the rebased head it passed twice in one pinned container, with the wrapper absent after each invocation. A separate seeded-wrapper replay restored the exact pre-run checksum:

```
3242e86d38e486d0f6ba7c1f536c18e277b030f9679583d7029c17f4fcca7f95  /home/dev/bin/tmux
```

### Final verification after second review

Pushed head: `a9f9363f8b9dc9d7f254ef00bf616266e20b5ed3`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- complete `app` package
- `bash -n scripts/tui-2591-scenario.sh`
- `shellcheck scripts/tui-2591-scenario.sh`
- pinned reusable TUI scenario twice, wrapper absent after both runs
- seeded pre-existing wrapper restored byte-for-byte
- `make test-container` last against the pushed head
## Third exact-head review follow-up

The Codex review of `d95115abd39d255df6f789735dd46eaaf22f86dd` found one more P2: the first daemon tombstone snapshot could clear the TUI-owned optimistic kill fence before the local projection had adopted `UserKilled`. All three liveness variants were observed red before the fix:

```
--- FAIL: TestSnapshotPreservesOptimisticKillForAdoptedTombstone/first_adoption_running
    expected: 2
    actual  : 0
--- FAIL: TestSnapshotPreservesOptimisticKillForAdoptedTombstone/first_adoption_lost
    expected: 2
    actual  : 0
--- FAIL: TestSnapshotPreservesOptimisticKillForAdoptedTombstone/first_adoption_archived
    expected: 2
    actual  : 0
    a tombstone poll must preserve the retry's optimistic kill fence
```

`ReconcileUserKilledSnapshot` now preserves projection-owned `OpKilling` during first tombstone adoption as well as later polls, while still clearing every other stale snapshot operation. The same table covers first and already-adopted `Running`, `Lost`, and `Archived` rows.

### Final verification after third review

Pushed head: `a9f9363f8b9dc9d7f254ef00bf616266e20b5ed3`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- complete `app` package
- focused first/adopted tombstone reconciliation regressions
- `bash -n scripts/tui-2591-scenario.sh`
- `shellcheck scripts/tui-2591-scenario.sh`
- exact-head real-TUI cold-restore scenario on isolated tmux socket `-L af-2591`
- `make test-container` last against the pushed head