### PR TITLE
docs(skills): gate-pr is author-owned and gates on Codex, not Greptile

### DIFF
--- a/.claude/skills/create-pr.md
+++ b/.claude/skills/create-pr.md
@@ -12,12 +12,19 @@ Create a PR for the current branch against `master`.
 
 1. **Pre-flight checks** — before creating the PR, run these and fix any issues:
    ```bash
-   golangci-lint run --timeout=3m --fast
    gofmt -l .                    # fix any output with: gofmt -w <file>
    go build ./...
-   make test-container           # never run bare go test ./... on a shared host
+   golangci-lint run --timeout=3m --fast
    deadcode -test ./...
    scripts/lint-file-length.sh
+   go test ./<only the package you changed>/...   # skip if it is daemon/ or app/
+
+   # Do NOT run make test-container as a routine gate — CI runs
+   # `go test -race ./...` on every push, and a local container run rebuilds the
+   # whole Go tree, which takes the shared box down when sessions do it in
+   # parallel. Never bare `go test ./...` on the host. If your change is in
+   # daemon/ or app/, run NO tests for it locally — they spawn real af daemons
+   # and drive real tmux next to live sessions. Push and let CI test it.
    ```
 
 2. **Review changes** — examine the diff against master:
@@ -47,7 +54,7 @@ Create a PR for the current branch against `master`.
    - [x] `golangci-lint run --timeout=3m --fast` passes
    - [x] `gofmt -l .` produces no output
    - [x] `go build ./...` passes
-   - [x] `make test-container` passes
+   - [x] `go test` on the changed package passes (CI runs the full matrix)
    - [x] `deadcode -test ./...` produces no output
    - [x] `scripts/lint-file-length.sh` passes
    - [ ] Manually tested in TUI (if applicable)

--- a/.claude/skills/decompose-file.md
+++ b/.claude/skills/decompose-file.md
@@ -44,12 +44,15 @@ merges before the next file begins.
 6. **Run the gates**:
    ```bash
    gofmt -w <changed-go-files>
-   golangci-lint run --timeout=3m --fast
    gofmt -l .
    go build ./...
-   make test-container
+   golangci-lint run --timeout=3m --fast
    deadcode -test ./...
    scripts/lint-file-length.sh
+   go test ./<the package you split>/...   # skip if it is daemon/ or app/
+
+   # No make test-container — CI runs `go test -race ./...` on every push.
+   # A decomposition is exactly the case CI covers well: same code, moved.
    ```
 
    If the change is TUI-visible, also play-test the affected flow before

--- a/.claude/skills/dispatch-af-session.md
+++ b/.claude/skills/dispatch-af-session.md
@@ -7,7 +7,9 @@ user_invocable: true
 # Dispatch AF Session
 
 Dispatch focused implementation work to an `af` session with the standard
-Captain Claude contract. Root verifies and merges; worker sessions do not.
+Captain Claude contract. **The session that writes the PR gates and merges it.**
+Root does not sit between a finished PR and master — that queue is what turns a
+green PR into a week-old PR.
 
 ## Steps
 
@@ -19,22 +21,35 @@ Captain Claude contract. Root verifies and merges; worker sessions do not.
 
    Task: <specific implementation request>
 
-   Do NOT merge. Root verifies the PR.
+   You own this PR end to end, including the merge. Follow the gate-pr skill
+   and merge it yourself when its gates pass. Do not hand the PR back to root.
 
-   Gates:
-   - golangci-lint run --timeout=3m --fast
+   Local gates (cheap only, before opening the PR):
    - gofmt -l .
    - go build ./...
-   - make test-container
+   - golangci-lint run --timeout=3m --fast
    - deadcode -test ./...
    - scripts/lint-file-length.sh
+   - go test ./<only the package you changed>/...  (skip if it is daemon/ or app/)
    - <any task-specific gate>
+
+   Do NOT run make test-container / remote-roundtrip-container /
+   playtest-container as a routine gate — CI runs the full matrix on every
+   push, and concurrent container runs take the shared box down. Push, let CI
+   run the rest, and fix what it reports on your PR head.
+
+   Merge gates (gate-pr, after the PR is open):
+   - every triggered check finished, none failed
+   - a Codex review for the exact head SHA — no review is NOT a clean review
+   - zero unresolved inline findings, each cleared by an in-reply-to RESOLVED
+   - merge with: gh pr merge <n> --squash --match-head-commit <gated sha>
 
    Sign the PR as Captain Claude.
    Include: Closes #<n>
 
-   NOTIFY ROOT:
-   af sessions send-prompt root "DONE <name>: <PR#/status>"
+   NOTIFY ROOT when the PR is merged, or when a gate blocks you and you
+   cannot clear it yourself:
+   af sessions send-prompt root "DONE <name>: <PR# merged | blocked on X>"
    ```
 
    If the notification message contains backticks, write it to a temp file and
@@ -42,13 +57,17 @@ Captain Claude contract. Root verifies and merges; worker sessions do not.
    shell-execute in root's repo:
    ```bash
    tmp="$(mktemp)"
-   printf '%s\n' 'DONE <name>: PR #<n> (`make test-container` passed)' > "$tmp"
+   printf '%s\n' 'DONE <name>: PR #<n> merged (`golangci-lint` + CI green)' > "$tmp"
    af sessions send-prompt root "$(cat "$tmp")"
    rm -f "$tmp"
    ```
 
 2. **Include box-safety rules** — every prompt must say:
-   - No bare host `go test`; use `make test-container` only.
+   - No bare host `go test ./...`. Test only the package you changed, and if
+     that package is `daemon/` or `app/`, run NO tests for it locally — push
+     and let CI. They spawn real af daemons and drive real tmux on a box with
+     ~15 live sessions.
+   - No routine container runs; CI covers the matrix.
    - Never run `scripts/tui-driver.sh` against a real repo (#1303).
    - No sub-sessions.
    - No dev-install.
@@ -82,9 +101,9 @@ Captain Claude contract. Root verifies and merges; worker sessions do not.
    Use a unique session name that identifies the issue or slice. Keep the
    prompt self-contained because the receiving agent inherits no root context.
 
-4. **Expect work to completion** — after notifying root, the worker should
-   continue to the next assigned slice when one exists. It should not idle
-   just because the first PR is open.
+4. **Expect work to completion** — a session is done when its PR is **merged**,
+   not when it is open. After notifying root it should continue to the next
+   assigned slice when one exists, rather than idling on an open PR.
 
 5. **Run the idle sweep** — periodically inspect sessions for stale, blocked,
    or completed work:
@@ -93,13 +112,17 @@ Captain Claude contract. Root verifies and merges; worker sessions do not.
    af sessions preview <name>
    ```
 
-   Re-prompt sessions that have stopped without a root notification. Archive or
-   kill only when the session is genuinely done or unrecoverable.
+   Re-prompt sessions that have stopped without a root notification. A session
+   sitting idle on an open, un-merged PR is the failure this contract exists to
+   prevent — ask it which gate is blocking rather than merging on its behalf.
 
 6. **Reap completed sessions** — once all PRs for a session's ticket have
-   merged, clean up the session and its worktree:
+   merged, archive it (restorable) rather than killing it:
    ```bash
-   af sessions kill <name>
+   af sessions archive <name>
    ```
 
-   Do not reap a session while any of its PRs are still under review.
+   Archive is the default "done" action because it stays restorable. Use
+   `af sessions kill` only when you mean to permanently destroy the session and
+   prune its owned branch. Do not reap a session while any of its PRs are still
+   open — it is the one that has to clear the findings.

--- a/.claude/skills/gate-pr.md
+++ b/.claude/skills/gate-pr.md
@@ -160,7 +160,10 @@ jq -s -r --slurpfile ru "$G/rules.json" --slurpfile st "$G/statuses.json" '
   | ($st[0].statuses // [] | map(select(.context == $req.context and ($req.integration_id // null) == null))) as $sctx
   | if (($mine | length) == 0 and ($sctx | length) == 0)
     then "  MISSING REQUIRED  \($req.context)\(if $req.integration_id then " (app \($req.integration_id))" else "" end)"
-    elif (($mine | map(select(.status == "completed" and .conclusion == "success")) | length) == 0
+    elif (($mine | map(select(.status == "completed"
+            and (.conclusion == "success"
+                 or (.conclusion == "skipped" and $req.context == "Deploy" and .app.slug == "github-actions"))))
+           | length) == 0
           and ($sctx | map(select(.state == "success")) | length) == 0)
     then "  REQUIRED NOT GREEN  \($req.context)"
     else empty end' "$G/checkruns.json" >> "$G/bad.txt"
@@ -233,6 +236,10 @@ jq -s --arg head "$HEAD" '
   | sort_by(.updated_at // .submitted_at // .created_at // "")
   | last // empty
 ' "$G/reviews.json" "$G/issue-comments.json" > "$G/verdict.json"
+
+# A marker from an earlier run must never outlive it: once a real verdict exists
+# for this head, the freshness and body checks below have to run again.
+rm -f "$G/verdict-override"
 
 if [[ ! -s "$G/verdict.json" ]]; then
   # The ONLY sanctioned way past a missing verdict. It must name the exact head,
@@ -458,7 +465,7 @@ remove --force "$WT"` when you are done — not with `rm -rf`, which leaves the
 worktree registered and blocks the next run's `git worktree add`.
 
 - **Cheap checks locally, the matrix in CI.** Run `gofmt -l .`, `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh`, and `go test` on **only the package you changed**. Do **not** run `make test-container`, `make remote-roundtrip-container`, or `make playtest-container` as a routine gate — CI runs `go test -race ./...` on every push, so a local container run duplicates it while rebuilding the whole Go tree; ~20 sessions doing that concurrently took the shared box to a load average of 160. Push, then fix what CI reports on your PR head. One targeted container run is fine to reproduce a CI failure you cannot diagnose from the logs — then stop.
-- **Never bare `go test ./...` on the host. If your change is in `daemon/` or `app/`, run no tests for it locally at all — push and let CI test it.** Not `go test ./daemon/`, not a `-run`-scoped subset, not `-race`. This is a safety rule rather than a performance one: those tests spawn real `af` daemons and drive real tmux on a box where the maintainer's own daemon and ~15 live sessions are running, so a local run risks killing production sessions, not just burning CPU. `go test $(go list ./... | grep -v '/daemon')` if you need breadth elsewhere.
+- **Never bare `go test ./...` on the host. If your change is in `daemon/` or `app/`, run no tests for it locally at all — push and let CI test it.** Not `go test ./daemon/`, not a `-run`-scoped subset, not `-race`. This is a safety rule rather than a performance one: those tests spawn real `af` daemons and drive real tmux on a box where the maintainer's own daemon and ~15 live sessions are running, so a local run risks killing production sessions, not just burning CPU. `go test $(go list ./... | grep -vE '/(daemon|app)')` if you need breadth elsewhere.
 - **Watch every new test FAIL first**, against the unmodified tree. Quote the failure in the PR. A test never observed red is not evidence.
 - **TUI changes: drive the real TUI.** `app/` tests swap the backend factory and cannot see real provisioning — a green unit suite proves nothing about them. The scenario subcommand needs a script path:
   ```bash

--- a/.claude/skills/gate-pr.md
+++ b/.claude/skills/gate-pr.md
@@ -1,159 +1,585 @@
 ---
 name: gate-pr
-description: Review and gate Captain Claude pull requests through CI, the Codex review, play-test, and squash merge
+description: Gate and merge YOUR OWN pull request — CI, the Codex review for the exact head, zero unresolved findings, real testing, then merge
 user_invocable: true
 ---
 
-# Gate Pull Request
+# Gate your own pull request
 
-Review a PR authored by `sachiniyer` or `app/detail-app`, verify it is truly
-ready, and merge it only after the required gates pass. Detail dead-code PRs
-from `app/detail-app` may auto-merge once the gates are clean.
+**You own your PR end to end, including the merge.** Nobody reviews it before it
+reaches users. If your change breaks master, ships a regression, or has to be
+reverted, that is yours to detect and fix.
 
-## Steps
+Do not wait for a maintainer to gate you, and do not merge before the gates below
+pass. Both failures cost the same thing: a defect in production.
 
-1. **Fetch the PR state** — inspect the base branch, author, merge state, and
-   check rollup:
+## The rule every command here obeys: fail loud
+
+A check that could not run is **not** a check that passed.
+
+The dangerous failure mode of a merge gate is not a red gate — it is a gate that
+prints something clean-looking when it never ran. `gh api` fails on auth, rate
+limits, and transient 5xx. If that failure reaches `jq` through a pipe, `jq -s`
+slurps an empty stream, prints `0`, and exits `0`. `0` reads as *all findings
+resolved*, so a dead API call authorizes the merge it existed to block.
+
+That is why every block below:
+
+- starts with `set -euo pipefail`, so it is safe **run on its own** — the options
+  from a previous block do not carry into a new shell;
+- captures each response to a **file** and checks that request's own status,
+  rather than piping `gh api` straight into `jq`;
+- never uses `cmd || echo "clean"`. Both "the check failed" and "the check found
+  nothing" exit non-zero, so that form cannot tell them apart;
+- **validates the file before trusting it.** `> file` truncates *before* the
+  command runs, so a failed fetch leaves a zero-byte file behind. That file
+  parses fine and means nothing — and a `// []` fallback would quietly turn it
+  into "no findings". Fetch to `.part` and `mv` into place on success, then
+  check the input is a real JSON array before every gate that reads it.
+
+Never write a gate command whose failure output is indistinguishable from its
+pass output.
+
+## Why this is not bureaucracy
+
+On 2026-07-30 three PRs merged on green CI before their Codex reviews landed. The
+reviews found real defects in all three. One was **#2705**: a forged `AF_HOME`
+marker that let `af reset` classify a **foreign** session as owned, kill it, and
+delete its worktree. It reached master because the merge beat the review.
+
+CI going green is not permission to merge. The review posts minutes to hours
+later, so "green" and "reviewed" are different states that look identical if you
+only check the first.
+
+## Set up
+
+Every check below is against **the PR's head**, not your current checkout. Fetch
+that state once, into `$G`, and read every gate from those files.
+
+```bash
+set -euo pipefail
+
+PR=<n>
+G="${TMPDIR:-/tmp}/gate-pr-$PR"
+R=repos/sachiniyer/agent-factory
+rm -rf "$G"; mkdir -p "$G"
+
+gh api "$R/pulls/$PR"                       > "$G/pr.json.part"
+gh api "$R/pulls/$PR/reviews"   --paginate  > "$G/reviews.json.part"
+gh api "$R/issues/$PR/comments" --paginate  > "$G/issue-comments.json.part"
+gh api "$R/pulls/$PR/comments"  --paginate  > "$G/inline.json.part"
+for f in pr reviews issue-comments inline; do mv "$G/$f.json.part" "$G/$f.json"; done
+
+HEAD=$(jq -r '.head.sha'   "$G/pr.json")
+BASE=$(jq -r '.base.ref'   "$G/pr.json")
+STATE=$(jq -r '.state'     "$G/pr.json")
+DRAFT=$(jq -r '.draft'     "$G/pr.json")
+MERGEABLE=$(jq -r '.mergeable' "$G/pr.json")
+
+[[ "$HEAD" =~ ^[0-9a-f]{40}$ ]] || { echo "ABORT: head is not a 40-hex sha ($HEAD)"; exit 1; }
+
+# Same .part/mv discipline — a truncated head-date is worse than a missing one,
+# because an empty $HD makes the step-2 freshness compare accept any timestamp.
+gh api "$R/commits/$HEAD" --jq '.commit.committer.date' > "$G/head-date.txt.part"
+mv "$G/head-date.txt.part" "$G/head-date.txt"
+grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}' "$G/head-date.txt" \
+  || { echo "ABORT: head-date is not an RFC3339 timestamp"; exit 1; }
+
+[[ "$BASE" == master ]] || { echo "ABORT: base is $BASE, not master"; exit 1; }
+[[ "$STATE" == open && "$DRAFT" == false ]] || { echo "ABORT: state=$STATE draft=$DRAFT"; exit 1; }
+# Three states, three different actions — do not collapse them into one message.
+case "$MERGEABLE" in
+  true)  ;;
+  false) echo "ABORT: mergeable=false — the PR conflicts with master, which stops CI entirely; rebase it"; exit 1 ;;
+  *)     echo "ABORT: mergeable=$MERGEABLE — GitHub is still computing mergeability; wait and rerun, do not rebase yet"; exit 1 ;;
+esac
+```
+
+`set -e` is what makes this safe: a failing `gh api` aborts before any `mv`, so
+`$G` holds no half-written file for a later gate to read and call clean. It
+starts from `rm -rf` for the same reason — a stale file from an earlier run is
+just as wrong an answer as a truncated one.
+
+Assign each field separately. Do **not** `eval` a composed string — a branch name
+may legally contain shell metacharacters, and evaluating repository metadata as
+code is an injection vector.
+
+`BASE` must be `master`, because every comparison below is against
+`origin/master` and is meaningless otherwise. A draft cannot merge.
+
+Later blocks re-derive `$G` and `$HEAD` from `$PR`, so each one stands alone.
+**Re-run this block after every push** — it overwrites `$G`, and a stale `$HEAD`
+is the bug that steps 2 and 8 exist to catch.
+
+## The gates
+
+### 1. Every triggered check has finished, and none failed
+
+Two different failures hide here: a triggered check that is red or still
+running, and a **required context that never reported at all**. The rollup only
+lists checks GitHub has for this PR, so a required context that never fired is
+invisible in it — `auto-gate.js` blocks separately on `required check … is
+missing`, and this gate has to as well.
+
+```bash
+set -euo pipefail
+PR=<n>; G="${TMPDIR:-/tmp}/gate-pr-$PR"
+
+HEAD=$(jq -r '.head.sha' "$G/pr.json")
+R=repos/sachiniyer/agent-factory
+gh api "$R/commits/$HEAD/check-runs" --paginate > "$G/checkruns.json.part"
+gh api "$R/commits/$HEAD/status"                > "$G/statuses.json.part"
+gh api "$R/rules/branches/master"               > "$G/rules.json.part"
+for f in checkruns statuses rules; do mv "$G/$f.json.part" "$G/$f.json"; done
+jq -s -e '[.[].check_runs[]] | length > 0' "$G/checkruns.json" >/dev/null \
+  || { echo "ABORT: no check runs on $HEAD — the request failed, or nothing was triggered"; exit 1; }
+
+# a) every triggered signal has finished and passed. `success` only — a skipped
+#    required check does not go red, so accepting skips is how a build that
+#    never ran reads as green. `Deploy` is the one conditional skip auto-gate
+#    allows; CodeQL `neutral` means its analysis is still settling, not passing.
+jq -s -r '[.[].check_runs[]][] | .name as $n | (.conclusion // "") as $c
+  | if .status != "completed" then "  pending  \($n)"
+    elif $c == "success" then empty
+    elif ($c == "skipped" and $n == "Deploy" and .app.slug == "github-actions") then empty
+    elif ($n == "CodeQL" and $c == "neutral") then "  settling  \($n)"
+    else "  \($c)  \($n)" end' "$G/checkruns.json" > "$G/bad.txt"
+
+jq -r '.statuses[]? | select(.state != "success") | "  \(.state)  \(.context)"' "$G/statuses.json" >> "$G/bad.txt"
+
+# b) every required context reported FROM THE APP THE RULESET PINS IT TO, and
+#    succeeded. Matching on name alone would let a same-named check from another
+#    app satisfy a requirement the real one never met.
+jq -s -r --slurpfile ru "$G/rules.json" --slurpfile st "$G/statuses.json" '
+  [.[].check_runs[]] as $runs
+  | [$ru[0][] | select(.type == "required_status_checks") | .parameters.required_status_checks[]]
+  | .[]
+  | . as $req
+  | ($runs | map(select(.name == $req.context
+        and (($req.integration_id // null) == null or (.app.id == $req.integration_id))))) as $mine
+  | ($st[0].statuses // [] | map(select(.context == $req.context and ($req.integration_id // null) == null))) as $sctx
+  | if (($mine | length) == 0 and ($sctx | length) == 0)
+    then "  MISSING REQUIRED  \($req.context)\(if $req.integration_id then " (app \($req.integration_id))" else "" end)"
+    elif (($mine | map(select(.status == "completed" and .conclusion == "success")) | length) == 0
+          and ($sctx | map(select(.state == "success")) | length) == 0)
+    then "  REQUIRED NOT GREEN  \($req.context)"
+    else empty end' "$G/checkruns.json" >> "$G/bad.txt"
+
+[[ -s "$G/bad.txt" ]] && { cat "$G/bad.txt"; echo "not every check has passed — do not merge"; exit 1; }
+echo "all checks passed, all required contexts reported"
+```
+
+Wait for **every** signal, not just required ones. Some workflows (for example
+`web-selftest`) are deliberately not required, so "no pending required check"
+will happily let you merge while a real suite is still running or already red.
+CodeQL reports mid-run non-success states; only a completed conclusion is real —
+which is why an incomplete `CheckRun` counts as pending rather than passing.
+
+**A skipped required check is not a passed one.** `.github/workflows/pr.yml`
+documents the trap directly: a failed dependency leaves `Build` SKIPPED, and a
+skipped required check never goes red, so GitHub's own merge button stays live.
+`auto-gate.js` blocks it by demanding `conclusion === "success"`, allowing a
+conditional skip only for `Deploy` — this gate mirrors that exactly. Treating
+any skip as a pass is how a build that never ran gets merged.
+
+**Match a required check by its app, not just its name.** The ruleset pins each
+required context to an `integration_id` (here `15368`, GitHub Actions), and
+`auto-gate.js` enforces it — `checkRunMatchesSpec` compares `run.app.id` against
+the spec, and its test suite covers a spoof `Build` from app `999` sitting
+alongside the real one still in progress. Name-only matching would let that
+spoof satisfy a requirement the real check never met.
+
+This is why the commands above read `commits/$HEAD/check-runs` rather than
+`gh pr view --json statusCheckRollup`: **the rollup does not expose the app at
+all.** Its `CheckRun` carries only `__typename`, `completedAt`, `conclusion`,
+`detailsUrl`, `name`, `startedAt`, `status`, and `workflowName` — so an
+app-aware check is not expressible against it. The REST endpoint is also the one
+`auto-gate.js` itself uses, which is the point: the hand gate should read the
+same source as the automated one.
+
+Do not parse the human table from `gh pr checks` — it is presentation output
+whose columns can change under you. `gh pr checks --json` and `gh api --slurp`
+are **not** available in the gh 2.45 installed here, though newer builds have
+them; `gh api` and `jq -s` work on both.
+
+### 2. A Codex review exists **for this exact head**
+
+The artifact carries `Reviewed commit: <sha>` and lands in **either** reviews or
+issue comments. Extract that SHA and compare it — counting artifacts is not
+enough, because a review of an older commit still matches a naive text search.
+
+This selects the single newest artifact whose reviewed SHA prefixes `$HEAD`, the
+same way `evaluateCodex` does in `.github/scripts/auto-gate.js`. Everything
+downstream reads **that one verdict**, so a stale artifact can neither satisfy a
+gate nor block one.
+
+```bash
+set -euo pipefail
+PR=<n>; G="${TMPDIR:-/tmp}/gate-pr-$PR"
+for f in pr reviews issue-comments; do
+  jq -s -e 'length > 0' "$G/$f.json" >/dev/null || { echo "ABORT: $G/$f.json is missing or empty — rerun Set up"; exit 1; }
+done
+HEAD=$(jq -r '.head.sha' "$G/pr.json")
+
+jq -s --arg head "$HEAD" '
+  add
+  | map(select(.user.login == "chatgpt-codex-connector[bot]"))
+  | map(select((.body // "") | test("\\bCodex Review\\b"; "i")))
+  | map(select((.body // "") | test("reached your Codex usage limits for code reviews"; "i") | not))
+  | map(select((.body // "")
+      | capture("(?:\\*\\*Reviewed commit:\\*\\*|Reviewed commit:)\\s*`(?<sha>[0-9a-f]{7,40})`"; "i")
+      | .sha | ascii_downcase as $rc
+      | ($head | ascii_downcase | startswith($rc))))
+  | sort_by(.updated_at // .submitted_at // .created_at // "")
+  | last // empty
+' "$G/reviews.json" "$G/issue-comments.json" > "$G/verdict.json"
+
+if [[ ! -s "$G/verdict.json" ]]; then
+  # The ONLY sanctioned way past a missing verdict. It must name the exact head,
+  # so it cannot be set once and forgotten across pushes. See "When no review
+  # exists" — this is an override, and it is loud on purpose.
+  if [[ -n "${GATE_SUBSTITUTE_REVIEW:-}" ]] && [[ "$GATE_SUBSTITUTE_REVIEW" == *"$HEAD"* ]]; then
+    echo "OVERRIDE: no Codex verdict for $HEAD"
+    echo "  substitute review: $GATE_SUBSTITUTE_REVIEW"
+    echo "  bypassed: step 3 (verdict body). Steps 1, 4-8 still apply and are NOT bypassed."
+    echo "  record this in the PR body before merging, naming the reviewer and this SHA"
+    : > "$G/verdict-override"
+  else
+    echo "NOT REVIEWED at $HEAD — this is not 'clean'"
+    echo "  to merge on a recorded substitute review, see 'When no review exists';"
+    echo "  it requires GATE_SUBSTITUTE_REVIEW to name $HEAD"
+    exit 1
+  fi
+fi
+
+if [[ ! -e "$G/verdict-override" ]]; then
+  # A verdict older than the commit it claims to review did not review it.
+  # LC_ALL=C so the timestamp compare is bytewise, not locale collation.
+  VAT=$(jq -r '.updated_at // .submitted_at // .created_at' "$G/verdict.json")
+  HD=$(cat "$G/head-date.txt")
+  [[ -n "$HD" ]] || { echo "ABORT: empty head-date — an empty bound accepts any verdict; rerun Set up"; exit 1; }
+  LC_ALL=C; [[ "$VAT" > "$HD" ]] || { echo "ABORT: verdict $VAT predates head commit $HD"; exit 1; }
+
+  jq -r --arg head "$HEAD" '"verdict for \($head) at \(.updated_at // .submitted_at // .created_at)"' "$G/verdict.json"
+fi
+```
+
+An empty verdict means **not reviewed yet** — not "clean". A usage-limit comment
+is also not a review; the filter drops it exactly as `parseReviewedCommit` does.
+Trigger a review with a `@codex review` comment and wait. If none arrives, read
+**"When no review exists"** below — do not skip to step 8.
+
+### 3. No `P0`–`P3` finding in the verdict body
+
+Codex sometimes puts a finding in the verdict body without a live inline comment.
+An inline count of zero does not mean clean.
+
+Scan **only the exact-head verdict** from step 2. Scanning every Codex body
+instead is its own bug in the other direction: bodies are immutable, so a
+P1 in a review of an older commit would block the PR forever even after the
+current head reviews clean.
+
+```bash
+set -euo pipefail
+PR=<n>; G="${TMPDIR:-/tmp}/gate-pr-$PR"
+
+if [[ -e "$G/verdict-override" ]]; then
+  echo "SKIPPED: no Codex verdict body to scan — running on the substitute review recorded in step 2"
+  exit 0
+fi
+[[ -s "$G/verdict.json" ]] || { echo "ABORT: no exact-head verdict — rerun step 2; an absent verdict is not clean"; exit 1; }
+jq -r '.body // ""' "$G/verdict.json" > "$G/verdict-body.txt"
+[[ -s "$G/verdict-body.txt" ]] || { echo "ABORT: verdict has an empty body — rerun step 2"; exit 1; }
+
+if grep -nEi '\bP[0-3]\b' "$G/verdict-body.txt"; then
+  echo "BODY FINDING in the exact-head verdict — do not merge"; exit 1
+fi
+echo "verdict body clean"
+```
+
+**Do not** write this as `grep … || echo "clean"`. A failed read and a
+no-match grep both exit non-zero, so that form reports clean when the check did
+not run. An unrun check is not a passed check.
+
+### 4. Zero unresolved inline findings
+
+This mirrors `.github/scripts/auto-gate.js`. A reply only resolves a finding when
+it comes from an **allowed author** and carries a whole-word `RESOLVED` or
+`ACCEPTED` — note `UNRESOLVED` contains `RESOLVED` as a substring, so match on
+word boundaries.
+
+```bash
+set -euo pipefail
+PR=<n>; G="${TMPDIR:-/tmp}/gate-pr-$PR"
+jq -s -e 'length > 0 and all(type == "array")' "$G/inline.json" >/dev/null \
+  || { echo "ABORT: $G/inline.json is missing, empty, or not a JSON array — rerun Set up"; exit 1; }
+
+jq -s '
+  add as $all
+  | ["sachiniyer","app-detail-app","app-detail-app[bot]"] as $allowed
+  | ($all
+     | map(select(
+         .in_reply_to_id != null
+         and (.user.login | IN($allowed[]))
+         and ((((.body // "") | test("\\b(RESOLVED|ACCEPTED)\\b"))
+               or ((.body // "") | contains("[gate-ack]"))))))
+     | map(.in_reply_to_id)) as $resolved
+  | $all
+  | map(select(
+      .user.login == "chatgpt-codex-connector[bot]"
+      and .in_reply_to_id == null
+      and .line != null
+      and ((.id | IN($resolved[])) | not)))
+  | map({id, path, line})
+' "$G/inline.json" > "$G/unresolved.json"
+
+jq -r '.[] | "  \(.id)  \(.path):\(.line)"' "$G/unresolved.json"
+N=$(jq 'length' "$G/unresolved.json")
+[[ "$N" == 0 ]] || { echo "$N unresolved finding(s) — do not merge"; exit 1; }
+echo "no unresolved inline findings"
+
+# A RESOLVED reply is a CLAIM. The commit is the evidence. If the head predates
+# the finding the reply claims to fix, that fix cannot be in what you are about
+# to merge. ACCEPTED is exempt — it claims the finding does not apply, which
+# needs no commit.
+HD=$(cat "$G/head-date.txt")
+[[ -n "$HD" ]] || { echo "ABORT: empty head-date — rerun Set up"; exit 1; }
+
+jq -s -r --arg hd "$HD" '
+  add as $all
+  | ["sachiniyer","app-detail-app","app-detail-app[bot]"] as $allowed
+  | ($all
+     | map(select(
+         .in_reply_to_id != null
+         and (.user.login | IN($allowed[]))
+         and ((.body // "") | test("\\bRESOLVED\\b"))))
+     | map(.in_reply_to_id)) as $claimed
+  | $all
+  | map(select(
+      .user.login == "chatgpt-codex-connector[bot]"
+      and .in_reply_to_id == null
+      and .line != null
+      and (.id | IN($claimed[]))
+      and (.created_at >= $hd)))
+  | .[] | "  \(.id)  \(.path):\(.line)  filed \(.created_at), head committed \($hd)"
+' "$G/inline.json" > "$G/unpushed.txt"
+
+[[ -s "$G/unpushed.txt" ]] && {
+  cat "$G/unpushed.txt"
+  echo "RESOLVED was claimed but the head is older than the finding — the fix is not pushed"
+  exit 1
+}
+echo "every RESOLVED finding predates the head commit"
+```
+
+**A resolution marker is a claim, not evidence.** Replying `RESOLVED` clears the
+finding for the gate whether or not you actually pushed the fix, and that is how
+#2799 shipped broken: its findings were cleared in-thread, Auto Gate merged the
+moment the count hit zero, and the fix commit landed minutes *after* the merge.
+Master then carried the uncorrected commands — the exact defects the review had
+caught (#2822).
+
+The check above is the cheapest necessary condition: a fix for a finding filed
+at time T cannot exist in a commit made before T. It does not prove the fix is
+*correct*, only that something was pushed after the finding. This is one place
+the hand gate is deliberately **stricter** than `auto-gate.js`, which trusts the
+marker alone — stricter is fine, looser never is.
+
+Read from the captured file rather than piping `gh api … --jq` into `jq`, and
+check that file first. Two reasons, and the first is the one that bites:
+
+- A pipe hides the failure. `gh api` dying leaves `jq -s` an empty stream, which
+  prints `0` — indistinguishable from a genuinely clean PR. An empty *file* does
+  the same thing, which is why the guard above runs before the query and why
+  the filter says `add` rather than `add // []`.
+- `gh api --paginate --jq` runs the filter **per page**, so a finding on page 1
+  whose resolving reply is on page 2 is counted unresolved. Without `--jq`,
+  `--paginate` merges the pages into one array, and `jq -s 'add'` flattens
+  whatever shape arrives — after the guard has established there is something
+  to flatten.
+
+Do not reach for `gh api --slurp` — it is **not in the gh 2.45 installed here**
+and fails with `unknown flag: --slurp`, even though newer gh builds do have it.
+A command that errors out is not a check, and `jq -s` works on every version.
+
+**Inline findings override the verdict, never the other way round.** A PR can
+carry a "didn't find any major issues" verdict for the exact head *and* live
+findings from an earlier pass on that same head. Step 3 coming back clean does
+not excuse this step.
+
+Clear each finding by replying **to that comment id, under this PR**:
+
+```bash
+gh api "repos/sachiniyer/agent-factory/pulls/$PR/comments/<comment-id>/replies" \
+  -f body='RESOLVED — <what you actually changed>'
+```
+
+- `RESOLVED` — you fixed it. Say what you did; a bare marker tells a later reader nothing.
+- `ACCEPTED` — it does not apply. Say why. Never ignore a finding silently.
+- A **top-level PR comment does not clear a finding.** It must be a reply.
+- A fix without a reply still blocks. Fix *and* reply.
+
+### 5. If you pushed after the review, the review is stale
+
+**Evidence has a head SHA too.** Re-run **Set up** and step 2 after every push —
+that is the whole point of comparing the SHA rather than counting artifacts.
+Re-trigger `@codex review`, and re-run any play-test or manual verification
+against the new head.
+
+### 6. You actually tested it
+
+Test `$HEAD` in a **clean, isolated worktree**. Your development checkout is not
+a substitute: `gh pr checkout` keeps staged, unstaged, and untracked files when
+they do not conflict, so a scenario script or fixture that exists only on your
+disk can turn the suite green for code that is not in the commit you are about
+to merge.
+
+```bash
+set -euo pipefail
+PR=<n>; G="${TMPDIR:-/tmp}/gate-pr-$PR"
+HEAD=$(jq -r '.head.sha' "$G/pr.json")
+
+git fetch --no-tags origin "refs/pull/$PR/head"
+FETCHED=$(git rev-parse FETCH_HEAD)
+[[ "$FETCHED" == "$HEAD" ]] || { echo "ABORT: refs/pull/$PR/head is $FETCHED, not $HEAD — someone pushed; restart"; exit 1; }
+
+WT="$G-worktree"   # a sibling of $G, so re-running Set up cannot delete it out from under git
+git worktree remove --force "$WT" 2>/dev/null || true
+git worktree add --detach "$WT" "$HEAD"
+cd "$WT"
+[[ "$(git rev-parse HEAD)" == "$HEAD" ]] || { echo "ABORT: worktree is not at $HEAD"; exit 1; }
+[[ -z "$(git status --porcelain)" ]] || { git status --porcelain; echo "ABORT: worktree is dirty"; exit 1; }
+```
+
+Run every gate and every manual test from `$WT`. Re-check `git status
+--porcelain` after the run: a suite that leaves the tree dirty was reading or
+writing files the commit does not contain. Tear it down with `git worktree
+remove --force "$WT"` when you are done — not with `rm -rf`, which leaves the
+worktree registered and blocks the next run's `git worktree add`.
+
+- **Cheap checks locally, the matrix in CI.** Run `gofmt -l .`, `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh`, and `go test` on **only the package you changed**. Do **not** run `make test-container`, `make remote-roundtrip-container`, or `make playtest-container` as a routine gate — CI runs `go test -race ./...` on every push, so a local container run duplicates it while rebuilding the whole Go tree; ~20 sessions doing that concurrently took the shared box to a load average of 160. Push, then fix what CI reports on your PR head. One targeted container run is fine to reproduce a CI failure you cannot diagnose from the logs — then stop.
+- **Never bare `go test ./...` on the host. If your change is in `daemon/` or `app/`, run no tests for it locally at all — push and let CI test it.** Not `go test ./daemon/`, not a `-run`-scoped subset, not `-race`. This is a safety rule rather than a performance one: those tests spawn real `af` daemons and drive real tmux on a box where the maintainer's own daemon and ~15 live sessions are running, so a local run risks killing production sessions, not just burning CPU. `go test $(go list ./... | grep -v '/daemon')` if you need breadth elsewhere.
+- **Watch every new test FAIL first**, against the unmodified tree. Quote the failure in the PR. A test never observed red is not evidence.
+- **TUI changes: drive the real TUI.** `app/` tests swap the backend factory and cannot see real provisioning — a green unit suite proves nothing about them. The scenario subcommand needs a script path:
+  ```bash
+  scripts/testbox.sh scenario scripts/tui-<issue>-scenario.sh
+  ```
+  See `scripts/tui-2599-scenario.sh` for the shape.
+- **A PR-specific scenario does not replace the shared acceptance gate.** Your scenario proves your change works; `make tui-driver-selftest` proves you did not break someone else's. Run both. Require the self-test to report **all** steps green — match the `N/N` in its final `SELF-TEST PASSED` line rather than a hard-coded number, because the suite grows.
+
+  These two are the **only** container runs that survive the no-routine-containers rule above, and only for a TUI-touching PR. They are not exempt because TUI work is special — they are exempt because **CI does not run them at all.** `go test -race ./...` covers the Go suite, but nothing in `.github/workflows/` invokes `scripts/testbox.sh selftest`, so skipping them locally means the interaction is never exercised anywhere. That is also why `auto-gate.js` demands the `play-tested` label on TUI paths. If your PR touches no TUI path, run neither.
+- **tmux work: isolated socket only.** `-L <unique-name>`, removed afterward. Never the default server, never `tmux kill-server`, never `af reset`. An agent once destroyed every live session on this box that way (#2175).
+- **A fake must model production's real error shape**, not the shape your assertion needs. #2711 shipped a test that injected `context.DeadlineExceeded` directly while production returned `signal: killed` — green, and proving a property the code did not have.
+
+### 7. Branch shape
+
+Compare the **PR head** against master, not your current checkout:
+
+```bash
+set -euo pipefail
+PR=<n>; G="${TMPDIR:-/tmp}/gate-pr-$PR"
+HEAD=$(jq -r '.head.sha' "$G/pr.json")
+
+git fetch --no-tags origin master "refs/pull/$PR/head"
+git diff --stat "origin/master...$HEAD"
+git log --oneline "origin/master..$HEAD"
+```
+
+Only the files your change needs. Unrelated files mean the branch is stacked or
+stale — fix it rather than merging it.
+
+For a decomposition PR the diff must show exactly the one source file being
+decomposed, its split files, and any expected `scripts/file-length-allowlist.txt`
+or docs changes. Anything else is a tangled branch.
+
+### 8. Merge
+
+```bash
+gh pr merge "$PR" --squash --match-head-commit "$HEAD"
+```
+
+`--match-head-commit` pins the merge to the head you actually gated. Without it,
+a push landing after `$HEAD` was captured — or during the gates — merges an
+unvetted commit, which is the same staleness bug as step 2 in the other
+direction.
+
+**Never `--auto`.** `gh pr merge --auto` is GitHub-native auto-merge: it merges
+as soon as the *branch ruleset's* required checks pass, which on `master` is
+`Lint` and `Build` only. It does not consult `.github/scripts/auto-gate.js`, so
+arming it routes around steps 2–4 entirely — and it fires while the Codex review
+is still minutes-to-hours away, so the finding count it merges on is zero
+because nothing has looked yet. Either merge by hand once every gate above
+holds, or leave the PR alone and let the Auto Gate workflow merge it. (Detail
+dead-code PRs from `app/detail-app` are the exception the repo already allows to
+auto-merge on clean gates.)
+
+Do not use another merge strategy unless the maintainer explicitly asks.
+
+Your PR body needs `Closes #<issue>`. Since #2745 the Auto Gate token has
+`issues: write`, so a linked issue closes on merge — verify it did, and close it
+explicitly if not.
+
+## When no review exists
+
+Codex reviewing is intermittent: the account hits usage limits, and stretches
+pass where PRs get no verdict at all. Absence shows up two ways, and **neither
+is a pass**:
+
+- **No artifact.** Step 2 writes an empty `verdict.json`. That means the review
+  step *did not run*, not that it ran and found nothing.
+- **A usage-limit comment** (`reached your Codex usage limits for code reviews`).
+  Step 2 filters it out, and so does `parseReviewedCommit` in `auto-gate.js`.
+  A message saying the reviewer declined to look is the opposite of a clean
+  verdict, and it is the one most likely to be misread as "Codex responded".
+
+Auto Gate blocks an unreviewed head — `Codex has not reviewed head <sha> yet` —
+so it will not merge for you. What to do:
+
+1. **Re-trigger** with a `@codex review` comment and wait. Limits reset.
+2. **If it still does not post, get a real review from something that is not
+   you.** Dispatch a reviewer af session, or run `/code-review`. Self-review is
+   the state this gate exists to prevent, and re-reading your own diff does not
+   change that.
+3. **Record it on the PR**, naming the reviewer and the SHA it covers — the
+   substitute needs a head SHA for the same reason the Codex artifact does.
+4. **Say so in the PR body**: "Codex did not review `<sha>`; reviewed instead by
+   `<who>`." Merging an unreviewed head is an override. Overrides are allowed;
+   silent ones are not, because the next person reading the PR cannot tell an
+   unreviewed merge from a reviewed one.
+5. **Then run the gates with the override set**, which is the only sanctioned
+   way past step 2:
+
    ```bash
-   gh pr view <n> --json number,title,url,author,baseRefName,headRefName,mergeStateStatus,statusCheckRollup
-   gh pr checks <n> --watch
+   export GATE_SUBSTITUTE_REVIEW="reviewed by <who> at $HEAD — <where it is recorded>"
    ```
 
-   - Gate only PRs authored by `sachiniyer` or `app/detail-app`.
-   - Require `baseRefName` to be `master`.
-   - Require `mergeStateStatus` to be mergeable or clean enough to merge.
-   - Inspect `statusCheckRollup` for failing and pending checks.
-   - CodeQL can report mid-run non-success states; only a completed
-     conclusion is real. Do not fail a PR on an in-progress CodeQL state.
+   It must contain the exact head SHA, so it cannot be exported once and
+   forgotten across pushes — a new head invalidates it exactly as it invalidates
+   a Codex verdict. Step 2 prints a loud `OVERRIDE:` line naming what is
+   bypassed, and **only step 3 (the verdict body) is bypassed** — there is no
+   verdict body to scan. Steps 1 and 4–8 still run and still block: a substitute
+   review does not excuse a red check, and live inline findings from an earlier
+   Codex pass on this same head remain live.
 
-2. **Require green CI** — do not merge while any required signal is red or
-   pending:
-   - No `FAILURE` conclusions.
-   - Zero pending checks.
-   - No missing required check that is expected to report.
+Without this variable the gates hard-fail, which is deliberate — the fallback
+has to be an explicit, recorded act, not a step you can drift into by skipping a
+command that returned non-zero.
 
-3. **Gate the Codex review** — the AI reviewer on this repo is
-   `chatgpt-codex-connector[bot]`. `.github/scripts/auto-gate.js` already
-   enforces the conditions below on every PR; this step is the same gate run by
-   hand, so a manual merge cannot be looser than the automated one.
+Never write "no findings" when the truth is "nobody looked". Those are different
+claims, and collapsing them is the exact failure this gate exists to prevent —
+in prose this time instead of in a shell pipeline.
 
-   ```bash
-   head="$(gh pr view <n> --json headRefOid -q .headRefOid)"
-   echo "head=$head committed=$(gh api repos/sachiniyer/agent-factory/commits/$head --jq .commit.committer.date)"
+## After you merge
 
-   # a) every Codex verdict, NEWEST FIRST. The body carries "Reviewed commit:
-   #    `abc1234…`", an abbreviation that must prefix $head. Codex posts a
-   #    verdict as a review on some PRs and as an issue comment on others, and
-   #    can post several for one head — auto-gate.js merges both kinds into one
-   #    list and judges only the newest matching artifact, so read them in that
-   #    order rather than as two separate streams.
-   { gh api --paginate repos/sachiniyer/agent-factory/pulls/<n>/reviews
-     gh api --paginate repos/sachiniyer/agent-factory/issues/<n>/comments
-   } | jq -s -r 'add
-     | map(select(.user.login == "chatgpt-codex-connector[bot]"))
-     | sort_by(.updated_at // .submitted_at // .created_at) | reverse
-     | .[] | "=== \(.updated_at // .submitted_at // .created_at)\n\(.body)"'
+Watch master. If the build goes red, if your change appears in the daemon log, or
+if a **late** Codex finding lands on your already-merged PR — that is yours to
+handle. Check back on your own work rather than assuming it landed clean.
 
-   # b) live inline findings, minus the ones an allowed reply already cleared —
-   #    the same subtraction auto-gate.js makes, so this can never block a PR
-   #    the workflow would merge. A null .line is stale, already fixed.
-   gh api --paginate repos/sachiniyer/agent-factory/pulls/<n>/comments | jq -s -r 'add
-     | ([ .[] | select(.in_reply_to_id
-                       and (.user.login | IN("sachiniyer", "app-detail-app", "app-detail-app[bot]"))
-                       and ((.body | test("\\b(?:RESOLVED|ACCEPTED)\\b")) or (.body | contains("[gate-ack]"))))
-              | .in_reply_to_id ] | unique) as $cleared
-     | .[] | select(.user.login == "chatgpt-codex-connector[bot]"
-                    and .line and (.in_reply_to_id | not)
-                    and (.id | IN($cleared[]) | not))
-     | "\(.id) \(.path):\(.line)\n\(.body)"'
-   ```
+## Reviewing someone else's PR
 
-   `--paginate` is not optional. A page is 30 comments, and `gh api` fetches one
-   page without it — so a finding on page 2 reads as "no findings", which is the
-   single wrong answer this step must never produce. `auto-gate.js` paginates
-   these same lists (`github.paginate`, `per_page: 100`).
-
-   Every filter above mirrors `auto-gate.js` exactly, in both directions: an
-   author is an exact login (a `sachiniyer-…` account is not `sachiniyer`), and
-   a marker is a whole word (`UNRESOLVED — sent back` contains `RESOLVED` and
-   must not clear anything). Looser than the workflow lets a live finding
-   through; stricter blocks a PR the workflow would merge. Neither is acceptable.
-
-   Require all three:
-
-   - **A verdict that names this head.** Its `Reviewed commit:` must prefix
-     `headRefOid`, and its timestamp must be newer than the head commit's — the
-     `committed=` value printed above, which is why it is printed. An older
-     verdict read different bytes. Judge the **newest** matching artifact; an
-     older one it superseded is not the gate. Silence is not a pass: an
-     unreviewed PR and a clean one are byte-identical through the findings API,
-     so (b) means nothing until (a) holds. If nothing has posted, comment
-     `@codex review this PR` and wait — hours is normal. A `reached your Codex
-     usage limits for code reviews` reply is *not* a verdict.
-   - **No `P0`–`P3` in that verdict body.** Findings usually live inline, but
-     Codex does sometimes file one in the body with zero inline comments.
-   - **Zero unresolved live inline findings.** These are independent of the
-     verdict text — a PR can carry a "didn't find any major issues" verdict for
-     the exact head *and* live P1s from an earlier pass on the same head. The
-     inline query overrides the verdict, never the other way round.
-
-   Clear a finding by replying **in-thread**, from `sachiniyer` or
-   `app-detail-app`, with `RESOLVED`, `ACCEPTED`, or `[gate-ack]` — all three
-   clear it (`hasResolutionMarker`) — plus what changed or why the finding is
-   wrong. A top-level PR comment does not clear it; the reply has to hang off
-   that comment id:
-
-   ```bash
-   gh api repos/sachiniyer/agent-factory/pulls/<n>/comments/<comment-id>/replies \
-     -f body='RESOLVED — <what changed, or why this is wrong>'
-   ```
-
-   The PR number belongs in that path. `pulls/comments/<id>/replies` — the shape
-   the review-comment objects themselves are fetched from — is not a route, and
-   answers `404 Not Found` while looking like a posted reply if you do not read
-   the response.
-
-   If a finding is valid, route it back to the authoring session and stop. Do
-   not merge a PR with a valid unresolved finding.
-
-4. **Verify branch shape** — catch stacked or tangled branches before merge:
-   ```bash
-   git fetch origin master
-   gh pr checkout <n>
-   git diff --stat origin/master
-   git log --oneline origin/master..HEAD
-   ```
-
-   For decomposition PRs, `git diff --stat origin/master` must show exactly
-   the one source file being decomposed, its split files, and any expected
-   `scripts/file-length-allowlist.txt` or docs changes. If unrelated files
-   appear, the PR is stacked or stale; send it back instead of merging.
-
-5. **Play-test TUI-visible changes** — for `VISIBLE-TUI`, pane-focus, attach,
-   or similar interaction changes, play-test before merge:
-   ```bash
-   git fetch origin pull/<n>/head:gate-pr-<n>
-   git worktree add ../gate-pr-<n> gate-pr-<n>
-   make -C ../gate-pr-<n> tui-driver-selftest
-   ```
-
-   Require the self-test to report all steps green (the count grows as the
-   suite is extended — match the `N/N` in its final `SELF-TEST PASSED` line,
-   not a hard-coded number). If it fails, send the failure back to the
-   authoring session.
-
-6. **Merge only after all gates pass**:
-   ```bash
-   gh pr merge <n> --squash
-   ```
-
-   Do not use another merge strategy unless the maintainer explicitly asks.
-
-   **Never `--auto`.** `gh pr merge --auto` is GitHub-native auto-merge: it
-   merges as soon as the *branch ruleset's* required checks pass, which on
-   `master` is `Lint` and `Build` only. It does not consult
-   `.github/scripts/auto-gate.js`, so arming it routes around step 3 entirely —
-   and it fires while the Codex review is still minutes-to-hours away, so the
-   finding count it merges on is zero because nothing has looked yet. Either
-   merge by hand once every gate above holds, or leave the PR alone and let the
-   Auto Gate workflow merge it.
+Same gates, and set `PR` to theirs — every command above is parameterised on
+`$PR`, and step 6 builds its own worktree, so nothing reads your local checkout.
+Additionally: verify the claims rather than reading the summary. The
+highest-value review comments this repo has produced came from checking whether a
+stated mechanism was real — several PR descriptions have been confidently wrong
+about the cause while the fix happened to be right.

--- a/.claude/skills/incident-response.md
+++ b/.claude/skills/incident-response.md
@@ -40,7 +40,9 @@ lost sessions as recoverable until proven otherwise.
 6. **Never use broad host kills**:
    - Never run bare `tmux kill-server`; sandbox tmux work needs a private
      `TMUX` or `TMUX_TMPDIR`.
-   - Never run bare `go test ./...` on the host; use `make test-container`.
+   - Never run bare `go test ./...` on the host, and never `./daemon/...` or
+     `./app/...` — they spawn real af daemons and drive real tmux beside live
+     sessions. Test one non-daemon package, or let CI run the matrix.
    - Never `pgrep` and kill the real daemon by broad process name.
 
    If cleanup is required, scope it to the recorded sandbox path, private tmux

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Working style:
   daemon and ~15 live sessions are running, so a local run risks disturbing
   production sessions rather than merely burning CPU. `app/` is the same deal —
   its tests drive real tmux. Never bare `go test ./...`; use
-  `go test $(go list ./... | grep -v '/daemon')` if you need breadth.
+  `go test $(go list ./... | grep -vE '/(daemon|app)')` if you need breadth.
 - Captain Claude is fully autonomous: ship without waiting for greenlight,
   merge own PRs once the `gate-pr` gates pass, close issues that aren't worth
   doing. Green CI is the floor, not the bar — the Codex review lands after it.
@@ -98,7 +98,7 @@ go build ./...
 # box, and never ./daemon/... or ./app/... on the host — they spawn real af
 # daemons and drive real tmux, next to ~15 live sessions.
 go test ./<changed-package>/...
-go test $(go list ./... | grep -v '/daemon')   # only if you need breadth
+go test $(go list ./... | grep -vE '/(daemon|app)')   # only if you need breadth
 
 # The containerized suites below are NOT routine pre-PR gates — CI runs
 # `go test -race ./...` on every push, and ~20 concurrent container runs took

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,13 +59,32 @@ Working style:
   permanently destroy the session and prune its owned branch. Don't let sessions
   accumulate.
 - Never run `pkill tmux`/`pkill af` or bare `tmux kill-server` on a shared host; tmux teardown must name an isolated socket with `-L` or `-S`.
-- Run `golangci-lint run --timeout=3m --fast`, `gofmt -l .`, `go build ./...`,
-  `make test-container`, `deadcode -test ./...`, and
-  `scripts/lint-file-length.sh` before opening a PR — CI blocks on all six. On
-  a shared dev box, never run bare `go test ./...` on the host; see
-  docs/container-testing.md.
+- Before opening a PR run the **cheap local checks** — `gofmt -l .`,
+  `go build ./...`, `golangci-lint run --timeout=3m --fast`,
+  `deadcode -test ./...`, `scripts/lint-file-length.sh` — plus `go test` on
+  **only the non-daemon package you changed**. Then push and let CI run the
+  rest, and fix what CI reports on your PR head.
+- **Do not run containerized suites as a routine pre-PR gate.** Not
+  `make test-container`, not `make remote-roundtrip-container`, not
+  `make playtest-container`. Each spins a container that rebuilds the whole Go
+  tree; ~20 sessions doing it at once took this 16-core box to a load average of
+  160 and made the maintainer's machine unusable. CI already runs
+  `go test -race ./...` on every push, so a local container run buys nothing and
+  costs him the box. One exception: if CI fails on something you genuinely
+  cannot diagnose from the logs, **one** targeted container run to reproduce —
+  then stop.
+- **If your change is in `daemon/`, run no daemon tests locally at all — push
+  and let CI test it.** Not `go test ./daemon/`, not a `-run`-scoped subset,
+  not `-race`. This is a safety rule rather than a performance one: those tests
+  spawn real `af` daemons and touch tmux on a machine where the maintainer's own
+  daemon and ~15 live sessions are running, so a local run risks disturbing
+  production sessions rather than merely burning CPU. `app/` is the same deal —
+  its tests drive real tmux. Never bare `go test ./...`; use
+  `go test $(go list ./... | grep -v '/daemon')` if you need breadth.
 - Captain Claude is fully autonomous: ship without waiting for greenlight,
-  merge own PRs after CI green, close issues that aren't worth doing. The
+  merge own PRs once the `gate-pr` gates pass, close issues that aren't worth
+  doing. Green CI is the floor, not the bar — the Codex review lands after it.
+  Whoever wrote the PR gates and merges it; that is not a root queue. The
   audit trail is in PR descriptions and issue close-out comments, not
   pre-approval.
 
@@ -75,21 +94,19 @@ Working style:
 # Build
 go build ./...
 
-# Run the full test suite — inside a container, isolated from the host
-# tmux server and real AF home (see docs/container-testing.md)
-make test-container
+# Test the package you changed. Never bare `go test ./...` on a shared dev
+# box, and never ./daemon/... or ./app/... on the host — they spawn real af
+# daemons and drive real tmux, next to ~15 live sessions.
+go test ./<changed-package>/...
+go test $(go list ./... | grep -v '/daemon')   # only if you need breadth
 
-# Focused remote-hook integration harness — mock remote round-trip
-# inside the same container fence (see docs/container-testing.md)
-make remote-roundtrip-container
-
-# Host-side runs: never bare `go test ./...` on a shared dev box — the
-# daemon package spawns real af daemons. Skip it, or use the container.
-go test $(go list ./... | grep -v '/daemon')
-
-# TUI play-testing — containerized sandbox (throwaway home, mock repo,
-# private tmux); see docs/container-testing.md
-make playtest-container
+# The containerized suites below are NOT routine pre-PR gates — CI runs
+# `go test -race ./...` on every push, and ~20 concurrent container runs took
+# this box to load 160. Reach for one ONLY to reproduce a CI failure you
+# cannot diagnose from the logs, then stop. See docs/container-testing.md.
+make test-container                # full suite, isolated tmux + AF home
+make remote-roundtrip-container    # mock remote round-trip
+make playtest-container            # TUI sandbox (throwaway home, mock repo)
 
 # Reclaim the docker disk the container harness holds — and only that (#2133).
 # Every target above already cleans up after itself on the way out; this one


### PR DESCRIPTION
## What

Rewrites `.claude/skills/gate-pr.md` around one rule — **a gate that cannot run must fail loud, never report clean** — and makes the surrounding contract match: the PR author gates and merges their own work, and containerized suites stop being a routine local gate.

Also updated: `dispatch-af-session.md`, `create-pr.md`, `decompose-file.md`, `incident-response.md`, `CLAUDE.md`.

## Rebased onto master three times; nothing of master's was reverted

#2799, #2808 and #2824 all landed in these files while this branch was open. This branch is a wholesale rewrite from an older base, so a naive merge would have replaced those regions **with no conflict marker** — a clean merge was the dangerous outcome. Each rebase re-applied this branch's changes onto master's files rather than overwriting them, and the result was verified rather than assumed:

| from master | verified present |
|---|---|
| #2808's full "Git hygiene in a shared repo" section, `refs/worktree/` substitutes, `stash store` ban | 10 mentions in CLAUDE.md, 7 in dispatch — both unchanged from master |
| #2799's **Never `--auto`** (auto-merge waits only for `Lint`/`Build`, never consults auto-gate.js) | present |
| #2824's pagination-is-mandatory, exact-login authors, whole-word markers, `[gate-ack]`, newest-artifact-wins | present |
| `N/N` in `SELF-TEST PASSED`; inline-findings-override-verdict; decomposition diff shape; usage-limit exclusion | present |

## The gate fails loud

master's step 3 still pipes `gh api` into `jq -s`. A dead API call leaves an empty stream, prints nothing, and reads as **"no findings"** — the single wrong answer that step must never give. Reproduced with a stub `gh` that fails the way a rate limit does:

```
gh: HTTP 403 rate limit exceeded
0
[exit=0]
```

`0` and exit 0 — indistinguishable from a clean PR, and it authorizes the merge it exists to block.

Every finding below was reproduced before being fixed, and several were defects in *this branch's own* fixes:

- **Setup fetches to `.part` and `mv`s into place** under `set -e`, from a `rm -rf`'d dir. A redirect truncates the file *before* the command runs, so a failed fetch used to leave a zero-byte file that parsed fine and meant nothing.
- **Every block starts with `set -euo pipefail`** and validates its input, so it is safe pasted alone.
- **The brace group is gone.** `{ a; b; } || handler` takes only `b`'s status, so a failed reviews request was invisible behind a live issue-comments request.
- **`head-date.txt`** was the one file not written through `.part`/`mv`; an empty bound made `[[ "$VAT" > "$HD" ]]` accept any verdict timestamp.
- **Gate 1 matches required checks by app**, not name — the ruleset pins them to `integration_id: 15368`, and a spoof `Build` from another app satisfied name-only matching while the real one was still in progress.
- **A skipped required check is not a passed one.** `pr.yml` documents the trap: a failed dependency leaves `Build` SKIPPED, which never goes red. The old pass-set printed *nothing* for that rollup.
- **Tests run in a clean `git worktree`** at the fetched head with empty `git status --porcelain` — `gh pr checkout` preserves dirty files that can green a suite for code not in the commit.

## A resolution marker is a claim, not evidence

Replying `RESOLVED` clears a finding whether or not the fix was pushed. That is how #2799 shipped broken: findings cleared in-thread, Auto Gate merged the moment the count hit zero, fix commit landed minutes *after* the merge, and master inherited the defects the review had caught (#2822).

Step 4 now requires the head commit to be newer than every finding a `RESOLVED` reply claims to fix. `ACCEPTED` is exempt — it claims the finding does not apply. Verified against the exact #2799 shape (finding 21:00, RESOLVED 21:05, head 20:00): caught and blocked.

## No review is never a clean review

Codex is intermittent under usage limits. Absence arrives two ways — no artifact, or a comment saying the reviewer declined to look — and **neither is a pass**. There is now one sanctioned override, `GATE_SUBSTITUTE_REVIEW`, which must contain the exact head SHA so it cannot be exported once and forgotten across pushes, and which prints exactly what it bypasses. Without it the gates hard-fail, deliberately.

## Containerized suites are not a routine gate

Owner policy: a local container run rebuilds the whole Go tree, and ~20 sessions doing it concurrently took the 16-core box to a load average of 160. CI already runs `go test -race ./...` on every push (`pr.yml:132`, `:331`).

All six files now prescribe the cheap checks plus a package-scoped `go test`, with **`daemon/` and `app/` excluded outright** as a safety rule — those spawn real `af` daemons and drive real tmux beside ~15 live sessions, so the risk is disturbing production, not burning CPU.

One carve-out, stated rather than implied: `make tui-driver-selftest` and `scripts/testbox.sh scenario` stay required for TUI-touching PRs, because **CI does not run them at all** — nothing in `.github/workflows/` invokes `scripts/testbox.sh selftest`. That is also why auto-gate demands the `play-tested` label on TUI paths.

## Verification

Every `bash` block was extracted from the file and executed verbatim against real API data — positive (it selected the right verdict out of three and listed exactly the open findings, refusing to merge itself) and negative (killed API call, zero-byte file, truncated JSON, missing verdict, unreviewed head, spoofed app, skipped required check, override with the wrong SHA). All exit non-zero with an `ABORT`; none print a count or a clean line. `bash -n` on every block. Predicate parity with `auto-gate.js` checked directly against its exported helpers, and `auto-gate.test.js` passes 20/20.

Local gates on the pushed head: `gofmt -l .`, `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean. No `go test` package run: this PR changes no Go. No container run, per the policy it encodes.

## Issues

Closes nothing — all three related issues were closed by other PRs while this was open, which is itself an argument for the fail-loud rewrite:

- **#2583** → closed by #2799 (Greptile → Codex)
- **#2822** → closed by #2824 (the three broken queries)
- **#2825** → closed as stale; #2824 had already landed the fixed reply route, verified with `grep -rn 'pulls/comments/' .claude/ docs/` returning nothing
