### PR TITLE
fix: preserve committed task update success

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -576,8 +576,19 @@ var tasksUpdateCmd = &cobra.Command{
 			// record back so the update command preserves its normal output.
 			stored, readErr := task.GetTask(args[0])
 			if readErr != nil {
-				return jsonError(fmt.Errorf(
-					"task update committed, but its durable value could not be read back: %w", readErr))
+				// The mutation outcome is known even though the task's current value
+				// is not: another client may have removed it after this commit, or the
+				// disk read may have failed transiently. Preserve a successful exit so
+				// callers do not retry an update that definitely committed, and make
+				// the missing readback explicit instead of inventing a task snapshot.
+				fmt.Fprintf(os.Stderr,
+					"warning: task update committed, but its durable value could not be read back: %v; the final task value is unknown\n",
+					readErr)
+				return jsonOut(map[string]any{
+					"id":                 args[0],
+					"mutation_committed": true,
+					"value_read_back":    false,
+				})
 			}
 			updated = *stored
 		}

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -405,6 +406,40 @@ func TestTasksUpdate_DisablePersistsViaDaemon(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, got.Enabled)
 	assert.Equal(t, 1, calls.writes, "update must dispatch the write to the daemon")
+}
+
+func TestTasksUpdate_CommittedReadbackFailureIsNotRetryable(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	stubDaemon(t)
+
+	seedTask(t, task.Task{ID: "committed-update", Name: "before", Prompt: "p", CronExpr: "0 9 * * *", Enabled: true})
+	taskUpdateNameFlag = "after"
+	daemonUpdateTask = func(id string, update task.TaskUpdate, expect task.ProjectExpectation) (task.Task, error) {
+		_, err := task.UpdateTask(id, update, expect)
+		require.NoError(t, err)
+		// Model another client removing the task after this update committed but
+		// before the CLI's post-error readback. The update outcome is still known:
+		// retrying it would be wrong even though its final value is no longer readable.
+		require.NoError(t, task.RemoveTask(id, expect))
+		return task.Task{}, committedTaskMutationTestError{}
+	}
+
+	var runErr error
+	stdout := captureStdout(t, func() {
+		runErr = tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"committed-update"})
+	})
+	require.NoError(t, runErr, "a committed update must remain successful when its follow-up readback is inconclusive")
+
+	var result struct {
+		ID                string `json:"id"`
+		MutationCommitted bool   `json:"mutation_committed"`
+		ValueReadBack     bool   `json:"value_read_back"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result), "the degraded success path must still emit valid JSON")
+	assert.Equal(t, "committed-update", result.ID)
+	assert.True(t, result.MutationCommitted)
+	assert.False(t, result.ValueReadBack)
 }
 
 func TestTasksUpdate_SwitchWatchToCronAndDisableWithoutPrompt(t *testing.T) {


### PR DESCRIPTION
## Summary

- keep `af tasks update` successful when the daemon reports that the update committed but the CLI cannot read the task back
- emit a truthful degraded-success JSON payload with `mutation_committed: true` and `value_read_back: false`
- warn that the final task value is unknown instead of returning a retryable error or inventing a snapshot

## Diagnosis

The #2701 follow-up review is correct. net/rpc discards the response body when the daemon returns a post-commit reload error, so the CLI reads the durable task back to preserve normal output. If another client removes the task before that read, or the disk read fails transiently, the old branch returned nonzero even though the update outcome was definitely committed. That collapses “current value could not be determined” into “update failed” and invites a duplicate retry.

The commit result and readback result are independent: this fix preserves committed success while explicitly reporting that no final value was observed.

## Adjacent call-site audit

- CLI Add and Remove do not perform a post-commit readback and already return success for the known committed outcome.
- The TUI acknowledges the durable edit baseline before surfacing the scheduler warning, so it does not retain a retryable edit.
- Web callers refresh their projection after committed outcomes.
- No other `IsMutationCommitted` path turns a secondary readback failure into a failed mutation.

## Red regression

Observed before the production fix on current master:

```
--- FAIL: TestTasksUpdate_CommittedReadbackFailureIsNotRetryable (0.02s)
    tasks_test.go:432:
        Error: Received unexpected error:
          task update committed, but its durable value could not be read back: task with id "committed-update" not found
        Messages: a committed update must remain successful when its follow-up readback is inconclusive
FAIL
```

The old command also emitted:

```
{"error":"task update committed, but its durable value could not be read back: task with id \"committed-update\" not found"}
```

## Validation

Validated pushed head `d28be7d1e6970483c6696eb552505df7f2a2f250` after rebasing onto current `master` (including #2702’s overlapping API changes):

- `GOTOOLCHAIN=go1.25.0 golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (empty)
- `GOTOOLCHAIN=go1.25.0 go build ./...`
- `GOTOOLCHAIN=go1.25.0 deadcode -test ./...`
- `scripts/lint-file-length.sh`
- focused regression and all committed Add/Update/Remove API regressions via `make test-container`
- `GOTOOLCHAIN=go1.25.0 make test-container` (full suite, run last against the pushed head)

Follow-up to #2701.

Closes #2588