### PR TITLE
Fix VS Code tabs opening another session's worktree

### DIFF
--- a/daemon/vscode_server.go
+++ b/daemon/vscode_server.go
@@ -228,6 +228,12 @@ func vscodeArgs(flavor vscodeFlavor, socketPath, worktree string) []string {
 			"--disable-telemetry",
 			"--disable-update-check",
 			"--disable-workspace-trust",
+			// AF runs one editor per session but deliberately leaves code-server's
+			// user-data directory shared so settings and extensions carry across
+			// them. Its remembered last workspace is shared too, and without this
+			// flag a second server can redirect to another session's folder even
+			// though the positional argument below names the right worktree (#2683).
+			"--ignore-last-opened",
 			worktree,
 		}
 	}

--- a/daemon/vscode_server_test.go
+++ b/daemon/vscode_server_test.go
@@ -781,6 +781,24 @@ func TestVSCodeArgs_FlavorDialects(t *testing.T) {
 	}
 }
 
+// TestVSCodeArgs_CodeServerIgnoresSharedLastWorkspace pins the flag that makes
+// the positional worktree authoritative. AF deliberately shares code-server's
+// user-data directory so settings and extensions carry across sessions. Without
+// --ignore-last-opened, two concurrently running editors also share the last
+// workspace: opening session B can make its server redirect to session A's folder
+// even though B's argv ends in B's worktree (#2683).
+func TestVSCodeArgs_CodeServerIgnoresSharedLastWorkspace(t *testing.T) {
+	cs := strings.Join(vscodeArgs(flavorCodeServer, "/run/af/e.sock", "/session-b"), " ")
+	if !strings.Contains(cs, "--ignore-last-opened") {
+		t.Fatalf("code-server argv = %q; missing --ignore-last-opened lets shared user data override /session-b with another session's workspace", cs)
+	}
+
+	ov := strings.Join(vscodeArgs(flavorOpenVSCode, "/run/af/e.sock", "/session-b"), " ")
+	if strings.Contains(ov, "--ignore-last-opened") {
+		t.Fatalf("openvscode-server argv = %q; code-server's --ignore-last-opened flag must not leak into the other CLI dialect", ov)
+	}
+}
+
 // TestVSCodeArgs_ScrubsIPCHookFromChildEnv is codex's [33]. code-server's
 // shouldOpenInExistingInstance reads VSCODE_IPC_HOOK_CLI UNCONDITIONALLY, before
 // it starts any server: when it is set the CLI forwards the folder to that


### PR DESCRIPTION
## Summary

- make code-server ignore its shared remembered workspace so the requested session worktree remains authoritative
- keep the flag scoped to code-server; OpenVSCode Server retains its own CLI dialect
- add a regression test for the shared-user-data failure mode

## Root cause

Agent Factory intentionally shares code-server's user-data directory so settings and extensions carry across session editors. code-server also stores its last opened workspace there. With two concurrent non-`--here` sessions, opening session B could therefore redirect to session A's worktree even though B's process argv ended with B's correct worktree.

On the live daemon I reproduced a `db-hardening` VS Code tab whose iframe addressed that session but redirected to the separate `detail-costs-calc` session worktree and branch. This was not the repository root, an in-place session, or merely a stale branch.

The fix passes code-server's `--ignore-last-opened`, preserving shared settings/extensions while making the positional worktree authoritative.

## Validation

- fail-first: `TestVSCodeArgs_CodeServerIgnoresSharedLastWorkspace` failed on master because code-server argv omitted `--ignore-last-opened`
- real code-server 4.129.0 repro: two servers sharing one user-data directory redirected the second server to the first session's worktree before the fix
- real post-fix play-test: the same two-server setup redirected each server to its own requested worktree
- `GOTOOLCHAIN=go1.25.0 go test ./daemon -count=1`
- `make web-build`
- `make web-test` (455 passed)
- `make web-selftest-container` (126 passed)
- `GOTOOLCHAIN=go1.25.0 golangci-lint run --timeout=3m --fast`
- `GOTOOLCHAIN=go1.25.0 go build ./...`
- `GOTOOLCHAIN=go1.25.0 deadcode -test ./...`
- `gofmt -l daemon/vscode_server.go daemon/vscode_server_test.go`
- `scripts/lint-file-length.sh`
- `make test-container` (full suite, run last against the pushed head below)

Pushed and fully tested head: `77d158066f9da2d5d1da2e933ea79faefe65d067`

Closes #2683