### PR TITLE
fix archived sessions staying in web rail

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -37,12 +37,12 @@ var ErrAlreadyArchived = errors.New("already archived")
 // kill, and Lost-recovery never interleave). Returns the relocated worktree's
 // new path.
 // ArchiveSession archives the resolved session and returns the relocated worktree
-// path AND the stable identity (id + title) of the session it ACTUALLY resolved and
-// acted on, so the control server publishes the archived event for exactly that
-// session — never the request's own (possibly stale) id under a cross-repo title
-// collision (#1592 Phase 5 follow-up).
+// path AND the full committed projection of the session it ACTUALLY resolved and
+// acted on. The control server publishes that projection so clients learn Archived
+// directly from the event instead of depending on a second Snapshot request (#2680),
+// while its stable id still prevents cross-repo title misrouting (#1592 Phase 5).
 func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, session.InstanceData, error) {
-	instance, repoID, title, resolvedID, _, err := m.resolveActionSession(req.ID, req.Title, req.RepoID)
+	instance, repoID, title, _, _, err := m.resolveActionSession(req.ID, req.Title, req.RepoID)
 	if err != nil {
 		return "", session.InstanceData{}, err
 	}
@@ -50,7 +50,6 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, session.Ins
 	// killsInFlight key, and the relocation key off the id-resolved identity,
 	// not the request's title. req is a value copy, so this is local.
 	req.Title = title
-	resolved := session.InstanceData{ID: resolvedID, Title: title}
 	if session.IsReservedTitle(req.Title) {
 		return "", session.InstanceData{}, fmt.Errorf("cannot archive the reserved %q session", req.Title)
 	}
@@ -81,7 +80,7 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, session.Ins
 		// idempotent success and still report the right {id, title}, while a caller
 		// archiving one named session — the CLI/TUI verbs — keeps the same message
 		// and the same failure it has always shown.
-		return "", resolved, fmt.Errorf("session %q is %w", req.Title, ErrAlreadyArchived)
+		return "", instance.ToInstanceData(), fmt.Errorf("session %q is %w", req.Title, ErrAlreadyArchived)
 	}
 	if instance.GetInFlightOp() != session.OpNone {
 		return "", session.InstanceData{}, fmt.Errorf("session %q is busy (%v); try again in a moment", req.Title, instance.GetStatus())
@@ -125,7 +124,7 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, session.Ins
 		if rerr != nil {
 			return "", session.InstanceData{}, rerr
 		}
-		return archivedPath, resolved, nil
+		return archivedPath, instance.ToInstanceData(), nil
 	}
 
 	dest, err := archivedWorktreePath(repoID, req.Title)
@@ -216,7 +215,7 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, session.Ins
 		return "", session.InstanceData{}, fmt.Errorf("failed to durably archive session %q; rolled it back and left it Lost to be restored in place: %w", req.Title, perr)
 	}
 	log.InfoLog.Printf("archived session %q (repo %s): tmux torn down, worktree moved to %s", req.Title, repoID, archivedPath)
-	return archivedPath, resolved, nil
+	return archivedPath, instance.ToInstanceData(), nil
 }
 
 // undoCommittedArchive rolls a committed-but-unpersisted archive back to a

--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
@@ -38,9 +39,10 @@ var ErrAlreadyArchived = errors.New("already archived")
 // new path.
 // ArchiveSession archives the resolved session and returns the relocated worktree
 // path AND the full committed projection of the session it ACTUALLY resolved and
-// acted on. The control server publishes that projection so clients learn Archived
-// directly from the event instead of depending on a second Snapshot request (#2680),
-// while its stable id still prevents cross-repo title misrouting (#1592 Phase 5).
+// acted on. It publishes that projection before releasing the per-session operation
+// lock so a later restore cannot overtake it, and clients learn Archived directly
+// instead of depending on a second Snapshot request (#2680). Its stable id still
+// prevents cross-repo title misrouting (#1592 Phase 5).
 func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, session.InstanceData, error) {
 	instance, repoID, title, _, _, err := m.resolveActionSession(req.ID, req.Title, req.RepoID)
 	if err != nil {
@@ -124,7 +126,9 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, session.Ins
 		if rerr != nil {
 			return "", session.InstanceData{}, rerr
 		}
-		return archivedPath, instance.ToInstanceData(), nil
+		archived := instance.ToInstanceData()
+		m.publishEvent(agentproto.EventSessionArchived, archived)
+		return archivedPath, archived, nil
 	}
 
 	dest, err := archivedWorktreePath(repoID, req.Title)
@@ -215,7 +219,12 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, session.Ins
 		return "", session.InstanceData{}, fmt.Errorf("failed to durably archive session %q; rolled it back and left it Lost to be restored in place: %w", req.Title, perr)
 	}
 	log.InfoLog.Printf("archived session %q (repo %s): tmux torn down, worktree moved to %s", req.Title, repoID, archivedPath)
-	return archivedPath, instance.ToInstanceData(), nil
+	archived := instance.ToInstanceData()
+	// Still inside opLock: lifecycle event order must match committed operation
+	// order. Publishing after this method returns lets an immediate restore finish
+	// and publish before this older Archived projection (#2680 Codex review).
+	m.publishEvent(agentproto.EventSessionArchived, archived)
+	return archivedPath, archived, nil
 }
 
 // undoCommittedArchive rolls a committed-but-unpersisted archive back to a

--- a/daemon/archive_test.go
+++ b/daemon/archive_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"os/exec"
@@ -8,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/session"
 	sessiongit "github.com/sachiniyer/agent-factory/session/git"
 
@@ -88,6 +90,31 @@ func TestArchiveSession_MovesWorktreeAndMarksArchived(t *testing.T) {
 	list, lerr := exec.Command("git", "-C", repoPath, "worktree", "list", "--porcelain").CombinedOutput()
 	require.NoError(t, lerr, string(list))
 	assert.Contains(t, string(list), archivedPath, "git must still register the worktree at its new path")
+}
+
+// TestArchiveSessionPublishesCommittedProjectionBeforeReturn pins the lifecycle
+// ordering domain: ArchiveSession holds the per-session operation lock until it
+// returns, so its committed event must already be queued before that return. If
+// the control layer publishes afterward, a restore can acquire the lock, finish,
+// and publish first; the delayed stale Archived projection then wins in clients.
+func TestArchiveSessionPublishesCommittedProjectionBeforeReturn(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, _ := registerArchivable(t, manager, repoID, repoPath, "ordered-event")
+	_, events := manager.events.subscribe()
+
+	_, _, err := manager.ArchiveSession(ArchiveSessionRequest{ID: inst.ID, Title: inst.Title, RepoID: repoID})
+	require.NoError(t, err)
+
+	select {
+	case event := <-events:
+		require.Equal(t, agentproto.EventSessionArchived, event.Type)
+		var archived session.InstanceData
+		require.NoError(t, json.Unmarshal(event.Data, &archived))
+		assert.Equal(t, inst.ID, archived.ID)
+		assert.Equal(t, session.LiveArchived, archived.Liveness)
+	default:
+		t.Fatal("ArchiveSession returned before publishing its committed projection; a concurrent restore can overtake the stale event")
+	}
 }
 
 // TestArchiveSessionRejectsStartupUnknown prevents archive from turning an

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -629,15 +629,16 @@ func (s *controlServer) ArchiveSession(req ArchiveSessionRequest, resp *ArchiveS
 		return err
 	}
 	// ArchiveSession resolves the target (id-first, erroring on a stale/missing id)
-	// and returns the stable identity it ACTUALLY archived — so the event names that
-	// exact session, never the request's own id (#1592 Phase 5 PR5 + follow-up).
+	// and returns the full projection it ACTUALLY archived. Publishing that exact
+	// session both preserves stable identity and lets clients consume the daemon's
+	// Archived liveness without a fallible follow-up Snapshot (#2680).
 	archivedPath, archived, err := s.manager.ArchiveSession(req)
 	if err != nil {
 		return err
 	}
 	resp.OK = true
 	resp.ArchivedPath = archivedPath
-	s.manager.publishEvent(agentproto.EventSessionArchived, session.InstanceData{ID: archived.ID, Title: archived.Title})
+	s.manager.publishEvent(agentproto.EventSessionArchived, archived)
 	return nil
 }
 
@@ -709,7 +710,7 @@ func (s *controlServer) DeleteProject(req DeleteProjectRequest, resp *DeleteProj
 	}
 	result, err := s.manager.DeleteProject(req)
 	for _, a := range result.Archived {
-		s.manager.publishEvent(agentproto.EventSessionArchived, session.InstanceData{ID: a.ID, Title: a.Title})
+		s.manager.publishEvent(agentproto.EventSessionArchived, a)
 	}
 	for _, k := range result.Killed {
 		s.manager.publishEvent(agentproto.EventSessionKilled, session.InstanceData{ID: k.ID, Title: k.Title})

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -628,17 +628,15 @@ func (s *controlServer) ArchiveSession(req ArchiveSessionRequest, resp *ArchiveS
 	if err := validateRPCRepoID(req.RepoID); err != nil {
 		return err
 	}
-	// ArchiveSession resolves the target (id-first, erroring on a stale/missing id)
-	// and returns the full projection it ACTUALLY archived. Publishing that exact
-	// session both preserves stable identity and lets clients consume the daemon's
-	// Archived liveness without a fallible follow-up Snapshot (#2680).
-	archivedPath, archived, err := s.manager.ArchiveSession(req)
+	// ArchiveSession resolves the target (id-first, erroring on a stale/missing id),
+	// commits it, and publishes the full projection inside its operation lock. That
+	// keeps lifecycle event order identical to operation order (#2680).
+	archivedPath, _, err := s.manager.ArchiveSession(req)
 	if err != nil {
 		return err
 	}
 	resp.OK = true
 	resp.ArchivedPath = archivedPath
-	s.manager.publishEvent(agentproto.EventSessionArchived, archived)
 	return nil
 }
 
@@ -709,9 +707,6 @@ func (s *controlServer) DeleteProject(req DeleteProjectRequest, resp *DeleteProj
 		return err
 	}
 	result, err := s.manager.DeleteProject(req)
-	for _, a := range result.Archived {
-		s.manager.publishEvent(agentproto.EventSessionArchived, a)
-	}
 	for _, k := range result.Killed {
 		s.manager.publishEvent(agentproto.EventSessionKilled, session.InstanceData{ID: k.ID, Title: k.Title})
 	}

--- a/daemon/deleteproject.go
+++ b/daemon/deleteproject.go
@@ -56,10 +56,10 @@ var deregisterRootAgents = config.DeregisterRootAgentsForRepo
 // projects-changed signal), and the CLI/TUI can report the counts.
 type DeleteProjectResult struct {
 	RepoID string
-	// Archived carries the {ID, Title} of every session archived (restorable via
-	// RestoreArchived). Killed carries the {ID, Title} of every in-place/external
-	// session torn down instead (archive can't relocate an external worktree; its
-	// kill never touches the user's tree/branch).
+	// Archived carries the full committed projection of every archived session so
+	// lifecycle events are directly applicable by clients (#2680). Killed needs only
+	// {ID, Title} for every in-place/external session torn down instead (archive can't
+	// relocate an external worktree; its kill never touches the user's tree/branch).
 	Archived []session.InstanceData
 	Killed   []session.InstanceData
 	// Deregistered is true when this delete removed the repo's durable #2355 registry
@@ -290,7 +290,7 @@ func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 			errs = append(errs, fmt.Errorf("session %q: %w", t.title, err))
 			continue
 		}
-		result.Archived = append(result.Archived, session.InstanceData{ID: archived.ID, Title: archived.Title})
+		result.Archived = append(result.Archived, archived)
 	}
 
 	if len(errs) > 0 {

--- a/daemon/deleteproject_test.go
+++ b/daemon/deleteproject_test.go
@@ -69,6 +69,10 @@ func TestDeleteProject_ArchivesAllSessionsRestorableRepoUntouched(t *testing.T) 
 	require.NoError(t, err)
 	assert.Len(t, result.Archived, 2, "both live sessions must be archived")
 	assert.Empty(t, result.Killed, "neither session is in-place, so none is torn down")
+	for _, archived := range result.Archived {
+		assert.Equal(t, session.LiveArchived, archived.Liveness, "bulk archive returns the daemon's committed liveness")
+		assert.Equal(t, session.LifecycleActionRestore, archived.LifecycleAction, "bulk archive returns the daemon's projected next action")
+	}
 
 	// Both sessions are now inert Archived rows, worktrees relocated out.
 	for _, title := range []string{"alpha", "beta"} {

--- a/daemon/lifecycle_event_id_test.go
+++ b/daemon/lifecycle_event_id_test.go
@@ -81,6 +81,9 @@ func TestArchiveAndRestoreEventsCarryStableID(t *testing.T) {
 	if archived.ID != data.ID {
 		t.Fatalf("archived event ID = %q, want %q", archived.ID, data.ID)
 	}
+	if archived.Liveness != session.LiveArchived {
+		t.Fatalf("archived event liveness = %v, want %v; a partial event leaves web clients stale when their follow-up Snapshot fails", archived.Liveness, session.LiveArchived)
+	}
 
 	var rResp RestoreArchivedResponse
 	if err := cs.RestoreArchived(RestoreArchivedRequest{ID: data.ID, Title: "stale-display-title", RepoID: repo.ID}, &rResp); err != nil {

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -8981,6 +8981,9 @@ function applyEvent(list, ev) {
       return { sessions: list, needsResync: false };
     case "session.archived":
     case "session.restored":
+      if (ev.data && ev.data.title && ev.data.liveness !== void 0) {
+        return { sessions: upsertSession(list, ev.data), needsResync: false };
+      }
       return { sessions: list, needsResync: true };
     case "projects.changed":
       return { sessions: list, needsResync: true };

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "1d42b52a2fde";
+const VERSION = "cb0d788f8e4d";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -37,7 +37,7 @@
 // playwright.config.ts): AF_WEB_BASE_URL and the two seeded session titles
 // AF_WEB_SESSION_A / AF_WEB_SESSION_B. No token is needed.
 
-import { expect, type Browser, type BrowserContext, type Locator, type Page, test } from "@playwright/test";
+import { expect, type Browser, type BrowserContext, type Locator, type Page, type Route, test } from "@playwright/test";
 import { decode, Op } from "../src/frame.js";
 
 const SESSION_A = process.env.AF_WEB_SESSION_A ?? "probe-a";
@@ -3427,7 +3427,7 @@ test.describe("create → kill (one session, two flows)", () => {
   });
 });
 
-test("archive: an unselected row's hover action retires that session, not the selection", REAL_FIXTURE, async () => {
+test("#2680: archive retires an unselected row even when the follow-up Snapshot fails", REAL_FIXTURE, async () => {
   // Keep A selected, then invoke B's hover-revealed action. The modal target must be
   // the row that owns the button; deriving it from the current selection would archive
   // A instead (#2223).
@@ -3443,13 +3443,40 @@ test("archive: an unselected row's hover action retires that session, not the se
   await expect(modal).toContainText(SESSION_B);
   await expect(row(page, SESSION_A)).toHaveClass(/af-row-selected/);
   await expect(row(page, SESSION_B)).not.toHaveClass(/af-row-selected/);
+
+  // The archived event itself must carry the daemon's projected Archived row. If
+  // the browser needs a second Snapshot to learn the liveness, one transient fetch
+  // failure leaves the old live row in place forever even though the archive
+  // committed; only a reload repairs it (#2680). Make that dependency unavailable
+  // so this test watches the actual live-update contract rather than a lucky refetch.
+  let failedSnapshots = 0;
+  const failSnapshot = async (route: Route): Promise<void> => {
+    failedSnapshots += 1;
+    await route.abort("connectionfailed");
+  };
+  await page.route("**/v1/Snapshot", failSnapshot);
   await modal.locator("button.af-primary").click();
 
   // B LEAVES the default rail (feat: hide archived by default) — archived sessions are
   // history, and the rail shows the work you can still act on. This is the real
-  // archive flow, not a filter toggle: the row goes as the daemon's archived event
-  // lands, which is the end-to-end proof the filter reads live projection state.
-  await expect(row(page, SESSION_B)).toHaveCount(0, { timeout: 30_000 });
+  // archive flow, not a filter toggle: the full daemon projection on the archived
+  // event moves the row without depending on a fallible second request.
+  try {
+    await expect(row(page, SESSION_B)).toHaveCount(0, { timeout: 5_000 });
+  } catch (liveError) {
+    // Preserve the issue's cheapest diagnostic in the fail-first output: on the
+    // broken client the live row stays, but a fresh Snapshot on reload clears it.
+    await page.unroute("**/v1/Snapshot", failSnapshot);
+    await page.reload();
+    await expect(row(page, SESSION_B), "reload must clear the stale archived row").toHaveCount(0, {
+      timeout: 15_000,
+    });
+    throw new Error(
+      `archived row stayed live after ${failedSnapshots} failed Snapshot request(s); reload cleared it: ${String(liveError)}`,
+    );
+  } finally {
+    await page.unroute("**/v1/Snapshot", failSnapshot);
+  }
 
   // B is NOT killed, though — revealing the archive brings the very same row back,
   // muted, carrying the static archive shape (no spinner): the error/terminal states

--- a/web/src/sessions.test.ts
+++ b/web/src/sessions.test.ts
@@ -102,13 +102,23 @@ test("applyEvent: an id-less killed event falls back to the title", () => {
   assert.deepEqual(r.sessions.map((s) => s.title), ["y"]);
 });
 
-test("applyEvent: archived/restored ask for a resync and leave the list untouched", () => {
+test("applyEvent: legacy partial archived/restored events still ask for a resync", () => {
   const list = [sess("x", { id: "id-x" })];
   for (const type of ["session.archived", "session.restored"] as const) {
     const r = applyEvent(list, { type, data: { id: "id-x", title: "x", branch: "" } });
     assert.equal(r.needsResync, true, `${type} → resync`);
     assert.equal(r.sessions, list, "list reference unchanged pending the refetch");
   }
+});
+
+test("#2680: a full archived projection updates the row without a fallible resync", () => {
+  const list = [sess("x", { id: "id-x", liveness: Liveness.Ready })];
+  const archived = sess("x", { id: "id-x", liveness: Liveness.Archived });
+  const r = applyEvent(list, { type: "session.archived", data: archived });
+
+  assert.equal(r.needsResync, false, "the daemon projection is already authoritative");
+  assert.notEqual(r.sessions, list, "the archived event updates the store immediately");
+  assert.equal(r.sessions[0]?.liveness, Liveness.Archived, "the rail consumes the daemon-projected liveness");
 });
 
 test("applyEvent: task.* and dataless events are no-ops", () => {

--- a/web/src/sessions.ts
+++ b/web/src/sessions.ts
@@ -19,10 +19,9 @@
 import type { SessionData, WireEvent } from "./types.js";
 
 /** The result of applying one event: the next list plus whether the caller must
- *  re-Snapshot. Partial events (archived/restored carry only {id,title}, with no
- *  liveness to reconstruct) set needsResync so index.ts refetches authoritative
- *  state; the common created/updated/killed deltas apply in place (needsResync
- *  false) for an instant, poll-free update. */
+ *  re-Snapshot. Full session projections apply in place. Older partial archive or
+ *  restore events set needsResync because their liveness cannot be reconstructed;
+ *  the browser never derives daemon-owned lifecycle state itself. */
 export interface ApplyResult {
   sessions: SessionData[];
   needsResync: boolean;
@@ -63,8 +62,8 @@ export function removeSession(list: SessionData[], target: { id?: string; title:
  * contract (agentproto/message.go, daemon/control_server.go):
  *  - created/updated carry the full projection → upsert by id in place;
  *  - killed carries {id,title} → remove the row keyed by id;
- *  - archived/restored carry {id,title} and flip a liveness the event can't
- *    convey → signal a resync so the caller refetches Snapshot;
+ *  - archived/restored carry the daemon's full projection → upsert immediately;
+ *    tolerate an older {id,title}-only event by asking for a Snapshot instead;
  *  - task.* are not a sidebar concern → no-op.
  * The list is returned unchanged (same reference) for events that don't touch it.
  */
@@ -83,6 +82,9 @@ export function applyEvent(list: SessionData[], ev: WireEvent): ApplyResult {
       return { sessions: list, needsResync: false };
     case "session.archived":
     case "session.restored":
+      if (ev.data && ev.data.title && ev.data.liveness !== undefined) {
+        return { sessions: upsertSession(list, ev.data), needsResync: false };
+      }
       return { sessions: list, needsResync: true };
     case "projects.changed":
       // A project was deleted as a whole (#1735): the per-session archived events


### PR DESCRIPTION
## Summary

- publish the daemon's full committed session projection on archive events, including bulk project deletion
- publish archive projections inside the per-session operation lock so restore cannot overtake an older archive event
- apply full archive/restore projections immediately in the web session store while retaining Snapshot fallback for older partial events
- cover the live-update failure mode by aborting the follow-up Snapshot in the real browser harness

## Reproduction and root cause

A reload clears the stale archived row, so the fetched Snapshot is authoritative and already excludes it. The live `session.archived` event carried only `{id,title}`; the browser left the row untouched and requested another Snapshot. If that second request failed, the old live projection remained indefinitely.

Fail-first browser result on the pre-fix tree: 1 failed, 125 passed. The failure reported: `archived row stayed live after 1 failed Snapshot request(s); reload cleared it`.

The browser continues to consume daemon-projected liveness and does not re-derive lifecycle state client-side.

## Review follow-up

Codex identified that publishing the full archive projection after `ArchiveSession` returned allowed an immediate restore to overtake it. A new regression failed first with `ArchiveSession returned before publishing its committed projection`; archive publication now occurs after the durable commit and before the operation lock is released. Single-archive and bulk-delete control-layer duplicate publishers were removed.

## Validation

- `make web-build`
- `make web-test` — 456 passed
- focused daemon archive/event/delete-project/ordering tests
- `make web-selftest-container` — 126 passed, including forced Snapshot failure
- `golangci-lint run --timeout=3m --fast`
- `go build ./...`
- `deadcode -test ./...`
- `gofmt -l .`
- `scripts/lint-file-length.sh`
- `make test-container` — full suite passed last against pushed head `6abf9568d485bb00e9afdaaf7d3d268e13fb4925`

Closes #2680