### PR TITLE
Allow Auto Gate to close linked issues

### DIFF
--- a/.github/workflows/auto-gate.yml
+++ b/.github/workflows/auto-gate.yml
@@ -18,7 +18,7 @@ permissions:
   actions: write
   checks: read
   statuses: read
-  issues: read
+  issues: write
 
 concurrency:
   group: auto-gate-${{ github.event.pull_request.number || github.event.issue.number || github.event.check_suite.pull_requests[0].number || github.event.check_suite.head_sha || github.event.sha || github.run_id }}


### PR DESCRIPTION
## Summary

- grant Auto Gate's `GITHUB_TOKEN` write access to issues
- restore automatic issue closure when Auto Gate squash-merges a PR carrying `Closes #N`

## Verified root cause

Repository Actions secrets contain no `AUTO_GATE_TOKEN`, and the Auto Gate job declares no environment. Real merge run `30583811218` for PR #2734 reported `Issues: read`, merged as `github-actions[bot]`, referenced #2645 at merge, and left it open until a later manual close. Human merges in the same period auto-closed their linked issues, excluding the repository-wide auto-close setting.

## Red-first evidence

Before the change, the focused permission assertion failed:

`FAIL: Auto Gate does not grant issues write; linked issues cannot be closed by its GITHUB_TOKEN`

## Validation

Validated pushed SHA `12bb7a99442850438d37acca4fcd4f32550336ea`:

- focused permission assertion
- `node --test .github/scripts/auto-gate.test.js` (20/20)
- `actionlint .github/workflows/auto-gate.yml`
- `git diff --check`
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container` (full suite, run last)

Closes #2738