### PR TITLE
fix(doctor): keep unproven findings advisory

### DIFF
--- a/commands/doctorcmd.go
+++ b/commands/doctorcmd.go
@@ -59,9 +59,16 @@ answering while rejecting fields a newer client sends, which surfaces as
 
 Use --json to emit each check as {name, section, status, detail, remedy,
 actionable} in the shared {data,error} envelope for scripting. Branch on
-"actionable", not on the status: doctor emits advisory warnings (no autostart
-unit, a legacy config that still loads) that carry a remedy while leaving the
-run healthy. Only the actionable rows make it exit nonzero.
+"actionable", not on the status or whether --fix supports the row. Actionable
+means doctor established a specific unhealthy condition and named a correction
+that must happen before the run is healthy. Some exact corrections are manual
+and remain actionable even though --fix does not perform them.
+
+UNKNOWN observations stay visible as advisory warnings with inspection
+guidance, but they are not actionable: "inspect it and decide" is not a finding
+that the run is unhealthy. A CI step or health probe should fail on the command
+exit code (equivalently, JSON summary.unresolved > 0), which includes only
+actionable rows.
 
 High-volume process findings are summarized by default so the actionable
 problem is visible first. Use --verbose to show each process behind those
@@ -70,9 +77,11 @@ summaries.
 Read-only by default. With --fix, applies the safe remediations — killing
 orphans whose ancestry markers prove they came from a dead af session, and
 removing stale temp homes — logging each action. Ambiguous cases are always
-reported rather than acted on.
+reported rather than acted on, and remain advisory unless another check
+establishes a specific unhealthy condition.
 
-Exits 1 when unresolved issues remain, 0 when healthy.`,
+Exits 1 when unresolved actionable issues remain, 0 when doctor established no
+unhealthy condition (advisory warnings may still be present).`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)
 		defer log.Close()

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -918,9 +918,16 @@ answering while rejecting fields a newer client sends, which surfaces as
 
 Use --json to emit each check as {name, section, status, detail, remedy,
 actionable} in the shared {data,error} envelope for scripting. Branch on
-"actionable", not on the status: doctor emits advisory warnings (no autostart
-unit, a legacy config that still loads) that carry a remedy while leaving the
-run healthy. Only the actionable rows make it exit nonzero.
+"actionable", not on the status or whether --fix supports the row. Actionable
+means doctor established a specific unhealthy condition and named a correction
+that must happen before the run is healthy. Some exact corrections are manual
+and remain actionable even though --fix does not perform them.
+
+UNKNOWN observations stay visible as advisory warnings with inspection
+guidance, but they are not actionable: "inspect it and decide" is not a finding
+that the run is unhealthy. A CI step or health probe should fail on the command
+exit code (equivalently, JSON summary.unresolved > 0), which includes only
+actionable rows.
 
 High-volume process findings are summarized by default so the actionable
 problem is visible first. Use --verbose to show each process behind those
@@ -929,9 +936,11 @@ summaries.
 Read-only by default. With --fix, applies the safe remediations — killing
 orphans whose ancestry markers prove they came from a dead af session, and
 removing stale temp homes — logging each action. Ambiguous cases are always
-reported rather than acted on.
+reported rather than acted on, and remain advisory unless another check
+establishes a specific unhealthy condition.
 
-Exits 1 when unresolved issues remain, 0 when healthy.
+Exits 1 when unresolved actionable issues remain, 0 when doctor established no
+unhealthy condition (advisory warnings may still be present).
 
 ```
 af doctor [flags]

--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -511,14 +511,12 @@ func checkLeakedTmuxSessions(ctx *scanContext, report *Report) {
 	for _, name := range leaked {
 		origin := "no ancestry marker"
 		ownedByActiveHome := false
-		if procs := tmux.SessionProcessTrees(ctx.opts.Exec, name); len(procs) > 0 {
-			if home, st := proctree.LookupEnv(procs[0].PID, tmux.EnvMarkerHome); st == proctree.EnvFound {
-				if filepath.Clean(home) == filepath.Clean(ctx.opts.ConfigDir) {
-					origin = "created by this install"
-					ownedByActiveHome = true
-				} else {
-					origin = "created by another agent-factory home: " + home
-				}
+		if home, ok := tmuxSessionHomeMarker(ctx, name); ok && home != "" {
+			if filepath.Clean(home) == filepath.Clean(ctx.opts.ConfigDir) {
+				origin = "created by this install"
+				ownedByActiveHome = true
+			} else {
+				origin = "created by another agent-factory home: " + home
 			}
 		}
 		finding := Finding{

--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -339,7 +339,7 @@ func checkOrphanedProcesses(ctx *scanContext, report *Report) {
 				if inSession[p.PID] {
 					continue
 				}
-				report.Findings = append(report.Findings, Finding{
+				report.addAdvisoryFinding(Finding{
 					Check: "escaped-process",
 					Detail: fmt.Sprintf("%s escaped the pane tree of live session %s "+
 						"(left alone while the session is alive)", describeProc(p), name),
@@ -362,7 +362,7 @@ func checkOrphanedProcesses(ctx *scanContext, report *Report) {
 			hasHome := homeStatus == proctree.EnvFound
 			switch {
 			case hasHome && filepath.Clean(home) == filepath.Clean(ctx.opts.ConfigDir):
-				report.Findings = append(report.Findings, Finding{
+				report.addActionableFinding(Finding{
 					Check: "orphaned-process",
 					Detail: fmt.Sprintf("%s was spawned by dead session %s (home %s)",
 						describeProc(p), name, home),
@@ -370,7 +370,7 @@ func checkOrphanedProcesses(ctx *scanContext, report *Report) {
 					fix:       killFix(ctx, p),
 				})
 			case hasHome:
-				report.Findings = append(report.Findings, Finding{
+				report.addAdvisoryFinding(Finding{
 					Check: "orphaned-process",
 					Detail: fmt.Sprintf("%s marks dead session %s but belongs to another "+
 						"agent-factory home (%s) — its session may be live on that install's "+
@@ -378,7 +378,7 @@ func checkOrphanedProcesses(ctx *scanContext, report *Report) {
 						"with that home active", describeProc(p), name, home),
 				})
 			default:
-				report.Findings = append(report.Findings, Finding{
+				report.addAdvisoryFinding(Finding{
 					Check: "orphaned-process",
 					Detail: fmt.Sprintf("%s marks dead session %s but carries no readable "+
 						"home marker — cannot prove which install owns it, so it is "+
@@ -409,14 +409,14 @@ func checkOrphanedProcesses(ctx *scanContext, report *Report) {
 	const maxPossibleOrphans = 15
 	for i, r := range rankedPossibles {
 		if i == maxPossibleOrphans {
-			report.Findings = append(report.Findings, Finding{
+			report.addAdvisoryFinding(Finding{
 				Check: "possible-orphan",
 				Detail: fmt.Sprintf("… and %d more processes of dead tmux servers (all idle or near-idle; "+
 					"none carry an agent-factory marker, so none are killed)", len(rankedPossibles)-maxPossibleOrphans),
 			})
 			break
 		}
-		report.Findings = append(report.Findings, Finding{
+		report.addAdvisoryFinding(Finding{
 			Check: "possible-orphan",
 			Detail: fmt.Sprintf("%s belongs to a dead tmux server (no agent-factory marker — "+
 				"cannot verify ownership, so it is reported, not killed)", describeProc(r.p)),
@@ -480,7 +480,7 @@ func checkRunawayChildren(ctx *scanContext, report *Report) {
 			if err != nil || frac < runawayCPUFraction || age < runawayMinAge.Seconds() {
 				continue
 			}
-			report.Findings = append(report.Findings, Finding{
+			report.addAdvisoryFinding(Finding{
 				Check: "runaway-cpu",
 				Detail: fmt.Sprintf("%s in live session %s has averaged a pegged core — "+
 					"check the session; doctor never kills children of live sessions", describeProc(p), name),
@@ -510,23 +510,35 @@ func checkLeakedTmuxSessions(ctx *scanContext, report *Report) {
 	sort.Strings(leaked)
 	for _, name := range leaked {
 		origin := "no ancestry marker"
+		ownedByActiveHome := false
 		if procs := tmux.SessionProcessTrees(ctx.opts.Exec, name); len(procs) > 0 {
 			if home, st := proctree.LookupEnv(procs[0].PID, tmux.EnvMarkerHome); st == proctree.EnvFound {
 				if filepath.Clean(home) == filepath.Clean(ctx.opts.ConfigDir) {
 					origin = "created by this install"
+					ownedByActiveHome = true
 				} else {
 					origin = "created by another agent-factory home: " + home
 				}
 			}
 		}
-		report.Findings = append(report.Findings, Finding{
+		finding := Finding{
 			Check: "leaked-tmux-session",
 			Detail: fmt.Sprintf("tmux session %s has no backing record in %s (%s); "+
 				"kill it with: %s", name, ctx.opts.ConfigDir, origin,
 				// "=name:" is tmux's exact-match target syntax — one argument, so
 				// it is one piece the seam quotes as a whole.
 				shellsuggest.Command("tmux", "kill-session", "-t", "="+name+":")),
-		})
+		}
+		if ownedByActiveHome {
+			// This install's marker plus no record is a proven leak with an
+			// exact manual remedy. --fix support is not required for a row to
+			// be actionable.
+			report.addActionableFinding(finding)
+		} else {
+			// A shared tmux server can expose another install's healthy session,
+			// and a pre-marker session has unknown ownership.
+			report.addAdvisoryFinding(finding)
+		}
 	}
 }
 
@@ -640,7 +652,7 @@ func checkStaleTempHomes(ctx *scanContext, report *Report) {
 			// and no live tmux session names it, so the home is provably unused.
 			// The fix re-verifies every precondition at fix time (TOCTOU): a
 			// daemon may have started, or a tmux session appeared, since detection.
-			report.Findings = append(report.Findings, Finding{
+			report.addActionableFinding(Finding{
 				Check: "stale-temp-home",
 				Detail: fmt.Sprintf("agent-factory home %s is abandoned (untouched for %s) and no live daemon "+
 					"holds its lock, so it is safe to remove", dir, formatAge(age.Seconds())),
@@ -656,7 +668,7 @@ func checkStaleTempHomes(ctx *scanContext, report *Report) {
 		// non-use), a filesystem whose flock cannot be trusted (NFS), or an I/O
 		// error. Report it — reporting is safe — but never authorise the delete
 		// on a proof we do not have. The operator decides.
-		report.Findings = append(report.Findings, Finding{
+		report.addAdvisoryFinding(Finding{
 			Check: "stale-temp-home",
 			Detail: fmt.Sprintf("agent-factory home %s looks abandoned (untouched for %s), but nothing here can "+
 				"PROVE it is unused (%s) — inspect it and remove it yourself if it is dead",
@@ -888,7 +900,7 @@ func checkForeignDaemons(ctx *scanContext, report *Report) {
 			continue // this install's daemon; covered by checkDaemonHealth
 		}
 		if _, err := os.Stat(home); os.IsNotExist(err) {
-			report.Findings = append(report.Findings, Finding{
+			report.addActionableFinding(Finding{
 				Check: "foreign-daemon",
 				Detail: fmt.Sprintf("%s serves agent-factory home %s which no longer exists "+
 					"(abandoned daemon will run its cron tasks forever)", describeProc(p), home),
@@ -896,13 +908,13 @@ func checkForeignDaemons(ctx *scanContext, report *Report) {
 				fix:       killFix(ctx, p),
 			})
 		} else if err != nil {
-			report.Findings = append(report.Findings, Finding{
+			report.addAdvisoryFinding(Finding{
 				Check: "foreign-daemon",
 				Detail: fmt.Sprintf("%s serves agent-factory home %s whose status cannot be verified: %v",
 					describeProc(p), home, err),
 			})
 		} else {
-			report.Findings = append(report.Findings, Finding{
+			report.addAdvisoryFinding(Finding{
 				Check: "foreign-daemon",
 				Detail: fmt.Sprintf("%s serves a different agent-factory home (%s) — "+
 					"left alone in case it is intentional", describeProc(p), home),

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -44,13 +44,18 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 )
 
-// Finding is one detected problem. FixAction is empty for report-only
-// findings; when set, applying opts.Fix runs the attached fix.
+// Finding is one visible diagnostic observation.
 type Finding struct {
 	// Check is the detector that produced this finding (stable slug).
 	Check string
 	// Detail is the human-readable description.
 	Detail string
+	// Actionable means doctor established a specific unhealthy condition that
+	// must be corrected before the run is healthy. It is deliberately
+	// independent of FixAction: some proven conditions require an exact manual
+	// command, while UNKNOWN observations remain advisory even though they carry
+	// inspection guidance.
+	Actionable bool
 	// FixAction describes what --fix will do; empty means report-only.
 	FixAction string
 	fix       func() error
@@ -103,12 +108,30 @@ type Report struct {
 	Findings []Finding
 }
 
+// addActionableFinding records a condition doctor established is unhealthy.
+// Keeping the classification in the call name makes detector authors choose it
+// separately from automated fix support.
+func (r *Report) addActionableFinding(f Finding) {
+	f.Actionable = true
+	r.Findings = append(r.Findings, f)
+}
+
+// addAdvisoryFinding records a visible observation that does not establish an
+// unhealthy run. Typical examples are UNKNOWN ownership/liveness and behavior
+// that may be intentional. Advisories never drive a health probe or exit code.
+func (r *Report) addAdvisoryFinding(f Finding) {
+	f.Actionable = false
+	r.Findings = append(r.Findings, f)
+}
+
 // UnresolvedCount returns how many underlying issues remain un-remediated
-// (either report-only, fix not requested, or fix failed). It is the number the
-// summary leads with and the exit code keys on, so it counts TRUE underlying
+// (whether automated or manual). Advisory observations are intentionally
+// excluded: the count is the health-probe boundary and may only include
+// conditions doctor established are unhealthy. It is the number the summary
+// leads with and the exit code keys on, so it counts TRUE underlying actionable
 // issues — a collapsed "… and N more" summary finding stands for N issues, not
-// one — and therefore equals the sum of the per-check counts a reader sees, not
-// the smaller number of collapsed rows (#1979).
+// one — and therefore equals the sum of the actionable per-check counts, not the
+// smaller number of collapsed rows (#1979).
 func (r *Report) UnresolvedCount() int {
 	n := 0
 	for _, c := range r.Checks {

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/internal/proctree"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 // Every test here is hermetic by construction (#1104 hard rules): the AF
@@ -288,6 +289,16 @@ func TestOrphanWithoutProvenHomeSurvivesFix(t *testing.T) {
 	require.True(t, foreignDetail, "foreign-home orphan must say whose it is")
 	require.True(t, unmarkedDetail, "unmarked orphan must say why it is not killed")
 
+	payload := BuildJSONReport(report, true, true)
+	require.Zero(t, payload.Summary.Unresolved,
+		"processes whose owning install cannot be established must stay visible without failing a health probe")
+	for _, row := range payload.Checks {
+		if row.Name == "orphaned-process" {
+			require.False(t, row.Actionable,
+				"an UNKNOWN ownership row cannot claim the run is unhealthy until the user changes something")
+		}
+	}
+
 	require.True(t, alive(foreign), "a foreign home's process must survive --fix")
 	require.True(t, alive(unmarked), "an unproven orphan must survive --fix")
 }
@@ -312,27 +323,95 @@ func TestMarkedProcessOfLiveSessionIsNeverKilled(t *testing.T) {
 	require.Len(t, escaped, 1)
 	require.Empty(t, escaped[0].FixAction, "escaped processes of live sessions are report-only")
 	require.True(t, alive(escapee), "process of a live session must never be killed")
+
+	payload := BuildJSONReport(report, true, false)
+	require.Zero(t, payload.Summary.Unresolved,
+		"a process merely observed outside a live pane tree is not an established health failure")
+	for _, row := range payload.Checks {
+		if row.Name == "escaped-processes" {
+			require.False(t, row.Actionable,
+				"inspection advice must remain visible without making the run fail")
+		}
+	}
 }
 
-// TestLeakedTmuxSessionReportedNotKilled: an af_ session with no backing
-// record is reported with a suggested command, and --fix must NOT kill it
-// (it may belong to another agent-factory home).
+// TestLeakedTmuxSessionReportedNotKilled distinguishes the two facts hidden
+// behind "no backing record": a session marked as this install's is a definite
+// leak with an exact manual remedy, while a session with no ownership marker is
+// UNKNOWN. Neither is auto-fixed, proving that --fix support does not define
+// actionability.
 func TestLeakedTmuxSessionReportedNotKilled(t *testing.T) {
 	testguard.IsolateTmux(t)
 
-	const name = "af_doctor-leaked"
-	out, err := exec.Command("tmux", "new-session", "-d", "-s", name, "sleep 300").CombinedOutput()
-	require.NoError(t, err, "tmux new-session: %s", out)
-	t.Cleanup(func() { _ = exec.Command("tmux", "kill-session", "-t", "="+name+":").Run() })
+	home := testguard.SocketTempDir(t)
+	const unknownName = "af_doctor-leaked-unknown"
+	const ownedName = "af_doctor-leaked-owned"
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: unknownName, args: []string{"new-session", "-d", "-s", unknownName, "sleep 300"}},
+		{name: ownedName, args: []string{
+			"new-session", "-d", "-s", ownedName, "-e", tmux.EnvMarkerHome + "=" + home, "sleep 300",
+		}},
+	} {
+		out, err := exec.Command("tmux", tc.args...).CombinedOutput()
+		require.NoError(t, err, "tmux new-session %s: %s", tc.name, out)
+		name := tc.name
+		t.Cleanup(func() { _ = exec.Command("tmux", "kill-session", "-t", "="+name+":").Run() })
+	}
 
-	report, err := Run(testOptions(t, true))
+	report, err := Run(testOptionsWithHome(t, home, true))
 	require.NoError(t, err)
 	leaked := findByCheck(report, "leaked-tmux-session")
-	require.Len(t, leaked, 1)
-	require.Contains(t, leaked[0].Detail, name)
-	require.Empty(t, leaked[0].FixAction)
-	require.NoError(t, exec.Command("tmux", "has-session", "-t", "="+name+":").Run(),
-		"leaked session must survive --fix")
+	require.Len(t, leaked, 2)
+
+	var unknownRow, ownedRow *JSONCheck
+	payload := BuildJSONReport(report, true, true)
+	for i := range payload.Checks {
+		row := &payload.Checks[i]
+		switch {
+		case strings.Contains(row.Detail, unknownName):
+			unknownRow = row
+		case strings.Contains(row.Detail, ownedName):
+			ownedRow = row
+		}
+	}
+	require.NotNil(t, unknownRow)
+	require.False(t, unknownRow.Actionable,
+		"a session with no ownership marker is visible UNKNOWN, not a failed health check")
+	require.NotNil(t, ownedRow)
+	require.True(t, ownedRow.Actionable,
+		"a session proven to belong to this install has a specific manual kill remedy and remains actionable")
+	require.Equal(t, 1, payload.Summary.Unresolved,
+		"only the proven leak, not the UNKNOWN row, should fail a health probe")
+
+	for _, name := range []string{unknownName, ownedName} {
+		require.NoError(t, exec.Command("tmux", "has-session", "-t", "="+name+":").Run(),
+			"leaked session %s must survive --fix", name)
+	}
+}
+
+func TestPossibleOrphanWithoutAgentFactoryMarkerIsAdvisory(t *testing.T) {
+	testguard.IsolateTmux(t)
+
+	possible := spawnWithEnv(t, "sh", nil, map[string]string{
+		"TMUX": fmt.Sprintf("/tmp/af-doctor-dead-tmux,%d,0", 1<<30),
+	})
+	report, err := Run(testOptions(t, true, possible.PID))
+	require.NoError(t, err)
+	require.Len(t, findByCheck(report, "possible-orphan"), 1,
+		"the unowned process must stay visible for manual inspection")
+	require.True(t, alive(possible), "an unowned process must never be killed")
+
+	payload := BuildJSONReport(report, true, false)
+	require.Zero(t, payload.Summary.Unresolved,
+		"no agent-factory marker means doctor has not established an unhealthy af state")
+	for _, row := range payload.Checks {
+		if row.Name == "possible-orphans" {
+			require.False(t, row.Actionable)
+		}
+	}
 }
 
 // TestStaleTempHomeReportedButNeverRemoved: an abandoned AF home with NO
@@ -381,6 +460,16 @@ func TestStaleTempHomeReportedButNeverRemoved(t *testing.T) {
 		"stale-temp-home with no lock file must carry NO fix action: absence of a lock is not proof of "+
 			"non-use, so it must not authorise deleting one")
 	require.False(t, findings[0].Fixed, "a --fix run must not have removed anything")
+
+	payload := BuildJSONReport(report, true, true)
+	require.Zero(t, payload.Summary.Unresolved,
+		"an UNKNOWN temp home must remain visible without holding the exit code at 1")
+	for _, row := range payload.Checks {
+		if row.Name == "stale-temp-home" {
+			require.False(t, row.Actionable,
+				"`--fix` cannot establish whether this home needs removal, so neither can a health probe")
+		}
+	}
 
 	require.DirExists(t, stale, "a --fix run must NOT delete a home it cannot prove is unused")
 	require.DirExists(t, fresh, "recently-touched home must be spared")
@@ -443,6 +532,15 @@ func TestForeignDaemonHandling(t *testing.T) {
 	}
 	require.Equal(t, 1, fixed, "the daemon with a deleted home must be killed")
 	require.Equal(t, 1, reported, "the daemon with an existing home must be left alone")
+	payload := BuildJSONReport(report, true, true)
+	require.Zero(t, payload.Summary.Unresolved,
+		"the proven dead-home daemon was fixed; an intentional second home is advisory")
+	for _, row := range payload.Checks {
+		if row.Name == "foreign-daemon" && strings.Contains(row.Detail, liveHome) {
+			require.False(t, row.Actionable,
+				"a daemon serving an existing home may be intentional and cannot fail this home's health probe")
+		}
+	}
 	require.Eventually(t, func() bool { return !alive(broken) }, 5*time.Second, 25*time.Millisecond)
 	require.True(t, alive(intentional))
 }
@@ -464,6 +562,28 @@ func TestForeignDaemonStatErrorIsNotReportedAsMissing(t *testing.T) {
 	require.Empty(t, findings[0].FixAction, "non-ENOENT stat errors must be report-only")
 	require.False(t, findings[0].Fixed)
 	require.True(t, alive(uncertain), "an uncertain foreign daemon must survive --fix")
+	payload := BuildJSONReport(report, true, true)
+	require.Zero(t, payload.Summary.Unresolved,
+		"a stat error is failure to establish the home's state, not proof that the daemon is unhealthy")
+	for _, row := range payload.Checks {
+		if row.Name == "foreign-daemon" {
+			require.False(t, row.Actionable)
+		}
+	}
+}
+
+func TestRunawayCPUInspectionAdviceIsAdvisory(t *testing.T) {
+	r := &Report{Findings: []Finding{{
+		Check:  "runaway-cpu",
+		Detail: "pid 42 averaged a pegged core inside a live session; inspect it",
+	}}}
+
+	payload := BuildJSONReport(r, false, false)
+	require.Len(t, payload.Checks, 1)
+	require.Equal(t, "runaway-cpu", payload.Checks[0].Name)
+	require.False(t, payload.Checks[0].Actionable,
+		"high CPU can be legitimate work; an inspect-it row does not establish an unhealthy run")
+	require.Zero(t, payload.Summary.Unresolved)
 }
 
 // TestCleanRunHasNoFindings: an empty environment yields a clean bill of
@@ -486,9 +606,9 @@ func TestRenderShapes(t *testing.T) {
 	r := &Report{
 		OK: []string{"daemon: not running (starts on demand)"},
 		Findings: []Finding{
-			{Check: "orphaned-process", Detail: "pid 1234 (yes)", FixAction: "kill pid 1234"},
-			{Check: "leaked-tmux-session", Detail: "tmux session af_x has no backing record"},
-			{Check: "stale-temp-home", Detail: "abandoned home /tmp/x", FixAction: "remove /tmp/x", Fixed: true},
+			{Check: "orphaned-process", Detail: "pid 1234 (yes)", Actionable: true, FixAction: "kill pid 1234"},
+			{Check: "leaked-tmux-session", Detail: "tmux session af_x has no backing record", Actionable: true},
+			{Check: "stale-temp-home", Detail: "abandoned home /tmp/x", Actionable: true, FixAction: "remove /tmp/x", Fixed: true},
 		},
 	}
 	var buf bytes.Buffer
@@ -840,8 +960,8 @@ func TestDaemonPingRefusalStaysFail(t *testing.T) {
 func TestSummaryLeadsWithActionableCountMatchingUnresolved(t *testing.T) {
 	r := &Report{
 		Findings: []Finding{
-			{Check: "possible-orphan", Detail: "pid 1 (x) belongs to a dead tmux server"},
-			{Check: "possible-orphan", Detail: "… and 46 more processes of dead tmux servers"},
+			{Check: "orphaned-process", Detail: "pid 1 (x) was spawned by a dead session", Actionable: true},
+			{Check: "orphaned-process", Detail: "… and 46 more processes from dead sessions", Actionable: true},
 		},
 	}
 	// 1 shown + 46 folded into the summary row = 47 underlying issues, the same
@@ -854,7 +974,7 @@ func TestSummaryLeadsWithActionableCountMatchingUnresolved(t *testing.T) {
 	out := buf.String()
 
 	require.Contains(t, out, "47 issues require action")
-	require.Contains(t, out, "47 processes belong to dead tmux servers",
+	require.Contains(t, out, "47 orphaned processes from dead sessions",
 		"the per-check row and the summary total must be the same arithmetic (#1979)")
 
 	idxCount := strings.Index(out, "issues require action")
@@ -875,7 +995,7 @@ func TestSummaryLeadsWithActionableCountMatchingUnresolved(t *testing.T) {
 func TestSummarizedMoreCountIsAnchoredNotOpportunistic(t *testing.T) {
 	embedded := &Report{
 		Findings: []Finding{
-			{Check: "possible-orphan", Detail: "pid 42 (sh): /bin/sh -c 'sync and 5 more files' belongs to a dead tmux server"},
+			{Check: "orphaned-process", Detail: "pid 42 (sh): /bin/sh -c 'sync and 5 more files'", Actionable: true},
 		},
 	}
 	require.Equal(t, 1, embedded.UnresolvedCount(),
@@ -883,7 +1003,9 @@ func TestSummarizedMoreCountIsAnchoredNotOpportunistic(t *testing.T) {
 
 	// The genuine roll-up still expands to what it folded.
 	rollup := &Report{
-		Findings: []Finding{{Check: "possible-orphan", Detail: "… and 46 more processes of dead tmux servers"}},
+		Findings: []Finding{{
+			Check: "orphaned-process", Detail: "… and 46 more processes from dead sessions", Actionable: true,
+		}},
 	}
 	require.Equal(t, 46, rollup.UnresolvedCount(),
 		"the real roll-up must still stand for every process it folded")

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -352,7 +352,8 @@ func TestLeakedTmuxSessionReportedNotKilled(t *testing.T) {
 	}{
 		{name: unknownName, args: []string{"new-session", "-d", "-s", unknownName, "sleep 300"}},
 		{name: ownedName, args: []string{
-			"new-session", "-d", "-s", ownedName, "-e", tmux.EnvMarkerHome + "=" + home, "sleep 300",
+			"new-session", "-d", "-s", ownedName, "-e", tmux.EnvMarkerHome + "=" + home,
+			"env", "-u", tmux.EnvMarkerHome, "sleep", "300",
 		}},
 	} {
 		out, err := exec.Command("tmux", tc.args...).CombinedOutput()

--- a/doctor/json.go
+++ b/doctor/json.go
@@ -8,12 +8,13 @@ import (
 
 // JSONCheck is one check in `af doctor --json`.
 //
-// Actionable — not Status, and not "Remedy is non-empty" — is the field a
-// script should branch on. Doctor deliberately emits advisory WARNs (no
-// autostart unit installed, a legacy config that still loads) that carry a
-// useful remedy while leaving the run healthy and the exit code 0. Only
-// Actionable separates those from the WARNs that mean something is broken, and
-// it is derived from the same rule as the exit code, so the two cannot disagree.
+// Actionable — not Status, "Remedy is non-empty", or automated fix support — is
+// the field a script should branch on. It means doctor established a specific
+// unhealthy condition that must be corrected before the run is healthy. Doctor
+// deliberately emits advisory WARNs and UNKNOWN observations with useful
+// inspection guidance while leaving the exit code 0. Conversely, a proven
+// condition can be actionable even when its exact remedy is manual. Actionable
+// is derived from the same rule as the exit code, so the two cannot disagree.
 type JSONCheck struct {
 	Name    string `json:"name"`
 	Section string `json:"section"`
@@ -22,18 +23,20 @@ type JSONCheck struct {
 	// Remedy is what to do about it. Present on advisory rows too — the hint is
 	// worth having either way — and empty only when there is nothing to do.
 	Remedy string `json:"remedy"`
-	// Actionable reports whether this row requires action. Rows with
-	// actionable=true are what make the run exit nonzero.
+	// Actionable reports whether doctor established that this row requires
+	// correction before the run is healthy. Rows with actionable=true are what
+	// make the run exit nonzero.
 	Actionable bool `json:"actionable"`
 }
 
 // JSONSummary counts the run by status. Unresolved is the count that drives the
 // exit code, so a script can branch on it without re-deriving the rules.
 //
-// Unresolved counts underlying ISSUES, which is not always the number of
-// actionable rows: without --verbose, many process findings collapse into one
-// row. Use Unresolved for "is anything wrong", and per-row Actionable for
-// "which rows".
+// Unresolved counts underlying ACTIONABLE ISSUES, which is not always the
+// number of actionable rows: without --verbose, many process findings collapse
+// into one row. Advisory observations are excluded. Use Unresolved for "did
+// doctor establish anything unhealthy", and per-row Actionable for "which
+// rows".
 type JSONSummary struct {
 	Pass       int `json:"pass"`
 	Warn       int `json:"warn"`

--- a/doctor/report.go
+++ b/doctor/report.go
@@ -221,6 +221,7 @@ func collapsedProcessRow(check string, findings []Finding, fixMode bool) renderR
 	fixable := 0
 	fixed := 0
 	failed := 0
+	actionable := false
 	for _, f := range findings {
 		if f.Fixed {
 			fixed++
@@ -228,8 +229,11 @@ func collapsedProcessRow(check string, findings []Finding, fixMode bool) renderR
 		if f.FixErr != nil {
 			failed++
 		}
-		if f.FixAction != "" && !f.Fixed {
+		if f.Actionable && f.FixAction != "" && !f.Fixed {
 			fixable++
+		}
+		if f.Actionable && !f.Fixed {
+			actionable = true
 		}
 	}
 
@@ -247,9 +251,9 @@ func collapsedProcessRow(check string, findings []Finding, fixMode bool) renderR
 		status:      status,
 		detail:      collapsedProcessDetail(check, total, fixable, fixed, failed, fixMode),
 		remediation: collapsedProcessRemediation(check, fixable, fixMode),
-		// One row standing in for several findings is actionable while any of
-		// them is still unresolved.
-		actionable: fixed < len(findings),
+		// One row can mix proven and UNKNOWN findings. It is actionable only
+		// while at least one proven condition remains unresolved.
+		actionable: actionable,
 	}
 }
 
@@ -323,16 +327,15 @@ func collapsedCount(findings []Finding) int {
 	return total
 }
 
-// countUnresolvedFindings counts the TRUE number of underlying issues the
-// un-remediated findings represent. It mirrors collapsedCount's expansion of a
-// "… and N more" summary into N, so the total the summary reports and the
-// per-check counts a reader sees are the same arithmetic — 1 + 15 + 62, not
-// 1 + 15 + 16 (#1979). Without this the summary's total counts collapsed ROWS
-// while the per-check details count PROCESSES, and the two never add up.
+// countUnresolvedFindings counts the TRUE number of underlying actionable
+// issues the un-remediated findings represent. Advisory observations remain
+// visible but do not enter the health-probe total. It mirrors collapsedCount's
+// expansion of a "… and N more" summary into N, so the actionable total and the
+// actionable per-check counts use the same arithmetic (#1979).
 func countUnresolvedFindings(findings []Finding) int {
 	n := 0
 	for _, f := range findings {
-		if f.Fixed {
+		if !f.Actionable || f.Fixed {
 			continue
 		}
 		if c, ok := summarizedMoreCount(f.Detail); ok {
@@ -384,9 +387,9 @@ func findingRow(f Finding, fixMode bool) renderRow {
 		status:      status,
 		detail:      detail,
 		remediation: findingRemediation(f, fixMode),
-		// Mirrors UnresolvedCount's rule for findings: every un-remediated
-		// finding is a real problem — findings are only ever raised for those.
-		actionable: !f.Fixed,
+		// Mirrors UnresolvedCount's rule for findings. Visibility, automated
+		// fixability, and actionability are separate axes.
+		actionable: f.Actionable && !f.Fixed,
 	}
 }
 
@@ -528,7 +531,7 @@ func issuePhrase(n int) string {
 func fixableCount(r *Report) int {
 	n := 0
 	for _, f := range r.Findings {
-		if f.FixAction != "" && !f.Fixed {
+		if f.Actionable && f.FixAction != "" && !f.Fixed {
 			n++
 		}
 	}

--- a/doctor/setup.go
+++ b/doctor/setup.go
@@ -30,14 +30,14 @@ func checkSetup(ctx *scanContext, report *Report) {
 
 func checkAFHome(ctx *scanContext, report *Report) {
 	if ctx.opts.ConfigDir == "" {
-		report.Findings = append(report.Findings, Finding{
+		report.addActionableFinding(Finding{
 			Check:  "af-home",
 			Detail: "agent-factory home could not be resolved",
 		})
 		return
 	}
 	if err := writableDir(ctx.opts.ConfigDir); err != nil {
-		report.Findings = append(report.Findings, Finding{
+		report.addActionableFinding(Finding{
 			Check: "af-home",
 			Detail: fmt.Sprintf("agent-factory home %s is not writable — "+
 				"fix directory permissions or set AGENT_FACTORY_HOME to a writable directory",
@@ -58,7 +58,7 @@ func checkStateDirs(ctx *scanContext, report *Report) {
 		{"repo-state-dir", "repo state storage", filepath.Join(ctx.opts.ConfigDir, "repos")},
 	} {
 		if err := writableDir(d.dir); err != nil {
-			report.Findings = append(report.Findings, Finding{
+			report.addActionableFinding(Finding{
 				Check:  d.check,
 				Detail: fmt.Sprintf("%s directory %s is not writable — fix directory permissions: %v", d.label, d.dir, err),
 			})
@@ -71,7 +71,7 @@ func checkStateDirs(ctx *scanContext, report *Report) {
 func checkLogStorage(report *Report) {
 	path := aflog.LogFilePath()
 	if path == "" {
-		report.Findings = append(report.Findings, Finding{
+		report.addActionableFinding(Finding{
 			Check:  "log-storage",
 			Detail: "could not resolve application log path — set AGENT_FACTORY_HOME to a writable directory and retry",
 		})
@@ -79,7 +79,7 @@ func checkLogStorage(report *Report) {
 	}
 	dir := filepath.Dir(path)
 	if err := writableDir(dir); err != nil {
-		report.Findings = append(report.Findings, Finding{
+		report.addActionableFinding(Finding{
 			Check:  "log-storage",
 			Detail: fmt.Sprintf("log directory %s is not writable — fix directory permissions or set AGENT_FACTORY_HOME to a writable directory: %v", dir, err),
 		})
@@ -91,7 +91,7 @@ func checkLogStorage(report *Report) {
 func checkConfig(_ *scanContext, report *Report) *config.Config {
 	cfg, err := config.LoadConfig()
 	if err != nil {
-		report.Findings = append(report.Findings, Finding{
+		report.addActionableFinding(Finding{
 			Check:  "config",
 			Detail: fmt.Sprintf("config is not valid — fix the reported file or delete it to regenerate defaults: %v", err),
 		})
@@ -99,14 +99,14 @@ func checkConfig(_ *scanContext, report *Report) *config.Config {
 	}
 	path, err := config.GlobalConfigPath()
 	if err != nil {
-		report.Findings = append(report.Findings, Finding{
+		report.addActionableFinding(Finding{
 			Check:  "config",
 			Detail: fmt.Sprintf("could not resolve config path: %v", err),
 		})
 		return cfg
 	}
 	if _, statErr := os.Stat(path); statErr != nil {
-		report.Findings = append(report.Findings, Finding{
+		report.addActionableFinding(Finding{
 			Check:  "config",
 			Detail: fmt.Sprintf("config loaded in memory but %s is not materialized on disk — run `%s` or fix AF home permissions: %v", path, shellsuggest.Command("af", "config", "set", "default_program", cfg.DefaultProgram), statErr),
 		})
@@ -120,7 +120,7 @@ func checkConfig(_ *scanContext, report *Report) *config.Config {
 func checkGit(report *Report) {
 	gitPath, err := exec.LookPath("git")
 	if err != nil {
-		report.Findings = append(report.Findings, Finding{
+		report.addActionableFinding(Finding{
 			Check:  "git",
 			Detail: "git is not installed or not on PATH — install git and retry",
 		})
@@ -130,7 +130,7 @@ func checkGit(report *Report) {
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		report.Findings = append(report.Findings, Finding{
+		report.addActionableFinding(Finding{
 			Check:  "git-repo",
 			Detail: fmt.Sprintf("could not determine current directory: %v", err),
 		})
@@ -138,7 +138,7 @@ func checkGit(report *Report) {
 	}
 	out, err := exec.Command(gitPath, "-C", cwd, "rev-parse", "--show-toplevel").Output()
 	if err != nil {
-		report.Findings = append(report.Findings, Finding{
+		report.addActionableFinding(Finding{
 			Check:  "git-repo",
 			Detail: fmt.Sprintf("%s is not inside a git repository — run `af` from a repo root or pass --repo where supported", cwd),
 		})
@@ -157,7 +157,7 @@ func checkGitIdentity(gitPath, cwd string, report *Report) {
 		}
 	}
 	if len(missing) > 0 {
-		report.Findings = append(report.Findings, Finding{
+		report.addActionableFinding(Finding{
 			Check: "git-identity",
 			Detail: fmt.Sprintf("git identity is incomplete (missing %s) — run: "+
 				"git config --global user.name \"Your Name\" && git config --global user.email you@example.com",
@@ -171,7 +171,7 @@ func checkGitIdentity(gitPath, cwd string, report *Report) {
 func checkTmux(report *Report) {
 	version, err := preflight.CheckTmux()
 	if err != nil {
-		report.Findings = append(report.Findings, Finding{Check: "tmux", Detail: err.Error()})
+		report.addActionableFinding(Finding{Check: "tmux", Detail: err.Error()})
 		return
 	}
 	report.Pass(sectionEnvironment, "tmux", version)
@@ -179,7 +179,7 @@ func checkTmux(report *Report) {
 
 func checkAgentPrograms(cfg *config.Config, report *Report) {
 	if cfg.DefaultProgram == "" {
-		report.Findings = append(report.Findings, Finding{
+		report.addActionableFinding(Finding{
 			Check:  "agent-program",
 			Detail: fmt.Sprintf("default_program is empty — set it to one of %s in ~/.agent-factory/config.toml", tmux.SupportedProgramsString()),
 		})
@@ -198,7 +198,7 @@ func checkAgentPrograms(cfg *config.Config, report *Report) {
 func checkOneProgram(field, agent, command string, report *Report) {
 	check, err := preflight.CheckCommand(command)
 	if err != nil {
-		report.Findings = append(report.Findings, Finding{
+		report.addActionableFinding(Finding{
 			Check:  "agent-program",
 			Detail: fmt.Sprintf("%s resolves to %q but is not runnable — %v", field, command, preflight.ProgramError(agent, command, err)),
 		})


### PR DESCRIPTION
## Summary

- make finding actionability an explicit detector decision instead of treating every visible, unfixed finding as an unhealthy state
- keep UNKNOWN process, tmux, temp-home, and foreign-daemon observations visible as advisory WARN rows
- keep proven conditions actionable, including exact manual remedies that `--fix` intentionally does not perform
- document the scripting and health-probe contract in `af doctor --help`

## Deliberate contract

`--fix` support does **not** define actionability. A proven leak can require an exact manual command and still be actionable; an UNKNOWN row is advisory because doctor has not established that the run is unhealthy, even when it offers inspection guidance.

CI and health probes should fail on `af doctor`'s exit code, equivalently JSON `summary.unresolved > 0`. That total now includes only established, unresolved unhealthy conditions. Advisory rows stay present in both human and JSON output with `actionable: false`.

## Root cause

`Report.UnresolvedCount`, verbose finding rendering, and collapsed process rendering all inferred actionability from `!Fixed`. That made every report-only observation count as an issue requiring action, including rows whose own evidence said ownership or liveness could not be proven.

## Fail-first evidence

Against unmodified `master`, the new isolated doctor tests failed with unresolved counts for each UNKNOWN class, including:

```text
TestStaleTempHomeReportedButNeverRemoved: Should be zero, but was 1
TestPossibleOrphanWithoutAgentFactoryMarkerIsAdvisory: Should be zero, but was 1
TestForeignDaemonHandling: Should be zero, but was 1
TestRunawayCPUInspectionAdviceIsAdvisory: Should be false
```

The paired leaked-session test distinguishes an unmarked UNKNOWN session from a session positively marked as this install's: only the latter remains actionable, despite both being manual-only.

Codex review then identified that pane-process environment was weaker evidence than the existing authoritative tmux session marker. The added regression clears `AF_HOME` in the pane while retaining the session marker and failed before the review fix:

```text
TestLeakedTmuxSessionReportedNotKilled: Should be true
```

The detector now reads ownership through `tmuxSessionHomeMarker`.

## Validation

Exact pushed head: `90e54abc41ea11b24fc177e99335079b98407806`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container` (full suite, run last on the pushed head)

Closes #2617