### PR TITLE
test(auth): property-check token redaction

### DIFF
--- a/agentproto/auth.go
+++ b/agentproto/auth.go
@@ -36,12 +36,18 @@ func RedactAccessTokenURL(raw string) string {
 		return "[url redacted]"
 	}
 	q := parsed.Query()
-	if _, ok := q[AccessTokenQueryParam]; !ok {
+	found := false
+	for key := range q {
+		if strings.EqualFold(key, AccessTokenQueryParam) {
+			q.Set(key, accessTokenRedaction)
+			found = true
+		}
+	}
+	if !found {
 		// URL.Query discards malformed query pairs. The text pass still catches
 		// an exact access_token field without trusting a partially parsed query.
 		return RedactAccessTokenText(raw)
 	}
-	q.Set(AccessTokenQueryParam, accessTokenRedaction)
 	parsed.RawQuery = q.Encode()
 	return parsed.String()
 }

--- a/agentproto/auth.go
+++ b/agentproto/auth.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -53,14 +54,12 @@ func RedactAccessTokenError(err error, token string) error {
 	if err == nil {
 		return nil
 	}
-	safeStructuredURL := ""
 	var urlErr *url.Error
 	if errors.As(err, &urlErr) {
 		urlErr.URL = RedactAccessTokenURL(urlErr.URL)
-		safeStructuredURL = urlErr.URL
 	}
 
-	message := redactAccessTokenTextOutside(err.Error(), safeStructuredURL)
+	message := redactAccessTokenTextOutsideStructuredURL(err.Error(), urlErr)
 	if token != "" {
 		message = strings.ReplaceAll(message, token, accessTokenRedaction)
 	}
@@ -109,15 +108,27 @@ func RedactAccessTokenText(text string) string {
 	}
 }
 
-func redactAccessTokenTextOutside(text, safe string) string {
-	if safe == "" {
+func redactAccessTokenTextOutsideStructuredURL(text string, urlErr *url.Error) string {
+	if urlErr == nil {
 		return RedactAccessTokenText(text)
 	}
-	parts := strings.Split(text, safe)
-	for i := range parts {
-		parts[i] = RedactAccessTokenText(parts[i])
+
+	structured := urlErr.Error()
+	quotedURL := strconv.Quote(urlErr.URL)
+	structuredPrefix := urlErr.Op + " " + quotedURL + ": "
+	if !strings.HasPrefix(structured, structuredPrefix) ||
+		strings.Count(text, structured) != 1 {
+		// A custom wrapper changed the nested error's text, so there is no
+		// unique structured occurrence whose provenance is safe to exempt.
+		return RedactAccessTokenText(text)
 	}
-	return strings.Join(parts, safe)
+	structuredStart := strings.Index(text, structured)
+	urlOffset := len(urlErr.Op) + 1
+	urlStart := structuredStart + urlOffset
+	urlEnd := urlStart + len(quotedURL)
+	return RedactAccessTokenText(text[:urlStart]) +
+		text[urlStart:urlEnd] +
+		RedactAccessTokenText(text[urlEnd:])
 }
 
 func indexFoldASCII(text, lowerASCII string) int {

--- a/agentproto/auth.go
+++ b/agentproto/auth.go
@@ -53,12 +53,14 @@ func RedactAccessTokenError(err error, token string) error {
 	if err == nil {
 		return nil
 	}
+	safeStructuredURL := ""
 	var urlErr *url.Error
 	if errors.As(err, &urlErr) {
 		urlErr.URL = RedactAccessTokenURL(urlErr.URL)
+		safeStructuredURL = urlErr.URL
 	}
 
-	message := RedactAccessTokenText(err.Error())
+	message := redactAccessTokenTextOutside(err.Error(), safeStructuredURL)
 	if token != "" {
 		message = strings.ReplaceAll(message, token, accessTokenRedaction)
 	}
@@ -93,11 +95,6 @@ func RedactAccessTokenText(text string) string {
 			rest = rest[valueStart:]
 			continue
 		}
-		if alreadyRedactedValueEnd := accessTokenRedactionEnd(rest, valueStart); alreadyRedactedValueEnd >= 0 {
-			redacted.WriteString(rest[:alreadyRedactedValueEnd])
-			rest = rest[alreadyRedactedValueEnd:]
-			continue
-		}
 
 		// Query separators inside the value are ambiguous. Redact through the next
 		// unambiguous text boundary rather than risk preserving credential material
@@ -110,6 +107,17 @@ func RedactAccessTokenText(text string) string {
 		redacted.WriteString(accessTokenRedaction)
 		rest = rest[valueEnd:]
 	}
+}
+
+func redactAccessTokenTextOutside(text, safe string) string {
+	if safe == "" {
+		return RedactAccessTokenText(text)
+	}
+	parts := strings.Split(text, safe)
+	for i := range parts {
+		parts[i] = RedactAccessTokenText(parts[i])
+	}
+	return strings.Join(parts, safe)
 }
 
 func indexFoldASCII(text, lowerASCII string) int {
@@ -128,17 +136,6 @@ func indexFoldASCII(text, lowerASCII string) int {
 		if matches {
 			return i
 		}
-	}
-	return -1
-}
-
-func accessTokenRedactionEnd(text string, valueStart int) int {
-	valueEnd := valueStart + len(accessTokenRedaction)
-	if valueEnd > len(text) || text[valueStart:valueEnd] != accessTokenRedaction {
-		return -1
-	}
-	if valueEnd == len(text) || strings.ContainsRune("&; \t\r\n#\"'", rune(text[valueEnd])) {
-		return valueEnd
 	}
 	return -1
 }

--- a/agentproto/auth.go
+++ b/agentproto/auth.go
@@ -75,36 +75,76 @@ func RedactAccessTokenError(err error, token string) error {
 // handling a URL or request error must still use the structured helpers above.
 func RedactAccessTokenText(text string) string {
 	needle := AccessTokenQueryParam + "="
-	if !strings.Contains(text, needle) {
+	if indexFoldASCII(text, needle) < 0 {
 		return text
 	}
 
 	var redacted strings.Builder
 	rest := text
 	for {
-		i := strings.Index(rest, needle)
+		i := indexFoldASCII(rest, needle)
 		if i < 0 {
 			redacted.WriteString(rest)
 			return redacted.String()
 		}
 		valueStart := i + len(needle)
-		if i > 0 && rest[i-1] != '?' && rest[i-1] != '&' && rest[i-1] != ';' {
+		if i > 0 && !accessTokenFieldBoundary(rest[i-1]) {
 			redacted.WriteString(rest[:valueStart])
 			rest = rest[valueStart:]
 			continue
 		}
+		if alreadyRedactedValueEnd := accessTokenRedactionEnd(rest, valueStart); alreadyRedactedValueEnd >= 0 {
+			redacted.WriteString(rest[:alreadyRedactedValueEnd])
+			rest = rest[alreadyRedactedValueEnd:]
+			continue
+		}
 
-		// A preceding semicolon can introduce a legacy query field, but a semicolon
-		// inside the value is ambiguous. Redact through the next unambiguous boundary
-		// rather than risk preserving credential material after it.
+		// Query separators inside the value are ambiguous. Redact through the next
+		// unambiguous text boundary rather than risk preserving credential material
+		// after one. Losing neighbouring fields is safe; retaining a token is not.
 		valueEnd := valueStart
-		for valueEnd < len(rest) && !strings.ContainsRune("& \t\r\n#\"'", rune(rest[valueEnd])) {
+		for valueEnd < len(rest) && !strings.ContainsRune(" \t\r\n#\"'", rune(rest[valueEnd])) {
 			valueEnd++
 		}
 		redacted.WriteString(rest[:valueStart])
 		redacted.WriteString(accessTokenRedaction)
 		rest = rest[valueEnd:]
 	}
+}
+
+func indexFoldASCII(text, lowerASCII string) int {
+	for i := 0; i+len(lowerASCII) <= len(text); i++ {
+		matches := true
+		for j := range lowerASCII {
+			got := text[i+j]
+			if got >= 'A' && got <= 'Z' {
+				got += 'a' - 'A'
+			}
+			if got != lowerASCII[j] {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return i
+		}
+	}
+	return -1
+}
+
+func accessTokenRedactionEnd(text string, valueStart int) int {
+	valueEnd := valueStart + len(accessTokenRedaction)
+	if valueEnd > len(text) || text[valueStart:valueEnd] != accessTokenRedaction {
+		return -1
+	}
+	if valueEnd == len(text) || strings.ContainsRune("&; \t\r\n#\"'", rune(text[valueEnd])) {
+		return valueEnd
+	}
+	return -1
+}
+
+func accessTokenFieldBoundary(char byte) bool {
+	return strings.ContainsRune("?&; \t\r\n", rune(char))
 }
 
 // BearerToken extracts the token from an Authorization header value, matching the

--- a/agentproto/auth_test.go
+++ b/agentproto/auth_test.go
@@ -2,10 +2,14 @@ package agentproto
 
 import (
 	"errors"
+	"math/rand"
 	"net/http"
 	"net/url"
+	"reflect"
+	"strconv"
 	"strings"
 	"testing"
+	"testing/quick"
 )
 
 func TestURLRedactedLeavesAccessTokenQueryUntouched(t *testing.T) {
@@ -125,6 +129,86 @@ func TestRedactAccessTokenText(t *testing.T) {
 			t.Errorf("text redactor lost %q: %s", want, got)
 		}
 	}
+}
+
+type accessTokenRedactionCase struct {
+	Input string
+	Token string
+}
+
+func TestRedactAccessTokenTextNeverRetainsTokenValue(t *testing.T) {
+	const generatedCases = 3 * 3 * 6 * 3 * 8
+	caseNumber := 0
+	config := &quick.Config{
+		MaxCount: generatedCases,
+		Rand:     rand.New(rand.NewSource(2695)),
+		Values: func(values []reflect.Value, source *rand.Rand) {
+			generated := generateAccessTokenRedactionCase(caseNumber, source)
+			caseNumber++
+			values[0] = reflect.ValueOf(generated)
+		},
+	}
+
+	property := func(generated accessTokenRedactionCase) bool {
+		got := RedactAccessTokenText(generated.Input)
+		if strings.Contains(got, generated.Token) {
+			t.Logf("RedactAccessTokenText(%q) = %q; token value %q survived",
+				generated.Input, got, generated.Token)
+			return false
+		}
+		return true
+	}
+	if err := quick.Check(property, config); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func generateAccessTokenRedactionCase(n int, source *rand.Rand) accessTokenRedactionCase {
+	caseID := n
+	position := n % 8
+	n /= 8
+	separators := []string{";", "&", "?"}
+	shapes := []func(string, string, string) string{
+		func(separator, marker, decoration string) string {
+			return separator + marker + decoration
+		},
+		func(separator, marker, decoration string) string {
+			return marker + separator + decoration
+		},
+		func(separator, marker, decoration string) string {
+			return marker + decoration + separator
+		},
+	}
+	decorations := []string{"", "=", "%3F", "%26", "%3B", "%3D"}
+	parameterNames := []string{"access_token", "Access_Token", "ACCESS_TOKEN"}
+
+	separator := separators[n%len(separators)]
+	n /= len(separators)
+	shape := shapes[n%len(shapes)]
+	n /= len(shapes)
+	decoration := decorations[n%len(decorations)]
+	n /= len(decorations)
+	parameterName := parameterNames[n%len(parameterNames)]
+
+	const letters = "abcdefghijklmnopqrstuvwxyz0123456789"
+	randomPart := make([]byte, 12)
+	for i := range randomPart {
+		randomPart[i] = letters[source.Intn(len(letters))]
+	}
+	marker := "af-token-" + strconv.Itoa(caseID) + "-" + string(randomPart)
+	token := shape(separator, marker, decoration)
+	field := parameterName + "=" + token
+	inputs := []string{
+		"https://box.test/stream?before=1;" + field + ";after=2",
+		"https://box.test/stream?" + field,
+		"https://box.test/stream?" + field + "&after=trailing",
+		"https://box.test/stream?before=1&" + field + "&after=2",
+		"https://box.test/stream?before=1&" + field,
+		"Get \"ws://box.test/stream?" + field + "\": dial failed",
+		"failure " + field + " # fragment",
+		"https://box.test/stream?" + field + "&before=1&" + field,
+	}
+	return accessTokenRedactionCase{Input: inputs[position], Token: token}
 }
 
 func TestBearerToken(t *testing.T) {

--- a/agentproto/auth_test.go
+++ b/agentproto/auth_test.go
@@ -115,6 +115,15 @@ func TestRedactAccessTokenError(t *testing.T) {
 	if RedactAccessTokenError(nil, token) != nil {
 		t.Fatal("nil error must remain nil")
 	}
+
+	shortURL := &url.Error{
+		Op:  "Get",
+		URL: "token",
+		Err: errors.New("failure access_token=sekrit"),
+	}
+	if got := RedactAccessTokenError(shortURL, ""); strings.Contains(got.Error(), "sekrit") {
+		t.Fatalf("short structured URL split the redaction needle: %s", got)
+	}
 }
 
 func TestRedactAccessTokenText(t *testing.T) {

--- a/agentproto/auth_test.go
+++ b/agentproto/auth_test.go
@@ -83,6 +83,16 @@ func TestRedactAccessTokenURL(t *testing.T) {
 	}
 }
 
+func TestRedactAccessTokenURLRedactsEveryKeyCase(t *testing.T) {
+	got := RedactAccessTokenURL(
+		"https://box.test/stream?access_token=lower-secret&Access_Token=upper-secret")
+	for _, token := range []string{"lower-secret", "upper-secret"} {
+		if strings.Contains(got, token) {
+			t.Fatalf("RedactAccessTokenURL retained token value %q: %s", token, got)
+		}
+	}
+}
+
 func TestRedactAccessTokenError(t *testing.T) {
 	const token = "af-sentinel-error-redaction"
 	cause := errors.New("connection refused")

--- a/agentproto/auth_test.go
+++ b/agentproto/auth_test.go
@@ -137,7 +137,7 @@ type accessTokenRedactionCase struct {
 }
 
 func TestRedactAccessTokenTextNeverRetainsTokenValue(t *testing.T) {
-	const generatedCases = 3 * 3 * 6 * 3 * 8
+	const generatedCases = 3 * 4 * 6 * 3 * 8
 	caseNumber := 0
 	config := &quick.Config{
 		MaxCount: generatedCases,
@@ -177,6 +177,9 @@ func generateAccessTokenRedactionCase(n int, source *rand.Rand) accessTokenRedac
 		},
 		func(separator, marker, decoration string) string {
 			return marker + decoration + separator
+		},
+		func(separator, marker, decoration string) string {
+			return accessTokenRedaction + separator + marker + decoration
 		},
 	}
 	decorations := []string{"", "=", "%3F", "%26", "%3B", "%3D"}


### PR DESCRIPTION
## Summary

- property-check 1,296 generated access-token redaction cases across query positions, separator placement, casing, free text, duplicates, and encoded forms
- assert only the security invariant that the generated token value is absent; neighboring fields are intentionally unconstrained
- treat every ambiguous query separator as credential material and recognize case/whitespace variants without breaking idempotent structured redaction

Closes #2695

## Red-first evidence

Current master before the fix:

```
RedactAccessTokenText("https://box.test/stream?access_token=&af-token-1-0bdnux7cjqq0") = "https://box.test/stream?access_token=REDACTED&af-token-1-0bdnux7cjqq0"; token value "&af-token-1-0bdnux7cjqq0" survived
```

The same property test on pre-#2687 commit `4955ab3d` rediscovered the semicolon class:

```
RedactAccessTokenText("https://box.test/stream?before=1;access_token=;af-token-0-kvljc1qtyx16;after=2") = "https://box.test/stream?before=1;access_token=;af-token-0-kvljc1qtyx16;after=2"; token value ";af-token-0-kvljc1qtyx16" survived
```

## Test Plan

Validated on exact pushed head `cdbe6c304f2ed13ed3e65d8be0d4aa6c5dfeb3c4`:

- [x] focused `agentproto` redaction tests
- [x] `golangci-lint run --timeout=3m --fast`
- [x] `gofmt -l .` produces no output
- [x] `go build ./...`
- [x] `deadcode -test ./...` produces no output
- [x] `scripts/lint-file-length.sh`
- [x] `make test-container` run last on the pushed head