### PR TITLE
test(integration): skip real backends in short mode

### DIFF
--- a/integration/backend_archive_test.go
+++ b/integration/backend_archive_test.go
@@ -32,6 +32,9 @@ import (
 // Run on a host with docker: make backend-docker-roundtrip (it matches
 // TestDockerBackend*). SKIPS cleanly where docker is unavailable.
 func TestDockerBackendArchiveRestore(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive real-backend E2E/integration; skipped under -short — see #2052")
+	}
 	requireDocker(t)
 	requireTool(t, "git")
 
@@ -167,6 +170,9 @@ func TestDockerBackendArchiveRestore(t *testing.T) {
 // against the Runtime interface, so this exercises the same push-then-teardown /
 // re-provision-then-clone flow the docker test does, over the ssh transport.
 func TestSSHBackendArchiveRestore(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive real-backend E2E/integration; skipped under -short — see #2052")
+	}
 	requireDocker(t)
 	requireTool(t, "git")
 	requireTool(t, "ssh-keygen")

--- a/integration/backend_docker_test.go
+++ b/integration/backend_docker_test.go
@@ -38,6 +38,9 @@ import (
 // where docker is unavailable (e.g. inside the test-container fence), so the full
 // suite stays green there.
 func TestDockerBackendRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive real-backend E2E/integration; skipped under -short — see #2052")
+	}
 	requireDocker(t)
 	requireTool(t, "git")
 

--- a/integration/backend_ssh_test.go
+++ b/integration/backend_ssh_test.go
@@ -36,6 +36,9 @@ import (
 // Run it on a host with docker: make backend-ssh-roundtrip. It SKIPS cleanly where
 // docker is unavailable, so the full suite stays green there.
 func TestSSHBackendRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive real-backend E2E/integration; skipped under -short — see #2052")
+	}
 	requireDocker(t)
 	requireTool(t, "git")
 	requireTool(t, "ssh-keygen")


### PR DESCRIPTION
## Summary

- honor `testing.Short` in the four Docker/SSH round-trip and archive/restore tests
- keep the standard #2052 skip reason shared by the adjacent timing-sensitive integration tests
- retain full coverage in build linux/amd64, both required PR test jobs, and auto/stable release workflows

Closes #2614

## Red-first evidence

Before the guards, `go test -short` ran real provisioning instead of skipping:

```
=== RUN   TestDockerBackendArchiveRestore
... ARCHIVE ✓ ... container reaped
... RESTORE ✓ fresh container ...
--- PASS: TestDockerBackendArchiveRestore (22.98s)
=== RUN   TestSSHBackendArchiveRestore
...
ok github.com/sachiniyer/agent-factory/integration 49.834s
```

After the guards, all four skip in `0.00s` and the package finishes in `0.035s`. A non-short run still executed and passed all four real backends in `33.588s`.

## Adjacent audit

The four named tests are the only default-running Docker-backed integration tests missing the guard. `TestImageBuildsWithRegistryBlocked` is already opt-in through `AF_REGISTRY_BLOCKED_CHECK`, and the real-systemd test is separately CI-environment-gated.

## Test Plan

Validated on exact pushed head `d7aa2a6017338a895be0285f0a9fe819eb34d675`:

- [x] four real backends skip under `-short`
- [x] four real backends execute and pass without `-short`
- [x] `golangci-lint run --timeout=3m --fast`
- [x] `gofmt -l .` produces no output
- [x] `go build ./...`
- [x] `deadcode -test ./...` produces no output
- [x] `scripts/lint-file-length.sh`
- [x] `make test-container` run last on the pushed head