### PR TITLE
Keep removed guard hooks permissive across upgrades

### DIFF
--- a/commands/legacy_tmuxguardcmd.go
+++ b/commands/legacy_tmuxguardcmd.go
@@ -1,0 +1,19 @@
+package commands
+
+import "github.com/spf13/cobra"
+
+// legacyTmuxGuardHookCmd is a no-op compatibility seam for already-running
+// Codex sessions that loaded the versioned pre-#2563 guard hook. Their retained
+// script still invokes this hidden command after af upgrades. The guard itself
+// remains removed; treating the legacy call as "no guard" prevents a stale hook
+// from denying every Bash command (#2608).
+var legacyTmuxGuardHookCmd = &cobra.Command{
+	Use:    "hook-guard-tmux",
+	Hidden: true,
+	Args:   cobra.NoArgs,
+	Run:    func(*cobra.Command, []string) {},
+}
+
+func init() {
+	rootCmd.AddCommand(legacyTmuxGuardHookCmd)
+}

--- a/commands/legacy_tmuxguardcmd_test.go
+++ b/commands/legacy_tmuxguardcmd_test.go
@@ -1,0 +1,38 @@
+package commands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestLegacyTmuxGuardHookCommandIsNoop covers the installable Codex side of
+// #2608. Its versioned v3.3 hook script survives an af upgrade and invokes this
+// removed command. Running sessions must see the removal as "no guard", even
+// when their cached hook input names a command the former guard denied.
+func TestLegacyTmuxGuardHookCommandIsNoop(t *testing.T) {
+	originalVersion := version
+	originalRootVersion := rootCmd.Version
+	cmd := NewRootCommand(Options{Version: "test"})
+	t.Cleanup(func() {
+		version = originalVersion
+		rootCmd.Version = originalRootVersion
+		cmd.SetArgs(nil)
+		cmd.SetIn(nil)
+		cmd.SetOut(nil)
+		cmd.SetErr(nil)
+	})
+
+	var output bytes.Buffer
+	cmd.SetIn(strings.NewReader(`{"tool_name":"Bash","tool_input":{"command":"tmux kill-server"}}`))
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"hook-guard-tmux"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("legacy Codex hook denied Bash after upgrade: %v\n%s", err, output.String())
+	}
+	if output.Len() != 0 {
+		t.Fatalf("compatibility no-op wrote unexpected output: %q", output.String())
+	}
+}

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -1086,10 +1086,10 @@
       },
       "cli": {
         "status": "yes",
-        "pointer": "commands/docs_gen.go:29 (hidden); commands/docs_gen.go:61 (--plugin-root); commands/agentservercmd.go:34"
+        "pointer": "commands/docs_gen.go:29 (hidden); commands/docs_gen.go:61 (--plugin-root); commands/agentservercmd.go:34; commands/legacy_tmuxguardcmd.go"
       },
       "verdict": "deliberate",
-      "notes": "af gen-docs is Hidden:true (CI docs generation). af agent-server is daemon-consumed plumbing — its own Long says it 'exists to be consumed by a daemon rather than opened by a person' — and af --daemon is a hidden flag. None are user capabilities. af gen-docs --plugin-root (#2172) regenerates the committed per-agent plugin artifacts from the canonical af usage text; like the rest of gen-docs it is build tooling, run by scripts/gen-docs.sh and the CI drift gate. The TUI and web will deliberately never expose it — regenerating a repo's committed build artifacts is not something either surface should offer — so this is a recorded decision, not a parity gap to re-report."
+      "notes": "af gen-docs is Hidden:true (CI docs generation). af agent-server is daemon-consumed plumbing — its own Long says it 'exists to be consumed by a daemon rather than opened by a person' — and af --daemon is a hidden flag. af hook-guard-tmux is also hidden: #2608 retains the removed command name only as an exit-0 compatibility tombstone for already-running pre-#2563 Codex hooks; it performs no guard or user operation. None are user capabilities. af gen-docs --plugin-root (#2172) regenerates the committed per-agent plugin artifacts from the canonical af usage text; like the rest of gen-docs it is build tooling, run by scripts/gen-docs.sh and the CI drift gate. The TUI and web will deliberately never expose these internals — regenerating a repo's committed build artifacts and legacy hook compatibility are not things either surface should offer — so this is a recorded decision, not a parity gap to re-report."
     },
     {
       "id": "tui.navigation",
@@ -1357,6 +1357,7 @@
       "af doctor": "install.doctor",
       "af gen-docs": "meta.internal",
       "af help": "meta.discovery",
+      "af hook-guard-tmux": "meta.internal",
       "af keys": "meta.discovery",
       "af projects add": "project.add",
       "af projects delete": "project.delete",
@@ -1571,6 +1572,7 @@
       "af gen-docs --help": "meta.discovery",
       "af gen-docs --plugin-root": "meta.internal",
       "af help --help": "meta.discovery",
+      "af hook-guard-tmux --help": "meta.internal",
       "af keys --help": "meta.discovery",
       "af projects --help": "meta.discovery",
       "af projects --json": "cli.json-envelope",

--- a/session/plugin.go
+++ b/session/plugin.go
@@ -34,6 +34,12 @@ const pluginManifest = `{
 }
 `
 
+// legacyGuardNoop keeps already-running pre-#2563 Claude sessions usable after
+// an af upgrade. Those sessions retain their loaded PreToolUse wrapper, which
+// still executes this path even after hooks.json is removed. New sessions never
+// load the tombstone because ensurePluginDir removes hooks.json.
+const legacyGuardNoop = "#!/bin/sh\nexit 0\n"
+
 // pluginCommands defines the command files to write into the plugin directory.
 // ensurePluginDir writes this map to disk on every session launch and prunes any
 // .md file that isn't listed here, so adding/removing/editing a skill is as simple
@@ -61,9 +67,9 @@ var pluginCommands = map[string]string{
 //
 // This is called on every claude-based session launch (see injectSystemPrompt),
 // and rewrites the manifest, writes every file in pluginCommands, prunes any
-// stray .md in commands/ that isn't in the map, and removes the stale hooks/
-// directory an older af wrote — so inserts, edits, and removes all propagate on
-// the next session start.
+// stray .md in commands/ that isn't in the map, and disarms the stale hook an
+// older af wrote — so inserts, edits, and removes all propagate on the next
+// session start.
 func ensurePluginDir() (string, error) {
 	configDir, err := config.GetConfigDir()
 	if err != nil {
@@ -72,6 +78,7 @@ func ensurePluginDir() (string, error) {
 
 	pluginDir := filepath.Join(configDir, "plugin")
 	commandsDir := filepath.Join(pluginDir, "commands")
+	hooksDir := filepath.Join(pluginDir, "hooks")
 	manifestDir := filepath.Join(pluginDir, ".claude-plugin")
 
 	if err := os.MkdirAll(commandsDir, 0755); err != nil {
@@ -81,14 +88,15 @@ func ensurePluginDir() (string, error) {
 		return "", err
 	}
 
-	// Remove the hooks/ directory a prior af version wrote for the tmux-command
-	// guard (its hooks.json + guard-tmux.sh). This af installs no PreToolUse hook,
-	// and a lingering one would invoke the removed `af hook-guard-tmux` and fail
-	// CLOSED on every Bash call for an upgraded user — worse than the guard it
-	// replaced. Pruning here, on the next session launch after upgrade, is what
-	// keeps the removal safe for existing installs. RemoveAll is idempotent, so this
-	// is a clean no-op once the directory is gone.
-	if err := os.RemoveAll(filepath.Join(pluginDir, "hooks")); err != nil {
+	// A prior af wrote hooks.json + guard-tmux.sh. Remove only the registration
+	// so new sessions load no PreToolUse guard, then replace its executable with
+	// a no-op for already-running Claude sessions that cached the old wrapper at
+	// startup (#2608). Deleting the whole directory leaves those live wrappers
+	// failing closed on every Bash call.
+	if err := os.Remove(filepath.Join(hooksDir, "hooks.json")); err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+	if err := config.AtomicWriteFile(filepath.Join(hooksDir, "guard-tmux.sh"), []byte(legacyGuardNoop), 0755); err != nil {
 		return "", err
 	}
 

--- a/session/plugin_test.go
+++ b/session/plugin_test.go
@@ -3,7 +3,9 @@ package session
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -71,32 +73,55 @@ func TestEnsurePluginDir_ConcurrentStalePrune(t *testing.T) {
 	}
 }
 
-// TestEnsurePluginDir_PrunesStaleGuardHooks is the upgrade-safety lock for the
-// tmux-guard removal. An af that shipped the guard left a hooks/ directory
-// (hooks.json + guard-tmux.sh) in the runtime Claude plugin. This af installs no
-// PreToolUse hook, so a lingering one would invoke the removed `af hook-guard-tmux`
-// and fail CLOSED on every Bash call for an upgraded user. ensurePluginDir must
-// remove it on the next launch after upgrade.
-func TestEnsurePluginDir_PrunesStaleGuardHooks(t *testing.T) {
+// TestEnsurePluginDir_DisarmsStaleGuardWithoutBreakingLiveHook is the upgrade-
+// safety lock for #2608. Claude Code loads hooks.json once, so removing the
+// stale file disarms new sessions but an already-running session keeps invoking
+// the exact legacy wrapper below. The removed guard must remain as an executable
+// no-op until those sessions end.
+func TestEnsurePluginDir_DisarmsStaleGuardWithoutBreakingLiveHook(t *testing.T) {
 	tmpDir := testguard.SocketTempDir(t)
 	t.Setenv("AGENT_FACTORY_HOME", tmpDir)
 
-	// Seed the hooks/ directory a pre-removal af wrote.
+	// Seed the two files v1.0.209 wrote before #2563 removed the guard.
 	hooksDir := filepath.Join(tmpDir, "plugin", "hooks")
 	if err := os.MkdirAll(hooksDir, 0755); err != nil {
 		t.Fatalf("seed hooks dir: %v", err)
 	}
-	for _, name := range []string{"hooks.json", "guard-tmux.sh"} {
-		if err := os.WriteFile(filepath.Join(hooksDir, name), []byte("stale"), 0644); err != nil {
-			t.Fatalf("seed %s: %v", name, err)
-		}
+	if err := os.WriteFile(filepath.Join(hooksDir, "hooks.json"), []byte(`{"hooks":{"PreToolUse":[]}}`), 0644); err != nil {
+		t.Fatalf("seed hooks.json: %v", err)
+	}
+	legacyGuard := "#!/bin/sh\n" +
+		"guard_binary=/removed/v1.0.209/af\n" +
+		"if [ ! -x \"$guard_binary\" ]; then\n" +
+		"  echo 'Agent Factory tmux safety guard binary is unavailable; refusing the Bash command.' >&2\n" +
+		"  exit 2\n" +
+		"fi\n" +
+		"\"$guard_binary\" hook-guard-tmux\n" +
+		"status=$?\n" +
+		"if [ \"$status\" -ne 0 ]; then\n" +
+		"  echo 'Agent Factory tmux safety guard failed; refusing the Bash command.' >&2\n" +
+		"  exit 2\n" +
+		"fi\n"
+	if err := os.WriteFile(filepath.Join(hooksDir, "guard-tmux.sh"), []byte(legacyGuard), 0755); err != nil {
+		t.Fatalf("seed guard-tmux.sh: %v", err)
 	}
 
-	if _, err := ensurePluginDir(); err != nil {
+	pluginDir, err := ensurePluginDir()
+	if err != nil {
 		t.Fatalf("ensurePluginDir: %v", err)
 	}
 
-	if _, err := os.Stat(hooksDir); !os.IsNotExist(err) {
-		t.Errorf("stale hooks/ directory survived upgrade (err=%v); it would keep firing the removed guard against every Bash call", err)
+	if _, err := os.Stat(filepath.Join(hooksDir, "hooks.json")); !os.IsNotExist(err) {
+		t.Errorf("stale hooks.json survived upgrade (err=%v); a new session would register the removed guard", err)
+	}
+
+	const legacyWrapper = `if [ ! -x "${CLAUDE_PLUGIN_ROOT}/hooks/guard-tmux.sh" ]; then
+  echo 'Agent Factory tmux safety guard is unavailable; refusing the Bash command.' >&2; exit 2; fi;
+  "${CLAUDE_PLUGIN_ROOT}/hooks/guard-tmux.sh"`
+	wrapper := exec.Command("sh", "-c", legacyWrapper)
+	wrapper.Env = append(os.Environ(), "CLAUDE_PLUGIN_ROOT="+pluginDir)
+	output, err := wrapper.CombinedOutput()
+	if err != nil {
+		t.Fatalf("live v1.0.209 hook denied Bash after upgrade: %v\n%s", err, strings.TrimSpace(string(output)))
 	}
 }


### PR DESCRIPTION
## Summary

- disarm the pre-#2563 runtime Claude hook for new sessions by removing its stale `hooks.json`
- keep an executable no-op `guard-tmux.sh` tombstone for already-running Claude sessions that cached the old wrapper
- restore the removed hidden `af hook-guard-tmux` name as a no-op for already-running versioned Codex hooks

The tmux guard itself remains removed. Both compatibility paths interpret its removal as “no guard” and exit successfully.

## Verified root cause

The report is correct about the live-session failure, but the proposed wrapper line was deleted by #2563 and is already cached in running agents, so changing that historical source cannot repair an upgrade. On current `master`, `ensurePluginDir` removes the whole runtime `hooks/` directory; a running v1.0.209 Claude wrapper then fails its executable check with exit 2. The versioned Codex v3.3 script survives update but invokes the removed hidden command, which also exits nonzero.

## Red-first evidence

Both production-shaped regressions failed before the compatibility change:

- Claude: `live v1.0.209 hook denied Bash after upgrade: exit status 2` followed by `Agent Factory tmux safety guard is unavailable; refusing the Bash command.`
- Codex: `legacy Codex hook denied Bash after upgrade: unknown command "hook-guard-tmux" for "af"`

## Adjacent hook audit

- The retained Codex `SessionStart` preflight is informational, not a Bash `PreToolUse` gate, and its versioned script is not pruned during update.
- The installable Claude plugin never shipped this hook.
- No other current hook wrapper uses the removed guard path.

## Validation

Validated pushed SHA `6595dac2fbe1fbe0e90929d154bcbf76d31b5d1a`:

- both focused fail-first regressions now pass in `make test-container`
- full isolated `./session ./commands` package suites pass
- existing concurrent/idempotent plugin-directory regressions pass
- focused parity suite passes
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container` (full suite, run last)

The first full-suite pass on the prior head exposed the hidden command's missing parity inventory entry. That contract was added, focused parity passed, and the entire gate above was repeated successfully on the final pushed head after rebasing.

Closes #2608