### PR TITLE
Make the help overlay readable at narrow widths

### DIFF
--- a/app/help.go
+++ b/app/help.go
@@ -40,17 +40,16 @@ type helpSection struct {
 	rows  []helpRow
 }
 
-// renderHelpSections lays the sections out with a single key column whose
-// width fits the widest effective key across ALL sections, so the dashes stay
-// aligned no matter how wide a rebind makes a key. Computing the width at
-// render time (rather than the old hardcoded padding) is what keeps the
-// overlay correct under arbitrary rebinds.
-func renderHelpSections(header string, sections []helpSection) string {
-	width := 0
+// renderHelpSections lays the sections out with a single key column whose width
+// fits the widest effective key across ALL sections. When contentWidth is
+// known, the description is a separate block: lipgloss wraps it beneath its
+// first word, never beneath the key (#2577).
+func renderHelpSections(header string, sections []helpSection, contentWidth int) string {
+	keyWidth := 0
 	for _, s := range sections {
 		for _, r := range s.rows {
-			if w := lipgloss.Width(r.key); w > width {
-				width = w
+			if w := lipgloss.Width(r.key); w > keyWidth {
+				keyWidth = w
 			}
 		}
 	}
@@ -60,8 +59,27 @@ func renderHelpSections(header string, sections []helpSection) string {
 	for _, s := range sections {
 		lines = append(lines, headerStyle.Render(s.title))
 		for _, r := range s.rows {
-			pad := strings.Repeat(" ", width-lipgloss.Width(r.key)+2)
-			lines = append(lines, keyStyle.Render(r.key)+pad+descStyle.Render("- "+r.desc))
+			if contentWidth <= 0 {
+				pad := strings.Repeat(" ", keyWidth-lipgloss.Width(r.key)+2)
+				lines = append(lines, keyStyle.Render(r.key)+pad+descStyle.Render("- "+r.desc))
+				continue
+			}
+
+			keyColumnWidth := keyWidth + 2
+			if keyColumnWidth+3 > contentWidth {
+				keyColumnWidth = contentWidth / 2
+				if keyColumnWidth < 1 {
+					keyColumnWidth = 1
+				}
+			}
+			descWidth := contentWidth - keyColumnWidth - 2
+			if descWidth < 1 {
+				descWidth = 1
+			}
+			keyBlock := lipgloss.NewStyle().Width(keyColumnWidth).Render(keyStyle.Render(r.key))
+			dashBlock := descStyle.Render("- ")
+			descBlock := lipgloss.NewStyle().Width(descWidth).Render(descStyle.Render(r.desc))
+			lines = append(lines, lipgloss.JoinHorizontal(lipgloss.Top, keyBlock, dashBlock, descBlock))
 		}
 		lines = append(lines, "")
 	}
@@ -78,6 +96,10 @@ type helpText interface {
 	// mask returns the bit mask for this help text. These are used to track which help screens
 	// have been seen in the config and app state.
 	mask() uint32
+}
+
+type responsiveHelpText interface {
+	toContentWidth(width int) string
 }
 
 type helpTypeGeneral struct{}
@@ -131,6 +153,10 @@ func firstRunActionLine(actions string) string {
 }
 
 func (h helpTypeGeneral) toContent() string {
+	return h.toContentWidth(0)
+}
+
+func (h helpTypeGeneral) toContentWidth(contentWidth int) string {
 	// Every key glyph below is pulled from the generated binding table via
 	// helpKey, so [keys] rebinds appear here identically to the bottom menu
 	// (#1026). The tmux detach key is the one entry with no rebindable action
@@ -141,6 +167,10 @@ func (h helpTypeGeneral) toContent() string {
 		titleStyle.Render(fmt.Sprintf("Agent Factory v%s", Version)),
 		"",
 		"A terminal UI that manages multiple Claude Code (and other local agents) in separate workspaces.",
+		"",
+		descStyle.Render("Page: pgup/pgdn · ")+keyStyle.Render(helpKey(keys.KeyShiftUp)+"/"+helpKey(keys.KeyShiftDown)),
+		descStyle.Render("Line: ")+keyStyle.Render(navKeys)+descStyle.Render(" · home/end jump"),
+		descStyle.Render("Close: esc · ")+keyStyle.Render(helpKey(keys.KeyHelp))+descStyle.Render(" toggles help"),
 	)
 	return renderHelpSections(header, []helpSection{
 		{title: "Managing:", rows: []helpRow{
@@ -196,7 +226,7 @@ func (h helpTypeGeneral) toContent() string {
 		{title: "Other:", rows: []helpRow{
 			{helpKey(keys.KeyQuit), "Quit the application"},
 		}},
-	})
+	}, contentWidth)
 }
 
 func (h helpTypeInstanceStart) toContent() string {
@@ -337,9 +367,11 @@ func (m *home) showHelpScreen(helpType helpText, onDismiss func() tea.Cmd) (tea.
 			log.WarningLog.Printf("failed to save help screen state: %v", err)
 		}
 
-		content := helpType.toContent()
-
-		m.textOverlay = overlay.NewTextOverlay(content)
+		if responsive, ok := helpType.(responsiveHelpText); ok {
+			m.textOverlay = overlay.NewResponsiveTextOverlay(responsive.toContentWidth)
+		} else {
+			m.textOverlay = overlay.NewTextOverlay(helpType.toContent())
+		}
 		m.textOverlay.OnDismiss = onDismiss
 		m.textOverlayDismissAnyKey = true
 		if _, ok := helpType.(helpTypeGeneral); ok {
@@ -366,11 +398,27 @@ func (m *home) showHelpScreen(helpType helpText, onDismiss func() tea.Cmd) (tea.
 
 // handleHelpState handles key events when in help state
 func (m *home) handleHelpState(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if isHelpScrollUpKey(msg) {
+	if isHelpJumpTopKey(msg) {
+		m.textOverlay.ScrollToTop()
+		return m, nil
+	}
+	if isHelpJumpBottomKey(msg) {
+		m.textOverlay.ScrollToBottom()
+		return m, nil
+	}
+	if isHelpPageUpKey(msg) {
+		m.textOverlay.PageUp()
+		return m, nil
+	}
+	if isHelpPageDownKey(msg) {
+		m.textOverlay.PageDown()
+		return m, nil
+	}
+	if isHelpLineUpKey(msg) {
 		m.textOverlay.ScrollUp()
 		return m, nil
 	}
-	if isHelpScrollDownKey(msg) {
+	if isHelpLineDownKey(msg) {
 		m.textOverlay.ScrollDown()
 		return m, nil
 	}
@@ -437,12 +485,35 @@ func attachHelpDismissPolicy(msg tea.KeyMsg) (bool, bool) {
 	}
 }
 
-func isHelpScrollUpKey(msg tea.KeyMsg) bool {
-	return msg.Type == tea.KeyShiftUp || key.Matches(msg, keys.GlobalKeyBindings[keys.KeyShiftUp])
+func isHelpJumpTopKey(msg tea.KeyMsg) bool {
+	return msg.Type == tea.KeyHome
 }
 
-func isHelpScrollDownKey(msg tea.KeyMsg) bool {
-	return msg.Type == tea.KeyShiftDown || key.Matches(msg, keys.GlobalKeyBindings[keys.KeyShiftDown])
+func isHelpJumpBottomKey(msg tea.KeyMsg) bool {
+	return msg.Type == tea.KeyEnd
+}
+
+func isHelpPageUpKey(msg tea.KeyMsg) bool {
+	return msg.Type == tea.KeyPgUp ||
+		msg.Type == tea.KeyCtrlB ||
+		msg.Type == tea.KeyShiftUp ||
+		key.Matches(msg, keys.GlobalKeyBindings[keys.KeyShiftUp])
+}
+
+func isHelpPageDownKey(msg tea.KeyMsg) bool {
+	return msg.Type == tea.KeyPgDown ||
+		msg.Type == tea.KeyCtrlF ||
+		msg.Type == tea.KeySpace ||
+		msg.Type == tea.KeyShiftDown ||
+		key.Matches(msg, keys.GlobalKeyBindings[keys.KeyShiftDown])
+}
+
+func isHelpLineUpKey(msg tea.KeyMsg) bool {
+	return key.Matches(msg, keys.GlobalKeyBindings[keys.KeyUp])
+}
+
+func isHelpLineDownKey(msg tea.KeyMsg) bool {
+	return key.Matches(msg, keys.GlobalKeyBindings[keys.KeyDown])
 }
 
 func isHelpDismissKey(msg tea.KeyMsg) bool {

--- a/app/help.go
+++ b/app/help.go
@@ -152,14 +152,12 @@ func firstRunActionLine(actions string) string {
 	return descStyle.Render(actions)
 }
 
-func helpPagingAliases() string {
-	aliases := []struct {
-		label string
-		msg   tea.KeyMsg
-	}{
-		{label: "pgup", msg: tea.KeyMsg{Type: tea.KeyPgUp}},
-		{label: "pgdn", msg: tea.KeyMsg{Type: tea.KeyPgDown}},
-	}
+type helpAlias struct {
+	label string
+	msg   tea.KeyMsg
+}
+
+func visibleHelpAliases(aliases []helpAlias) string {
 	bindings := []keys.KeyName{
 		keys.KeyHelp,
 		keys.KeyUp,
@@ -184,6 +182,20 @@ func helpPagingAliases() string {
 	return strings.Join(visible, "/")
 }
 
+func helpPagingAliases() string {
+	return visibleHelpAliases([]helpAlias{
+		{label: "pgup", msg: tea.KeyMsg{Type: tea.KeyPgUp}},
+		{label: "pgdn", msg: tea.KeyMsg{Type: tea.KeyPgDown}},
+	})
+}
+
+func helpJumpAliases() string {
+	return visibleHelpAliases([]helpAlias{
+		{label: "home", msg: tea.KeyMsg{Type: tea.KeyHome}},
+		{label: "end", msg: tea.KeyMsg{Type: tea.KeyEnd}},
+	})
+}
+
 func (h helpTypeGeneral) toContent() string {
 	return h.toContentWidth(0)
 }
@@ -200,13 +212,17 @@ func (h helpTypeGeneral) toContentWidth(contentWidth int) string {
 		pageLine += descStyle.Render(aliases + " · ")
 	}
 	pageLine += keyStyle.Render(helpKey(keys.KeyShiftUp) + "/" + helpKey(keys.KeyShiftDown))
+	lineControls := descStyle.Render("Line: ") + keyStyle.Render(navKeys)
+	if aliases := helpJumpAliases(); aliases != "" {
+		lineControls += descStyle.Render(" · " + aliases + " jump")
+	}
 	header := lipgloss.JoinVertical(lipgloss.Left,
 		titleStyle.Render(fmt.Sprintf("Agent Factory v%s", Version)),
 		"",
 		"A terminal UI that manages multiple Claude Code (and other local agents) in separate workspaces.",
 		"",
 		pageLine,
-		descStyle.Render("Line: ")+keyStyle.Render(navKeys)+descStyle.Render(" · home/end jump"),
+		lineControls,
 		descStyle.Render("Close: esc · ")+keyStyle.Render(helpKey(keys.KeyHelp))+descStyle.Render(" toggles help"),
 	)
 	return renderHelpSections(header, []helpSection{

--- a/app/help.go
+++ b/app/help.go
@@ -361,6 +361,7 @@ func (m *home) showHelpScreen(helpType helpText, onDismiss func() tea.Cmd) (tea.
 	// in the seen bitmask.
 	m.replayHelpDismissKey = false
 	m.textOverlayDismissPolicy = nil
+	m.textOverlayScrollable = false
 	if alwaysShow || (m.appState.GetHelpScreensSeen()&flag) == 0 {
 		// Mark this help screen as seen and save state
 		if err := m.appState.SetHelpScreensSeen(m.appState.GetHelpScreensSeen() | flag); err != nil {
@@ -376,6 +377,7 @@ func (m *home) showHelpScreen(helpType helpText, onDismiss func() tea.Cmd) (tea.
 		m.textOverlayDismissAnyKey = true
 		if _, ok := helpType.(helpTypeGeneral); ok {
 			m.textOverlayDismissAnyKey = false
+			m.textOverlayScrollable = true
 		}
 		if _, ok := helpType.(helpTypeInstanceAttach); ok {
 			m.textOverlayDismissAnyKey = false
@@ -398,29 +400,31 @@ func (m *home) showHelpScreen(helpType helpText, onDismiss func() tea.Cmd) (tea.
 
 // handleHelpState handles key events when in help state
 func (m *home) handleHelpState(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if isHelpJumpTopKey(msg) {
-		m.textOverlay.ScrollToTop()
-		return m, nil
-	}
-	if isHelpJumpBottomKey(msg) {
-		m.textOverlay.ScrollToBottom()
-		return m, nil
-	}
-	if isHelpPageUpKey(msg) {
-		m.textOverlay.PageUp()
-		return m, nil
-	}
-	if isHelpPageDownKey(msg) {
-		m.textOverlay.PageDown()
-		return m, nil
-	}
-	if isHelpLineUpKey(msg) {
-		m.textOverlay.ScrollUp()
-		return m, nil
-	}
-	if isHelpLineDownKey(msg) {
-		m.textOverlay.ScrollDown()
-		return m, nil
+	if m.textOverlayScrollable && !isHelpDismissKey(msg) {
+		if isHelpJumpTopKey(msg) {
+			m.textOverlay.ScrollToTop()
+			return m, nil
+		}
+		if isHelpJumpBottomKey(msg) {
+			m.textOverlay.ScrollToBottom()
+			return m, nil
+		}
+		if isHelpPageUpKey(msg) {
+			m.textOverlay.PageUp()
+			return m, nil
+		}
+		if isHelpPageDownKey(msg) {
+			m.textOverlay.PageDown()
+			return m, nil
+		}
+		if isHelpLineUpKey(msg) {
+			m.textOverlay.ScrollUp()
+			return m, nil
+		}
+		if isHelpLineDownKey(msg) {
+			m.textOverlay.ScrollDown()
+			return m, nil
+		}
 	}
 
 	runOnDismiss := true
@@ -456,6 +460,7 @@ func (m *home) handleHelpState(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		replayDismissKey := m.replayHelpDismissKey
 		m.replayHelpDismissKey = false
 		m.textOverlayDismissAnyKey = false
+		m.textOverlayScrollable = false
 		m.textOverlayDismissPolicy = nil
 		m.state = stateDefault
 		// Menu.SetState rebuilds the options slice; call it synchronously

--- a/app/help.go
+++ b/app/help.go
@@ -152,6 +152,38 @@ func firstRunActionLine(actions string) string {
 	return descStyle.Render(actions)
 }
 
+func helpPagingAliases() string {
+	aliases := []struct {
+		label string
+		msg   tea.KeyMsg
+	}{
+		{label: "pgup", msg: tea.KeyMsg{Type: tea.KeyPgUp}},
+		{label: "pgdn", msg: tea.KeyMsg{Type: tea.KeyPgDown}},
+	}
+	bindings := []keys.KeyName{
+		keys.KeyHelp,
+		keys.KeyUp,
+		keys.KeyDown,
+		keys.KeyShiftUp,
+		keys.KeyShiftDown,
+	}
+
+	var visible []string
+	for _, alias := range aliases {
+		shadowed := false
+		for _, name := range bindings {
+			if key.Matches(alias.msg, keys.GlobalKeyBindings[name]) {
+				shadowed = true
+				break
+			}
+		}
+		if !shadowed {
+			visible = append(visible, alias.label)
+		}
+	}
+	return strings.Join(visible, "/")
+}
+
 func (h helpTypeGeneral) toContent() string {
 	return h.toContentWidth(0)
 }
@@ -163,12 +195,17 @@ func (h helpTypeGeneral) toContentWidth(contentWidth int) string {
 	// and stays literal; the task-manager run shortcut is folded into the
 	// tasks row (its `r` is overlay-local, not the global restore key #1605).
 	navKeys := helpKey(keys.KeyUp) + ", " + helpKey(keys.KeyDown)
+	pageLine := descStyle.Render("Page: ")
+	if aliases := helpPagingAliases(); aliases != "" {
+		pageLine += descStyle.Render(aliases + " · ")
+	}
+	pageLine += keyStyle.Render(helpKey(keys.KeyShiftUp) + "/" + helpKey(keys.KeyShiftDown))
 	header := lipgloss.JoinVertical(lipgloss.Left,
 		titleStyle.Render(fmt.Sprintf("Agent Factory v%s", Version)),
 		"",
 		"A terminal UI that manages multiple Claude Code (and other local agents) in separate workspaces.",
 		"",
-		descStyle.Render("Page: pgup/pgdn · ")+keyStyle.Render(helpKey(keys.KeyShiftUp)+"/"+helpKey(keys.KeyShiftDown)),
+		pageLine,
 		descStyle.Render("Line: ")+keyStyle.Render(navKeys)+descStyle.Render(" · home/end jump"),
 		descStyle.Render("Close: esc · ")+keyStyle.Render(helpKey(keys.KeyHelp))+descStyle.Render(" toggles help"),
 	)

--- a/app/help.go
+++ b/app/help.go
@@ -401,6 +401,24 @@ func (m *home) showHelpScreen(helpType helpText, onDismiss func() tea.Cmd) (tea.
 // handleHelpState handles key events when in help state
 func (m *home) handleHelpState(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.textOverlayScrollable && !isHelpDismissKey(msg) {
+		// Effective bindings precede hardcoded aliases so an advertised rebind
+		// such as up=pgdown keeps its configured meaning inside help.
+		if isHelpLineUpKey(msg) {
+			m.textOverlay.ScrollUp()
+			return m, nil
+		}
+		if isHelpLineDownKey(msg) {
+			m.textOverlay.ScrollDown()
+			return m, nil
+		}
+		if isHelpPageUpBinding(msg) {
+			m.textOverlay.PageUp()
+			return m, nil
+		}
+		if isHelpPageDownBinding(msg) {
+			m.textOverlay.PageDown()
+			return m, nil
+		}
 		if isHelpJumpTopKey(msg) {
 			m.textOverlay.ScrollToTop()
 			return m, nil
@@ -409,20 +427,12 @@ func (m *home) handleHelpState(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.textOverlay.ScrollToBottom()
 			return m, nil
 		}
-		if isHelpPageUpKey(msg) {
+		if isHelpPageUpAlias(msg) {
 			m.textOverlay.PageUp()
 			return m, nil
 		}
-		if isHelpPageDownKey(msg) {
+		if isHelpPageDownAlias(msg) {
 			m.textOverlay.PageDown()
-			return m, nil
-		}
-		if isHelpLineUpKey(msg) {
-			m.textOverlay.ScrollUp()
-			return m, nil
-		}
-		if isHelpLineDownKey(msg) {
-			m.textOverlay.ScrollDown()
 			return m, nil
 		}
 	}
@@ -498,19 +508,25 @@ func isHelpJumpBottomKey(msg tea.KeyMsg) bool {
 	return msg.Type == tea.KeyEnd
 }
 
-func isHelpPageUpKey(msg tea.KeyMsg) bool {
-	return msg.Type == tea.KeyPgUp ||
-		msg.Type == tea.KeyCtrlB ||
-		msg.Type == tea.KeyShiftUp ||
-		key.Matches(msg, keys.GlobalKeyBindings[keys.KeyShiftUp])
+func isHelpPageUpBinding(msg tea.KeyMsg) bool {
+	return key.Matches(msg, keys.GlobalKeyBindings[keys.KeyShiftUp])
 }
 
-func isHelpPageDownKey(msg tea.KeyMsg) bool {
+func isHelpPageDownBinding(msg tea.KeyMsg) bool {
+	return key.Matches(msg, keys.GlobalKeyBindings[keys.KeyShiftDown])
+}
+
+func isHelpPageUpAlias(msg tea.KeyMsg) bool {
+	return msg.Type == tea.KeyPgUp ||
+		msg.Type == tea.KeyCtrlB ||
+		msg.Type == tea.KeyShiftUp
+}
+
+func isHelpPageDownAlias(msg tea.KeyMsg) bool {
 	return msg.Type == tea.KeyPgDown ||
 		msg.Type == tea.KeyCtrlF ||
 		msg.Type == tea.KeySpace ||
-		msg.Type == tea.KeyShiftDown ||
-		key.Matches(msg, keys.GlobalKeyBindings[keys.KeyShiftDown])
+		msg.Type == tea.KeyShiftDown
 }
 
 func isHelpLineUpKey(msg tea.KeyMsg) bool {

--- a/app/help_test.go
+++ b/app/help_test.go
@@ -55,6 +55,29 @@ func TestGeneralHelpReboundDismissKeyWinsOverPaging(t *testing.T) {
 		"a configured help key must dismiss help even when it is also a paging key")
 }
 
+func TestGeneralHelpReboundLineKeyWinsOverPagingAlias(t *testing.T) {
+	require.NoError(t, keys.ApplyOverrides(map[string][]string{
+		"up": {"pgdown"},
+	}))
+	t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
+
+	actual := newTestHome(t)
+	resizeHome(actual, 80, 24)
+	_, _ = actual.showHelpScreen(helpTypeGeneral{}, nil)
+	_, _ = actual.handleHelpState(tea.KeyMsg{Type: tea.KeyCtrlD})
+
+	want := newTestHome(t)
+	resizeHome(want, 80, 24)
+	_, _ = want.showHelpScreen(helpTypeGeneral{}, nil)
+	_, _ = want.handleHelpState(tea.KeyMsg{Type: tea.KeyCtrlD})
+	want.textOverlay.ScrollUp()
+
+	_, _ = actual.handleHelpState(tea.KeyMsg{Type: tea.KeyPgDown})
+
+	require.Equal(t, xansi.Strip(want.View()), xansi.Strip(actual.View()),
+		"a configured line key must win over a hardcoded paging alias")
+}
+
 // TestGeneralHelpNavigationMatchesBindings guards against regressing #764, where
 // the help screen documented "↑/j, ↓/k" while the canonical bindings in
 // keys/keys.go map k=up and j=down (standard vim convention).

--- a/app/help_test.go
+++ b/app/help_test.go
@@ -78,6 +78,27 @@ func TestGeneralHelpReboundLineKeyWinsOverPagingAlias(t *testing.T) {
 		"a configured line key must win over a hardcoded paging alias")
 }
 
+func TestGeneralHelpHidesPagingAliasShadowedByRebind(t *testing.T) {
+	require.NoError(t, keys.ApplyOverrides(map[string][]string{
+		"up": {"pgdown"},
+	}))
+	t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
+
+	var pageLine string
+	for _, line := range strings.Split(xansi.Strip(helpTypeGeneral{}.toContent()), "\n") {
+		if strings.HasPrefix(line, "Page:") {
+			pageLine = line
+			break
+		}
+	}
+
+	require.NotEmpty(t, pageLine)
+	require.NotContains(t, pageLine, "pgdn",
+		"the page controls must not advertise an alias shadowed by a rebind")
+	require.Contains(t, xansi.Strip(helpTypeGeneral{}.toContent()), "pgdown, ↓/j",
+		"the effective line binding remains advertised on its actual action")
+}
+
 // TestGeneralHelpNavigationMatchesBindings guards against regressing #764, where
 // the help screen documented "↑/j, ↓/k" while the canonical bindings in
 // keys/keys.go map k=up and j=down (standard vim convention).

--- a/app/help_test.go
+++ b/app/help_test.go
@@ -39,6 +39,22 @@ func TestHelpReflectsKeymapRebinds(t *testing.T) {
 	}
 }
 
+func TestGeneralHelpReboundDismissKeyWinsOverPaging(t *testing.T) {
+	require.NoError(t, keys.ApplyOverrides(map[string][]string{
+		"help": {"space"},
+	}))
+	t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
+
+	h := newTestHome(t)
+	resizeHome(h, 80, 24)
+	_, _ = h.showHelpScreen(helpTypeGeneral{}, nil)
+
+	_, _ = h.handleHelpState(tea.KeyMsg{Type: tea.KeySpace})
+
+	require.Equal(t, stateDefault, h.state,
+		"a configured help key must dismiss help even when it is also a paging key")
+}
+
 // TestGeneralHelpNavigationMatchesBindings guards against regressing #764, where
 // the help screen documented "↑/j, ↓/k" while the canonical bindings in
 // keys/keys.go map k=up and j=down (standard vim convention).

--- a/app/help_test.go
+++ b/app/help_test.go
@@ -99,6 +99,28 @@ func TestGeneralHelpHidesPagingAliasShadowedByRebind(t *testing.T) {
 		"the effective line binding remains advertised on its actual action")
 }
 
+func TestGeneralHelpHidesJumpAliasShadowedByRebind(t *testing.T) {
+	require.NoError(t, keys.ApplyOverrides(map[string][]string{
+		"help": {"home"},
+	}))
+	t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
+
+	var lineControls string
+	content := xansi.Strip(helpTypeGeneral{}.toContent())
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(line, "Line:") {
+			lineControls = line
+			break
+		}
+	}
+
+	require.NotEmpty(t, lineControls)
+	require.NotContains(t, lineControls, "home",
+		"the line controls must not advertise a jump alias shadowed by a rebind")
+	require.Contains(t, content, "Close: esc · home toggles help",
+		"the effective help binding remains advertised on its actual action")
+}
+
 // TestGeneralHelpNavigationMatchesBindings guards against regressing #764, where
 // the help screen documented "↑/j, ↓/k" while the canonical bindings in
 // keys/keys.go map k=up and j=down (standard vim convention).

--- a/app/help_test.go
+++ b/app/help_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	xansi "github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/keys"
@@ -281,4 +282,72 @@ func TestGeneralHelpOverlayShiftArrowsScrollAt80x24(t *testing.T) {
 
 	_, _ = h.handleHelpState(tea.KeyMsg{Type: tea.KeyEsc})
 	require.Equal(t, stateDefault, h.state, "Esc remains the explicit help dismiss key")
+}
+
+func TestGeneralHelpOverlayPagesAndJumpsAt80x24(t *testing.T) {
+	h := newTestHome(t)
+	resizeHome(h, 80, 24)
+	_, _ = h.showHelpScreen(helpTypeGeneral{}, nil)
+
+	initial := xansi.Strip(h.View())
+	require.Contains(t, initial, "pgup/pgdn",
+		"the initial viewport must advertise its page-sized controls")
+
+	_, _ = h.handleHelpState(tea.KeyMsg{Type: tea.KeyPgDown})
+	paged := xansi.Strip(h.View())
+	require.NotEqual(t, initial, paged, "PageDown must move the help viewport")
+	require.NotContains(t, paged, "Agent Factory v",
+		"one page step must move by a viewport, not one row")
+	require.Contains(t, paged, "↑ more")
+
+	_, _ = h.handleHelpState(tea.KeyMsg{Type: tea.KeyEnd})
+	require.Contains(t, xansi.Strip(h.View()), "Other:",
+		"End must jump to the bottom of help")
+
+	_, _ = h.handleHelpState(tea.KeyMsg{Type: tea.KeyHome})
+	require.Contains(t, xansi.Strip(h.View()), "Agent Factory v",
+		"Home must jump back to the top of help")
+
+	_, _ = h.handleHelpState(tea.KeyMsg{Type: tea.KeyCtrlD})
+	require.NotContains(t, xansi.Strip(h.View()), "Agent Factory v",
+		"the advertised Ctrl-D binding must page rather than move one row")
+
+	_, _ = h.handleHelpState(tea.KeyMsg{Type: tea.KeyPgUp})
+	require.Contains(t, xansi.Strip(h.View()), "Agent Factory v",
+		"PageUp must move a viewport back toward the top")
+
+	_, _ = h.handleHelpState(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	require.Contains(t, xansi.Strip(h.View()), "↑ more",
+		"the advertised down binding must provide line-sized navigation")
+	_, _ = h.handleHelpState(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	require.Contains(t, xansi.Strip(h.View()), "Agent Factory v",
+		"the advertised up binding must return one line toward the top")
+}
+
+func TestGeneralHelpWrappedDescriptionsStayOutOfKeyColumnAt80x24(t *testing.T) {
+	h := newTestHome(t)
+	resizeHome(h, 80, 24)
+	_, _ = h.showHelpScreen(helpTypeGeneral{}, nil)
+	h.textOverlay.SetHeight(100)
+
+	lines := strings.Split(xansi.Strip(h.textOverlay.Render()), "\n")
+	var retryLine, continuationLine string
+	for _, line := range lines {
+		if strings.Contains(line, "Retry") {
+			retryLine = line
+		}
+		if strings.Contains(line, "usage limit") {
+			continuationLine = line
+		}
+	}
+	require.NotEmpty(t, retryLine, "the narrow help viewport must contain the retry binding")
+	require.NotEmpty(t, continuationLine, "the retry description must wrap at 80 columns")
+
+	retryContent := strings.TrimSuffix(strings.TrimPrefix(retryLine, "│"), "│")
+	continuationContent := strings.TrimSuffix(strings.TrimPrefix(continuationLine, "│"), "│")
+	descriptionColumn := strings.Index(retryContent, "Retry")
+	require.GreaterOrEqual(t, descriptionColumn, 0)
+	continuationColumn := len(continuationContent) - len(strings.TrimLeft(continuationContent, " "))
+	require.Equal(t, descriptionColumn, continuationColumn,
+		"wrapped descriptions must use a hanging indent at the description column")
 }

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -375,6 +375,10 @@ type home struct {
 	// (attachHelpDismissPolicy) distinguishing Enter (proceed) from Esc/Ctrl+C
 	// (cancel).
 	textOverlayDismissAnyKey bool
+	// textOverlayScrollable limits viewport navigation to overlays whose
+	// content is intentionally browsable. First-run and attach overlays still
+	// treat navigation keys as dismissal or policy input.
+	textOverlayScrollable bool
 	// textOverlayDismissPolicy, when set, decides whether a help overlay key
 	// closes the overlay and whether its OnDismiss callback should run.
 	textOverlayDismissPolicy func(tea.KeyMsg) (dismiss bool, runOnDismiss bool)

--- a/app/home_view.go
+++ b/app/home_view.go
@@ -55,6 +55,7 @@ func (m *home) showErrorDetails() (tea.Model, tea.Cmd) {
 	}
 	m.textOverlay = overlay.NewTextOverlay("Last error\n\n" + full)
 	m.textOverlayDismissAnyKey = false
+	m.textOverlayScrollable = true
 	m.textOverlayDismissPolicy = nil
 	m.replayHelpDismissKey = false
 	m.layoutTextOverlay()

--- a/app/interactive_test.go
+++ b/app/interactive_test.go
@@ -159,6 +159,23 @@ func TestFirstRunInteractiveHelpForwardsDismissKey(t *testing.T) {
 		"the key that dismisses the first-run interactive help must reach the pane")
 }
 
+func TestFirstRunInteractiveHelpForwardsNavigationKey(t *testing.T) {
+	h, _ := liveTestHome(t)
+	fakes, _ := stubLiveTermFactory(t)
+
+	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+	require.Nil(t, cmd, "first-time interactive entry waits on the help overlay")
+	require.Equal(t, stateHelp, h.state)
+
+	_, cmd = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	runHermeticCmd(t, h, cmd, 0)
+
+	require.True(t, h.interactive, "j must dismiss first-run help rather than scroll it")
+	require.Len(t, *fakes, 1)
+	assert.Equal(t, []string{"j"}, (*fakes)[0].keys,
+		"the navigation key that dismisses first-run help must reach the pane")
+}
+
 func TestInteractiveForwardsAllKeysIncludingTab(t *testing.T) {
 	h, _, fakes := interactiveTestHome(t)
 	enterInteractive(t, h)

--- a/scripts/tui-2577-scenario.sh
+++ b/scripts/tui-2577-scenario.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Real-TUI regression for #2577, via:
+#
+#   scripts/testbox.sh scenario scripts/tui-2577-scenario.sh
+#
+# The help surface must advertise and honor page-sized navigation, and its
+# wrapped descriptions must stay aligned under the description rather than
+# masquerading as extra bindings in the key column.
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source /src/scripts/tui-driver.sh
+
+export AF_DRIVER_COLS=80 AF_DRIVER_ROWS=24
+export AF_DRIVER_REPO="$HOME/sandbox/mock-repo"
+
+af_reset_sandbox
+af_boot
+af_send '?'
+af_wait_for 'Agent Factory v' "$AF_DRIVER_TIMEOUT" 'general help opens'
+af_assert_screen 'pgup/pgdn' 'help advertises page-sized navigation'
+
+af_send PageDown
+af_wait_for '↑ more' 5 'PageDown moves the help viewport'
+af_refute_screen 'Agent Factory v' 'PageDown moves a screenful rather than one row'
+
+af_send End
+af_wait_for 'Other:' 5 'End jumps to the bottom of help'
+
+screen="$(af_capture)"
+quit_line="$(printf '%s\n' "$screen" | grep -m1 'Quit the' || true)"
+continuation_line="$(printf '%s\n' "$screen" | grep -m1 'application' || true)"
+if [ -z "$quit_line" ] || [ -z "$continuation_line" ]; then
+    printf '%s\n' "$screen" >&2
+    _af_fail '#2577: the quit description did not wrap in the real 80-column TUI'
+    exit 1
+fi
+quit_payload="${quit_line#*│}"
+continuation_payload="${continuation_line#*│}"
+quit_prefix="${quit_payload%%Quit*}"
+continuation_prefix="${continuation_payload%%[! ]*}"
+if [ "${#quit_prefix}" -ne "${#continuation_prefix}" ]; then
+    printf '%s\n%s\n' "$quit_line" "$continuation_line" >&2
+    _af_fail "#2577: wrapped description starts in the key column (description col ${#quit_prefix}, continuation col ${#continuation_prefix})"
+    exit 1
+fi
+_af_log 'assert OK: wrapped help description uses the description column'
+
+af_send Home
+af_wait_for 'Agent Factory v' 5 'Home jumps to the top of help'
+
+af_send C-d
+af_wait_gone 'Agent Factory v' 5 'Ctrl-D pages by a viewport'
+
+echo 'PASS: #2577 help navigation and wrapped-column alignment'

--- a/ui/overlay/textOverlay.go
+++ b/ui/overlay/textOverlay.go
@@ -27,6 +27,10 @@ type TextOverlay struct {
 	OnDismiss func() tea.Cmd
 	// Content to display in the overlay
 	content string
+	// contentRenderer rebuilds width-aware content whenever the overlay is
+	// resized. Most text overlays use the static content above; general help
+	// uses this seam so key/description rows can wrap with a hanging indent.
+	contentRenderer func(width int) string
 
 	width  int
 	height int
@@ -43,6 +47,16 @@ func NewTextOverlay(content string) *TextOverlay {
 		width:  60,
 		height: 20,
 	}
+}
+
+// NewResponsiveTextOverlay creates a text overlay whose content is rendered
+// against the current inner text width. The callback must return display-ready
+// text no wider than width; the overlay still applies its ANSI-aware safety
+// wrapper for any over-long fragments.
+func NewResponsiveTextOverlay(renderer func(width int) string) *TextOverlay {
+	overlay := NewTextOverlay("")
+	overlay.contentRenderer = renderer
+	return overlay
 }
 
 // HandleKeyPress processes a key press and updates the state. Returns the
@@ -76,6 +90,7 @@ func (t *TextOverlay) Render() string {
 
 func (t *TextOverlay) SetWidth(width int) {
 	t.width = width
+	t.clampScroll(t.innerHeight())
 }
 
 func (t *TextOverlay) SetHeight(height int) {
@@ -92,6 +107,34 @@ func (t *TextOverlay) ScrollUp() {
 func (t *TextOverlay) ScrollDown() {
 	t.scroll++
 	t.clampScroll(t.innerHeight())
+}
+
+func (t *TextOverlay) PageUp() {
+	t.scroll -= t.pageStep()
+	t.clampScroll(t.innerHeight())
+}
+
+func (t *TextOverlay) PageDown() {
+	t.scroll += t.pageStep()
+	t.clampScroll(t.innerHeight())
+}
+
+func (t *TextOverlay) ScrollToTop() {
+	t.scroll = 0
+}
+
+func (t *TextOverlay) ScrollToBottom() {
+	t.scroll = len(t.wrappedContentLines())
+	t.clampScroll(t.innerHeight())
+}
+
+func (t *TextOverlay) pageStep() int {
+	// Keep the two marker rows as overlap so page-to-page context is not lost.
+	step := t.innerHeight() - 2
+	if step < 1 {
+		return 1
+	}
+	return step
 }
 
 func (t *TextOverlay) innerHeight() int {
@@ -137,7 +180,7 @@ func (t *TextOverlay) contentOverflows(inner int) bool {
 func (t *TextOverlay) visibleContent() string {
 	inner := t.innerHeight()
 	if inner <= 0 {
-		return t.content
+		return t.currentContent()
 	}
 	lines := t.wrappedContentLines()
 	t.clampScroll(inner)
@@ -167,7 +210,14 @@ func (t *TextOverlay) visibleContent() string {
 // row — under-counts, the box grows past the terminal, and PlaceOverlay dumps
 // the raw un-centered frame with its top border clipped (#1998).
 func (t *TextOverlay) wrappedContentLines() []string {
-	return strings.Split(xansi.Wrap(t.content, t.textWidth(), ""), "\n")
+	return strings.Split(xansi.Wrap(t.currentContent(), t.textWidth(), ""), "\n")
+}
+
+func (t *TextOverlay) currentContent() string {
+	if t.contentRenderer != nil {
+		return t.contentRenderer(t.textWidth())
+	}
+	return t.content
 }
 
 func textOverlayScrollMarker(width int, marker string) string {


### PR DESCRIPTION
## What changed

- add advertised page, line, and jump controls to the general help overlay
- make `ctrl+u`/`ctrl+d` and `pgup`/`pgdn` move by a viewport, with `home`/`end` jumps and arrow/vim line movement
- render key/description rows responsively so wrapped descriptions use a hanging indent under the description column
- keep first-run and attach overlays on their original dismissal policies
- give configured dismiss, line, and page bindings precedence over hardcoded navigation aliases
- hide page and jump aliases when effective rebindings shadow them
- add an isolated real-TUI scenario at 80x24

## Root cause

The text overlay exposed only one-row `scroll++` / `scroll--` operations, and the help state mapped only the preview-scroll bindings to them. Generic ANSI wrapping also had no knowledge of the help table's key and description columns, so every continuation returned to column zero.

## Regression proof

The focused tests failed before their respective production changes:

- page navigation: the initial viewport did not contain `pgup/pgdn`, and PageDown left it unchanged
- hanging indent: description column `30`, continuation column `2`
- first-run routing: `j must dismiss first-run help rather than scroll it`
- rebound dismissal: expected default state `0`, remained in help state `2`
- rebound line navigation: `up = pgdown` paged down instead of moving one line up
- shadowed page alias copy: the Page line still advertised `pgdn` when `up = pgdown`
- shadowed jump alias copy: the Line line still advertised `home` when `help = home`

The untouched real TUI failed with `expected screen to match: help advertises page-sized navigation`.

## Validation

Pushed head: `4ed7b00082da2110635c8a75193bad9a5fa2ab15`

- `scripts/testbox.sh scenario scripts/tui-2577-scenario.sh`
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container` (full suite, final local gate on the pushed head)

Closes #2577

-- Captain Claude