### PR TITLE
fix(session): reject nonregular Codex rollouts

### DIFF
--- a/session/conversation_capture.go
+++ b/session/conversation_capture.go
@@ -6,10 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/session/tmux"
@@ -221,7 +223,7 @@ func codexPromptReceiptOnce(snap ConversationCaptureSnapshot, prompt string) (bo
 }
 
 func codexRolloutHasPrompt(path, prompt string) (bool, error) {
-	data, err := os.ReadFile(path)
+	data, err := readCodexRollout(path)
 	if err != nil {
 		return false, err
 	}
@@ -261,6 +263,32 @@ func codexRolloutHasPrompt(path, prompt string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func readCodexRollout(path string) ([]byte, error) {
+	file, err := os.OpenFile(
+		path,
+		os.O_RDONLY|syscall.O_NONBLOCK|syscall.O_CLOEXEC|syscall.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open Codex rollout %s: %w", path, err)
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("inspect opened Codex rollout %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("read Codex rollout %s: not a regular file (%s)", path, info.Mode().Type())
+	}
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("read Codex rollout %s: %w", path, err)
+	}
+	return data, nil
 }
 
 func jsonValueContainsPrompt(value any, prompt string) bool {

--- a/session/conversation_capture_test.go
+++ b/session/conversation_capture_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -154,6 +155,42 @@ func TestWaitForPromptReceipt_ConcurrentRolloutsRemainAmbiguous(t *testing.T) {
 	err := WaitForPromptReceipt(context.Background(), tmux.ProgramCodex, snap, "config briefing", 0)
 	require.ErrorIs(t, err, ErrPromptReceiptAmbiguous,
 		"prompt coincidence cannot prove which new rollout belongs to the launched pane")
+}
+
+func TestWaitForPromptReceipt_RejectsNamedPipeWithoutBlocking(t *testing.T) {
+	codexHome := t.TempDir()
+	snap := BeginConversationCaptureAtCodexHome(codexHome)
+	rolloutDir := filepath.Join(codexHome, "sessions", "2026", "07", "30")
+	require.NoError(t, os.MkdirAll(rolloutDir, 0755))
+	fifo := filepath.Join(rolloutDir,
+		"rollout-2026-07-30T12-00-00-019f386f-7206-7fc2-803b-f7045e07a242.jsonl")
+	require.NoError(t, syscall.Mkfifo(fifo, 0600))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- WaitForPromptReceipt(
+			context.Background(), tmux.ProgramCodex, snap, "briefing", 100*time.Millisecond)
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		require.ErrorContains(t, err, "not a regular file")
+	case <-time.After(time.Second):
+		fd, unblockErr := syscall.Open(
+			fifo, syscall.O_WRONLY|syscall.O_NONBLOCK|syscall.O_CLOEXEC, 0)
+		if unblockErr == nil {
+			require.NoError(t, syscall.Close(fd))
+		}
+		select {
+		case eventualErr := <-done:
+			t.Fatalf("HUNG: the 100ms prompt-receipt window blocked opening rollout FIFO %s; "+
+				"after bounded cleanup supplied a writer, it returned %v", fifo, eventualErr)
+		case <-time.After(time.Second):
+			t.Fatalf("HUNG: the prompt-receipt reader did not return after bounded "+
+				"nonblocking FIFO cleanup (%v)", unblockErr)
+		}
+	}
 }
 
 func TestWaitForPromptReceipt_UnsupportedAgentDoesNotInventReceipt(t *testing.T) {


### PR DESCRIPTION
## Summary

- open discovered Codex rollout paths nonblocking and without following symlinks
- validate the opened descriptor is a regular file, then read from that descriptor instead of resolving the path again
- prove a correctly named FIFO cannot defeat the prompt-receipt deadline or hang config-agent startup

Closes #2724

## Diagnosis

The visible receipt timeout was not a real bound: `WaitForPromptReceipt` checks its deadline only between polls, while `os.ReadFile` could block forever inside a poll. `CaptureAgentConversation` only stats rollout names and does not read contents, so the blocking user-visible path is prompt receipt. Config-agent would never reach its attach-anyway fallback.

Codex writes the rollout store, and same-user session processes can create entries there, so a named pipe is reachable. The adjacent tree-walk audit remains as recorded on #2714: archive copying is fixed there, plugin pruning never opens entries, and this was the sole other discovered-path reader.

## Red-first evidence

```
--- FAIL: TestWaitForPromptReceipt_RejectsNamedPipeWithoutBlocking (1.00s)
HUNG: the 100ms prompt-receipt window blocked opening rollout FIFO ...; after bounded cleanup supplied a writer, it returned prompt receipt not observed in Codex rollout within 100ms
```

The test cleanup opens the writer nonblocking and separately bounds the final receive, so a regression fails promptly rather than hanging the suite.

## Test Plan

Validated on exact pushed head `ac28690751b7efb1bfc44fbbe4d1ae6a46437ba8`:

- [x] focused conversation-capture and prompt-receipt tests
- [x] Darwin arm64 build of `./session`
- [x] `golangci-lint run --timeout=3m --fast`
- [x] `gofmt -l .` produces no output
- [x] `go build ./...`
- [x] `deadcode -test ./...` produces no output
- [x] `scripts/lint-file-length.sh`
- [x] `make test-container` run last on the pushed head