### PR TITLE
doctor: ignore transient process leaks

### DIFF
--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -42,11 +42,16 @@ var (
 	daemonProcessCwd       = proctree.WorkingDir
 )
 
-// runawayCPUFraction and runawayMinAge define "pegging a core for an
-// extended period": lifetime-average CPU ≥ 80% of a core for a process at
-// least 30 minutes old. A legitimate build rarely sustains that average; the
-// leaked `yes` processes from the outage sat at ~100% for 15 days.
+// processLeakMinAge separates durable escaped/orphaned processes from ordinary
+// session teardown. A minute is far longer than one doctor scan but negligible
+// beside the 8-hour-to-10-day leaks this check found in production (#2627).
+//
+// runawayCPUFraction and runawayMinAge define "pegging a core for an extended
+// period": lifetime-average CPU ≥ 80% of a core for a process at least 30
+// minutes old. A legitimate build rarely sustains that average; the leaked
+// `yes` processes from the outage sat at ~100% for 15 days.
 const (
+	processLeakMinAge  = time.Minute
 	runawayCPUFraction = 0.8
 	runawayMinAge      = 30 * time.Minute
 )
@@ -308,6 +313,7 @@ func checkOrphanedProcesses(ctx *scanContext, report *Report) {
 
 	marked := map[string][]proctree.Process{}
 	var possibles []proctree.Process
+	var observations processLeakObservations
 	for pid, p := range ctx.snap {
 		if ctx.selfAncestors[pid] {
 			continue
@@ -319,11 +325,15 @@ func checkOrphanedProcesses(ctx *scanContext, report *Report) {
 		// rather than act on one we never identified.
 		name, nameStatus := proctree.LookupEnv(pid, tmux.EnvMarkerSession)
 		if nameStatus == proctree.EnvFound && name != "" {
-			marked[name] = append(marked[name], p)
+			if observations.oldEnough(ctx, p) {
+				marked[name] = append(marked[name], p)
+			}
 			continue
 		}
 		if tmuxEnv, st := proctree.LookupEnv(pid, "TMUX"); st == proctree.EnvFound && tmuxServerDead(ctx, tmuxEnv) {
-			possibles = append(possibles, p)
+			if observations.oldEnough(ctx, p) {
+				possibles = append(possibles, p)
+			}
 		}
 	}
 
@@ -336,7 +346,7 @@ func checkOrphanedProcesses(ctx *scanContext, report *Report) {
 				inSession[p.PID] = true
 			}
 			for _, p := range procs {
-				if inSession[p.PID] {
+				if inSession[p.PID] || !observations.stillPresent(p) {
 					continue
 				}
 				report.addAdvisoryFinding(Finding{
@@ -348,6 +358,9 @@ func checkOrphanedProcesses(ctx *scanContext, report *Report) {
 			continue
 		}
 		for _, p := range procs {
+			if !observations.stillPresent(p) {
+				continue
+			}
 			// A kill requires a PROVEN home match, not just a dead-looking
 			// session: another agent-factory home (e.g. a play-test sandbox
 			// on a private `tmux -L` server) has sessions that are invisible
@@ -397,6 +410,9 @@ func checkOrphanedProcesses(ctx *scanContext, report *Report) {
 	}
 	rankedPossibles := make([]ranked, 0, len(possibles))
 	for _, p := range possibles {
+		if !observations.stillPresent(p) {
+			continue
+		}
 		frac, _, _ := proctree.CPUFraction(p)
 		rankedPossibles = append(rankedPossibles, ranked{p, frac})
 	}
@@ -422,6 +438,50 @@ func checkOrphanedProcesses(ctx *scanContext, report *Report) {
 				"cannot verify ownership, so it is reported, not killed)", describeProc(r.p)),
 		})
 	}
+	observations.report(report)
+}
+
+// processLeakObservations keeps every unprovable state visible without mixing
+// it into the leak counts. A vanished process is normal churn and needs no row;
+// missing age or an identity-read failure means the check was blind.
+type processLeakObservations struct {
+	unknownAge      int
+	unknownIdentity int
+}
+
+func (o *processLeakObservations) oldEnough(ctx *scanContext, p proctree.Process) bool {
+	if p.StartedAt.IsZero() {
+		o.unknownAge++
+		return false
+	}
+	return ctx.snapAt.Sub(p.StartedAt) >= ctx.opts.minProcessLeakAge
+}
+
+func (o *processLeakObservations) stillPresent(p proctree.Process) bool {
+	same, err := proctree.SameIdentity(p)
+	if err != nil {
+		o.unknownIdentity++
+		return false
+	}
+	return same
+}
+
+func (o processLeakObservations) report(report *Report) {
+	var blind []string
+	if o.unknownAge > 0 {
+		blind = append(blind, fmt.Sprintf("could not determine the age of %s",
+			plural(o.unknownAge, "candidate process", "candidate processes")))
+	}
+	if o.unknownIdentity > 0 {
+		blind = append(blind, fmt.Sprintf("could not revalidate the identity of %s",
+			plural(o.unknownIdentity, "candidate process", "candidate processes")))
+	}
+	if len(blind) == 0 {
+		return
+	}
+	report.Warn(sectionProcesses, "process-leak-inspection",
+		strings.Join(blind, " and ")+"; they are omitted from the escaped, orphaned, and possible-orphan counts",
+		"those candidates are UNKNOWN, not proven leaks; rerun doctor or inspect them manually", false)
 }
 
 // tmuxServerDead parses a TMUX env value ("socketPath,serverPID,sessionIdx")

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -204,6 +204,11 @@ type Options struct {
 	killGrace    time.Duration
 	killTermWait time.Duration
 
+	// minProcessLeakAge is the persistence window for orphan/escape findings.
+	// Production uses processLeakMinAge; tests shorten it when their freshly
+	// spawned fixtures represent already-durable leaks.
+	minProcessLeakAge time.Duration
+
 	// snapshot overrides the process-table scan; tests inject a snapshot
 	// containing only their own spawned processes so a --fix run can never act
 	// on anything outside the test.
@@ -221,6 +226,10 @@ type scanContext struct {
 	// genuinely has none, and the operator cannot tell which one they got.
 	// checkProcessInspection turns that state into a FAIL row; see snapErr.
 	snap map[int]proctree.Process
+	// snapAt is the instant immediately before snap was collected. Process age
+	// is measured against this fixed point so later shell-outs cannot age a
+	// candidate across the leak threshold during one doctor run.
+	snapAt time.Time
 	// snapErr is why snap is nil. Held so the report can name the cause
 	// instead of asserting health from an empty table (#1939).
 	snapErr error
@@ -265,6 +274,9 @@ func (o *Options) applyDefaults() error {
 	}
 	if o.killTermWait == 0 {
 		o.killTermWait = 2 * time.Second
+	}
+	if o.minProcessLeakAge == 0 {
+		o.minProcessLeakAge = processLeakMinAge
 	}
 	if o.snapshot == nil {
 		o.snapshot = proctree.Snapshot
@@ -326,8 +338,10 @@ func Run(opts Options) (*Report, error) {
 	// A failed snapshot is recorded, never discarded: checkProcessInspection
 	// reports it as a failure to OBSERVE, and the process checks below stay
 	// silent only because that row already spoke for them (#1939).
+	snapAt := time.Now()
 	if snap, err := ctx.opts.snapshot(); err == nil {
 		ctx.snap = snap
+		ctx.snapAt = snapAt
 		for pid := range selfAndAncestors(snap) {
 			ctx.selfAncestors[pid] = true
 		}

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/cmd"
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/internal/proctree"
@@ -80,7 +81,10 @@ func testOptionsWithHome(t *testing.T, home string, fix bool, pids ...int) Optio
 		MinTempHomeAge: time.Hour,
 		killGrace:      100 * time.Millisecond,
 		killTermWait:   200 * time.Millisecond,
-		snapshot:       snapshotOf(t, pids...),
+		// Most process fixtures below model durable leaks; age-specific tests
+		// opt back into the production grace period explicitly.
+		minProcessLeakAge: time.Nanosecond,
+		snapshot:          snapshotOf(t, pids...),
 		// Default to "no remote configured" so the non-remote suite stays
 		// hermetic (no git shell-out, no reading the real repo's in-repo
 		// config). The remote tests below inject their own resolver.
@@ -333,6 +337,155 @@ func TestMarkedProcessOfLiveSessionIsNeverKilled(t *testing.T) {
 				"inspection advice must remain visible without making the run fail")
 		}
 	}
+}
+
+// TestLiveSessionTransientChildIsNotReportedAsEscaped stages the production
+// self-observation race deterministically on a real private tmux server. The
+// child exists in the process snapshot and still carries the live session's
+// marker when doctor maps candidates, then exits immediately before the later
+// real list-panes/tree observation. That is ordinary pane work completing, not
+// evidence that the process escaped.
+func TestLiveSessionTransientChildIsNotReportedAsEscaped(t *testing.T) {
+	testguard.IsolateTmux(t)
+
+	const name = "af_doctor-transient-child"
+	dir := t.TempDir()
+	script := filepath.Join(dir, "spawn-child")
+	pidFile := filepath.Join(dir, "child.pid")
+	require.NoError(t, os.WriteFile(script, []byte(
+		"#!/bin/sh\nsleep 300 &\nchild=$!\nprintf '%s\\n' \"$child\" > \"$1\"\nwait \"$child\"\nexec sleep 300\n",
+	), 0o700))
+	out, err := exec.Command("tmux", "new-session", "-d", "-s", name,
+		"-e", tmux.EnvMarkerSession+"="+name, script, pidFile).CombinedOutput()
+	require.NoError(t, err, "tmux new-session: %s", out)
+	t.Cleanup(func() { _ = exec.Command("tmux", "kill-session", "-t", "="+name+":").Run() })
+
+	var transientPID int
+	require.Eventually(t, func() bool {
+		raw, readErr := os.ReadFile(pidFile)
+		if readErr != nil {
+			return false
+		}
+		_, scanErr := fmt.Sscanf(strings.TrimSpace(string(raw)), "%d", &transientPID)
+		return scanErr == nil && transientPID > 1
+	}, 5*time.Second, 10*time.Millisecond, "tmux pane never published its transient child pid")
+
+	full, err := proctree.Snapshot()
+	require.NoError(t, err)
+	transient, ok := full[transientPID]
+	require.True(t, ok, "transient pane child %d missing from snapshot", transientPID)
+	marker, markerStatus := proctree.LookupEnv(transientPID, tmux.EnvMarkerSession)
+	require.Equal(t, proctree.EnvFound, markerStatus)
+	require.Equal(t, name, marker)
+
+	realExec := cmd.MakeExecutor()
+	stopped := false
+	opts := testOptions(t, false)
+	opts.snapshot = func() (map[int]proctree.Process, error) {
+		return map[int]proctree.Process{transient.PID: transient}, nil
+	}
+	opts.Exec = cmd_test.MockCmdExec{
+		RunFunc: realExec.Run,
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			if len(c.Args) > 1 && c.Args[1] == "list-panes" && !stopped {
+				stopped = true
+				require.NoError(t, proctree.Signal(transient, syscall.SIGTERM))
+				require.Eventually(t, func() bool { return !proctree.AliveSame(transient) },
+					5*time.Second, 10*time.Millisecond,
+					"transient pane child did not exit before the later pane-tree observation")
+			}
+			return realExec.Output(c)
+		},
+	}
+
+	report, err := Run(opts)
+	require.NoError(t, err)
+	require.True(t, stopped, "test did not reach the later real pane-tree observation")
+	require.Empty(t, findByCheck(report, "escaped-process"),
+		"a pane child completing between the two observations must not be reported as escaped")
+}
+
+func TestYoungProcessesExcludedFromEveryLeakPopulation(t *testing.T) {
+	testguard.IsolateTmux(t)
+
+	home := testguard.SocketTempDir(t)
+	const liveName = "af_doctor-young-live"
+	out, err := exec.Command("tmux", "new-session", "-d", "-s", liveName, "sleep 300").CombinedOutput()
+	require.NoError(t, err, "tmux new-session: %s", out)
+	t.Cleanup(func() { _ = exec.Command("tmux", "kill-session", "-t", "="+liveName+":").Run() })
+
+	escaped := spawnWithEnv(t, "sh", nil, map[string]string{
+		tmux.EnvMarkerSession: liveName,
+	})
+	orphaned := spawnWithEnv(t, "sh", nil, map[string]string{
+		tmux.EnvMarkerSession: "af_doctor-young-dead",
+		tmux.EnvMarkerHome:    home,
+	})
+	possible := spawnWithEnv(t, "sh", nil, map[string]string{
+		"TMUX": fmt.Sprintf("/tmp/af-doctor-young-dead-tmux,%d,0", 1<<30),
+	})
+
+	opts := testOptionsWithHome(t, home, false, escaped.PID, orphaned.PID, possible.PID)
+	opts.minProcessLeakAge = processLeakMinAge
+	report, err := Run(opts)
+	require.NoError(t, err)
+	require.Empty(t, findByCheck(report, "escaped-process"),
+		"a newly-started live-session child is ordinary process churn, not an escapee")
+	require.Empty(t, findByCheck(report, "orphaned-process"),
+		"a newly-started marked process has not persisted long enough to be a leak")
+	require.Empty(t, findByCheck(report, "possible-orphan"),
+		"a newly-started unmarked process has not persisted long enough to be a possible orphan")
+
+	opts.snapshot = func() (map[int]proctree.Process, error) {
+		snap, snapErr := snapshotOf(t, escaped.PID, orphaned.PID, possible.PID)()
+		if snapErr != nil {
+			return nil, snapErr
+		}
+		for pid, p := range snap {
+			p.StartedAt = time.Now().Add(-2 * processLeakMinAge)
+			snap[pid] = p
+		}
+		return snap, nil
+	}
+	report, err = Run(opts)
+	require.NoError(t, err)
+	require.Len(t, findByCheck(report, "escaped-process"), 1,
+		"a durable process outside its live pane tree remains visible")
+	require.Len(t, findByCheck(report, "orphaned-process"), 1,
+		"a durable marked process from a dead session remains visible")
+	require.Len(t, findByCheck(report, "possible-orphan"), 1,
+		"a durable process from a dead tmux server remains visible")
+}
+
+func TestUnknownProcessAgeIsReportedWithoutClaimingALeak(t *testing.T) {
+	testguard.IsolateTmux(t)
+
+	home := testguard.SocketTempDir(t)
+	candidate := spawnWithEnv(t, "sh", nil, map[string]string{
+		tmux.EnvMarkerSession: "af_doctor-age-unknown",
+		tmux.EnvMarkerHome:    home,
+	})
+	opts := testOptionsWithHome(t, home, false, candidate.PID)
+	opts.snapshot = func() (map[int]proctree.Process, error) {
+		snap, err := snapshotOf(t, candidate.PID)()
+		if err != nil {
+			return nil, err
+		}
+		p := snap[candidate.PID]
+		p.StartedAt = time.Time{}
+		snap[candidate.PID] = p
+		return snap, nil
+	}
+
+	report, err := Run(opts)
+	require.NoError(t, err)
+	require.Empty(t, findByCheck(report, "orphaned-process"),
+		"unknown age cannot establish that a candidate persisted long enough to be a leak")
+	rows := findCheckRows(report, "process-leak-inspection")
+	require.Len(t, rows, 1, "age blindness must stay visible rather than reading as a clean leak scan")
+	require.Equal(t, StatusWarn, rows[0].Status)
+	require.False(t, rows[0].Problem,
+		"rerunning or inspecting an unmeasurable candidate is advice, not an established unhealthy state")
 }
 
 // TestLeakedTmuxSessionReportedNotKilled distinguishes the two facts hidden

--- a/internal/proctree/proctree_linux.go
+++ b/internal/proctree/proctree_linux.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 // The Linux backend reads /proc. See proctree.go for the contract every
@@ -30,18 +32,11 @@ const clkTck = 100
 // same instant for all of them, and re-reading it per entry would let a
 // snapshot's processes disagree about when the machine booted.
 //
-// AN UNREADABLE /proc/uptime IS NOT FATAL, and that is deliberate. It used to
-// fail the whole snapshot, which meant a procfs mounted `subset=pid` — where
-// /proc/<pid>/stat reads fine but /proc/uptime is not there — reported "cannot
-// read the process table" and turned off orphan reaping and doctor's process
-// map entirely. That is this package's own disease pointing the other way:
-// manufacturing NO DATA where data exists, having been built to stop
-// manufacturing health where no data exists.
-//
-// So the table still comes back; only StartedAt is left zero. It feeds nothing
-// but CPUFraction, which already reports a zero StartedAt as unknown — so we
-// lose a nice-to-have (runaway-CPU detection says it could not measure, out
-// loud) and keep the load-bearing part (reaping, orphan and escape detection).
+// AN UNREADABLE /proc/uptime IS NOT FATAL, and that is deliberate. A procfs
+// mounted `subset=pid` still serves /proc/<pid>/stat, so bootTime falls back to
+// the kernel's CLOCK_BOOTTIME. Only if both sources fail does StartedAt remain
+// zero; the process table and identity data still come back, while consumers
+// report that age-dependent checks are UNKNOWN.
 func snapshot() (map[int]Process, error) {
 	entries, err := os.ReadDir("/proc")
 	if err != nil {
@@ -117,22 +112,37 @@ func bootID() (string, error) {
 	return namespaceID, nil
 }
 
-// bootTime returns the wall-clock instant the machine booted, from
-// /proc/uptime.
+// bootTime returns the wall-clock instant the machine booted. /proc/uptime is
+// the ordinary source; CLOCK_BOOTTIME is the equivalent kernel clock available
+// when procfs is mounted subset=pid and hides the global uptime file.
 func bootTime() (time.Time, error) {
+	uptime, procErr := procUptime()
+	if procErr == nil {
+		return time.Now().Add(-uptime), nil
+	}
+
+	var ts unix.Timespec
+	if err := unix.ClockGettime(unix.CLOCK_BOOTTIME, &ts); err != nil {
+		return time.Time{}, errors.Join(procErr, fmt.Errorf("reading CLOCK_BOOTTIME: %w", err))
+	}
+	uptime = time.Duration(ts.Sec)*time.Second + time.Duration(ts.Nsec)
+	return time.Now().Add(-uptime), nil
+}
+
+func procUptime() (time.Duration, error) {
 	data, err := os.ReadFile(uptimePath)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("reading %s: %w", uptimePath, err)
+		return 0, fmt.Errorf("reading %s: %w", uptimePath, err)
 	}
 	fields := strings.Fields(string(data))
 	if len(fields) == 0 {
-		return time.Time{}, errors.New("malformed /proc/uptime")
+		return 0, errors.New("malformed /proc/uptime")
 	}
 	uptime, err := strconv.ParseFloat(fields[0], 64)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("malformed /proc/uptime: %w", err)
+		return 0, fmt.Errorf("malformed /proc/uptime: %w", err)
 	}
-	return time.Now().Add(-time.Duration(uptime * float64(time.Second))), nil
+	return time.Duration(uptime * float64(time.Second)), nil
 }
 
 // readProc parses /proc/<pid>/stat. Format: `pid (comm) state ppid ...`.

--- a/internal/proctree/proctree_linux_test.go
+++ b/internal/proctree/proctree_linux_test.go
@@ -3,9 +3,9 @@
 package proctree
 
 import (
-	"errors"
 	"strings"
 	"testing"
+	"time"
 )
 
 // This file is linux-tagged because its subject is: /proc/uptime, and the
@@ -24,10 +24,10 @@ import (
 // health where there is no data; failing here manufactured NO DATA where there
 // is data.
 //
-// Boot time is unreadable only in the sense that matters: the test points the
-// backend at a path that does not exist, which is exactly what subset=pid
-// presents. StartedAt then stays zero and CPUFraction reports unknown — a
-// nice-to-have lost, loudly — while the table itself is intact.
+// Boot time is unreadable from procfs only: the test points the backend at a
+// path that does not exist, exactly what subset=pid presents. The kernel's
+// CLOCK_BOOTTIME must still supply StartedAt, because doctor uses process age
+// to distinguish durable leaks from teardown churn.
 func TestSnapshotSurvivesUnreadableBootTime(t *testing.T) {
 	child := startSleeper(t)
 
@@ -45,11 +45,15 @@ func TestSnapshotSurvivesUnreadableBootTime(t *testing.T) {
 			child.Process.Pid)
 	}
 
-	// And the part we genuinely lost must say so rather than read as idle.
 	p := snap[child.Process.Pid]
-	if _, _, err := CPUFraction(p); !errors.Is(err, ErrCPUUnknown) {
-		t.Errorf("CPUFraction without a boot time = %v, want ErrCPUUnknown: an unmeasurable process "+
-			"must never report as 0%% CPU, which is indistinguishable from idle", err)
+	if p.StartedAt.IsZero() {
+		t.Fatal("StartedAt is zero when /proc/uptime is hidden: subset=pid must fall back to CLOCK_BOOTTIME")
+	}
+	if age := time.Since(p.StartedAt); age < 0 || age > time.Minute {
+		t.Errorf("child age with CLOCK_BOOTTIME fallback = %s, want a recent process", age)
+	}
+	if _, _, err := CPUFraction(p); err != nil {
+		t.Errorf("CPUFraction with CLOCK_BOOTTIME fallback = %v, want a measurable process", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- require escaped, orphaned, and possible-orphan candidates to be at least one minute old at the process snapshot
- revalidate `(pid, start-id)` after the later tmux observation so a child that exits mid-run is not counted as escaped
- keep age/identity blindness visible as a non-actionable `process-leak-inspection` WARN instead of claiming either a leak or a clean scan
- preserve measurable process ages when Linux procfs uses `subset=pid` by falling back from hidden `/proc/uptime` to `CLOCK_BOOTTIME`

## Diagnosis and decision

The report was correct about the split observation: `Run` takes one process snapshot, then `checkOrphanedProcesses` later shells out to enumerate each live tmux pane tree. A real private-tmux regression now proves that a pane child can be alive and marked in the first observation, exit before `list-panes`, and be reported as escaped by the old code.

The durable signal is persistence, not one mismatched sample. This PR uses a one-minute snapshot-relative threshold: it is much longer than ordinary doctor/teardown churn, while the independently enumerated genuine escapees were 8 hours to 10 days old. The threshold applies to all three populations sharing the sample (`escaped-process`, `orphaned-process`, and `possible-orphan`) so the headline total cannot keep flickering through an ungated sibling path. Identity is also revalidated immediately before reporting; this directly closes the between-observations race without a retry or settle loop.

Age is measured against the instant before the snapshot, not wall time later in the run, so doctor's own shell-outs cannot age a process across the threshold. A missing age or failed identity read produces a visible advisory UNKNOWN row and remains non-actionable. On Linux `subset=pid`, age is still provable: `CLOCK_BOOTTIME` supplies the same boot-relative clock when procfs hides its global uptime file, preserving specific leak and `--fix` findings.

Adjacent audit: `runaway-cpu` is deliberately excluded. It already requires 30 minutes of measured age and starts from a current live-pane enumeration, rather than joining the shared process snapshot to later pane state.

## Fail-first evidence

Against the unmodified detector:

```text
--- FAIL: TestLiveSessionTransientChildIsNotReportedAsEscaped
Should be empty, but was [{escaped-process pid 134 (sleep) escaped the pane tree of live session af_doctor-transient-child ...}]

--- FAIL: TestYoungProcessesExcludedFromEveryLeakPopulation
Should be empty, but was [{escaped-process pid 154 (sh, 0% CPU over 0s) ...}]

--- FAIL: TestUnknownProcessAgeIsReportedWithoutClaimingALeak
Should be empty, but was [{orphaned-process pid 135 (sh) ... was spawned by dead session af_doctor-age-unknown ...}]
```

Against reviewed head `52378eb0`, before resolving the subset=pid review finding:

```text
--- FAIL: TestSnapshotSurvivesUnreadableBootTime
StartedAt is zero when /proc/uptime is hidden: subset=pid must fall back to CLOCK_BOOTTIME
```

The self-observation test uses a real tmux server on an isolated socket and a real child spawned inside the live pane; no default tmux server is touched. The subset=pid regression hides the real proc uptime path, matching that mount's production error shape, and obtains age from the real kernel clock.

## Verification

Exact pushed head: `c38954c91234a3adde7461c5dc921d075a73aeda`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- focused regressions and full `doctor` + `internal/proctree` packages through `scripts/testbox.sh`
- `make test-container` (run last on the exact pushed head)

Closes #2627