### PR TITLE
fix(web): escape application mouse capture

### DIFF
--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -1317,6 +1317,29 @@ body {
 .af-pane-host .xterm {
   height: 100%;
 }
+.af-mouse-capture-hint {
+  position: absolute;
+  right: var(--af-sp-2);
+  bottom: var(--af-sp-2);
+  z-index: 5;
+  max-width: calc(100% - 2 * var(--af-sp-2));
+  padding: var(--af-sp-1) var(--af-sp-2);
+  border: 1px solid var(--af-border);
+  border-radius: var(--af-r-sm);
+  background: var(--af-bg-surface);
+  color: var(--af-text);
+  box-shadow: var(--af-shadow-sm);
+  font-size: var(--af-fs-sm);
+  line-height: 1.25;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(0.25rem);
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+.af-mouse-capture-hint.af-visible {
+  opacity: 0.96;
+  transform: translateY(0);
+}
 .af-webpane {
   display: flex;
   flex-direction: column;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7280,6 +7280,29 @@ function terminalUserScrollPlan(source, hasScheduledVisibleFit) {
   }
 }
 
+// src/terminal-mouse.ts
+function terminalMouseOverride(platform) {
+  return /Mac|iPhone|iPad|iPod/i.test(platform) ? "Option" : "Shift";
+}
+function terminalMouseOverrideHeld(event, override) {
+  return override === "Option" ? event.altKey : event.shiftKey;
+}
+function historyWheelPlan(event, rows, rowHeight, remainder) {
+  if (event.deltaY === 0) {
+    return { lines: 0, remainder };
+  }
+  let rowDelta = event.deltaY;
+  if (event.deltaMode === 0) {
+    rowDelta /= Math.max(1, rowHeight);
+  } else if (event.deltaMode === 2) {
+    rowDelta *= Math.max(1, rows);
+  }
+  const total = remainder + rowDelta;
+  const wholeRows = total < 0 ? Math.ceil(total) : Math.floor(total);
+  const lines = Object.is(wholeRows, -0) ? 0 : wholeRows;
+  return { lines, remainder: total - lines };
+}
+
 // src/theme.ts
 var THEME_CHOICES = ["auto", "light", "dark"];
 var STORAGE_KEY = "af-theme";
@@ -7409,6 +7432,7 @@ var AttachTerminal = class {
     this.token = token2;
     this.endpoint = endpoint;
     this.cb = cb;
+    this.mouseOverride = terminalMouseOverride(navigator.platform);
     this.term = new import_xterm.Terminal({
       allowProposedApi: true,
       cursorBlink: true,
@@ -7419,11 +7443,22 @@ var AttachTerminal = class {
       theme: currentXtermTheme(),
       // The stream is the source of truth; local echo/scrollback beyond the ring is
       // fine but the server never sees our convert-eol, so leave it raw.
-      scrollback: 5e3
+      scrollback: 5e3,
+      // xterm uses Shift to force selection outside macOS. Opt macOS into its
+      // matching Option escape so every platform can leave app mouse mode.
+      macOptionClickForcesSelection: true
     });
     this.fit = new import_addon_fit.FitAddon();
     this.term.loadAddon(this.fit);
     this.term.open(container);
+    this.mouseCaptureHint = document.createElement("div");
+    this.mouseCaptureHint.className = "af-mouse-capture-hint";
+    this.mouseCaptureHint.setAttribute("role", "status");
+    this.mouseCaptureHint.setAttribute("aria-live", "polite");
+    this.mouseCaptureHint.setAttribute("aria-hidden", "true");
+    this.mouseCaptureHint.textContent = `App mouse active \xB7 Hold ${this.mouseOverride} to select or scroll`;
+    this.term.element?.append(this.mouseCaptureHint);
+    this.term.attachCustomWheelEventHandler((event) => this.handleHistoryWheel(event));
     const textarea = this.term.textarea;
     if (textarea) {
       textarea.addEventListener("focus", () => {
@@ -7432,14 +7467,19 @@ var AttachTerminal = class {
         }
       });
       textarea.addEventListener("blur", () => {
+        this.mouseOverrideKeyHeld = false;
         if (!this.stopped) {
           this.cb.onFocusChange(false);
         }
       });
     }
     this.term.onData((data) => this.sendInput(data));
-    this.term.attachCustomKeyEventHandler(
-      (ev) => handleClipboardKeydown(ev, {
+    this.term.attachCustomKeyEventHandler((ev) => {
+      const overrideKey = this.mouseOverride === "Option" ? "Alt" : "Shift";
+      if (ev.key === overrideKey) {
+        this.mouseOverrideKeyHeld = ev.type !== "keyup";
+      }
+      return handleClipboardKeydown(ev, {
         composerNewline: this.endpoint.composerNewline,
         hasSelection: () => this.term.hasSelection(),
         getSelection: () => this.term.getSelection(),
@@ -7449,8 +7489,8 @@ var AttachTerminal = class {
         // Public Terminal.input(..., true) is xterm's genuine-user-input path:
         // it scrolls to bottom and clears selection, then fires onData above.
         sendUserInput: (text) => this.term.input(text, true)
-      })
-    );
+      });
+    });
     this.ro = new ResizeObserver(() => this.scheduleFit());
     this.ro.observe(container);
     this.io = new IntersectionObserver((entries) => {
@@ -7481,6 +7521,11 @@ var AttachTerminal = class {
   resizeTimer = null;
   visibleFitFrame = null;
   viewportRestoreFrame = null;
+  mouseOverride;
+  mouseCaptureHint;
+  mouseCaptureHintTimer = null;
+  mouseOverrideKeyHeld = false;
+  historyWheelRemainder = 0;
   // Incremented only by an actual user scroll input while a peer-owned anchor is
   // pending. Output and resize reflows can move viewportY too, so position deltas
   // alone do not prove that a user intended to override the saved reading line.
@@ -7518,9 +7563,17 @@ var AttachTerminal = class {
   // PTY without the pointer ever leaving this pane. Capture repairs that less-common
   // path; pointer entry above handles the ordinary first gesture. The pending-peer
   // gate makes every ordinary input a no-op before even measuring layout.
-  onWheel = () => this.handleUserScroll("wheel");
+  onWheel = (event) => {
+    this.handleUserScroll("wheel");
+    if (!terminalMouseOverrideHeld(event, this.mouseOverride) && this.applicationOwnsMouse()) {
+      this.showMouseCaptureHint();
+    }
+  };
   onTouchMove = () => this.handleUserScroll("touch");
   onPointerDown = (event) => {
+    if (!terminalMouseOverrideHeld(event, this.mouseOverride) && this.applicationOwnsMouse()) {
+      this.showMouseCaptureHint();
+    }
     if (event.target === this.container.querySelector(".xterm-viewport")) {
       this.handleUserScroll("scrollbar");
     }
@@ -7540,6 +7593,10 @@ var AttachTerminal = class {
    *  disconnects the observer, and disposes xterm (freeing its DOM/renderer). */
   dispose() {
     this.stopped = true;
+    if (this.mouseCaptureHintTimer !== null) {
+      window.clearTimeout(this.mouseCaptureHintTimer);
+      this.mouseCaptureHintTimer = null;
+    }
     if (this.reconnectTimer !== null) {
       window.clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
@@ -7560,6 +7617,35 @@ var AttachTerminal = class {
     this.container.removeEventListener("pointerdown", this.onPointerDown, true);
     this.closeSocket();
     this.term.dispose();
+  }
+  applicationOwnsMouse() {
+    return this.term.modes.mouseTrackingMode !== "none";
+  }
+  showMouseCaptureHint() {
+    this.mouseCaptureHint.classList.add("af-visible");
+    this.mouseCaptureHint.setAttribute("aria-hidden", "false");
+    if (this.mouseCaptureHintTimer !== null) {
+      window.clearTimeout(this.mouseCaptureHintTimer);
+    }
+    this.mouseCaptureHintTimer = window.setTimeout(() => {
+      this.mouseCaptureHint.classList.remove("af-visible");
+      this.mouseCaptureHint.setAttribute("aria-hidden", "true");
+      this.mouseCaptureHintTimer = null;
+    }, 4e3);
+  }
+  handleHistoryWheel(event) {
+    if (!terminalMouseOverrideHeld(event, this.mouseOverride) && !this.mouseOverrideKeyHeld) {
+      return true;
+    }
+    const renderedRow = this.container.querySelector(".xterm-rows > div");
+    const rowHeight = renderedRow?.getBoundingClientRect().height ?? (this.term.options.fontSize ?? 13) * 1.2;
+    const plan = historyWheelPlan(event, this.term.rows, rowHeight, this.historyWheelRemainder);
+    this.historyWheelRemainder = plan.remainder;
+    if (plan.lines !== 0) {
+      this.term.scrollLines(plan.lines);
+    }
+    event.preventDefault();
+    return false;
   }
   /** Gives the terminal the keyboard (focuses xterm's helper textarea) so typed
    *  keys reach the agent — the attach half of the #1693 nav/attach model. */

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7282,7 +7282,7 @@ function terminalUserScrollPlan(source, hasScheduledVisibleFit) {
 
 // src/terminal-mouse.ts
 function terminalMouseOverride(platform) {
-  return /Mac|iPhone|iPad|iPod/i.test(platform) ? "Option" : "Shift";
+  return ["Macintosh", "MacIntel", "MacPPC", "Mac68K"].includes(platform) ? "Option" : "Shift";
 }
 function terminalMouseOverrideHeld(event, override) {
   return override === "Option" ? event.altKey : event.shiftKey;
@@ -7500,6 +7500,7 @@ var AttachTerminal = class {
     });
     this.io.observe(container);
     window.addEventListener("focus", this.onWindowFocus);
+    window.addEventListener("blur", this.onWindowBlur);
     document.addEventListener("visibilitychange", this.onVisibilityChange);
     container.addEventListener("pointerenter", this.onPointerEnter);
     container.addEventListener("wheel", this.onWheel, { capture: true, passive: true });
@@ -7550,9 +7551,14 @@ var AttachTerminal = class {
   // becomes the local writer: refit once instead of leaving a peer-sized emulator in
   // an unchanged container until the user physically resizes the window (#2347).
   onWindowFocus = () => this.scheduleVisibleFit();
+  onWindowBlur = () => {
+    this.mouseOverrideKeyHeld = false;
+  };
   onVisibilityChange = () => {
     if (document.visibilityState === "visible") {
       this.scheduleVisibleFit();
+    } else {
+      this.mouseOverrideKeyHeld = false;
     }
   };
   // Entering a pane is the earliest reliable activation signal for side-by-side
@@ -7571,11 +7577,13 @@ var AttachTerminal = class {
   };
   onTouchMove = () => this.handleUserScroll("touch");
   onPointerDown = (event) => {
+    const viewport = this.container.querySelector(".xterm-viewport");
+    if (event.target === viewport) {
+      this.handleUserScroll("scrollbar");
+      return;
+    }
     if (!terminalMouseOverrideHeld(event, this.mouseOverride) && this.applicationOwnsMouse()) {
       this.showMouseCaptureHint();
-    }
-    if (event.target === this.container.querySelector(".xterm-viewport")) {
-      this.handleUserScroll("scrollbar");
     }
   };
   handleUserScroll(source) {
@@ -7610,6 +7618,7 @@ var AttachTerminal = class {
     this.ro.disconnect();
     this.io.disconnect();
     window.removeEventListener("focus", this.onWindowFocus);
+    window.removeEventListener("blur", this.onWindowBlur);
     document.removeEventListener("visibilitychange", this.onVisibilityChange);
     this.container.removeEventListener("pointerenter", this.onPointerEnter);
     this.container.removeEventListener("wheel", this.onWheel, true);
@@ -7634,7 +7643,7 @@ var AttachTerminal = class {
     }, 4e3);
   }
   handleHistoryWheel(event) {
-    if (!terminalMouseOverrideHeld(event, this.mouseOverride) && !this.mouseOverrideKeyHeld) {
+    if (!this.applicationOwnsMouse() || !terminalMouseOverrideHeld(event, this.mouseOverride) && !this.mouseOverrideKeyHeld) {
       return true;
     }
     const renderedRow = this.container.querySelector(".xterm-rows > div");

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7571,7 +7571,7 @@ var AttachTerminal = class {
   // gate makes every ordinary input a no-op before even measuring layout.
   onWheel = (event) => {
     this.handleUserScroll("wheel");
-    if (!terminalMouseOverrideHeld(event, this.mouseOverride) && this.applicationOwnsMouse()) {
+    if (!terminalMouseOverrideHeld(event, this.mouseOverride) && !this.mouseOverrideKeyHeld && this.applicationOwnsWheel()) {
       this.showMouseCaptureHint();
     }
   };
@@ -7630,6 +7630,10 @@ var AttachTerminal = class {
   applicationOwnsMouse() {
     return this.term.modes.mouseTrackingMode !== "none";
   }
+  applicationOwnsWheel() {
+    const mode = this.term.modes.mouseTrackingMode;
+    return mode !== "none" && mode !== "x10";
+  }
   showMouseCaptureHint() {
     this.mouseCaptureHint.classList.add("af-visible");
     this.mouseCaptureHint.setAttribute("aria-hidden", "false");
@@ -7643,7 +7647,7 @@ var AttachTerminal = class {
     }, 4e3);
   }
   handleHistoryWheel(event) {
-    if (!this.applicationOwnsMouse() || !terminalMouseOverrideHeld(event, this.mouseOverride) && !this.mouseOverrideKeyHeld) {
+    if (!this.applicationOwnsWheel() || !terminalMouseOverrideHeld(event, this.mouseOverride) && !this.mouseOverrideKeyHeld) {
       return true;
     }
     const renderedRow = this.container.querySelector(".xterm-rows > div");

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "fa3f617d44d0";
+const VERSION = "1600f7b3d020";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "1600f7b3d020";
+const VERSION = "1435a6b9a722";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "1435a6b9a722";
+const VERSION = "2ba2679c4da8";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -1387,8 +1387,8 @@ test("#2681: application mouse mode offers a modifier escape for copy and histor
     await expect(mouseHint).not.toHaveClass(/af-visible/, { timeout: 5_000 });
     const beforeLatchedScroll = await viewport.evaluate((el) => el.scrollTop);
     await p.locator(".xterm-helper-textarea").dispatchEvent("keydown", { key: "Shift", shiftKey: true });
-    await p.mouse.wheel(0, -120);
-    await expect.poll(() => viewport.evaluate((el) => el.scrollTop), { message: "latched modifier scrolls history" }).toBeLessThan(beforeLatchedScroll);
+    await p.mouse.wheel(0, 120);
+    await expect.poll(() => viewport.evaluate((el) => el.scrollTop), { message: "latched modifier scrolls history" }).toBeGreaterThan(beforeLatchedScroll);
     await expect(mouseHint, "a successful latched override must not advertise its own modifier").not.toHaveClass(/af-visible/);
     await p.locator(".xterm-helper-textarea").dispatchEvent("keyup", { key: "Shift" });
 

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -1301,6 +1301,26 @@ test("#2681: application mouse mode offers a modifier escape for copy and histor
     await p.keyboard.up("Shift");
     expect(await viewport.evaluate((el) => el.scrollTop), "normal-mode modifier wheel stays xterm-owned").toBe(normalBottom);
 
+    // DECSET 9/X10 captures button-down only, not wheel. Its plain wheel must
+    // remain browser-owned, and its modifier wheel must retain xterm semantics.
+    await p.keyboard.type("printf '\\033[?9h'");
+    await p.keyboard.press("Enter");
+    await expect(xterm).toHaveClass(/enable-mouse-events/);
+    inputPayloads.length = 0;
+    const x10Bottom = await viewport.evaluate((el) => el.scrollTop);
+    await p.mouse.wheel(0, -900);
+    await expect.poll(() => viewport.evaluate((el) => el.scrollTop), { message: "X10 plain wheel stays browser-owned" }).toBeLessThan(x10Bottom);
+    expect(inputPayloads, "X10 does not report wheel bytes").toHaveLength(0);
+    const x10Scrolled = await viewport.evaluate((el) => el.scrollTop);
+    await p.keyboard.down("Shift");
+    await p.mouse.wheel(0, -900);
+    await p.keyboard.up("Shift");
+    expect(await viewport.evaluate((el) => el.scrollTop), "X10 modifier wheel keeps xterm behavior").toBe(x10Scrolled);
+    const mouseHint = host.locator(".af-mouse-capture-hint");
+    await expect(mouseHint, "X10 wheel never advertises an unnecessary escape").not.toHaveClass(/af-visible/);
+    await p.keyboard.type("printf '\\033[?9l'");
+    await p.keyboard.press("Enter");
+
     // A full-screen TUI enables DEC mouse tracking. Drive the real terminal mode,
     // rather than mocking pointer handlers, so xterm itself decides who owns each
     // event. This is the state-dependent boundary behind both reported symptoms.
@@ -1333,7 +1353,6 @@ test("#2681: application mouse mode offers a modifier escape for copy and histor
     // The UI must explain the escape at the moment a user hits the application-owned
     // pointer path. Selection and scroll then share one modifier rather than becoming
     // two unrelated fixes.
-    const mouseHint = host.locator(".af-mouse-capture-hint");
     await expect.soft(mouseHint).toHaveClass(/af-visible/, { timeout: 2_000 });
     await expect.soft(mouseHint).toHaveAttribute("aria-hidden", "false");
     await expect.soft(mouseHint).toContainText("Hold Shift to select or scroll");
@@ -1362,6 +1381,16 @@ test("#2681: application mouse mode offers a modifier escape for copy and histor
       })
       .toBeLessThan(beforeHistoryScroll);
     expect(inputPayloads, "the history override must not leak a wheel report to the application").toHaveLength(0);
+
+    // Chromium can omit modifier flags on a momentum wheel while xterm still has
+    // the matching keydown. The fallback must both scroll and suppress the hint.
+    await expect(mouseHint).not.toHaveClass(/af-visible/, { timeout: 5_000 });
+    const beforeLatchedScroll = await viewport.evaluate((el) => el.scrollTop);
+    await p.locator(".xterm-helper-textarea").dispatchEvent("keydown", { key: "Shift", shiftKey: true });
+    await p.mouse.wheel(0, -120);
+    await expect.poll(() => viewport.evaluate((el) => el.scrollTop), { message: "latched modifier scrolls history" }).toBeLessThan(beforeLatchedScroll);
+    await expect(mouseHint, "a successful latched override must not advertise its own modifier").not.toHaveClass(/af-visible/);
+    await p.locator(".xterm-helper-textarea").dispatchEvent("keyup", { key: "Shift" });
 
     // A key released while the page is unfocused never produces keyup here. Window
     // blur must clear the fallback latch or the next plain wheel would be stolen

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -1292,6 +1292,15 @@ test("#2681: application mouse mode offers a modifier escape for copy and histor
     await p.keyboard.press("Enter");
     await expect(host).toContainText("mouse-mode-80", { timeout: 15_000 });
 
+    // Outside application mouse mode, leave modifier-wheel semantics entirely to
+    // xterm. On Linux xterm intentionally treats Shift+wheel as a no-op; the af
+    // escape must not introduce a new scroll path in an ordinary shell.
+    const normalBottom = await viewport.evaluate((el) => el.scrollTop);
+    await p.keyboard.down("Shift");
+    await p.mouse.wheel(0, -900);
+    await p.keyboard.up("Shift");
+    expect(await viewport.evaluate((el) => el.scrollTop), "normal-mode modifier wheel stays xterm-owned").toBe(normalBottom);
+
     // A full-screen TUI enables DEC mouse tracking. Drive the real terminal mode,
     // rather than mocking pointer handlers, so xterm itself decides who owns each
     // event. This is the state-dependent boundary behind both reported symptoms.
@@ -1353,6 +1362,21 @@ test("#2681: application mouse mode offers a modifier escape for copy and histor
       })
       .toBeLessThan(beforeHistoryScroll);
     expect(inputPayloads, "the history override must not leak a wheel report to the application").toHaveLength(0);
+
+    // A key released while the page is unfocused never produces keyup here. Window
+    // blur must clear the fallback latch or the next plain wheel would be stolen
+    // from the mouse-aware application indefinitely.
+    await p.locator(".xterm-helper-textarea").dispatchEvent("keydown", { key: "Shift", shiftKey: true });
+    await p.evaluate(() => window.dispatchEvent(new Event("blur")));
+    inputPayloads.length = 0;
+    await p.mouse.wheel(0, -120);
+    await expect.poll(() => inputPayloads.length, { message: "plain wheel after window blur returns to the application" }).toBeGreaterThan(0);
+
+    // The scrollbar is browser-owned even while the application owns the screen.
+    // Once the prior hint expires, using that working control must not re-show it.
+    await expect(mouseHint).not.toHaveClass(/af-visible/, { timeout: 5_000 });
+    await viewport.dispatchEvent("pointerdown", { bubbles: true });
+    await expect(mouseHint, "a working scrollbar must not advertise an unnecessary modifier").not.toHaveClass(/af-visible/);
   } finally {
     try {
       await resetToAgentTab(p);

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -1255,6 +1255,118 @@ test("click-to-attach opens the xterm terminal and shows live output", REAL_FIXT
   await expect(page.locator(".af-term-head button", { hasText: "Kill" })).toHaveCount(0);
 });
 
+test("#2681: application mouse mode offers a modifier escape for copy and history scroll", REAL_FIXTURE, async ({
+  browser,
+}) => {
+  const ctx = await browser.newContext({ permissions: ["clipboard-read", "clipboard-write"] });
+  const p = await ctx.newPage();
+  const inputPayloads: number[][] = [];
+
+  p.on("websocket", (ws) => {
+    if (!ws.url().includes("/v1/sessions/") || !ws.url().includes("/stream")) {
+      return;
+    }
+    ws.on("framesent", ({ payload }) => {
+      const raw = typeof payload === "string" ? new TextEncoder().encode(payload) : new Uint8Array(payload);
+      const frame = decode(raw);
+      if (frame.op === Op.Input) {
+        inputPayloads.push(Array.from(frame.data));
+      }
+    });
+  });
+
+  try {
+    await openTokenless(p);
+    // Keep the suite's long-lived default page on A untouched. This test mutates
+    // B's tab roster in its isolated context and removes that tab in finally.
+    await row(p, SESSION_B).click();
+    await resetToAgentTab(p);
+    await createTerminalTab(p);
+    await expect(p.locator(".af-main")).toHaveAttribute("data-term-status", "open");
+
+    const host = p.locator(".af-term-host");
+    const xterm = host.locator(".xterm");
+    const viewport = host.locator(".xterm-viewport");
+    await host.click();
+    await p.keyboard.type("for i in $(seq 1 80); do printf 'mouse-mode-%s\\n' \"$i\"; done");
+    await p.keyboard.press("Enter");
+    await expect(host).toContainText("mouse-mode-80", { timeout: 15_000 });
+
+    // A full-screen TUI enables DEC mouse tracking. Drive the real terminal mode,
+    // rather than mocking pointer handlers, so xterm itself decides who owns each
+    // event. This is the state-dependent boundary behind both reported symptoms.
+    await p.keyboard.type("printf '\\033[?1000h\\033[?1006h'");
+    await p.keyboard.press("Enter");
+    await expect(xterm).toHaveClass(/enable-mouse-events/);
+
+    inputPayloads.length = 0;
+    const bottom = await viewport.evaluate((el) => el.scrollTop);
+    await host.hover();
+    await p.mouse.wheel(0, -900);
+    await expect.poll(() => inputPayloads.length, { message: "application mouse mode must receive the plain wheel" }).toBeGreaterThan(0);
+    expect(await viewport.evaluate((el) => el.scrollTop), "plain wheel is application-owned by design").toBe(bottom);
+
+    const newestRow = host.locator(".xterm-rows > div", { hasText: "mouse-mode-80" }).last();
+    await expect(newestRow).toBeVisible();
+    const rowBox = await newestRow.boundingBox();
+    expect(rowBox, "the visible output row must have selectable geometry").toBeTruthy();
+    const { x, y, width, height } = rowBox as { x: number; y: number; width: number; height: number };
+    const drag = async (): Promise<void> => {
+      await p.mouse.move(x + 4, y + height / 2);
+      await p.mouse.down();
+      await p.mouse.move(x + Math.min(width - 4, 150), y + height / 2, { steps: 8 });
+      await p.mouse.up();
+    };
+    await drag();
+    const selection = host.locator(".xterm-selection > div");
+    await expect(selection, "plain drag is also application-owned by design").toHaveCount(0);
+
+    // The UI must explain the escape at the moment a user hits the application-owned
+    // pointer path. Selection and scroll then share one modifier rather than becoming
+    // two unrelated fixes.
+    const mouseHint = host.locator(".af-mouse-capture-hint");
+    await expect.soft(mouseHint).toHaveClass(/af-visible/, { timeout: 2_000 });
+    await expect.soft(mouseHint).toHaveAttribute("aria-hidden", "false");
+    await expect.soft(mouseHint).toContainText("Hold Shift to select or scroll");
+
+    await p.keyboard.down("Shift");
+    await drag();
+    await p.keyboard.up("Shift");
+    await expect(selection, "Shift+drag must force terminal selection while the app owns the mouse").not.toHaveCount(0);
+
+    const beforeCopyInputs = inputPayloads.length;
+    await p.keyboard.press("Control+c");
+    await expect(selection, "copy clears the selection so the next Ctrl+C can interrupt").toHaveCount(0);
+    expect(inputPayloads, "copy must not send an interrupt or mouse bytes to the PTY").toHaveLength(beforeCopyInputs);
+    await expect
+      .poll(() => p.evaluate(() => navigator.clipboard.readText()), { message: "the forced selection must reach the clipboard" })
+      .toContain("mode-80");
+
+    const beforeHistoryScroll = await viewport.evaluate((el) => el.scrollTop);
+    inputPayloads.length = 0;
+    await p.keyboard.down("Shift");
+    await p.mouse.wheel(0, -900);
+    await p.keyboard.up("Shift");
+    await expect
+      .poll(() => viewport.evaluate((el) => el.scrollTop), {
+        message: "Shift+wheel must scroll terminal history while application mouse mode is active",
+      })
+      .toBeLessThan(beforeHistoryScroll);
+    expect(inputPayloads, "the history override must not leak a wheel report to the application").toHaveLength(0);
+  } finally {
+    try {
+      await resetToAgentTab(p);
+    } finally {
+      await ctx.close();
+    }
+    // The real-browser suite intentionally shares one long-lived page between
+    // serial tests. Restore its selection explicitly so this isolated B-tab
+    // exercise cannot perturb the #1694 keyboard flow that follows.
+    await row(page, SESSION_A).click();
+    await expect(row(page, SESSION_A)).toHaveClass(/af-row-selected/);
+  }
+});
+
 test("#2337: agent Shift+Enter preserves xterm input effects while shell keeps CR", REAL_FIXTURE, async ({
   browser,
 }) => {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1728,6 +1728,36 @@ body {
   height: 100%;
 }
 
+/* A mouse-aware TUI intentionally owns plain drag/wheel events. Surface the
+ * terminal-history escape only when the user hits that captured path; the hint is
+ * transient, pointer-inert, and lives inside xterm's positioned root (#2681). */
+.af-mouse-capture-hint {
+  position: absolute;
+  right: var(--af-sp-2);
+  bottom: var(--af-sp-2);
+  z-index: 5;
+  max-width: calc(100% - 2 * var(--af-sp-2));
+  padding: var(--af-sp-1) var(--af-sp-2);
+  border: 1px solid var(--af-border);
+  border-radius: var(--af-r-sm);
+  background: var(--af-bg-surface);
+  color: var(--af-text);
+  box-shadow: var(--af-shadow-sm);
+  font-size: var(--af-fs-sm);
+  line-height: 1.25;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(0.25rem);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
+}
+
+.af-mouse-capture-hint.af-visible {
+  opacity: 0.96;
+  transform: translateY(0);
+}
+
 /* A web/iframe tab: fills the pane host with a thin control bar above the frame. It
  * matches the terminal pane's treatment — the pane canvas is --af-bg-term (so the
  * .af-pane-host inset gutter blends seamlessly in both themes), with a raised

--- a/web/src/terminal-mouse.test.ts
+++ b/web/src/terminal-mouse.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { historyWheelPlan, terminalMouseOverride, terminalMouseOverrideHeld } from "./terminal-mouse.js";
+
+test("application-mouse escape matches xterm's platform selection modifier", () => {
+  assert.equal(terminalMouseOverride("Linux x86_64"), "Shift");
+  assert.equal(terminalMouseOverride("Win32"), "Shift");
+  assert.equal(terminalMouseOverride("MacIntel"), "Option");
+  assert.equal(terminalMouseOverride("iPad"), "Option");
+
+  assert.equal(terminalMouseOverrideHeld({ shiftKey: true, altKey: false }, "Shift"), true);
+  assert.equal(terminalMouseOverrideHeld({ shiftKey: false, altKey: true }, "Option"), true);
+  assert.equal(terminalMouseOverrideHeld({ shiftKey: true, altKey: false }, "Option"), false);
+});
+
+test("history wheel converts pixels, lines, and pages without losing trackpad fractions", () => {
+  assert.deepEqual(historyWheelPlan({ deltaY: -5, deltaMode: 0 }, 24, 10, 0), {
+    lines: 0,
+    remainder: -0.5,
+  });
+  assert.deepEqual(historyWheelPlan({ deltaY: -5, deltaMode: 0 }, 24, 10, -0.5), {
+    lines: -1,
+    remainder: 0,
+  });
+  assert.deepEqual(historyWheelPlan({ deltaY: 3, deltaMode: 1 }, 24, 10, 0), { lines: 3, remainder: 0 });
+  assert.deepEqual(historyWheelPlan({ deltaY: -1, deltaMode: 2 }, 24, 10, 0), { lines: -24, remainder: 0 });
+});

--- a/web/src/terminal-mouse.test.ts
+++ b/web/src/terminal-mouse.test.ts
@@ -7,7 +7,9 @@ test("application-mouse escape matches xterm's platform selection modifier", () 
   assert.equal(terminalMouseOverride("Linux x86_64"), "Shift");
   assert.equal(terminalMouseOverride("Win32"), "Shift");
   assert.equal(terminalMouseOverride("MacIntel"), "Option");
-  assert.equal(terminalMouseOverride("iPad"), "Option");
+  // Match xterm's own Platform.isMac predicate exactly. It classifies iPad
+  // separately, so selection remains Shift there even though it is Apple-made.
+  assert.equal(terminalMouseOverride("iPad"), "Shift");
 
   assert.equal(terminalMouseOverrideHeld({ shiftKey: true, altKey: false }, "Shift"), true);
   assert.equal(terminalMouseOverrideHeld({ shiftKey: false, altKey: true }, "Option"), true);

--- a/web/src/terminal-mouse.ts
+++ b/web/src/terminal-mouse.ts
@@ -21,7 +21,9 @@ export interface HistoryWheelPlan {
 
 /** xterm itself uses Option to force selection on macOS and Shift elsewhere. */
 export function terminalMouseOverride(platform: string): TerminalMouseOverride {
-  return /Mac|iPhone|iPad|iPod/i.test(platform) ? "Option" : "Shift";
+  // Keep this in lockstep with xterm 5.5 Platform.isMac. In particular, xterm
+  // classifies iPad separately and SelectionService therefore uses Shift there.
+  return ["Macintosh", "MacIntel", "MacPPC", "Mac68K"].includes(platform) ? "Option" : "Shift";
 }
 
 export function terminalMouseOverrideHeld(event: MouseModifierEvent, override: TerminalMouseOverride): boolean {

--- a/web/src/terminal-mouse.ts
+++ b/web/src/terminal-mouse.ts
@@ -1,0 +1,55 @@
+// Application mouse tracking deliberately gives a TUI the terminal's pointer.
+// These helpers define af's one escape hatch back to browser-owned selection and
+// scrollback without teaching the terminal component platform/delta arithmetic.
+
+export type TerminalMouseOverride = "Shift" | "Option";
+
+export interface MouseModifierEvent {
+  altKey: boolean;
+  shiftKey: boolean;
+}
+
+export interface HistoryWheelEvent {
+  deltaMode: number;
+  deltaY: number;
+}
+
+export interface HistoryWheelPlan {
+  lines: number;
+  remainder: number;
+}
+
+/** xterm itself uses Option to force selection on macOS and Shift elsewhere. */
+export function terminalMouseOverride(platform: string): TerminalMouseOverride {
+  return /Mac|iPhone|iPad|iPod/i.test(platform) ? "Option" : "Shift";
+}
+
+export function terminalMouseOverrideHeld(event: MouseModifierEvent, override: TerminalMouseOverride): boolean {
+  return override === "Option" ? event.altKey : event.shiftKey;
+}
+
+/** Convert browser wheel units into whole terminal rows while retaining sub-row
+ * trackpad motion for the next event. deltaMode follows WheelEvent: pixels=0,
+ * lines=1, pages=2. */
+export function historyWheelPlan(
+  event: HistoryWheelEvent,
+  rows: number,
+  rowHeight: number,
+  remainder: number,
+): HistoryWheelPlan {
+  if (event.deltaY === 0) {
+    return { lines: 0, remainder };
+  }
+
+  let rowDelta = event.deltaY;
+  if (event.deltaMode === 0) {
+    rowDelta /= Math.max(1, rowHeight);
+  } else if (event.deltaMode === 2) {
+    rowDelta *= Math.max(1, rows);
+  }
+
+  const total = remainder + rowDelta;
+  const wholeRows = total < 0 ? Math.ceil(total) : Math.floor(total);
+  const lines = Object.is(wholeRows, -0) ? 0 : wholeRows;
+  return { lines, remainder: total - lines };
+}

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -165,7 +165,11 @@ export class AttachTerminal {
   // gate makes every ordinary input a no-op before even measuring layout.
   private readonly onWheel = (event: WheelEvent): void => {
     this.handleUserScroll("wheel");
-    if (!terminalMouseOverrideHeld(event, this.mouseOverride) && this.applicationOwnsMouse()) {
+    if (
+      !terminalMouseOverrideHeld(event, this.mouseOverride) &&
+      !this.mouseOverrideKeyHeld &&
+      this.applicationOwnsWheel()
+    ) {
       this.showMouseCaptureHint();
     }
   };
@@ -348,6 +352,13 @@ export class AttachTerminal {
     return this.term.modes.mouseTrackingMode !== "none";
   }
 
+  private applicationOwnsWheel(): boolean {
+    const mode = this.term.modes.mouseTrackingMode;
+    // DECSET 9/X10 reports button-down only. xterm keeps wheel events for
+    // scrollback there; VT200, drag, and any-event modes report wheel input.
+    return mode !== "none" && mode !== "x10";
+  }
+
   private showMouseCaptureHint(): void {
     this.mouseCaptureHint.classList.add("af-visible");
     this.mouseCaptureHint.setAttribute("aria-hidden", "false");
@@ -366,7 +377,7 @@ export class AttachTerminal {
     // remains down (notably through automation and trackpad momentum). xterm sees
     // the matching keydown/up, so retain that state as the authoritative fallback.
     if (
-      !this.applicationOwnsMouse() ||
+      !this.applicationOwnsWheel() ||
       (!terminalMouseOverrideHeld(event, this.mouseOverride) && !this.mouseOverrideKeyHeld)
     ) {
       return true;

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -144,9 +144,15 @@ export class AttachTerminal {
   // becomes the local writer: refit once instead of leaving a peer-sized emulator in
   // an unchanged container until the user physically resizes the window (#2347).
   private readonly onWindowFocus = (): void => this.scheduleVisibleFit();
+  private readonly onWindowBlur = (): void => {
+    // A modifier released in another tab/window never sends this terminal keyup.
+    this.mouseOverrideKeyHeld = false;
+  };
   private readonly onVisibilityChange = (): void => {
     if (document.visibilityState === "visible") {
       this.scheduleVisibleFit();
+    } else {
+      this.mouseOverrideKeyHeld = false;
     }
   };
   // Entering a pane is the earliest reliable activation signal for side-by-side
@@ -165,14 +171,16 @@ export class AttachTerminal {
   };
   private readonly onTouchMove = (): void => this.handleUserScroll("touch");
   private readonly onPointerDown = (event: PointerEvent): void => {
-    if (!terminalMouseOverrideHeld(event, this.mouseOverride) && this.applicationOwnsMouse()) {
-      this.showMouseCaptureHint();
-    }
     // The xterm screen is a sibling of its scrollable viewport. A pointer whose
     // target is the viewport itself is therefore a scrollbar/track gesture, while
     // an ordinary terminal click targets the screen and keeps the saved anchor.
-    if (event.target === this.container.querySelector(".xterm-viewport")) {
+    const viewport = this.container.querySelector(".xterm-viewport");
+    if (event.target === viewport) {
       this.handleUserScroll("scrollbar");
+      return;
+    }
+    if (!terminalMouseOverrideHeld(event, this.mouseOverride) && this.applicationOwnsMouse()) {
+      this.showMouseCaptureHint();
     }
   };
 
@@ -296,6 +304,7 @@ export class AttachTerminal {
     });
     this.io.observe(container);
     window.addEventListener("focus", this.onWindowFocus);
+    window.addEventListener("blur", this.onWindowBlur);
     document.addEventListener("visibilitychange", this.onVisibilityChange);
     container.addEventListener("pointerenter", this.onPointerEnter);
     container.addEventListener("wheel", this.onWheel, { capture: true, passive: true });
@@ -325,6 +334,7 @@ export class AttachTerminal {
     this.ro.disconnect();
     this.io.disconnect();
     window.removeEventListener("focus", this.onWindowFocus);
+    window.removeEventListener("blur", this.onWindowBlur);
     document.removeEventListener("visibilitychange", this.onVisibilityChange);
     this.container.removeEventListener("pointerenter", this.onPointerEnter);
     this.container.removeEventListener("wheel", this.onWheel, true);
@@ -355,7 +365,10 @@ export class AttachTerminal {
     // Chromium's wheel event can omit modifier flags even while the keyboard key
     // remains down (notably through automation and trackpad momentum). xterm sees
     // the matching keydown/up, so retain that state as the authoritative fallback.
-    if (!terminalMouseOverrideHeld(event, this.mouseOverride) && !this.mouseOverrideKeyHeld) {
+    if (
+      !this.applicationOwnsMouse() ||
+      (!terminalMouseOverrideHeld(event, this.mouseOverride) && !this.mouseOverrideKeyHeld)
+    ) {
       return true;
     }
 

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -50,6 +50,12 @@ import {
   viewportAnchorLine,
   viewportMarkerOffset,
 } from "./terminal-geometry.js";
+import {
+  historyWheelPlan,
+  terminalMouseOverride,
+  terminalMouseOverrideHeld,
+  type TerminalMouseOverride,
+} from "./terminal-mouse.js";
 import type { StreamEndpoint } from "./stream_endpoint.js";
 import { currentXtermTheme } from "./theme.js";
 
@@ -107,6 +113,11 @@ export class AttachTerminal {
   private resizeTimer: number | null = null;
   private visibleFitFrame: number | null = null;
   private viewportRestoreFrame: number | null = null;
+  private readonly mouseOverride: TerminalMouseOverride;
+  private readonly mouseCaptureHint: HTMLDivElement;
+  private mouseCaptureHintTimer: number | null = null;
+  private mouseOverrideKeyHeld = false;
+  private historyWheelRemainder = 0;
   // Incremented only by an actual user scroll input while a peer-owned anchor is
   // pending. Output and resize reflows can move viewportY too, so position deltas
   // alone do not prove that a user intended to override the saved reading line.
@@ -146,9 +157,17 @@ export class AttachTerminal {
   // PTY without the pointer ever leaving this pane. Capture repairs that less-common
   // path; pointer entry above handles the ordinary first gesture. The pending-peer
   // gate makes every ordinary input a no-op before even measuring layout.
-  private readonly onWheel = (): void => this.handleUserScroll("wheel");
+  private readonly onWheel = (event: WheelEvent): void => {
+    this.handleUserScroll("wheel");
+    if (!terminalMouseOverrideHeld(event, this.mouseOverride) && this.applicationOwnsMouse()) {
+      this.showMouseCaptureHint();
+    }
+  };
   private readonly onTouchMove = (): void => this.handleUserScroll("touch");
   private readonly onPointerDown = (event: PointerEvent): void => {
+    if (!terminalMouseOverrideHeld(event, this.mouseOverride) && this.applicationOwnsMouse()) {
+      this.showMouseCaptureHint();
+    }
     // The xterm screen is a sibling of its scrollable viewport. A pointer whose
     // target is the viewport itself is therefore a scrollbar/track gesture, while
     // an ordinary terminal click targets the screen and keeps the saved anchor.
@@ -178,6 +197,7 @@ export class AttachTerminal {
     private readonly endpoint: StreamEndpoint,
     private readonly cb: TerminalCallbacks,
   ) {
+    this.mouseOverride = terminalMouseOverride(navigator.platform);
     this.term = new Terminal({
       allowProposedApi: true,
       cursorBlink: true,
@@ -189,10 +209,25 @@ export class AttachTerminal {
       // The stream is the source of truth; local echo/scrollback beyond the ring is
       // fine but the server never sees our convert-eol, so leave it raw.
       scrollback: 5000,
+      // xterm uses Shift to force selection outside macOS. Opt macOS into its
+      // matching Option escape so every platform can leave app mouse mode.
+      macOptionClickForcesSelection: true,
     });
     this.fit = new FitAddon();
     this.term.loadAddon(this.fit);
     this.term.open(container);
+    this.mouseCaptureHint = document.createElement("div");
+    this.mouseCaptureHint.className = "af-mouse-capture-hint";
+    this.mouseCaptureHint.setAttribute("role", "status");
+    this.mouseCaptureHint.setAttribute("aria-live", "polite");
+    this.mouseCaptureHint.setAttribute("aria-hidden", "true");
+    this.mouseCaptureHint.textContent = `App mouse active · Hold ${this.mouseOverride} to select or scroll`;
+    this.term.element?.append(this.mouseCaptureHint);
+
+    // xterm normally forwards every wheel to a mouse-aware application and
+    // cancels browser scrollback. The selection modifier instead scrolls terminal
+    // history, so copy and scroll share one discoverable escape (#2681).
+    this.term.attachCustomWheelEventHandler((event) => this.handleHistoryWheel(event));
 
     // Report focus/blur of xterm's helper textarea so index.ts can track which pane
     // owns the keyboard (#1693) even when the user clicks straight into the terminal
@@ -206,6 +241,7 @@ export class AttachTerminal {
         }
       });
       textarea.addEventListener("blur", () => {
+        this.mouseOverrideKeyHeld = false;
         if (!this.stopped) {
           this.cb.onFocusChange(false);
         }
@@ -223,8 +259,12 @@ export class AttachTerminal {
     // xterm's CR. Ctrl+C copies a present selection (else interrupts),
     // Ctrl+Shift+C is explicit copy, and Ctrl+V defers to native paste. False
     // suppresses xterm's own handling.
-    this.term.attachCustomKeyEventHandler((ev) =>
-      handleClipboardKeydown(ev, {
+    this.term.attachCustomKeyEventHandler((ev) => {
+      const overrideKey = this.mouseOverride === "Option" ? "Alt" : "Shift";
+      if (ev.key === overrideKey) {
+        this.mouseOverrideKeyHeld = ev.type !== "keyup";
+      }
+      return handleClipboardKeydown(ev, {
         composerNewline: this.endpoint.composerNewline,
         hasSelection: () => this.term.hasSelection(),
         getSelection: () => this.term.getSelection(),
@@ -234,8 +274,8 @@ export class AttachTerminal {
         // Public Terminal.input(..., true) is xterm's genuine-user-input path:
         // it scrolls to bottom and clears selection, then fires onData above.
         sendUserInput: (text) => this.term.input(text, true),
-      }),
-    );
+      });
+    });
 
     // Re-fit + re-announce size whenever the container changes (window resize,
     // rail collapse, devtools). Debounced; the server echo reconciles multi-writer.
@@ -268,6 +308,10 @@ export class AttachTerminal {
    *  disconnects the observer, and disposes xterm (freeing its DOM/renderer). */
   dispose(): void {
     this.stopped = true;
+    if (this.mouseCaptureHintTimer !== null) {
+      window.clearTimeout(this.mouseCaptureHintTimer);
+      this.mouseCaptureHintTimer = null;
+    }
     if (this.reconnectTimer !== null) {
       window.clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
@@ -288,6 +332,42 @@ export class AttachTerminal {
     this.container.removeEventListener("pointerdown", this.onPointerDown, true);
     this.closeSocket();
     this.term.dispose();
+  }
+
+  private applicationOwnsMouse(): boolean {
+    return this.term.modes.mouseTrackingMode !== "none";
+  }
+
+  private showMouseCaptureHint(): void {
+    this.mouseCaptureHint.classList.add("af-visible");
+    this.mouseCaptureHint.setAttribute("aria-hidden", "false");
+    if (this.mouseCaptureHintTimer !== null) {
+      window.clearTimeout(this.mouseCaptureHintTimer);
+    }
+    this.mouseCaptureHintTimer = window.setTimeout(() => {
+      this.mouseCaptureHint.classList.remove("af-visible");
+      this.mouseCaptureHint.setAttribute("aria-hidden", "true");
+      this.mouseCaptureHintTimer = null;
+    }, 4_000);
+  }
+
+  private handleHistoryWheel(event: WheelEvent): boolean {
+    // Chromium's wheel event can omit modifier flags even while the keyboard key
+    // remains down (notably through automation and trackpad momentum). xterm sees
+    // the matching keydown/up, so retain that state as the authoritative fallback.
+    if (!terminalMouseOverrideHeld(event, this.mouseOverride) && !this.mouseOverrideKeyHeld) {
+      return true;
+    }
+
+    const renderedRow = this.container.querySelector<HTMLElement>(".xterm-rows > div");
+    const rowHeight = renderedRow?.getBoundingClientRect().height ?? (this.term.options.fontSize ?? 13) * 1.2;
+    const plan = historyWheelPlan(event, this.term.rows, rowHeight, this.historyWheelRemainder);
+    this.historyWheelRemainder = plan.remainder;
+    if (plan.lines !== 0) {
+      this.term.scrollLines(plan.lines);
+    }
+    event.preventDefault();
+    return false;
   }
 
   /** Gives the terminal the keyboard (focuses xterm's helper textarea) so typed


### PR DESCRIPTION
## Summary

- confirm xterm application mouse tracking is the shared cause of suppressed native selection and history scrolling
- preserve plain pointer and wheel input for mouse-aware TUIs while making Shift on xterm non-Mac platforms and Option on xterm Mac platforms a shared selection and scrollback escape
- show a transient hint only when a captured screen gesture occurs, without changing normal-shell, X10 wheel, or scrollbar behavior
- clear the modifier fallback on blur or hidden so a missed keyup cannot latch the override

## Fail-first evidence

The new Playwright case enabled DEC 1000 and SGR 1006 mouse tracking in a real terminal. Against the pre-fix bundle it proved that plain wheel emitted PTY input without moving scrollback and plain drag made no selection, then failed because the escape hint was absent and Shift-wheel left scrollTop unchanged at 799.

The review regressions also failed first: unit coverage caught iPad being assigned Option despite xterm using Shift, browser coverage caught modifier-wheel interception outside mouse tracking, and follow-up coverage pinned X10 wheel ownership plus missed-keyup hint behavior.

## Verification

- make web-test: 459 passed
- make web-build
- make web-selftest-container: 127 passed
- golangci-lint run --timeout=3m --fast
- gofmt -l .
- go build ./...
- deadcode -test ./...
- scripts/lint-file-length.sh
- make test-container: passed last against pushed head 31ce23f9957d1090835bfd5f80dc0484eba26c9f

Closes #2681