### PR TITLE
fix(tui): skip repo state restore in registry mode

### DIFF
--- a/app/tui_state.go
+++ b/app/tui_state.go
@@ -20,6 +20,14 @@ const tuiFocusRegionPane = "pane"
 // after the daemon snapshot has populated the projection. It never fails the
 // launch; unreadable state files fall back to the ordinary cold-start path.
 func (m *home) restoreTUIViewStateOnLaunch() int {
+	// Registry mode has no active repository and therefore no repo-scoped view
+	// state. An empty repo ID is the mode's sentinel, not a malformed persisted
+	// key, so do not send it through the config validator and manufacture a
+	// warning on every supported outside-a-repo launch.
+	if m.repoID == "" {
+		m.rememberTUIViewState()
+		return 0
+	}
 	state, ok := config.LoadTUIRepoViewState(m.repoID)
 	restored := 0
 	if ok {

--- a/app/tui_state_test.go
+++ b/app/tui_state_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -13,6 +14,17 @@ import (
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 )
+
+func TestNewHomeRegistryModeSkipsRepoScopedTUIViewState(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	warnings := captureWarningLog(t)
+
+	h := newHome(context.Background(), "bash", nil)
+
+	require.Empty(t, h.repoID, "a nil repo must exercise registry mode")
+	require.NotContains(t, warnings.String(), "invalid repo id: empty",
+		"registry mode has no repo-scoped TUI state to restore")
+}
 
 func TestTUIViewStateRestorePanesSelectionAndFocus(t *testing.T) {
 	h := newTestHome(t)

--- a/app/tui_state_test.go
+++ b/app/tui_state_test.go
@@ -18,6 +18,14 @@ import (
 func TestNewHomeRegistryModeSkipsRepoScopedTUIViewState(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	warnings := captureWarningLog(t)
+	// Unlike newTestHome, this drives the REAL newHome — which is the point, since
+	// the regression is in its launch sequence. That also means it reaches
+	// refreshSidebarProjects and the real cross-repo fetcher, so without a stub it
+	// spends the daemon HTTP timeout dialing a daemon no unit test has. Stub
+	// BEFORE newHome: the fetch happens during construction.
+	t.Cleanup(SetAllReposSnapshotFetcherForTest(func() ([]session.InstanceData, error) {
+		return nil, nil
+	}))
 
 	h := newHome(context.Background(), "bash", nil)
 

--- a/scripts/tui-2660-scenario.sh
+++ b/scripts/tui-2660-scenario.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Real-TUI regression for #2660, via:
+#
+#   scripts/testbox.sh scenario scripts/tui-2660-scenario.sh
+#
+# Registry mode is a supported launch from outside a git repository. It carries
+# an intentionally empty repo ID until the user selects a project, so startup
+# must not try to restore repo-scoped TUI state and report that sentinel as an
+# invalid persisted key.
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source /src/scripts/tui-driver.sh
+
+export AF_DRIVER_COLS=100 AF_DRIVER_ROWS=30
+nonrepo="$(mktemp -d "${TMPDIR:-/tmp}/af-2660-nonrepo.XXXXXX")"
+export AF_DRIVER_REPO="$nonrepo"
+
+cleanup() {
+    af_quit >/dev/null 2>&1 || true
+    rm -rf "$nonrepo"
+}
+trap cleanup EXIT
+
+af_reset_sandbox
+af_boot
+
+log_file="$AGENT_FACTORY_HOME/agent-factory.log"
+if grep -Fq 'invalid repo id: empty' "$log_file"; then
+    _af_fail '#2660: registry-mode startup treated its empty repo ID as invalid TUI state:'
+    grep -F 'invalid repo id: empty' "$log_file" >&2
+    exit 1
+fi
+
+_af_log 'assert OK: registry-mode startup emitted no empty-repo TUI-state warning'
+echo 'PASS: #2660 registry-mode startup skips repo-scoped TUI-state restore'


### PR DESCRIPTION
## What

Recognize registry mode's empty repository ID as the supported no-active-repository sentinel and skip repo-scoped TUI view-state restore. The ordinary cold-start state is remembered without passing the sentinel to persisted-key validation.

## Why

Launching af outside a repository is supported registry-mode behavior. The old startup path sent its intentional empty ID through the repo-state loader and emitted "invalid repo id: empty" as a warning.

## Red-first evidence

- Unit regression: warnings contained "failed to load TUI state: invalid repo id: empty".
- Real TUI scenario: "#2660: registry-mode startup treated its empty repo ID as invalid TUI state".

## Verification

Exact pushed head: 16a0315eaeb15575551d4e8d1680e578adb2db53

## Review round

Codex found that the regression drives the REAL `newHome` — deliberately, since the bug is in its launch sequence — and therefore reaches `refreshSidebarProjects` and the live cross-repo fetcher, paying the full daemon HTTP timeout on every unit-test run. Stubbing it with `SetAllReposSnapshotFetcherForTest` BEFORE `newHome` (the fetch happens during construction) took the test from 6.99s to 1.59s with the same assertions. Codex re-reviewed `16a0315eae` clean.

Verified on the original head (baf0d083f57dd7e20b196b79826061f946642aa8):

- scripts/testbox.sh scenario scripts/tui-2660-scenario.sh from a real non-repository directory
- affected app package suite
- golangci-lint run --timeout=3m --fast
- gofmt -l .
- go build ./...
- deadcode -test ./...
- scripts/lint-file-length.sh
- make test-container passed on the pre-rebase head

The follow-up commit is test-only; the exact head 16a0315e is covered by CI (Lint, Test, Test (macOS), Test (systemd) all green) plus a local `go test ./app/` run of the changed test.

Closes #2660
