### PR TITLE
fix(tmux): wait for Codex safety picker rendering

### DIFF
--- a/scripts/tmux-2673-scenario.sh
+++ b/scripts/tmux-2673-scenario.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /src
+go test ./session/tmux \
+  -run '^TestCheckAndHandleTrustPrompt_CodexSafetyWaitsForRealTmuxRender$' \
+  -count=1
+echo "PASS: #2673 delayed Codex rendering is verified on an isolated real tmux socket"

--- a/session/tmux/codex_safety.go
+++ b/session/tmux/codex_safety.go
@@ -7,7 +7,10 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 )
 
-const codexSafetyModelVerificationPolls = 30
+const (
+	codexSafetyModelVerificationPolls     = 30
+	codexSafetySelectionVerificationPolls = 3
+)
 
 const (
 	codexSafetyRetryLabel       = "Retry with a faster model"
@@ -28,6 +31,9 @@ type codexSafetyBufferingState struct {
 	modelChangedTo     string
 	verificationPolls  int
 	awaitingModelCheck bool
+	selectionTarget    string
+	selectionPolls     int
+	selectionFailed    bool
 	notified           bool
 }
 
@@ -67,6 +73,35 @@ func (t *TmuxSession) handleCodexSafetyBuffering(content string) bool {
 		return safetyPromptPresent
 	}
 
+	// Navigation and terminal painting are asynchronous. Once af has sent the
+	// cursor movement, do not send it again from the next Snapshot poll: a stale
+	// frame can otherwise make repeated Down keys overshoot the safe row. Keep
+	// failing closed until a later capture proves the literal target owns the
+	// cursor, and surface an error only when that proof stays absent for a
+	// bounded number of daemon polls.
+	if state.selectionTarget != "" {
+		if dialogPresent && codexSafetySelectionVerified(dialog, state.selectionTarget) {
+			if state.selectionFailed {
+				log.InfoLog.Printf(
+					"Codex session %q additional safety-check selection became verifiable after %d polls",
+					t.sanitizedName, state.selectionPolls,
+				)
+			}
+			state.clearSelectionVerification()
+		} else if safetyPromptPresent {
+			t.recordPendingCodexSafetySelection()
+			return true
+		} else {
+			state.clearSelectionVerification()
+			if model != "" {
+				state.observeModel(model)
+			}
+			state.notified = false
+			log.InfoLog.Printf("Codex session %q additional safety checks resolved before af accepted a choice", t.sanitizedName)
+			return true
+		}
+	}
+
 	if !dialogPresent {
 		if safetyPromptPresent {
 			if !state.notified {
@@ -104,6 +139,7 @@ func (t *TmuxSession) handleCodexSafetyBuffering(content string) bool {
 			log.ErrorLog.Printf("could not navigate Codex additional safety checks for session %q: %v", t.sanitizedName, err)
 			return true
 		}
+		state.beginSelectionVerification(dialog.targetLabel)
 
 		// Selection is a terminal UI state, not a numbered form value. Read
 		// the pane again and require the literal wait label to own the cursor
@@ -117,12 +153,10 @@ func (t *TmuxSession) handleCodexSafetyBuffering(content string) bool {
 		selectedDialog, stillPresent := parseCodexSafetyDialog(selectedContent, selectedTarget, selectedPromptActive)
 		if !stillPresent {
 			if selectedPromptPresent {
-				log.ErrorLog.Printf(
-					"refusing to accept Codex additional safety checks for session %q: could not prove the selected row while the picker remained visible",
-					t.sanitizedName,
-				)
+				t.recordPendingCodexSafetySelection()
 				return true
 			}
+			state.clearSelectionVerification()
 			if current := codexStatusLineModel(selectedContent); current != "" {
 				state.observeModel(current)
 			}
@@ -131,15 +165,11 @@ func (t *TmuxSession) handleCodexSafetyBuffering(content string) bool {
 			return true
 		}
 		dialog = selectedDialog
-	}
-
-	if dialog.selectedIndex != dialog.targetIndex ||
-		dialog.selectedIndex < 0 || dialog.labels[dialog.selectedIndex] != dialog.targetLabel {
-		log.ErrorLog.Printf(
-			"refusing to accept Codex additional safety checks for session %q: selected row is not %q",
-			t.sanitizedName, dialog.targetLabel,
-		)
-		return true
+		if !codexSafetySelectionVerified(dialog, state.selectionTarget) {
+			t.recordPendingCodexSafetySelection()
+			return true
+		}
+		state.clearSelectionVerification()
 	}
 
 	if err := t.tapPromptKeys("Enter"); err != nil {
@@ -150,6 +180,40 @@ func (t *TmuxSession) handleCodexSafetyBuffering(content string) bool {
 	state.verificationPolls = 0
 	state.awaitingModelCheck = true
 	return true
+}
+
+func codexSafetySelectionVerified(dialog codexSafetyDialog, target string) bool {
+	return target != "" &&
+		dialog.targetLabel == target &&
+		dialog.selectedIndex == dialog.targetIndex &&
+		dialog.selectedIndex >= 0 &&
+		dialog.selectedIndex < len(dialog.labels) &&
+		dialog.labels[dialog.selectedIndex] == target
+}
+
+func (t *TmuxSession) recordPendingCodexSafetySelection() {
+	state := &t.codexSafety
+	state.selectionPolls++
+	if state.selectionFailed || state.selectionPolls < codexSafetySelectionVerificationPolls {
+		return
+	}
+	state.selectionFailed = true
+	log.ErrorLog.Printf(
+		"refusing to accept Codex additional safety checks for session %q: could not verify %q as the selected row after %d polls",
+		t.sanitizedName, state.selectionTarget, state.selectionPolls,
+	)
+}
+
+func (s *codexSafetyBufferingState) beginSelectionVerification(target string) {
+	s.selectionTarget = target
+	s.selectionPolls = 0
+	s.selectionFailed = false
+}
+
+func (s *codexSafetyBufferingState) clearSelectionVerification() {
+	s.selectionTarget = ""
+	s.selectionPolls = 0
+	s.selectionFailed = false
 }
 
 func (t *TmuxSession) verifyCodexSafetyModel(model string, dialogPresent bool) {

--- a/session/tmux/codex_safety.go
+++ b/session/tmux/codex_safety.go
@@ -3,13 +3,25 @@ package tmux
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/log"
 )
 
 const (
-	codexSafetyModelVerificationPolls     = 30
-	codexSafetySelectionVerificationPolls = 3
+	codexSafetyModelVerificationPolls = 30
+	// codexSafetySelectionVerificationWindow bounds how long af waits for Codex
+	// to paint the row it just moved the cursor to before calling the selection
+	// unverifiable.
+	//
+	// It is a duration and not a poll count on purpose. This handler runs from
+	// the daemon's Snapshot poll, whose period is the operator-configurable
+	// daemon_poll_interval; a fixed number of captures therefore means anything
+	// from a fraction of a second to minutes. A 100ms interval would spend a
+	// three-poll budget before a 500ms repaint could possibly land and report
+	// ordinary rendering lag as a failed safety operation — the #2673 false
+	// ERROR, one layer down.
+	codexSafetySelectionVerificationWindow = 5 * time.Second
 )
 
 const (
@@ -18,6 +30,10 @@ const (
 	codexSafetyDismissWaitLabel = "Dismiss and keep waiting"
 	codexSafetyLearnLabel       = "Learn more"
 )
+
+// codexSafetyNow is time.Now, indirected so tests can drive the selection
+// verification window without sleeping through it.
+var codexSafetyNow = time.Now
 
 // codexSafetyBufferingState spans daemon Snapshot polls. Codex replaces its
 // normal composer with the picker, so its default model status line is no
@@ -32,6 +48,7 @@ type codexSafetyBufferingState struct {
 	verificationPolls  int
 	awaitingModelCheck bool
 	selectionTarget    string
+	selectionStarted   time.Time
 	selectionPolls     int
 	selectionFailed    bool
 	notified           bool
@@ -77,10 +94,18 @@ func (t *TmuxSession) handleCodexSafetyBuffering(content string) bool {
 	// cursor movement, do not send it again from the next Snapshot poll: a stale
 	// frame can otherwise make repeated Down keys overshoot the safe row. Keep
 	// failing closed until a later capture proves the literal target owns the
-	// cursor, and surface an error only when that proof stays absent for a
-	// bounded number of daemon polls.
+	// cursor, and surface an error only when that proof stays absent for the
+	// whole render window.
+	//
+	// The pending selection outlives every capture that does not answer the
+	// question. Only two things end it: the target row proven selected, or
+	// positive evidence the picker closed. Holding costs a session that stays
+	// blocked on a modal it was already blocked on, which the startup path
+	// bounds and reports; releasing early costs a second movement key af cannot
+	// take back.
 	if state.selectionTarget != "" {
-		if dialogPresent && codexSafetySelectionVerified(dialog, state.selectionTarget) {
+		switch {
+		case dialogPresent && codexSafetySelectionVerified(dialog, state.selectionTarget):
 			if state.selectionFailed {
 				log.InfoLog.Printf(
 					"Codex session %q additional safety-check selection became verifiable after %d polls",
@@ -88,10 +113,15 @@ func (t *TmuxSession) handleCodexSafetyBuffering(content string) bool {
 				)
 			}
 			state.clearSelectionVerification()
-		} else if safetyPromptPresent {
+		case safetyPromptPresent || !t.codexSafetyPickerProvenClosed():
+			// Either the picker is still on screen with the wrong row selected,
+			// or the capture matches no Codex shape at all because it landed
+			// mid-repaint. Both are pending renders. Releasing here on the
+			// second one would let the next complete-but-stale frame re-enter
+			// navigation below and send the same movement key twice.
 			t.recordPendingCodexSafetySelection()
 			return true
-		} else {
+		default:
 			state.clearSelectionVerification()
 			if model != "" {
 				state.observeModel(model)
@@ -152,7 +182,7 @@ func (t *TmuxSession) handleCodexSafetyBuffering(content string) bool {
 		selectedTarget, selectedPromptPresent, selectedPromptActive := t.inspectCodexSafetyPrompt(selectedContent)
 		selectedDialog, stillPresent := parseCodexSafetyDialog(selectedContent, selectedTarget, selectedPromptActive)
 		if !stillPresent {
-			if selectedPromptPresent {
+			if selectedPromptPresent || !t.codexSafetyPickerProvenClosed() {
 				t.recordPendingCodexSafetySelection()
 				return true
 			}
@@ -182,6 +212,28 @@ func (t *TmuxSession) handleCodexSafetyBuffering(content string) bool {
 	return true
 }
 
+// codexSafetyPickerProvenClosed reports POSITIVE evidence that Codex's modal
+// picker no longer owns the pane: a visible terminal cursor, which its
+// ListSelectionView never exposes and its ordinary composer always does. It is
+// the same oracle inspectCodexSafetyPrompt trusts to decide the picker IS
+// active, read in the other direction.
+//
+// The absence of the picker's chrome is deliberately not accepted as that
+// evidence. A capture can land while Codex has cleared the menu and not yet
+// finished repainting it, matching neither shape; treating that frame as a
+// resolved picker releases a selection af has already navigated and cannot
+// take back. An unreadable cursor is likewise not proof, so it holds too: this
+// runs only in the narrow window between af moving the cursor and seeing where
+// it landed, and every outcome of holding is recoverable while accepting the
+// wrong row is not.
+func (t *TmuxSession) codexSafetyPickerProvenClosed() bool {
+	cursor, err := t.readPaneCursorState()
+	if err != nil {
+		return false
+	}
+	return cursor.Visible
+}
+
 func codexSafetySelectionVerified(dialog codexSafetyDialog, target string) bool {
 	return target != "" &&
 		dialog.targetLabel == target &&
@@ -191,27 +243,34 @@ func codexSafetySelectionVerified(dialog codexSafetyDialog, target string) bool 
 		dialog.labels[dialog.selectedIndex] == target
 }
 
+// recordPendingCodexSafetySelection keeps a navigated-but-unproven selection
+// pending and escalates once its render window has elapsed. af keeps failing
+// closed afterwards either way — the escalation is the operator-visible signal,
+// not a change of behavior.
 func (t *TmuxSession) recordPendingCodexSafetySelection() {
 	state := &t.codexSafety
 	state.selectionPolls++
-	if state.selectionFailed || state.selectionPolls < codexSafetySelectionVerificationPolls {
+	elapsed := codexSafetyNow().Sub(state.selectionStarted)
+	if state.selectionFailed || elapsed < codexSafetySelectionVerificationWindow {
 		return
 	}
 	state.selectionFailed = true
 	log.ErrorLog.Printf(
-		"refusing to accept Codex additional safety checks for session %q: could not verify %q as the selected row after %d polls",
-		t.sanitizedName, state.selectionTarget, state.selectionPolls,
+		"refusing to accept Codex additional safety checks for session %q: could not verify %q as the selected row after %s and %d polls",
+		t.sanitizedName, state.selectionTarget, elapsed.Round(time.Millisecond), state.selectionPolls,
 	)
 }
 
 func (s *codexSafetyBufferingState) beginSelectionVerification(target string) {
 	s.selectionTarget = target
+	s.selectionStarted = codexSafetyNow()
 	s.selectionPolls = 0
 	s.selectionFailed = false
 }
 
 func (s *codexSafetyBufferingState) clearSelectionVerification() {
 	s.selectionTarget = ""
+	s.selectionStarted = time.Time{}
 	s.selectionPolls = 0
 	s.selectionFailed = false
 }

--- a/session/tmux/codex_safety_real_test.go
+++ b/session/tmux/codex_safety_real_test.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/term"
+
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 )
 
 const codexSafetyRealFixtureEnv = "AF_CODEX_SAFETY_REAL_FIXTURE"
@@ -23,7 +25,7 @@ const codexSafetyRealFixtureEnv = "AF_CODEX_SAFETY_REAL_FIXTURE"
 // onto one test-owned server. It leaves the user's default tmux server entirely
 // untouched while still exercising the real capture-pane/send-keys boundary.
 type socketExecutor struct {
-	label string
+	socket string
 }
 
 func (e socketExecutor) Run(command *exec.Cmd) error {
@@ -37,7 +39,18 @@ func (e socketExecutor) Output(command *exec.Cmd) ([]byte, error) {
 }
 
 func (e socketExecutor) scope(command *exec.Cmd) {
-	command.Args = append([]string{command.Args[0], "-L", e.label}, command.Args[1:]...)
+	command.Args = append([]string{command.Args[0], "-S", e.socket}, command.Args[1:]...)
+}
+
+// tmuxAt builds a tmux command against this test's private server. `-S` names
+// the socket outright rather than deriving it from TMUX_TMPDIR, because the
+// derived path is what breaks: the package sandbox roots TMUX_TMPDIR under
+// os.TempDir(), which on macOS is /var/folders/<hash>/T (~49 bytes), and a
+// label appended to that overruns darwin's 104-byte sun_path — tmux then
+// refuses with a bare "exit status 1" that names nothing. testguard.SocketPath
+// hands back a short path and fails up front if it ever stops being short.
+func tmuxAt(socket string, args ...string) *exec.Cmd {
+	return exec.Command("tmux", append([]string{"-S", socket}, args...)...)
 }
 
 func TestCodexSafetyDelayedRenderFixtureProcess(t *testing.T) {
@@ -62,7 +75,13 @@ func TestCodexSafetyDelayedRenderFixtureProcess(t *testing.T) {
 	renderFixturePane(codexCurrentSafetyBufferingWaitSelected, false)
 	require.NoError(t, waitForFixtureByte(reader, '\r'))
 	renderFixturePane(codexSafetyRealNormalPane, true)
-	time.Sleep(5 * time.Second)
+
+	// Hold the pane open until the test's cleanup kills the session, and no
+	// longer. A timed exit races the runner: exit-empty would tear the server
+	// down mid-assertion on a loaded box, and cleanup would then report the
+	// session it wanted gone as a failure to remove it. Reads end at EOF when
+	// the server does go away, so nothing outlives it either.
+	_, _ = reader.ReadByte()
 }
 
 const codexSafetyRealNormalPane = `• Working
@@ -90,8 +109,11 @@ func waitForFixtureByte(reader *bufio.Reader, wanted byte) error {
 }
 
 func TestCheckAndHandleTrustPrompt_CodexSafetyWaitsForRealTmuxRender(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skipf("tmux is not installed: %v", err)
+	}
 	info, _, errorLogs := captureTrustPromptLogs(t)
-	label := fmt.Sprintf("af2673-%d-%d", os.Getpid(), time.Now().UnixNano())
+	socketPath := testguard.SocketPath(t, "af2673.sock")
 	name := "af_safety-render-2673"
 	fixtureDir := t.TempDir()
 	fixturePath := filepath.Join(fixtureDir, ProgramCodex)
@@ -100,19 +122,24 @@ func TestCheckAndHandleTrustPrompt_CodexSafetyWaitsForRealTmuxRender(t *testing.
 	require.NoError(t, os.Symlink(executable, fixturePath))
 
 	program := fixturePath + " -test.run=^TestCodexSafetyDelayedRenderFixtureProcess$"
-	start := exec.Command(
-		"tmux", "-L", label, "new-session", "-d",
-		"-s", name, "-x", "100", "-y", "24", program,
-	)
+	start := tmuxAt(socketPath, "new-session", "-d", "-s", name, "-x", "100", "-y", "24", program)
 	start.Env = append(os.Environ(), codexSafetyRealFixtureEnv+"=1")
-	require.NoError(t, start.Run())
-	require.NoError(t, exec.Command("tmux", "-L", label, "set-option", "-g", "exit-empty", "on").Run())
+	// CombinedOutput, not Run: tmux explains every refusal on stderr, and
+	// discarding it leaves a bare "exit status 1" to diagnose from CI alone.
+	out, err := start.CombinedOutput()
+	require.NoError(t, err, "start isolated tmux fixture session: %s", out)
+	out, err = tmuxAt(socketPath, "set-option", "-g", "exit-empty", "on").CombinedOutput()
+	require.NoError(t, err, "set exit-empty on the isolated server: %s", out)
 
-	socketPath := tmuxSocketPath(t, label, name)
-	serverPID := tmuxServerPID(t, label, name)
+	serverPID := tmuxServerPID(t, socketPath, name)
 	t.Cleanup(func() {
-		if killErr := exec.Command("tmux", "-L", label, "kill-session", "-t", name).Run(); killErr != nil {
-			t.Errorf("kill isolated tmux session: %v", killErr)
+		if killOut, killErr := tmuxAt(socketPath, "kill-session", "-t", exactTarget(name)).CombinedOutput(); killErr != nil {
+			// A session that is already gone is cleanup's goal reached early,
+			// not a failure — kill-session and has-session both exit nonzero
+			// once the server is down, so ask before reporting.
+			if probeErr := tmuxAt(socketPath, "has-session", "-t", exactTarget(name)).Run(); probeErr == nil {
+				t.Errorf("kill isolated tmux session: %v: %s", killErr, killOut)
+			}
 		}
 		if !eventually(2*time.Second, 20*time.Millisecond, func() bool {
 			return stderrors.Is(syscall.Kill(serverPID, 0), syscall.ESRCH)
@@ -125,11 +152,12 @@ func TestCheckAndHandleTrustPrompt_CodexSafetyWaitsForRealTmuxRender(t *testing.
 		}
 	})
 
-	session := newTmuxSession(name, program, MakePtyFactory(), socketExecutor{label: label})
+	session := newTmuxSession(name, program, MakePtyFactory(), socketExecutor{socket: socketPath})
 	waitForRealPane(t, session, codexSafetyRealNormalPane)
 	require.False(t, session.CheckAndHandleTrustPrompt(), "normal pane establishes the pre-dialog model")
 
-	require.NoError(t, exec.Command("tmux", "-L", label, "send-keys", "-t", exactTarget(name), "x").Run())
+	out, err = tmuxAt(socketPath, "send-keys", "-t", exactTarget(name), "x").CombinedOutput()
+	require.NoError(t, err, "raise the fixture's safety picker: %s", out)
 	waitForRealPane(t, session, "Dismiss and keep waiting")
 	require.True(t, session.CheckAndHandleTrustPrompt(), "the live safety picker blocks prompt delivery")
 	require.Empty(t, errorLogs.String(), "one stale frame after a real navigation key is pending, not an error")
@@ -143,20 +171,9 @@ func TestCheckAndHandleTrustPrompt_CodexSafetyWaitsForRealTmuxRender(t *testing.
 	require.Contains(t, info.String(), "verified model unchanged: gpt-5.6-sol max")
 }
 
-func tmuxSocketPath(t *testing.T, label, name string) string {
+func tmuxServerPID(t *testing.T, socket, name string) int {
 	t.Helper()
-	output, err := exec.Command(
-		"tmux", "-L", label, "display-message", "-p", "-t", exactTarget(name), "#{socket_path}",
-	).Output()
-	require.NoError(t, err)
-	return strings.TrimSpace(string(output))
-}
-
-func tmuxServerPID(t *testing.T, label, name string) int {
-	t.Helper()
-	output, err := exec.Command(
-		"tmux", "-L", label, "display-message", "-p", "-t", exactTarget(name), "#{pid}",
-	).Output()
+	output, err := tmuxAt(socket, "display-message", "-p", "-t", exactTarget(name), "#{pid}").Output()
 	require.NoError(t, err)
 	pid, err := strconv.Atoi(strings.TrimSpace(string(output)))
 	require.NoError(t, err)

--- a/session/tmux/codex_safety_real_test.go
+++ b/session/tmux/codex_safety_real_test.go
@@ -1,0 +1,189 @@
+package tmux
+
+import (
+	"bufio"
+	stderrors "errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/term"
+)
+
+const codexSafetyRealFixtureEnv = "AF_CODEX_SAFETY_REAL_FIXTURE"
+
+// socketExecutor forces every production tmux command issued by TmuxSession
+// onto one test-owned server. It leaves the user's default tmux server entirely
+// untouched while still exercising the real capture-pane/send-keys boundary.
+type socketExecutor struct {
+	label string
+}
+
+func (e socketExecutor) Run(command *exec.Cmd) error {
+	e.scope(command)
+	return command.Run()
+}
+
+func (e socketExecutor) Output(command *exec.Cmd) ([]byte, error) {
+	e.scope(command)
+	return command.Output()
+}
+
+func (e socketExecutor) scope(command *exec.Cmd) {
+	command.Args = append([]string{command.Args[0], "-L", e.label}, command.Args[1:]...)
+}
+
+func TestCodexSafetyDelayedRenderFixtureProcess(t *testing.T) {
+	if os.Getenv(codexSafetyRealFixtureEnv) != "1" {
+		t.Skip("fixture process")
+	}
+
+	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+	require.NoError(t, err)
+	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }()
+
+	renderFixturePane(codexSafetyRealNormalPane, true)
+	reader := bufio.NewReader(os.Stdin)
+	require.NoError(t, waitForFixtureByte(reader, 'x'))
+	renderFixturePane(codexCurrentSafetyBufferingDialog, false)
+	require.NoError(t, waitForFixtureByte(reader, 'B'))
+
+	// This is the production rendering race from #2673: tmux has delivered the
+	// navigation key, but Codex has not painted the new selected row by af's
+	// immediate capture.
+	time.Sleep(500 * time.Millisecond)
+	renderFixturePane(codexCurrentSafetyBufferingWaitSelected, false)
+	require.NoError(t, waitForFixtureByte(reader, '\r'))
+	renderFixturePane(codexSafetyRealNormalPane, true)
+	time.Sleep(5 * time.Second)
+}
+
+const codexSafetyRealNormalPane = `• Working
+
+  gpt-5.6-sol max · ~/agent-factory`
+
+func renderFixturePane(content string, cursorVisible bool) {
+	cursorMode := "\x1b[?25l"
+	if cursorVisible {
+		cursorMode = "\x1b[?25h"
+	}
+	_, _ = fmt.Fprintf(os.Stdout, "\x1b[2J\x1b[H%s%s\r\n", cursorMode, strings.ReplaceAll(content, "\n", "\r\n"))
+}
+
+func waitForFixtureByte(reader *bufio.Reader, wanted byte) error {
+	for {
+		got, err := reader.ReadByte()
+		if err != nil {
+			return err
+		}
+		if got == wanted {
+			return nil
+		}
+	}
+}
+
+func TestCheckAndHandleTrustPrompt_CodexSafetyWaitsForRealTmuxRender(t *testing.T) {
+	info, _, errorLogs := captureTrustPromptLogs(t)
+	label := fmt.Sprintf("af2673-%d-%d", os.Getpid(), time.Now().UnixNano())
+	name := "af_safety-render-2673"
+	fixtureDir := t.TempDir()
+	fixturePath := filepath.Join(fixtureDir, ProgramCodex)
+	executable, err := os.Executable()
+	require.NoError(t, err)
+	require.NoError(t, os.Symlink(executable, fixturePath))
+
+	program := fixturePath + " -test.run=^TestCodexSafetyDelayedRenderFixtureProcess$"
+	start := exec.Command(
+		"tmux", "-L", label, "new-session", "-d",
+		"-s", name, "-x", "100", "-y", "24", program,
+	)
+	start.Env = append(os.Environ(), codexSafetyRealFixtureEnv+"=1")
+	require.NoError(t, start.Run())
+	require.NoError(t, exec.Command("tmux", "-L", label, "set-option", "-g", "exit-empty", "on").Run())
+
+	socketPath := tmuxSocketPath(t, label, name)
+	serverPID := tmuxServerPID(t, label, name)
+	t.Cleanup(func() {
+		if killErr := exec.Command("tmux", "-L", label, "kill-session", "-t", name).Run(); killErr != nil {
+			t.Errorf("kill isolated tmux session: %v", killErr)
+		}
+		if !eventually(2*time.Second, 20*time.Millisecond, func() bool {
+			return stderrors.Is(syscall.Kill(serverPID, 0), syscall.ESRCH)
+		}) {
+			t.Errorf("isolated tmux server %d did not exit", serverPID)
+			return
+		}
+		if removeErr := os.Remove(socketPath); removeErr != nil && !os.IsNotExist(removeErr) {
+			t.Errorf("remove isolated tmux socket %s: %v", socketPath, removeErr)
+		}
+	})
+
+	session := newTmuxSession(name, program, MakePtyFactory(), socketExecutor{label: label})
+	waitForRealPane(t, session, codexSafetyRealNormalPane)
+	require.False(t, session.CheckAndHandleTrustPrompt(), "normal pane establishes the pre-dialog model")
+
+	require.NoError(t, exec.Command("tmux", "-L", label, "send-keys", "-t", exactTarget(name), "x").Run())
+	waitForRealPane(t, session, "Dismiss and keep waiting")
+	require.True(t, session.CheckAndHandleTrustPrompt(), "the live safety picker blocks prompt delivery")
+	require.Empty(t, errorLogs.String(), "one stale frame after a real navigation key is pending, not an error")
+
+	waitForRealPane(t, session, codexCurrentSafetyBufferingWaitSelected)
+	require.True(t, session.CheckAndHandleTrustPrompt(), "af accepts only after the target row is visibly selected")
+	waitForRealPane(t, session, codexSafetyRealNormalPane)
+	require.False(t, session.CheckAndHandleTrustPrompt(), "the next live poll verifies the unchanged model")
+
+	require.Empty(t, errorLogs.String())
+	require.Contains(t, info.String(), "verified model unchanged: gpt-5.6-sol max")
+}
+
+func tmuxSocketPath(t *testing.T, label, name string) string {
+	t.Helper()
+	output, err := exec.Command(
+		"tmux", "-L", label, "display-message", "-p", "-t", exactTarget(name), "#{socket_path}",
+	).Output()
+	require.NoError(t, err)
+	return strings.TrimSpace(string(output))
+}
+
+func tmuxServerPID(t *testing.T, label, name string) int {
+	t.Helper()
+	output, err := exec.Command(
+		"tmux", "-L", label, "display-message", "-p", "-t", exactTarget(name), "#{pid}",
+	).Output()
+	require.NoError(t, err)
+	pid, err := strconv.Atoi(strings.TrimSpace(string(output)))
+	require.NoError(t, err)
+	return pid
+}
+
+func waitForRealPane(t *testing.T, session *TmuxSession, wanted string) {
+	t.Helper()
+	var last string
+	require.Eventually(t, func() bool {
+		content, err := session.CapturePaneContent()
+		if err != nil {
+			last = err.Error()
+			return false
+		}
+		last = content
+		return strings.Contains(content, wanted)
+	}, 3*time.Second, 20*time.Millisecond, "pane never rendered %q; last capture:\n%s", wanted, last)
+}
+
+func eventually(timeout, interval time.Duration, check func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if check() {
+			return true
+		}
+		time.Sleep(interval)
+	}
+	return check()
+}

--- a/session/tmux/doc_trust_prompt_test.go
+++ b/session/tmux/doc_trust_prompt_test.go
@@ -81,6 +81,18 @@ const codexCurrentSafetyBufferingDialog = `  Our systems are thinking a bit more
   No action is required. Codex will keep waiting, and this menu will close when
   the response is ready.`
 
+// A capture taken while Codex has cleared its menu but has not finished
+// repainting it. The footer that makes the pane recognizable as the picker is
+// not on screen yet, so this frame matches no Codex shape at all — it is
+// neither the picker nor the ordinary composer.
+const codexCurrentSafetyBufferingPartialRedraw = `  Our systems are thinking a bit more about this request before responding.
+  Hang tight or retry with a faster model for a quicker response, though it
+  may be less capable of handling complex requests.
+
+› 1. Retry with a faster model
+  2. Dismiss and keep waiting
+  3. Learn more`
+
 const codexCurrentSafetyBufferingWaitSelected = `  Our systems are thinking a bit more about this request before responding.
   Hang tight or retry with a faster model for a quicker response, though it
   may be less capable of handling complex requests.
@@ -112,15 +124,42 @@ func runTrustPromptCheck(t *testing.T, program, content string) (handled bool, c
 	return session.CheckAndHandleTrustPrompt(), cmds
 }
 
+// trustPromptFrame is one pane capture paired with the cursor state tmux would
+// report while it is on screen. The pair is what the safety-picker path reads:
+// Codex's ListSelectionView implements no cursor position and so hides the
+// terminal cursor, while the ordinary composer exposes one. Cursor visibility is
+// therefore the only POSITIVE evidence that the modal is gone — the absence of
+// its chrome is not, because a mid-repaint capture also has none (#2760).
+type trustPromptFrame struct {
+	content       string
+	cursorVisible bool
+}
+
 // runTrustPromptSequence feeds one pane capture per Output call while keeping
 // one TmuxSession alive across checks. The safety-buffering path is stateful in
 // production: it remembers the model footer from a normal poll, navigates and
 // re-captures the picker, then verifies the model on a later poll.
+//
+// Every frame reports a hidden cursor, matching a pane the picker owns. Use
+// runTrustPromptFrames when a test needs the composer's visible cursor back.
 func runTrustPromptSequence(t *testing.T, program string, contents ...string) (*TmuxSession, *[]string) {
+	t.Helper()
+	frames := make([]trustPromptFrame, len(contents))
+	for idx, content := range contents {
+		frames[idx] = trustPromptFrame{content: content}
+	}
+	return runTrustPromptFrames(t, program, frames...)
+}
+
+// runTrustPromptFrames is runTrustPromptSequence with per-capture cursor state.
+// A frame's cursor answer stays in force until the next capture, matching
+// production order: the pane is captured first, then queried for its cursor.
+func runTrustPromptFrames(t *testing.T, program string, frames ...trustPromptFrame) (*TmuxSession, *[]string) {
 	t.Helper()
 	var (
 		cmds       []string
 		captureIdx int
+		cursor     = "0 0 0"
 	)
 	cmdExec := cmd_test.MockCmdExec{
 		RunFunc: func(c *exec.Cmd) error {
@@ -129,14 +168,16 @@ func runTrustPromptSequence(t *testing.T, program string, contents ...string) (*
 		},
 		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
 			if strings.Contains(strings.Join(c.Args, " "), "display-message") {
-				// Codex's active ListSelectionView has no cursor position, so
-				// the TUI hides the terminal cursor while the picker is open.
-				return []byte("0 0 0"), nil
+				return []byte(cursor), nil
 			}
-			require.Less(t, captureIdx, len(contents), "unexpected extra pane capture")
-			content := contents[captureIdx]
+			require.Less(t, captureIdx, len(frames), "unexpected extra pane capture")
+			frame := frames[captureIdx]
 			captureIdx++
-			return []byte(content), nil
+			cursor = "0 0 0"
+			if frame.cursorVisible {
+				cursor = "0 0 1"
+			}
+			return []byte(frame.content), nil
 		},
 	}
 	session := newTmuxSession(toTmuxName("trust", ""), program, NewMockPtyFactory(t), cmdExec)
@@ -330,32 +371,161 @@ func TestCheckAndHandleTrustPrompt_CodexSafetyWaitsForDelayedSelectionRender(t *
 		"a recovered selection-render delay must not leave a false ERROR behind")
 }
 
-func TestCheckAndHandleTrustPrompt_CodexSafetyEscalatesUnverifiedSelection(t *testing.T) {
+// A partial redraw matches no Codex shape at all, so it is not evidence that
+// the picker closed. Dropping the pending selection there lets the NEXT
+// complete-but-stale frame re-enter navigation and send the same Down a second
+// time: two rows of movement for one intended step, which parks the cursor on
+// "Learn more" and then accepts it — the overshoot this whole path exists to
+// prevent (#2181).
+func TestCheckAndHandleTrustPrompt_CodexSafetyPartialRedrawDoesNotRepeatNavigation(t *testing.T) {
+	info, _, errors := captureTrustPromptLogs(t)
+	const normalPane = "gpt-5.6-sol max · ~/agent-factory"
+	session, commands := runTrustPromptSequence(t, ProgramCodex,
+		normalPane,
+		codexCurrentSafetyBufferingDialog,
+		codexCurrentSafetyBufferingPartialRedraw, // immediate post-navigation capture, mid-repaint
+		codexCurrentSafetyBufferingDialog,        // chrome is back, selection still stale
+		codexCurrentSafetyBufferingWaitSelected,
+		normalPane,
+	)
+
+	require.False(t, session.CheckAndHandleTrustPrompt())
+	require.True(t, session.CheckAndHandleTrustPrompt(),
+		"a mid-repaint frame leaves the picker pending, not resolved")
+	require.True(t, session.CheckAndHandleTrustPrompt())
+	require.Equal(t, []string{
+		"tmux send-keys -t =af_trust: Down",
+	}, sentKeystrokes(*commands),
+		"one intended row of movement must be sent exactly once, however the pane repaints")
+
+	require.True(t, session.CheckAndHandleTrustPrompt(),
+		"the target row finally renders as selected and is accepted")
+	require.Equal(t, []string{
+		"tmux send-keys -t =af_trust: Down",
+		"tmux send-keys -t =af_trust: Enter",
+	}, sentKeystrokes(*commands))
+	require.False(t, session.CheckAndHandleTrustPrompt())
+	require.Empty(t, errors.String())
+	require.Contains(t, info.String(), "verified model unchanged: gpt-5.6-sol max")
+}
+
+// The counterpart: Codex closes the picker itself ("this menu will close when
+// the response is ready"). The composer's visible cursor is the positive signal
+// that releases the pending selection, so a picker that resolves under af still
+// hands the session straight back.
+func TestCheckAndHandleTrustPrompt_CodexSafetyReleasesPendingSelectionWhenPickerCloses(t *testing.T) {
+	info, _, errors := captureTrustPromptLogs(t)
+	const normalPane = "gpt-5.6-sol max · ~/agent-factory"
+	session, commands := runTrustPromptFrames(t, ProgramCodex,
+		trustPromptFrame{content: normalPane},
+		trustPromptFrame{content: codexCurrentSafetyBufferingDialog},
+		trustPromptFrame{content: normalPane, cursorVisible: true},
+		trustPromptFrame{content: normalPane, cursorVisible: true},
+	)
+
+	require.False(t, session.CheckAndHandleTrustPrompt())
+	require.True(t, session.CheckAndHandleTrustPrompt())
+	require.Equal(t, []string{
+		"tmux send-keys -t =af_trust: Down",
+	}, sentKeystrokes(*commands), "Enter must never reach a picker that closed itself")
+	require.Contains(t, info.String(), "resolved before af accepted a choice")
+	require.False(t, session.CheckAndHandleTrustPrompt(),
+		"the released session is an ordinary pane again")
+	require.Empty(t, errors.String())
+}
+
+// The verification budget is a duration, not a capture count. daemon_poll_interval
+// is operator-configurable, so counting polls makes the budget mean whatever the
+// operator set: at 100ms a three-capture budget expires before a 500ms repaint can
+// land, reporting ordinary rendering lag as a failed safety operation.
+func TestCheckAndHandleTrustPrompt_CodexSafetyBudgetsRenderTimeNotPollCount(t *testing.T) {
 	_, _, errors := captureTrustPromptLogs(t)
+	clock := fakeCodexSafetyClock(t)
+	const normalPane = "gpt-5.6-sol max · ~/agent-factory"
+	session, commands := runTrustPromptSequence(t, ProgramCodex,
+		normalPane,
+		codexCurrentSafetyBufferingDialog,
+		codexCurrentSafetyBufferingDialog, // immediate post-navigation capture
+		codexCurrentSafetyBufferingDialog, // fast daemon polls, all inside the window
+		codexCurrentSafetyBufferingDialog,
+		codexCurrentSafetyBufferingDialog,
+		codexCurrentSafetyBufferingWaitSelected,
+		normalPane,
+	)
+
+	require.False(t, session.CheckAndHandleTrustPrompt())
+	require.True(t, session.CheckAndHandleTrustPrompt())
+	for poll := 0; poll < 3; poll++ {
+		*clock = clock.Add(100 * time.Millisecond)
+		require.True(t, session.CheckAndHandleTrustPrompt())
+		require.Empty(t, errors.String(),
+			"a 100ms daemon_poll_interval must not spend the render budget in %d polls", poll+1)
+	}
+
+	*clock = clock.Add(500 * time.Millisecond)
+	require.True(t, session.CheckAndHandleTrustPrompt(),
+		"the repaint the real fixture exercises lands well inside the window")
+	require.Equal(t, []string{
+		"tmux send-keys -t =af_trust: Down",
+		"tmux send-keys -t =af_trust: Enter",
+	}, sentKeystrokes(*commands))
+	require.False(t, session.CheckAndHandleTrustPrompt())
+	require.Empty(t, errors.String())
+}
+
+func TestCheckAndHandleTrustPrompt_CodexSafetyEscalatesUnverifiedSelection(t *testing.T) {
+	info, _, errors := captureTrustPromptLogs(t)
+	clock := fakeCodexSafetyClock(t)
 	const normalPane = "gpt-5.6-sol max · ~/agent-factory"
 	session, commands := runTrustPromptSequence(t, ProgramCodex,
 		normalPane,
 		codexCurrentSafetyBufferingDialog,
 		codexCurrentSafetyBufferingDialog, // immediate post-navigation capture
 		codexCurrentSafetyBufferingDialog, // first later daemon poll
-		codexCurrentSafetyBufferingDialog, // bounded retry window expires
+		codexCurrentSafetyBufferingDialog, // bounded render window expires
+		codexCurrentSafetyBufferingWaitSelected,
+		normalPane,
 	)
 
 	require.False(t, session.CheckAndHandleTrustPrompt())
 	require.True(t, session.CheckAndHandleTrustPrompt())
 	require.Empty(t, errors.String(),
 		"one stale render after navigation is expected and remains pending")
+	*clock = clock.Add(codexSafetySelectionVerificationWindow - time.Millisecond)
 	require.True(t, session.CheckAndHandleTrustPrompt())
 	require.Empty(t, errors.String(),
 		"the bounded verification window must not escalate early")
+	*clock = clock.Add(time.Millisecond)
 	require.True(t, session.CheckAndHandleTrustPrompt())
 	require.Contains(t, errors.String(),
-		`could not verify "Dismiss and keep waiting" as the selected row after 3 polls`,
+		`could not verify "Dismiss and keep waiting" as the selected row after 5s`,
 		"a picker that never renders the safe selection is a real operator-visible failure")
 	require.Equal(t, []string{
 		"tmux send-keys -t =af_trust: Down",
 	}, sentKeystrokes(*commands),
 		"af must fail closed without repeating navigation or pressing Enter")
+
+	// Escalation is a report, not a terminal state. A picker that finally paints
+	// the safe row is still accepted, and the operator gets the correction next
+	// to the ERROR rather than being left with a warning that never resolved.
+	require.True(t, session.CheckAndHandleTrustPrompt())
+	require.Contains(t, info.String(), "selection became verifiable")
+	require.Equal(t, []string{
+		"tmux send-keys -t =af_trust: Down",
+		"tmux send-keys -t =af_trust: Enter",
+	}, sentKeystrokes(*commands))
+	require.False(t, session.CheckAndHandleTrustPrompt())
+}
+
+// fakeCodexSafetyClock freezes the selection-verification clock and returns the
+// handle a test advances to model daemon polls arriving at a given interval.
+func fakeCodexSafetyClock(t *testing.T) *time.Time {
+	t.Helper()
+	now := time.Date(2026, time.August, 4, 12, 0, 0, 0, time.UTC)
+	previous := codexSafetyNow
+	codexSafetyNow = func() time.Time { return now }
+	t.Cleanup(func() { codexSafetyNow = previous })
+	return &now
 }
 
 func TestCheckAndHandleTrustPrompt_CodexSafetyModelDowngradeIsSurfaced(t *testing.T) {

--- a/session/tmux/doc_trust_prompt_test.go
+++ b/session/tmux/doc_trust_prompt_test.go
@@ -297,6 +297,67 @@ func TestCheckAndHandleTrustPrompt_CurrentCodexSafetyWording(t *testing.T) {
 	}, sentKeystrokes(*commands))
 }
 
+func TestCheckAndHandleTrustPrompt_CodexSafetyWaitsForDelayedSelectionRender(t *testing.T) {
+	_, _, errors := captureTrustPromptLogs(t)
+	const normalPane = "gpt-5.6-sol max · ~/agent-factory"
+	session, commands := runTrustPromptSequence(t, ProgramCodex,
+		normalPane,
+		codexCurrentSafetyBufferingDialog,
+		codexCurrentSafetyBufferingDialog, // immediate post-navigation capture is stale
+		codexCurrentSafetyBufferingWaitSelected,
+		normalPane,
+	)
+
+	require.False(t, session.CheckAndHandleTrustPrompt())
+	require.True(t, session.CheckAndHandleTrustPrompt(),
+		"a stale post-navigation frame must leave the picker pending")
+	require.Equal(t, []string{
+		"tmux send-keys -t =af_trust: Down",
+	}, sentKeystrokes(*commands),
+		"Enter must wait until a later pane capture proves the literal target row is selected")
+	require.Empty(t, errors.String(),
+		"normal terminal rendering lag is not a failed safety-picker operation")
+
+	require.True(t, session.CheckAndHandleTrustPrompt(),
+		"the next daemon poll observes the delayed selected frame and accepts it")
+	require.Equal(t, []string{
+		"tmux send-keys -t =af_trust: Down",
+		"tmux send-keys -t =af_trust: Enter",
+	}, sentKeystrokes(*commands))
+	require.False(t, session.CheckAndHandleTrustPrompt(),
+		"the following poll verifies the unchanged model")
+	require.Empty(t, errors.String(),
+		"a recovered selection-render delay must not leave a false ERROR behind")
+}
+
+func TestCheckAndHandleTrustPrompt_CodexSafetyEscalatesUnverifiedSelection(t *testing.T) {
+	_, _, errors := captureTrustPromptLogs(t)
+	const normalPane = "gpt-5.6-sol max · ~/agent-factory"
+	session, commands := runTrustPromptSequence(t, ProgramCodex,
+		normalPane,
+		codexCurrentSafetyBufferingDialog,
+		codexCurrentSafetyBufferingDialog, // immediate post-navigation capture
+		codexCurrentSafetyBufferingDialog, // first later daemon poll
+		codexCurrentSafetyBufferingDialog, // bounded retry window expires
+	)
+
+	require.False(t, session.CheckAndHandleTrustPrompt())
+	require.True(t, session.CheckAndHandleTrustPrompt())
+	require.Empty(t, errors.String(),
+		"one stale render after navigation is expected and remains pending")
+	require.True(t, session.CheckAndHandleTrustPrompt())
+	require.Empty(t, errors.String(),
+		"the bounded verification window must not escalate early")
+	require.True(t, session.CheckAndHandleTrustPrompt())
+	require.Contains(t, errors.String(),
+		`could not verify "Dismiss and keep waiting" as the selected row after 3 polls`,
+		"a picker that never renders the safe selection is a real operator-visible failure")
+	require.Equal(t, []string{
+		"tmux send-keys -t =af_trust: Down",
+	}, sentKeystrokes(*commands),
+		"af must fail closed without repeating navigation or pressing Enter")
+}
+
 func TestCheckAndHandleTrustPrompt_CodexSafetyModelDowngradeIsSurfaced(t *testing.T) {
 	_, _, errors := captureTrustPromptLogs(t)
 	session, _ := runTrustPromptSequence(t, ProgramCodex,


### PR DESCRIPTION
## What

Keep Codex's safety-picker selection pending across daemon polls after af sends
the navigation key. A stale immediate frame is normal rendering lag, not an
ERROR. af still fails closed: it never repeats navigation or presses Enter until
the literal safe row is visibly selected, and it escalates when the safe row
stays unproven for the whole render window.

## Why

tmux key delivery and terminal repaint are asynchronous. The old same-frame
verification treated a correctly delivered Down key followed by one stale
capture as a failed safety operation.

## Review round

All three Codex findings were real. Each is fixed on its merits, red-first.

**P1 — pending selection had to survive a partial redraw.** A capture that lands
while Codex has cleared the menu and not finished repainting it matches no Codex
shape at all: not the picker, not the composer. The first version read that as
"the picker resolved" and dropped the pending selection, so the next
complete-but-stale frame re-entered navigation and sent the same Down a second
time. The regression test pins the harm exactly — before the fix the sequence
issues `Down, Down, Enter`, i.e. two rows of movement for one intended step,
landing on "Learn more" and accepting it.

The selection now ends only on the target row proven selected, or on positive
evidence the picker closed: the composer's visible cursor, which is the same
oracle `inspectCodexSafetyPrompt` already trusts to decide the picker IS active,
read in the other direction. Absence of chrome is not evidence, and neither is
an unreadable cursor, so both hold. Holding costs a session that stays blocked
on a modal it was already blocked on — bounded and reported by
`DismissTrustPrompt`'s attempt budget — while releasing early costs a movement
key af cannot take back.

**P2 — the budget is a duration, not a capture count.** `daemon_poll_interval`
is operator-configurable, so three polls meant anything from 300ms to minutes.
At 100ms the budget expired before the 500ms repaint the real fixture exercises
could possibly land, reproducing #2673's false ERROR one layer down. Verified
red: with a 100ms interval the ERROR fired after 200ms of elapsed time. The
window is now 5s of wall clock from navigation, driven in tests through a
`codexSafetyNow` seam rather than by sleeping.

**P2 — the fixture must not exit on a timer.** It slept 5s after its final
render; `exit-empty` then removed the session and server, and a loaded runner
that had not finished asserting would find cleanup's `kill-session` returning
nonzero and turn a passing test red. Confirmed directly: `kill-session` against
an already-gone session exits 1, and with the old unconditional cleanup that
surfaces as `kill isolated tmux session: exit status 1`. The fixture now holds
the pane open until cleanup kills it (reads end at EOF if the server goes away
anyway), and cleanup treats an already-absent session as success.

## Also fixed: the red macOS lane

`Test (macOS)` was failing at the fixture's `tmux new-session` with a bare
`exit status 1`. The isolated server was named with `-L <label>`, which tmux
resolves under the package sandbox's `TMUX_TMPDIR` — rooted at `os.TempDir()`,
which on macOS is `/var/folders/<hash>/T` (~49 bytes). The label pushed the
socket past darwin's 104-byte `sun_path` and tmux refused with a message the
test discarded.

Reproduced on Linux with a long `TMPDIR` — same test, same line 108, same
`exit status 1` — and confirmed fixed the same way. The socket is now named
outright with `-S` via `testguard.SocketPath`, which is short by construction
and fails up front if it ever stops being. tmux's stderr is no longer thrown
away, so the next failure here names itself.

## Verification

Exact pushed head: cb686a25157a29830dce20461af6ab6f4a65a50e (rebased onto
master b232d5a8).

- each finding watched RED before its fix and green after
- real tmux server on a private `-S` socket; session killed, server exit
  confirmed, socket removed; repeated for cleanup-race stability
- `TMPDIR`-lengthened run reproducing the darwin path condition on Linux
- scripts/testbox.sh scenario scripts/tmux-2673-scenario.sh
- golangci-lint run --timeout=3m --fast
- gofmt -l .
- go build ./...
- deadcode -test ./...
- scripts/lint-file-length.sh
- make test-container

Closes #2673
