### PR TITLE
fix(webtab): ignore canceled proxy requests

### DIFF
--- a/daemon/webtab_error_marker_test.go
+++ b/daemon/webtab_error_marker_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"bytes"
+	"context"
 	stdlog "log"
 	"net/http"
 	"net/http/httptest"
@@ -35,6 +36,48 @@ func TestWebTabProxyFailureDoesNotLogTargetAccessToken(t *testing.T) {
 	}
 	if strings.Contains(rec.Body.String(), token) {
 		t.Fatalf("web-tab proxy error response exposed the target access_token: %s", rec.Body.String())
+	}
+}
+
+func TestWebTabProxy_ClientCancellationIsNotAnUpstreamFailure(t *testing.T) {
+	upstreamStarted := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(upstreamStarted)
+		<-r.Context().Done()
+	}))
+	defer upstream.Close()
+
+	var warnings bytes.Buffer
+	previous := aflog.WarningLog
+	aflog.WarningLog = stdlog.New(&warnings, "", 0)
+	t.Cleanup(func() { aflog.WarningLog = previous })
+
+	mux, sessionID, tabID := newWebTabProxyFixture(t, upstream.URL)
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/v1/webtab/"+sessionID+"/"+tabID+"/",
+		nil,
+	).WithContext(requestCtx)
+	rec := httptest.NewRecorder()
+	proxyDone := make(chan struct{})
+	go func() {
+		defer close(proxyDone)
+		mux.ServeHTTP(rec, req)
+	}()
+
+	<-upstreamStarted
+	cancelRequest()
+	<-proxyDone
+
+	if got := warnings.String(); got != "" {
+		t.Fatalf("a canceled client request logged an upstream failure: %s", got)
+	}
+	if got := rec.Header().Get(webtabErrorHeader); got != "" {
+		t.Fatalf("a canceled client request was marked as an unreachable upstream: %s=%q", webtabErrorHeader, got)
+	}
+	if rec.Code == http.StatusBadGateway {
+		t.Fatalf("a canceled client request manufactured an upstream 502")
 	}
 }
 

--- a/daemon/webtab_proxy.go
+++ b/daemon/webtab_proxy.go
@@ -659,7 +659,15 @@ func (cs *controlServer) webTabProxyHandler(w http.ResponseWriter, r *http.Reque
 			rewriteRefreshURL(resp.Header, tabPathPrefix, targetURL)
 			return nil
 		},
-		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
+		ErrorHandler: func(w http.ResponseWriter, proxyReq *http.Request, err error) {
+			// ReverseProxy reports the request context ending as a transport
+			// error. That means the browser navigated away, disconnected, or the
+			// tab was torn down; there is no live client to warn or manufacture a
+			// dead-server response for. Keep genuine live-request transport
+			// failures on the warning + marked-502 path below.
+			if proxyReq != nil && errors.Is(err, proxyReq.Context().Err()) {
+				return
+			}
 			safeErr := agentproto.RedactAccessTokenError(err,
 				agentproto.AccessTokenFromQuery(targetURL.Query()))
 			log.WarningLog.Printf("web tab proxy to %s failed: %v",
@@ -674,7 +682,7 @@ func (cs *controlServer) webTabProxyHandler(w http.ResponseWriter, r *http.Reque
 			// Set before writeHTTPError: that writes the status, after which headers
 			// no longer reach the client.
 			w.Header().Set(webtabErrorHeader, webtabErrorUpstreamUnreachable)
-			writeHTTPError(w, r, http.StatusBadGateway,
+			writeHTTPError(w, proxyReq, http.StatusBadGateway,
 				fmt.Errorf("web tab dev server at %s is unreachable: %w", targetURL.Host, safeErr))
 		},
 	}


### PR DESCRIPTION
## What

Treat a ReverseProxy error matching the ended client request context as expected cancellation. That path emits no production WARNING and does not manufacture af's marked 502. Genuine live-request transport failures retain the existing warning, redaction, marker, and 502 response.

## Why

Browser navigation, disconnect, and tab teardown cancel the proxied request by design. Reporting context canceled as an upstream outage makes expected client lifecycle look identical to a broken dev server.

## Red-first evidence

The real proxy regression failed on master with:

"a canceled client request logged an upstream failure: web tab proxy ... failed: context canceled"

## Verification

Exact pushed head: fa8365ba20ee5946e7513c079ebfbfc9f3a72b05

- canceled-client, af-generated-failure-marker, and access-token-redaction regressions
- affected daemon package suite
- golangci-lint run --timeout=3m --fast
- gofmt -l .
- go build ./...
- deadcode -test ./...
- scripts/lint-file-length.sh
- make test-container passed on the pre-rebase head; exact-head PR Test is pending after the final base refresh

Closes #2674