### PR TITLE
fix(daemon): surface an on-archive hook failure when the worktree move also fails

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -303,11 +303,25 @@ func (m *Manager) archiveSession(req ArchiveSessionRequest, taskTargets map[stri
 		// it. A logged-and-swallowed write failure would leave the record pointing
 		// at the pre-archive path, so a restart would send the Lost-restore loop to
 		// rebuild a worktree whose bytes are sitting in the archive directory.
+		//
+		// The hook ran BEFORE the move, so this branch is reachable with both
+		// failing. The move error stays the primary cause — it is what the caller
+		// must act on — but the hook error is not redundant with it and must not be
+		// dropped (#2763): a broken cleanup command is invisible otherwise, since
+		// this path never reaches the committed-archive warning below, and every
+		// later attempt fails the same way and reports the same single cause. Log
+		// it as well as returning it, matching the committed path, so an archive
+		// driven by a task still leaves the diagnosis in the daemon log.
+		hookNote := ""
+		if hookErr != nil {
+			log.WarningLog.Printf("archive of session %q failed and its on-archive hook also failed: %v", req.Title, hookErr)
+			hookNote = fmt.Sprintf(" (its on-archive hook also failed: %v)", hookErr)
+		}
 		_ = instance.Transition(session.AbortArchiveToLost())
 		if perr := m.persistInstanceErr(repoID, instance); perr != nil {
-			return "", session.InstanceData{}, fmt.Errorf("failed to archive session %q AND could not record its recovered state on disk (%v); its worktree is at %s — check that path before restarting the daemon: %w", req.Title, perr, instance.GetWorktreePath(), err)
+			return "", session.InstanceData{}, fmt.Errorf("failed to archive session %q AND could not record its recovered state on disk (%v); its worktree is at %s — check that path before restarting the daemon: %w%s", req.Title, perr, instance.GetWorktreePath(), err, hookNote)
 		}
-		return "", session.InstanceData{}, fmt.Errorf("failed to archive session %q (its agent will be restored in place): %w", req.Title, err)
+		return "", session.InstanceData{}, fmt.Errorf("failed to archive session %q (its agent will be restored in place): %w%s", req.Title, err, hookNote)
 	}
 
 	// Success: worktree relocated, tmux down. Commit the inert Archived state

--- a/daemon/archive_test.go
+++ b/daemon/archive_test.go
@@ -183,6 +183,37 @@ func TestArchiveSessionHookFailureCommitsArchiveAndSurfacesWarning(t *testing.T)
 	assert.Equal(t, session.Archived, persistedStatus(t, repoID, "worker"))
 }
 
+// TestArchiveSessionMoveFailureAlsoSurfacesHookFailure is the #2763 regression.
+// The hook runs at the teardown chokepoint, BEFORE the relocation, so a single
+// archive attempt can fail both. The move failure is what the caller must act
+// on, but it is not the only thing that broke: an operator whose cleanup command
+// is failing learns that only from this message, and every later archive of that
+// session fails the same way and reports the same single cause. An occupied
+// destination is the deterministic move failure — the relocate refuses to move
+// onto an existing path, before touching the source.
+func TestArchiveSessionMoveFailureAlsoSurfacesHookFailure(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, srcPath := registerArchivable(t, manager, repoID, repoPath, "worker")
+	writeOnArchiveCommand(t, "printf 'prune failed loudly\\n'; exit 23")
+	dest, err := archivedWorktreePath(repoID, "worker")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(dest, 0755))
+
+	_, _, err = manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to archive session")
+	assert.Contains(t, err.Error(), dest, "the move failure must stay the primary reported cause")
+	assert.Contains(t, err.Error(), "on-archive hook",
+		"a hook failure must not be discarded because the move failed too")
+	assert.Contains(t, err.Error(), "exit status 23")
+	assert.Contains(t, err.Error(), "prune failed loudly",
+		"the operator needs the hook's own output to fix it")
+
+	assert.True(t, exists(srcPath), "a failed move must leave the worktree where the agent can be restored")
+	assert.Equal(t, session.Lost, inst.GetStatus(), "the session must be left recoverable in place")
+}
+
 func TestArchiveSessionHookFailureBoundsCapturedOutputToATail(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	_, _ = registerArchivable(t, manager, repoID, repoPath, "worker")


### PR DESCRIPTION
## Summary

The on-archive hook runs at the teardown chokepoint — every pane confirmed dead, worktree still at its live path — and the relocation runs immediately after it. `archiveTeardown` therefore returns two independent errors, and one archive attempt can fail both.

The move-failure branch returned only the move error and silently discarded `hookErr`. This makes that surface complete:

- append the hook failure to both returns in the branch, keeping the move error as the primary wrapped cause (`errors.Is`/`errors.As` behavior is unchanged)
- log a warning as well, matching what the committed path already does, so an archive driven by a scheduled task still leaves the diagnosis in the daemon log

## Why

An operator whose cleanup command is broken had no signal at all on this path. It never reaches the committed-archive warning (the archive did not commit), so the hook error was the only evidence, and it was dropped. Every later archive of that session fails the same way and reports the same single cause, while the hook keeps failing unseen — and it is the hook that just ran against the live worktree, so its failure is exactly what explains a half-pruned tree left behind by the rolled-back attempt.

Before:

```
failed to archive session "worker" (its agent will be restored in place): cannot relocate worktree: destination /…/archived/5b9198a45cc6/worker already exists
```

After:

```
failed to archive session "worker" (its agent will be restored in place): cannot relocate worktree: destination /…/archived/5b9198a45cc6/worker already exists (its on-archive hook also failed: exit status 23: prune failed loudly)
```

`DeleteProject` inherits the improvement: a non-committed archive failure goes into its `errs` list verbatim.

## Red-first proof

`TestArchiveSessionMoveFailureAlsoSurfacesHookFailure` uses a real failing hook and a real move failure — an occupied destination, which the relocate refuses before touching the source — so nothing is stubbed. Observed on master:

```
--- FAIL: TestArchiveSessionMoveFailureAlsoSurfacesHookFailure
    "failed to archive session \"worker\" (its agent will be restored in place): cannot relocate worktree: destination /tmp/af-2841833475/archived/5b9198a45cc6/worker already exists" does not contain "on-archive hook"
    … does not contain "exit status 23"
    … does not contain "prune failed loudly"
```

The test's other assertions — the move failure stays the primary cause, the worktree stays where the agent can be restored, the session lands in `Lost` — pass before and after, so the added coverage is exactly the discarded diagnostic.

Closes #2763
