### PR TITLE
fix(daemon): publish session.updated after SetPRInfo

### DIFF
--- a/daemon/manager_tabs.go
+++ b/daemon/manager_tabs.go
@@ -364,10 +364,26 @@ func (m *Manager) SetPRInfo(req SetPRInfoRequest) error {
 	prev := instance.GetPRInfo()
 	instance.SetPRInfo(info)
 
-	if err := persistInstanceData(repoID, instance.ToInstanceData()); err != nil {
+	data := instance.ToInstanceData()
+	if err := persistInstanceData(repoID, data); err != nil {
 		// Keep memory consistent with disk on a persist failure.
 		instance.SetPRInfo(prev)
 		return fmt.Errorf("failed to persist PR info: %w", err)
 	}
+
+	// Announce the recorded badge (#2769). This is the same class of mutation as
+	// the tab verbs — a durable metadata change one client makes on behalf of every
+	// client — and it was the last one still persisting silently. Only the TUI
+	// window that ran `gh pr view` knew the PR existed; a second window and the web
+	// rail kept rendering no badge (or a stale state, after a merge) until some
+	// unrelated update happened to republish the session.
+	//
+	// Published after the persist so no client can observe a badge that isn't
+	// durable yet, and while the repo start lock is still held so this announcement
+	// cannot be reordered behind a concurrent tab mutation's — session.updated
+	// carries a WHOLE InstanceData and every client re-projects the session
+	// wholesale from it, so the last event landing is the one that wins. Same
+	// discipline and same reasoning as CreateTab's publish.
+	m.publishEvent(agentproto.EventSessionUpdated, data)
 	return nil
 }

--- a/daemon/set_prinfo_test.go
+++ b/daemon/set_prinfo_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/session"
@@ -129,6 +130,39 @@ func TestSetPRInfo_ClearsWithZeroValue(t *testing.T) {
 	}
 	if data[0].PRInfo != (session.PRInfoData{}) {
 		t.Fatalf("persisted PR info after clear = %+v, want zero value", data[0].PRInfo)
+	}
+}
+
+// TestSetPRInfo_PublishesSessionUpdated pins the multi-client half of the
+// mutation (#2769). SetPRInfo is how the TUI's async `gh pr view` fetch lands, so
+// the PR badge it records is state every OTHER connected client — a second TUI
+// window, an open web rail — has to repaint from. A client only re-Snapshots
+// after its OWN mutation, so without this event the badge stays invisible
+// everywhere else until something unrelated happens to republish the session.
+//
+// The assertion is on the event payload rather than on a later Snapshot on
+// purpose: a Snapshot passes with no event published at all, which is exactly the
+// state this test exists to fail.
+func TestSetPRInfo_PublishesSessionUpdated(t *testing.T) {
+	const title = "prbadge"
+	manager, repo := tabEventSession(t, title)
+
+	// Subscribe after the session exists so the create's own events cannot be
+	// mistaken for this mutation's.
+	id, ch := manager.events.subscribe()
+	defer manager.events.unsubscribe(id)
+
+	want := session.PRInfoData{Number: 42, Title: "feat: thing", URL: "https://example/pr/42", State: "OPEN"}
+	if err := manager.SetPRInfo(SetPRInfoRequest{Title: title, RepoID: repo.ID, PRInfo: want}); err != nil {
+		t.Fatalf("SetPRInfo: %v", err)
+	}
+
+	got := drainNextSessionEvent(t, ch, agentproto.EventSessionUpdated)
+	if got.Title != title {
+		t.Fatalf("session.updated carried session %q, want %q", got.Title, title)
+	}
+	if got.PRInfo != want {
+		t.Fatalf("session.updated PR info = %+v, want %+v", got.PRInfo, want)
 	}
 }
 


### PR DESCRIPTION
## The bug

`Manager.SetPRInfo` mutated the instance, persisted it, and returned. It was
the last durable session mutation still doing that silently — `CreateTab`,
`CloseTab`, `RenameTab` and `ReorderTab` all publish `session.updated` after
their persist (#1812), and the status/limit poll does the same for its own
projection.

The consequence is a multi-client one. `SetPRInfo` is where the TUI's async
`gh pr view` result lands, so **the client that ran the fetch is the only one
that learns the PR exists**. A second TUI window and an open web rail keep
rendering the session with no PR badge — or, after a merge or close, with a
stale one — until something unrelated happens to republish the session.

## The fix

Publish the persisted `InstanceData` after a successful write:

```go
data := instance.ToInstanceData()
if err := persistInstanceData(repoID, data); err != nil { … }
m.publishEvent(agentproto.EventSessionUpdated, data)
```

Published **after** the persist so no client can observe a badge that isn't
durable yet, and **while the repo start lock is still held** so the
announcement can't be reordered behind a concurrent tab mutation's:
`session.updated` carries a WHOLE `InstanceData` and every client re-projects
the session wholesale from it, so the last event to land is the one that wins.
Same discipline and same reasoning as `CreateTab`'s publish.

The rollback path is untouched — a failed persist still restores the previous
PR info and returns the error without announcing anything.

## Verification

`TestSetPRInfo_PublishesSessionUpdated` asserts on the **event payload**, not
on a later `Snapshot`: a Snapshot assertion passes with no event published at
all, which is exactly the state this test exists to fail on.

Watched it fail on `master` first:

```
=== RUN   TestSetPRInfo_PublishesSessionUpdated
    set_prinfo_test.go:160: no session.updated event published within the deadline
--- FAIL: TestSetPRInfo_PublishesSessionUpdated (3.05s)
```

and pass with the fix, alongside the sibling publish tests
(`TestCreateTab_*PublishesSessionUpdated`, `TestCloseTab_PublishesSessionUpdated`,
`TestRenameTab_PublishesSessionUpdated`).

Full local gate on the pushed head `c504da00`: `golangci-lint --fast`,
`gofmt -l .` (empty), `go build ./...`, `make test-container` (whole suite
green, `daemon 222.5s`), `deadcode -test ./...`, `scripts/lint-file-length.sh`.

Closes #2769

🤖 Generated with [Claude Code](https://claude.com/claude-code)
