### PR TITLE
fix(config): keep the auto_yes removal warning quiet for auto_yes = false

### DIFF
--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -302,11 +302,13 @@ func LoadInRepoConfig(repoRoot string) (*InRepoConfig, []byte, error) {
 	if !isToml && metadata.shape == nil {
 		return nil, nil, fmt.Errorf("in-repo config %s must be a JSON object, not null", prettyPath)
 	}
-	if _, present := metadata.shape["auto_yes"]; present {
-		warnRemovedAutoYesAt("in-repo config " + prettyPath)
-		// The raw bytes still feed the tolerant typed decoder below; removing the
-		// key from presence metadata is what keeps the allowlist and config
-		// provenance from treating this compatibility tombstone as live config.
+	if value, present := metadata.shape["auto_yes"]; present {
+		// Only a value that actually changed meaning on upgrade earns the notice
+		// (#2574) — but the key leaves the shape either way. The raw bytes still
+		// feed the tolerant typed decoder below; removing the key from presence
+		// metadata is what keeps the allowlist and config provenance from treating
+		// this compatibility tombstone as live config.
+		warnRemovedAutoYesValue(value, "in-repo config "+prettyPath)
 		delete(metadata.shape, "auto_yes")
 	}
 	presentKeys := make(map[string]bool, len(metadata.shape))

--- a/config/project_config.go
+++ b/config/project_config.go
@@ -140,8 +140,11 @@ func parseProjectConfig(data []byte, path string) (*ProjectConfig, error) {
 	if err != nil {
 		return nil, tomlParseError("personal project config "+prettyPath, err)
 	}
-	if _, present := metadata.shape["auto_yes"]; present {
-		warnRemovedAutoYesAt("personal project config " + prettyPath)
+	if value, present := metadata.shape["auto_yes"]; present {
+		// Warn only for a value that changed meaning on upgrade (#2574); strip the
+		// key regardless, or the allowlist check below would reject the file for a
+		// setting af itself removed.
+		warnRemovedAutoYesValue(value, "personal project config "+prettyPath)
 		delete(metadata.shape, "auto_yes")
 	}
 	for key := range metadata.shape {

--- a/config/removed.go
+++ b/config/removed.go
@@ -26,6 +26,36 @@ func warnRemovedAutoYes(shape map[string]any, source string) {
 	}
 }
 
+// warnRemovedAutoYesValue is warnRemovedAutoYes for the loaders that find the
+// removed key themselves (in-repo, personal project) because they also have to
+// strip it from their presence shape. They pass the decoded value so the same
+// #2574 rule decides, rather than each re-deriving "is this worth saying".
+func warnRemovedAutoYesValue(value any, source string) {
+	if removedAutoYesWarrantsNotice(value) {
+		warnRemovedAutoYesAt(source)
+	}
+}
+
+// removedAutoYesWarrantsNotice reports whether a decoded auto_yes value earns
+// the migration notice.
+//
+// `false` does not (#2574). The warning's job is to tell a user that behavior
+// they asked for silently stopped happening: `auto_yes = true` genuinely
+// changed meaning on upgrade, but `auto_yes = false` asked for nothing — the
+// post-removal default IS "don't auto-approve", so that user already has
+// exactly the behavior they configured. Pointing them at
+// `program_overrides.codex = "codex --ask-for-approval never"` is advice to
+// enable the thing they explicitly turned off. This is the difference between
+// "your setting was dropped" and "your setting was redundant", and only the
+// first is worth a notice on every af invocation forever.
+//
+// Anything that is not a boolean still warns: the value is malformed for a key
+// that no longer exists, and silence there would hide a typo.
+func removedAutoYesWarrantsNotice(value any) bool {
+	enabled, isBool := value.(bool)
+	return !isBool || enabled
+}
+
 // removedAutoYesWarned memoizes which sources have already received the
 // auto_yes-removal heads-up. A genuinely removed key deserves ONE migration
 // notice per source, not one per config load: the daemon loads config ~10x per
@@ -55,11 +85,14 @@ func resetRemovedAutoYesWarnings() {
 	removedAutoYesWarned.Clear()
 }
 
+// removedAutoYesInShape reports whether a decoded config carries an auto_yes
+// worth warning about — at the top level or under any root_agents profile. It
+// tests the VALUE, not mere presence: see removedAutoYesWarrantsNotice.
 func removedAutoYesInShape(shape map[string]any) bool {
 	if shape == nil {
 		return false
 	}
-	if _, present := shape["auto_yes"]; present {
+	if value, present := shape["auto_yes"]; present && removedAutoYesWarrantsNotice(value) {
 		return true
 	}
 	rootAgents, ok := shape["root_agents"].(map[string]any)
@@ -71,7 +104,7 @@ func removedAutoYesInShape(shape map[string]any) bool {
 		if !ok {
 			continue
 		}
-		if _, present := profile["auto_yes"]; present {
+		if value, present := profile["auto_yes"]; present && removedAutoYesWarrantsNotice(value) {
 			return true
 		}
 	}

--- a/config/removed_autoyes_test.go
+++ b/config/removed_autoyes_test.go
@@ -28,15 +28,17 @@ func TestRemovedAutoYesConfigLoadsForUpgradeAndWarns(t *testing.T) {
 			},
 		},
 		{
+			// `true` in every case: only a value that changed meaning on upgrade
+			// warns, so `false` here would be pinning the #2574 bug.
 			name: "root-agent TOML",
 			parse: func() (*Config, error) {
-				return parseConfigTOML([]byte("[root_agents.\"/repo\"]\nauto_yes = false\n"), "config.toml")
+				return parseConfigTOML([]byte("[root_agents.\"/repo\"]\nauto_yes = true\n"), "config.toml")
 			},
 		},
 		{
 			name: "root-agent JSON",
 			parse: func() (*Config, error) {
-				return parseConfig([]byte(`{"root_agents":{"/repo":{"auto_yes":false}}}`), "config.json")
+				return parseConfig([]byte(`{"root_agents":{"/repo":{"auto_yes":true}}}`), "config.json")
 			},
 		},
 	}
@@ -118,4 +120,100 @@ func TestRemovedAutoYesInRepoConfigLoadsForUpgradeAndWarns(t *testing.T) {
 	require.Contains(t, warnings.String(), "program_overrides")
 	require.Equal(t, 1, strings.Count(warnings.String(), "auto_yes was removed"))
 	require.NotContains(t, warnings.String(), "unknown key")
+}
+
+// TestRemovedAutoYesFalseIsSilent is #2574. The presence-only check warned for
+// any auto_yes at all, so `auto_yes = false` — a no-op value asking for exactly
+// the post-removal default — collected permanent migration advice telling the
+// user to go enable the thing they explicitly turned off. Only a value that
+// genuinely changed meaning on upgrade earns the notice.
+func TestRemovedAutoYesFalseIsSilent(t *testing.T) {
+	tests := []struct {
+		name  string
+		parse func() (*Config, error)
+	}{
+		{
+			name: "global TOML",
+			parse: func() (*Config, error) {
+				return parseConfigTOML([]byte("auto_yes = false\n"), "config.toml")
+			},
+		},
+		{
+			name: "global JSON",
+			parse: func() (*Config, error) {
+				return parseConfig([]byte(`{"auto_yes":false}`), "config.json")
+			},
+		},
+		{
+			name: "root-agent TOML",
+			parse: func() (*Config, error) {
+				return parseConfigTOML([]byte("[root_agents.\"/repo\"]\nauto_yes = false\n"), "config.toml")
+			},
+		},
+		{
+			name: "root-agent JSON",
+			parse: func() (*Config, error) {
+				return parseConfig([]byte(`{"root_agents":{"/repo":{"auto_yes":false}}}`), "config.json")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			warnings := captureLog(t, &aflog.WarningLog)
+			cfg, err := tc.parse()
+			require.NoError(t, err)
+			require.NotNil(t, cfg)
+			require.NotContains(t, warnings.String(), "auto_yes was removed",
+				"auto_yes = false asked for the post-removal default; it was never dropped (#2574)")
+			require.NotContains(t, warnings.String(), "unknown key",
+				"the removed key must stay a recognized tombstone, not become an unknown key")
+		})
+	}
+}
+
+// A malformed value for a key that no longer exists still warns: staying quiet
+// about it would hide a typo behind a migration the user never made.
+func TestRemovedAutoYesNonBooleanStillWarns(t *testing.T) {
+	warnings := captureLog(t, &aflog.WarningLog)
+	cfg, err := parseConfigTOML([]byte("auto_yes = \"no\"\n"), "config.toml")
+	require.NoError(t, err, "a malformed removed key must not make an af upgrade fail")
+	require.NotNil(t, cfg)
+	require.Contains(t, warnings.String(), "auto_yes was removed")
+}
+
+// The in-repo and personal-project loaders detect the removed key themselves
+// rather than going through removedAutoYesInShape, so they need their own pin:
+// `false` must be silent there too, and — separately — the key must still be
+// stripped from the presence shape, or the personal-project allowlist would
+// reject the file outright.
+func TestRemovedAutoYesFalseIsSilentInRepoAndProjectConfigs(t *testing.T) {
+	t.Run("in-repo", func(t *testing.T) {
+		repo := t.TempDir()
+		dir := filepath.Join(repo, InRepoConfigDirName)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, TomlConfigFileName), []byte("auto_yes = false\n"), 0o600))
+
+		warnings := captureLog(t, &aflog.WarningLog)
+		cfg, _, err := LoadInRepoConfig(repo)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		require.NotContains(t, warnings.String(), "auto_yes was removed", "#2574")
+	})
+
+	t.Run("personal project", func(t *testing.T) {
+		warnings := captureLog(t, &aflog.WarningLog)
+		cfg, err := parseProjectConfig([]byte("auto_yes = false\n"), "/repo/project.toml")
+		require.NoError(t, err, "the removed key must still be stripped before the allowlist check")
+		require.NotNil(t, cfg)
+		require.NotContains(t, warnings.String(), "auto_yes was removed", "#2574")
+	})
+
+	t.Run("personal project true still warns", func(t *testing.T) {
+		warnings := captureLog(t, &aflog.WarningLog)
+		cfg, err := parseProjectConfig([]byte("auto_yes = true\n"), "/repo/project-true.toml")
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		require.Contains(t, warnings.String(), "auto_yes was removed")
+	})
 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -56,9 +56,12 @@
 
 The `auto_yes` config key, `af --autoyes` / `-y`, and
 `af agent-server --auto-yes` have been removed. Existing config files that still
-carry `auto_yes` load successfully, ignore it, and log migration guidance so an
-upgrade cannot strand the daemon. New config writes, stale flags, and stale API
-fields fail with that guidance instead of silently doing nothing.
+carry `auto_yes` load successfully and ignore it, so an upgrade cannot strand
+the daemon. `auto_yes = true` also logs migration guidance, because behavior
+that config asked for stopped happening; `auto_yes = false` loads silently,
+since the post-removal default is already "don't auto-approve". New config
+writes, stale flags, and stale API fields fail with that guidance instead of
+silently doing nothing.
 Configure approval behavior in the agent itself; the exact recipe for every
 supported agent is in [Agent approval
 behavior](configuration.md#agent-approval-behavior). Existing persisted session


### PR DESCRIPTION
## Summary

The removed-`auto_yes` check tested **presence**, never value, so a config
carrying `auto_yes = false` collected permanent migration advice on every `af`
invocation — advice telling the user to go add
`program_overrides.codex = "codex --ask-for-approval never"`, i.e. to enable the
exact thing they had explicitly turned off.

#2496 fixed the *volume* (once per source instead of ~10× per session-create).
This fixes the *trigger*.

## The rule

| value | warns? | why |
| --- | --- | --- |
| `auto_yes = true` | yes | behavior the config asked for stopped happening on upgrade |
| `auto_yes = false` | **no** | the post-removal default *is* "don't auto-approve" — the user already has exactly what they configured |
| non-boolean | yes | malformed for a key that no longer exists; silence would hide a typo |

The difference is "your setting was dropped" vs "your setting was redundant".
Only the first is worth saying on every process start, forever.

## Sites

All four presence-only checks move to one shared value test
(`removedAutoYesWarrantsNotice`):

- `config/removed.go` — top-level `auto_yes` and `root_agents.<name>.auto_yes`
- `config/inrepo.go` and `config/project_config.go` — these detect the key
  themselves because they also strip it from their presence shape

That strip stays **unconditional**. Gating it on the warning would make the
personal-project allowlist reject a file outright for a setting af itself
removed — there is a regression test for exactly that.

`af config set auto_yes …` is untouched: writing a removed key is still
rejected whatever the value.

## Tests

`TestRemovedAutoYesFalseIsSilent` (4 cases: global/root-agent × TOML/JSON),
`TestRemovedAutoYesFalseIsSilentInRepoAndProjectConfigs` (3 cases), and
`TestRemovedAutoYesNonBooleanStillWarns`. The six "silent" cases were watched
failing against `master` before the fix; the non-boolean case passed both
before and after, pinning behavior this change must not disturb.

Two pre-existing cases in `TestRemovedAutoYesConfigLoadsForUpgradeAndWarns`
used `auto_yes = false` as a stand-in for "any value warns" — they now use
`true`, since `false` there would pin the bug.

`docs/release-notes.md` said existing files "log migration guidance" without
qualification; that is now conditional, so the sentence is corrected rather
than left to rot.

## Gate

All six on the pushed head `79a03092`: `golangci-lint run --timeout=3m --fast`,
`gofmt -l .` (empty), `go build ./...`, `make test-container` (full suite green),
`deadcode -test ./...` (empty), `scripts/lint-file-length.sh`.

Closes #2574

-- Captain Claude
