### PR TITLE
fix(auth): redact access_token wherever it appears, not only after a listed separator

### DIFF
--- a/agentproto/auth.go
+++ b/agentproto/auth.go
@@ -26,16 +26,31 @@ const (
 	accessTokenRedaction  = "REDACTED"
 )
 
-// RedactAccessTokenURL replaces every access_token query value in raw while
-// preserving the rest of the URL for diagnostics. url.URL.Redacted is not a
-// substitute: it redacts userinfo only and leaves query parameters untouched.
+// RedactAccessTokenURL replaces every access_token value in raw while preserving
+// the rest of the URL for diagnostics. url.URL.Redacted is not a substitute: it
+// redacts userinfo only and leaves query parameters untouched.
 func RedactAccessTokenURL(raw string) string {
 	parsed, err := url.Parse(raw)
 	if err != nil {
 		// An unparseable URL cannot be safely separated from its credential.
 		return "[url redacted]"
 	}
-	q := parsed.Query()
+	if !redactAccessTokenQuery(parsed) {
+		// URL.Query discards malformed query pairs, so a structured miss says
+		// nothing about the raw text. The text pass reads the whole string
+		// rather than trusting a partially parsed query.
+		return RedactAccessTokenText(raw)
+	}
+	redactAccessTokenComponents(parsed)
+	return parsed.String()
+}
+
+// redactAccessTokenQuery replaces every access_token value in u's parsed query,
+// reporting whether the query carried one at all. Working through url.Values is
+// what keeps the neighbouring parameters readable: their separators are known to
+// be separators here, which is exactly the fact unstructured text lacks.
+func redactAccessTokenQuery(u *url.URL) bool {
+	q := u.Query()
 	found := false
 	for key := range q {
 		if strings.EqualFold(key, AccessTokenQueryParam) {
@@ -44,12 +59,55 @@ func RedactAccessTokenURL(raw string) string {
 		}
 	}
 	if !found {
-		// URL.Query discards malformed query pairs. The text pass still catches
-		// an exact access_token field without trusting a partially parsed query.
-		return RedactAccessTokenText(raw)
+		return false
 	}
-	parsed.RawQuery = q.Encode()
-	return parsed.String()
+	u.RawQuery = q.Encode()
+	return true
+}
+
+// redactAccessTokenComponents runs the text backstop over every part of u that
+// the query pass does not reach — most realistically the fragment, where an
+// implicit-grant callback parks its token (#2771), but a rootless URL carries
+// its whole body in Opaque and nothing stops a field from appearing in the path
+// or the userinfo either. url.URL's string fields are a closed set, so covering
+// them is a claim that stays true; covering "the separators a token can hide
+// behind" is the open-ended guess that missed ';' in #2687 and '#' in #2771.
+// Scheme is the one field left out, because the parser rejects '=' in it.
+//
+// Re-running the text pass over the serialized URL instead would defeat the
+// query pass: '&' does not end a value, so the scan would swallow every
+// parameter behind the one it just redacted.
+func redactAccessTokenComponents(u *url.URL) {
+	u.Opaque = RedactAccessTokenText(u.Opaque)
+	u.Host = RedactAccessTokenText(u.Host)
+	if path := RedactAccessTokenText(u.Path); path != u.Path {
+		// RawPath is honoured only while it still encodes Path, and a rewritten
+		// Path leaves it stale. Drop it so String re-escapes from the redacted
+		// value rather than reprinting the credential it was holding.
+		u.Path, u.RawPath = path, ""
+	}
+	if fragment := RedactAccessTokenText(u.Fragment); fragment != u.Fragment {
+		u.Fragment, u.RawFragment = fragment, ""
+	}
+	if u.User != nil {
+		u.User = redactAccessTokenUserinfo(u.User)
+	}
+}
+
+// redactAccessTokenUserinfo returns user with any access_token field redacted
+// out of its name or password, and returns user itself when there is none — an
+// untouched Userinfo reprints exactly as it parsed.
+func redactAccessTokenUserinfo(user *url.Userinfo) *url.Userinfo {
+	name := RedactAccessTokenText(user.Username())
+	password, hasPassword := user.Password()
+	redactedPassword := RedactAccessTokenText(password)
+	if name == user.Username() && redactedPassword == password {
+		return user
+	}
+	if !hasPassword {
+		return url.User(name)
+	}
+	return url.UserPassword(name, redactedPassword)
 }
 
 // RedactAccessTokenError strips an access_token from a failed request while
@@ -78,8 +136,17 @@ func RedactAccessTokenError(err error, token string) error {
 }
 
 // RedactAccessTokenText is the logging-boundary backstop for an access_token
-// query embedded in otherwise unstructured text. Call sites that know they are
+// field embedded in otherwise unstructured text. Call sites that know they are
 // handling a URL or request error must still use the structured helpers above.
+//
+// Every occurrence of the field name is redacted, whatever precedes it. The
+// match used to be gated on a hand-listed set of separators the field may follow
+// (`?&;` and whitespace), which made the default answer for an unlisted byte
+// "leave the credential alone": ';' had to be added in #2687 and '#' in #2771,
+// and the byte after that would have been the third fix. Matching a longer name
+// like "my_access_token=" now costs a diagnostic field whose value is a
+// credential anyway — the same trade the value scan below already makes, in the
+// same direction.
 func RedactAccessTokenText(text string) string {
 	needle := AccessTokenQueryParam + "="
 	if indexFoldASCII(text, needle) < 0 {
@@ -95,17 +162,8 @@ func RedactAccessTokenText(text string) string {
 			return redacted.String()
 		}
 		valueStart := i + len(needle)
-		if i > 0 && !accessTokenFieldBoundary(rest[i-1]) {
-			redacted.WriteString(rest[:valueStart])
-			rest = rest[valueStart:]
-			continue
-		}
-
-		// Query separators inside the value are ambiguous. Redact through the next
-		// unambiguous text boundary rather than risk preserving credential material
-		// after one. Losing neighbouring fields is safe; retaining a token is not.
 		valueEnd := valueStart
-		for valueEnd < len(rest) && !strings.ContainsRune(" \t\r\n#\"'", rune(rest[valueEnd])) {
+		for valueEnd < len(rest) && !accessTokenValueEnd(rest[valueEnd]) {
 			valueEnd++
 		}
 		redacted.WriteString(rest[:valueStart])
@@ -157,8 +215,18 @@ func indexFoldASCII(text, lowerASCII string) int {
 	return -1
 }
 
-func accessTokenFieldBoundary(char byte) bool {
-	return strings.ContainsRune("?&; \t\r\n", rune(char))
+// accessTokenValueEnd reports whether char is an unambiguous end of an
+// access_token value. Whitespace and quotes close a field in any text, and '#'
+// opens a URL fragment — which RedactAccessTokenURL hands back to this scan as
+// its own string, so a fragment token is still redacted rather than folded into
+// the query one.
+//
+// Every other byte counts as credential material, including the '&' and ';'
+// separators an upstream parser may or may not honour (#2690). That default is
+// the reason this half of the scan has never leaked: an unfamiliar delimiter
+// costs the neighbouring field, never the token.
+func accessTokenValueEnd(char byte) bool {
+	return strings.ContainsRune(" \t\r\n#\"'", rune(char))
 }
 
 // BearerToken extracts the token from an Authorization header value, matching the

--- a/agentproto/auth_test.go
+++ b/agentproto/auth_test.go
@@ -55,6 +55,18 @@ func TestRedactAccessTokenURL(t *testing.T) {
 			wantPresent: []string{"box:8080", "access_token=REDACTED"},
 		},
 		{
+			name:        "fragment token redacted",
+			raw:         "http://box:8080/callback#access_token=sekrit",
+			wantAbsent:  []string{"sekrit"},
+			wantPresent: []string{"box:8080", "/callback", "access_token=REDACTED"},
+		},
+		{
+			name:        "fragment token redacted alongside a query token",
+			raw:         "http://box:8080/callback?tab=2&access_token=query-sekrit#access_token=fragment-sekrit",
+			wantAbsent:  []string{"query-sekrit", "fragment-sekrit"},
+			wantPresent: []string{"box:8080", "tab=2", "access_token=REDACTED"},
+		},
+		{
 			name:        "no token untouched",
 			raw:         "http://box:8080/v1/sessions/s/stream?tab=2",
 			wantAbsent:  []string{"REDACTED"},
@@ -89,6 +101,65 @@ func TestRedactAccessTokenURLRedactsEveryKeyCase(t *testing.T) {
 	for _, token := range []string{"lower-secret", "upper-secret"} {
 		if strings.Contains(got, token) {
 			t.Fatalf("RedactAccessTokenURL retained token value %q: %s", token, got)
+		}
+	}
+}
+
+// TestRedactAccessTokenURLRedactsEveryComponent is the structural counterpart to
+// the byte sweep below. Structured query redaction reaches the query and nothing
+// else, so every OTHER component of a url.URL is a place a token can ride past
+// it — the fragment of an implicit-grant callback most realistically (#2771).
+// The set of components is closed, so sweeping it is a claim the next added
+// field cannot quietly falsify, unlike "the separators we thought of".
+func TestRedactAccessTokenURLRedactsEveryComponent(t *testing.T) {
+	// Every case also carries a query token, so the structured pass matches and
+	// the whole-string text fallback never runs. That is the path the component
+	// token has to survive redaction on.
+	for _, tc := range []struct {
+		component string
+		raw       string
+	}{
+		{"fragment", "http://box:8080/callback?access_token=q-sekrit#access_token=component-sekrit"},
+		{"path", "http://box:8080/access_token=component-sekrit?access_token=q-sekrit"},
+		{"host", "http://access_token=component-sekrit/stream?access_token=q-sekrit"},
+		{"userinfo", "http://user:access_token=component-sekrit@box:8080/?access_token=q-sekrit"},
+		{"opaque", "mailto:access_token=component-sekrit?access_token=q-sekrit"},
+	} {
+		t.Run(tc.component, func(t *testing.T) {
+			got := RedactAccessTokenURL(tc.raw)
+			for _, secret := range []string{"component-sekrit", "q-sekrit"} {
+				if strings.Contains(got, secret) {
+					t.Errorf("RedactAccessTokenURL(%q) = %q, %s token %q survived",
+						tc.raw, got, tc.component, secret)
+				}
+			}
+		})
+	}
+}
+
+// TestRedactAccessTokenTextRedactsAfterEveryPrecedingByte sweeps the exact
+// dimension this redactor keeps losing credentials on. The field match used to
+// be gated on a hand-listed set of separators that may precede it, so the
+// default answer for an unlisted byte was "leave the credential alone": ';' had
+// to be added in #2687 and '#' in #2771. A sweep of the whole byte space is the
+// only version of this test that cannot go stale the same way.
+func TestRedactAccessTokenTextRedactsAfterEveryPrecedingByte(t *testing.T) {
+	// No value terminator in the token, so a byte that fails to start the
+	// redaction leaves the whole sentinel visible.
+	const token = "af-sentinel-preceding-byte-sweep"
+	for b := 0; b < 256; b++ {
+		preceding := byte(b)
+		// []byte, not string(preceding): the latter would UTF-8 encode anything
+		// above 0x7f and never place the raw byte in front of the field.
+		input := "context" + string([]byte{preceding}) + AccessTokenQueryParam + "=" + token
+		got := RedactAccessTokenText(input)
+		if strings.Contains(got, token) {
+			t.Errorf("RedactAccessTokenText(%q) = %q; token survived after preceding byte %#02x",
+				input, got, preceding)
+		}
+		if !strings.Contains(got, accessTokenRedaction) {
+			t.Errorf("RedactAccessTokenText(%q) = %q; want the redaction marker after preceding byte %#02x",
+				input, got, preceding)
 		}
 	}
 }
@@ -156,7 +227,7 @@ type accessTokenRedactionCase struct {
 }
 
 func TestRedactAccessTokenTextNeverRetainsTokenValue(t *testing.T) {
-	const generatedCases = 3 * 4 * 6 * 3 * 8
+	const generatedCases = 3 * 4 * 6 * 3 * 10
 	caseNumber := 0
 	config := &quick.Config{
 		MaxCount: generatedCases,
@@ -184,8 +255,12 @@ func TestRedactAccessTokenTextNeverRetainsTokenValue(t *testing.T) {
 
 func generateAccessTokenRedactionCase(n int, source *rand.Rand) accessTokenRedactionCase {
 	caseID := n
-	position := n % 8
-	n /= 8
+	position := n % 10
+	n /= 10
+	// '#' is deliberately absent: it is a value TERMINATOR, so a token shaped
+	// around one is genuinely two fields, and the fragment half gets its own
+	// match. Its role as a field PREFIX is swept exhaustively by
+	// TestRedactAccessTokenTextRedactsAfterEveryPrecedingByte instead.
 	separators := []string{";", "&", "?"}
 	shapes := []func(string, string, string) string{
 		func(separator, marker, decoration string) string {
@@ -229,6 +304,10 @@ func generateAccessTokenRedactionCase(n int, source *rand.Rand) accessTokenRedac
 		"Get \"ws://box.test/stream?" + field + "\": dial failed",
 		"failure " + field + " # fragment",
 		"https://box.test/stream?" + field + "&before=1&" + field,
+		// Implicit-grant callbacks put the credential in the fragment, where no
+		// query separator precedes it at all (#2771).
+		"https://box.test/callback#" + field,
+		"https://box.test/callback?tab=2#" + field,
 	}
 	return accessTokenRedactionCase{Input: inputs[position], Token: token}
 }


### PR DESCRIPTION
## Summary

Closes #2771

`access_token` values in a URL **fragment** were logged in the clear —
`http://box/callback#access_token=sekrit` came back from
`RedactAccessTokenURL` byte-for-byte unchanged. The obvious patch is to add
`'#'` to the boundary set, but that set has already been patched twice this
way, so this PR removes the thing that keeps producing the bug instead.

### The class

`RedactAccessTokenText` gated its match on a hand-listed set of separators the
field is permitted to follow — `?&;` plus whitespace. Anything else meant "not a
real field, skip it". That makes the default answer for an unfamiliar byte
*leave the credential alone*, and it is why this function has now leaked three
times:

| PR | Byte the list was missing | Result |
|----|---------------------------|--------|
| #2684 | — (`?&` only) | original |
| #2687 | `;` | semicolon-delimited tokens leaked |
| #2771 | `#` | fragment tokens leak (this PR) |

The value scan on the *other* side of the `=` already defaults the opposite way:
an unrecognised byte is treated as credential material and redacted, which is
exactly why that half has never leaked (and why #2690 fixed a leak by *removing*
`;` from it).

**Fix:** delete the gate. Every occurrence of `access_token=` is redacted,
whatever precedes it. The cost is that a longer name like `my_access_token=`
also matches — a field whose value is a credential anyway, and no such
diagnostic string exists in this tree. There is no separator list left to be
incomplete.

### The same shape one level up

`RedactAccessTokenURL` redacts the query structurally (so neighbouring
parameters stay readable) and, on a match, returned immediately. Structured
query redaction reaches the query and **nothing else**, so a URL carrying a
token in two places redacted one and printed the other:

```
in:  http://box:8080/callback?access_token=a#access_token=b
out: http://box:8080/callback?access_token=REDACTED#access_token=b   ← leak
```

It now runs the text backstop over every remaining `url.URL` component —
`Opaque`, `Host`, `Path`, `Fragment`, userinfo. That set is closed and
compiler-visible; "the separators a token can hide behind" is not. Scheme is
excluded because the parser rejects `=` in it. Re-scanning the *serialized* URL
was not an option: `&` does not end a value, so the pass would swallow every
parameter behind the one it just redacted.

## Tests

Three new checks, each of which fails on `master`:

- **`TestRedactAccessTokenTextRedactsAfterEveryPrecedingByte`** — sweeps all 256
  byte values in front of the field. This is the test that cannot go stale the
  way a hand-listed separator set does; it catches #2687, #2771, and the next
  one. Fails on master for 249 of 256 bytes.
- **`TestRedactAccessTokenURLRedactsEveryComponent`** — a token in each URL
  component *alongside* a query token, so the structured path is the one under
  test. Fails on master for all five components.
- **`TestRedactAccessTokenURL`** — two fragment cases, including the
  query+fragment pair above.

The existing property generator also grew two implicit-grant callback shapes
(`https://box/callback#<field>`), which fail on master as well. `#` is
deliberately *not* added to that generator's separator list: there it would sit
inside the value, where `#` is a legitimate terminator.

Sanity-checked in both directions — reverting only `agentproto/auth.go` to
master turns all four red; restoring it turns them green.

## On the short-token note in the issue

The issue observes that tokens of five characters or fewer also slip past the
bug-report scrubber, whose bare-value alternation requires `{6,}`
(`bugreport/redact.go`). That threshold is not touched here. It is a deliberate
bound that keeps short structural values readable, and loosening it is a
different judgement call on a different surface. It also stops mattering for the
path the issue describes: `log/redact.go` wraps the log sink in
`RedactAccessTokenText`, so with this fix a fragment token of *any* length is
already `REDACTED` in `agent-factory.log` before a bundle ever reads it.

## Test Plan

- [x] `go test ./...` passes — `make test-container`, full suite green
- [x] `gofmt` applied to changed files — `gofmt -l .` empty
- [x] Manually tested in TUI — n/a, pure logging/redaction helper

Gate run on exact head `019d5fe1c3527db4b173516391a4dde29c210f06`:

- `golangci-lint run --timeout=3m --fast` — clean
- `gofmt -l .` — no output
- `go build ./...` — clean
- `make test-container` — all packages ok, no FAIL
- `deadcode -test ./...` — no output
- `scripts/lint-file-length.sh` — passed (1139 files)

Captain Claude