### PR TITLE
docs: gate strict builds on dead anchors

### DIFF
--- a/docs/agent-plugins.md
+++ b/docs/agent-plugins.md
@@ -19,7 +19,7 @@ curl -fsSL https://raw.githubusercontent.com/sachiniyer/agent-factory/master/ins
 
 The plugin checks for `af` and tells you this if it is missing. It never
 downloads or runs an installer itself — see [what the hook does
-not do](#the-preflight-hook) below.
+not do](#codex-hooks) below.
 
 ## Codex
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,16 +92,24 @@ extra:
 plugins:
   - search
 
-# Fail the build on broken in-repo links (the valuable check), but don't choke
-# on links that intentionally point outside docs/ (e.g. ../.github/…) or on
-# every cross-page anchor. `mkdocs build --strict` turns the warnings below into
-# errors.
+# Fail the build on broken in-repo links and on `#fragment` targets that no
+# heading produces, but don't choke on links that intentionally point outside
+# docs/ (e.g. ../.github/…). `mkdocs build --strict` turns the warnings below
+# into errors.
+#
+# `anchors` was `ignore` until #2623, on the theory that cross-page anchors
+# would be too noisy to gate on. Measured on the real tree instead of assumed:
+# the whole site produced exactly one warning, and it was a genuine dead link
+# (#2621 had just fixed five more of the same class, none of which this build
+# had ever complained about).
+# If some future link really is unfixable, name it here rather than switching
+# the whole class back off.
 validation:
   omitted_files: warn
   not_found: warn
   absolute_links: ignore
   unrecognized_links: ignore
-  anchors: ignore
+  anchors: warn
 
 nav:
   - Home: index.md


### PR DESCRIPTION
## Summary

`mkdocs.yml:104` set `validation.anchors: ignore` while
`.github/workflows/docs.yml:95` runs `mkdocs build --strict`. Strict mode
promotes *warnings* into errors — but a class set to `ignore` never produces a
warning to promote, so the one check that would have caught the five dead
anchors fixed in #2621 was switched off, and every anchor fix since is
unverifiable and free to rot again.

This turns the check on. The check cannot be green while the tree still holds a
dead anchor, so the anchor fix comes first in the same PR.

## Measured, not assumed

The rationale comment feared that gating on anchors would "choke on ... every
cross-page anchor". That is empirically false on this tree. Same pinned
toolchain as CI (`requirements-docs.txt`: mkdocs 1.6.1, mkdocs-material 9.6.14),
config identical to `master` except the one line:

```
$ mkdocs build --strict          # master, anchors: ignore
Documentation built in 2.20 seconds                          -> exit 0

$ mkdocs build --strict          # anchors: warn, nothing else changed
WARNING -  Doc file 'agent-plugins.md' contains a link '#the-preflight-hook',
           but there is no such anchor on this page.
Aborted with 1 warnings in strict mode!                      -> exit 1
```

Exactly one warning site-wide, and it is a real bug rather than noise.
Cross-page anchors produced zero complaints.

## The one warning is a real dead link

`docs/agent-plugins.md:21-22` links to `#the-preflight-hook`. No such heading
exists in the file — the headings are `Install af first`, `Codex`, `Claude
Code`, `Gemini CLI`, `amp`, `Codex hooks`, `Relationship to
global_agent_skills`, `What is not here`, `For maintainers`.

The section the link text promises ("what the hook does not do") is `## Codex
hooks` (`docs/agent-plugins.md:78`), whose body reads "The preflight
deliberately does not fetch or install anything." Checked against the real
slugifier rather than by eye (`markdown` 3.10.3, the same `toc` extension
`mkdocs.yml` configures):

```
'Codex hooks'  ->  #codex-hooks
```

## Why the previous audit scan missed it

Worth recording, because it is the argument for using mkdocs' own validation
over a bespoke checker. The link wraps across a newline:

```markdown
It never downloads or runs an installer itself — see [what the hook does
not do](#the-preflight-hook) below.
```

A per-line `\[[^\]]*\]\(([^)]+)\)` scan cannot see a link whose text contains a
newline, which is why the #2583 audit reported "0 broken" while mkdocs finds
one. mkdocs parses the real document; a hand-rolled regex keeps having blind
spots like this one.

## Verification — a real build, in both directions

| build | anchors | agent-plugins.md link | result |
|---|---|---|---|
| master baseline | `ignore` | broken | **exit 0** — the dead anchor passes |
| config change alone | `warn` | broken (stashed the fix) | **exit 1**, 1 warning |
| this PR | `warn` | fixed | **exit 0** |

And the gate covers the class #2583 catalogued, not just this one link. With
the fix in place I re-introduced a `#archive--restore` doubled dash in
`docs/backends.md` (one of the five #2621 fixed) and planted a cross-page
`remote-hooks.md#no-such-heading-here`, then built again:

```
WARNING -  Doc file 'backends.md' contains a link '#archive--restore',
           but there is no such anchor on this page.
WARNING -  Doc file 'backends.md' contains a link
           'remote-hooks.md#no-such-heading-here', but the doc
           'remote-hooks.md' does not contain an anchor '#no-such-heading-here'.
Aborted with 2 warnings in strict mode!                      -> exit 1
```

Both the same-file and the cross-file case fail the build now. Those two scratch
edits were reverted and are not in this diff.

The `Build & verify` job in `.github/workflows/docs.yml` runs on every PR with no
path filter, so this is a real gate on every change, not only on docs PRs.

Required gates, on the pushed head `3eb58afa87353a9a3a8d9492ba845cf5a61205f0`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (empty)
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`

Closes #2623
