### PR TITLE
fix(web): make Cmd+C copy and let a plain drag select (#2787)

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,25 @@
 # Release Notes
 
+## Copying out of the web terminal
+
+- **macOS `Cmd+C` now copies.** The web terminal claimed `Ctrl` chords only, so on
+  macOS the copy gesture fell through to the browser — which had nothing to copy,
+  because xterm paints its own selection rather than making a DOM one. It failed
+  **silently**: no error, no hint, and the next paste produced whatever had been on
+  the clipboard before. `Cmd+C` over a selection now copies it, through the same
+  never-silent path as `Ctrl+C`. With nothing selected it stays untouched, so it
+  never sends an interrupt — `Cmd+C` is not an interrupt on macOS. `Cmd+V` is
+  unchanged; it already worked.
+- **Behavior change — a plain drag now selects text, even while an agent owns the
+  mouse.** Claude Code and Codex both enable mouse tracking, which handed every drag
+  to the application: making a selection (and so copying anything) required holding
+  Option on macOS or Shift elsewhere. That is now inverted. **Dragging selects with
+  no modifier, and holding Option/Shift is what sends the drag to the application** —
+  so clicking an agent's own mouse-driven UI now needs the modifier. Nothing was
+  removed; only which gesture needs the modifier changed.
+- The wheel is deliberately **not** inverted: a mouse-aware application still
+  receives a plain scroll, and Option/Shift + wheel still scrolls terminal history.
+
 ## A healed root agent keeps its conversation
 
 - When the root agent's tmux vanished, the daemon re-created it as a **brand-new

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7147,6 +7147,14 @@ function handleClipboardKeydown(ev, deps) {
     deps.sendUserInput(LF);
     return false;
   }
+  if (ev.metaKey && !ev.ctrlKey && !ev.altKey && !ev.shiftKey && ev.key.toLowerCase() === "c") {
+    if (!deps.hasSelection()) {
+      return true;
+    }
+    ev.preventDefault();
+    deps.copy(deps.getSelection());
+    return false;
+  }
   if (ev.metaKey || ev.altKey || !ev.ctrlKey) {
     return true;
   }
@@ -7284,8 +7292,15 @@ function terminalUserScrollPlan(source, hasScheduledVisibleFit) {
 function terminalMouseOverride(platform) {
   return ["Macintosh", "MacIntel", "MacPPC", "Mac68K"].includes(platform) ? "Option" : "Shift";
 }
+function terminalMouseOverrideFlag(override) {
+  return override === "Option" ? "altKey" : "shiftKey";
+}
 function terminalMouseOverrideHeld(event, override) {
-  return override === "Option" ? event.altKey : event.shiftKey;
+  return event[terminalMouseOverrideFlag(override)];
+}
+function invertTerminalMouseOverride(event, override) {
+  const flag = terminalMouseOverrideFlag(override);
+  Object.defineProperty(event, flag, { value: !event[flag], configurable: true, enumerable: true });
 }
 function historyWheelPlan(event, rows, rowHeight, remainder) {
   if (event.deltaY === 0) {
@@ -7444,8 +7459,10 @@ var AttachTerminal = class {
       // The stream is the source of truth; local echo/scrollback beyond the ring is
       // fine but the server never sees our convert-eol, so leave it raw.
       scrollback: 5e3,
-      // xterm uses Shift to force selection outside macOS. Opt macOS into its
-      // matching Option escape so every platform can leave app mouse mode.
+      // Names Option as macOS's force-selection modifier (Shift is xterm's built-in
+      // choice elsewhere), giving onMouseDownCapture ONE bit to invert on every
+      // platform. It also keeps Option out of xterm's block-select gesture, which
+      // would otherwise fire on the inverted bit.
       macOptionClickForcesSelection: true
     });
     this.fit = new import_addon_fit.FitAddon();
@@ -7456,7 +7473,8 @@ var AttachTerminal = class {
     this.mouseCaptureHint.setAttribute("role", "status");
     this.mouseCaptureHint.setAttribute("aria-live", "polite");
     this.mouseCaptureHint.setAttribute("aria-hidden", "true");
-    this.mouseCaptureHint.textContent = `App mouse active \xB7 Hold ${this.mouseOverride} to select or scroll`;
+    this.pointerHint = `App mouse active \xB7 Drag selects \xB7 Hold ${this.mouseOverride} for app clicks`;
+    this.wheelHint = `App mouse active \xB7 Hold ${this.mouseOverride} to scroll history`;
     this.term.element?.append(this.mouseCaptureHint);
     this.term.attachCustomWheelEventHandler((event) => this.handleHistoryWheel(event));
     const textarea = this.term.textarea;
@@ -7506,6 +7524,7 @@ var AttachTerminal = class {
     container.addEventListener("wheel", this.onWheel, { capture: true, passive: true });
     container.addEventListener("touchmove", this.onTouchMove, { capture: true, passive: true });
     container.addEventListener("pointerdown", this.onPointerDown, true);
+    container.addEventListener("mousedown", this.onMouseDownCapture, true);
     this.scheduleVisibleFit();
   }
   term;
@@ -7524,6 +7543,8 @@ var AttachTerminal = class {
   viewportRestoreFrame = null;
   mouseOverride;
   mouseCaptureHint;
+  pointerHint;
+  wheelHint;
   mouseCaptureHintTimer = null;
   mouseOverrideKeyHeld = false;
   historyWheelRemainder = 0;
@@ -7572,7 +7593,7 @@ var AttachTerminal = class {
   onWheel = (event) => {
     this.handleUserScroll("wheel");
     if (!terminalMouseOverrideHeld(event, this.mouseOverride) && !this.mouseOverrideKeyHeld && this.applicationOwnsWheel()) {
-      this.showMouseCaptureHint();
+      this.showMouseCaptureHint(this.wheelHint);
     }
   };
   onTouchMove = () => this.handleUserScroll("touch");
@@ -7583,8 +7604,24 @@ var AttachTerminal = class {
       return;
     }
     if (!terminalMouseOverrideHeld(event, this.mouseOverride) && this.applicationOwnsMouse()) {
-      this.showMouseCaptureHint();
+      this.showMouseCaptureHint(this.pointerHint);
     }
+  };
+  // The inversion itself (#2787). It runs in the CAPTURE phase on the pane host, so
+  // it lands before both of xterm's mousedown listeners — they sit on xterm's own
+  // element, a descendant — and therefore before either reads the modifier.
+  //
+  // mousedown ONLY. mouseup carries xterm's alt-click-moves-cursor gesture, which
+  // reads the same altKey: a synthetic Option there would fire cursor-movement
+  // sequences into the PTY on every plain click. It is also unnecessary — xterm only
+  // registers its PTY mouseup/mousedrag forwarders inside the mousedown branch this
+  // inversion already diverts, and the selection drag that replaces it is driven by
+  // document listeners that read no modifier at all.
+  onMouseDownCapture = (event) => {
+    if (!this.applicationOwnsMouse()) {
+      return;
+    }
+    invertTerminalMouseOverride(event, this.mouseOverride);
   };
   handleUserScroll(source) {
     if (this.pendingViewport === null) {
@@ -7624,6 +7661,7 @@ var AttachTerminal = class {
     this.container.removeEventListener("wheel", this.onWheel, true);
     this.container.removeEventListener("touchmove", this.onTouchMove, true);
     this.container.removeEventListener("pointerdown", this.onPointerDown, true);
+    this.container.removeEventListener("mousedown", this.onMouseDownCapture, true);
     this.closeSocket();
     this.term.dispose();
   }
@@ -7634,7 +7672,8 @@ var AttachTerminal = class {
     const mode = this.term.modes.mouseTrackingMode;
     return mode !== "none" && mode !== "x10";
   }
-  showMouseCaptureHint() {
+  showMouseCaptureHint(message) {
+    this.mouseCaptureHint.textContent = message;
     this.mouseCaptureHint.classList.add("af-visible");
     this.mouseCaptureHint.setAttribute("aria-hidden", "false");
     if (this.mouseCaptureHintTimer !== null) {

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "2ba2679c4da8";
+const VERSION = "5cb73e76c8eb";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -236,6 +236,40 @@ async function createTerminalTab(page: Page): Promise<void> {
   await expect(menu).toBeHidden();
 }
 
+/**
+ * Focuses a freshly created shell tab and does not return until the shell is
+ * demonstrably READING keystrokes.
+ *
+ * `data-term-status="open"` says the socket is open, which is NOT the same as the
+ * shell being ready for input: on a loaded runner the first characters typed into a
+ * new tab can be lost before anything reads them. What that produces is not an
+ * obvious dropped keystroke but a MANGLED command — observed in CI, where the
+ * leading `for i in $(seq 1 80); do printf 'mouse` of a setup command vanished, the
+ * surviving tail left the shell sitting at a PS2 continuation prompt, the loop never
+ * ran, and the test then failed waiting on output that was never going to appear.
+ * The assertion that failed was 56 lines away from the behaviour under test, which
+ * is exactly what makes this kind of red expensive to read (#1897).
+ *
+ * A comment line is inert to the shell, so re-sending it can never change shell
+ * state; its ECHO is the proof that keystrokes now reach something that reads them.
+ * (If the leading `#` itself is the character that gets lost, the shell answers
+ * "command not found" — which contains the marker too, and equally proves it is
+ * reading.) This is setup only: it asserts nothing about the product beyond the
+ * precondition every one of these tests already assumed silently.
+ */
+async function typeableShellTab(p: Page): Promise<Locator> {
+  const host = p.locator(".af-term-host");
+  await expect(p.locator(".af-main")).toHaveAttribute("data-term-status", "open");
+  await host.click();
+  const marker = "af-shell-typeable";
+  await expect(async () => {
+    await p.keyboard.type(`# ${marker}`);
+    await p.keyboard.press("Enter");
+    await expect(host).toContainText(marker, { timeout: 3_000 });
+  }).toPass({ timeout: 45_000, intervals: [500, 1_000, 2_000] });
+  return host;
+}
+
 interface ElementBox {
   x: number;
   y: number;
@@ -1282,12 +1316,10 @@ test("#2681/#2787: application mouse mode selects on a plain drag and keeps a mo
     await row(p, SESSION_B).click();
     await resetToAgentTab(p);
     await createTerminalTab(p);
-    await expect(p.locator(".af-main")).toHaveAttribute("data-term-status", "open");
 
-    const host = p.locator(".af-term-host");
+    const host = await typeableShellTab(p);
     const xterm = host.locator(".xterm");
     const viewport = host.locator(".xterm-viewport");
-    await host.click();
     await p.keyboard.type("for i in $(seq 1 80); do printf 'mouse-mode-%s\\n' \"$i\"; done");
     await p.keyboard.press("Enter");
     await expect(host).toContainText("mouse-mode-80", { timeout: 15_000 });
@@ -1464,10 +1496,8 @@ test("#2787: Cmd+C copies the terminal selection to the system clipboard", REAL_
     await row(p, SESSION_B).click();
     await resetToAgentTab(p);
     await createTerminalTab(p);
-    await expect(p.locator(".af-main")).toHaveAttribute("data-term-status", "open");
 
-    const host = p.locator(".af-term-host");
-    await host.click();
+    const host = await typeableShellTab(p);
     await p.keyboard.type("printf 'af-2787-copy-me\\n'");
     await p.keyboard.press("Enter");
     await expect(host).toContainText("af-2787-copy-me", { timeout: 15_000 });
@@ -1633,7 +1663,9 @@ test("#2337: agent Shift+Enter preserves xterm input effects while shell keeps C
     await createTerminalTab(p);
     shellCreated = true;
     await expect(p.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Terminal", { timeout: 30_000 });
-    await expect(p.locator(".af-main")).toHaveAttribute("data-term-status", "open");
+    // Same latent race as the tabs above: prove the shell reads keystrokes before
+    // typing one this test measures. The reset below discards the handshake's bytes.
+    await typeableShellTab(p);
 
     inputPayloads.length = 0;
     await p.keyboard.type("echo $((233700 + 42))");

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -1255,7 +1255,7 @@ test("click-to-attach opens the xterm terminal and shows live output", REAL_FIXT
   await expect(page.locator(".af-term-head button", { hasText: "Kill" })).toHaveCount(0);
 });
 
-test("#2681: application mouse mode offers a modifier escape for copy and history scroll", REAL_FIXTURE, async ({
+test("#2681/#2787: application mouse mode selects on a plain drag and keeps a modifier escape", REAL_FIXTURE, async ({
   browser,
 }) => {
   const ctx = await browser.newContext({ permissions: ["clipboard-read", "clipboard-write"] });
@@ -1346,29 +1346,42 @@ test("#2681: application mouse mode offers a modifier escape for copy and histor
       await p.mouse.move(x + Math.min(width - 4, 150), y + height / 2, { steps: 8 });
       await p.mouse.up();
     };
+    // #2787: a PLAIN drag selects, even while the application owns the mouse. This is
+    // the whole of Sachin's second complaint — nothing can be copied out of an agent
+    // pane if making a selection needs a modifier nobody discovers. No unit test can
+    // see this: xterm itself decides, off the raw MouseEvent.
+    inputPayloads.length = 0;
     await drag();
     const selection = host.locator(".xterm-selection > div");
-    await expect(selection, "plain drag is also application-owned by design").toHaveCount(0);
+    await expect(selection, "a plain drag must select text even while the app owns the mouse").not.toHaveCount(0);
+    expect(inputPayloads, "a selecting drag must not ALSO report the button to the application").toHaveLength(0);
 
-    // The UI must explain the escape at the moment a user hits the application-owned
-    // pointer path. Selection and scroll then share one modifier rather than becoming
-    // two unrelated fixes.
+    // The hint explains what the plain gesture no longer does — the application did
+    // not get that click — and names the modifier that still gives it one.
     await expect.soft(mouseHint).toHaveClass(/af-visible/, { timeout: 2_000 });
     await expect.soft(mouseHint).toHaveAttribute("aria-hidden", "false");
-    await expect.soft(mouseHint).toContainText("Hold Shift to select or scroll");
-
-    await p.keyboard.down("Shift");
-    await drag();
-    await p.keyboard.up("Shift");
-    await expect(selection, "Shift+drag must force terminal selection while the app owns the mouse").not.toHaveCount(0);
+    await expect.soft(mouseHint).toContainText("Drag selects · Hold Shift for app clicks");
 
     const beforeCopyInputs = inputPayloads.length;
     await p.keyboard.press("Control+c");
     await expect(selection, "copy clears the selection so the next Ctrl+C can interrupt").toHaveCount(0);
     expect(inputPayloads, "copy must not send an interrupt or mouse bytes to the PTY").toHaveLength(beforeCopyInputs);
     await expect
-      .poll(() => p.evaluate(() => navigator.clipboard.readText()), { message: "the forced selection must reach the clipboard" })
+      .poll(() => p.evaluate(() => navigator.clipboard.readText()), { message: "the plain-drag selection must reach the clipboard" })
       .toContain("mode-80");
+
+    // The inverse half — the capability #2681 protects. Mouse-aware TUIs keep their
+    // pointer: the modifier hands the drag to the application instead of selecting.
+    inputPayloads.length = 0;
+    await p.keyboard.down("Shift");
+    await drag();
+    await p.keyboard.up("Shift");
+    // Both halves of the button — press AND release — so no straggling report can
+    // land in the log after the history-wheel check below zeroes it.
+    await expect
+      .poll(() => inputPayloads.length, { message: "Shift+drag must report the button to the mouse-aware application" })
+      .toBeGreaterThan(1);
+    await expect(selection, "the modifier hands the drag to the app, so it makes no selection").toHaveCount(0);
 
     const beforeHistoryScroll = await viewport.evaluate((el) => el.scrollTop);
     inputPayloads.length = 0;
@@ -1415,6 +1428,114 @@ test("#2681: application mouse mode offers a modifier escape for copy and histor
     // The real-browser suite intentionally shares one long-lived page between
     // serial tests. Restore its selection explicitly so this isolated B-tab
     // exercise cannot perturb the #1694 keyboard flow that follows.
+    await row(page, SESSION_A).click();
+    await expect(row(page, SESSION_A)).toHaveClass(/af-row-selected/);
+  }
+});
+
+test("#2787: Cmd+C copies the terminal selection to the system clipboard", REAL_FIXTURE, async ({ browser }) => {
+  // The defect this pins is invisible to a unit test, which is how it shipped: the
+  // old unit test asserted only that our handler declined Cmd+C, under a NAME that
+  // claimed "the macOS browser copies before xterm". It does not. xterm keeps its own
+  // selection model and paints an overlay, so document.getSelection() is empty and
+  // the browser's native copy writes NOTHING — silently. Only a real browser holding
+  // a real system clipboard can tell the two apart, so this reads the clipboard back.
+  const ctx = await browser.newContext({ permissions: ["clipboard-read", "clipboard-write"] });
+  const p = await ctx.newPage();
+  const inputPayloads: number[][] = [];
+
+  p.on("websocket", (ws) => {
+    if (!ws.url().includes("/v1/sessions/") || !ws.url().includes("/stream")) {
+      return;
+    }
+    ws.on("framesent", ({ payload }) => {
+      const raw = typeof payload === "string" ? new TextEncoder().encode(payload) : new Uint8Array(payload);
+      const frame = decode(raw);
+      if (frame.op === Op.Input) {
+        inputPayloads.push(Array.from(frame.data));
+      }
+    });
+  });
+
+  try {
+    await openTokenless(p);
+    // Isolated context on B, like the mouse-mode exercise above: this mutates B's tab
+    // roster and restores it in finally, leaving the suite's shared page untouched.
+    await row(p, SESSION_B).click();
+    await resetToAgentTab(p);
+    await createTerminalTab(p);
+    await expect(p.locator(".af-main")).toHaveAttribute("data-term-status", "open");
+
+    const host = p.locator(".af-term-host");
+    await host.click();
+    await p.keyboard.type("printf 'af-2787-copy-me\\n'");
+    await p.keyboard.press("Enter");
+    await expect(host).toContainText("af-2787-copy-me", { timeout: 15_000 });
+
+    const outputRow = host.locator(".xterm-rows > div", { hasText: "af-2787-copy-me" }).last();
+    await expect(outputRow).toBeVisible();
+    const rowBox = await outputRow.boundingBox();
+    expect(rowBox, "the visible output row must have selectable geometry").toBeTruthy();
+    const { x, y, width, height } = rowBox as { x: number; y: number; width: number; height: number };
+    await p.mouse.move(x + 4, y + height / 2);
+    await p.mouse.down();
+    await p.mouse.move(x + Math.min(width - 4, 150), y + height / 2, { steps: 8 });
+    await p.mouse.up();
+    const selection = host.locator(".xterm-selection > div");
+    await expect(selection, "the drag must produce a terminal selection to copy").not.toHaveCount(0);
+
+    // Seed a sentinel so a failure is unambiguous: an unclaimed Cmd+C leaves THIS in
+    // the clipboard — the silent no-op the report describes — rather than erroring.
+    // Best-effort: if the seed itself is refused the assertion below still fails on
+    // the stale content, so it must not become its own failure mode.
+    await p.evaluate(() => navigator.clipboard.writeText("af-2787-clipboard-untouched").catch(() => {}));
+    inputPayloads.length = 0;
+    await p.keyboard.press("Meta+c");
+    // Not the leading "af-": a drag that starts past the midpoint of a cell snaps the
+    // selection to the next column, exactly as a real terminal does. What is being
+    // asserted is that the SELECTED TEXT reached the clipboard, not the pixel the
+    // drag began on.
+    await expect
+      .poll(() => p.evaluate(() => navigator.clipboard.readText()), {
+        message: "Cmd+C must put the xterm selection on the system clipboard",
+      })
+      .toContain("2787-copy-me");
+    expect(
+      await p.evaluate(() => navigator.clipboard.readText()),
+      "the seeded sentinel must be GONE — an unclaimed Cmd+C leaves it in place",
+    ).not.toContain("untouched");
+    await expect(selection, "Cmd+C keeps the selection — it has no interrupt to fall through to").not.toHaveCount(0);
+    expect(inputPayloads, "Cmd+C is a copy, never an interrupt: nothing may reach the PTY").toHaveLength(0);
+
+    // Drop the selection through the path that owns clearing it — Ctrl+C copies and
+    // then clears, so the NEXT Ctrl+C can interrupt — rather than assuming a bare
+    // click deselects.
+    await p.keyboard.press("Control+c");
+    await expect(selection, "Ctrl+C copies and clears the selection").toHaveCount(0);
+
+    // With NOTHING selected, Cmd+C must stay a no-op. On macOS it is not the
+    // interrupt gesture, so emitting \x03 here would kill a running agent. Ordering
+    // the assertion behind a byte that MUST arrive makes the negative real: an
+    // interrupt would already be in the log ahead of the marker keystroke.
+    inputPayloads.length = 0;
+    await p.keyboard.press("Meta+c");
+    await p.keyboard.press("x");
+    await expect.poll(() => inputPayloads.length, { message: "the marker keystroke must reach the PTY" }).toBeGreaterThan(0);
+    expect(inputPayloads.flat(), "Cmd+C with no selection sends nothing — least of all \\x03").toEqual([0x78]);
+
+    // Ctrl+C keeps BOTH of its meanings on every platform (the reflex the interrupt
+    // path exists for): nothing selected, so this one really does interrupt.
+    inputPayloads.length = 0;
+    await p.keyboard.press("Control+c");
+    await expect
+      .poll(() => inputPayloads.flat(), { message: "Ctrl+C with no selection still interrupts" })
+      .toEqual([0x03]);
+  } finally {
+    try {
+      await resetToAgentTab(p);
+    } finally {
+      await ctx.close();
+    }
     await row(page, SESSION_A).click();
     await expect(row(page, SESSION_A)).toHaveClass(/af-row-selected/);
   }

--- a/web/src/clipboard.test.ts
+++ b/web/src/clipboard.test.ts
@@ -222,16 +222,51 @@ test("Ctrl+Shift+V also defers to native paste without preventDefault", () => {
   assert.equal(r.prevented(), 0);
 });
 
-// --- macOS Cmd+* and Alt+* are left entirely to the browser -------------------
+// --- macOS Cmd+C: copy a selection, otherwise stay out of the way -------------
+//
+// The previous version of this block was named "Cmd+C is NOT claimed (macOS browser
+// copies before xterm)" and asserted only that the handler returned true — trivially
+// true of ANY unclaimed key. The name asserted an ENVIRONMENT fact nothing checked,
+// and it was false: xterm paints its own selection overlay instead of making a DOM
+// selection, so the browser's native copy wrote nothing (#2787). Each test below now
+// asserts exactly what its name claims, and the browser half — that a real Cmd+C
+// really does land in the system clipboard — is pinned by the Playwright case in
+// web/selftest/web-driver.spec.ts, because no unit test can see it.
 
-test("Cmd+C is NOT claimed (macOS browser copies before xterm)", () => {
+test("Cmd+C WITH a selection copies it through the same never-silent ladder as Ctrl+C", () => {
   const r = rig({ selection: "sel" });
   const ret = handleClipboardKeydown(keyEvent({ key: "c", metaKey: true }, r.markPrevented), r.deps);
 
-  assert.equal(ret, true, "leave Cmd+C to the browser");
-  assert.deepEqual(r.clipboard, [], "our handler must not double-copy on macOS");
-  assert.equal(wireInput(r.wire), "");
+  assert.equal(ret, false, "we handled the copy, so xterm must not also process the key");
+  assert.deepEqual(r.clipboard, ["sel"], "the selection must reach deps.copy — the browser cannot copy it for us");
+  assert.equal(wireInput(r.wire), "", "Cmd+C is not an interrupt: nothing may reach the wire");
+  assert.equal(r.prevented(), 1, "preventDefault stops the browser's own (empty) copy from racing ours");
+  assert.equal(r.cleared(), 0, "Cmd+C keeps the selection — it has no interrupt to fall through to");
+});
+
+test("Cmd+C with NO selection is left untouched and NEVER interrupts", () => {
+  const r = rig({ selection: "" });
+  const ret = handleClipboardKeydown(keyEvent({ key: "c", metaKey: true }, r.markPrevented), r.deps);
+
+  assert.equal(ret, true, "nothing to copy — leave the gesture to the browser");
+  assert.deepEqual(r.clipboard, []);
+  assert.equal(wireInput(r.wire), "", "on macOS Cmd+C is not an interrupt: \\x03 here would kill the agent");
   assert.equal(r.prevented(), 0);
+});
+
+test("Cmd+Shift+C and Cmd+Alt+C stay with the browser (its devtools shortcuts)", () => {
+  for (const modifiers of [{ shiftKey: true }, { altKey: true }]) {
+    const r = rig({ selection: "sel" });
+    const ret = handleClipboardKeydown(
+      keyEvent({ key: "c", metaKey: true, ...modifiers }, r.markPrevented),
+      r.deps,
+    );
+
+    assert.equal(ret, true, JSON.stringify(modifiers));
+    assert.deepEqual(r.clipboard, [], `only the BARE Cmd+C is ours: ${JSON.stringify(modifiers)}`);
+    assert.equal(wireInput(r.wire), "", JSON.stringify(modifiers));
+    assert.equal(r.prevented(), 0, JSON.stringify(modifiers));
+  }
 });
 
 test("Cmd+V is NOT claimed (native paste path untouched)", () => {

--- a/web/src/clipboard.ts
+++ b/web/src/clipboard.ts
@@ -12,6 +12,8 @@
 //     runaway-agent reflex is preserved.
 //   - Ctrl+Shift+C → an EXPLICIT always-copy: copies the selection if any, a
 //     no-op otherwise, and NEVER interrupts.
+//   - Cmd+C (macOS) → copy the selection when there IS one; otherwise untouched.
+//     Cmd+C is not an interrupt anywhere, so it never sends \x03 (#2787).
 //   - Ctrl+V / Ctrl+Shift+V → paste, by deferring to xterm's native browser
 //     paste (see below).
 //   - Shift+Enter in the AGENT tab → LF (Ctrl+J), which Codex and Claude bind to
@@ -71,9 +73,10 @@ const LF = "\n";
  *   - `false` → we fully handled it; xterm skips its own processing so it does not
  *     ALSO emit bytes for the key.
  *
- * Only Ctrl+* clipboard gestures and bare Shift+Enter in an agent composer are
- * claimed. Cmd+* (metaKey), Alt+*, and every Enter in a shell/process tab are left
- * untouched so their browser/xterm/application bindings keep working as before.
+ * Only Ctrl+* clipboard gestures, bare Cmd+C over a selection, and bare Shift+Enter
+ * in an agent composer are claimed. Every other Cmd+* (metaKey), Alt+*, and every
+ * Enter in a shell/process tab are left untouched so their browser/xterm/application
+ * bindings keep working as before.
  *
  * Paste note: for Ctrl+V (and Ctrl+Shift+V) we return `false` WITHOUT calling
  * preventDefault. In xterm, a custom handler that returns false makes _keyDown
@@ -109,7 +112,36 @@ export function handleClipboardKeydown(ev: ClipboardKeyEvent, deps: ClipboardDep
     deps.sendUserInput(LF);
     return false;
   }
-  // Leave Cmd+* (macOS) and Alt+* to the browser/xterm untouched.
+  // macOS copies with Cmd+C, and that gesture CANNOT be left to the browser (#2787).
+  // xterm keeps its own selection model and paints an overlay — it never makes a DOM
+  // selection — so the browser's native copy finds document.getSelection() empty and
+  // writes NOTHING, silently, without ever reaching the never-silent copy ladder in
+  // terminal.ts. (Cmd+V is the asymmetry that hid this: paste works because the
+  // browser fires a trusted `paste` event xterm forwards to the PTY; copy has no
+  // counterpart.) So claim the BARE gesture, and only when there is something to
+  // copy:
+  //
+  //   - a selection → preventDefault + copy, through the same deps.copy ladder as
+  //     Ctrl+C, so a failed write still surfaces a visible hint;
+  //   - no selection → untouched. Cmd+C is not an interrupt on macOS, so this path
+  //     must never emit \x03.
+  //
+  // The selection is deliberately KEPT. Clearing exists on Ctrl+C so a second press
+  // falls through to the interrupt; Cmd+C has no interrupt to fall through to, so
+  // clearing would just be a surprising selection loss.
+  //
+  // Bare only: Cmd+Shift+C is the browser's inspect-element toggle, and Cmd+Alt+C
+  // devtools too — claiming those would trade one broken shortcut for another.
+  // Cmd+V stays untouched; its trusted-paste path already works.
+  if (ev.metaKey && !ev.ctrlKey && !ev.altKey && !ev.shiftKey && ev.key.toLowerCase() === "c") {
+    if (!deps.hasSelection()) {
+      return true;
+    }
+    ev.preventDefault();
+    deps.copy(deps.getSelection());
+    return false;
+  }
+  // Leave every other Cmd+* (macOS) and Alt+* to the browser/xterm untouched.
   if (ev.metaKey || ev.altKey || !ev.ctrlKey) {
     return true;
   }

--- a/web/src/terminal-mouse.test.ts
+++ b/web/src/terminal-mouse.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { historyWheelPlan, terminalMouseOverride, terminalMouseOverrideHeld } from "./terminal-mouse.js";
+import {
+  historyWheelPlan,
+  invertTerminalMouseOverride,
+  terminalMouseOverride,
+  terminalMouseOverrideFlag,
+  terminalMouseOverrideHeld,
+} from "./terminal-mouse.js";
 
 test("application-mouse escape matches xterm's platform selection modifier", () => {
   assert.equal(terminalMouseOverride("Linux x86_64"), "Shift");
@@ -14,6 +20,34 @@ test("application-mouse escape matches xterm's platform selection modifier", () 
   assert.equal(terminalMouseOverrideHeld({ shiftKey: true, altKey: false }, "Shift"), true);
   assert.equal(terminalMouseOverrideHeld({ shiftKey: false, altKey: true }, "Option"), true);
   assert.equal(terminalMouseOverrideHeld({ shiftKey: true, altKey: false }, "Option"), false);
+});
+
+test("inverting the override flips exactly the bit xterm reads to force selection", () => {
+  // The flag names must stay xterm's own (SelectionService.shouldForceSelection):
+  // Option/altKey on macOS, Shift/shiftKey elsewhere. Inverting the wrong one would
+  // silently leave app mouse mode owning every drag.
+  assert.equal(terminalMouseOverrideFlag("Option"), "altKey");
+  assert.equal(terminalMouseOverrideFlag("Shift"), "shiftKey");
+
+  // A plain drag must LOOK modified to xterm, so it selects instead of reporting.
+  const plain = { shiftKey: false, altKey: false };
+  invertTerminalMouseOverride(plain, "Shift");
+  assert.equal(terminalMouseOverrideHeld(plain, "Shift"), true, "plain drag now forces selection");
+  assert.equal(plain.altKey, false, "the other modifier is untouched — Alt still means column select");
+
+  // …and a held modifier must look plain, so the drag reaches the application.
+  const held = { shiftKey: true, altKey: false };
+  invertTerminalMouseOverride(held, "Shift");
+  assert.equal(terminalMouseOverrideHeld(held, "Shift"), false, "the modifier hands the drag to the app");
+
+  const macPlain = { shiftKey: false, altKey: false };
+  invertTerminalMouseOverride(macPlain, "Option");
+  assert.equal(macPlain.altKey, true, "macOS forces selection via Option");
+  assert.equal(macPlain.shiftKey, false, "Shift is not macOS's flag and must not move");
+
+  const macHeld = { shiftKey: false, altKey: true };
+  invertTerminalMouseOverride(macHeld, "Option");
+  assert.equal(macHeld.altKey, false);
 });
 
 test("history wheel converts pixels, lines, and pages without losing trackpad fractions", () => {

--- a/web/src/terminal-mouse.ts
+++ b/web/src/terminal-mouse.ts
@@ -9,6 +9,10 @@ export interface MouseModifierEvent {
   shiftKey: boolean;
 }
 
+/** The MouseEvent flag xterm's SelectionService.shouldForceSelection reads to decide
+ *  "select text" vs. "report this to the application". */
+export type TerminalMouseOverrideFlag = "altKey" | "shiftKey";
+
 export interface HistoryWheelEvent {
   deltaMode: number;
   deltaY: number;
@@ -26,8 +30,34 @@ export function terminalMouseOverride(platform: string): TerminalMouseOverride {
   return ["Macintosh", "MacIntel", "MacPPC", "Mac68K"].includes(platform) ? "Option" : "Shift";
 }
 
+export function terminalMouseOverrideFlag(override: TerminalMouseOverride): TerminalMouseOverrideFlag {
+  return override === "Option" ? "altKey" : "shiftKey";
+}
+
 export function terminalMouseOverrideHeld(event: MouseModifierEvent, override: TerminalMouseOverride): boolean {
-  return override === "Option" ? event.altKey : event.shiftKey;
+  return event[terminalMouseOverrideFlag(override)];
+}
+
+/**
+ * Inverts the force-selection modifier xterm will read off this mousedown, so the
+ * UNMODIFIED drag selects text and the held modifier is what hands the drag to a
+ * mouse-tracking application (#2787).
+ *
+ * xterm resolves that fork from exactly one bit on the raw event — Option on macOS
+ * (gated by macOptionClickForcesSelection), Shift elsewhere — and consults it from
+ * BOTH of its mousedown listeners: the one that starts a selection and the one that
+ * reports the button to the PTY. Flipping the bit before either runs therefore moves
+ * the whole fork, keeping both behaviours; only which gesture needs a modifier
+ * changes. There is no xterm option for this and no custom-mouse-handler hook (the
+ * wheel is the only one), so the event itself is the seam.
+ *
+ * The flag is a readonly accessor on MouseEvent.prototype; an own data property
+ * shadows it for every later listener without touching the prototype and without
+ * re-dispatching a synthetic (untrusted, focus-losing) event.
+ */
+export function invertTerminalMouseOverride(event: MouseModifierEvent, override: TerminalMouseOverride): void {
+  const flag = terminalMouseOverrideFlag(override);
+  Object.defineProperty(event, flag, { value: !event[flag], configurable: true, enumerable: true });
 }
 
 /** Convert browser wheel units into whole terminal rows while retaining sub-row

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -52,6 +52,7 @@ import {
 } from "./terminal-geometry.js";
 import {
   historyWheelPlan,
+  invertTerminalMouseOverride,
   terminalMouseOverride,
   terminalMouseOverrideHeld,
   type TerminalMouseOverride,
@@ -115,6 +116,8 @@ export class AttachTerminal {
   private viewportRestoreFrame: number | null = null;
   private readonly mouseOverride: TerminalMouseOverride;
   private readonly mouseCaptureHint: HTMLDivElement;
+  private readonly pointerHint: string;
+  private readonly wheelHint: string;
   private mouseCaptureHintTimer: number | null = null;
   private mouseOverrideKeyHeld = false;
   private historyWheelRemainder = 0;
@@ -170,7 +173,7 @@ export class AttachTerminal {
       !this.mouseOverrideKeyHeld &&
       this.applicationOwnsWheel()
     ) {
-      this.showMouseCaptureHint();
+      this.showMouseCaptureHint(this.wheelHint);
     }
   };
   private readonly onTouchMove = (): void => this.handleUserScroll("touch");
@@ -184,8 +187,26 @@ export class AttachTerminal {
       return;
     }
     if (!terminalMouseOverrideHeld(event, this.mouseOverride) && this.applicationOwnsMouse()) {
-      this.showMouseCaptureHint();
+      this.showMouseCaptureHint(this.pointerHint);
     }
+  };
+  // The inversion itself (#2787). It runs in the CAPTURE phase on the pane host, so
+  // it lands before both of xterm's mousedown listeners — they sit on xterm's own
+  // element, a descendant — and therefore before either reads the modifier.
+  //
+  // mousedown ONLY. mouseup carries xterm's alt-click-moves-cursor gesture, which
+  // reads the same altKey: a synthetic Option there would fire cursor-movement
+  // sequences into the PTY on every plain click. It is also unnecessary — xterm only
+  // registers its PTY mouseup/mousedrag forwarders inside the mousedown branch this
+  // inversion already diverts, and the selection drag that replaces it is driven by
+  // document listeners that read no modifier at all.
+  private readonly onMouseDownCapture = (event: MouseEvent): void => {
+    if (!this.applicationOwnsMouse()) {
+      // Outside application mouse mode a plain drag already selects, and the
+      // modifier keeps its xterm meaning (Shift extends an existing selection).
+      return;
+    }
+    invertTerminalMouseOverride(event, this.mouseOverride);
   };
 
   private handleUserScroll(source: TerminalUserScrollSource): void {
@@ -221,8 +242,10 @@ export class AttachTerminal {
       // The stream is the source of truth; local echo/scrollback beyond the ring is
       // fine but the server never sees our convert-eol, so leave it raw.
       scrollback: 5000,
-      // xterm uses Shift to force selection outside macOS. Opt macOS into its
-      // matching Option escape so every platform can leave app mouse mode.
+      // Names Option as macOS's force-selection modifier (Shift is xterm's built-in
+      // choice elsewhere), giving onMouseDownCapture ONE bit to invert on every
+      // platform. It also keeps Option out of xterm's block-select gesture, which
+      // would otherwise fire on the inverted bit.
       macOptionClickForcesSelection: true,
     });
     this.fit = new FitAddon();
@@ -233,12 +256,20 @@ export class AttachTerminal {
     this.mouseCaptureHint.setAttribute("role", "status");
     this.mouseCaptureHint.setAttribute("aria-live", "polite");
     this.mouseCaptureHint.setAttribute("aria-hidden", "true");
-    this.mouseCaptureHint.textContent = `App mouse active · Hold ${this.mouseOverride} to select or scroll`;
+    // Two messages, because the pointer and the wheel now sit on opposite sides of
+    // the modifier: a drag is terminal-owned by default (#2787) while the wheel stays
+    // application-owned (#2681). One combined line would have to describe both
+    // directions at once, and the hint exists precisely to say which gesture the user
+    // just lost.
+    this.pointerHint = `App mouse active · Drag selects · Hold ${this.mouseOverride} for app clicks`;
+    this.wheelHint = `App mouse active · Hold ${this.mouseOverride} to scroll history`;
     this.term.element?.append(this.mouseCaptureHint);
 
-    // xterm normally forwards every wheel to a mouse-aware application and
-    // cancels browser scrollback. The selection modifier instead scrolls terminal
-    // history, so copy and scroll share one discoverable escape (#2681).
+    // xterm normally forwards every wheel to a mouse-aware application and cancels
+    // browser scrollback. The modifier instead scrolls terminal history (#2681). The
+    // wheel is deliberately NOT inverted alongside the drag: an agent TUI that turns
+    // mouse mode on is usually doing it to own the wheel, and taking scroll away from
+    // it by default would break the pane it draws.
     this.term.attachCustomWheelEventHandler((event) => this.handleHistoryWheel(event));
 
     // Report focus/blur of xterm's helper textarea so index.ts can track which pane
@@ -269,7 +300,8 @@ export class AttachTerminal {
     // BEFORE xterm turns it into input. Bare Shift+Enter emits LF only for the
     // invariant agent tab at index 0; shell/process tabs and plain Enter retain
     // xterm's CR. Ctrl+C copies a present selection (else interrupts),
-    // Ctrl+Shift+C is explicit copy, and Ctrl+V defers to native paste. False
+    // Ctrl+Shift+C is explicit copy, Cmd+C copies a present selection (macOS, and
+    // never an interrupt — #2787), and Ctrl+V defers to native paste. False
     // suppresses xterm's own handling.
     this.term.attachCustomKeyEventHandler((ev) => {
       const overrideKey = this.mouseOverride === "Option" ? "Alt" : "Shift";
@@ -314,6 +346,7 @@ export class AttachTerminal {
     container.addEventListener("wheel", this.onWheel, { capture: true, passive: true });
     container.addEventListener("touchmove", this.onTouchMove, { capture: true, passive: true });
     container.addEventListener("pointerdown", this.onPointerDown, true);
+    container.addEventListener("mousedown", this.onMouseDownCapture, true);
     this.scheduleVisibleFit();
   }
 
@@ -344,6 +377,7 @@ export class AttachTerminal {
     this.container.removeEventListener("wheel", this.onWheel, true);
     this.container.removeEventListener("touchmove", this.onTouchMove, true);
     this.container.removeEventListener("pointerdown", this.onPointerDown, true);
+    this.container.removeEventListener("mousedown", this.onMouseDownCapture, true);
     this.closeSocket();
     this.term.dispose();
   }
@@ -359,7 +393,8 @@ export class AttachTerminal {
     return mode !== "none" && mode !== "x10";
   }
 
-  private showMouseCaptureHint(): void {
+  private showMouseCaptureHint(message: string): void {
+    this.mouseCaptureHint.textContent = message;
     this.mouseCaptureHint.classList.add("af-visible");
     this.mouseCaptureHint.setAttribute("aria-hidden", "false");
     if (this.mouseCaptureHintTimer !== null) {


### PR DESCRIPTION
Copying out of the web terminal was broken on macOS in two independent ways, and
either one alone leaves copy broken. Both are fixed here.

Closes #2787

## 1. `Cmd+C` never reached the copy path

`clipboard.ts` claimed **Ctrl chords only** — `if (ev.metaKey || ev.altKey ||
!ev.ctrlKey) return true` — so on macOS the copy gesture was handed to the
browser. The browser copies the **DOM selection**, and xterm has none: it keeps
its own selection model and paints an overlay, so `document.getSelection()` is
empty and the native copy wrote **nothing**.

It failed *silently*. `terminal.ts`'s `copyToClipboard` was written to never fail
quietly — secure-context check, `execCommand` fallback, `flashCopyHint()` as a
visible backstop — and none of it ran, because we returned "not mine" before
entering that path. The user pasted stale content unaware.

Bare `Cmd+C` is now claimed, but **only when there is a selection**:

- selection → `preventDefault` + `deps.copy(...)`, the same never-silent ladder
  as `Ctrl+C`;
- no selection → returned untouched. `Cmd+C` is not an interrupt on macOS, so
  this path must never emit `\x03`;
- the selection is **kept**. Clearing exists on `Ctrl+C` so a second press falls
  through to the interrupt; `Cmd+C` has no interrupt to fall through to.

`Cmd+V` is untouched (it already worked via the trusted `paste` event), and
`Cmd+Shift+C` / `Cmd+Alt+C` stay with the browser — those are its devtools
shortcuts.

## 2. Selecting at all required a modifier

`macOptionClickForcesSelection: true` plus xterm's own rule meant that while an
agent had mouse tracking on (Claude Code and Codex both do), **every** drag went
to the application — so a user could not even make a selection without holding
Option/Shift. Stacked on defect 1, macOS users hit two obstacles before a copy
could succeed.

**The default is inverted, not removed.** A plain drag now selects; holding
Option (macOS) / Shift (elsewhere) sends the drag to the application. App mouse
forwarding is fully intact on the modifier — deleting it would break clicking
inside agent TUIs, which is what #2681 recently fixed.

Mechanically, xterm resolves "select vs. report" from exactly one bit on the raw
mousedown (`SelectionService.shouldForceSelection`) and reads it from *both* of
its mousedown listeners. There is no xterm option for this and no custom-mouse
hook (the wheel is the only one), so a capture-phase listener on the pane host
inverts that bit before either listener runs. `mousedown` only: `mouseup` carries
xterm's alt-click-moves-cursor gesture, which reads the same `altKey` and would
fire cursor sequences into the PTY on every plain click.

The **wheel is deliberately not inverted** — an agent that turns mouse mode on is
usually doing it to own the wheel. Plain wheel still reaches the application;
modifier+wheel still scrolls history (#2681).

The on-screen hint follows the new mapping, and now says which gesture you lost:
`App mouse active · Drag selects · Hold Shift for app clicks` on the pointer path,
`App mouse active · Hold Shift to scroll history` on the wheel path.

## Verification

A green unit test is what let this ship, so the bar was a real browser.

**The misnamed test is fixed.** `clipboard.test.ts` had a test literally named
`"Cmd+C is NOT claimed (macOS browser copies before xterm)"` — a name asserting
an environment fact nothing in the body checked, and which was false. Its body
only asserted the handler returned `true`, trivially true of any unclaimed key.
It is replaced by tests that assert exactly what they claim (copies / stays out
of the way / never interrupts / leaves the devtools chords alone).

**New Playwright coverage in `web/selftest/web-driver.spec.ts`**, both watched
failing against `master` first:

| Case | On master |
| --- | --- |
| `#2787`: drag-select, `Meta+C`, read `navigator.clipboard.readText()` back | ❌ clipboard still held the seeded sentinel `af-2787-clipboard-untouched` — the silent no-op, reproduced |
| `#2681/#2787`: plain drag with app mouse mode ON | ❌ `.xterm-selection > div` resolved to 0 elements, 19 polls |

Both pass with the fix. The new cases also pin the negatives that make this safe:
`Cmd+C` with no selection sends nothing (asserted behind a marker keystroke that
*must* arrive, so the negative is real rather than a missed race), `Ctrl+C` with
no selection still sends exactly `\x03`, `Ctrl+C` still copies-then-clears, and
Shift+drag still reports both button halves to the application while making no
selection.

Full gate green on this head — `golangci-lint`, `gofmt -l`, `go build ./...`,
`make test-container`, `deadcode -test ./...`, `scripts/lint-file-length.sh`,
plus `make web-build` with the regenerated bundle committed and
`make web-selftest-container`.

Behaviour change #2 is written up in `docs/release-notes.md`: it is visible to
anyone who today drags inside an agent's own mouse UI, and copy-out-of-the-box
was the explicit call.

Co-Authored-By: Captain Claude <noreply@anthropic.com>
