### PR TITLE
docs: gate PRs on the Codex review, not on Greptile

### DIFF
--- a/.claude/skills/gate-pr.md
+++ b/.claude/skills/gate-pr.md
@@ -1,6 +1,6 @@
 ---
 name: gate-pr
-description: Review and gate Captain Claude pull requests through CI, Greptile, play-test, and squash merge
+description: Review and gate Captain Claude pull requests through CI, the Codex review, play-test, and squash merge
 user_invocable: true
 ---
 
@@ -32,12 +32,56 @@ from `app/detail-app` may auto-merge once the gates are clean.
    - Zero pending checks.
    - No missing required check that is expected to report.
 
-3. **Gate Greptile** — require one of these outcomes:
-   - Greptile Confidence `5/5`.
-   - Greptile Confidence `4/5` with zero unresolved inline findings.
+3. **Gate the Codex review** — the AI reviewer on this repo is
+   `chatgpt-codex-connector[bot]`. `.github/scripts/auto-gate.js` already
+   enforces the conditions below on every PR; this step is the same gate run by
+   hand, so a manual merge cannot be looser than the automated one.
 
-   If a Greptile finding is valid, route it back to the authoring session and
-   stop. Do not merge a PR with a valid unresolved finding.
+   ```bash
+   head="$(gh pr view <n> --json headRefOid -q .headRefOid)"; echo "head=$head"
+
+   # a) a verdict for THIS head. The body carries "Reviewed commit: `abc1234…`",
+   #    an abbreviation that must prefix $head. Codex posts it as a review on
+   #    some PRs and as an issue comment on others, so read both.
+   gh api repos/sachiniyer/agent-factory/pulls/<n>/reviews \
+     --jq '.[] | select(.user.login=="chatgpt-codex-connector[bot]") | "\(.submitted_at)\n\(.body)"'
+   gh api repos/sachiniyer/agent-factory/issues/<n>/comments \
+     --jq '.[] | select(.user.login=="chatgpt-codex-connector[bot]") | "\(.created_at)\n\(.body)"'
+
+   # b) live inline findings — a null .line is stale, already fixed
+   gh api repos/sachiniyer/agent-factory/pulls/<n>/comments \
+     --jq '.[] | select(.user.login=="chatgpt-codex-connector[bot]" and .line != null and .in_reply_to_id == null)
+                 | "\(.id) \(.path):\(.line)\n\(.body)"'
+   ```
+
+   Require all three:
+
+   - **A verdict that names this head.** Its `Reviewed commit:` must match
+     `headRefOid` and it must be newer than the head commit. An older verdict
+     read different bytes. Silence is not a pass: an unreviewed PR and a clean
+     one are byte-identical through the findings API, so (b) means nothing until
+     (a) holds. If nothing has posted, comment `@codex review this PR` and wait —
+     hours is normal. A `reached your Codex usage limits for code reviews` reply
+     is *not* a verdict.
+   - **No `P0`–`P3` in that verdict body.** Findings usually live inline, but
+     Codex does sometimes file one in the body with zero inline comments.
+   - **Zero unresolved live inline findings.** These are independent of the
+     verdict text — a PR can carry a "didn't find any major issues" verdict for
+     the exact head *and* live P1s from an earlier pass on the same head. The
+     inline query overrides the verdict, never the other way round.
+
+   Clear a finding by replying **in-thread**, from `sachiniyer` or
+   `app-detail-app`, with `RESOLVED` or `ACCEPTED` and what changed or why the
+   finding is wrong. A top-level PR comment does not clear it — the reply has to
+   hang off that comment id:
+
+   ```bash
+   gh api repos/sachiniyer/agent-factory/pulls/comments/<comment-id>/replies \
+     -f body='RESOLVED — <what changed, or why this is wrong>'
+   ```
+
+   If a finding is valid, route it back to the authoring session and stop. Do
+   not merge a PR with a valid unresolved finding.
 
 4. **Verify branch shape** — catch stacked or tangled branches before merge:
    ```bash
@@ -71,3 +115,12 @@ from `app/detail-app` may auto-merge once the gates are clean.
    ```
 
    Do not use another merge strategy unless the maintainer explicitly asks.
+
+   **Never `--auto`.** `gh pr merge --auto` is GitHub-native auto-merge: it
+   merges as soon as the *branch ruleset's* required checks pass, which on
+   `master` is `Lint` and `Build` only. It does not consult
+   `.github/scripts/auto-gate.js`, so arming it routes around step 3 entirely —
+   and it fires while the Codex review is still minutes-to-hours away, so the
+   finding count it merges on is zero because nothing has looked yet. Either
+   merge by hand once every gate above holds, or leave the PR alone and let the
+   Auto Gate workflow merge it.


### PR DESCRIPTION
## Summary

#2583 filed three remainders from the docs-drift audit. Two of them landed in
#2621 and are verified gone below; this PR is the third — `.claude/skills/gate-pr.md`
step 3 gating on a reviewer that has not looked at this repo in weeks.

## The stale gate

Step 3 required a **Greptile** verdict: Confidence `5/5`, or `4/5` with zero
unresolved inline findings. Re-checked today, not taken from the issue:

```
$ for n in <last 25 merged PRs>; do
    gh api repos/:owner/:repo/issues/$n/comments --jq '[.[]|select(.user.login|test("greptile";"i"))]|length'
    gh api repos/:owner/:repo/pulls/$n/reviews   --jq '[.[]|select(.user.login|test("greptile";"i"))]|length'
  done
(no PR reported a non-zero count)
```

No Greptile comment, no Greptile review, no Greptile status check, no Greptile
config in the tree. The verdict step 3 waits for cannot arrive — and the reviewer
that *is* running, `chatgpt-codex-connector[bot]`, has no `Confidence N/5` field,
so the pass condition cannot be evaluated even in principle. An agent following
the step literally either blocks forever or waves it through and skips the only
AI review the repo has.

The ~20 `Greptile P1/P2` mentions in shell/Go comments are historical provenance
for past findings and are untouched.

## What replaces it, and why it is not a judgement call

The issue held back on rewording because "what the gate should require instead is
a load-bearing ops choice." It turns out the choice is already made and already
executing: **`.github/scripts/auto-gate.js` enforces the conditions on every PR**,
and `AUTO_GATE_ENABLED` is `true` on this repo. So step 3 is now the same gate
stated as hand-runnable commands, which keeps a manual merge from being looser
than the automated one:

| step 3 requires | enforced by |
|---|---|
| a `Codex Review` verdict whose `Reviewed commit:` prefixes `headRefOid` | `auto-gate.js:483-493` (`parseReviewedCommit` / `reviewedCommitMatchesHead`) |
| that verdict is newer than the head commit | `auto-gate.js:496-497` |
| no `P0`–`P3` in the verdict body | `auto-gate.js:503-505` (`CODEX_BODY_FINDING_RE`) |
| zero unresolved live inline findings (`.line != null`, no `in_reply_to_id`) | `auto-gate.js:524-538` |
| cleared by an in-thread `RESOLVED`/`ACCEPTED` reply from an allowed author | `auto-gate.js:513-523`, `RESOLUTION_MARKER_RE` |
| a usage-limited reply is not a verdict | `auto-gate.js:547` (`CODEX_RATE_LIMIT_RE` excluded) |

Two things the old step could not say and the new one does: silence is not a pass
(an unreviewed PR and a clean one are byte-identical through the findings API),
and the inline findings **override** the verdict text rather than being implied by
it — a PR can carry a "didn't find any major issues" verdict for the exact head
*and* live findings from an earlier pass on that same head.

## Step 6: never `--auto`

Verified against the live config rather than asserted:

```
$ gh api repos/:owner/:repo/rules/branches/master --jq '.[]|select(.type=="required_status_checks")|.parameters.required_status_checks'
[{"context":"Lint",...},{"context":"Build",...}]
$ gh api repos/:owner/:repo/branches/master/protection
Branch not protected (HTTP 404)
```

`gh pr merge --auto` is GitHub-native auto-merge. It waits for that ruleset —
`Lint` and `Build` — and nothing else, and it never consults `auto-gate.js`. So
arming it routes around step 3 entirely, and it fires while the Codex review is
still minutes-to-hours away, meaning the finding count it merges on is zero
because nothing has looked yet.

## The other two remainders are already fixed

Both landed in #2621; re-verified on `b232d5a8`:

- **Five doubled-dash anchors** (`#archive--restore`,
  `#capabilities--the-agent-server`,
  `#backgrounding-a-tunnel-is-supported--you-need-do-nothing`):
  `grep -rn 'archive--restore\|capabilities--the-agent-server\|backgrounding-a-tunnel-is-supported--you-need' docs/`
  returns nothing, and a real `mkdocs build --strict` with `validation.anchors: warn`
  reports **no warning for any of the five**. They are also about to stop being
  able to rot: #2795 turns that setting on so CI fails on the next dead anchor.
- **`af projects register`** in `docs/configuration.md`: `grep -rn 'projects register' docs/ README.md .claude/`
  returns nothing.

## Verification

This is a skill document, so the verification that matters is that every command
in it runs and returns what the step claims. Each was executed against real PRs:

- the verdict queries on **#2785**, which returned its `Codex Review` review body
  with `**Reviewed commit:** \`77976bb441\`` — a prefix of that PR's head
  `77976bb441e2a2c66cbd5fc4b9ded94158f3141d`, exactly the match `auto-gate.js`
  performs;
- the live-inline-findings query on **#2785**, which returned
  `3714169184 docs/concepts/daemon.md:37` (a real P2, live on `master` and
  unaddressed — filed as #2797);
- the same query on PRs #2786/#2783/#2780/#2775/#2774/#2772/#2767, which returned
  empty;
- the resolution-reply shape against `.github/scripts/auto-gate.test.js:477-485`
  and its `an allowed author resolves a live finding only with an explicit marker`
  case.

Required gates, on the pushed head `301eec2b9a6df5f489bb11adbe29131665fa5fc1`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (empty)
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`

Closes #2583

---

## Review round (head `b606fa54`)

Codex filed three P2s on `301eec2b`, all against the commands the step
prescribes. All three were real, reproduced before fixing, and cleared in-thread:

1. **Pagination.** `gh api` fetches one page (30 comments) without `--paginate`,
   so the findings query could answer "no findings" for a PR whose findings are
   on page 2 — the single wrong answer this step must never give. Both queries
   now paginate, and the step says why it is not optional.
2. **The reply route needs the PR number.** Probed the shape the step shipped
   with, rather than trusting either side of the argument:
   ```
   $ gh api -X POST repos/sachiniyer/agent-factory/pulls/comments/3716067572/replies -f body=probe
   {"message": "Not Found", ...}
   ```
   The documented route is `pulls/{pull_number}/comments/{comment_id}/replies` —
   the three RESOLVED replies on this PR were posted with the corrected form,
   which is the proof it works.
3. **Cleared findings were still listed.** The query dropped replies and then
   listed every top-level finding, so one already cleared by a
   RESOLVED/ACCEPTED reply still read as unresolved — making the hand gate
   *stricter* than `auto-gate.js` and able to block a PR the workflow would
   merge. It now subtracts cleared ids the way `resolvedByAllowedReply` does.
   Verified on this PR's own findings: three listed before the replies, zero
   after, while the old query still lists three.
