### PR TITLE
fix(bugreport): redact pending tab cleanup tmux names on the typed path

### DIFF
--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -401,6 +401,13 @@ func (r *redactor) noteSession(d *session.InstanceData) {
 	for _, tab := range d.Tabs {
 		r.noteTmuxName(tab.TmuxName)
 	}
+	// A pending-teardown handle names a tmux session the same way a live tab
+	// does, and the retry logs it on every daemon start until the kill is
+	// confirmed — so the log tail prints these names most often for exactly the
+	// sessions whose teardown is stuck (#2776).
+	for _, cleanup := range d.PendingTabCleanup {
+		r.noteTmuxName(cleanup.TmuxName)
+	}
 }
 
 // noteTitle records one raw session title for structured-string and log
@@ -607,11 +614,14 @@ var sensitiveJSONKeys = map[string]bool{
 	// command, remote session directory, or container id.
 	"runtime_cleanup": true,
 	// tmux_name and session_name mirror the typed-path redaction
-	// (redactInstanceData drops TmuxName, Worktree.SessionName, and
-	// Tabs[].TmuxName): each carries the free-text session title. Without
-	// them the fallback path leaked titles the typed path already scrubs,
-	// including the nested tabs[].tmux_name and worktree.session_name the
-	// recursive walk below reaches (#1680).
+	// (redactInstanceData drops TmuxName, Worktree.SessionName,
+	// Tabs[].TmuxName, and PendingTabCleanup[].TmuxName): each carries the
+	// free-text session title. Without them the fallback path leaked titles
+	// the typed path already scrubs, including the nested tabs[].tmux_name
+	// and worktree.session_name the recursive walk below reaches (#1680).
+	// This walk is key-driven and depth-agnostic, which is why it kept
+	// covering pending_tab_cleanup[].tmux_name for the whole window the typed
+	// path did not (#2776) — the fallback is the broader net by design.
 	"tmux_name": true, "session_name": true,
 	// conversation and agent_conversation mirror the typed-path redaction
 	// (redactInstanceData clears Tabs[].Conversation.ID and
@@ -687,6 +697,17 @@ func redactInstanceData(d *session.InstanceData) {
 	// so it leaks the same free-text name Title carries and must be redacted too.
 	if d.TmuxName != "" {
 		d.TmuxName = redactedMarker
+	}
+	// A pending-teardown handle is a tmux name and nothing else, so it carries
+	// the title exactly as TmuxName above does. It was added with durable tab
+	// close (#2669) after this policy was written and inherited none of it, which
+	// left the title in pending_tab_cleanup[].tmux_name of every bundle whose
+	// instances.json decoded typed — the common case (#2776). The tab id beside
+	// it is minted, never derived from user text, and survives for triage.
+	for i := range d.PendingTabCleanup {
+		if d.PendingTabCleanup[i].TmuxName != "" {
+			d.PendingTabCleanup[i].TmuxName = redactedMarker
+		}
 	}
 	for i := range d.Tabs {
 		if d.Tabs[i].Command != "" {

--- a/bugreport/redact_pending_tab_cleanup_test.go
+++ b/bugreport/redact_pending_tab_cleanup_test.go
@@ -1,0 +1,209 @@
+package bugreport
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// TestRedactInstanceDataRedactsPendingTabCleanupTmuxName is the #2776 regression
+// guard for the typed path. PendingTabCleanup arrived with durable tab teardown
+// (#2669) carrying a TmuxName derived from the session title, exactly like
+// InstanceData.TmuxName and Tabs[].TmuxName — but the redaction policy was not
+// taught about it, so the title shipped in a publicly shared bundle's
+// instances.json under pending_tab_cleanup[].tmux_name.
+func TestRedactInstanceDataRedactsPendingTabCleanupTmuxName(t *testing.T) {
+	d := session.InstanceData{
+		ID:      "abc123",
+		Program: "claude",
+		Status:  session.Status(1),
+		PendingTabCleanup: []session.TabCleanupData{
+			{TabID: "tab-1", TmuxName: "af_ProjectKingfisherAcquisition__shell"},
+			{TabID: "tab-2", TmuxName: "af_ProjectKingfisherAcquisition__web"},
+		},
+	}
+
+	redactInstanceData(&d)
+
+	for i, cleanup := range d.PendingTabCleanup {
+		if cleanup.TmuxName != redactedMarker {
+			t.Errorf("pending_tab_cleanup[%d].tmux_name not redacted: %q", i, cleanup.TmuxName)
+		}
+		// The tab id is a minted identifier, not user text: it stays for triage,
+		// the same way ids survive everywhere else in this policy.
+		if cleanup.TabID == redactedMarker {
+			t.Errorf("pending_tab_cleanup[%d].tab_id should survive redaction", i)
+		}
+	}
+	if d.ID != "abc123" || d.Program != "claude" || d.Status != session.Status(1) {
+		t.Errorf("structural fields mutated: %+v", d)
+	}
+}
+
+// TestRedactInstancesJSONRedactsPendingTabCleanupTmuxName exercises the leak the
+// way a bundle actually produces it: through the typed decode of instances.json,
+// which is the path that succeeds for every well-formed record. The generic
+// fallback already blanked `tmux_name`, so the defense existed only for the
+// records that fail to parse — the uncommon case.
+func TestRedactInstancesJSONRedactsPendingTabCleanupTmuxName(t *testing.T) {
+	r := &redactor{}
+	raw := json.RawMessage(`[{"id":"s-1","title":"Kingfisher","status":1,` +
+		`"pending_tab_cleanup":[{"tab_id":"tab-1","tmux_name":"af_Kingfisher__shell"}]}]`)
+
+	out := string(r.redactInstancesJSON(raw))
+
+	if strings.Contains(out, "Kingfisher") {
+		t.Errorf("typed path leaked a pending-cleanup tmux name:\n%s", out)
+	}
+	if !strings.Contains(out, "tab-1") {
+		t.Errorf("typed path dropped the structural tab id:\n%s", out)
+	}
+}
+
+// TestNoteSessionRecordsPendingTabCleanupTmuxName covers the other half of the
+// gap. Structural redaction blanks the JSON field; noteSession is what tells
+// scrubLog the same name must come out of the bundled daemon log tail. A
+// non-repo-scoped name (af_<title>, no hash) can only be removed from the log by
+// exact match, so a name noteSession never saw survives there verbatim (#1584).
+func TestNoteSessionRecordsPendingTabCleanupTmuxName(t *testing.T) {
+	const name = "af_ProjectKingfisherAcquisition__shell"
+	r := &redactor{}
+	r.noteSession(&session.InstanceData{
+		PendingTabCleanup: []session.TabCleanupData{{TabID: "tab-1", TmuxName: name}},
+	})
+
+	got := r.scrubLog("daemon: retrying teardown for " + name + " after restart")
+
+	if strings.Contains(got, name) {
+		t.Errorf("log tail retained an unrecorded pending-cleanup tmux name: %q", got)
+	}
+}
+
+// titleDerivedFields are the InstanceData string fields that carry user free
+// text — a session title, a tmux name derived from one, or a prompt. Every one
+// of them must be blanked at every depth, and this list is keyed by field NAME
+// rather than by path precisely because the recurring failure is a new struct
+// nesting an old field: tabs[].tmux_name (#1680), pending_handoff_mission
+// (#2419), and now pending_tab_cleanup[].tmux_name (#2776) each shipped a leak
+// by adding a field the path-by-path policy had never heard of.
+//
+// URL is deliberately absent: Tabs[].URL keeps loopback targets on purpose, so
+// "always redacted" is not a true statement about it.
+var titleDerivedFields = map[string]bool{
+	"TmuxName":              true,
+	"Title":                 true,
+	"SessionName":           true,
+	"Prompt":                true,
+	"PendingHandoffMission": true,
+	"Command":               true,
+}
+
+const unredactedSentinel = "af-sentinel-unredacted-free-text"
+
+// TestRedactInstanceDataRedactsTitleDerivedFieldsAtEveryDepth is the structural
+// guard. It seeds EVERY string in a fully populated InstanceData — one element
+// per slice, one value per pointer, so no field can hide behind a zero value —
+// and fails on any title-derived field that still holds its sentinel afterwards.
+// A future record that nests a TmuxName one struct deeper fails here without
+// anyone remembering to write a test for it.
+func TestRedactInstanceDataRedactsTitleDerivedFieldsAtEveryDepth(t *testing.T) {
+	var d session.InstanceData
+	seedStringFields(reflect.ValueOf(&d).Elem(), 0)
+
+	redactInstanceData(&d)
+
+	var leaked []string
+	collectUnredactedFields(reflect.ValueOf(d), "InstanceData", &leaked)
+	for _, path := range leaked {
+		t.Errorf("%s still holds its seeded free text after redactInstanceData", path)
+	}
+}
+
+// maxSeedDepth bounds the walk so a type that ever gains a pointer to itself
+// fails the test loudly instead of recursing until the stack runs out.
+const maxSeedDepth = 16
+
+// seedStringFields fills every settable string reachable from v with the
+// sentinel, allocating one element per slice, map, and pointer so the walk
+// reaches fields a zero InstanceData leaves empty. Unexported fields
+// (time.Time's internals) are not settable and are skipped.
+//
+// Every composite kind is handled, not just the ones InstanceData uses today: a
+// walker that quietly skips the shape a future field arrives in would report
+// "nothing leaked" about a field it never looked at, which is the failure this
+// whole test exists to prevent.
+func seedStringFields(v reflect.Value, depth int) {
+	if depth > maxSeedDepth {
+		return
+	}
+	switch v.Kind() {
+	case reflect.String:
+		v.SetString(unredactedSentinel)
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if field := v.Field(i); field.CanSet() {
+				seedStringFields(field, depth+1)
+			}
+		}
+	case reflect.Slice:
+		v.Set(reflect.MakeSlice(v.Type(), 1, 1))
+		seedStringFields(v.Index(0), depth+1)
+	case reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			seedStringFields(v.Index(i), depth+1)
+		}
+	case reflect.Map:
+		// Map entries are not addressable, so seed a detached key/value pair and
+		// store it.
+		key := reflect.New(v.Type().Key()).Elem()
+		seedStringFields(key, depth+1)
+		value := reflect.New(v.Type().Elem()).Elem()
+		seedStringFields(value, depth+1)
+		seeded := reflect.MakeMap(v.Type())
+		seeded.SetMapIndex(key, value)
+		v.Set(seeded)
+	case reflect.Pointer:
+		v.Set(reflect.New(v.Type().Elem()))
+		seedStringFields(v.Elem(), depth+1)
+	}
+}
+
+// collectUnredactedFields appends the path of every titleDerivedFields string
+// that still equals the sentinel. A nil pointer contributes nothing: a redactor
+// that drops a whole sub-record (RuntimeCleanup) has redacted everything in it.
+func collectUnredactedFields(v reflect.Value, path string, leaked *[]string) {
+	switch v.Kind() {
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			field := v.Type().Field(i)
+			if !field.IsExported() {
+				continue
+			}
+			child := v.Field(i)
+			childPath := path + "." + field.Name
+			if child.Kind() == reflect.String {
+				if titleDerivedFields[field.Name] && child.String() == unredactedSentinel {
+					*leaked = append(*leaked, childPath)
+				}
+				continue
+			}
+			collectUnredactedFields(child, childPath, leaked)
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			collectUnredactedFields(v.Index(i), fmt.Sprintf("%s[%d]", path, i), leaked)
+		}
+	case reflect.Map:
+		for _, key := range v.MapKeys() {
+			collectUnredactedFields(v.MapIndex(key), fmt.Sprintf("%s[%v]", path, key), leaked)
+		}
+	case reflect.Pointer:
+		if !v.IsNil() {
+			collectUnredactedFields(v.Elem(), path, leaked)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #2776

`PendingTabCleanup[].TmuxName` shipped unredacted in the `instances.json` of
publicly shared bug bundles. The tmux name is derived from the session title, so
a session called `Project-Alpha-Acquisition` left that string in the bundle
under `pending_tab_cleanup[].tmux_name`.

The field arrived with durable tab teardown (#2669). `redactInstanceData`
enumerates the title-bearing paths one at a time — `TmuxName`,
`Worktree.SessionName`, `Tabs[].TmuxName` — and was never taught the new one.
The generic fallback path *did* cover it, because that walk blanks `tmux_name`
by key at any depth; but the fallback only runs when the typed decode fails, so
the protection existed for the uncommon case and not the common one.

## What changed

- `redactInstanceData` blanks `PendingTabCleanup[i].TmuxName`. The `TabID`
  beside it is a minted identifier, never derived from user text, and survives
  for triage like every other id in this policy.
- `noteSession` records the same name, so `scrubLog` strips it from the bundled
  daemon log tail. This half matters more than it looks: the teardown retry logs
  that name on every daemon start until the kill is confirmed, so the log prints
  it most often for exactly the sessions whose cleanup is stuck. A
  non-repo-scoped name (`af_<title>`, no hash) does not match the
  `af_<hash>_<title>` shape matcher and can *only* be removed by exact match
  against a recorded name (#1584).
- Corrected the `sensitiveJSONKeys` comment, which claimed to mirror a
  typed-path list that no longer matched.

## The recurring part

This is the fourth field-addition leak in this one function —
`tabs[].tmux_name` (#1680), tab `url` (#1954), `pending_handoff_mission`
(#2419), and now this. Each was a new field the path-by-path policy had never
heard of, and each was found in production rather than by a test.

So the guard here is not another path assertion.
`TestRedactInstanceDataRedactsTitleDerivedFieldsAtEveryDepth` seeds **every**
string in a fully populated `InstanceData` — one element per slice and map, one
value per pointer, so nothing hides behind a zero value — runs
`redactInstanceData`, then walks the result and fails on any field *named*
`TmuxName`, `Title`, `SessionName`, `Prompt`, `PendingHandoffMission`, or
`Command` that still holds its sentinel. It is keyed by field name at any depth,
so a future record nesting a `TmuxName` one struct deeper fails it without
anyone remembering to write a test.

On `master` it reports exactly one path — `InstanceData.PendingTabCleanup[0].TmuxName`
— which is also a useful confirmation that nothing else in that set is currently
leaking.

`URL` is deliberately excluded from the set: `Tabs[].URL` keeps loopback targets
on purpose, so "always redacted" is not a true statement about it.

## Tests

Four new tests, all red on `master`:

- `TestRedactInstanceDataRedactsPendingTabCleanupTmuxName` — the typed path.
- `TestRedactInstancesJSONRedactsPendingTabCleanupTmuxName` — through the real
  `instances.json` decode, the path a bundle actually takes.
- `TestNoteSessionRecordsPendingTabCleanupTmuxName` — the log-tail half.
- `TestRedactInstanceDataRedactsTitleDerivedFieldsAtEveryDepth` — the structural
  guard above.

Sanity-checked in both directions — reverting only `bugreport/redact.go` to
master turns all four red; restoring it turns them green.

## Test Plan

- [x] `go test ./...` passes — `make test-container`, exit 0, zero FAIL lines
- [x] `gofmt` applied to changed files — `gofmt -l .` empty
- [x] Manually tested in TUI — n/a, bug-bundle redaction only

Gate run on exact head `f46c89f494ab9162c9724d916d34ab42bb4c0b44`:

- `golangci-lint run --timeout=3m --fast` — clean
- `gofmt -l .` — no output
- `go build ./...` — clean
- `make test-container` — exit 0
- `deadcode -test ./...` — no output
- `scripts/lint-file-length.sh` — passed (1139 files)

Captain Claude
