### PR TITLE
fix(daemon): publish session.updated across the handoff transaction

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -744,16 +744,26 @@ func (m *Manager) persistInstanceErr(repoID string, instance *session.Instance) 
 	return persistInstanceData(repoID, instance.ToInstanceData())
 }
 
-// persistInstanceSnapshotErr is persistInstanceErr for a caller-owned atomic
-// projection. Handoff uses it to checkpoint the durable post-swap facts while
-// retaining its process-local OpReplacing delivery fence in memory. It is
-// intentionally separate from persistInstanceErr: ordinary writers must take
-// their Instance snapshot only after acquiring this serialization lock.
-func (m *Manager) persistInstanceSnapshotErr(repoID string, data session.InstanceData) error {
+// persistHandoffCheckpointErr is persistInstanceErr for the one writer whose
+// durable and live projections differ ON PURPOSE: the post-swap handoff
+// checkpoint. Disk takes the caller's atomic projection — the crash-recovery
+// posture, which cannot retain a process-local operation — while memory keeps the
+// OpReplacing delivery fence. It is intentionally separate from persistInstanceErr:
+// ordinary writers must take their Instance snapshot only after acquiring this
+// serialization lock, which is exactly why the caller's snapshot is a parameter here.
+//
+// The EVENT carries the live projection, not the checkpoint (#2782). Other clients
+// have to render the truth — incoming agent, replacement still in flight — and the
+// fence is what closes their action gates (CanHandoff/CanKill project off it).
+// Announcing the checkpoint would tell them the swap had already settled and
+// re-open gates the daemon is still holding shut.
+func (m *Manager) persistHandoffCheckpointErr(repoID string, instance *session.Instance, checkpoint session.InstanceData) error {
 	repoStartLock := m.startLockForRepo(repoID)
 	repoStartLock.Lock()
 	defer repoStartLock.Unlock()
-	return persistInstanceData(repoID, data)
+	err := persistInstanceData(repoID, checkpoint)
+	m.publishEvent(agentproto.EventSessionUpdated, instance.ToInstanceData())
+	return err
 }
 
 // persistInstance is the best-effort form of persistInstanceErr: a failed write
@@ -764,6 +774,46 @@ func (m *Manager) persistInstanceSnapshotErr(repoID string, data session.Instanc
 // held. Under m.mu, call persistInstanceData directly.
 func (m *Manager) persistInstance(repoID string, instance *session.Instance) {
 	if err := m.persistInstanceErr(repoID, instance); err != nil {
+		log.WarningLog.Printf("failed to persist instance %q: %v", instance.Title, err)
+	}
+}
+
+// persistAndPublishInstance is persistInstance plus the session.updated
+// announcement a committed change owes every OTHER client (#1812, #2782).
+//
+// The two belong together wherever a mutation — not a poll — is what changed the
+// session. A client that did not make the change learns of it ONLY from the events
+// plane: it re-Snapshots after its own mutations, never after anyone else's. And
+// the status poll cannot be relied on to repair the gap, because it deliberately
+// skips a session with an operation in flight and, once the operation finishes,
+// snapshots the already-final state as its own baseline — seeing no change to
+// report.
+//
+// Published INSIDE the repo ordering lock, in the same critical section as the
+// persist that produced it, for the reason spelled out at the poll's publish in
+// limit.go: session.updated carries a WHOLE InstanceData and every client
+// re-projects the session wholesale from it, so publishing after the unlock lets an
+// older payload land last and revert newer state.
+//
+// The announcement goes out even when the write failed. That is deliberate and
+// matches the poll: what the other clients must converge on is MEMORY, which has
+// already changed. persistInstance is best-effort by contract — the next checkpoint
+// retries the write — so a failed write is not a reason to leave every other client
+// stale about a change that really happened.
+//
+// LOCK CONTRACT (#2106): inherits persistInstance's — never call it with m.mu held.
+func (m *Manager) persistAndPublishInstance(repoID string, instance *session.Instance) {
+	repoStartLock := m.startLockForRepo(repoID)
+	repoStartLock.Lock()
+	// Snapshot only AFTER serialization, for the #1917 reason on persistInstanceErr:
+	// a projection taken before the lock can erase state a writer committed while we
+	// waited. The same snapshot is both persisted and announced, so disk and the
+	// events plane can never disagree about which one this was.
+	data := instance.ToInstanceData()
+	err := persistInstanceData(repoID, data)
+	m.publishEvent(agentproto.EventSessionUpdated, data)
+	repoStartLock.Unlock()
+	if err != nil {
 		log.WarningLog.Printf("failed to persist instance %q: %v", instance.Title, err)
 	}
 }

--- a/daemon/handoff.go
+++ b/daemon/handoff.go
@@ -234,7 +234,15 @@ func (m *Manager) HandoffSession(req HandoffSessionRequest) (HandoffSessionRespo
 	// window must restore the incoming Program rather than lie that the outgoing
 	// agent still owns the pane. The projection also clears any outgoing-provider
 	// limit state, matching CommitHandoff's recovery posture.
-	if err := m.persistInstanceSnapshotErr(repoID, checkpoint); err != nil {
+	//
+	// This is also where the swap becomes visible to every OTHER client (#2782).
+	// Announcing it HERE rather than only at settlement is what the readiness wait
+	// makes necessary: it can run for a minute, and until it returns the rail in a
+	// second window would otherwise still offer the outgoing agent — including in
+	// the handoff picker, which excludes the current agent and would therefore
+	// exclude the wrong one. The event carries the LIVE projection, so those clients
+	// see the incoming agent WITH the fence raised, not a settled row.
+	if err := m.persistHandoffCheckpointErr(repoID, instance, checkpoint); err != nil {
 		// Preserve the existing best-effort persist contract: delivery can still
 		// make the live agent useful, and the final settled write retries below.
 		log.WarningLog.Printf("handoff %q: failed to persist the post-swap checkpoint before mission delivery: %v", req.Title, err)

--- a/daemon/handoff_delivery.go
+++ b/daemon/handoff_delivery.go
@@ -43,7 +43,13 @@ func (m *Manager) deliverHandoffMission(delivery handoffDelivery) error {
 		// Persist only settled outcomes. Disk persistence strips transient ops, so
 		// writing while OpReplacing is raised would manufacture an unfenced state
 		// no in-memory reader was ever allowed to observe.
-		m.persistInstance(delivery.repoID, delivery.instance)
+		//
+		// The same write announces the settlement (#2782). Other clients were told
+		// about the swap at the checkpoint, with the fence raised; this is the event
+		// that lowers it for them. Without it a second window would sit on a
+		// permanently "working" row — the poll skips a fenced session and, once the
+		// fence drops, takes the settled state as its own baseline and reports nothing.
+		m.persistAndPublishInstance(delivery.repoID, delivery.instance)
 		m.captureAgentConversationAsync(delivery.repoID, delivery.key, delivery.instance, delivery.conversationCapture)
 		return nil
 	}
@@ -80,7 +86,7 @@ func (m *Manager) deliverHandoffMission(delivery handoffDelivery) error {
 		// turns a startup death into a fake delivery failure and invites commands
 		// into an unconfirmed binding.
 		delivery.instance.MarkStartupStateUnknown()
-		m.persistInstance(delivery.repoID, delivery.instance)
+		m.persistAndPublishInstance(delivery.repoID, delivery.instance)
 		return fmt.Errorf(
 			"handed %q off to %s, but the incoming agent never reached a confirmed ready state (%w); "+
 				"the session was retained as startup-unknown with its mission pending for inspection",

--- a/daemon/handoff_event_test.go
+++ b/daemon/handoff_event_test.go
@@ -1,0 +1,226 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+// The multi-client half of agent handoff (#2013 / #2782). A handoff rewrites the
+// session's agent program, which is the single most visible fact about a row —
+// the rail renders it, and the handoff picker EXCLUDES it when offering targets.
+// Every other session mutation announces itself on the events plane; this one did
+// not, so a second web window kept offering to hand off to the agent the session
+// had just been handed off to.
+//
+// These assert on the published EVENTS. A Snapshot assertion would pass with
+// nothing published at all — which is exactly the state these exist to fail on —
+// and the status poll cannot substitute: it skips a session with an operation in
+// flight, and afterwards takes the already-final state as its own baseline.
+
+// drainSessionUpdates collects every session.updated already queued for ch.
+//
+// The handoff verbs publish synchronously, so by the time the call under test
+// returns, its whole sequence is sitting in the subscriber's buffer. Reading it
+// all (rather than the first event) is what lets a test say something about the
+// ORDER of the announcements, and keeps an unrelated poll event from being
+// mistaken for the one under test.
+func drainSessionUpdates(t *testing.T, ch <-chan agentproto.Event) []session.InstanceData {
+	t.Helper()
+	var out []session.InstanceData
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				// The hub closes an evicted subscriber's channel on buffer overflow.
+				return out
+			}
+			if ev.Type != agentproto.EventSessionUpdated {
+				continue
+			}
+			var data session.InstanceData
+			if err := json.Unmarshal(ev.Data, &data); err != nil {
+				t.Fatalf("unmarshal session.updated payload: %v", err)
+			}
+			out = append(out, data)
+		default:
+			return out
+		}
+	}
+}
+
+// firstUpdateWhere returns the index of the first collected update satisfying
+// pred, or -1. Tests match on SHAPE rather than position so an unrelated poll
+// publish cannot shift them.
+func firstUpdateWhere(updates []session.InstanceData, pred func(session.InstanceData) bool) int {
+	for i := range updates {
+		if pred(updates[i]) {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestHandoffSession_PublishesSwapThenSettlement covers the interactive path, and
+// pins BOTH announcements plus their order.
+//
+// The mid-flight one is not a nicety: the readiness wait can run for a minute, and
+// it carries the replacement fence, which is what closes the other clients' action
+// gates (CanHandoff/CanKill project off it). Announcing the durable checkpoint
+// there instead would tell them the swap had settled and re-open gates the daemon
+// is still holding shut.
+//
+// The settlement one is what lowers that fence again. Without it a second window
+// would sit on a permanently "working" row.
+func TestHandoffSession_PublishesSwapThenSettlement(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &handoffBackend{FakeBackend: session.NewFakeBackend()}
+	const title = "handoff-events"
+	registerHandoffSubject(t, manager, repoID, repoPath, title, backend)
+
+	id, ch := manager.events.subscribe()
+	defer manager.events.unsubscribe(id)
+
+	if _, err := manager.HandoffSession(HandoffSessionRequest{
+		Title: title, RepoID: repoID, To: tmux.ProgramGemini,
+	}); err != nil {
+		t.Fatalf("HandoffSession: %v", err)
+	}
+
+	updates := drainSessionUpdates(t, ch)
+	if len(updates) == 0 {
+		t.Fatal("handoff published no session.updated: every other client keeps rendering the OUTGOING agent, " +
+			"and the handoff picker keeps excluding the wrong one")
+	}
+
+	inFlight := firstUpdateWhere(updates, func(d session.InstanceData) bool {
+		return d.Program == tmux.ProgramGemini && d.InFlightOp == session.OpReplacing
+	})
+	if inFlight < 0 {
+		t.Fatalf("no session.updated announced the swap while the replacement was still in flight; got %s",
+			describeUpdates(updates))
+	}
+	settled := firstUpdateWhere(updates, func(d session.InstanceData) bool {
+		return d.Program == tmux.ProgramGemini && d.InFlightOp == session.OpNone
+	})
+	if settled < 0 {
+		t.Fatalf("no session.updated lowered the replacement fence; other clients stay stuck on a working row: got %s",
+			describeUpdates(updates))
+	}
+	if settled < inFlight {
+		t.Fatalf("settlement was announced before the swap (%d < %d): session.updated replaces a client's WHOLE "+
+			"projection, so the older payload would win: got %s", settled, inFlight, describeUpdates(updates))
+	}
+
+	// Every announcement must name the session it is about, or a client cannot
+	// route it to a row.
+	for i, u := range updates {
+		if u.Title != title {
+			t.Fatalf("update %d carried session %q, want %q", i, u.Title, title)
+		}
+	}
+}
+
+// TestHandoffSession_UndeliveredMissionStillAnnouncesTheSwap is the case the
+// checkpoint publish exists for. A post-ready paste failure leaves the mission
+// pending behind the fence and NEVER settles inside this call — the recovery loop
+// owns it from here. The agent program has still changed, and the requester learns
+// that from the RPC error path; everyone else has only the events plane.
+func TestHandoffSession_UndeliveredMissionStillAnnouncesTheSwap(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	sendErr := errors.New("paste transport failed")
+	backend := &handoffBackend{FakeBackend: session.NewFakeBackend(), sendErr: sendErr}
+	const title = "handoff-undelivered"
+	inst := registerHandoffSubject(t, manager, repoID, repoPath, title, backend)
+
+	id, ch := manager.events.subscribe()
+	defer manager.events.unsubscribe(id)
+
+	_, err := manager.HandoffSession(HandoffSessionRequest{
+		Title: title, RepoID: repoID, To: tmux.ProgramGemini,
+	})
+	if !errors.Is(err, task.ErrPromptDelivery) {
+		t.Fatalf("HandoffSession error = %v, want a post-ready prompt-delivery failure", err)
+	}
+	if got := inst.GetInFlightOp(); got != session.OpReplacing {
+		t.Fatalf("op = %v, want the fence still raised for the retry path", got)
+	}
+
+	updates := drainSessionUpdates(t, ch)
+	if firstUpdateWhere(updates, func(d session.InstanceData) bool {
+		return d.Program == tmux.ProgramGemini && d.InFlightOp == session.OpReplacing
+	}) < 0 {
+		t.Fatalf("an undelivered handoff announced nothing: the pane already runs the incoming agent, "+
+			"so every other client is now wrong about which agent this session is: got %s", describeUpdates(updates))
+	}
+}
+
+// TestResumePendingHandoffs_PublishesSettlement covers the recovery loop, where
+// the events plane matters MORE than on the interactive path: no client asked for
+// this work, so not even the window that started the handoff has a reason to
+// re-Snapshot afterwards.
+func TestResumePendingHandoffs_PublishesSettlement(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	sendErr := errors.New("paste transport failed")
+	backend := &handoffBackend{FakeBackend: session.NewFakeBackend(), sendErr: sendErr}
+	const title = "handoff-recovered"
+	inst := registerHandoffSubject(t, manager, repoID, repoPath, title, backend)
+
+	if _, err := manager.HandoffSession(HandoffSessionRequest{
+		Title: title, RepoID: repoID, To: tmux.ProgramGemini,
+	}); !errors.Is(err, task.ErrPromptDelivery) {
+		t.Fatalf("HandoffSession error = %v, want a post-ready prompt-delivery failure", err)
+	}
+
+	// Subscribe AFTER the failed handoff so only the recovery's own announcement
+	// can satisfy the assertion.
+	id, ch := manager.events.subscribe()
+	defer manager.events.unsubscribe(id)
+
+	backend.setSendErr(nil)
+	manager.ResumePendingHandoffs()
+
+	if got := inst.GetInFlightOp(); got != session.OpNone {
+		t.Fatalf("op = %v, want the fence lowered after a delivered recovery mission", got)
+	}
+	updates := drainSessionUpdates(t, ch)
+	if firstUpdateWhere(updates, func(d session.InstanceData) bool {
+		return d.Program == tmux.ProgramGemini && d.InFlightOp == session.OpNone
+	}) < 0 {
+		t.Fatalf("handoff recovery settled silently: the row stays working on every open rail until something "+
+			"unrelated republishes it: got %s", describeUpdates(updates))
+	}
+}
+
+// describeUpdates renders the collected payloads in the two axes these tests turn
+// on, so a failure names what WAS published instead of only what was not.
+func describeUpdates(updates []session.InstanceData) string {
+	if len(updates) == 0 {
+		return "no session.updated events"
+	}
+	out := ""
+	for i, u := range updates {
+		if i > 0 {
+			out += ", "
+		}
+		out += u.Program + "/" + opLabelForTest(u.InFlightOp)
+	}
+	return "[" + out + "]"
+}
+
+func opLabelForTest(op session.InFlightOp) string {
+	switch op {
+	case session.OpNone:
+		return "none"
+	case session.OpReplacing:
+		return "replacing"
+	default:
+		return fmt.Sprintf("op(%d)", int(op))
+	}
+}

--- a/daemon/handoff_recovery.go
+++ b/daemon/handoff_recovery.go
@@ -29,6 +29,14 @@ type pendingHandoffEntry struct {
 // settled row waits for RefreshStatuses to provide LiveReady first. The same
 // target-before-op locks as handoff/send-prompt prevent a recovery paste from
 // racing a newer mutation.
+//
+// Every settlement below persists AND publishes (#2782). The events plane matters
+// more here than on the interactive path, not less: no client asked for this work,
+// so not even the window that started the handoff has a reason to re-Snapshot
+// afterwards — and the status poll is precisely what cannot report it, because it
+// skips a fenced row and then takes the settled state as its own baseline. Without
+// the publish, a row this loop finishes stays "working" on every open rail until
+// something unrelated republishes it.
 func (m *Manager) ResumePendingHandoffs() {
 	m.mu.Lock()
 	entries := make([]pendingHandoffEntry, 0, len(m.instances))
@@ -86,7 +94,7 @@ func (m *Manager) resumePendingHandoff(entry pendingHandoffEntry, mission string
 		if !entry.instance.ClearPendingHandoffMission(mission) {
 			return fmt.Errorf("pending mission changed while transferring it to limit retry")
 		}
-		m.persistInstance(entry.repoID, entry.instance)
+		m.persistAndPublishInstance(entry.repoID, entry.instance)
 		m.clearPendingHandoffRetry(entry.repoID, entry.instance)
 		return nil
 	case session.LiveReady:
@@ -117,13 +125,13 @@ func (m *Manager) resumePendingHandoff(entry pendingHandoffEntry, mission string
 			if !entry.instance.ClearPendingHandoffMission(mission) {
 				return fmt.Errorf("pending mission changed while parking its usage limit")
 			}
-			m.persistInstance(entry.repoID, entry.instance)
+			m.persistAndPublishInstance(entry.repoID, entry.instance)
 			m.clearPendingHandoffRetry(entry.repoID, entry.instance)
 			return nil
 		}
 		if op == session.OpReplacing && errors.Is(err, task.ErrAgentReadiness) {
 			entry.instance.MarkStartupStateUnknown()
-			m.persistInstance(entry.repoID, entry.instance)
+			m.persistAndPublishInstance(entry.repoID, entry.instance)
 			m.clearPendingHandoffRetry(entry.repoID, entry.instance)
 		}
 		return err
@@ -136,7 +144,7 @@ func (m *Manager) resumePendingHandoff(entry pendingHandoffEntry, mission string
 	if !entry.instance.ClearPendingHandoffMission(mission) {
 		return fmt.Errorf("pending mission changed after delivery")
 	}
-	m.persistInstance(entry.repoID, entry.instance)
+	m.persistAndPublishInstance(entry.repoID, entry.instance)
 	m.clearPendingHandoffRetry(entry.repoID, entry.instance)
 	log.InfoLog.Printf("handoff %q: delivered pending mission", entry.instance.Title)
 	return nil


### PR DESCRIPTION
## The bug

A handoff rewrites a session's **agent program** — the single most visible fact
about a row, and the one the handoff picker *excludes* when offering targets — and
announced nothing on the events plane. The requester learned about the swap from
`HandoffSessionResponse`; every other client had no way to find out. A second web
window kept rendering the outgoing agent and kept offering to hand off to the agent
the session had just become.

The status poll cannot cover for this, in either direction:

- it returns early while an operation is in flight (`OpReplacing`), so it is blind
  for the whole handoff;
- once the handoff finishes, it snapshots the already-final state as its own
  "before" baseline and therefore sees no change to report.

And `projectionChanged` covers `AgentModelChange` (the model variant), not
`Program` (the agent itself), so a swap alone would never trigger a publish.

## The fix

Every committed point of the transaction now persists **and** publishes:

| where | why it needs its own announcement |
|---|---|
| post-swap checkpoint (`handoff.go`) | the readiness wait can run for a minute; other clients must not spend it offering actions against an agent that is already gone |
| settlement + startup-unknown (`handoff_delivery.go`) | this is what lowers the fence again for those clients |
| all four settlements in `handoff_recovery.go` | matters most: no client asked for that work, so not even the window that started the handoff has a reason to re-Snapshot afterwards |

Two helpers carry it, both publishing **inside the repo ordering lock**, in the same
critical section as the persist. `session.updated` replaces a client's WHOLE session
projection, so publishing after the unlock lets an older payload land last and revert
newer state — the same reason `limit.go`'s poll publishes under the lock.

- **`persistAndPublishInstance`** — the announcing form of `persistInstance`. Like
  `persistInstance` it is best-effort about the write, and it announces even when the
  write fails: what the other clients must converge on is *memory*, which has already
  changed, and the next checkpoint retries the write.
- **`persistHandoffCheckpointErr`** — replaces `persistInstanceSnapshotErr` for the
  one writer whose durable and live projections differ *on purpose*. Disk takes the
  crash-recovery checkpoint, which cannot retain a process-local op and so reads as a
  settled row; the **event** takes the live projection, fence and all. Announcing the
  checkpoint instead would tell other clients the swap had settled and **re-open the
  action gates the daemon is still holding shut** — `CanHandoff`/`CanKill` project
  off that fence.

`web/src/api.ts` already documented this event as the thing that repaints the rail
after a handoff. It does now. No web change is needed: `session.updated` carries a
whole `InstanceData` and the client's existing `upsertSession` re-projects from it.

## Verification

Three new tests, each failing on `master` for its own reason:

```
--- FAIL: TestHandoffSession_PublishesSwapThenSettlement
    handoff published no session.updated: every other client keeps rendering the
    OUTGOING agent, and the handoff picker keeps excluding the wrong one
--- FAIL: TestHandoffSession_UndeliveredMissionStillAnnouncesTheSwap
    an undelivered handoff announced nothing: the pane already runs the incoming
    agent, so every other client is now wrong about which agent this session is
--- FAIL: TestResumePendingHandoffs_PublishesSettlement
    handoff recovery settled silently: the row stays working on every open rail
    until something unrelated republishes it
```

They assert on the published **events**, not on a later `Snapshot` — a Snapshot
assertion passes with nothing published at all. The first also pins the **order** of
the two announcements, since the later one must not be the older payload. All 20
pre-existing handoff/recovery tests still pass unchanged.

Full local gate on the pushed head `593ea763`: `golangci-lint --fast`, `gofmt -l .`
(empty), `go build ./...`, `make test-container` (whole suite green, `daemon 285.5s`),
`deadcode -test ./...`, `scripts/lint-file-length.sh`.

Closes #2782

🤖 Generated with [Claude Code](https://claude.com/claude-code)
