### PR TITLE
fix(ci): give the web selftest teeth and run it on master (#2762)

### DIFF
--- a/.github/scripts/web-selftest-scope.js
+++ b/.github/scripts/web-selftest-scope.js
@@ -1,0 +1,101 @@
+// Decides whether a change needs the Playwright web-driver selftest (#2762).
+//
+// The suite is a REQUIRED gate — pr.yml's Build job lists it in `needs`, which is
+// what gives a red run teeth (docs/web-selftest.md, and the header on
+// .github/workflows/web-selftest.yml). But it is also the most expensive thing in
+// CI: a Go+Node+Chromium image, then a real daemon and a real browser. Running it
+// on every PR would tax every docs typo with that; running it on none of them is
+// the hole #2762 recorded. So it runs on exactly the changes that can break it.
+//
+// The path list below is the ONE source of truth for that decision. The `paths:`
+// filter on web-selftest.yml's push trigger repeats it as literal YAML — GitHub
+// gives no way to compute a trigger filter — and web-selftest-scope.test.js reads
+// that file and fails if the two disagree, so the copy cannot drift silently.
+//
+// The workflow chooses to RUN whenever it cannot compute a diff (an unexpected
+// event, a shallow clone with no base parent). This helper is only consulted with
+// a real file list; "I don't know" never reaches it, because the safe answer to
+// that question is to run the suite, not to ask a predicate about an empty list.
+
+// Paths whose change can break the web selftest.
+//
+//   * web/**            the SPA, and the committed bundle the harness serves.
+//   * daemon/**         the harness drives a REAL daemon, so its HTTP/WS surface
+//     agentproto/**     and the wire types are as able to break the suite as web/
+//     apiproto/**       is. #1932 (a stale header) and #1894 (a detach that
+//                       dropped scroll) were both found exactly this way.
+//   * the harness itself, and the CI wiring that decides whether it gates — a
+//     change to this file or to pr.yml's Build `needs` must re-prove the gate on
+//     the PR that makes it, not on some later one.
+const SELFTEST_PATHS = [
+  "web/**",
+  "daemon/**",
+  "agentproto/**",
+  "apiproto/**",
+  "scripts/testbox.sh",
+  "scripts/container/Dockerfile.web-selftest",
+  "scripts/container/web-selftest-entry.sh",
+  ".github/workflows/web-selftest.yml",
+  ".github/workflows/pr.yml",
+  ".github/scripts/web-selftest-scope.js",
+];
+
+// A deliberately tiny subset of GitHub's `paths:` globbing: a trailing `/**`
+// matches everything under a directory, anything else is an exact file path.
+// Every pattern above is one of those two shapes and the test asserts it stays
+// that way — a `*.ts`-style pattern would be silently mismatched here rather than
+// half-supported, which is how a filter starts skipping the suite it exists to
+// schedule.
+function matchesPattern(pattern, path) {
+  if (pattern.endsWith("/**")) {
+    return path.startsWith(pattern.slice(0, -2));
+  }
+  return path === pattern;
+}
+
+/**
+ * @param {string[]} changedPaths repo-relative paths changed by the PR/push.
+ * @returns {{run: boolean, matched: string[]}} whether to run, and the paths that
+ *   decided it (capped by the caller for logging).
+ */
+function scopeWebSelftest(changedPaths) {
+  const matched = changedPaths.filter((path) =>
+    SELFTEST_PATHS.some((pattern) => matchesPattern(pattern, path)),
+  );
+  return { run: matched.length > 0, matched };
+}
+
+// CLI: `node web-selftest-scope.js <file-of-changed-paths>` prints `run=true` or
+// `run=false` on stdout for `>> "$GITHUB_OUTPUT"`, and the reasoning on stderr so
+// the job log says why it did what it did. A missing/unreadable file is not an
+// empty diff — it is a broken diff, so it prints run=true.
+if (require.main === module) {
+  const fs = require("node:fs");
+  const file = process.argv[2];
+  let changed;
+  try {
+    changed = fs.readFileSync(file, "utf8").split("\n");
+  } catch (error) {
+    process.stderr.write(`web-selftest-scope: cannot read ${file} (${error.message}) — running the suite\n`);
+    process.stdout.write("run=true\n");
+    process.exit(0);
+  }
+  const paths = changed.map((line) => line.trim()).filter((line) => line.length > 0);
+  const { run, matched } = scopeWebSelftest(paths);
+  if (run) {
+    process.stderr.write(
+      `web-selftest-scope: ${matched.length} of ${paths.length} changed path(s) are in scope, e.g.\n` +
+        matched
+          .slice(0, 10)
+          .map((path) => `  ${path}\n`)
+          .join(""),
+    );
+  } else {
+    process.stderr.write(
+      `web-selftest-scope: none of ${paths.length} changed path(s) can reach the web selftest — skipping it.\n`,
+    );
+  }
+  process.stdout.write(`run=${run}\n`);
+}
+
+module.exports = { SELFTEST_PATHS, scopeWebSelftest, matchesPattern };

--- a/.github/scripts/web-selftest-scope.js
+++ b/.github/scripts/web-selftest-scope.js
@@ -19,11 +19,33 @@
 
 // Paths whose change can break the web selftest.
 //
-//   * web/**            the SPA, and the committed bundle the harness serves.
-//   * daemon/**         the harness drives a REAL daemon, so its HTTP/WS surface
-//     agentproto/**     and the wire types are as able to break the suite as web/
-//     apiproto/**       is. #1932 (a stale header) and #1894 (a detach that
-//                       dropped scroll) were both found exactly this way.
+// **Go source is watched wholesale**, and that is a deliberate correction. The
+// first cut enumerated the packages thought to matter (daemon, agentproto,
+// apiproto) and was wrong twice in review: it missed the harness invocation chain,
+// then missed `session/**` and `task/**` — which the entry script drives directly
+// via `$BIN sessions create|list|get|archive|restore|kill|tab-create|tab-delete`
+// and `$BIN tasks add`, with the spec round-tripping those flows in the browser.
+//
+// The second miss is the tell. The harness BUILDS AND RUNS THE WHOLE `af` BINARY,
+// so the honest predicate is not "which packages did I remember?" — a question
+// nobody answers correctly twice running — but "does this change any Go the binary
+// is built from?", which is decidable. Enumerating packages made the filter's
+// blind spots a function of my memory, and a gate whose blind spots nobody can
+// enumerate is the #2762 failure one level in.
+//
+// The cost that argued for a narrow list is gone: measured cold on a runner the
+// suite is ~4 minutes, and it runs in parallel with `Test` and `Test (macOS)`,
+// which are longer — so a Go-touching PR pays approximately nothing in wall clock.
+// Docs-, plugin- and prose-only PRs still skip it, which is what the filter is
+// actually for.
+//
+//   * **/*.go, go.mod, go.sum   everything the binary is built from.
+//   * web/**                    the SPA, and the committed bundle the harness serves.
+//   * daemon/**                 kept alongside `**/*.go` on purpose: these also
+//     agentproto/**             carry non-Go files (testdata, fixtures) that the
+//     apiproto/**               suite can depend on. #1932 (a stale header) and
+//                               #1894 (a detach that dropped scroll) were both
+//                               found exactly this way.
 //   * the harness itself — the WHOLE invocation chain, not just its middle. CI
 //     runs `make web-selftest-container`, so the closure is Makefile ->
 //     scripts/testbox.sh -> Dockerfile.web-selftest + web-selftest-entry.sh ->
@@ -34,6 +56,9 @@
 //     pr.yml's Build `needs` must re-prove the gate on the PR that makes it, not
 //     on some later one.
 const SELFTEST_PATHS = [
+  "**/*.go",
+  "go.mod",
+  "go.sum",
   "web/**",
   "daemon/**",
   "agentproto/**",
@@ -48,13 +73,24 @@ const SELFTEST_PATHS = [
   ".github/scripts/web-selftest-scope.js",
 ];
 
-// A deliberately tiny subset of GitHub's `paths:` globbing: a trailing `/**`
-// matches everything under a directory, anything else is an exact file path.
-// Every pattern above is one of those two shapes and the test asserts it stays
-// that way — a `*.ts`-style pattern would be silently mismatched here rather than
-// half-supported, which is how a filter starts skipping the suite it exists to
-// schedule.
+// A deliberately tiny subset of GitHub's `paths:` globbing, matching what the
+// trigger filter does for the three shapes actually used:
+//
+//   `**/*.ext`  any file with that extension, at any depth INCLUDING the root
+//               (GitHub's `**` matches zero or more directories, so `**/*.go`
+//               covers `main.go` as well as `daemon/x.go`)
+//   `dir/**`    everything under a directory
+//   anything else is an exact file path
+//
+// The test asserts every pattern stays one of those three — a shape this does not
+// implement would be silently mismatched rather than half-supported, which is how
+// a filter starts skipping the suite it exists to schedule.
 function matchesPattern(pattern, path) {
+  if (pattern.startsWith("**/*.")) {
+    // slice(4) keeps the dot: "**/*.go" -> ".go", so "cargo.go" matches on the
+    // extension but "going.md" cannot match on a bare suffix.
+    return path.endsWith(pattern.slice(4));
+  }
   if (pattern.endsWith("/**")) {
     return path.startsWith(pattern.slice(0, -2));
   }

--- a/.github/scripts/web-selftest-scope.js
+++ b/.github/scripts/web-selftest-scope.js
@@ -24,17 +24,25 @@
 //     agentproto/**     and the wire types are as able to break the suite as web/
 //     apiproto/**       is. #1932 (a stale header) and #1894 (a detach that
 //                       dropped scroll) were both found exactly this way.
-//   * the harness itself, and the CI wiring that decides whether it gates — a
-//     change to this file or to pr.yml's Build `needs` must re-prove the gate on
-//     the PR that makes it, not on some later one.
+//   * the harness itself — the WHOLE invocation chain, not just its middle. CI
+//     runs `make web-selftest-container`, so the closure is Makefile ->
+//     scripts/testbox.sh -> Dockerfile.web-selftest + web-selftest-entry.sh ->
+//     copy-src.sh (the entry sources it to stage /src into /work). Miss a link and
+//     a PR editing only that link merges without running the suite it just
+//     changed, which is the same "reads as coverage" failure as #2762 itself.
+//   * the CI wiring that decides whether it gates — a change to this file or to
+//     pr.yml's Build `needs` must re-prove the gate on the PR that makes it, not
+//     on some later one.
 const SELFTEST_PATHS = [
   "web/**",
   "daemon/**",
   "agentproto/**",
   "apiproto/**",
+  "Makefile",
   "scripts/testbox.sh",
   "scripts/container/Dockerfile.web-selftest",
   "scripts/container/web-selftest-entry.sh",
+  "scripts/container/copy-src.sh",
   ".github/workflows/web-selftest.yml",
   ".github/workflows/pr.yml",
   ".github/scripts/web-selftest-scope.js",

--- a/.github/scripts/web-selftest-scope.test.js
+++ b/.github/scripts/web-selftest-scope.test.js
@@ -1,0 +1,208 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const { SELFTEST_PATHS, scopeWebSelftest, matchesPattern } = require("./web-selftest-scope.js");
+
+const WORKFLOWS = path.join(__dirname, "..", "workflows");
+const readWorkflow = (name) => fs.readFileSync(path.join(WORKFLOWS, name), "utf8");
+
+// ── the predicate ─────────────────────────────────────────────────────────────
+
+test("a change under a watched directory runs the suite", () => {
+  assert.equal(scopeWebSelftest(["web/src/ui.ts"]).run, true);
+  assert.equal(scopeWebSelftest(["daemon/server.go"]).run, true);
+  assert.equal(scopeWebSelftest(["agentproto/frame.go"]).run, true);
+  assert.equal(scopeWebSelftest(["apiproto/envelope.go"]).run, true);
+  // The committed bundle counts: it is what the harness actually serves.
+  assert.equal(scopeWebSelftest(["web/dist/af-web.js"]).run, true);
+});
+
+test("a change that cannot reach the web client skips the suite", () => {
+  const { run, matched } = scopeWebSelftest([
+    "docs/web-selftest.md",
+    "README.md",
+    "session/git/worktree.go",
+    "ui/overlay.go",
+  ]);
+  assert.equal(run, false);
+  assert.deepEqual(matched, []);
+});
+
+test("one in-scope path among many out-of-scope ones still runs the suite", () => {
+  const { run, matched } = scopeWebSelftest(["README.md", "main.go", "daemon/tasks.go"]);
+  assert.equal(run, true);
+  assert.deepEqual(matched, ["daemon/tasks.go"]);
+});
+
+test("an exact-file pattern does not match a longer sibling name", () => {
+  // scripts/testbox.sh is watched; scripts/testbox-selftest.sh is a DIFFERENT
+  // file and must not match it. A prefix-matching bug here would run the
+  // expensive suite on unrelated harness edits — the cheap direction, but it
+  // would also mean the pattern semantics are not what the workflow's `paths:`
+  // filter does, and then the two schedules disagree.
+  assert.equal(matchesPattern("scripts/testbox.sh", "scripts/testbox.sh"), true);
+  assert.equal(matchesPattern("scripts/testbox.sh", "scripts/testbox-selftest.sh"), false);
+  assert.equal(scopeWebSelftest(["scripts/testbox-selftest.sh"]).run, false);
+  assert.equal(scopeWebSelftest(["scripts/testbox.sh"]).run, true);
+});
+
+test("a directory pattern does not match a same-prefixed sibling directory", () => {
+  assert.equal(matchesPattern("web/**", "web/src/ui.ts"), true);
+  assert.equal(matchesPattern("web/**", "webhooks/handler.go"), false);
+});
+
+test("an empty change list skips — the workflow never asks about an unknown diff", () => {
+  // Documented contract, not an accident: pr.yml resolves "I could not compute
+  // the diff" to run=true WITHOUT consulting this helper, so an empty list here
+  // always means a genuinely empty diff.
+  assert.equal(scopeWebSelftest([]).run, false);
+});
+
+test("the CI wiring watches itself, so a change to the gate re-proves the gate", () => {
+  assert.equal(scopeWebSelftest([".github/workflows/pr.yml"]).run, true);
+  assert.equal(scopeWebSelftest([".github/scripts/web-selftest-scope.js"]).run, true);
+  assert.equal(scopeWebSelftest([".github/workflows/web-selftest.yml"]).run, true);
+});
+
+test("every pattern is a shape this matcher actually implements", () => {
+  for (const pattern of SELFTEST_PATHS) {
+    if (pattern.endsWith("/**")) {
+      assert.equal(pattern.slice(0, -3).includes("*"), false, `${pattern}: only a TRAILING /** is supported`);
+      continue;
+    }
+    assert.equal(
+      pattern.includes("*"),
+      false,
+      `${pattern}: matchesPattern implements exact paths and a trailing /** only. ` +
+        "Teach it the new shape (and teach the workflow's paths: filter the same one) before adding this.",
+    );
+  }
+});
+
+// ── the copy of the list that lives in the workflow trigger ───────────────────
+
+/** The `paths:` list under a workflow trigger, in file order. */
+function triggerPaths(yaml) {
+  const lines = yaml.split("\n");
+  const start = lines.findIndex((line) => /^\s+paths:\s*$/.test(line));
+  assert.notEqual(start, -1, "no `paths:` trigger filter found");
+  const indent = lines[start].match(/^\s*/)[0].length;
+  const found = [];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.trim() === "") continue;
+    if (line.match(/^\s*/)[0].length <= indent) break;
+    if (line.trim().startsWith("#")) continue;
+    const item = line.trim().match(/^- '(.+)'$/);
+    if (!item) break;
+    found.push(item[1]);
+  }
+  return found;
+}
+
+test("web-selftest.yml's push filter matches the helper's path list exactly", () => {
+  // The whole point of this file. A trigger `paths:` cannot be computed, so that
+  // list is a literal copy of SELFTEST_PATHS — and a copy nobody checks is a copy
+  // that is wrong. Drift in either direction is a hole: the PR gate and the master
+  // signal would then watch different things, and the one that stopped watching
+  // would keep reporting green.
+  assert.deepEqual(
+    triggerPaths(readWorkflow("web-selftest.yml")),
+    SELFTEST_PATHS,
+    "web-selftest.yml's `paths:` and SELFTEST_PATHS have drifted — update both.",
+  );
+});
+
+// ── the wiring that gives a red run teeth (#2762) ─────────────────────────────
+
+/** Top-level job ids of a workflow, in file order. */
+function jobIds(yaml) {
+  const lines = yaml.split("\n");
+  const start = lines.findIndex((line) => /^jobs:\s*$/.test(line));
+  assert.notEqual(start, -1, "no `jobs:` block found");
+  return lines
+    .slice(start + 1)
+    .map((line) => line.match(/^ {2}([A-Za-z0-9_-]+):\s*$/))
+    .filter(Boolean)
+    .map((match) => match[1]);
+}
+
+/** One job's inline `needs: [a, b]` list, or null. */
+function jobNeeds(yaml, jobId) {
+  let inJob = false;
+  for (const line of yaml.split("\n")) {
+    const job = line.match(/^ {2}([A-Za-z0-9_-]+):\s*$/);
+    if (job) {
+      inJob = job[1] === jobId;
+      continue;
+    }
+    if (!inJob) continue;
+    const needs = line.match(/^ {4}needs:\s*\[(.*)\]\s*$/);
+    if (needs) {
+      return needs[1]
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+    }
+  }
+  return null;
+}
+
+test("every job in pr.yml is listed in Build's needs", () => {
+  // "Lint" and "Build" are this repo's only required checks (ruleset 14851503), so
+  // a job that Build does not depend on gates NOTHING — it renders as a check,
+  // reads as coverage, and can be red on a PR that merges. That is #2762 (the web
+  // selftest) and #2623 (a docs check switched off) in one sentence.
+  //
+  // So: adding a job to pr.yml without adding it to `needs` fails Lint. If a job is
+  // ever meant to be advisory, that is a deliberate decision — delete it from this
+  // assertion with a comment saying why, rather than letting it be an omission
+  // nobody notices.
+  const yaml = readWorkflow("pr.yml");
+  const needs = jobNeeds(yaml, "build");
+  assert.notEqual(needs, null, "pr.yml's build job has no inline `needs: [...]` list");
+  for (const id of jobIds(yaml)) {
+    if (id === "build") continue;
+    assert.ok(needs.includes(id), `pr.yml job "${id}" is not in Build's needs, so it gates nothing`);
+  }
+});
+
+test("Build runs even when a need fails, so the required check goes red not skipped", () => {
+  // GitHub skips a job whose `needs` failed, and a SKIPPED required check does not
+  // fail — the merge button stays live. `if: always()` plus the gate step is what
+  // converts a failed need into a red "Build". Without it, every `needs` entry
+  // above is decorative.
+  const yaml = readWorkflow("pr.yml");
+  const build = yaml.slice(yaml.indexOf("\n  build:\n"));
+  assert.match(build, /^ {4}if: always\(\)$/m, "pr.yml's build job must keep `if: always()`");
+  assert.match(
+    build,
+    /^ {8}if: contains\(needs\.\*\.result, 'failure'\) \|\| contains\(needs\.\*\.result, 'cancelled'\)$/m,
+    "pr.yml's build gate step must fail on a failed or cancelled need",
+  );
+});
+
+test("pr.yml calls the web selftest workflow, and it is scoped rather than unconditional", () => {
+  const yaml = readWorkflow("pr.yml");
+  assert.match(
+    yaml,
+    /^ {4}uses: \.\/\.github\/workflows\/web-selftest\.yml$/m,
+    "pr.yml must call web-selftest.yml as a reusable workflow — that is the only way Build can `needs` it",
+  );
+  assert.deepEqual(jobNeeds(yaml, "web-selftest"), ["web-selftest-scope"]);
+  assert.match(yaml, /^ {4}if: needs\.web-selftest-scope\.outputs\.run == 'true'$/m);
+});
+
+test("web-selftest.yml is callable AND runs on master", () => {
+  const yaml = readWorkflow("web-selftest.yml");
+  // Callable: the PR gate. Without this pr.yml cannot call it and nothing gates.
+  assert.match(yaml, /^ {2}workflow_call:$/m, "web-selftest.yml must stay callable — pr.yml's gate depends on it");
+  // Master: the signal run (#2762). Without this a regression that lands stays
+  // invisible until some later PR happens to touch these paths.
+  assert.match(yaml, /^ {2}push:\n {4}branches: \[master\]$/m, "web-selftest.yml must keep its master push trigger");
+  // A second `pull_request:` trigger would double every PR run — once standalone,
+  // once through pr.yml — and the standalone one would gate nothing.
+  assert.doesNotMatch(yaml, /^ {2}pull_request:$/m, "the PR run goes through pr.yml now, not a pull_request trigger");
+});

--- a/.github/scripts/web-selftest-scope.test.js
+++ b/.github/scripts/web-selftest-scope.test.js
@@ -60,6 +60,23 @@ test("an empty change list skips — the workflow never asks about an unknown di
   assert.equal(scopeWebSelftest([]).run, false);
 });
 
+test("the whole harness invocation chain is watched, not just its middle", () => {
+  // CI runs `make web-selftest-container`, so every link between that command and
+  // the browser can break the suite. Missing a link means a PR that edits only
+  // that link merges without running the suite it just changed — the same "reads
+  // as coverage" failure this whole PR exists to remove (Codex review on #2762
+  // caught Makefile and copy-src.sh absent from the first cut).
+  for (const link of [
+    "Makefile", // defines the web-selftest-container target CI invokes
+    "scripts/testbox.sh", // the target's implementation
+    "scripts/container/Dockerfile.web-selftest", // the image it builds
+    "scripts/container/web-selftest-entry.sh", // what runs inside
+    "scripts/container/copy-src.sh", // sourced by the entry to stage /src -> /work
+  ]) {
+    assert.equal(scopeWebSelftest([link]).run, true, `${link} is part of the harness and must be watched`);
+  }
+});
+
 test("the CI wiring watches itself, so a change to the gate re-proves the gate", () => {
   assert.equal(scopeWebSelftest([".github/workflows/pr.yml"]).run, true);
   assert.equal(scopeWebSelftest([".github/scripts/web-selftest-scope.js"]).run, true);

--- a/.github/scripts/web-selftest-scope.test.js
+++ b/.github/scripts/web-selftest-scope.test.js
@@ -23,17 +23,53 @@ test("a change that cannot reach the web client skips the suite", () => {
   const { run, matched } = scopeWebSelftest([
     "docs/web-selftest.md",
     "README.md",
-    "session/git/worktree.go",
-    "ui/overlay.go",
+    "CLAUDE.md",
+    "plugins/claude/agent-factory/skills/agent-factory/SKILL.md",
+    ".github/workflows/stale.yml",
   ]);
   assert.equal(run, false);
   assert.deepEqual(matched, []);
 });
 
+test("ANY Go source runs the suite — the harness builds and runs the whole binary", () => {
+  // This replaced an enumerated package list. The old list called
+  // session/git/worktree.go out of scope, which was wrong: the entry script
+  // seeds through `$BIN sessions create` and the spec round-trips those flows.
+  // Rather than add the packages review found (twice), the predicate now asks a
+  // question that is decidable: is this Go the binary is built from?
+  for (const path of [
+    "main.go", // root package — `**/*.go` must match at depth 0 too
+    "session/git/worktree.go",
+    "task/runner.go",
+    "api/sessions.go",
+    "commands/configcmd.go",
+    "apiclient/client.go",
+    "ui/overlay.go",
+    "internal/proctree/proctree_darwin.go",
+  ]) {
+    assert.equal(scopeWebSelftest([path]).run, true, `${path} is compiled into af and must be watched`);
+  }
+  assert.equal(scopeWebSelftest(["go.mod"]).run, true);
+  assert.equal(scopeWebSelftest(["go.sum"]).run, true);
+});
+
 test("one in-scope path among many out-of-scope ones still runs the suite", () => {
-  const { run, matched } = scopeWebSelftest(["README.md", "main.go", "daemon/tasks.go"]);
+  const { run, matched } = scopeWebSelftest(["README.md", "CHANGELOG.md", "daemon/tasks.go"]);
   assert.equal(run, true);
   assert.deepEqual(matched, ["daemon/tasks.go"]);
+});
+
+test("a rename OUT of a watched path is still seen (the --no-renames contract)", () => {
+  // `git diff --name-only` reports a pure rename as the NEW path only, so the
+  // scope job passes --no-renames and git emits the delete AND the add. This
+  // pins the helper's half of that contract: given both paths, the watched
+  // source still matches even though the destination does not.
+  const { run, matched } = scopeWebSelftest([
+    "scripts/container/backup-entry.sh", // the rename destination — not watched
+    "scripts/container/web-selftest-entry.sh", // the deleted source — watched
+  ]);
+  assert.equal(run, true);
+  assert.deepEqual(matched, ["scripts/container/web-selftest-entry.sh"]);
 });
 
 test("an exact-file pattern does not match a longer sibling name", () => {
@@ -85,6 +121,10 @@ test("the CI wiring watches itself, so a change to the gate re-proves the gate",
 
 test("every pattern is a shape this matcher actually implements", () => {
   for (const pattern of SELFTEST_PATHS) {
+    if (pattern.startsWith("**/*.")) {
+      assert.equal(pattern.slice(5).includes("*"), false, `${pattern}: only a plain **/*.ext is supported`);
+      continue;
+    }
     if (pattern.endsWith("/**")) {
       assert.equal(pattern.slice(0, -3).includes("*"), false, `${pattern}: only a TRAILING /** is supported`);
       continue;
@@ -92,10 +132,17 @@ test("every pattern is a shape this matcher actually implements", () => {
     assert.equal(
       pattern.includes("*"),
       false,
-      `${pattern}: matchesPattern implements exact paths and a trailing /** only. ` +
+      `${pattern}: matchesPattern implements exact paths, a trailing /** and a leading **/*.ext only. ` +
         "Teach it the new shape (and teach the workflow's paths: filter the same one) before adding this.",
     );
   }
+});
+
+test("**/*.ext matches by extension, not by a same-prefixed name", () => {
+  assert.equal(matchesPattern("**/*.go", "main.go"), true);
+  assert.equal(matchesPattern("**/*.go", "a/b/c.go"), true);
+  assert.equal(matchesPattern("**/*.go", "docs/going-further.md"), false);
+  assert.equal(matchesPattern("**/*.go", "web/src/ui.ts"), false);
 });
 
 // ── the copy of the list that lives in the workflow trigger ───────────────────

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -343,7 +343,15 @@ jobs:
             echo "run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          git diff --name-only "$base" HEAD > changed-paths.txt
+          # --no-renames is load-bearing, not stylistic. With rename detection on,
+          # `git diff --name-only` reports a rename as the NEW path ONLY — so
+          # moving scripts/container/web-selftest-entry.sh to an unwatched name
+          # would delete a harness entrypoint while the changed-path list never
+          # mentions it, and the suite would skip the PR that broke it. Disabling
+          # detection reports the rename as a delete plus an add, so the watched
+          # source path is present. Verified: `git diff --name-only` prints 1 path
+          # for a pure rename, `--no-renames` prints both.
+          git diff --no-renames --name-only "$base" HEAD > changed-paths.txt
           node .github/scripts/web-selftest-scope.js changed-paths.txt >> "$GITHUB_OUTPUT"
 
   # The web client's acceptance proof (#1592 Phase 5 PR6, docs/web-selftest.md),

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -80,6 +80,15 @@ jobs:
       - name: Test auto-gate helper
         run: node --test .github/scripts/auto-gate.test.js
 
+      # Same rationale again, one layer up: this helper decides whether the web
+      # selftest RUNS, and its tests also assert the wiring that gives a red run
+      # teeth — that every job in this file is in Build's `needs`, that Build still
+      # runs when a need fails, and that the trigger filter and the helper's path
+      # list have not drifted apart. #2762 is what a check with no teeth costs, so
+      # the teeth are asserted in the required job rather than assumed.
+      - name: Test web-selftest scope helper and the gate wiring
+        run: node --test .github/scripts/web-selftest-scope.test.js
+
       # Same rationale as the auto-gate test above: the stale-external-pr helper
       # decides which fork PRs to auto-close, so its pure decision logic gates
       # here in the required Lint job. Built-in node:test, no install step.
@@ -281,6 +290,81 @@ jobs:
           fi
           echo "web/dist matches a fresh build."
 
+  # Should the Playwright web-driver selftest run on this PR? (#2762)
+  #
+  # The suite gates from here (see the `web-selftest` job below), and it is the
+  # most expensive thing in CI — a Go+Node+Chromium image, then a real daemon and a
+  # real browser. Charging every docs typo for that would slow the whole repo, so
+  # this job answers the question first, in ~20s, and the expensive job runs only
+  # when the answer is yes.
+  #
+  # The DECISION lives in a tested helper (.github/scripts/web-selftest-scope.js,
+  # gated by the Lint job above), not in this YAML: a filter that silently stops
+  # matching is a gate that silently stops gating, which is the exact failure #2762
+  # recorded. This step only resolves the changed-file list and hands it over.
+  #
+  # Every way of NOT knowing the diff answers "run it". A skipped expensive job is
+  # a hole; a needlessly-run one is just slow.
+  web-selftest-scope:
+    name: Web selftest scope
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run: ${{ steps.scope.outputs.run }}
+    steps:
+      # depth 2 is exactly what the diff below needs and no more: on a
+      # pull_request event the checked-out HEAD is refs/pull/N/merge, whose first
+      # parent is the base tip and whose second is the PR head.
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Decide whether the web selftest applies
+        id: scope
+        run: |
+          set -euo pipefail
+
+          # merge_group (and anything else that ever gains this workflow) has no
+          # merge commit to diff against here. Run the suite rather than guess:
+          # the queue only ever runs changes a PR already scoped.
+          if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
+            echo "::notice::event is ${GITHUB_EVENT_NAME}, not pull_request — running the web selftest."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # `git diff HEAD^1 HEAD` on the merge commit is the PR's effective change
+          # against the base — the same thing the workflow-level `paths:` filter
+          # would compute. If the parent is missing (a shallower clone than
+          # expected, a ref that is not a merge commit), that is a broken diff, not
+          # an empty one.
+          if ! base="$(git rev-parse --verify --quiet HEAD^1)"; then
+            echo "::warning::no base parent on HEAD — running the web selftest rather than guessing."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git diff --name-only "$base" HEAD > changed-paths.txt
+          node .github/scripts/web-selftest-scope.js changed-paths.txt >> "$GITHUB_OUTPUT"
+
+  # The web client's acceptance proof (#1592 Phase 5 PR6, docs/web-selftest.md),
+  # called as a reusable workflow so that Build can list it in `needs` — a job in
+  # another workflow cannot be a `needs` dependency, and `needs` is the only way to
+  # gate on anything but "Lint" and "Build" without a ruleset edit.
+  #
+  # Until #2762 this ran as a standalone `pull_request` workflow that gated
+  # nothing: a red run could merge, and nothing then ran it on master. The suite
+  # has caught real regressions the deterministic checks do not (#1932 a stale
+  # header, #1894 a detach that dropped scroll), so "advisory signal" was
+  # understating what it is.
+  #
+  # When the scope job says no, this is `skipped` — which Build's gate step treats
+  # as fine, unlike a failure or a cancellation.
+  web-selftest:
+    name: Web selftest
+    needs: [web-selftest-scope]
+    if: needs.web-selftest-scope.outputs.run == 'true'
+    uses: ./.github/workflows/web-selftest.yml
+
   # We cross-compile and ship darwin/arm64 and darwin/amd64 binaries from
   # stable-release.yml, but every job in this repo ran on ubuntu — so no test had
   # ever executed on the OS we ship to. macOS-only defects reached users instead
@@ -345,7 +429,12 @@ jobs:
     # blocks anyway, since it demands conclusion === "success", but the native path
     # would not.) So: run ALWAYS, and fail loudly on any unsuccessful need. Now a
     # red macOS job turns the REQUIRED check red instead of quietly skipping it.
-    needs: [lint, test, test-systemd, test-macos, web, registry-free]
+    #
+    # `skipped` is deliberately NOT a failure here: web-selftest skips whenever its
+    # scope job says the PR cannot reach the web client, and that is the normal
+    # answer on most PRs. A skipped *scope* job would be a different matter, but it
+    # has no `if:` and so only skips when the run itself is going away.
+    needs: [lint, test, test-systemd, test-macos, web, registry-free, web-selftest-scope, web-selftest]
     if: always()
     steps:
       - name: Gate on the jobs this check stands in for
@@ -355,6 +444,7 @@ jobs:
           # needs['test-macos'], not needs.test-macos: a hyphen in a property path is
           # parsed as subtraction, so the dotted form silently yields an empty string.
           echo "lint=${{ needs.lint.result }} test=${{ needs.test.result }} test-systemd=${{ needs['test-systemd'].result }} test-macos=${{ needs['test-macos'].result }} web=${{ needs.web.result }} registry-free=${{ needs['registry-free'].result }}"
+          echo "web-selftest-scope=${{ needs['web-selftest-scope'].result }} web-selftest=${{ needs['web-selftest'].result }}"
           exit 1
 
       - uses: actions/checkout@v6

--- a/.github/workflows/web-selftest.yml
+++ b/.github/workflows/web-selftest.yml
@@ -33,11 +33,20 @@ on:
       # web-selftest-scope.test.js reads this file and fails Lint if the two ever
       # disagree, so the copy cannot drift silently.
       #
+      # Go source wholesale. The harness BUILDS AND RUNS the whole `af` binary —
+      # it seeds through `$BIN sessions create` and `$BIN tasks add` and the spec
+      # round-trips those flows — so the packages that can break it are not a list
+      # anyone enumerates correctly (two review rounds proved that). Measured cold
+      # at ~4 minutes, in parallel with the longer Test jobs, so a Go-touching PR
+      # pays approximately nothing. Docs- and prose-only PRs still skip.
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
       # The SPA itself, and the committed bundle the harness actually serves.
       - 'web/**'
-      # The harness drives a REAL daemon, so the daemon's HTTP/WS surface and the
-      # embedding are as capable of breaking it as web/ is. #1932 (a header that
-      # went stale) and #1894 (a detach that dropped scroll) were both found here.
+      # Kept alongside '**/*.go' deliberately: these carry non-Go files (testdata,
+      # fixtures) the suite can depend on. #1932 (a header that went stale) and
+      # #1894 (a detach that dropped scroll) were both found here.
       - 'daemon/**'
       - 'agentproto/**'
       - 'apiproto/**'

--- a/.github/workflows/web-selftest.yml
+++ b/.github/workflows/web-selftest.yml
@@ -6,22 +6,33 @@ name: Web selftest
 # for the web client and, until #2069, it ran only when someone typed `make
 # web-selftest-container` by hand.
 #
-# It lives in its OWN workflow rather than as a job in pr.yml for two reasons:
+# It lives in its OWN workflow rather than as a job in pr.yml because it is
+# REUSABLE: pr.yml calls it (`jobs.web-selftest.uses`) so that Build can list it in
+# `needs` and it actually gates, while the `push` trigger below runs the same
+# definition on master. One harness definition, two schedules — a CI-only second
+# copy is how the thing CI runs stops being the thing developers run.
 #
-#   * pr.yml has no `paths:` filter because its Lint/Build jobs must run on every
-#     PR. This one is expensive — it builds a Go+Node+Chromium image, then boots a
-#     daemon and a browser — so it is worth filtering, and a workflow-level
-#     `paths:` is the only native way to do that.
-#   * It is deliberately NOT wired into pr.yml's Build job, so it does not gate
-#     merges. See "Why this does not gate" below.
-#
-# The fast, deterministic web checks (parity tests + bundle reproducibility) DO
-# gate — they are the `Web` job in pr.yml.
+# The fast, deterministic web checks (parity tests + bundle reproducibility) gate
+# separately — they are the `Web` job in pr.yml, and they run on every PR.
 
 on:
-  pull_request:
+  # Master (#2762). Before this trigger existed the suite ran on `pull_request`
+  # only, so nothing ever ran it on master: a red run could merge (it did not gate
+  # either) and then stayed invisible until some later PR happened to touch these
+  # paths — and then it looked like THAT PR's fault. Same shape as #2576, where
+  # tui-driver-selftest sat red on master for two days.
+  #
+  # This is a signal run, not a gate: master has already merged. Its job is to name
+  # the commit, so nobody inherits a bisect.
+  push:
     branches: [master]
     paths:
+      # KEEP IN SYNC with SELFTEST_PATHS in .github/scripts/web-selftest-scope.js,
+      # which is the source of truth for the PR-side filter. A trigger `paths:`
+      # cannot be computed, so this list is a literal copy — and
+      # web-selftest-scope.test.js reads this file and fails Lint if the two ever
+      # disagree, so the copy cannot drift silently.
+      #
       # The SPA itself, and the committed bundle the harness actually serves.
       - 'web/**'
       # The harness drives a REAL daemon, so the daemon's HTTP/WS surface and the
@@ -35,13 +46,41 @@ on:
       - 'scripts/container/Dockerfile.web-selftest'
       - 'scripts/container/web-selftest-entry.sh'
       - '.github/workflows/web-selftest.yml'
+      # The CI wiring that decides whether this gates, and the filter that decides
+      # when it runs. A change to either must re-prove the gate on its own PR.
+      - '.github/workflows/pr.yml'
+      - '.github/scripts/web-selftest-scope.js'
+
+  # The PR gate. A job in ANOTHER workflow cannot be a `needs` dependency, which is
+  # why this is `workflow_call` and not a second `pull_request` trigger: pr.yml
+  # calls it as a job, and pr.yml's Build — one of the repo's two required checks
+  # (ruleset 14851503) — lists that job in `needs`. See "How this gates" below.
+  #
+  # There is deliberately NO `paths:` here. A called workflow does not honour one
+  # (filters apply to pull_request/push only), and the caller does the scoping with
+  # .github/scripts/web-selftest-scope.js so the decision is tested rather than
+  # implicit.
+  workflow_call:
+
+  # Manual re-run, for "did master recover?" after a red push run. No path filter
+  # applies to a dispatch, so this always runs the suite.
+  workflow_dispatch:
 
 concurrency:
   group: web-selftest-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Superseding a PR run is free — a newer head replaces the question being asked.
+  # NOTHING else is superseded, and the condition names the one event that may be
+  # rather than excluding the one that may not: a master run is its own verdict for
+  # its own commit, and cancelling it is how the per-commit attribution that is the
+  # entire reason for the push trigger gets lost. A `workflow_dispatch` shares this
+  # group with the master run (both key off github.ref), so an exclusionary
+  # condition would also let a manual "did master recover?" kill the push run it was
+  # asked about. Volume is bounded by the `paths:` filter above.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Read-only: checks out source and runs the harness in a container. It never
-# comments on or modifies the PR.
+# comments on or modifies the PR. pr.yml grants the same, which is what lets it
+# call this workflow — a called workflow can never request more than its caller.
 permissions:
   contents: read
 
@@ -79,21 +118,46 @@ jobs:
       # names the failing assertion. For a trace, reproduce locally:
       #   make web-selftest-container
 
-# ── Why this does not gate ────────────────────────────────────────────────────
+# ── How this gates ────────────────────────────────────────────────────────────
 #
 # This repo's ruleset (14851503) requires only "Lint" and "Build", so a new job
 # gates nothing unless pr.yml's Build job lists it in `needs` — the mechanism
-# documented on the auto-gate helper test. That was a deliberate choice NOT to
-# use here:
+# documented on the auto-gate helper test. That is how this gates:
 #
-#   * Cost: a cold Go+Node+Chromium image build plus a daemon+browser boot on
-#     every web PR, against ~40s for the deterministic checks that do gate.
+#   pr.yml: web-selftest-scope ─► web-selftest (uses: this workflow) ─► Build needs
+#
+# and Build fails loudly on any unsuccessful need rather than skipping, so a red
+# selftest turns the REQUIRED check red. A `skipped` need is fine and expected —
+# that is the scope job saying this PR cannot reach the web client.
+#
+# The two costs that once argued against gating are answered by the scope job, not
+# waived:
+#
+#   * Cost: a cold Go+Node+Chromium image build plus a daemon+browser boot. It is
+#     now paid only by PRs that touch the paths listed above; a docs typo skips it
+#     in seconds. Master pays it per matching commit, where it blocks nothing.
 #   * Flake surface: it drives a real browser against a real daemon over a real
-#     PTY. Those have been contention-sensitive (see the dev-box selftest flakes),
-#     and a flaky REQUIRED check blocks every merge in the repo, not just web PRs.
+#     PTY, and a flaky REQUIRED check blocks every merge in the repo. That risk is
+#     real and the answer is to keep it honest, never to defang it: a red run gets
+#     investigated, because twice on 2026-07-21 a "flake" here was a genuine
+#     product race (#2311, #2341). Retries, raised timeouts and xfail are how a
+#     real signal becomes silence.
 #
-# So it runs as a signal: red here means read it before merging. To promote it to
-# a gate, add `web-selftest` to pr.yml's Build `needs` — but note that a job in
-# ANOTHER workflow cannot be a `needs` dependency, so promoting it means moving it
-# into pr.yml (accepting the cost on every PR) or adding "Web selftest" to the
-# ruleset's required checks, which needs repo-admin access.
+# ── Why this serves the COMMITTED bundle rather than rebuilding ───────────────
+#
+# The harness builds af from source and web/embed.go embeds the COMMITTED
+# web/dist, so the suite exercises the bundle a released binary would actually
+# serve — which is what an acceptance proof should test. It deliberately does not
+# run `make web-build` first:
+#
+#   * pr.yml's `Web` job already owns dist↔src fidelity — it rebuilds the bundle
+#     and fails on any `git status --porcelain` diff — and Web is in Build's
+#     `needs` too. Rebuilding here would be a second implementation of a check
+#     that already blocks, and would HIDE a stale dist from the one job that
+#     catches it.
+#   * On master, where Web does not run, testing the committed artifact is the
+#     more useful of the two: it is the artifact that ships.
+#
+# So the pair is what covers source: Web proves dist == build(src), this proves
+# dist works. Locally, run `make web-build` before `make web-selftest-container`
+# or you validate the old bundle.

--- a/.github/workflows/web-selftest.yml
+++ b/.github/workflows/web-selftest.yml
@@ -41,10 +41,16 @@ on:
       - 'daemon/**'
       - 'agentproto/**'
       - 'apiproto/**'
-      # The harness itself.
+      # The harness itself — the WHOLE invocation chain. CI runs `make
+      # web-selftest-container`, so the closure is Makefile -> scripts/testbox.sh ->
+      # Dockerfile.web-selftest + web-selftest-entry.sh -> copy-src.sh (sourced by
+      # the entry to stage /src into /work). A PR editing only one link must run the
+      # suite it just changed.
+      - 'Makefile'
       - 'scripts/testbox.sh'
       - 'scripts/container/Dockerfile.web-selftest'
       - 'scripts/container/web-selftest-entry.sh'
+      - 'scripts/container/copy-src.sh'
       - '.github/workflows/web-selftest.yml'
       # The CI wiring that decides whether this gates, and the filter that decides
       # when it runs. A change to either must re-prove the gate on its own PR.

--- a/docs/web-selftest.md
+++ b/docs/web-selftest.md
@@ -34,18 +34,35 @@ ports**, no access to the host tmux server, and no touch of the real
 
 ## In CI
 
-Since #2069 a PR touching `web/`, `daemon/`, `agentproto/`, `apiproto/` or the
-harness itself also runs this on a GitHub runner
+Since #2069 a PR touching `web/`, `daemon/`, `agentproto/`, `apiproto/`, the
+harness itself or the CI wiring around it also runs this on a GitHub runner
 (`.github/workflows/web-selftest.yml`), using the same `make` target — CI does
 not keep its own copy of the steps.
 
-It is a **signal, not a gate**: it is not in `pr.yml`'s `Build` `needs`, so a red
-run does not block the merge button. Read it before merging anyway. The reasoning
-(cost on every web PR, and the flake surface of a real browser driving a real
-daemon) and the promotion path are written out in that workflow.
+Since #2762 it **gates, and it runs on master**:
+
+- **On a PR** `pr.yml` calls the workflow as a job and lists it in `Build`'s
+  `needs`, so a red run turns a required check red. A cheap `Web selftest scope`
+  job decides first whether the change can reach the web client — the decision
+  lives in `.github/scripts/web-selftest-scope.js`, whose tests run in `Lint` — and
+  the expensive job is `skipped` when it cannot. Every way of failing to work out
+  the diff resolves to *run it*.
+- **On master** a `push` trigger runs the same definition with the same path
+  filter. It blocks nothing (master has already merged); its job is to name the
+  commit. Before #2762 nothing ran the suite on master at all, so a regression
+  stayed invisible until some later PR happened to touch these paths — and then it
+  looked like that PR's fault. Master runs are not cancelled by a newer push, so
+  each commit keeps its own verdict.
+
+A red run is worth investigating rather than re-running: twice on 2026-07-21 a
+"flake" here was a genuine web-client race (#2311, #2341).
 
 The deterministic web checks — typecheck, the unit/parity suites, and
-`web/dist` reproducibility — **do** gate, as pr.yml's `Web` job.
+`web/dist` reproducibility — gate too, as pr.yml's `Web` job. The two are a pair:
+`Web` proves the committed bundle matches `web/src`, and this suite proves that
+bundle works. This harness deliberately serves the **committed** `web/dist` rather
+than rebuilding, so it exercises the artifact a released binary embeds — which is
+also why you run `make web-build` before it locally.
 
 Failures give you Playwright's assertion output in the job log but no trace: the
 harness works inside the container's own copy of the tree, so its


### PR DESCRIPTION
## Summary

`.github/workflows/web-selftest.yml` triggered on `pull_request` only and sat in
no required check's `needs`. Each half was defensible; together they were a hole:

1. a PR with a red web selftest **could merge**, because the suite did not gate;
2. once merged, **nothing ran it on master**;
3. so a regression stayed invisible until some later PR happened to touch `web/`,
   `daemon/`, `agentproto/`, `apiproto/` or the harness — and then it looked like
   *that* PR's fault.

This closes both halves. Same class as #2623 (a check switched off inside the
thing meant to enforce it) and #2576 (an acceptance suite nothing ran).

## What changed

**It gates.** `web-selftest.yml` becomes a **reusable workflow**
(`workflow_call`) that `pr.yml` calls as a job, and Build lists that job in
`needs`. A job in another workflow cannot be a `needs` dependency, and `needs` is
the only way to gate on anything but "Lint" and "Build" without a ruleset edit —
so this is the mechanism the repo already uses for the auto-gate helper test, the
`Web` job and `testbox-selftest`.

```
pr.yml:  web-selftest-scope ─► web-selftest (uses: web-selftest.yml) ─► Build needs
```

**It runs on master.** `web-selftest.yml` keeps its own `push: branches:
[master]` trigger with the same `paths:` filter. That run blocks nothing — master
has already merged — its job is to name the commit. Master runs are **not**
cancelled by a newer push, so each commit keeps its own verdict; PR runs still
cancel, since a newer head replaces the question.

**The cost argument is answered, not waived.** The suite is the most expensive
thing in CI — a Go+Node+Chromium image, then a real daemon and a real browser —
and the old header rejected gating on exactly that ground. A cheap `Web selftest
scope` job now answers "can this change reach the web client?" first, so a docs
typo skips it in seconds and only in-scope PRs pay. The decision lives in
`.github/scripts/web-selftest-scope.js` with tests in the required Lint job,
because a filter that silently stops matching is a gate that silently stops
gating. Every way of failing to work out the diff resolves to **run it**.

**The wiring is asserted, not assumed.** `web-selftest-scope.test.js` also pins
the things that make a red run matter:

- every job in `pr.yml` is in Build's `needs` — a job Build does not depend on
  gates nothing, renders as a check, and reads as coverage;
- Build keeps `if: always()` and its fail-on-unsuccessful-need step, because a
  *skipped* required check does not block a merge;
- the trigger `paths:` filter and the helper's path list have not drifted (a
  trigger filter cannot be computed, so that list is a literal copy);
- the caller points at the right workflow, and `web-selftest.yml` stays both
  callable and master-triggered.

## Verification

**The gate was watched failing, end to end — in this PR's own CI.** A deliberate
`#1932`-shaped regression in `web/src/ui.ts` (the rail count written once and never
refreshed) was committed to this branch with `src` and `dist` rebuilt **together**,
so the bundle stayed self-consistent and the deterministic checks could not see it.
That commit is reverted; the branch head is clean.

[Run 30950711223](https://github.com/sachiniyer/agent-factory/actions/runs/30950711223)
on the broken head `9552d8c9`:

| job | result |
| --- | --- |
| Lint · Test · Test (macOS) · Test (systemd ×2) · Registry-free · **Web** | ✅ success |
| Web selftest scope | ✅ success — `6 of 8 changed path(s) are in scope`, `run=true` |
| **Web selftest** | ❌ **failure** — 3 failed, 124 passed (3.2m) |
| **Build** (required) | ❌ **failure** |

The three failures are exactly the assertions that read the rail count
(`web-driver.spec.ts:930`, `:3738`, `:4254`) — identical to the local run, so the
failure is the regression and not runner noise.

**`Web` passed and `Build` still went red.** That is the whole point: this is a
regression that every other check in the repo waves through, and the required check
now goes red solely because this suite gates. Before this PR the same commit would
have merged.

Locally, same break, same instrument:

| tree | `make web-selftest-container` |
| --- | --- |
| clean | **127 passed** (4.8m) · exit 0 |
| broken bundle | **3 failed, 124 passed** (5.7m) · exit 1 |

**Measured cost, now that it has run cold on a real runner:** the `Web selftest`
job took **4m04s** end to end (image build + daemon + browser + 127 assertions),
against the 40m timeout budgeted for it. The issue suspected the original cost
argument had weakened since it was written; it has. Four minutes, on in-scope PRs
only, for the suite that catches what nothing else does.

**Scope was reworked twice under review, and the second time changed the design.**
Round 1 (Codex): `Makefile` and `scripts/container/copy-src.sh` were unwatched, so a
change to the harness invocation could merge without running the suite it changed.
Round 2 (Codex): `session/**` and `task/**` were unwatched, though the entry script
drives `$BIN sessions create|list|get|archive|restore|kill|tab-*` and `$BIN tasks add`
and the spec round-trips those flows.

Two rounds of "you missed a path" says the predicate is unsound, not incomplete —
`api/`, `commands/`, `apiclient/` would have been round three. The harness builds and
runs the **whole `af` binary**, so the scope is now `**/*.go` + `go.mod`/`go.sum`
(package entries kept alongside for their non-Go testdata). "Which packages did I
remember?" is a question nobody answers right twice; "does this change any Go the
binary is built from?" is decidable. Docs-, plugin- and prose-only PRs still skip,
which is what the filter is for.

Also fixed from round 2: the scope diff passes `--no-renames`. `git diff --name-only`
reports a pure rename as the **new path only**, so renaming `web-selftest-entry.sh`
out of scope would have deleted a harness entrypoint while the changed-path list
never mentioned it. Verified both behaviours in a scratch repo before fixing.

The third finding (scoping the merge-group diff) is answered inline with evidence
rather than changed: no ruleset carries a `merge_queue` rule and `merge_group` has
never fired in the last 100 `pr.yml` runs, so it is unreachable today — and untested
queue-diff logic that is subtly wrong stalls **every** merge in the repo, which is a
worse trade than four minutes on an event that cannot occur.

**The structural assertions were checked by mutation**, not just observed green —
each invariant broken in turn, each time exactly the matching test went red:

| mutation | test that caught it |
| --- | --- |
| drop `web-selftest` from Build's `needs` | every job in pr.yml is listed in Build's needs |
| reword one path in the push filter | push filter matches the helper's path list |
| make the workflow uncallable | web-selftest.yml is callable AND runs on master |
| remove the master push trigger | web-selftest.yml is callable AND runs on master |
| `if: always()` → `if: success()` | Build runs even when a need fails |
| point the caller at another workflow | pr.yml calls the web selftest workflow |

**The diff mechanism was verified against a real PR**, not assumed: a
`--depth=2` fetch of `refs/pull/2803/merge`, then `git diff --name-only HEAD^1
HEAD`, returns exactly the five files `GET /pulls/2803/files` reports. Parent 1
is the base tip, parent 2 the PR head, and the shallow clone the scope job uses
carries enough to diff them.

Also run: `actionlint` (all workflows, clean), and the hand-rolled YAML parsing
in the test was cross-checked against a real YAML parser on `pr.yml` — same nine
jobs, same `needs` list.

## Why it still serves the committed bundle rather than rebuilding

Worth stating, since the committed `web/dist` conflicts on every web PR and
"rebuild instead of trusting the artifact" is the obvious next thought:

- `pr.yml`'s `Web` job already owns dist↔src fidelity — it runs `make web-build`
  and fails on any `git status --porcelain` diff — and `Web` is in Build's `needs`
  too. Rebuilding inside the selftest would be a second implementation of a check
  that already blocks, and would **hide** a stale bundle from the one job that
  catches it.
- On master, where `Web` does not run, the committed artifact is the one a
  release embeds, so testing it is the more useful of the two.

The pair is what covers source: `Web` proves `dist == build(src)`, the selftest
proves that bundle works.

## Gate

`golangci-lint --fast` · `gofmt -l .` (empty) · `go build ./...` ·
`make test-container` · `deadcode -test ./...` · `scripts/lint-file-length.sh`

Closes #2762


