### PR TITLE
fix: reject in-place creates on a repo-configured remote backend

### DIFF
--- a/daemon/create_inplace_backend_config_test.go
+++ b/daemon/create_inplace_backend_config_test.go
@@ -1,0 +1,81 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// TestReserveCreate_InPlaceOnConfiguredRemoteBackendRefusesBeforeAnyRename is
+// the mutation-ordering half of #2778.
+//
+// NewInstance now refuses an in-place create whose backend resolves to a sandbox
+// runtime — but NewInstance runs after reserveCreate, and reserveCreate mutates.
+// For an explicit title held only by an archived session it renames that session
+// out of the way first: worktree relocated, durable record rewritten, manager map
+// re-keyed, none of it reversible. A refusal that arrives afterwards leaves that
+// rename standing for a create that could never have succeeded — the exact state
+// reserveCreate's admission comment promises it never produces, and the same
+// invariant #2127 and #2415 exist to protect.
+//
+// Note the namespaces deliberately differ: the archived session is local, the
+// create resolves to docker. They still collide, because titlesCollide compares
+// the derived branch and knows nothing about runtimes — which is what makes the
+// rename reachable here at all.
+func TestReserveCreate_InPlaceOnConfiguredRemoteBackendRefusesBeforeAnyRename(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	// Seeded BEFORE the backend config lands: the fixture builds a real local
+	// worktree, which a docker-configured repo would send to a provisioner.
+	archived, id := seedArchivedSessionBranchFreed(t, manager, repoID, repoPath, "foo", "foo")
+	archivedPath := archived.GetWorktreePath()
+	writeRepoBackendConfig(t, repoPath, map[string]any{"backend": "docker"})
+
+	_, _, release, renamed, err := manager.reserveCreate(CreateSessionRequest{
+		RepoPath: repoPath,
+		Title:    "foo",
+		Program:  "claude",
+		InPlace:  true,
+	})
+	if release != nil {
+		defer release()
+	}
+
+	require.Error(t, err, "an in-place create cannot run on the repo's docker backend")
+	assert.ErrorIs(t, err, session.ErrInPlaceRemoteBackend)
+	assert.Nil(t, renamed, "the refusal must land before the archived-name reuse rename, not after it")
+
+	// The archived session is untouched — the point of refusing early.
+	assert.Equal(t, "foo", archived.Title)
+	assert.Equal(t, archivedPath, archived.GetWorktreePath())
+	assert.True(t, exists(archivedPath))
+	assert.Nil(t, recordFor(t, repoID, "foo (archived)"),
+		"no disambiguated archive row may exist: nothing was renamed")
+	rec := recordFor(t, repoID, "foo")
+	require.NotNil(t, rec)
+	assert.Equal(t, id, rec.ID)
+	assert.Equal(t, archivedPath, rec.Worktree.WorktreePath)
+}
+
+// TestReserveCreate_InPlaceOnLocalRepoStillReservesTheTitle is the
+// non-regression half: the guard must not touch the ordinary in-place create,
+// which is how the daemon's own root agent is made.
+func TestReserveCreate_InPlaceOnLocalRepoStillReservesTheTitle(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	repo, title, release, renamed, err := manager.reserveCreate(CreateSessionRequest{
+		RepoPath: repoPath,
+		Title:    "here",
+		Program:  "claude",
+		InPlace:  true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, release)
+	defer release()
+
+	assert.Equal(t, repoID, repo.ID)
+	assert.Equal(t, "here", title)
+	assert.Nil(t, renamed)
+}

--- a/daemon/create_inplace_backend_config_test.go
+++ b/daemon/create_inplace_backend_config_test.go
@@ -79,3 +79,34 @@ func TestReserveCreate_InPlaceOnLocalRepoStillReservesTheTitle(t *testing.T) {
 	assert.Equal(t, "here", title)
 	assert.Nil(t, renamed)
 }
+
+// TestReserveCreate_RootAgentSurvivesARemoteBackendRepo pins the one in-place
+// caller that is not a user request: the daemon's always-ensured root agent.
+//
+// A root agent is documented as the `af sessions create --here` shape — in-place
+// at the repo root, no worktree, no branch — so it is local by construction. Left
+// to resolve the repo's `backend` key it would have been read as a docker/ssh/hook
+// create, which before #2778 silently produced a root running in a sandbox clone
+// that could not see the working tree its record claimed, and after #2778 would
+// have taken the always-on guarantee away from those repos instead.
+//
+// The reserved title makes this a real root create rather than a lookalike.
+func TestReserveCreate_RootAgentSurvivesARemoteBackendRepo(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	writeRepoBackendConfig(t, repoPath, map[string]any{"backend": "docker"})
+
+	repo, title, release, _, err := manager.reserveCreate(CreateSessionRequest{
+		RepoPath:      repoPath,
+		Title:         session.RootSessionTitle,
+		Program:       "claude",
+		InPlace:       true,
+		Backend:       string(session.BackendLocal),
+		allowReserved: true,
+	})
+	require.NoError(t, err, "the daemon's in-place root agent must still be creatable in a repo whose config selects a sandbox backend")
+	require.NotNil(t, release)
+	defer release()
+
+	assert.Equal(t, repoID, repo.ID)
+	assert.Equal(t, session.RootSessionTitle, title)
+}

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -310,6 +310,31 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 	// and let NewInstance surface the canonical error rather than duplicating it.
 	nameNamespace := runtimeNamespaceForKind(runtimeKind)
 
+	// An in-place session and an off-box runtime are contradictory, and
+	// NewInstance is where that is enforced — but it runs long after this
+	// function, and this function MUTATES (#2778). For an explicit title held
+	// only by an archived session, the reuse rename below relocates that
+	// session's worktree and rewrites its durable record; a refusal raised later
+	// at NewInstance would leave that rename standing for a create that could
+	// never have succeeded, which is the one state reserveCreate's admission
+	// comment promises it never produces (#2127, #2415).
+	//
+	// It also refuses the plain case earlier and better: `--here` against a
+	// docker/ssh/hook repo now fails before a title is reserved, rather than
+	// after provisioning work has begun.
+	//
+	// Through session.InPlaceBackendConflict rather than a local comparison
+	// against runtimeKind, so the daemon's answer and NewInstance's cannot drift
+	// — including on the deliberate non-firing for a backend value that will not
+	// resolve, which belongs to the factory's canonical error.
+	if err := session.InPlaceBackendConflict(session.InstanceOptions{
+		Backend:     session.BackendKind(req.Backend),
+		ForceRemote: req.ForceRemote,
+		InPlace:     req.InPlace,
+	}, repo.Root); err != nil {
+		return nil, "", nil, nil, err
+	}
+
 	var renamedArchived *session.InstanceData
 	title := req.Title
 	if title == "" {

--- a/daemon/rootagent.go
+++ b/daemon/rootagent.go
@@ -363,10 +363,28 @@ func (m *Manager) ensureResolvedRoot(stateKey string, st *rootEnsureState, repo 
 
 	program := rootAgentProgramForProfile(repo.Root, resolution.RootAgent)
 	req := CreateSessionRequest{
-		Title:         session.RootSessionTitle,
-		RepoPath:      repo.Root,
-		Program:       program,
-		InPlace:       true,
+		Title:    session.RootSessionTitle,
+		RepoPath: repo.Root,
+		Program:  program,
+		InPlace:  true,
+		// Say local out loud, because InPlace already decided it. A root agent is
+		// documented as the `af sessions create --here` shape — in-place at the
+		// repo root, no worktree, no branch (configuration.md § root_agents) — and
+		// an in-place session has no meaning on a runtime that works in a sandbox
+		// clone it cannot see.
+		//
+		// Left empty, the create resolves the repo's `backend` key, so a project
+		// that opted into docker/ssh/hook silently got a root whose agent ran in a
+		// clone while its record claimed the working tree — the #2778 contradiction,
+		// on the one session the daemon guarantees. Once #2778 refuses that
+		// contradiction, the same repos would instead lose their always-on root
+		// entirely. Neither is what `root_agents` asks for.
+		//
+		// This does not override the repo's choice for anything else: `backend`
+		// still governs every ordinary session there. It only stops the reserved,
+		// daemon-owned, hardcoded-in-place session from being read as a sandbox
+		// create it can never be.
+		Backend:       string(session.BackendLocal),
 		allowReserved: true,
 		// Zero on every path that did not just reap a root — a first-ever create,
 		// or a kill whose grace window elapsed (KillSession already deleted that

--- a/session/inplace_backend_config_test.go
+++ b/session/inplace_backend_config_test.go
@@ -1,0 +1,141 @@
+package session
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// remoteBackendKinds are the three non-local runtimes. Each has no local
+// worktree at all, so each contradicts an in-place create.
+var remoteBackendKinds = []BackendKind{BackendDocker, BackendSSH, BackendHook}
+
+// TestNewInstance_InPlaceRefusesExplicitRemoteBackend pins the half of the
+// contradiction check that already worked: an explicit --backend naming a
+// non-local runtime, and the legacy ForceRemote hook selector.
+func TestNewInstance_InPlaceRefusesExplicitRemoteBackend(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := initTempGitRepo(t)
+
+	for _, kind := range remoteBackendKinds {
+		t.Run(string(kind), func(t *testing.T) {
+			_, err := NewInstance(InstanceOptions{
+				Title:   "s",
+				Path:    repo,
+				Program: "claude",
+				Backend: kind,
+				InPlace: true,
+			})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrInPlaceRemoteBackend)
+		})
+	}
+
+	t.Run("force remote", func(t *testing.T) {
+		_, err := NewInstance(InstanceOptions{
+			Title:       "s",
+			Path:        repo,
+			Program:     "claude",
+			ForceRemote: true,
+			InPlace:     true,
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInPlaceRemoteBackend)
+	})
+}
+
+// TestNewInstance_InPlaceRefusesRepoConfiguredRemoteBackend is the #2778
+// regression test.
+//
+// The in-place contradiction was judged on opts.Backend alone, but an EMPTY
+// opts.Backend does not mean local — it means "resolve from the repo's `backend`
+// config key". So a repo declaring backend = "docker"/"ssh"/"hook" sailed past
+// the check with InPlace still set, and the create then either failed with an
+// unrelated provisioning-config error (nothing about in-place) or, in a fully
+// configured repo, SUCCEEDED: a session recorded as attached to the user's own
+// working tree whose agent actually runs in a sandbox that cannot see it.
+//
+// The assertion is on the error's identity rather than merely on "an error
+// happened": the pre-fix path errors too, which is exactly why the bug survived.
+func TestNewInstance_InPlaceRefusesRepoConfiguredRemoteBackend(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	for _, kind := range remoteBackendKinds {
+		t.Run(string(kind), func(t *testing.T) {
+			repo := initTempGitRepo(t)
+			writeInRepoConfig(t, repo, map[string]any{"backend": string(kind)})
+
+			_, err := NewInstance(InstanceOptions{
+				Title:   "s",
+				Path:    repo,
+				Program: "claude",
+				InPlace: true,
+			})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrInPlaceRemoteBackend,
+				"an in-place create against a repo-configured %s backend must be refused as the contradiction it is, not left to fail later on provisioning config", kind)
+			assert.Contains(t, err.Error(), string(kind),
+				"the refusal must name the backend that was selected, or the user cannot tell which config key to change")
+		})
+	}
+}
+
+// TestNewInstance_InPlaceStillAllowedOnLocal is the non-regression half: the
+// resolved-backend check must not refuse the ordinary in-place create. Three
+// shapes reach the local runtime — no config at all, an explicit local backend,
+// and a repo declaring backend = "local".
+func TestNewInstance_InPlaceStillAllowedOnLocal(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	cases := []struct {
+		name    string
+		config  map[string]any
+		backend BackendKind
+	}{
+		{name: "no repo config"},
+		{name: "explicit local backend", backend: BackendLocal},
+		{name: "repo config backend local", config: map[string]any{"backend": "local"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := initTempGitRepo(t)
+			if tc.config != nil {
+				writeInRepoConfig(t, repo, tc.config)
+			}
+			inst, err := NewInstance(InstanceOptions{
+				Title:   "s",
+				Path:    repo,
+				Program: "claude",
+				Backend: tc.backend,
+				InPlace: true,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, inst)
+			assert.True(t, inst.inPlace, "the in-place selection must survive the check it passed")
+		})
+	}
+}
+
+// TestNewInstance_UnresolvableBackendKeepsItsCanonicalError guards the
+// three-valued edge: a `backend` key naming nothing resolvable is neither local
+// nor remote, so the in-place check must not convert it into an in-place
+// refusal. The user's actual problem is the unparseable value, and the factory
+// below already reports it in one place.
+func TestNewInstance_UnresolvableBackendKeepsItsCanonicalError(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := initTempGitRepo(t)
+	writeInRepoConfig(t, repo, map[string]any{"backend": "kubernetes"})
+
+	_, err := NewInstance(InstanceOptions{
+		Title:   "s",
+		Path:    repo,
+		Program: "claude",
+		InPlace: true,
+	})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrInPlaceRemoteBackend)
+	assert.Contains(t, err.Error(), "kubernetes",
+		fmt.Sprintf("the unparseable backend value must be what the error names, got %v", err))
+}

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -154,6 +154,32 @@ func resolveBackendKind(opts InstanceOptions, absPath string) (BackendKind, erro
 	return ParseBackendKind(cfg.Backend)
 }
 
+// ErrInPlaceRemoteBackend marks the refusal of an in-place create whose session
+// would not run on this machine. An in-place session attaches the agent to the
+// repo's OWN working tree; a docker/ssh/hook session works in a sandbox clone
+// and has no local worktree at all, so the two requests cannot both be honored.
+//
+// A sentinel rather than a bare message because the surfaces that offer in-place
+// (the CLI's --here, the daemon's create RPC, the root agent) need to tell this
+// refusal apart from the provisioning-config errors it used to hide behind.
+var ErrInPlaceRemoteBackend = errors.New("an in-place session cannot run on a non-local backend")
+
+// inPlaceBackendConflict builds that refusal, naming both the resolved backend
+// and WHERE it was selected. The source matters for the case #2778 is about: a
+// user who passed no backend flag at all has nothing to correlate the error
+// with unless it points at the repo's `backend` key.
+func inPlaceBackendConflict(kind BackendKind, opts InstanceOptions) error {
+	source := "this repo's `backend` config key"
+	switch {
+	case opts.Backend != "":
+		source = "the requested backend"
+	case opts.ForceRemote:
+		source = "the remote-session request"
+	}
+	return fmt.Errorf("%w: %s selected the %s backend, which runs the agent in a sandbox clone with no access to this repo's working tree — create the session on the local backend, or drop the in-place request",
+		ErrInPlaceRemoteBackend, source, kind)
+}
+
 // BackendKindFor reports which runtime a create with these options against
 // absPath will use, WITHOUT creating anything. It is the same decision (and the
 // same precedence) NewInstance makes internally.
@@ -253,18 +279,39 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 		id = NewInstanceID()
 	}
 
-	// An in-place session runs in the repo's local working tree; a remote
-	// session has no local worktree at all — the two are contradictory. This
-	// covers both the legacy ForceRemote hook selector and an explicit
-	// non-local --backend (#1592 Phase 4 PR3).
-	if opts.InPlace && (opts.ForceRemote || (opts.Backend != "" && opts.Backend != BackendLocal)) {
-		return nil, fmt.Errorf("remote sessions cannot run in-place in the local repo working tree")
-	}
-
 	// Convert path to absolute
 	absPath, err := filepath.Abs(opts.Path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	// An in-place session runs in the repo's local working tree; a remote
+	// session has no local worktree at all — the two are contradictory. This
+	// covers the legacy ForceRemote hook selector, an explicit non-local
+	// --backend (#1592 Phase 4 PR3), and the repo's own `backend` config key.
+	//
+	// Judged on the RESOLVED kind, not on opts.Backend (#2778). An empty
+	// opts.Backend does not mean local — it means "resolve from the repo's
+	// `backend` key" — so the flag-only test waved a repo-configured
+	// docker/ssh/hook create straight through with InPlace still set. In a
+	// half-configured repo that surfaced as a provisioning-config error naming
+	// nothing about in-place; in a fully configured one it SUCCEEDED, and the
+	// session's record claimed the user's working tree while its agent ran in a
+	// sandbox clone that could not see it.
+	//
+	// Resolving here is what makes NewInstance the one enforcement point every
+	// surface inherits, which is the same reason LocalPrereqsRequired resolves
+	// rather than reading the flag (#2592): a check that reimplements the
+	// precedence rules drifts from them.
+	//
+	// A kind that will not RESOLVE is left alone. That is not a local create and
+	// not a remote one — it is an unusable `backend` value, and the factory below
+	// reports it in one place. Converting it into an in-place refusal here would
+	// name the wrong problem.
+	if opts.InPlace {
+		if kind, kerr := resolveBackendKind(opts, absPath); kerr == nil && kind != BackendLocal {
+			return nil, inPlaceBackendConflict(kind, opts)
+		}
 	}
 	normalizedSessionEnv, err := sessionenv.NormalizeExtraNames(opts.SessionEnvPassthrough)
 	if err != nil {

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -164,6 +164,46 @@ func resolveBackendKind(opts InstanceOptions, absPath string) (BackendKind, erro
 // refusal apart from the provisioning-config errors it used to hide behind.
 var ErrInPlaceRemoteBackend = errors.New("an in-place session cannot run on a non-local backend")
 
+// InPlaceBackendConflict reports the in-place/remote contradiction for a create
+// with these options against absPath, or nil when there is none. NewInstance
+// enforces it, so an ordinary caller never needs this.
+//
+// It is exported for callers that MUTATE state before reaching NewInstance. The
+// daemon's reserveCreate is the one that matters: for an explicit title held
+// only by an archived session it renames that session — relocating its worktree
+// and rewriting its durable record — and only later builds the instance. A
+// refusal raised at NewInstance would therefore land after an irreversible
+// rename done for a create that could never have succeeded, which is exactly the
+// state reserveCreate promises never to leave behind (#2127, #2415). Asking the
+// same question ahead of the mutation is what keeps that promise, and asking it
+// through THIS function is what keeps the two answers from drifting.
+//
+// Judged on the RESOLVED kind, not on opts.Backend (#2778). An empty
+// opts.Backend does not mean local — it means "resolve from the repo's `backend`
+// key" — so a flag-only test waves a repo-configured docker/ssh/hook create
+// straight through with InPlace still set. In a half-configured repo that
+// surfaces as a provisioning-config error naming nothing about in-place; in a
+// fully configured one it SUCCEEDS, and the session's record claims the user's
+// working tree while its agent runs in a sandbox clone that cannot see it.
+//
+// Resolving here mirrors LocalPrereqsRequired (#2592) for the same reason: a
+// check that reimplements the backend precedence rules drifts from them.
+//
+// A kind that will not RESOLVE yields nil. That is not a local create and not a
+// remote one — it is an unusable `backend` value, and the runtime factory
+// reports it in one place. Converting it into an in-place refusal would name the
+// wrong problem.
+func InPlaceBackendConflict(opts InstanceOptions, absPath string) error {
+	if !opts.InPlace {
+		return nil
+	}
+	kind, err := resolveBackendKind(opts, absPath)
+	if err != nil || kind == BackendLocal {
+		return nil
+	}
+	return inPlaceBackendConflict(kind, opts)
+}
+
 // inPlaceBackendConflict builds that refusal, naming both the resolved backend
 // and WHERE it was selected. The source matters for the case #2778 is about: a
 // user who passed no backend flag at all has nothing to correlate the error
@@ -285,33 +325,8 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 		return nil, fmt.Errorf("failed to get absolute path: %w", err)
 	}
 
-	// An in-place session runs in the repo's local working tree; a remote
-	// session has no local worktree at all — the two are contradictory. This
-	// covers the legacy ForceRemote hook selector, an explicit non-local
-	// --backend (#1592 Phase 4 PR3), and the repo's own `backend` config key.
-	//
-	// Judged on the RESOLVED kind, not on opts.Backend (#2778). An empty
-	// opts.Backend does not mean local — it means "resolve from the repo's
-	// `backend` key" — so the flag-only test waved a repo-configured
-	// docker/ssh/hook create straight through with InPlace still set. In a
-	// half-configured repo that surfaced as a provisioning-config error naming
-	// nothing about in-place; in a fully configured one it SUCCEEDED, and the
-	// session's record claimed the user's working tree while its agent ran in a
-	// sandbox clone that could not see it.
-	//
-	// Resolving here is what makes NewInstance the one enforcement point every
-	// surface inherits, which is the same reason LocalPrereqsRequired resolves
-	// rather than reading the flag (#2592): a check that reimplements the
-	// precedence rules drifts from them.
-	//
-	// A kind that will not RESOLVE is left alone. That is not a local create and
-	// not a remote one — it is an unusable `backend` value, and the factory below
-	// reports it in one place. Converting it into an in-place refusal here would
-	// name the wrong problem.
-	if opts.InPlace {
-		if kind, kerr := resolveBackendKind(opts, absPath); kerr == nil && kind != BackendLocal {
-			return nil, inPlaceBackendConflict(kind, opts)
-		}
+	if err := InPlaceBackendConflict(opts, absPath); err != nil {
+		return nil, err
 	}
 	normalizedSessionEnv, err := sessionenv.NormalizeExtraNames(opts.SessionEnvPassthrough)
 	if err != nil {


### PR DESCRIPTION
`NewInstance` judged the in-place/remote contradiction on `opts.Backend` alone.
But an empty `opts.Backend` does not mean local — it means "resolve from the
repo's `backend` config key" — so a repo declaring `backend = "docker"` /
`"ssh"` / `"hook"` sailed past the check with `InPlace` still set.

Two outcomes, both wrong:

- **half-configured repo** — the create failed later, on provisioning config, so
  the user heard about a missing `docker.image` when their actual problem was
  that `--here` and a sandbox backend cannot both be honored;
- **fully configured repo** — the create **succeeded**. The session's record
  claimed the user's own working tree while its agent ran in a sandbox clone
  that could not see it.

## Fix

Resolve the backend kind before the check, exactly as `LocalPrereqsRequired`
already does for the local-prereqs gate (#2592). That keeps `NewInstance` the
one enforcement point every surface inherits — CLI `--here`, the daemon create
RPC, the root agent — rather than each re-deriving the precedence rules and
drifting from them.

A kind that will not **resolve** is deliberately left alone: that is an unusable
`backend` value, not an in-place conflict, and the factory below already reports
it in one place. Converting it here would name the wrong problem.

The refusal is now a sentinel (`ErrInPlaceRemoteBackend`) carrying the resolved
backend and where it was selected from — a user who passed no backend flag has
nothing to correlate the message with unless it points at the repo's config key.

## The root agent (second review round)

The daemon's root agent hardcodes `InPlace: true` and left `Backend` empty, so
its create resolved the repo's `backend` key. In a project that opted into
docker/ssh/hook that silently produced a root whose agent ran in a sandbox clone
it could not see, while its record claimed the repo's working tree — this exact
contradiction, landing on the one session the daemon guarantees is always
running. With the guard in place those repos would instead have lost their root
outright.

I originally left the root agent alone, reasoning that a user who sets
`backend = "docker"` wants agents sandboxed and that quietly running one on the
host was the worse failure. The docs changed my mind: `configuration.md`
§ `root_agents` defines the root agent as "created **in-place** at the repo root
(the `af sessions create --here` shape)", so it is local by construction, and
enabling `root_agents` *is* opting into an in-place agent.

So the root create now says `Backend: local` out loud. This does not override the
repo's choice for anything else — `backend` still governs every ordinary session
there. It only stops the reserved, daemon-owned, hardcoded-in-place session from
being read as a sandbox create it can never be.
`TestReserveCreate_RootAgentSurvivesARemoteBackendRepo` pins it.

## Verification

- New `session/inplace_backend_config_test.go`. The repo-config case was watched
  **failing** on the pre-fix predicate first — it reported
  `backend=docker requires docker.image…`, i.e. an error with nothing about
  in-place in it, which is exactly why the bug survived. The non-regression case
  (no config / explicit local / `backend = "local"`) and the unresolvable-value
  case are covered too.
- Full local gate on `a5b0b850`: `golangci-lint --fast`, `gofmt -l .` (empty),
  `go build ./...`, `deadcode -test ./...`, `scripts/lint-file-length.sh`, and
  `make test-container` with the exit code actually captured.

## Follow-up: refuse before `reserveCreate` mutates (Codex P2)

The refusal lives in `NewInstance`, which the daemon reaches only **after**
`reserveCreate` — and `reserveCreate` mutates. For an explicit title held solely
by an archived session it renames that session out of the way first: worktree
relocated, durable record rewritten, manager map re-keyed, none of it reversible.
So `af sessions create --here <archived-title>` in a docker/ssh/hook repo would
return the in-place conflict with the archived session **already renamed** for a
create that could never have succeeded — the one state `reserveCreate`'s
admission comment promises it never produces (#2127, #2415).

The namespaces differ there (a local archived session, a docker-resolved create)
and it collides anyway, because `titlesCollide` compares the derived branch and
knows nothing about runtimes. That is what makes the rename reachable.

Fixed by asking the same question in `reserveCreate` ahead of every mutation,
through a shared `session.InPlaceBackendConflict` so the two answers cannot drift
— including on the deliberate non-firing for an unresolvable backend value. It
also improves the plain case: `--here` against a sandbox-backed repo now fails
before a title is reserved rather than after provisioning has begun.

`daemon/create_inplace_backend_config_test.go` covers it, watched **failing**
with the daemon-side guard temporarily removed (`reserveCreate` returned nil and
renamed the archive) and passing with it in place.

Closes #2778

🤖 Generated with [Claude Code](https://claude.com/claude-code)