### PR TITLE
test(lifecycle): ask the daemon its version instead of reading /proc

### DIFF
--- a/docs/lifecycle-testing.md
+++ b/docs/lifecycle-testing.md
@@ -86,18 +86,38 @@ gate keeps testing the current boundary as releases cut.
 
 ## How assertion 2 queries the daemon
 
-There is no "what version are you?" RPC on the daemon today — that is
-[#1920](https://github.com/sachiniyer/agent-factory/pull/1920). So the daemon's
-version is read from the image it is **actually executing**: copy
-`/proc/<pid>/exe` and ask it. This is a real query, not an inference from the
-binary on disk, and that distinction is the whole bug — after an upgrade the
-on-disk binary is N while a daemon that was never restarted is still executing
-the N-1 image. `/proc/<pid>/exe` still resolves to those bytes even though the
-path now reads `(deleted)`.
+The daemon answers a control-socket ping with **its own version**
+([#1920](https://github.com/sachiniyer/agent-factory/pull/1920) added
+`PingResponse.Version`), and `af daemon status --json` surfaces it as
+`.data.version`. That is what assertion 2 reads. It reports the *responding*
+daemon's version or nothing at all — never the client's — which is the property
+the assertion needs: after an upgrade the on-disk binary is N while a daemon
+that was never restarted still answers as N-1, and a version read off the
+installed binary would report N and call the skew healthy.
 
-`lc_doctor_fail_count` **feature-detects** `af doctor --json`: it parses the text
-summary today, and switches to the structured summary the moment #1920 lands. No
-follow-up edit needed here.
+When the daemon reports nothing, `lc_daemon_version` falls back to the image it
+is **actually executing**: copy `/proc/<pid>/exe` and ask it. `/proc/<pid>/exe`
+still resolves to those bytes even though the path now reads `(deleted)`. The
+fallback is feature-detected rather than version-gated, because two different
+daemons answer with nothing and only one of them is old:
+
+* one older than **v1.0.206**, before `af daemon status --json` grew the member
+  (`PingResponse.Version` itself landed in v1.0.200). Scenario B installs the
+  two newest stable releases, so this is only reachable if the boundary is ever
+  pinned backwards — but the harness must not quietly stop measuring if it is;
+* one that refuses *this* client's ping — which is the
+  [#1921](https://github.com/sachiniyer/agent-factory/issues/1921) skew the gate
+  exists to catch. The route that goes quiet is exactly the route under test, so
+  the fallback is load-bearing rather than legacy politeness.
+
+Neither route can read the new binary on disk, so a daemon left on the old bytes
+cannot hide behind it. If **both** come back empty, `lc_assert_no_version_skew`
+fails the run: `lc_assert_eq "" ""` would otherwise report "no skew" having
+compared nothing against nothing, and that green is worse than a red one.
+
+`lc_doctor_fail_count` **feature-detects** `af doctor --json` the same way: the
+structured summary when the flag is there (it is, since #1920), the text
+`Summary:` line for an older N-1 client.
 
 ## Isolation
 
@@ -251,13 +271,15 @@ you have seen it fail.
 * **macOS / launchd.** `lc_unit_active` and `lc_unit_main_pid` already have
   Darwin branches, so assertion #4 asserts the *same property* against launchd
   (`state = running` and `pid = N` in the `gui/<uid>` domain af restarts) rather
-  than a re-invented one. The blocker for the `macos-latest` leg is **assertion
-  2**: `lc_daemon_version` reads `/proc/<pid>/exe`, which macOS has no
-  equivalent of — `ps` would report the path, whose bytes are the NEW binary
-  after an upgrade, i.e. exactly the inference this assertion refuses to make.
-  The macOS leg therefore wants **#1920**'s daemon-reported version. Given
-  #1931 turned on macOS CI and immediately found three real darwin defects
-  (#1939, #1940, #1941), this leg is worth landing soon.
+  than a re-invented one. **Assertion 2 is no longer the blocker** — it asks the
+  daemon for its version and only falls back to `/proc/<pid>/exe`. What still
+  blocks the `macos-latest` leg is daemon **discovery**: `lc_daemon_pids`
+  identifies a daemon by reading `/proc/<pid>/cmdline` and `/proc/<pid>/environ`
+  (the check that proves a pid serves *this* throwaway home before the harness
+  signals it), and assertions 1 and 3 plus teardown are built on it. Porting
+  that scan is the work. Given #1931 turned on macOS CI and immediately found
+  three real darwin defects (#1939, #1940, #1941), this leg is worth landing
+  soon.
 * **#1916's reset-vs-relaunch race** — this scenario upgrades, it does not
   reset.
 * **Downgrades and channel switches** (`--allow-downgrade`, preview → stable).

--- a/scripts/lifecycle-lib.sh
+++ b/scripts/lifecycle-lib.sh
@@ -365,22 +365,59 @@ lc_daemon_pids() {
 
 lc_daemon_count() { lc_daemon_pids "$1" | wc -l | tr -d ' '; }
 
-# lc_daemon_version <pid> — the version of the image the daemon is ACTUALLY
-# running, by copying /proc/<pid>/exe and asking it.
+# lc_daemon_version <bin> <pid> — the version of the daemon that is ACTUALLY
+# running, asked of the daemon itself.
 #
-# This is a real query, not an inference from the binary on disk — which is the
-# whole point: after an upgrade the on-disk binary is N while a daemon that was
-# never restarted is still executing the N-1 image, and /proc/<pid>/exe still
-# resolves to those bytes even though the path now reads "(deleted)".
+# Never an inference from the binary on disk, by either route — that is the
+# whole assertion. After an upgrade the on-disk binary is N while a daemon that
+# was never restarted is still serving as N-1, and a version read off the
+# installed binary would report N and call the skew healthy.
 #
-# Linux-only (needs /proc). macOS has no equivalent, which is one reason the
-# macOS leg is not wired yet — see the header of scripts/lifecycle.sh.
+# The daemon answers a control-socket ping with its own version, which
+# `af daemon status --json` surfaces as .data.version (#1920 added
+# PingResponse.Version in v1.0.200; the status member arrived with #2240 in
+# v1.0.206). A daemon that never answers leaves it empty — `af daemon status`
+# reports the responding daemon's version or nothing, never the client's.
 #
-# SWAP POINT (#1920): once `af doctor --json` ships a `daemon version` check,
-# this can become a plain query of the daemon's own reported version. Until
-# then this is the only way to learn a running daemon's version.
+# FEATURE-DETECTED, not version-gated, because two different daemons answer
+# with nothing and only one of them is old:
+#
+#   * a daemon older than v1.0.206, which has no such field. Scenario B installs
+#     whatever the two newest stable releases are, so this is reachable only if
+#     the boundary is ever pinned backwards, but the harness must not silently
+#     stop measuring if it is.
+#   * a daemon that refuses THIS client's ping — the #1921 skew ("unknown field
+#     …") that this gate exists to catch. So the fallback is load-bearing, not
+#     legacy politeness: the case where the daemon-reported value goes quiet is
+#     exactly the case where the assertion must still have a number.
+#
+# When both are empty the caller must FAIL rather than compare nothing against
+# nothing — see lc_assert_no_version_skew.
 lc_daemon_version() {
+    local bin="$1" pid="$2" out
+    # jq prints the string "null" for a member the daemon did not report; that
+    # is an absent version, not a version named "null".
+    out="$(lc_status_field "$bin" '.data.version')"
+    case "$out" in
+    null | "") out="" ;;
+    esac
+    if [ -n "$out" ]; then
+        printf '%s\n' "$out"
+        return 0
+    fi
+    lc_daemon_image_version "$pid"
+}
+
+# lc_daemon_image_version <pid> — the fallback: the version of the image the
+# daemon is executing, by copying /proc/<pid>/exe and asking it. /proc/<pid>/exe
+# still resolves to those bytes even though the path now reads "(deleted)".
+#
+# Linux-only (needs /proc); macOS has no equivalent. Assertion 2 no longer
+# depends on this, but daemon DISCOVERY still does — see lc_daemon_pids and the
+# header of scripts/lifecycle.sh.
+lc_daemon_image_version() {
     local pid="$1" tmp out
+    [ -n "$pid" ] || return 1
     tmp="$(mktemp "${TMPDIR:-/tmp}/lc-daemon-image.XXXXXX")" || return 1
     if ! cp "/proc/$pid/exe" "$tmp" 2>/dev/null; then
         rm -f "$tmp"
@@ -391,6 +428,23 @@ lc_daemon_version() {
     rm -f "$tmp"
     [ -n "$out" ] || return 1
     printf '%s\n' "$out"
+}
+
+# lc_assert_no_version_skew <client-version> <daemon-version> <what> — assertion
+# 2, with its operands proven to exist first.
+#
+# AUDIT: `lc_assert_eq "" ""` PASSES. If the daemon's version could not be read
+# (it never answered AND /proc was unreadable, or the pid is dead) and the client
+# version also came back empty, the single most important assertion in this gate
+# would report "no skew" having compared nothing against nothing. An unreadable
+# version is a failure, never a pass.
+lc_assert_no_version_skew() {
+    local client="$1" daemon="$2" what="$3"
+    if [ -z "$client" ] || [ -z "$daemon" ]; then
+        lc_fail "$what: cannot compare versions (client='$client', daemon='$daemon') — refusing to report 'no skew' from unreadable values"
+        return 1
+    fi
+    lc_assert_eq "$client" "$daemon" "$what"
 }
 
 # lc_client_version <bin> — the version the installed binary reports.
@@ -407,15 +461,15 @@ lc_status_field() {
 
 # lc_doctor_fail_count <bin> — how many checks doctor reports as FAIL.
 #
-# Feature-detects `--json` so this auto-upgrades the moment #1920 lands: today
-# it parses the "Summary: 9 PASS, 7 WARN, 0 FAIL" line, and the instant doctor
-# grows a --json flag it reads the structured summary instead. No follow-up
-# edit needed here.
+# Feature-detects `--json`, which today's releases have (#1920) and older ones
+# do not: it reads the structured summary when the flag is there and falls back
+# to parsing the "Summary: 9 PASS, 7 WARN, 0 FAIL" line for a release that
+# predates it. The detection stays because scenario B runs an N-1 client.
 lc_doctor_fail_count() {
     local bin="$1" out n
     if "$bin" doctor --help 2>&1 | grep -q -- '--json'; then
         out=$("$bin" doctor --json 2>/dev/null)
-        # #1920's envelope: {data:{summary:{fail:N}}}. Fall through to the text
+        # {data:{summary:{fail:N}}} (doctor/json.go). Fall through to the text
         # parser if the shape is not what we expect rather than silently
         # reporting 0 FAILs — a wrong 0 here would make the whole gate a no-op.
         n=$(printf '%s' "$out" | jq -r '.data.summary.fail // empty' 2>/dev/null)

--- a/scripts/lifecycle-selftest.sh
+++ b/scripts/lifecycle-selftest.sh
@@ -87,6 +87,101 @@ else
     no "the no-injection case was treated as a missing injection"
 fi
 
+printf '\n=== assertion 2 must read the DAEMON, and unreadable is never a pass ===\n'
+
+# The version under test is the RUNNING daemon's, never the binary on disk: the
+# whole #1921 machine is "new binary installed, old daemon still serving". The
+# daemon reports its own version over the control socket, so that is what
+# lc_daemon_version asks for first, and the /proc image read is the fallback.
+if (
+    lc_status_field() { printf '1.0.215\n'; }
+    lc_daemon_image_version() { printf 'IMAGE-FALLBACK\n'; }
+    [ "$(lc_daemon_version af 4242)" = "1.0.215" ]
+); then
+    ok "the daemon's own reported version is used when it answers"
+else
+    no "lc_daemon_version did not use the version the daemon reported"
+fi
+
+# jq prints the STRING "null" for a member the daemon did not report. Taking it
+# at face value would hand assertion 2 a version named "null" and skip the
+# fallback — an old daemon (pre-v1.0.206) would then redden a healthy upgrade,
+# and, worse, so would a daemon that refused this client's ping, which is the
+# very skew the gate exists to catch.
+if (
+    lc_status_field() { printf 'null\n'; }
+    lc_daemon_image_version() { printf '1.0.214\n'; }
+    [ "$(lc_daemon_version af 4242)" = "1.0.214" ]
+); then
+    ok "an unreported version falls back to the running image, not the string 'null'"
+else
+    no "a 'null' daemon status member was treated as a version"
+fi
+if (
+    lc_status_field() { printf '\n'; }
+    lc_daemon_image_version() { printf '1.0.214\n'; }
+    [ "$(lc_daemon_version af 4242)" = "1.0.214" ]
+); then
+    ok "an empty daemon status member falls back to the running image"
+else
+    no "an empty daemon status member did not fall back"
+fi
+
+# Neither route could answer. The caller must see nothing and a non-zero status
+# — never a plausible-looking string.
+if (
+    lc_status_field() { printf 'null\n'; }
+    lc_daemon_image_version() { return 1; }
+    out="$(lc_daemon_version af 4242)"
+    rc=$?
+    [ -z "$out" ] && [ "$rc" != 0 ]
+); then
+    ok "both routes silent => empty version and a non-zero status"
+else
+    no "an unreadable daemon version produced output or a success status"
+fi
+
+# And the assertion itself. `lc_assert_eq "" ""` PASSES, so comparing two
+# unreadable versions would report "no skew" having compared nothing against
+# nothing — the exact shape of green this harness exists to refuse.
+for pair in "|" "1.0.215|" "|1.0.215"; do
+    client="${pair%|*}"
+    daemon="${pair#*|}"
+    if (
+        LC_FAIL=0
+        LC_PASS=0
+        LC_FAILED_NAMES=()
+        lc_assert_no_version_skew "$client" "$daemon" "assertion 2" >/dev/null 2>&1
+        [ "$LC_FAIL" = 1 ] && [ "$LC_PASS" = 0 ]
+    ); then
+        ok "an unreadable version FAILS assertion 2 (client='$client', daemon='$daemon')"
+    else
+        no "assertion 2 passed on an unreadable version (client='$client', daemon='$daemon')"
+    fi
+done
+if (
+    LC_FAIL=0
+    LC_PASS=0
+    LC_FAILED_NAMES=()
+    lc_assert_no_version_skew "1.0.215" "1.0.214" "assertion 2" >/dev/null 2>&1
+    [ "$LC_FAIL" = 1 ] && [ "$LC_PASS" = 0 ]
+); then
+    ok "a real skew still FAILS assertion 2"
+else
+    no "a real client/daemon skew did not fail assertion 2"
+fi
+if (
+    LC_FAIL=0
+    LC_PASS=0
+    LC_FAILED_NAMES=()
+    lc_assert_no_version_skew "1.0.215" "1.0.215" "assertion 2" >/dev/null 2>&1
+    [ "$LC_PASS" = 1 ] && [ "$LC_FAIL" = 0 ]
+); then
+    ok "matching versions pass assertion 2"
+else
+    no "matching client/daemon versions did not pass assertion 2"
+fi
+
 printf '\n=== external release availability is not a product failure ===\n'
 
 # The authenticated release-list probe must carry an unavailable result as a

--- a/scripts/lifecycle.sh
+++ b/scripts/lifecycle.sh
@@ -42,11 +42,13 @@
 #
 #   * macOS/launchd. Assertion #4 is already written for it (lc_unit_active /
 #     lc_unit_main_pid have Darwin branches, so the mac leg asserts the SAME
-#     property against launchd). The blocker for turning on the macos-latest leg
-#     is assertion 2: lc_daemon_version reads /proc/<pid>/exe, which macOS has no
-#     equivalent of — `ps` reports the path, whose bytes are the NEW binary after
-#     an upgrade, i.e. exactly the inference that assertion refuses to make. That
-#     leg wants #1920's daemon-reported version.
+#     property against launchd). Assertion 2 no longer blocks it: #1920 shipped
+#     the daemon-reported version and lc_daemon_version now asks the daemon,
+#     falling back to /proc only when it does not answer. What still blocks the
+#     macos-latest leg is daemon DISCOVERY — lc_daemon_pids matches a daemon by
+#     reading /proc/<pid>/cmdline and /proc/<pid>/environ, which macOS has no
+#     equivalent of, and assertions 1/3 plus teardown are built on it. Turning
+#     the leg on means porting that scan first, not just this one read.
 #   * Assertion #4 (supervision) on container runs: no systemd inside, so it is
 #     SKIPped there and only really runs on the CI runner. A SKIP is not a pass —
 #     the run exits non-zero unless AF_LIFECYCLE_ALLOW_PARTIAL=1 acknowledges it.
@@ -521,7 +523,7 @@ scenario_b() {
         lc_fail "scenario-b/$mode: no daemon came up on the old release; nothing to upgrade"
         return 1
     fi
-    before_daemon_ver="$(lc_daemon_version "$before_pid")"
+    before_daemon_ver="$(lc_daemon_version "$bin" "$before_pid")"
     lc_say "before upgrade: daemon pid=$before_pid version=$before_daemon_ver sessions=$before_sessions"
 
     # Hard gate. Scenario B's whole premise is "there is state to preserve"; if
@@ -622,7 +624,7 @@ scenario_b() {
     if [ -z "$after_pid" ]; then
         lc_fail "assertion 1/2/3: NO daemon is running after the upgrade"
     else
-        after_daemon_ver="$(lc_daemon_version "$after_pid")"
+        after_daemon_ver="$(lc_daemon_version "$bin" "$after_pid")"
         lc_say "after upgrade: daemon pid=$after_pid version=$after_daemon_ver client=$client_ver"
 
         # 1. the daemon is RESTARTED onto the NEW binary — not left on the old.
@@ -631,21 +633,14 @@ scenario_b() {
             "assertion 1: the daemon is not running a since-replaced binary"
 
         # 2. client version == daemon version. Queried, not inferred: the
-        #    daemon's version comes from the image it is ACTUALLY executing
-        #    (/proc/<pid>/exe), so a daemon left on the old bytes cannot hide
-        #    behind a new binary on disk. This is the #1921 skew condition.
-        #
-        #    AUDIT: `lc_assert_eq "" ""` PASSES. If lc_daemon_version could not
-        #    read /proc/<pid>/exe (a permission change, a macOS runner, a dead
-        #    pid) and lc_client_version also came back empty, the single most
-        #    important assertion in this gate would report "no skew" having
-        #    compared nothing against nothing. Both operands must exist first.
-        if [ -z "$after_daemon_ver" ] || [ -z "$client_ver" ]; then
-            lc_fail "assertion 2: cannot compare versions (daemon='$after_daemon_ver', client='$client_ver') — refusing to report 'no skew' from unreadable values"
-        else
-            lc_assert_eq "$client_ver" "$after_daemon_ver" \
-                "assertion 2: no version skew (client == daemon)"
-        fi
+        #    daemon reports its own version over the control socket, and when it
+        #    will not answer, the fallback reads the image it is ACTUALLY
+        #    executing (/proc/<pid>/exe). Neither route can read the new binary
+        #    on disk, so a daemon left on the old bytes cannot hide behind it.
+        #    This is the #1921 skew condition. lc_assert_no_version_skew refuses
+        #    to compare an unreadable version against anything.
+        lc_assert_no_version_skew "$client_ver" "$after_daemon_ver" \
+            "assertion 2: no version skew (client == daemon)"
 
         # 3. exactly ONE daemon; no orphan/second survived the restart.
         lc_assert_eq "1" "$(lc_daemon_count "$home")" "assertion 3: exactly one daemon afterwards"


### PR DESCRIPTION
## Summary

#2648 has two clusters. The remote-hook half landed in #2662, which deliberately
left the issue open for this one: the lifecycle harness still treats #1920 as
future work.

`scripts/lifecycle-lib.sh`, `scripts/lifecycle.sh` and `docs/lifecycle-testing.md`
all said the daemon has no "what version are you?" RPC and that `af doctor --json`
would arrive "the moment #1920 lands". #1920 merged in **v1.0.200**:

- `daemon/control_types.go` — `PingResponse.Version`
- `daemon/control_server.go:55` — `resp.Version = Version()`
- `daemon/health.go:90` — `h.DaemonVersion = ping.Version`
- `commands/daemoncmd.go:171` — `af daemon status --json` → `.data.version`
  (that member arrived with #2240, in **v1.0.206**)
- `doctor/json.go:40-52` — `af doctor --json` → `.data.summary.fail`, which
  `lc_doctor_fail_count`'s feature-detect has silently been using all along

## What changes

`lc_daemon_version <bin> <pid>` now asks the daemon for its own version and falls
back to copying `/proc/<pid>/exe`. The `/proc` read moves to
`lc_daemon_image_version` and stays reachable, because the fallback is
**feature-detected, not version-gated** — two different daemons answer with
nothing and only one of them is old:

* one older than v1.0.206, which has no such field. Scenario B installs the two
  newest stable releases, so that is only reachable if the boundary is ever
  pinned backwards — but the harness must not quietly stop measuring if it is.
* one that refuses *this* client's ping — the #1921 skew this gate exists to
  catch. **The route that can go quiet is the route under test**, so the
  fallback is load-bearing, not legacy politeness.

### The regression this could have been

Assertion 2's whole value is that neither route can read the *new binary on
disk*: if the daemon-reported value were ever the asking client's version, a
skewed machine would report "no skew" and the gate would pass on the #1921
machine it was written for. Checked against each release the harness can
install rather than assumed:

```
$ git show v1.0.206:commands/daemoncmd.go | grep 'Version: *h\.DaemonVersion'
150:		Version:           h.DaemonVersion,
$ git show v1.0.214:… / v1.0.215:…
171:		Version:           h.DaemonVersion,
$ git show v1.0.2{06,14,15}:daemon/health.go | grep DaemonVersion
h.DaemonVersion = ping.Version        # the RESPONDING daemon, in all three
```

`af daemon status` reports the responding daemon's version or nothing at all,
never the client's — and `daemon/health.go:23-29` documents answered-but-empty
as its own state.

### An empty version cannot pass

The inline "both operands must exist" audit in `scenario_b` becomes
`lc_assert_no_version_skew`, so it can be tested. `lc_assert_eq "" ""` **passes** —
an unreadable version compared against an unreadable version would report "no
skew" having compared nothing against nothing, which is precisely the green this
harness exists to refuse.

## Verification

**The new selftests were watched failing first.** Run against `master`'s
`lifecycle-lib.sh`/`lifecycle.sh` with only the selftest file swapped in, 8 of
the 9 new cases are red:

```
=== assertion 2 must read the DAEMON, and unreadable is never a pass ===
  FAIL  lc_daemon_version did not use the version the daemon reported
  FAIL  a 'null' daemon status member was treated as a version
  FAIL  an empty daemon status member did not fall back
  PASS  both routes silent => empty version and a non-zero status
  FAIL  assertion 2 passed on an unreadable version (client='', daemon='')
  FAIL  assertion 2 passed on an unreadable version (client='1.0.215', daemon='')
  FAIL  assertion 2 passed on an unreadable version (client='', daemon='1.0.215')
  FAIL  a real client/daemon skew did not fail assertion 2
  FAIL  matching client/daemon versions did not pass assertion 2
```

One of the nine ("both routes silent") passes on `master` too — it pins a
property the old single-route implementation already had, and keeping it is what
stops the fallback from being deleted later.

`make lifecycle-selftest`: **28 → 37 PASS, 0 FAIL**. `master`'s 28 cases also
pass unmodified against the new library, so nothing existing was loosened.

**`make lifecycle-container LIFECYCLE_SCENARIO=scenario-b`** — the real gate,
real release tarballs, v1.0.214 → v1.0.215, both upgrade modes:

```
[lifecycle] before upgrade: daemon pid=400 version=1.0.214 sessions=2
[lifecycle] after upgrade:  daemon pid=634 version=1.0.215 client=1.0.215
[lifecycle]   PASS  assertion 2: no version skew (client == daemon) (= 1.0.215)
[lifecycle] 20 PASS, 0 FAIL, 2 SKIP
```

The pre-upgrade `version=1.0.214` is the daemon-reported value in use — v1.0.214
answers `.data.version`, so the new route, not the fallback, produced it.

**`AF_LIFECYCLE_INJECT=skip-daemon-restart`** — the #1921 machine: binary swapped
to N, daemon never restarted. Assertion 2 must still bite, and does:

```
[lifecycle] INJECT: applied — client is now 1.0.215, daemon deliberately left on the old image
[lifecycle] after upgrade: daemon pid=785 version=1.0.214 client=1.0.215
[lifecycle]   FAIL  assertion 1: the daemon was restarted (pid): expected a change, but it is still '785'
[lifecycle]   FAIL  assertion 2: no version skew (client == daemon): want '1.0.215', got '1.0.214'
[lifecycle]   PASS  fault injection 'skip-daemon-restart' was actually applied during this run
[lifecycle] 13 PASS, 8 FAIL, 2 SKIP        -> exit 2
```

The new client asked; the *old* daemon answered `1.0.214`. That is the whole
assertion, and it survives the change.

The whole gate, both scenarios and both upgrade modes
(`make lifecycle-container`): **34 PASS, 0 FAIL, 2 SKIP** (the 2 SKIPs are
assertion #4, which needs systemd and never runs in a container).

`shellcheck -x` is clean on all three scripts. This PR touches
`scripts/lifecycle*.sh`, so `.github/workflows/lifecycle.yml` runs the whole gate
on the PR itself.

## Also corrected: what actually blocks the macOS leg

Both the script header and the guide named assertion 2 as the blocker for the
`macos-latest` leg, on the grounds that `/proc/<pid>/exe` has no Darwin
equivalent. That is no longer true of assertion 2 — but it is still true of
**daemon discovery**: `lc_daemon_pids` identifies a daemon by reading
`/proc/<pid>/cmdline` and `/proc/<pid>/environ` (the check that proves a pid
serves *this* throwaway home before the harness signals it), and assertions 1
and 3 plus teardown are built on it. Porting that scan is the work; this PR says
so instead of implying the leg is now unblocked.

Required gates, on the pushed head `737ac2f3b219d3bf09016a2b3fc12854feab8559`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (empty)
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`

Closes #2648
