### PR TITLE
docs: ban git stash in this repo and give the worktree-local substitutes

### DIFF
--- a/.claude/skills/dispatch-af-session.md
+++ b/.claude/skills/dispatch-af-session.md
@@ -52,6 +52,27 @@ Captain Claude contract. Root verifies and merges; worker sessions do not.
    - Never run `scripts/tui-driver.sh` against a real repo (#1303).
    - No sub-sessions.
    - No dev-install.
+   - Never run a `git stash` command that touches the shared stack (#2801) —
+     `git stash`/`push`, `pop`, `drop`, `clear`, `branch`, `list`, `store`,
+     `apply stash@{N}`. `refs/stash` is one stack shared by every worktree,
+     so a sibling session's `git stash pop` can hand you its work or silently
+     consume yours — it has already happened twice. `git stash create` and
+     `git stash apply <your own ref>` are fine; they never touch `refs/stash`.
+     Set changes aside worktree-locally instead:
+     ```bash
+     git add -A && git commit -qm "wip: set aside" && wip=$(git rev-parse HEAD)
+     # …later, and only while $wip is still the tip: git reset "$wip^"
+     # or, closest to stash — refs/worktree/ is per-worktree, refs/stash is not.
+     # Keep it one chain: an empty sha means create recorded NOTHING, the
+     # trailing "" refuses to overwrite an earlier save, and `:/` cleans from the
+     # repo root (a bare `.` misses everything outside your cwd). Cleaning the
+     # tree after any of those failures destroys the work you set aside.
+     sha=$(git stash create "wip") && [ -n "$sha" ] \
+       && git update-ref refs/worktree/af-wip "$sha" "" && git checkout -- :/
+     # later, and only if the apply succeeds — a conflicted apply needs the ref:
+     # git stash apply refs/worktree/af-wip && git update-ref -d refs/worktree/af-wip
+     ```
+     CLAUDE.md's "Git hygiene in a shared repo" has the caveats.
 
 3. **Send or create the session**:
    ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,101 @@ new files to dodge the limit — split them. See `docs/file-length-lint.md`.
 - `docs/` — documentation (remote hooks, etc.)
 - `examples/` — example configurations
 
+## Git hygiene in a shared repo
+
+Every af session gets its own **worktree**, which isolates the branch, `HEAD`,
+the index, and the working tree. It does not isolate everything under `refs/`.
+
+**Never run a `git stash` command that touches the shared stack (#2801)** — that
+is `git stash` / `stash push`, `pop`, `drop`, `clear`, `branch`, `list`, and
+`apply` of a `stash@{N}` entry. **`git stash store` is banned too**, and it is the
+easy one to reach for by accident: it is the documented companion to `stash
+create`, and it pushes that commit straight onto the shared stack. Pin created
+commits under `refs/worktree/…` instead, exactly as below.
+
+Exactly two forms are fine, and they are the substitutes below: **`git stash
+create`**, which writes a dangling commit and never touches `refs/stash`, and
+**`git stash apply <a ref you named yourself>`**.
+
+`refs/stash` is a single stack for the whole repository, shared by every linked
+worktree: git-worktree(1) names `refs/bisect`, `refs/worktree`, and
+`refs/rewritten` as the only unshared namespaces under `refs/`, and `refs/stash`
+is not among them. With a dozen-plus sessions running against one project, a
+sibling's `git stash pop` takes whatever is on top of that shared stack, which
+may be *your* entry. Nothing errors — the pop succeeds and returns the wrong
+content, so foreign changes land in your tree looking like your own work. This
+has already happened twice, and the recent one was caught only because the popped
+files were visibly unrelated to that session's task. There is no `stash.ref`
+config and no way to make `refs/stash` per-worktree; the substitutes below are
+the fix.
+
+**Scratch commit, then reset** — durable, survives a crash, and needs no new
+concepts. Prefer this when untracked files are involved:
+
+```bash
+# one chain: if the commit does not happen, nothing is parked and $wip must stay
+# unset — see below for why an unconditional $wip is dangerous
+git add -A && git commit -qm "wip: set aside" && wip=$(git rev-parse HEAD)
+# …do the thing that needed a clean tree, and do not commit while parked…
+git reset "$wip^"               # a MIXED reset: tracked edits come back
+                                # unstaged, new files untracked again
+```
+
+Use a mixed reset, not `--soft`. `--soft` moves `HEAD` only, so after the
+`git add -A` above every parked change comes back **staged** — and the next
+`git commit` you make for unrelated reasons then sweeps the whole WIP into it.
+Neither reset restores an intentional staged/unstaged split; mixed at least
+restores the common case exactly.
+
+The `&&` before `wip=` is load-bearing. `git commit` fails on an already-clean
+tree and whenever a pre-commit hook rejects, and an unconditional
+`wip=$(git rev-parse HEAD)` after that names **a real commit you care about** —
+`git reset "$wip^"` then uncommits *that* instead of restoring anything. Chained,
+a failed commit leaves `$wip` unset and the reset refuses. If the commit did not
+happen, stop: nothing was parked.
+
+`$wip` is not decoration either. `HEAD~1` names *one commit back from wherever
+you are now*, so a cherry-pick, revert, or urgent fix while parked makes
+`git reset HEAD~1` uncommit **that** and strand the WIP in your history. Resetting
+to `"$wip^"` is still only right while `$wip` is the tip — check with
+`git rev-parse HEAD`. If you did commit on top, the WIP is already in the branch:
+drop that one commit with `git rebase --onto "$wip^" "$wip"`, then
+`git cherry-pick -n "$wip"` if you want its content back as uncommitted changes.
+
+**`git stash create` plus a per-worktree ref** — closest to `git stash`, and
+`refs/worktree/` genuinely *is* unshared, so no sibling can see or consume it:
+
+```bash
+sha=$(git stash create "wip")   # dangling commit; refs/stash is NOT touched
+if [ -z "$sha" ]; then
+  echo "nothing recorded — do NOT clean the tree"
+# the trailing "" means "must not already exist" — a second save under the same
+# name would otherwise orphan the first, leaving it fsck-only
+elif git update-ref refs/worktree/af-wip "$sha" ""; then
+  git checkout -- :/            # only now: create records, it does not clean.
+                                # `:/` is the repo root — a bare `.` cleans only
+                                # below your cwd while create recorded the lot
+else
+  echo "af-wip is taken — pick another name; tree left dirty on purpose"
+fi
+# …later. Delete the ref only if the apply succeeded: a conflicted apply exits
+# non-zero, and that is precisely when you still need the pointer.
+git stash apply refs/worktree/af-wip && git update-ref -d refs/worktree/af-wip
+```
+
+**That guard is the load-bearing line, not decoration.** `git stash create`
+records nothing and prints an empty sha in two different situations — a clean
+tree, and a failure — and the failure is easy to hit: a half-added `git add -N`
+file makes it exit non-zero with `Entry … not uptodate`. Clean the tree after
+that and you have destroyed exactly the work you were setting aside.
+
+Two more ways `create` differs from `push`: it does not clean the working tree
+(`push` does that; `create` only records), and it does not capture untracked
+files — `git add` them first, or use the scratch commit above.
+
+If you find a stash entry that is not yours, do not drop it: leave it on the
+stack, revert the foreign paths out of your tree, and say so in the PR.
+
 ## Conventions
 
 - All Go files must be `gofmt`-formatted


### PR DESCRIPTION
## What

Tells dispatched sessions never to run `git stash` in this repo, and gives them
the two worktree-local substitutes. Docs only — 81 added lines across the two
files a worker actually reads, no deletions, no code.

This is urgent rather than tidy: ~20 sessions are running against this repo
right now, and the shared stack is **live**. `git stash list` on the maintainer's
checkout is 11 entries deep across 9 different branches, and two of those entries
are the scar tissue from previous incidents:

```
stash@{0}:  rescued web/src WIP … — popped out of the shared stash stack by a
            concurrent worktree on 2026-08-04
stash@{10}: WIP on siyer/fix-611-… (restored after accidental pop in fix-610 worktree)
```

So it has happened at least twice, and today's case was caught only because the
popped files were visibly unrelated to that session's task. That is luck, not a
control.

## The mechanism

`refs/stash` is one stack for the whole repository. git-worktree(1) is explicit
about which refs escape that:

> In general, all pseudo refs are per-worktree and all refs starting with `refs/`
> are shared. … There are exceptions, however: refs inside `refs/bisect`,
> `refs/worktree` and `refs/rewritten` are not shared.

`refs/stash` is not in that list, and there is no config that puts it there — the
only `stash.*` keys git 2.43 defines are `showIncludeUntracked`, `showPatch`, and
`showStat`. So a session cannot opt out by configuring anything; it can only stop
using the command.

Every af session is a linked worktree of the same repo, so the failure is
ordinary LIFO behaviour meeting unexpected sharing:

1. B stashes. 2. A stashes — A's entry is now on top. 3. B pops, and gets **A's**
work. Nothing errors. The pop succeeds and returns the wrong content, which is
how a session commits changes it never wrote, with a plausible-looking diff.

## What the docs now say

`CLAUDE.md` gets a "Git hygiene in a shared repo" section with the prohibition
and both substitutes; `.claude/skills/dispatch-af-session.md` gets one more
box-safety rule, alongside "no bare host `go test`" and "no dev-install", with
the short form of both recipes inline. A bare "don't" would leave the next
session stuck at the same fork it stashed to get past, so both files carry the
alternative:

- **scratch commit + `git reset --soft HEAD~1`** — durable, survives a crash, and
  the right choice when untracked files are involved;
- **`git stash create` + `git update-ref refs/worktree/<name>`** — closest to
  `git stash`, and `refs/worktree/` genuinely *is* unshared, so two sessions can
  use the same ref name and never see each other.

## Verification

Every claim written down was run against git 2.43.0 in a throwaway two-worktree
repo first, not recalled:

- **The trap reproduces deterministically.** B stashed, A stashed, B popped, and
  B's tree received `A-SECRET-WORK` in a file it had never touched. A's entry was
  gone; B's own entry was still on the stack, relabelled `On b`.
- **`stash create` does not touch `refs/stash`** — `git stash list` stayed empty
  through the whole recipe.
- **`refs/worktree/af-wip` resolves to a different sha in each worktree** after
  both wrote that same name, and `git stash apply` in A restored only A's file.
- **The three caveats are real, and are in the docs because the run found them:**
  `stash create` does not clean the tree, it prints an empty sha on a clean tree,
  and it does not capture untracked files — a half-added `git add -N` file makes
  it fail with `Entry … not uptodate`.
- **The first draft of the recipe was wrong, and the run caught it.** It ran
  `git checkout -- .` unconditionally after `git stash create`. An empty sha
  means *either* a clean tree *or* a failure, so on the `add -N` path that
  snippet cleaned a tree whose work had never been recorded — destroying exactly
  what it was meant to protect. Both files now guard the clean step behind a
  successful record, and I re-ran the failure path to watch the tracked edits
  survive it.

Local gates on the pushed head `30b4db5c`: `golangci-lint`, `gofmt -l .`,
`go build ./...`, `deadcode -test ./...`, `scripts/lint-file-length.sh`,
`make test-container`.

## Three review findings, all valid

Codex filed three P2s against the first head, every one of them a *paste-safety*
defect — which is the whole point of a recipe an agent will paste. Each fix was
run before the reply:

- **`git update-ref -d` ran unconditionally after `git stash apply`.** A
  conflicted apply exits non-zero, and that next line then deleted the only named
  pointer to the commit — precisely when it was still needed. Now chained with
  `&&`; verified the ref survives a deliberately conflicting apply.
- **`git reset --soft HEAD~1` was not "exactly where you were".** After
  `git add -A`, `--soft` moves `HEAD` only, so the parked WIP comes back
  **staged** and the next unrelated commit sweeps it in. Now a mixed
  `git reset HEAD~1`: verified `--soft` gives `M  f.txt` / `A  new.txt` where
  mixed gives ` M f.txt` / `?? new.txt`, the original state.
- **A second save silently orphaned the first.** `git update-ref` now takes the
  empty old-value guard (`… "$sha" ""`), which refuses an existing ref.

The third fix exposed one more defect the finding did not mention: making
`update-ref` fail was not enough, because `git checkout -- .` still ran on the
next line — so a refused update would have cleaned a tree whose work was now
recorded under no ref at all. The clean step is now the `elif` branch of the
successful update, and **every** failure path leaves the tree dirty on purpose.
That is the third time this one shape (a destructive step not gated on the step
that was supposed to make it safe) appeared in this small diff.

## Coordination with #2739

#2739 also edits both of these files, so I checked before touching them and
test-merged after. My change is additive and lands in regions #2739 does not
touch: `git merge-tree` of this branch against #2739's head auto-merges both
files with **both** sides' content intact — its "you own your merge" contract and
this prohibition coexist. The one conflict that merge reports is in
`.claude/skills/gate-pr.md`, a file this PR does not touch; that conflict is
between #2739 and #2799, which landed the same Greptile→Codex correction on
master while #2739 sat open. Flagged separately on #2739.

## Why this does not `Closes` the issue

Deliberate. #2801 also asks whether af can isolate this structurally instead of
by asking agents to remember a rule. That evaluation and its regression test are
a follow-up PR, and that one carries the close. Shipping the docs on their own
gets the protection to the running fleet now instead of behind a test suite.

Refs #2801

🤖 Generated with [Claude Code](https://claude.com/claude-code)