### PR TITLE
docs: note the root agent's fresh-context fallback on the concepts page

### DIFF
--- a/docs/concepts/daemon.md
+++ b/docs/concepts/daemon.md
@@ -35,7 +35,10 @@ paragraph because it's why `af` doesn't corrupt itself:
   comes back where it was. The always-on [root agent](../configuration.md#root-agents-always-ensured)
   is re-created rather than re-spawned — its record is replaced, but its recorded
   conversation and its tabs are carried across, so it comes back on the same
-  context with the same tab strip.
+  context with the same tab strip. When that conversation cannot be resumed the
+  root still comes back, on a fresh context — an always-on root that exists
+  outranks one that keeps its history — and the application log says which
+  happened.
 - **Runs the scheduler.** All [tasks](../tasks.md) — cron schedules and
   watch-script triggers — are hosted by the daemon. It arms the timers, watches
   the scripts, and delivers prompts on time, whether or not a TUI is open.


### PR DESCRIPTION
## Summary

`docs/concepts/daemon.md:34-38` stated the healed-root guarantee unconditionally
— "its recorded conversation and its tabs are carried across, so it comes back
on the same context with the same tab strip". The daemon has a deliberate
fallback: `daemon/rootagent.go:382-394` catches a `CreateSession` failure on a
carried conversation id, logs "could not be re-created on its prior … conversation
… retrying with a fresh agent", clears `resumeConversation`, and re-creates —
because "the always-on guarantee outranks continuity".

`docs/configuration.md:306` ("A re-created root keeps its conversation") already
documents the fallback and its three causes, and `docs/release-notes.md:10-13`
carries the same caveat. The concepts page was the only outlier, so a user whose
root came back empty would read it and conclude `af` lost their history through a
bug when it did the documented thing.

This adds the qualifier at the weight an overview page wants — one clause naming
the fresh-context outcome and the log line that tells the two apart. The full
condition list stays on the authoritative page, which the same bullet already
links (`../configuration.md#root-agents-always-ensured`).

```diff
   context with the same tab strip.
+  ... When that conversation cannot be resumed the
+  root still comes back, on a fresh context — an always-on root that exists
+  outranks one that keeps its history — and the application log says which
+  happened.
```

Grepped the rest of `docs/`, `README.md`, and the web copy for the same
overclaim: `docs/configuration.md` and `docs/release-notes.md` are the only other
places that describe the carry, and both already name the fallback. No other
site to fix.

Closes #2797

## Test Plan

Prose-only change to one Markdown bullet — no code paths, no generated artifacts,
and nothing a Go test can assert. The gates it can fail are the docs build and
the repo lints, all run on the pushed head:

- [x] `mkdocs build --strict` gate: adds no new links; the one link in the bullet
      is pre-existing and its `#root-agents-always-ensured` anchor is produced by
      `### Root agents (always-ensured)` in `docs/configuration.md`. (`mkdocs` is
      not installed on the dev box — the docs workflow is the executing check.)
- [x] `golangci-lint run --timeout=3m --fast`
- [x] `gofmt -l .` (empty)
- [x] `go build ./...`
- [x] `make test-container` (green on `eb60b0ba`, the pushed head; 0 failures)
- [x] `deadcode -test ./...`
- [x] `scripts/lint-file-length.sh`
- [x] Manually tested in TUI — n/a, docs only

Captain Claude
