### PR TITLE
fix(attach): hand the terminal back on every exit from an attach

### DIFF
--- a/apiclient/attach.go
+++ b/apiclient/attach.go
@@ -15,7 +15,6 @@ import (
 	"golang.org/x/term"
 
 	"github.com/sachiniyer/agent-factory/agentproto"
-	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 // Seams for the terminal the driver proxies to/from. Production wires them to the
@@ -63,6 +62,17 @@ var attachDrainTimeout = 2 * time.Second
 // and restores the terminal on exit. The signature matches the attach seam
 // (app.attachOverlayCallback's `func() (chan struct{}, error)`), so local
 // full-screen attach drops in where the tmux driver used to be.
+//
+// ctx bounds the DIAL only. Once the stream is up, the driver reads on a
+// background context by design (see driveAttachStream), so cancelling ctx does
+// not end a live attach — verified against coder/websocket, whose conn outlives
+// the handshake context, and relied on by DialStream itself, which cancels its
+// own derived dial context for a remote target before this returns. Detach is a
+// WS-level signal, not a cancellation. Both callers pass a context that is never
+// cancelled mid-attach (the TUI passes Background; the CLI's command context is
+// rooted at Background), so this is a documented property rather than a live
+// exit path — but it is why terminal hand-back is armed against signals instead:
+// see terminalHandback.
 func (c *Client) AttachStream(ctx context.Context, title, repoID, tabID string, tab int) (chan struct{}, error) {
 	sc, err := c.DialStream(ctx, title, repoID, tabID, tab, 0) // 0 = live tail
 	if err != nil {
@@ -84,10 +94,16 @@ func (c *Client) AttachStream(ctx context.Context, title, repoID, tabID string, 
 		_ = sc.Conn.Close(websocket.StatusInternalError, "raw mode")
 		return nil, err
 	}
+	// Arm the hand-back HERE, in the statement right after the one that took the
+	// terminal, and hand it to the driver rather than the raw termios. Arming it
+	// inside the driver instead would leave a window — MakeRaw has already run,
+	// the driver goroutine has not been scheduled yet — in which a signal exits
+	// with the user's termios raw, which is the very bug this closes (#2784).
+	handback := beginTerminalHandback(attachStdout, oldState)
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		driveAttachStream(sc.Conn, oldState, in)
+		driveAttachStream(sc.Conn, handback, in)
 	}()
 	return done, nil
 }
@@ -120,8 +136,21 @@ var attachWriteTimeout = 10 * time.Second
 // timer and the drain-complete path close it). The io seams are captured as
 // locals up front so no goroutine re-reads package-level vars a test swaps back
 // in Cleanup.
-func driveAttachStream(conn *websocket.Conn, oldState *term.State, in cancelreader.CancelReader) {
+func driveAttachStream(conn *websocket.Conn, handback *terminalHandback, in cancelreader.CancelReader) {
 	defer in.Close()
+	// Give the terminal back on every exit from here — the drained detach at the
+	// bottom, a server disconnect, a signal, and the ones nobody wrote a handler
+	// for. A tail-called restore covers only the anticipated exits; #2784 is what
+	// the others cost the user. Deferred, so a panic anywhere below still hands
+	// the terminal back — and still crashes the process with its stack trace,
+	// because a recovered panic is a bug nobody ever sees. See terminalHandback.
+	//
+	// On the normal path the terminal still goes back exactly where it used to.
+	// Defers unwind last-registered-first, so this runs after the body has waited
+	// out copyDone (every byte the pane program wrote is on the terminal) and
+	// stdinDone (the input pump has proven it is gone, #2671), and still ahead of
+	// the in.Close registered above it.
+	defer handback.release()
 	// Snapshot EVERY package-level seam/tunable once, here, before any goroutine
 	// spawns. The goroutines then read only these locals — never the package vars
 	// a test swaps and restores in Cleanup. This single entry read is sequenced
@@ -259,13 +288,7 @@ func driveAttachStream(conn *websocket.Conn, oldState *term.State, in cancelread
 	_ = in.Cancel()
 	closeConn()
 	<-stdinDone
-	// The stream is fully drained (copyDone), so this lands strictly after any
-	// modes the pane program set — neutralize the terminal (#845, local edition),
-	// then hand the termios back to whatever owned it before attach (bubbletea for
-	// the TUI, the shell for the CLI). oldState is nil only in tests that drive the
-	// proxy without a real TTY.
-	_, _ = io.WriteString(out, tmux.NeutralTerminalRestore)
-	if oldState != nil {
-		_ = term.Restore(int(os.Stdin.Fd()), oldState)
-	}
+	// The terminal goes back from here via the deferred handback.release() above:
+	// the stream is fully drained (copyDone) and the stdin pump is gone, so the
+	// hand-back still lands strictly after any modes the pane program set.
 }

--- a/apiclient/attach_pty_test.go
+++ b/apiclient/attach_pty_test.go
@@ -1,0 +1,526 @@
+package apiclient
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/creack/pty"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/term"
+
+	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// A full-screen attach BORROWS the user's terminal: it puts the real terminal
+// into raw mode for the pane's lifetime and owes it back when the attach ends.
+// #2784 is what an exit path that skips the hand-back costs — a shell with no
+// echo and no line editing, where the recovery (reset, stty sane) is the hardest
+// thing there is to type.
+//
+// These are the tests that can see that. A unit test asserting that a restore
+// function was called would pass against a driver that hands back a terminal
+// nobody can type into; the assertion that matters is on the termios, so the
+// tests below run the production attach against a REAL pty in a REAL child
+// process and then prove the terminal works by typing into it and requiring the
+// line discipline to echo.
+//
+// The child process is not incidental. An unrecovered panic is only observable
+// as a process that dies, and the fix has to let it die: recovering it would
+// swallow the bug the panic is reporting. So the panic test requires BOTH halves
+// — the terminal comes back AND the panic still reaches the user.
+
+const (
+	// attachHelperEnv selects the child-process behaviour; empty means this is an
+	// ordinary suite run and the helper test skips itself.
+	attachHelperEnv = "AF_ATTACH_PTY_HELPER"
+	// attachHelperReady is printed once the attach owns the terminal in raw mode,
+	// so the parent knows when the process is in the state under test.
+	attachHelperReady = "AF-ATTACH-HELPER-READY"
+	// attachHelperPanic is the panic value injected through attachTermSize, an
+	// EXISTING production seam that driveAttachStream calls on its own goroutine
+	// (the initial resize). Injecting there needs no test-only hook in the driver
+	// and lands the panic exactly where #2784 describes it: after the terminal is
+	// raw, before the hand-back.
+	attachHelperPanic = "af attach: injected panic from the terminal-size seam"
+	// attachHelperSawPrefix leads the line the helper prints when the stub server
+	// receives typed bytes through the attach — proof the stream is still live. It
+	// carries everything typed so far, so a frame split mid-token resolves as soon
+	// as the rest arrives, and it cannot be confused with a local terminal echo of
+	// those same bytes.
+	attachHelperSawPrefix = "AF-ATTACH-STREAM-SAW:"
+)
+
+// TestAttachStream_PanicHandsTheTerminalBack is #2784. The attach driver panics
+// with the terminal in raw mode; the user must get a usable terminal back, and
+// must still see the panic.
+func TestAttachStream_PanicHandsTheTerminalBack(t *testing.T) {
+	h := startAttachInPTY(t, "panic")
+	err := h.wait(t)
+
+	// The panic SURFACES: the process dies and says why. If this ever starts
+	// passing because someone wrapped the driver in recover(), the terminal
+	// assertion below would pass too — and a real bug would be silently eaten.
+	//
+	// Waited for rather than asserted outright: process exit does not mean the
+	// terminal has finished handing us what the process wrote, so the tail of the
+	// trace can still be in flight when Wait returns.
+	require.Error(t, err, "an unrecovered panic must kill the process, not be swallowed")
+	h.waitForOutput(t, attachHelperPanic, "the panic must reach the user")
+	h.waitForOutput(t, "goroutine", "the panic must print its stack trace")
+
+	requireTerminalUsable(t, h, "after-panic",
+		"the attach panicked with the terminal in raw mode and never handed it back: "+
+			"the user is left in a shell with no echo and no line editing (#2784)")
+}
+
+// TestAttachStream_SignalHandsTheTerminalBack covers the other exit nobody wrote
+// a handler for: the attached process is killed from outside. Default signal
+// disposition terminates the process without running a single defer, so the
+// terminal stays raw for exactly the same reason the panic left it raw.
+func TestAttachStream_SignalHandsTheTerminalBack(t *testing.T) {
+	h := startAttachInPTY(t, "signal")
+	h.waitForOutput(t, attachHelperReady, "the helper should reach raw-mode attach")
+	require.NoError(t, h.cmd.Process.Signal(syscall.SIGTERM))
+	err := h.wait(t)
+
+	// The signal still kills the process — the hand-back must not turn a
+	// terminate into a survivor.
+	require.Error(t, err, "SIGTERM must still terminate the attached process")
+
+	requireTerminalUsable(t, h, "after-signal",
+		"the attached process was killed by SIGTERM with the terminal in raw mode and "+
+			"never handed it back (#2784)")
+}
+
+// TestAttachStream_IgnoredSignalDoesNotDisturbTheAttach is the other half of the
+// signal contract. A signal the process inherited as IGNORED (nohup, a disowned
+// job, a shell trap that ignores HUP — SIG_IGN survives execve) can never kill
+// it, so the attach must leave that signal alone.
+//
+// Watching it anyway is worse than not handling it: os/signal has to take the
+// ignore away to deliver the signal, and putting the default disposition back
+// restores the same ignore, so the re-raise is discarded — the process lives on
+// with a terminal it has already handed back while it is still proxying a raw
+// byte stream to it. Nothing here is about dying well; it is about a live attach
+// staying live.
+//
+// The child is started through a shell that ignores SIGHUP and then execs the
+// helper, which is the real inheritance path rather than a simulation of it.
+func TestAttachStream_IgnoredSignalDoesNotDisturbTheAttach(t *testing.T) {
+	h := startAttachInPTY(t, "ignored-hup")
+	h.waitForOutput(t, attachHelperReady, "the helper should reach raw-mode attach")
+	require.NoError(t, h.cmd.Process.Signal(syscall.SIGHUP))
+
+	// The FIRST round trip is a synchronization point, not an assertion. Signal
+	// delivery is asynchronous, so inspecting the terminal immediately after
+	// Signal returns would race a handler that has not run yet — and would pass
+	// against a build that does handle the ignored signal. A completed round trip
+	// (terminal to stdin pump to websocket to server and back out to stdout) puts
+	// many scheduling points between the signal and the inspection below.
+	h.roundTrip(t, "sync", "the attach must survive a signal it inherited as ignored")
+	h.roundTrip(t, "again", "the attach must survive a signal it inherited as ignored")
+
+	// NOW the terminal can be inspected, two independent ways — a handler that
+	// wrongly ran would have to beat BOTH. The hand-back writes the neutral
+	// restore to the terminal, so its bytes appearing at all mean the attach gave
+	// back a terminal it is still proxying to; and a restored terminal is cooked,
+	// so it would echo the round trip below locally.
+	require.NotContains(t, h.output(), tmux.NeutralTerminalRestore,
+		"the attach handed the terminal back on a signal that could never kill it")
+	from := len(h.output())
+	h.roundTrip(t, "ping", "the attach must still be reading the terminal")
+	require.NotContains(t, h.output()[from:], "ping\r\n",
+		"the terminal echoed locally, so the attach handed back a terminal it is still using")
+
+	// A signal that CAN kill it still hands the terminal back — skipping one
+	// signal must not disarm the others.
+	require.NoError(t, h.cmd.Process.Signal(syscall.SIGTERM))
+	require.Error(t, h.wait(t), "SIGTERM must still terminate the attached process")
+	requireTerminalUsable(t, h, "after-ignored-then-term",
+		"SIGTERM after an ignored SIGHUP left the terminal unusable (#2784)")
+}
+
+// TestAttachStream_UnkillableSignalRetakesTheTerminal is the case the ignored-
+// signal filter CANNOT see, and it is the TUI's normal state rather than an
+// exotic one.
+//
+// signal.Ignored only reports an inherited ignore while nothing has called
+// Notify for that signal — and Bubble Tea calls Notify for SIGINT/SIGTERM at
+// program start (tea.go handleSignals). So in the TUI the filter reports "not
+// ignored", the hand-back arms, and signal.Reset then restores the inherited
+// SIG_IGN, which discards the re-raise. Same shape when the kernel suppresses a
+// default action (pid 1 in a container).
+//
+// The process therefore survives a signal it handed the terminal back for. That
+// must not leave a live attach proxying raw bytes to a cooked terminal — which
+// would be WORSE than no handler at all, since the un-patched code ignored these
+// signals and left the attach intact. The terminal has to come back.
+func TestAttachStream_UnkillableSignalRetakesTheTerminal(t *testing.T) {
+	h := startAttachInPTY(t, "unkillable-int")
+	h.waitForOutput(t, attachHelperReady, "the helper should reach raw-mode attach")
+	require.NoError(t, h.cmd.Process.Signal(syscall.SIGINT))
+
+	// The attach is alive at all — the first thing the signal must not have done.
+	h.roundTrip(t, "sync", "the attach must survive a signal that cannot kill it")
+
+	// Then the terminal must come BACK to raw. This one is polled rather than
+	// asserted once: the retake deliberately waits out a grace period, so that a
+	// signal which really is fatal kills the process before anything re-raws a
+	// terminal it is about to abandon. Each probe round trip also re-proves the
+	// attach is still reading.
+	h.requireTerminalRetaken(t, "the terminal is still cooked after a signal that could not "+
+		"kill the process: the attach handed it back and never took it again")
+
+	// And the terminal it retook still comes back for real when the attach ends.
+	require.NoError(t, h.cmd.Process.Signal(syscall.SIGTERM))
+	require.Error(t, h.wait(t), "SIGTERM must still terminate the attached process")
+	requireTerminalUsable(t, h, "after-retake-then-term",
+		"a terminal retaken after an unkillable signal was never handed back (#2784)")
+}
+
+// TestAttachStream_FailedAttachLeavesTheTerminalAlone is the last exit in the
+// #2784 audit: an attach that never starts (daemon down, socket unresolved) —
+// the error path the TUI hits and then re-attaches through. It must hand back a
+// working terminal too, which today it does by never taking it: the dial runs
+// before MakeRaw, so a failure returns with the termios untouched.
+//
+// That makes this a guard rather than a fix witness, and it has teeth: move the
+// MakeRaw in AttachStream above the DialStream call and it fails, because the
+// error return then skips a hand-back it now owes.
+func TestAttachStream_FailedAttachLeavesTheTerminalAlone(t *testing.T) {
+	h := startAttachInPTY(t, "dial-failure")
+	require.NoError(t, h.wait(t), "the helper should report a clean failed attach; output: %s", h.output())
+
+	requireTerminalUsable(t, h, "after-failed-attach",
+		"an attach that failed to start left the terminal unusable (#2784)")
+}
+
+// TestAttachTerminalHandbackHelper is the child half of every test above: it
+// runs a REAL attach (raw mode and all) against a stub WS server, on the pty its
+// parent handed it, in the shape the named mode calls for. It is a no-op in an
+// ordinary suite run.
+func TestAttachTerminalHandbackHelper(t *testing.T) {
+	mode := os.Getenv(attachHelperEnv)
+	if mode == "" {
+		t.Skip("child-process helper for the attach terminal hand-back tests")
+	}
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		t.Fatalf("helper stdin is not a terminal, so there is no raw mode to leak")
+	}
+	switch mode {
+	case "panic":
+		// driveAttachStream calls this seam itself, on its own goroutine, once the
+		// terminal is already raw.
+		prev := attachTermSize
+		attachTermSize = func() (uint16, uint16, bool) { panic(attachHelperPanic) }
+		t.Cleanup(func() { attachTermSize = prev })
+	case "unkillable-int":
+		// Stand in for Bubble Tea, which calls Notify for SIGINT/SIGTERM at startup:
+		// that is what hides the inherited ignore from signal.Ignored. The parent
+		// started this process with SIGINT inherited as ignored, so the re-raise the
+		// hand-back performs is discarded and the process lives on.
+		bubbleteaLike := make(chan os.Signal, 1)
+		signal.Notify(bubbleteaLike, syscall.SIGINT)
+		t.Cleanup(func() { signal.Stop(bubbleteaLike) })
+	case "dial-failure":
+		// Nothing is listening on that socket, so the attach fails before it can
+		// own anything. Exiting 0 here is the child reporting a clean failure; the
+		// parent then checks what it left behind.
+		dead := NewWithSocket(filepath.Join(t.TempDir(), "no-daemon.sock"))
+		if _, derr := dead.AttachStream(context.Background(), "alpha", "", "", 0); derr == nil {
+			t.Fatalf("attaching over a dead socket must fail")
+		}
+		fmt.Println(attachHelperReady)
+		return
+	}
+
+	c, connCh := attachWSServer(t)
+	done, err := c.AttachStream(context.Background(), "alpha", "", "", 0)
+	if err != nil {
+		t.Fatalf("AttachStream: %v", err)
+	}
+	if mode != "panic" {
+		// AttachStream returning only means the driver GOROUTINE was spawned. The
+		// parent is about to signal this process, so READY has to mean the driver
+		// actually reached the state under test: wait for the initial RESIZE frame,
+		// which the driver writes strictly after it arms the terminal hand-back.
+		// Without this the test would race the goroutine scheduler.
+		server := <-connCh
+		waitForInitialResize(t, server)
+		if mode == "ignored-hup" || mode == "unkillable-int" {
+			// Report typed bytes arriving through the stream, so the parent can prove
+			// the attach is still reading the terminal after the ignored signal.
+			go reportInputToStdout(server)
+		}
+	}
+	fmt.Println(attachHelperReady)
+	<-done
+	t.Fatalf("helper: the attach ended on its own; nothing exercised the exit under test")
+}
+
+// reportInputToStdout prints everything typed so far, each time an INPUT frame
+// carries more of it, and stops when the stream ends. Reporting the accumulation
+// rather than the frame keeps the parent's wait exact even if the terminal
+// splits a token across reads.
+func reportInputToStdout(server *websocket.Conn) {
+	var typed strings.Builder
+	for {
+		msg, err := agentproto.ReadMessage(context.Background(), server)
+		if err != nil {
+			return
+		}
+		if msg.Binary && msg.Frame.Op == agentproto.OpInput {
+			// A cooked terminal delivers the line with a newline, a raw one delivers
+			// the carriage return; neither belongs to the token.
+			typed.WriteString(strings.NewReplacer("\r", "", "\n", "").Replace(string(msg.Frame.Data)))
+			fmt.Println(attachHelperSawPrefix + typed.String())
+		}
+	}
+}
+
+// waitForInitialResize blocks until the driver sends the RESIZE frame it emits
+// on connect — the proof that driveAttachStream is past its setup.
+func waitForInitialResize(t *testing.T, server *websocket.Conn) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	for {
+		msg, err := agentproto.ReadMessage(ctx, server)
+		if err != nil {
+			t.Fatalf("waiting for the attach initial resize: %v", err)
+		}
+		if msg.Binary && msg.Frame.Op == agentproto.OpResize {
+			return
+		}
+	}
+}
+
+// ptyAttach is a child af attach running on a pty the test owns both ends of.
+type ptyAttach struct {
+	ptmx *os.File
+	tty  *os.File
+	cmd  *exec.Cmd
+	out  *syncBuffer
+	// exited closes when the single owning Wait returns; exitErr is written
+	// before the close, so reading it after is ordered.
+	exited  chan struct{}
+	exitErr error
+	// typed accumulates what roundTrip has sent, matching what the helper reports.
+	typed string
+}
+
+// startAttachInPTY allocates a pty, proves it starts out as a working cooked
+// terminal, and starts the helper child attached to it.
+func startAttachInPTY(t *testing.T, mode string) *ptyAttach {
+	t.Helper()
+	ptmx, tty, err := pty.Open()
+	require.NoError(t, err, "open a pty pair")
+	t.Cleanup(func() {
+		_ = ptmx.Close()
+		_ = tty.Close()
+	})
+
+	// Drain the master continuously: a Go panic trace is far larger than the pty
+	// buffer, and a child blocked on a full terminal would never reach its exit.
+	out := &syncBuffer{}
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, rerr := ptmx.Read(buf)
+			if n > 0 {
+				_, _ = out.Write(buf[:n])
+			}
+			if rerr != nil {
+				return
+			}
+		}
+	}()
+
+	h := &ptyAttach{ptmx: ptmx, tty: tty, out: out}
+	// A fresh pty is cooked, exactly like the shell a user runs af from. Proving
+	// it HERE is what keeps the post-exit assertion honest: without this a probe
+	// that never echoes for some unrelated reason would read as a raw-mode leak,
+	// and one that always echoes would make the test vacuous.
+	requireTerminalUsable(t, h, "baseline",
+		"the harness pty must start as a working cooked terminal")
+
+	// Re-exec this very test binary: the child IS the test, one helper case deep.
+	helperArgs := []string{"-test.run=^TestAttachTerminalHandbackHelper$", "-test.timeout=60s"}
+	cmd := exec.Command(os.Args[0], helperArgs...)
+	if trap := shellTrapFor(mode); trap != "" {
+		// Inherit the signal as ignored the way nohup and a disowned job do: SIG_IGN
+		// survives execve, so the shell traps it and then execs the helper INTO the
+		// same process (same pid).
+		cmd = exec.Command("/bin/sh", append([]string{
+			"-c", trap + `; exec "$@"`, "sh", os.Args[0],
+		}, helperArgs...)...)
+	}
+	cmd.Env = append(os.Environ(),
+		attachHelperEnv+"="+mode,
+		// Fence the child off the developer real af home, same rule as testguard.
+		"AGENT_FACTORY_HOME="+t.TempDir())
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = tty, tty, tty
+	// The child gets the pty as its stdio and nothing else — no SysProcAttr.
+	//
+	// Neither a controlling terminal (Setctty) nor its own session (Setsid) is
+	// needed for what these tests measure: the hand-back is a tcsetattr on fd 0
+	// plus escape sequences, and the tests signal the child by pid rather than
+	// through the terminal. Both were here for realism, and on darwin both are
+	// harness poison — two halves of one rule, which is why dropping Setctty
+	// alone was not enough:
+	//
+	//   - a session leader that EXITS revokes its controlling terminal, and that
+	//     invalidates every descriptor for the pty in every process, so the
+	//     post-exit probe gets EIO instead of an answer;
+	//   - a session leader that OPENS a terminal ACQUIRES it as a controlling
+	//     terminal. The shell wrapping the ignored-signal child touches the
+	//     terminal where a Go binary never does, so it took the ctty straight back
+	//     and re-armed the revoke above.
+	//
+	// Linux does neither, so only the macOS CI leg ever sees this.
+	require.NoError(t, cmd.Start(), "start the attach helper on the pty")
+	h.cmd = cmd
+	// ONE Wait for the child, ever, owned here — so a test that fails before
+	// reaping cannot leave a second Wait racing this one.
+	h.exited = make(chan struct{})
+	go func() {
+		h.exitErr = cmd.Wait()
+		close(h.exited)
+	}()
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill() // ErrProcessDone once it has been reaped
+		<-h.exited
+	})
+	return h
+}
+
+// shellTrapFor returns the shell trap that gives a mode its inherited-ignored
+// signal, or empty for the modes that need none.
+func shellTrapFor(mode string) string {
+	switch mode {
+	case "ignored-hup":
+		return `trap "" HUP`
+	case "unkillable-int":
+		return `trap "" INT`
+	}
+	return ""
+}
+
+// requireTerminalRetaken polls until a typed probe stops being echoed locally —
+// the terminal going back to raw under a still-running attach. Polling is the
+// point: the transition happens after the watcher's grace period, so a one-shot
+// check races it and would pass against a build that never retakes.
+func (h *ptyAttach) requireTerminalRetaken(t *testing.T, why string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for i := 1; time.Now().Before(deadline); i++ {
+		token := fmt.Sprintf("probe%d", i)
+		from := len(h.output())
+		h.roundTrip(t, token, "the attach must still be reading the terminal")
+		if !strings.Contains(h.output()[from:], token+"\r\n") {
+			return // no local echo: raw again
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("%s\npty output: %q", why, h.output())
+}
+
+func (h *ptyAttach) output() string { return h.out.String() }
+
+// roundTrip types a token into the attached terminal and waits for the helper to
+// report it arriving through the PTY stream. It doubles as a synchronization
+// point: when it returns, the child has read the terminal, written the socket
+// and printed to stdout since whatever the caller did before it.
+func (h *ptyAttach) roundTrip(t *testing.T, token, why string) {
+	t.Helper()
+	h.typed += token
+	_, err := h.ptmx.WriteString(token + "\r")
+	require.NoError(t, err, "type into the attached terminal")
+	// Match the tokens THIS test typed at the tail of a report line rather than
+	// assuming they are the whole of it: the helper reports everything the stream
+	// has delivered, and a terminal hands the attach whatever was queued on it
+	// before the attach started — the harness baseline probe, typically.
+	//
+	// Anchoring to the report line also keeps a cooked terminal honest. Searching
+	// the raw output for the token would match the LOCAL ECHO of it, which is
+	// precisely the symptom the caller is testing for the absence of.
+	want := regexp.MustCompile(regexp.QuoteMeta(attachHelperSawPrefix) + `[^\r\n]*` + regexp.QuoteMeta(h.typed))
+	h.waitForOutputMatch(t, want, why)
+}
+
+// wait blocks until the child exits and returns its exit error (nil only if it
+// exited 0).
+func (h *ptyAttach) wait(t *testing.T) error {
+	t.Helper()
+	select {
+	case <-h.exited:
+		return h.exitErr
+	case <-time.After(30 * time.Second):
+		t.Fatalf("the attach helper never exited; pty output: %s", h.output())
+		return nil
+	}
+}
+
+// waitForOutput blocks until want shows up on the pty.
+func (h *ptyAttach) waitForOutput(t *testing.T, want, why string) {
+	t.Helper()
+	h.waitForOutputFunc(t, func(out string) bool { return strings.Contains(out, want) },
+		why, fmt.Sprintf("%q", want))
+}
+
+// waitForOutputMatch is waitForOutput for a pattern rather than a literal.
+func (h *ptyAttach) waitForOutputMatch(t *testing.T, want *regexp.Regexp, why string) {
+	t.Helper()
+	h.waitForOutputFunc(t, want.MatchString, why, want.String())
+}
+
+func (h *ptyAttach) waitForOutputFunc(t *testing.T, match func(string) bool, why, want string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if match(h.output()) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("%s: never saw %s on the pty; output: %q", why, want, h.output())
+}
+
+// requireTerminalUsable types a line into the terminal and requires the line
+// discipline to echo it back — the assertion #2784 is actually about. A raw
+// terminal echoes nothing (MakeRaw clears ECHO), and a cooked one echoes the
+// line with the carriage return translated (ICRNL then ONLCR), so the expected
+// bytes prove both halves of the termios came back.
+func requireTerminalUsable(t *testing.T, h *ptyAttach, tag, why string) {
+	t.Helper()
+	typed := "af-terminal-" + tag
+	from := len(h.output())
+	_, err := h.ptmx.WriteString(typed + "\r")
+	// A write that fails outright is the harness losing the pty, not the attach
+	// leaving it raw. Say so, so the two never get confused in a CI log.
+	require.NoError(t, err, "%s\ncould not type into the pty at all, so it was torn "+
+		"down rather than left in raw mode — this is a harness failure, not the bug under test", why)
+
+	want := typed + "\r\n"
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(h.output()[from:], want) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("%s\ntyped %q into the terminal and the line discipline never echoed %q back "+
+		"(terminal still in raw mode)\npty output after typing: %q",
+		why, typed, want, h.output()[from:])
+}

--- a/apiclient/attach_terminal.go
+++ b/apiclient/attach_terminal.go
@@ -1,0 +1,220 @@
+package apiclient
+
+import (
+	"io"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"golang.org/x/term"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// handbackSignals are the signals whose DEFAULT disposition terminates the
+// process without running a single deferred function. During an attach that is
+// a terminal leak: the process dies, the termios stays raw, and the shell the
+// user is dropped back into has no echo and no line editing.
+//
+// SIGQUIT is deliberately absent. Its default disposition in a Go program is
+// the runtime goroutine dump, and taking it over here would trade a debugging
+// affordance (kill -QUIT on a wedged attach) for a terminal the runtime is
+// about to scribble a traceback onto anyway.
+//
+// Keyboard-generated signals are not the case this covers: the attach holds the
+// terminal in raw mode, so ISIG is off and ctrl+c is a byte the pane receives.
+// What reaches an attached process is an external kill.
+//
+// This does not fight bubbletea for the TUI. Bubble Tea watches SIGINT/SIGTERM
+// too, but a full-screen attach is bracketed by ReleaseTerminal (#2157), which
+// sets its ignoreSignals flag — so for the whole attach it takes those signals
+// off its channel and DISCARDS them, and an attached TUI outlives a SIGTERM
+// today while leaving the user a raw terminal on any signal it does not catch.
+// Restoring and then re-raising ends that: the terminal comes back and the
+// signal means what it says.
+var handbackSignals = []os.Signal{syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP}
+
+// terminalHandback owns the one thing a full-screen attach borrows from the
+// user: the terminal. AttachStream takes it with term.MakeRaw, the pane program
+// then negotiates whatever modes it likes onto it (alt screen, mouse reporting,
+// kitty keyboard), and every exit from the attach owes all of that back.
+//
+// "Every exit" is the whole point, and is what #2784 was about. The driver used
+// to restore the terminal in its tail, which covers the exits somebody thought
+// of — a detach, a server disconnect — and silently skips the ones nobody wrote
+// a handler for. A panic anywhere in the driver, or a signal from outside, left
+// the user in a raw shell where the recovery (reset, or stty sane) is the
+// hardest thing there is to type. So the hand-back is deferred rather than
+// tail-called, and armed against the terminating signals as well.
+//
+// It is NOT a panic handler: nothing here recovers. The terminal comes back and
+// the panic still crashes the process with its stack trace, which is the only
+// way a real bug in the driver stays visible.
+type terminalHandback struct {
+	out      io.Writer
+	oldState *term.State
+	// mu guards restored/finished. A plain Once is not enough: the signal path can
+	// legitimately hand the terminal back and then take it BACK, so the state has
+	// to be readable and reversible rather than write-once.
+	mu       sync.Mutex
+	restored bool
+	// finished is set by release. It is what stops a signal watcher from retaking
+	// a terminal the attach has already given up for good — that would hand the
+	// user a raw shell, which is the bug, arrived at backwards.
+	finished bool
+	// stopWatch tears down the signal watch armed by beginTerminalHandback; nil
+	// when there was no raw mode to guard.
+	stopWatch func()
+}
+
+// handbackRetakeGrace is how long the signal watcher waits after re-raising a
+// signal before concluding that it could not terminate the process. A fatal
+// disposition kills us well inside this window; anything still running after it
+// was ignored.
+var handbackRetakeGrace = 200 * time.Millisecond
+
+// beginTerminalHandback arms the hand-back for an attach that has just put the
+// terminal into raw mode, and starts watching for the signals that would
+// otherwise kill the process with the terminal still borrowed. out is the
+// caller's already-snapshotted stdout seam; oldState is the termios MakeRaw
+// captured, and is nil when no raw mode was taken (a non-TTY, or a test driving
+// the proxy over pipes) — in which case there is nothing borrowed and nothing
+// to guard.
+func beginTerminalHandback(out io.Writer, oldState *term.State) *terminalHandback {
+	h := &terminalHandback{out: out, oldState: oldState}
+	if oldState == nil {
+		return h
+	}
+	// Watch only the signals that could actually kill this process. One inherited
+	// as ignored (nohup, a disowned job, a shell trap that ignores HUP — SIG_IGN
+	// survives execve) cannot, and notifying on it would be actively harmful:
+	// os/signal takes the ignore away to deliver it, then Reset puts the SAME
+	// ignore back, so the re-raise is discarded and the process lives on with a
+	// terminal it has already handed back while the attach is still proxying it.
+	// Nothing to guard against is the correct reading — leave those signals alone.
+	// Ignored must be asked BEFORE Notify, which reports false once a watch is
+	// armed.
+	watched := make([]os.Signal, 0, len(handbackSignals))
+	for _, sig := range handbackSignals {
+		if signal.Ignored(sig) {
+			continue
+		}
+		watched = append(watched, sig)
+	}
+	if len(watched) == 0 {
+		return h
+	}
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, watched...)
+	done := make(chan struct{})
+	var stopOnce sync.Once
+	h.stopWatch = func() {
+		stopOnce.Do(func() {
+			signal.Stop(sigs)
+			close(done)
+		})
+	}
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case sig := <-sigs:
+				h.restore()
+				// Then die exactly as we would have without the handler: reset the
+				// signal to its default disposition and re-raise it, so the process
+				// still terminates and still reports the signal in its wait status.
+				// Restoring and CONTINUING would be worse than not handling it —
+				// the attach would go on proxying a terminal it no longer owns.
+				signal.Reset(sig)
+				if s, ok := sig.(syscall.Signal); ok {
+					_ = syscall.Kill(os.Getpid(), s)
+				}
+				// Still here after the grace: that signal could not kill us, so the
+				// hand-back was premature and the attach still owns the terminal.
+				// TAKE IT BACK rather than proxying a raw byte stream to a cooked
+				// terminal. Without this the handler is WORSE than no handler at all
+				// for these signals, which ignored them and left the attach intact.
+				//
+				// Two ways to get here, and the filter above catches neither:
+				//   - the process inherited the signal as ignored, but something else
+				//     had already called Notify for it, so signal.Ignored could not
+				//     see it. Bubble Tea does exactly that for SIGINT/SIGTERM at
+				//     startup, which makes this the TUI's normal state, and Reset
+				//     restores that inherited ignore;
+				//   - the kernel suppresses the default action (pid 1 in a container).
+				//
+				// Looping also matters: returning would leave the remaining signals
+				// armed but unread, swallowing them for the rest of the process life.
+				time.Sleep(handbackRetakeGrace)
+				h.retake()
+			}
+		}
+	}()
+	return h
+}
+
+// restore hands the terminal back, at most once however many exits race for it.
+//
+// Two halves, both required: the pane program set modes on the terminal that no
+// termios restore touches (alt screen, mouse and paste reporting, keyboard
+// encoding), so the neutral restore drops those back to a plain terminal (#845,
+// local edition) before the termios itself goes back to whoever owned it before
+// the attach — bubbletea for the TUI, the shell for the CLI.
+func (h *terminalHandback) restore() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.restoreLocked()
+}
+
+func (h *terminalHandback) restoreLocked() {
+	if h.restored {
+		return
+	}
+	h.restored = true
+	_, _ = io.WriteString(h.out, tmux.NeutralTerminalRestore)
+	if h.oldState != nil {
+		_ = term.Restore(int(os.Stdin.Fd()), h.oldState)
+	}
+}
+
+// retake puts the terminal back into raw mode after a hand-back that turned out
+// to be premature — the signal it was made for could not end the process. The
+// attach is still running and still owns the terminal, so this restores the
+// invariant rather than leaving the two disagreeing.
+//
+// It deliberately does nothing once release has run: an attach that is over has
+// given the terminal up for good, and re-raw-ing it then would hand the user the
+// exact broken shell this file exists to prevent.
+func (h *terminalHandback) retake() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.finished || !h.restored || h.oldState == nil {
+		return
+	}
+	if _, err := term.MakeRaw(int(os.Stdin.Fd())); err != nil {
+		return // could not re-raw: a cooked terminal beats a wedged one
+	}
+	h.restored = false
+}
+
+// release is the deferred hand-back: restore, then stop the signal watch. Safe
+// to call after the signal path already restored — the terminal goes back
+// exactly once either way.
+//
+// The order is load-bearing. Disarming first would put the default disposition
+// back while the termios is still raw, so a signal landing in that window would
+// kill the process on exactly the exit this type exists to close. Restoring
+// first leaves only the harmless window: a signal after the terminal is already
+// back.
+func (h *terminalHandback) release() {
+	h.mu.Lock()
+	h.finished = true // no retake can follow the final hand-back
+	h.restoreLocked()
+	h.mu.Unlock()
+	if h.stopWatch != nil {
+		h.stopWatch()
+	}
+}

--- a/apiclient/attach_test.go
+++ b/apiclient/attach_test.go
@@ -201,7 +201,12 @@ func startDriverWithInput(t *testing.T, in io.Reader) (srvConn *websocket.Conn, 
 	input, err := newAttachInputReader(in)
 	require.NoError(t, err)
 	d := make(chan struct{})
-	go func() { defer close(d); driveAttachStream(sc.Conn, nil, input) }()
+	// nil termios: no raw mode was taken, so the hand-back writes the neutral
+	// restore to the captured stdout and touches no real terminal (and arms no
+	// signal watch). AttachStream is where production arms it, next to its
+	// MakeRaw; this stands in for that here.
+	handback := beginTerminalHandback(out, nil)
+	go func() { defer close(d); driveAttachStream(sc.Conn, handback, input) }()
 	return server, out, d
 }
 
@@ -454,6 +459,28 @@ func TestAttachStream_ServerExitClosesAttach(t *testing.T) {
 		t.Fatalf("write exit: %v", err)
 	}
 	waitClosed(t, done)
+}
+
+// TestAttachStream_ServerExitRestoresTheTerminal is the hand-back half of the
+// exit above. A pane that ends on its own is an exit the user never asked for,
+// and it owes the terminal back exactly like a detach does — the audit half of
+// #2784 that covers server disconnect. Unit-level companion to the real-pty
+// tests in attach_pty_test.go: this one pins the neutral restore bytes on the
+// stdout seam, those pin the termios.
+func TestAttachStream_ServerExitRestoresTheTerminal(t *testing.T) {
+	server, _, out, done := startDriver(t)
+	// Drain so the client's post-exit close handshake completes promptly.
+	go func() {
+		for {
+			if _, _, err := server.Read(context.Background()); err != nil {
+				return
+			}
+		}
+	}()
+	require.NoError(t, agentproto.WriteControl(context.Background(), server, agentproto.NewExitMessage(0)))
+	waitClosed(t, done)
+	require.True(t, strings.HasSuffix(out.String(), tmux.NeutralTerminalRestore),
+		"a server-side exit must hand the terminal back too; stdout ended with %q", out.String())
 }
 
 // TestAttachStream_ServerExitCancelsStdinBeforeReturning is the terminal


### PR DESCRIPTION
## Summary

A full-screen attach BORROWS the user's terminal: `AttachStream` puts the real
terminal into raw mode and the pane program then negotiates whatever modes it
likes onto it. The driver handed all of that back in its tail — which covers the
exits somebody wrote a handler for, and silently skips the ones nobody did.

- hand the terminal back from a `defer` that no exit can skip, panic included
- arm the same hand-back against the signals whose default disposition kills the
  process without running a single defer (SIGINT/SIGTERM/SIGHUP), restoring and
  then re-raising so the signal still means what it says — and skipping any of
  them this process inherited as IGNORED, which cannot kill it and must not be
  disturbed
- pin all four exits with tests that assert on the TERMIOS, not on a mock

Nothing recovers. The panic still crashes the process with its stack trace —
swallowing it would hide the bug the panic is reporting, and only the terminal
is this PR's business.

## Why this one is worse than it looks

The failure lands on the user's terminal rather than in af. A shell stuck in raw
mode has no echo and no line editing, so the recovery (`reset`, or `stty sane`)
is exactly the thing that is hardest to type in that state. Someone who does not
know the incantation closes the terminal and loses whatever else was in it.

## The audit — every exit from attach

| Exit | Before | After |
|---|---|---|
| Detach key | restored | restored (now via the defer) |
| Server disconnect / pane exit | restored | restored, and now pinned by a test |
| **Panic in the driver** | **terminal left raw** | **restored, panic still surfaces** |
| **Signal from outside** | **terminal left raw** | **restored, then re-raised** |
| Failed attach (dial error) | never took the terminal | unchanged, now guarded |
| Context cancellation | not an exit at all — see below | unchanged |

**Context cancellation** turned out not to be an exit path. `ctx` bounds the
dial only: a coder/websocket conn outlives its handshake context, which
`DialStream` already relies on (it cancels its own derived dial context for a
remote target before returning). I verified it rather than assumed it — a
throwaway test cancelled the dial context and then read a frame the server sent
afterwards, successfully. Both callers pass a context rooted at `Background`
anyway. That is now documented on `AttachStream` instead of being a surprise
waiting for whoever first wires a cancellable context through.

**Signals** are the interesting half. Keyboard signals are not the case: the
attach holds the terminal raw, so ISIG is off and ctrl+c is a byte the pane
receives. What reaches an attached process is an external kill, and its default
disposition terminates without running defers — the same bug as the panic, with
a different trigger. This does not fight Bubble Tea for the TUI: a full-screen
attach is bracketed by `ReleaseTerminal` (#2157), which sets bubbletea's
`ignoreSignals`, so today an attached TUI takes SIGINT/SIGTERM off its channel
and DISCARDS them — it outlives the signal AND leaves a raw terminal behind on
the ones it does not catch. After this, the terminal comes back and the signal
means what it says.

SIGQUIT is deliberately left alone: its default disposition in a Go program is
the runtime goroutine dump, which is worth more on a wedged attach than a
terminal the runtime is about to print a traceback onto anyway.

## Fail-first evidence

A unit test asserting that a restore function was called would pass against a
driver that hands back a terminal nobody can type into (the #2711 fake-shape
trap). So the new tests run the production attach on a REAL pty in a REAL child
process, then type into the terminal and require the line discipline to echo —
the assertion this issue is actually about. Both halves of the panic case are
required: the terminal comes back AND the panic reaches the user.

On master, before the fix:

```text
=== RUN   TestAttachStream_PanicHandsTheTerminalBack
    attach_pty_test.go:67: the attach panicked with the terminal in raw mode and never handed it back: the user is left in a shell with no echo and no line editing (#2784)
        typed "af-terminal-after-panic" into the terminal and the line discipline never echoed "af-terminal-after-panic\r\n" back (terminal still in raw mode)
--- FAIL: TestAttachStream_PanicHandsTheTerminalBack (5.05s)
=== RUN   TestAttachStream_SignalHandsTheTerminalBack
    attach_pty_test.go:86: the attached process was killed by SIGTERM with the terminal in raw mode and never handed it back (#2784)
        typed "af-terminal-after-signal" into the terminal and the line discipline never echoed "af-terminal-after-signal\r\n" back (terminal still in raw mode)
--- FAIL: TestAttachStream_SignalHandsTheTerminalBack (5.06s)
```

Both pass after. The panic assertions (`require.Error`, panic text present,
stack trace present) pass on BOTH sides — that is the point: the fix changes the
terminal, not the crash.

Two supporting tests are green on master by design, so their teeth were checked
by mutation rather than claimed:

- `TestAttachStream_FailedAttachLeavesTheTerminalAlone` — moving the `MakeRaw`
  above the `DialStream` call fails it exactly as the comment says it would.
- `TestAttachStream_ServerExitRestoresTheTerminal` — the unit-level pin for the
  disconnect exit #2699 touched, which nothing asserted the hand-back for.

The panic is injected through `attachTermSize`, an EXISTING production seam that
`driveAttachStream` calls on its own goroutine — no test-only hook in the driver,
and it lands the panic exactly where the report describes it: after the terminal
is raw, before the hand-back.

## Review round

Codex raised three P2s and all three were real; each is fixed, and the fixes are
in the diff rather than in a reply:

1. **Restore before disarming.** `release()` stopped the signal watch first, so
   a signal landing between the default disposition coming back and the termios
   going back would have killed the process raw — the exact exit this closes.
   Restore now runs first.
2. **Do not trap signals inherited as ignored.** Under `nohup`, a disowned job,
   or a shell trap, `Notify` takes the ignore away to deliver the signal and
   `Reset` puts the same ignore back, so the re-raise is discarded — leaving a
   live attach proxying a terminal it had already handed back. Those signals are
   now filtered out with `signal.Ignored` before the watch is armed.
3. **Arm before exposing the raw terminal.** The guard went up inside the driver
   goroutine, after `AttachStream` had already called `MakeRaw`. It is now armed
   in the statement right after the one that takes the terminal, and the driver
   receives the hand-back instead of the raw termios.

Chasing (2) turned up one more, unprompted: the watcher handled a single signal
and returned, which left the other watched signals armed but unread — silently
swallowing them for the rest of the process's life on any path where the
re-raise cannot kill (pid 1 in a container). It now loops.

`TestAttachStream_IgnoredSignalDoesNotDisturbTheAttach` pins (2) end to end: the
child inherits SIGHUP as ignored from a real shell trap, and after the signal the
attach must still be reading the terminal with no local echo and no hand-back
bytes written. Deleting the guard fails it **15/15**; the correct build passes it
**6/6**. Findings (1) and (3) close windows measured in microseconds — no
deterministic test is possible for those, and I did not fake one.

## What CI caught that local runs could not

**Round 1 — all four pty tests, macOS only**, on the write that probes the
terminal AFTER the child exits (`write /dev/ptmx: input/output error`). Nothing
else in the suite failed on any platform: the harness, not the fix. On BSD a
session leader that EXITS revokes its controlling terminal, invalidating every
descriptor for that pty in every process. Linux does not.

**Round 2 — one test left, the only one wrapped in `/bin/sh`.** Dropping
`Setctty` was not enough, because the same rule has a second half: a session
leader that OPENS a terminal ACQUIRES it as a controlling terminal, and the shell
touches the terminal where a Go binary never does. So it took the ctty straight
back. `Setsid` is gone too — neither it nor `Setctty` is needed for what these
tests measure, and on darwin both are harness poison.

That fix is confirmed: on the next macOS run `ok apiclient 7.418s`. That job was
still red, but on `TestStopForInstance_ReconcilesPersistedOwnerAfterInMemoryStop`
in `daemon` — a VS Code teardown test that signals a process group, unrelated to
anything here, which passed on this same branch twice before. It is already filed
as **#2823, "flaky (macOS): processGroupAlive turns an EPERM from a reused PGID
into a teardown failure"**. Pre-existing, not this PR.

## Review rounds

Two passes, five P2s, all real; the fixes are in the diff rather than in replies.

**First pass** — restore before disarming (the old order re-exposed the default
disposition while the termios was still raw); skip signals inherited as ignored;
arm the hand-back next to the `MakeRaw` that takes the terminal rather than
inside the driver goroutine. Chasing the second one turned up one more,
unprompted: the watcher handled a single signal and returned, leaving the others
armed but unread — silently swallowing them for the rest of the process's life.
It now loops.

**Second pass** found the hole in that ignored-signal filter, and it is the
sharper finding of the two rounds. `signal.Ignored` only reports an inherited
`SIG_IGN` while nothing has called `Notify` for that signal — and Bubble Tea
calls `signal.Notify(SIGINT, SIGTERM)` at program start. So in the TUI the filter
reports "not ignored", the watch arms, and `signal.Reset` then restores the
inherited ignore, discarding the re-raise. The process survives a signal it just
handed the terminal back for, and keeps proxying raw bytes to a cooked terminal —
WORSE than no handler, since the unpatched code ignored those signals and left
the attach intact.

Neither remedy the review proposed is right. `os.Exit` would kill a process
explicitly configured to survive that signal (`nohup af sessions attach` dying on
the HUP it was told to ignore is a bigger regression than the bug). "Do not
restore for signals that cannot terminate" is what the filter already attempts
and provably cannot do in the TUI. So: **restore, ask to die, and if we are still
alive after a grace period, take the terminal back.** No prediction required, and
for an unkillable signal the end state is now identical to the unpatched code.
`release()` sets a `finished` flag under the same mutex, so a late retake can
never re-raw a terminal the attach has already given up — that would be this bug
arrived at backwards.

The 200ms grace is a timing margin, not a proof: a signal that really is fatal
must kill the process before anything re-raws a terminal it is about to abandon.
It is the one part of this I would replace if a deterministic signal existed.

## Fail-first evidence

A unit test asserting that a restore function was called would pass against a
driver that hands back a terminal nobody can type into (the #2711 fake-shape
trap). So the new tests run the production attach on a REAL pty in a REAL child
process, then type into the terminal and require the line discipline to echo —
the assertion this issue is actually about. Both halves of the panic case are
required: the terminal comes back AND the panic reaches the user.

On master, before the fix:

```text
=== RUN   TestAttachStream_PanicHandsTheTerminalBack
    attach_pty_test.go:67: the attach panicked with the terminal in raw mode and never handed it back: the user is left in a shell with no echo and no line editing (#2784)
        typed "af-terminal-after-panic" into the terminal and the line discipline never echoed "af-terminal-after-panic\r\n" back (terminal still in raw mode)
--- FAIL: TestAttachStream_PanicHandsTheTerminalBack (5.05s)
=== RUN   TestAttachStream_SignalHandsTheTerminalBack
    attach_pty_test.go:86: the attached process was killed by SIGTERM with the terminal in raw mode and never handed it back (#2784)
        typed "af-terminal-after-signal" into the terminal and the line discipline never echoed "af-terminal-after-signal\r\n" back (terminal still in raw mode)
--- FAIL: TestAttachStream_SignalHandsTheTerminalBack (5.06s)
```

Both pass after. The panic assertions (`require.Error`, panic text present,
stack trace present) pass on BOTH sides — that is the point: the fix changes the
terminal, not the crash.

Two supporting tests are green on master by design, so their teeth were checked
by mutation rather than claimed:

- `TestAttachStream_FailedAttachLeavesTheTerminalAlone` — moving the `MakeRaw`
  above the `DialStream` call fails it exactly as the comment says it would.
- `TestAttachStream_ServerExitRestoresTheTerminal` — the unit-level pin for the
  disconnect exit #2699 touched, which nothing asserted the hand-back for.

The panic is injected through `attachTermSize`, an EXISTING production seam that
`driveAttachStream` calls on its own goroutine — no test-only hook in the driver,
and it lands the panic exactly where the report describes it: after the terminal
is raw, before the hand-back.

## Review round

Codex raised three P2s and all three were real; each is fixed, and the fixes are
in the diff rather than in a reply:

1. **Restore before disarming.** `release()` stopped the signal watch first, so
   a signal landing between the default disposition coming back and the termios
   going back would have killed the process raw — the exact exit this closes.
   Restore now runs first.
2. **Do not trap signals inherited as ignored.** Under `nohup`, a disowned job,
   or a shell trap, `Notify` takes the ignore away to deliver the signal and
   `Reset` puts the same ignore back, so the re-raise is discarded — leaving a
   live attach proxying a terminal it had already handed back. Those signals are
   now filtered out with `signal.Ignored` before the watch is armed.
3. **Arm before exposing the raw terminal.** The guard went up inside the driver
   goroutine, after `AttachStream` had already called `MakeRaw`. It is now armed
   in the statement right after the one that takes the terminal, and the driver
   receives the hand-back instead of the raw termios.

Chasing (2) turned up one more, unprompted: the watcher handled a single signal
and returned, which left the other watched signals armed but unread — silently
swallowing them for the rest of the process's life on any path where the
re-raise cannot kill (pid 1 in a container). It now loops.

`TestAttachStream_IgnoredSignalDoesNotDisturbTheAttach` pins (2) end to end: the
child inherits SIGHUP as ignored from a real shell trap, and after the signal the
attach must still be reading the terminal with no local echo and no hand-back
bytes written. Deleting the guard fails it **15/15**; the correct build passes it
**6/6**. Findings (1) and (3) close windows measured in microseconds — no
deterministic test is possible for those, and I did not fake one.

## What CI caught that local runs could not

The macOS leg failed all four pty tests, identically, on the write that probes
the terminal AFTER the child exits:

```text
Error:   Received unexpected error:
         write /dev/ptmx: input/output error
Messages: type into the terminal
```

Nothing else in the suite failed, on any platform — this was the harness, not
the fix. On BSD a session leader exiting REVOKES its controlling terminal, which
invalidates every descriptor for that pty in every process, so the probe got EIO
instead of an answer; Linux does not do that. The child asked for the pty as its
controlling terminal (`Setctty`) purely for realism, and nothing under test needs
one — the hand-back is a `tcsetattr` on fd 0 plus escape sequences, and the tests
signal the child by pid rather than through the terminal. `Setsid` stays,
`Setctty` is gone, and a write that fails outright now reports itself as a
harness failure rather than as a raw terminal.

## Fail-first evidence

A unit test asserting that a restore function was called would pass against a
driver that hands back a terminal nobody can type into (the #2711 fake-shape
trap). So the tests run the production attach on a REAL pty in a REAL child
process, then type into the terminal and require the line discipline to echo —
the assertion this issue is actually about. Both halves of the panic case are
required: the terminal comes back AND the panic reaches the user.

Against the pre-fix driver (restore tail-called, no signal watch), re-run with
the FINAL harness so the evidence matches what ships:

```text
--- FAIL: TestAttachStream_PanicHandsTheTerminalBack
    the attach panicked with the terminal in raw mode and never handed it back:
    the user is left in a shell with no echo and no line editing (#2784)
    typed "af-terminal-after-panic" into the terminal and the line discipline
    never echoed "af-terminal-after-panic\r\n" back (terminal still in raw mode)
--- FAIL: TestAttachStream_SignalHandsTheTerminalBack
    the attached process was killed by SIGTERM with the terminal in raw mode and
    never handed it back (#2784)
--- FAIL: TestAttachStream_IgnoredSignalDoesNotDisturbTheAttach
    SIGTERM after an ignored SIGHUP left the terminal unusable (#2784)
```

All pass after. The panic assertions (`require.Error`, panic text present, stack
trace present) pass on BOTH sides — that is the point: the fix changes the
terminal, not the crash.

`TestAttachStream_FailedAttachLeavesTheTerminalAlone` is green on master by
design, so its teeth were checked by mutation instead: moving the `MakeRaw` above
the `DialStream` call fails it exactly as its comment says.

The panic is injected through `attachTermSize`, an EXISTING production seam that
`driveAttachStream` calls on its own goroutine — no test-only hook in the driver,
and it lands the panic exactly where the report describes it: after the terminal
is raw, before the hand-back.

## Validation

On the pushed head `59a73218673fed7690ac749d91c1b453916d1c73`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (empty)
- `go build ./...`
- `deadcode -test ./...` (empty)
- `scripts/lint-file-length.sh` (1142 files, 0 grandfathered)
- `go test ./apiclient -race` (repeatedly) — the only package this touches

The full matrix is CI's job, per the 2026-08-04 policy: no local container suite
was run for this revision.

Each guard was proven by mutation rather than assumed:

| Mechanism | Delete it and | Correct build |
|---|---|---|
| ignored-signal filter | ignored-HUP test fails 6/6 | passes |
| retake after a non-fatal re-raise | unkillable-INT test fails 6/6 | passes |
| `MakeRaw` before the dial | failed-attach guard fails | passes |

These tests were flaky four ways before they were right, and each was fixed
rather than retried:

- the parent asserted on pty output the instant the child exited, racing the
  drain of the panic trace — it now waits for the output;
- the signal case could signal the child before the driver armed the hand-back,
  so READY now means the driver has sent its initial RESIZE frame, which is
  strictly after the arming;
- the round-trip probe assumed it owned the whole input stream, but a terminal
  hands the attach whatever was queued on it beforehand — it now anchors its
  match to the report line;
- the ignored-signal case inspected the terminal before the signal could have
  been handled, which passed against a build that mishandled it — it now forces
  a full round trip in between (mutation detection went from 12/13 to 15/15).

Related: #2699, #2671, #2157.

Closes #2784