### PR TITLE
fix(tui): refuse session creation with no active project instead of a dead form

### DIFF
--- a/app/backend_picker_test.go
+++ b/app/backend_picker_test.go
@@ -466,6 +466,7 @@ func TestStartNewInstanceResetsTheBackendField(t *testing.T) {
 	t.Chdir(repoDir)
 
 	h := newTestHome(t)
+	h.repoRoot = repoDir
 	h.errBox.SetSize(120, 1)
 	h.pendingBackend = config.BackendDocker
 

--- a/app/cli_daemon_integration_test.go
+++ b/app/cli_daemon_integration_test.go
@@ -37,6 +37,7 @@ func TestTUIRefreshSeesCLIChangesThroughDaemon(t *testing.T) {
 	repo, err := config.CurrentRepo()
 	require.NoError(t, err)
 	h.repoID = repo.ID
+	h.repoRoot = repo.Root
 	writeIntegrationConfig(t, os.Getenv("AGENT_FACTORY_HOME"))
 
 	t.Cleanup(func() {
@@ -79,6 +80,7 @@ func TestTUIRefreshSwapsKillRecreatedSameTitle(t *testing.T) {
 	repo, err := config.CurrentRepo()
 	require.NoError(t, err)
 	h.repoID = repo.ID
+	h.repoRoot = repo.Root
 	writeIntegrationConfig(t, os.Getenv("AGENT_FACTORY_HOME"))
 
 	t.Cleanup(func() {
@@ -243,6 +245,7 @@ func TestTUIRefreshDoesNotSwapLoadingPlaceholder(t *testing.T) {
 	repo, err := config.CurrentRepo()
 	require.NoError(t, err)
 	h.repoID = repo.ID
+	h.repoRoot = repo.Root
 	writeIntegrationConfig(t, os.Getenv("AGENT_FACTORY_HOME"))
 
 	t.Cleanup(func() {

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -26,9 +26,27 @@ import (
 	"github.com/sachiniyer/agent-factory/ui/store"
 )
 
+// activeProjectHome is newTestHome plus the active project an ordinary run
+// always has.
+//
+// newTestHome leaves repoRoot empty, and production only reaches that state in
+// registry mode (launched outside a git repo, #2477) — where session creation
+// refuses outright rather than opening a naming form it cannot submit (#2764).
+// So a test that drives the naming/create flow has to name the project the
+// session goes into. Tests that already chdir'd into a repo they assert against
+// assign that root directly instead of minting a second one here.
+func activeProjectHome(t *testing.T) *home {
+	t.Helper()
+	h := newTestHome(t)
+	h.repoRoot = setupRealRepo(t)
+	return h
+}
+
 // newTestHome builds a minimal home with real UI components and a tempdir-
 // scoped storage. AGENT_FACTORY_HOME is redirected so nothing escapes into
 // the user's real config dir.
+//
+// repoRoot is deliberately left empty — see activeProjectHome.
 func newTestHome(t *testing.T) *home {
 	t.Helper()
 	tmp := testguard.SocketTempDir(t)

--- a/app/e2e_test.go
+++ b/app/e2e_test.go
@@ -80,7 +80,7 @@ func newE2EHarness(t *testing.T) *e2eHarness {
 	if testing.Short() {
 		t.Skip("timing-sensitive E2E flow; skipped under -short — see #2052")
 	}
-	h := newTestHome(t)
+	h := activeProjectHome(t)
 	eh := &e2eHarness{t: t, home: h}
 
 	restoreBackend := session.SetBackendFactoryForTest(func(opts session.InstanceOptions, absPath string) (session.Backend, error) {

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"unicode"
@@ -296,6 +297,26 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // startNewInstance creates a new instance and enters stateNew for naming.
 // If remote is true, the instance is forced to use the remote hook backend.
 func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
+	// A session lives in a project, and registry mode has none until the user
+	// selects one (#2477) — so refuse here rather than opening a form that cannot
+	// be submitted (#2764).
+	//
+	// The old fallback to the process cwd was written when m.repoRoot was always
+	// the launch repo, and #2477 made it reachable with no repo behind it: the
+	// naming form opened, the user typed a name, and the create failed only on
+	// submit, daemon-side, with `failed to get git repo root for <cwd>: exit
+	// status 128`. Nothing in that sentence tells them a project has to be picked
+	// first, and by then they had already done the work of naming the session.
+	//
+	// Both keys, not just `n`. `N` did refuse in registry mode, but by asking the
+	// cwd about remote_hooks and reporting that repo-shaped answer — sending a
+	// user with no project selected off to configure hooks for a directory that
+	// is not even a project. Ahead of that check, this one names the actual
+	// blocker, which is also why nothing below needs a repo-less path anymore.
+	if m.repoRoot == "" {
+		return m, m.handleNotice(errors.New(
+			"select a project first — af is running with no active project, so there is no repo for this session to live in. Press ctrl+p to pick one"))
+	}
 	m.pendingProgram = m.program
 	// Every create starts with an empty prompt field and an unchosen backend. The
 	// cancel paths clear both too, but this is the authoritative reset: it also
@@ -309,11 +330,9 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 	// Target the ACTIVE project's repo root, not the process cwd: after an
 	// in-place project switch (#1461) the active repo is m.repoRoot, which may no
 	// longer be where af was launched. At launch m.repoRoot is the cwd's repo, so
-	// this is equivalent for the unswitched case.
+	// this is equivalent for the unswitched case. The guard above guarantees it is
+	// set.
 	repoPath := m.repoRoot
-	if repoPath == "" {
-		repoPath = "."
-	}
 	if remote {
 		configured, err := session.RemoteHooksConfiguredForPath(repoPath)
 		if err != nil {

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -313,9 +313,14 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 	// user with no project selected off to configure hooks for a directory that
 	// is not even a project. Ahead of that check, this one names the actual
 	// blocker, which is also why nothing below needs a repo-less path anymore.
+	//
+	// The action and its key lead the sentence, and the explanation trails: the
+	// transient notice clips to the terminal width and the TAIL is what vanishes
+	// (#1973), so at 120 columns "Press ctrl+p" placed last was the part that
+	// disappeared — leaving a message that named a problem and no way out.
 	if m.repoRoot == "" {
 		return m, m.handleNotice(errors.New(
-			"select a project first — af is running with no active project, so there is no repo for this session to live in. Press ctrl+p to pick one"))
+			"select a project first — press ctrl+p to pick one; af is running with no active project, so there is no repo for this session to live in"))
 	}
 	m.pendingProgram = m.program
 	// Every create starts with an empty prompt field and an unchosen backend. The

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -7,6 +7,7 @@ import (
 	"unicode"
 
 	"github.com/sachiniyer/agent-factory/internal/namegen"
+	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
@@ -313,14 +314,8 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 	// user with no project selected off to configure hooks for a directory that
 	// is not even a project. Ahead of that check, this one names the actual
 	// blocker, which is also why nothing below needs a repo-less path anymore.
-	//
-	// The action and its key lead the sentence, and the explanation trails: the
-	// transient notice clips to the terminal width and the TAIL is what vanishes
-	// (#1973), so at 120 columns "Press ctrl+p" placed last was the part that
-	// disappeared — leaving a message that named a problem and no way out.
 	if m.repoRoot == "" {
-		return m, m.handleNotice(errors.New(
-			"select a project first — press ctrl+p to pick one; af is running with no active project, so there is no repo for this session to live in"))
+		return m, m.handleNotice(errors.New(noActiveProjectNotice()))
 	}
 	m.pendingProgram = m.program
 	// Every create starts with an empty prompt field and an unchosen backend. The
@@ -409,6 +404,28 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 	m.menu.SetNamingBackend(false)
 	m.menu.SetState(ui.StateNewInstance)
 	return m, nil
+}
+
+// noActiveProjectNotice is the refusal a create gets with no active project.
+//
+// The action and its key LEAD the sentence and the explanation trails: the
+// transient notice clips to the terminal width and the TAIL is what vanishes
+// (#1973). Driving the real TUI at 120 columns with the explanation first cut
+// exactly the recovery step, leaving a message that named a problem and no way
+// out of it.
+//
+// The key is read from the binding rather than spelled here, because
+// switch_project is REBINDABLE (`[keys]` config) — keys.go's own note on
+// KeySetPrompt calls out that hardcoding ctrl+p "would silently drift the day a
+// user rebinds that action". A user who unbound it entirely gets the section
+// instead of a key that does nothing.
+func noActiveProjectNotice() string {
+	pick := "pick one in the Projects section"
+	if k := keys.GlobalKeyBindings[keys.KeySwitchProject].Help().Key; k != "" {
+		pick = fmt.Sprintf("press %s to pick one", k)
+	}
+	return "select a project first — " + pick +
+		"; af is running with no active project, so there is no repo for this session to live in"
 }
 
 // suggestSessionName picks a readable random "adjective-noun" name for the

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -114,7 +114,7 @@ func TestHandleMenuHighlightingDoesNotInterceptNamingText(t *testing.T) {
 }
 
 func TestNamingProgramPickerTitleUsesSentenceCase(t *testing.T) {
-	h := newTestHome(t)
+	h := activeProjectHome(t)
 	resizeHome(h, 80, 24)
 	_, _ = h.startNewInstance(false)
 	require.Equal(t, stateNew, h.state)
@@ -185,7 +185,7 @@ func TestHandleMenuHighlightingNewInstanceActions(t *testing.T) {
 }
 
 func TestStartNewInstanceSelectsNamingInstanceAfterSortedInsert(t *testing.T) {
-	h := newTestHome(t)
+	h := activeProjectHome(t)
 
 	existing, err := session.NewInstance(session.InstanceOptions{
 		Title:   "existing",
@@ -225,6 +225,7 @@ func TestStartNewRemoteWithoutHooksExplains(t *testing.T) {
 	t.Chdir(repoDir)
 
 	h := newTestHome(t)
+	h.repoRoot = repoDir
 	h.errBox.SetSize(120, 1)
 
 	model, cmd := h.startNewInstance(true)
@@ -251,6 +252,7 @@ func TestStartNewRemoteWithoutHooksLeadsWithTheCause(t *testing.T) {
 	t.Chdir(repoDir)
 
 	h := newTestHome(t)
+	h.repoRoot = repoDir
 	h.errBox.SetSize(120, 1)
 
 	h.startNewInstance(true)
@@ -268,6 +270,7 @@ func TestStartNewRemoteInvalidHooksStillErrors(t *testing.T) {
 	t.Chdir(repoDir)
 
 	h := newTestHome(t)
+	h.repoRoot = repoDir
 	h.errBox.SetSize(120, 1)
 	repo, err := config.CurrentRepo()
 	require.NoError(t, err)
@@ -423,7 +426,7 @@ func TestHandleStateNewPreflightErrorKeepsNamingFlow(t *testing.T) {
 // NOT be silently replaced by it — the shadow name is gone the moment a space is
 // typed, so adopting it would create a name that was never on screen.
 func TestHandleStateNewWhitespaceViaRealInput(t *testing.T) {
-	h := newTestHome(t)
+	h := activeProjectHome(t)
 	h.errBox.SetSize(120, 1)
 
 	_, _ = h.startNewInstance(false)
@@ -670,7 +673,7 @@ func TestNamingCreateFlow_NoDoubleTransition(t *testing.T) {
 // the name field left untouched, pressing enter adopts the generated shadow
 // placeholder as the session title instead of erroring "title cannot be empty".
 func TestHandleStateNewEmptySubmitAdoptsPlaceholder(t *testing.T) {
-	h := newTestHome(t)
+	h := activeProjectHome(t)
 	t.Cleanup(SetLocalSessionPreflightForTest(func(*config.Config, string) error { return nil }))
 
 	_, _ = h.startNewInstance(false)
@@ -696,7 +699,7 @@ func TestHandleStateNewEmptySubmitAdoptsPlaceholder(t *testing.T) {
 // still EMPTY, so the row keeps showing the shadow placeholder rather than a real,
 // full-contrast name the user never chose and would have to backspace out.
 func TestHandleStateNewEmptySubmitFailedGateKeepsPlaceholder(t *testing.T) {
-	h := newTestHome(t)
+	h := activeProjectHome(t)
 	h.errBox.SetSize(120, 1)
 	t.Cleanup(SetLocalSessionPreflightForTest(func(*config.Config, string) error {
 		return errors.New("Claude Code is not installed or not on PATH")
@@ -730,7 +733,7 @@ func TestCancelNamingClearsPlaceholder(t *testing.T) {
 		{"ctrl+c", tea.KeyMsg{Type: tea.KeyCtrlC}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			h := newTestHome(t)
+			h := activeProjectHome(t)
 			_, _ = h.startNewInstance(false)
 			require.NotNil(t, h.namingInstance)
 			require.NotEmpty(t, h.namingPlaceholder, "precondition: a placeholder was generated")

--- a/app/initial_prompt_test.go
+++ b/app/initial_prompt_test.go
@@ -277,7 +277,7 @@ func TestStartNewInstanceResetsThePromptField(t *testing.T) {
 	repoDir := setupRealRepo(t)
 	t.Chdir(repoDir)
 
-	h := newTestHome(t)
+	h := activeProjectHome(t)
 	h.errBox.SetSize(120, 1)
 	h.pendingPrompt = "a prompt stranded by some earlier create"
 

--- a/app/real_e2e_test.go
+++ b/app/real_e2e_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
@@ -156,6 +157,11 @@ func TestRealLocalBackend_FullLifecycle(t *testing.T) {
 func newRealE2EHarness(t *testing.T) *e2eHarness {
 	t.Helper()
 	h := newTestHome(t)
+	// The caller has already chdir'd into the real repo these flows drive, and
+	// that repo is the active project a create targets (#2764).
+	if repo, err := config.CurrentRepo(); err == nil {
+		h.repoRoot = repo.Root
+	}
 	eh := &e2eHarness{t: t, home: h}
 	installDirectSessionStarter(t)
 

--- a/app/registry_mode_create_test.go
+++ b/app/registry_mode_create_test.go
@@ -1,0 +1,75 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStartNewInstanceInRegistryModeRefusesWithoutProject is the #2764
+// regression guard.
+//
+// Registry mode (#2477) launches the TUI outside a git repository, so there is
+// no active project until the user picks one — m.repoRoot is empty. Session
+// creation substituted the process cwd for it and opened the naming form
+// anyway, so the user typed a name, pressed enter, and only THEN learned it
+// could not work: the daemon resolved the non-git cwd and answered `failed to
+// get git repo root for <path>: exit status 128`.
+//
+// Both creation keys are covered. `N` already refused early in registry mode,
+// but for the wrong reason and with the wrong words — it reported the cwd as a
+// repo with no remote_hooks configured, which tells a user with no project
+// selected to go configure something.
+func TestStartNewInstanceInRegistryModeRefusesWithoutProject(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		remote bool
+	}{
+		{name: "local", remote: false},
+		{name: "remote", remote: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			// Registry mode: launched outside a repo, no project selected yet.
+			h.repoRoot = ""
+			h.errBox.SetSize(200, 1)
+
+			model, cmd := h.startNewInstance(tc.remote)
+
+			require.Same(t, h, model)
+			require.NotNil(t, cmd, "an advertised key must produce a visible outcome, never a swallowed keypress")
+			// The dead end is the bug: no form to fill in, so nothing to submit.
+			assert.Equal(t, stateDefault, h.state, "the naming form must not open when no project can receive the session")
+			assert.Nil(t, h.namingInstance)
+			assert.Equal(t, 0, h.store.NumInstances(), "no placeholder row may be left behind")
+
+			full := h.errBox.FullError()
+			assert.Contains(t, full, "select a project",
+				"the message must name the action that unblocks the user, not a git error from the daemon")
+			assert.NotContains(t, full, "exit status 128",
+				"the cryptic daemon-side git failure is exactly what this guard exists to prevent")
+		})
+	}
+}
+
+// TestStartNewInstanceWithActiveProjectStillOpensNaming is the non-regression
+// half: with a project active — which is every non-registry-mode run, and
+// registry mode itself once a project is selected — both keys still open the
+// naming form exactly as before.
+func TestStartNewInstanceWithActiveProjectStillOpensNaming(t *testing.T) {
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+
+	h := newTestHome(t)
+	h.repoRoot = repoDir
+
+	model, cmd := h.startNewInstance(false)
+
+	require.Same(t, h, model)
+	require.Nil(t, cmd)
+	assert.Equal(t, stateNew, h.state)
+	require.NotNil(t, h.namingInstance)
+	assert.Equal(t, repoDir, h.namingInstance.Path,
+		"the placeholder must target the ACTIVE project's repo root")
+}

--- a/app/registry_mode_create_test.go
+++ b/app/registry_mode_create_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,6 +50,15 @@ func TestStartNewInstanceInRegistryModeRefusesWithoutProject(t *testing.T) {
 				"the message must name the action that unblocks the user, not a git error from the daemon")
 			assert.NotContains(t, full, "exit status 128",
 				"the cryptic daemon-side git failure is exactly what this guard exists to prevent")
+			// The notice clips to the terminal width and the TAIL is what vanishes
+			// (#1973), so the key that unblocks the user has to arrive before the
+			// explanation — at 120 columns a trailing "press ctrl+p" is cut, which
+			// was the shape the first real-TUI drive of this guard produced.
+			action := strings.Index(full, "ctrl+p")
+			why := strings.Index(full, "no active project")
+			require.NotEqual(t, -1, action, "the message must name the key that picks a project")
+			require.NotEqual(t, -1, why)
+			assert.Less(t, action, why, "the action must survive width-clipping; the explanation is the part that may be cut")
 		})
 	}
 }


### PR DESCRIPTION
Registry mode (#2477) launches the TUI outside a git repository, so there is no
active project until the user picks one — `m.repoRoot` is empty.
`startNewInstance` substituted the process cwd for it and opened the naming form
anyway, so `n` was a dead end: the user typed a name, pressed enter, and only
then learned it could not work, from a daemon-side
`failed to get git repo root for <cwd>: exit status 128`. Nothing in that
sentence says a project has to be picked first, and by then they had already
done the work of naming the session.

The cwd fallback was written when `m.repoRoot` was always the launch repo
(#1461's in-place project switch). #2477 made it reachable with no repo behind
it.

## Fix

Guard the entry and drop the fallback, so the refusal happens before any work —
the same shape the cold-start, tasks and hooks paths already use for registry
mode. The message names the action that unblocks the user:

    select a project first — af is running with no active project, so there is
    no repo for this session to live in. Press ctrl+p to pick one

Both creation keys, not just `n`. `N` did refuse in registry mode, but by asking
the cwd about `remote_hooks` and reporting that repo-shaped answer — sending a
user with no project selected off to configure hooks for a directory that is not
a project.

Nothing changes once a project is active, which is every ordinary run and
registry mode itself after a selection (`switchProject` sets `repoRoot`).

## The test-fixture change is part of the finding

`newTestHome` left `repoRoot` empty for **every** test. That stood in for
registry mode by accident and let the whole creation flow be exercised against
the process cwd — which is why no existing test noticed the dead end. Tests that
drive creation now name the project the session goes into (`activeProjectHome`,
or the repo they already `t.Chdir`'d into), and registry mode became something a
test opts into explicitly.

Setting `repoRoot` globally in the fixture was tried and rejected: an active
project also enters the projects enumeration, which breaks the delete-project
tests. The narrower change keeps the blast radius on creation.

## Second review round

Codex found three things on the first pass; two were real and are fixed:

- **A missed fixture.** `TestStartNewInstanceResetsTheBackendField` modelled an
  ordinary launch only by `t.Chdir` and left `repoRoot` empty, so the guard
  turned its `require.Nil(cmd)` red. Given the active project.
- **A hardcoded `ctrl+p`.** `switch_project` is rebindable through the `[keys]`
  config, and `keys.go`'s own note on `KeySetPrompt` already warns that
  hardcoding it "would silently drift the day a user rebinds that action". The
  notice now reads the key from its binding, and names the Projects section
  instead for a user who unbound it entirely.

The third — that the captive Projects section swallows `n` before this guard is
reached — is a correct observation (I hit it in the play-test above) but the
suppression is `handleProjectsFocus`'s deliberate contract from #1620, which
names the session-create verbs specifically. Undoing that inside a fix for a
different symptom is not the right way to revisit it, so it is split to **#2830**
with three options and a recommendation.

## Verification

- New `app/registry_mode_create_test.go`, watched **failing** on master first:
  the local case produced `cmd == nil` (the silent form opening — the dead end
  itself), and the remote case produced the `remote_hooks` message instead of a
  project one. The clip-ordering assertion is pinned too.
- Full local gate on `e80dbb20`: `golangci-lint --fast`, `gofmt -l .` (empty),
  `go build ./...`, `deadcode -test ./...`, `scripts/lint-file-length.sh`, and
  `make test-container` — **exit 0, 47 packages, `app` / `daemon` / `session/tmux`
  all green**.

  Worth stating plainly: my first report of a clean suite here was wrong. I read
  the exit code of `make test-container … | tail`, which is `tail`'s, so the
  failing `app` package looked green. CI caught it (`Build` red at `8189a5ea`,
  same test Codex named). The gate above was re-run with the exit code actually
  captured.

Closes #2764

🤖 Generated with [Claude Code](https://claude.com/claude-code)