### PR TITLE
fix(ui): stop the task editor echoing a Custom cron three times

### DIFF
--- a/scripts/tui-2596-scenario.sh
+++ b/scripts/tui-2596-scenario.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Real-TUI regression for #2596, via:
+#
+#   scripts/testbox.sh scenario scripts/tui-2596-scenario.sh
+#
+# Opening a Custom (cron) task in the editor used to print its expression three
+# times in two lines: once in the editable Cron input, then twice more on the
+# preview line, because Describe() ("Custom: <raw>") and Cron() (<raw>) collapse
+# to the same string for Custom. A render-string unit test can miss this — the
+# duplicate is only obviously wrong on the assembled screen — so this drives the
+# real TUI and reads the pane.
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source /src/scripts/tui-driver.sh
+
+export AF_DRIVER_COLS=120 AF_DRIVER_ROWS=30
+export AF_DRIVER_REPO="$HOME/sandbox/mock-repo"
+
+# The month field is restricted, so no preset matches and schedule.ParseCron
+# falls the picker back to Custom with the expression preserved verbatim.
+CRON='0 0 1 1 *'
+
+af_reset_sandbox
+af_set_config 'default_program = "claude"
+
+[program_overrides]
+claude = "bash"'
+
+af_boot
+
+bin="$(_af_resolve_bin)"
+"$bin" tasks add --repo "$AF_DRIVER_REPO" --name yearly-audit \
+    --cron "$CRON" --prompt 'echo TASK-RAN-OK' >/dev/null
+
+# `m` opens straight into the RAIL-selected task's config (#1249), so the rail
+# has to have picked the new task up before the editor can show its schedule.
+af_wait_for 'yearly-audit' "$AF_DRIVER_TIMEOUT" 'task lands in the automations rail'
+af_open_tasks
+af_wait_for 'Custom \(cron\)' "$AF_DRIVER_TIMEOUT" 'schedule picker opens on Custom'
+
+cron_re="$(_af_regex_escape "$CRON")"
+
+# The defect itself: the same expression twice on one rendered line. Matched
+# without naming the separator, so a later copy change to " · " cannot quietly
+# stop this from detecting a repeat.
+af_refute_screen "${cron_re}.*${cron_re}" \
+    '#2596: the expression is not printed twice on one line'
+af_refute_screen "Custom: ${cron_re}" \
+    "#2596: Describe()'s \"Custom: <raw>\" echo is gone from the preview line"
+
+# What must survive: the editable input still carries the expression, and the
+# preview line spends itself on the one thing that input cannot say.
+af_assert_screen "Cron.*${cron_re}" 'the editable Cron input still shows the expression'
+af_assert_screen 'Next run [A-Z][a-z][a-z] [0-9][0-9] [0-9][0-9]:[0-9][0-9]' \
+    'the preview line shows the next fire time instead'
+
+# Belt and braces on the whole pane: with the editor open over the rail the
+# expression is on screen exactly once.
+occurrences="$(af_capture | grep -cF -- "$CRON" || true)"
+if [ "$occurrences" != "1" ]; then
+    _af_fail "#2596: expected the cron expression on exactly 1 line, found ${occurrences}"
+    af_capture >&2
+    exit 1
+fi
+
+af_close_tasks
+af_assert_no_orphan_clients
+af_quit
+echo 'PASS: #2596 a Custom cron renders once in the real task editor, with a next-run preview'

--- a/scripts/tui-2596-scenario.sh
+++ b/scripts/tui-2596-scenario.sh
@@ -14,7 +14,10 @@ set -euo pipefail
 # shellcheck source=/dev/null
 source /src/scripts/tui-driver.sh
 
-export AF_DRIVER_COLS=120 AF_DRIVER_ROWS=30
+# 144 cols so the left rail reaches its TreeMaxWidth=36 cap (clamp(22, 25%·W,
+# 36)); the rail's detail line is indented 6 and reads "0 0 31 2 * · no
+# upcoming run" (28), which clips at the 30-col rail a narrower terminal gives.
+export AF_DRIVER_COLS=144 AF_DRIVER_ROWS=30
 export AF_DRIVER_REPO="$HOME/sandbox/mock-repo"
 
 # The month field is restricted, so no preset matches and schedule.ParseCron
@@ -30,8 +33,8 @@ claude = "bash"'
 af_boot
 
 bin="$(_af_resolve_bin)"
-"$bin" tasks add --repo "$AF_DRIVER_REPO" --name yearly-audit \
-    --cron "$CRON" --prompt 'echo TASK-RAN-OK' >/dev/null
+task_id="$("$bin" tasks add --repo "$AF_DRIVER_REPO" --name yearly-audit \
+    --cron "$CRON" --prompt 'echo TASK-RAN-OK' | jq -er '.id')"
 
 # `m` opens straight into the RAIL-selected task's config (#1249), so the rail
 # has to have picked the new task up before the editor can show its schedule.
@@ -65,6 +68,32 @@ if [ "$occurrences" != "1" ]; then
 fi
 
 af_close_tasks
+
+# A cron can be syntactically legal and still match no date: "0 0 31 2 *" is
+# February 31st. ValidateCronExpr accepts it and ParseCron succeeds, but Next
+# gives up after five years and hands back the ZERO time.Time, which formats as
+# a thoroughly plausible "Jan 01 00:00". Both readouts have to name the absence
+# rather than promise a fire time the task will never reach.
+"$bin" tasks update "$task_id" --repo "$AF_DRIVER_REPO" --cron '0 0 31 2 *' >/dev/null
+
+# The rail's next/last detail only renders on the FOCUSED row (#1126 made
+# collapsed rows title-only), and `]` is the "next section" binding that walks
+# focus from the instances tree onto the automations rail (#1706).
+af_ensure_nav
+af_send ']'
+af_wait_for '▾\[✓\]  yearly-audit' "$AF_DRIVER_TIMEOUT" 'automations row focused and expanded'
+af_wait_for '0 0 31 2 \* · no upcoming run' "$AF_DRIVER_TIMEOUT" \
+    'the automations rail names the absence instead of a zero-time next run'
+# Refute the PREFIX, not the whole timestamp: a clipped "next Jan 0…" would slip
+# past a refute that spells out "next Jan 01 00:00" in full.
+af_refute_screen '· next Jan' 'the rail never formats the zero time as a real next run'
+
+af_open_tasks
+af_wait_for 'No upcoming run' "$AF_DRIVER_TIMEOUT" \
+    'the schedule picker names the absence too'
+af_refute_screen 'Next run' 'the picker never promises a next run for a cron that cannot match'
+af_close_tasks
+
 af_assert_no_orphan_clients
 af_quit
-echo 'PASS: #2596 a Custom cron renders once in the real task editor, with a next-run preview'
+echo 'PASS: #2596 a Custom cron renders once in the real task editor, with an honest next-run preview'

--- a/ui/automations.go
+++ b/ui/automations.go
@@ -194,13 +194,24 @@ func (a *AutomationsPane) ScrollDown() {
 // nextRunSummary derives the "next/last" column of a compact row: a cron
 // task's next fire time (from its schedule), a watch task's supervision
 // state, plus the last run when one is recorded.
+//
+// A cron can be syntactically legal and still match no date at all —
+// "0 0 31 2 *" is February 31st. ParseCron succeeds on it, but Next gives up
+// after five years and returns the ZERO time.Time, which formats as a
+// thoroughly plausible "next Jan 01 00:00"; name the absence instead of
+// promising a fire time the task will never reach. The schedule picker's
+// Custom preview guards the same trap (see renderPreviewLine).
 func (a *AutomationsPane) nextRunSummary(tsk task.Task) string {
 	var parts []string
 	if tsk.IsWatch() {
 		parts = append(parts, watchTaskStatus(tsk))
 	} else if tsk.Enabled && tsk.CronExpr != "" {
 		if sched, err := task.ParseCron(tsk.CronExpr); err == nil {
-			parts = append(parts, "next "+sched.Next(a.now()).Format("Jan 02 15:04"))
+			if next := sched.Next(a.now()); next.IsZero() {
+				parts = append(parts, "no upcoming run")
+			} else {
+				parts = append(parts, "next "+next.Format("Jan 02 15:04"))
+			}
 		}
 	}
 	if tsk.LastRunAt != nil {

--- a/ui/automations_test.go
+++ b/ui/automations_test.go
@@ -51,6 +51,26 @@ func TestAutomationsCollapsedRowsAreTitleOnly(t *testing.T) {
 	assert.NotContains(t, out, "watch: tail -f ci.log", "the collapsed row hides the watch command")
 }
 
+// TestAutomationsExpandedRowOmitsUnsatisfiableNextRun is the rail's half of the
+// same trap the schedule picker's Custom preview hits: "0 0 31 2 *" validates
+// and parses, but robfig's Next gives up after five years and returns the ZERO
+// time.Time, which formats as a plausible-looking "next Jan 01 00:00". The row
+// must not promise a fire time the task will never reach.
+func TestAutomationsExpandedRowOmitsUnsatisfiableNextRun(t *testing.T) {
+	a := newTestAutomations([]task.Task{
+		{ID: "1", Name: "feb-31", CronExpr: "0 0 31 2 *", Enabled: true},
+	})
+	a.SetRect(layout.Rect{W: 100, H: 4})
+	a.Focus()
+
+	out := a.View()
+	require.Contains(t, out, "feb-31", "precondition: the row renders at all")
+	assert.NotContains(t, out, "next Jan 01 00:00",
+		"the zero time must never be formatted as a real next run:\n%s", out)
+	assert.Contains(t, out, "no upcoming run",
+		"say so plainly rather than dropping the fragment:\n%s", out)
+}
+
 // TestAutomationsExpandedRowRevealsDetail pins the #1126 expansion: the focused
 // cursor's row reveals its trigger and next/last-run detail on a line beneath
 // the title, and no other row does.

--- a/ui/schedule_picker.go
+++ b/ui/schedule_picker.go
@@ -524,7 +524,17 @@ func (p *schedulePicker) renderPreviewLine(preview, dim lipgloss.Style) string {
 		if err != nil {
 			return ""
 		}
-		return indentSub + preview.Render("Next run "+sched.Next(p.now()).Format("Jan 02 15:04"))
+		// A cron can be syntactically legal and still match no date at all —
+		// "0 0 31 2 *" is February 31st. ValidateCronExpr accepts it and
+		// ParseCron succeeds, but Next gives up after five years and returns
+		// the ZERO time.Time, which formats as a thoroughly plausible
+		// "Jan 01 00:00". Promising a fire time the task will never reach is
+		// worse than the echo this line replaced, so name the absence.
+		next := sched.Next(p.now())
+		if next.IsZero() {
+			return indentSub + preview.Render("No upcoming run")
+		}
+		return indentSub + preview.Render("Next run "+next.Format("Jan 02 15:04"))
 	}
 	return indentSub + preview.Render(p.Describe()) + dim.Render("  ·  "+p.Cron())
 }

--- a/ui/schedule_picker.go
+++ b/ui/schedule_picker.go
@@ -42,6 +42,10 @@ type schedulePicker struct {
 	cursor        int             // index into cells() — the focused cell
 	focused       bool
 	width         int
+	// now returns the current time for the Custom preview's next-run
+	// derivation; a fixed value in tests so the rendered time is deterministic
+	// (the same seam AutomationsPane uses for its next-run column).
+	now func() time.Time
 }
 
 // scheduleType pairs a schedule.Type with its selector label, in selector
@@ -90,7 +94,7 @@ func newSchedulePicker() *schedulePicker {
 	raw.CharLimit = 64
 	raw.Blur()
 
-	p := &schedulePicker{raw: raw}
+	p := &schedulePicker{raw: raw, now: time.Now}
 	p.reset()
 	return p
 }
@@ -469,10 +473,11 @@ func (p *schedulePicker) selectedWeekdays() []time.Weekday {
 }
 
 // render draws the picker block: the type selector, only the inputs the current
-// type needs, the plain-English preview, and the generated cron shown
-// read-only. Each line is clipped to the pane width; the returned block carries
-// no trailing newline (the form adds it). Sub-lines are indented so the block
-// reads as one unit under the "Schedule:" label even on a narrow terminal.
+// type needs, and the read-only preview line (see renderPreviewLine, which
+// decides what that line is worth saying and may drop it). Each line is clipped
+// to the pane width; the returned block carries no trailing newline (the form
+// adds it). Sub-lines are indented so the block reads as one unit under the
+// "Schedule:" label even on a narrow terminal.
 func (p *schedulePicker) render() string {
 	t := CurrentTheme()
 	labelStyle := lipgloss.NewStyle().Bold(true)
@@ -483,10 +488,9 @@ func (p *schedulePicker) render() string {
 
 	lines := []string{labelStyle.Render("Schedule:") + " " + p.renderTypeSelector(selectedStyle, dimSelectedStyle)}
 	lines = append(lines, p.renderContextLines()...)
-	// Preview (plain-English) and the generated cron share one read-only line to
-	// keep the picker compact enough to fit an 80x24 pane; the preview leads so
-	// it survives on a narrow terminal even if the trailing cron clips.
-	lines = append(lines, indentSub+previewStyle.Render(p.Describe())+dimStyle.Render("  ·  "+p.Cron()))
+	if preview := p.renderPreviewLine(previewStyle, dimStyle); preview != "" {
+		lines = append(lines, preview)
+	}
 	if p.focused {
 		lines = append(lines, indentSub+dimStyle.Render(p.hint()))
 	}
@@ -498,6 +502,32 @@ func (p *schedulePicker) render() string {
 }
 
 const indentSub = "  "
+
+// renderPreviewLine builds the read-only line under the picker's inputs, or ""
+// when there is nothing worth a line.
+//
+// For a preset the plain-English preview and the generated cron share the line
+// to keep the picker inside an 80x24 pane; the preview leads so it survives a
+// narrow terminal even if the trailing cron clips.
+//
+// Custom has no plain-English form: Describe() is "Custom: "+raw and Cron() is
+// raw, so that pairing printed the expression twice on the preview line and
+// three times in the block — the Cron input right above already shows it
+// (#2596). Custom gets the one fact that input line cannot carry instead: when
+// the expression next fires, in the same "Jan 02 15:04" shape the automations
+// rail's next-run column uses. A half-typed or invalid expression has no next
+// run, so the line is dropped rather than padded back out with a repeat —
+// which also retires the empty-raw case that used to render a bare "Custom:".
+func (p *schedulePicker) renderPreviewLine(preview, dim lipgloss.Style) string {
+	if p.kind() == schedule.Custom {
+		sched, err := task.ParseCron(p.Cron())
+		if err != nil {
+			return ""
+		}
+		return indentSub + preview.Render("Next run "+sched.Next(p.now()).Format("Jan 02 15:04"))
+	}
+	return indentSub + preview.Render(p.Describe()) + dim.Render("  ·  "+p.Cron())
+}
 
 func (p *schedulePicker) renderTypeSelector(selected, dim lipgloss.Style) string {
 	label := scheduleTypes[p.typ].label

--- a/ui/schedule_picker_test.go
+++ b/ui/schedule_picker_test.go
@@ -260,6 +260,35 @@ func TestSchedulePickerCustomPreviewShowsNextRun(t *testing.T) {
 	assert.Contains(t, out, "Schedule:", "the rest of the block still renders")
 }
 
+// TestSchedulePickerCustomPreviewOmitsUnsatisfiableNextRun covers the cron
+// expressions that are syntactically legal but can never match a date —
+// "0 0 31 2 *" (February 31st), "0 0 31 4 *" (April 31st). ValidateCronExpr
+// accepts them and ParseCron succeeds, but robfig's Next gives up after five
+// years and returns the ZERO time.Time, which formats as a perfectly plausible
+// "Jan 01 00:00". Rendering that would promise a fire time to a task that has
+// none — worse than saying nothing.
+func TestSchedulePickerCustomPreviewOmitsUnsatisfiableNextRun(t *testing.T) {
+	for _, expr := range []string{"0 0 31 2 *", "0 0 30 2 *", "0 0 31 4 *"} {
+		t.Run(expr, func(t *testing.T) {
+			require.NoError(t, task.ValidateCronExpr(expr),
+				"precondition: the picker accepts this expression, so the preview must cope with it")
+
+			p := newSchedulePicker()
+			p.now = func() time.Time { return time.Date(2026, time.August, 4, 12, 0, 0, 0, time.UTC) }
+			p.setType(schedule.Custom)
+			p.raw.SetValue(expr)
+			p.setWidth(80)
+			p.setFocused(true)
+
+			out := stripANSI(p.render())
+			assert.NotContains(t, out, "Next run",
+				"a cron that never matches has no next run to promise:\n%s", out)
+			assert.Contains(t, out, "No upcoming run",
+				"say so plainly rather than leaving the line blank:\n%s", out)
+		})
+	}
+}
+
 // TestSchedulePickerPresetPreviewKeepsCron guards the other half of #2596: only
 // Custom loses the trailing cron. Every preset still pairs its plain-English
 // preview with the generated expression, because there the two differ and the

--- a/ui/schedule_picker_test.go
+++ b/ui/schedule_picker_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/schedule"
@@ -212,6 +213,63 @@ func TestSchedulePickerCustomAcceptsAndValidatesRaw(t *testing.T) {
 	p.raw.SetValue("0 9 * * 1-5")
 	assert.Equal(t, "", p.validate())
 	assert.Equal(t, "0 9 * * 1-5", p.Cron())
+}
+
+// TestSchedulePickerCustomRendersExpressionOnce is the #2596 regression: a
+// Custom schedule used to print its expression three times in two lines — once
+// in the editable Cron input, then twice more on the preview line, because
+// Describe() ("Custom: <raw>") and Cron() (<raw>) collapse to the same string
+// for Custom. The expression must appear exactly once in the block.
+func TestSchedulePickerCustomRendersExpressionOnce(t *testing.T) {
+	p := newSchedulePicker()
+	p.setType(schedule.Custom)
+	p.raw.SetValue("0 0 1 1 *")
+	p.setWidth(80)
+	p.setFocused(true)
+
+	out := stripANSI(p.render())
+	assert.Equal(t, 1, strings.Count(out, "0 0 1 1 *"),
+		"the cron expression belongs in the Cron input only, not echoed by the preview:\n%s", out)
+	assert.NotContains(t, out, "Custom: ",
+		"Describe()'s \"Custom: <raw>\" echo adds nothing the Cron input above does not already show")
+	assert.Contains(t, out, "Cron", "the editable raw-cron input keeps its label")
+}
+
+// TestSchedulePickerCustomPreviewShowsNextRun pins what replaces the removed
+// echo (#2596): the one fact the Cron input line cannot carry — when the
+// expression next fires — in the same shape the automations rail uses. An
+// expression that does not parse yet (the user is mid-type) has no next run, so
+// the line is dropped rather than filled with a repeat.
+func TestSchedulePickerCustomPreviewShowsNextRun(t *testing.T) {
+	p := newSchedulePicker()
+	// Fixed clock in a fixed zone: Next() answers in its argument's location, so
+	// the rendered time is the same string on every machine and in CI.
+	p.now = func() time.Time { return time.Date(2026, time.August, 4, 12, 0, 0, 0, time.UTC) }
+	p.setType(schedule.Custom)
+	p.setWidth(80)
+	p.setFocused(true)
+
+	p.raw.SetValue("0 0 1 1 *")
+	assert.Contains(t, stripANSI(p.render()), "Next run Jan 01 00:00",
+		"a parseable custom expression previews its next fire time")
+
+	p.raw.SetValue("0 0 1 1")
+	out := stripANSI(p.render())
+	assert.NotContains(t, out, "Next run",
+		"a half-typed expression has no next run to show")
+	assert.Contains(t, out, "Schedule:", "the rest of the block still renders")
+}
+
+// TestSchedulePickerPresetPreviewKeepsCron guards the other half of #2596: only
+// Custom loses the trailing cron. Every preset still pairs its plain-English
+// preview with the generated expression, because there the two differ and the
+// pairing is what lets a user trust what gets saved.
+func TestSchedulePickerPresetPreviewKeepsCron(t *testing.T) {
+	p := newSchedulePicker()
+	p.setWidth(80)
+	p.setFocused(true)
+	assert.Contains(t, stripANSI(p.render()), "Every day at 9:00 AM  ·  0 9 * * *",
+		"a preset keeps preview · cron")
 }
 
 // TestSchedulePickerSwitchToCustomPrefillsCron verifies switching into Custom


### PR DESCRIPTION
Closes #2596

## The bug

Opening a **Custom (cron)** task in the TUI task editor printed its expression three times in two lines:

```
  Trigger: ▸ cron    watch
  Schedule: Custom (cron)
    Cron > 0 0 1 1 *                                              …
    Custom: 0 0 1 1 *  ·  0 0 1 1 *
```

The preview line pairs `Describe()` with `Cron()`. That earns its place for every preset — `Every day at 9:00 AM  ·  0 9 * * *` — because one half is plain English and the other is the generated expression, and seeing both is what lets a user trust what gets saved. Custom has no plain-English form: `Describe()` is `"Custom: " + Raw` and `Cron()` returns `Raw` verbatim, so both halves collapse onto the expression the `Cron` input directly above already shows.

## The fix

Split the preview line out of `render()` into `renderPreviewLine`, which decides what that line is worth saying:

- **Presets** keep `preview  ·  cron`, unchanged, including the deliberate ordering that keeps the preview readable when a narrow pane clips the trailing cron.
- **Custom** gets the one fact the `Cron` input line cannot carry — when the expression next fires — in the same `Jan 02 15:04` shape the automations rail's next-run column already uses.
- An expression that does not parse yet (the user is mid-type) has no next run, so the line is dropped rather than padded back out with a repeat. That also retires the bare `Custom:` the empty-raw case used to render.

Before:

```
  Schedule: Custom (cron)
    Cron > 0 0 1 1 *
    Custom: 0 0 1 1 *  ·  0 0 1 1 *
```

After:

```
  Schedule: Custom (cron)
    Cron > 0 0 1 1 *
    Next run Jan 01 00:00
```

The clock comes in through a `now func() time.Time` seam — the same one `AutomationsPane` already uses to keep its next-run column deterministic under test.

### …and the zero-time trap that came with it (second commit)

A cron can be syntactically legal and still match no date at all — `0 0 31 2 *` is February 31st. `ValidateCronExpr` accepts it and `task.ParseCron` succeeds, but robfig's `Next` gives up after five years and returns the **zero** `time.Time`, which formats as a thoroughly plausible `Jan 01 00:00`. Verified: `0 0 31 2 *`, `0 0 30 2 *` and `0 0 31 4 *` all validate, parse, and yield it (`0 0 29 2 *` is fine — leap years land inside the horizon). Caught by the Codex review of the first commit, confirmed, and fixed.

**`ui/automations.go` had the identical unguarded `Format` on master**, so an expanded rail row already read `0 0 31 2 * · next Jan 01 00:00`. Both cron `Next` call sites in the tree are now guarded — the picker says `No upcoming run`, the rail says `no upcoming run` alongside its `next …` / `last …` fragments.

Deliberately not `Never runs`: the zero return means "no match within the five-year search horizon", and a Feb-29 schedule evaluated in 2096 hits an eight-year gap (2100 is not a leap year), so "never" would overclaim.

`schedule.Describe()` itself is untouched. `web/src/schedule.ts` mirrors it byte-for-byte against the shared vectors in `schedule/testdata/vectors.json`, and the redundancy is a property of this one render site, not of the model.

## Gates

Both new gates fail on `master` and pass here.

**Unit** — `TestSchedulePickerCustomRendersExpressionOnce` counts occurrences in the rendered block. On `master` it reports `expected: 1, actual: 3` and prints the offending block. Companions pin the replacement (`…CustomPreviewShowsNextRun`, with a fixed UTC clock so the rendered time is identical on every machine — verified under `TZ=Pacific/Auckland`, `America/Sao_Paulo`, `Asia/Kolkata`, `UTC`), guard the untouched half (`…PresetPreviewKeepsCron`), and cover the zero-time trap on both surfaces (`…CustomPreviewOmitsUnsatisfiableNextRun`, a table over all three expressions behind a `require.NoError(ValidateCronExpr)` precondition, and `TestAutomationsExpandedRowOmitsUnsatisfiableNextRun`, which fails on master printing `0 0 31 2 * · next Jan 01 00:00` verbatim).

**Real TUI** — `scripts/tui-2596-scenario.sh` (`scripts/testbox.sh scenario scripts/tui-2596-scenario.sh`) boots `af` in the container sandbox, seeds a Custom-cron task, opens the editor with `m`, and reads the assembled pane. A render-string assertion alone can miss this — the duplicate is only obviously wrong on screen. Against the unfixed render it fails on the right assertion, with the defect visible in the captured pane:

```
[tui-driver] REFUTE FAILED: screen unexpectedly matched: #2596: the expression is not printed twice on one line
                       │  Schedule: Custom (cron)                                               │
                       │    Cron > 0 0 1 1 *                                                 …  │
                       │    Custom: 0 0 1 1 *  ·  0 0 1 1 *                                     │
```

and against this branch, now also driving both zero-time readouts (`]` walks focus onto the automations rail, whose detail only renders on the focused row per #1126; the terminal widens to 144 cols so the rail hits its `TreeMaxWidth=36` cap and the detail does not clip; and the rail refute matches the `· next Jan` **prefix**, because a clipped `next Jan 0…` would slip past a refute spelling the timestamp out in full):

```
[tui-driver] refute OK: #2596: the expression is not printed twice on one line
[tui-driver] refute OK: #2596: Describe()'s "Custom: <raw>" echo is gone from the preview line
[tui-driver] assert OK: the editable Cron input still shows the expression
[tui-driver] assert OK: the preview line shows the next fire time instead
[tui-driver] refute OK: the rail never formats the zero time as a real next run
[tui-driver] refute OK: the picker never promises a next run for a cron that cannot match
[tui-driver] assert OK: no orphan tmux attach clients
PASS: #2596 a Custom cron renders once in the real task editor, with an honest next-run preview
```

`make tui-driver-selftest` (the shared acceptance scenario) also reports 63/63 steps green.

Full local gate green on this head: `golangci-lint run --timeout=3m --fast`, `gofmt -l .` (empty), `go build ./...`, `make test-container` (all packages `ok`), `deadcode -test ./...` (empty), `scripts/lint-file-length.sh`.

## Adjacent surface

The web task modal has the same triplication — `rawInput`, `humanLine` (`Custom: <raw>`) and the read-only `cronOut` all show the expression, because `sync()` hides every type-specific row but never `previewRow`. It is **not** fixed here: the web has no cron evaluator in TypeScript, so "next run" is not a port of these three lines and the surface needs its own call. Filed with the pointers and the options as #2812.

— Captain Claude
