### PR TITLE
test(git): pin the shared stash stack and the worktree-local substitute

### DIFF
--- a/session/git/worktree_stash_isolation_test.go
+++ b/session/git/worktree_stash_isolation_test.go
@@ -1,0 +1,272 @@
+package git
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// gitStdoutTest runs a git command in dir and returns trimmed stdout ONLY.
+// runGitInPlaceTest folds stderr in, which is fine for assertions on prose but
+// not for capturing a value: `git stash create` writes the sha to stdout and
+// advice to stderr, and a mixed capture cannot be fed back to update-ref.
+func gitStdoutTest(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	require.NoError(t, cmd.Run(), "git %v: %s", args, stderr.String())
+	return strings.TrimSpace(stdout.String())
+}
+
+// twoSessionWorktrees builds a repo with two tracked files and hands back two
+// session worktrees created through af's OWN Setup() path — the same call the
+// daemon makes when a session is created — plus the repo root.
+//
+// The worktrees must come from Setup() rather than a hand-rolled `git worktree
+// add`: the claim under test is about what an af *session* gets, and a test
+// that built its own worktrees could keep passing after af switched sessions to
+// a mechanism (a clone, a separate GIT_DIR) that does not share refs.
+func twoSessionWorktrees(t *testing.T) (repoRoot, wtA, wtB string) {
+	t.Helper()
+	sandboxHome(t)
+
+	repoRoot = createGitRepo(t)
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "a.txt"), []byte("base\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "b.txt"), []byte("base\n"), 0644))
+	runGitInPlaceTest(t, repoRoot, "add", "-A")
+	runGitInPlaceTest(t, repoRoot, "commit", "-m", "initial")
+
+	cfg := config.DefaultConfig()
+	cfg.BranchPrefix = "test/"
+	require.NoError(t, config.SaveConfig(cfg))
+
+	gwA, _, err := NewGitWorktree(repoRoot, "stash-sess-a")
+	require.NoError(t, err)
+	require.NoError(t, gwA.Setup())
+	t.Cleanup(func() { _, _ = gwA.Cleanup() })
+
+	gwB, _, err := NewGitWorktree(repoRoot, "stash-sess-b")
+	require.NoError(t, err)
+	require.NoError(t, gwB.Setup())
+	t.Cleanup(func() { _, _ = gwB.Cleanup() })
+
+	wtA, wtB = gwA.GetWorktreePath(), gwB.GetWorktreePath()
+	require.NotEqual(t, wtA, wtB, "the two sessions must land in distinct worktrees")
+	return repoRoot, wtA, wtB
+}
+
+// TestSessionWorktreesShareOneStashStack pins the trap behind #2801: two af
+// session worktrees of one repo share a single `refs/stash`, so one session's
+// `git stash pop` can take a sibling's entry. Nothing errors — the pop succeeds
+// and delivers the wrong content, which is how a session commits changes it
+// never wrote.
+//
+// This asserts the hazard, not a fix. git-worktree(1) documents refs/bisect,
+// refs/worktree, and refs/rewritten as the only unshared namespaces under
+// refs/, and there is no config that moves refs/stash into that set, so af
+// cannot isolate the stack — it can only tell sessions not to use it. The
+// assertion therefore guards a documentation claim: if this test ever fails
+// because the pop stopped crossing worktrees, the prohibition in CLAUDE.md
+// ("Git hygiene in a shared repo") and .claude/skills/dispatch-af-session.md is
+// obsolete and should be deleted along with this test.
+func TestSessionWorktreesShareOneStashStack(t *testing.T) {
+	_, wtA, wtB := twoSessionWorktrees(t)
+
+	// B stashes first, so A's entry lands on top of the shared stack. This
+	// ordering is what makes the theft deterministic; in a real fleet it is
+	// whichever two sessions happen to interleave.
+	require.NoError(t, os.WriteFile(filepath.Join(wtB, "b.txt"), []byte("base\nB session work\n"), 0644))
+	runGitInPlaceTest(t, wtB, "stash", "push", "-m", "B work")
+
+	require.NoError(t, os.WriteFile(filepath.Join(wtA, "a.txt"), []byte("base\nA session work\n"), 0644))
+	runGitInPlaceTest(t, wtA, "stash", "push", "-m", "A work")
+
+	// B pops what it believes is its own entry.
+	runGitInPlaceTest(t, wtB, "stash", "pop")
+
+	popped, err := os.ReadFile(filepath.Join(wtB, "a.txt"))
+	require.NoError(t, err)
+	assert.Contains(t, string(popped), "A session work",
+		"B's pop took A's stash entry: refs/stash is shared across worktrees")
+
+	// B's own work is still on the stack — it did not get what it asked for,
+	// and A's entry is gone from A's point of view.
+	stillStashed, err := os.ReadFile(filepath.Join(wtB, "b.txt"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(stillStashed), "B session work",
+		"B's own entry should still be stashed — the pop returned A's, not B's")
+
+	listInA := runGitInPlaceTest(t, wtA, "stash", "list")
+	assert.NotContains(t, listInA, "A work",
+		"A's entry was consumed by a pop in another worktree")
+	assert.Contains(t, listInA, "B work",
+		"A sees B's entry: one stack, both sessions")
+}
+
+// TestStashCreateWithWorktreeRefIsPerWorktree is the guard on the substitute
+// CLAUDE.md now tells every session to use instead of `git stash`. Two claims
+// have to hold for that advice to be safe, and both are git behavior this repo
+// depends on rather than owns:
+//
+//  1. `git stash create` records a dangling commit and does NOT push onto the
+//     shared `refs/stash`, so it adds no writer to the contended stack; and
+//  2. `refs/worktree/<name>` really is per-worktree, so two sessions can use
+//     the SAME ref name without seeing each other.
+//
+// If a future git breaks either one, the documented recipe becomes as dangerous
+// as the thing it replaced, and this test is what says so.
+func TestStashCreateWithWorktreeRefIsPerWorktree(t *testing.T) {
+	_, wtA, wtB := twoSessionWorktrees(t)
+
+	const ref = "refs/worktree/af-wip"
+
+	require.NoError(t, os.WriteFile(filepath.Join(wtA, "a.txt"), []byte("base\nA session work\n"), 0644))
+	shaA := gitStdoutTest(t, wtA, "stash", "create", "A wip")
+	require.NotEmpty(t, shaA, "stash create must record a commit for a dirty tree")
+	runGitInPlaceTest(t, wtA, "update-ref", ref, shaA)
+	runGitInPlaceTest(t, wtA, "checkout", "--", ".")
+
+	require.NoError(t, os.WriteFile(filepath.Join(wtB, "b.txt"), []byte("base\nB session work\n"), 0644))
+	shaB := gitStdoutTest(t, wtB, "stash", "create", "B wip")
+	require.NotEmpty(t, shaB)
+	runGitInPlaceTest(t, wtB, "update-ref", ref, shaB)
+	runGitInPlaceTest(t, wtB, "checkout", "--", ".")
+
+	require.NotEqual(t, shaA, shaB, "the two sessions set aside different work")
+
+	// The same ref name resolves differently in each worktree. This is the
+	// property `refs/stash` does not have.
+	assert.Equal(t, shaA, gitStdoutTest(t, wtA, "rev-parse", ref),
+		"A's %s must still be A's commit after B wrote the same ref name", ref)
+	assert.Equal(t, shaB, gitStdoutTest(t, wtB, "rev-parse", ref),
+		"B's %s must be B's own commit", ref)
+
+	// Nothing reached the shared stack.
+	assert.Empty(t, gitStdoutTest(t, wtA, "stash", "list"),
+		"stash create must not push onto the shared refs/stash")
+	assert.Empty(t, gitStdoutTest(t, wtB, "stash", "list"))
+
+	// Restoring in A brings back A's work and nothing of B's.
+	runGitInPlaceTest(t, wtA, "stash", "apply", ref)
+	restored, err := os.ReadFile(filepath.Join(wtA, "a.txt"))
+	require.NoError(t, err)
+	assert.Contains(t, string(restored), "A session work")
+	foreign, err := os.ReadFile(filepath.Join(wtA, "b.txt"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(foreign), "B session work",
+		"A must not receive B's set-aside work")
+}
+
+// TestStashCreateEdgeCasesFailLoudly covers the ways the documented recipe can
+// bite a session that pastes it without reading the caveats. Each is worth
+// pinning because the failure has to stay LOUD: a `stash create` that quietly
+// recorded nothing, followed by a clean, would destroy the work the session was
+// trying to protect.
+func TestStashCreateEdgeCasesFailLoudly(t *testing.T) {
+	_, wtA, _ := twoSessionWorktrees(t)
+
+	// A clean tree records nothing and prints an empty sha — hence the
+	// `[ -n "$sha" ]` guard in the documented recipe. update-ref then refuses
+	// rather than silently pointing the ref at nothing.
+	assert.Empty(t, gitStdoutTest(t, wtA, "stash", "create", "nothing to save"),
+		"stash create on a clean tree must record nothing")
+	cmd := exec.Command("git", "update-ref", "refs/worktree/af-wip", "")
+	cmd.Dir = wtA
+	out, err := cmd.CombinedOutput()
+	assert.Error(t, err, "update-ref with an empty sha must fail, not create a dangling ref")
+	assert.Contains(t, string(out), "not a valid SHA1")
+
+	// An untracked file is not captured at all: `stash create` reports nothing
+	// for it. `git checkout -- .` also leaves untracked files in place, so the
+	// content survives — but a session that expected it in the set-aside commit
+	// would not find it there.
+	require.NoError(t, os.WriteFile(filepath.Join(wtA, "untracked.txt"), []byte("new work\n"), 0644))
+	assert.Empty(t, gitStdoutTest(t, wtA, "stash", "create", "untracked only"),
+		"stash create does not capture untracked files")
+
+	// Half-adding it with `git add -N` does not help — it makes stash create
+	// fail outright. Fully `git add` it (or use the scratch-commit recipe).
+	runGitInPlaceTest(t, wtA, "add", "-N", "untracked.txt")
+	cmd = exec.Command("git", "stash", "create", "intent to add")
+	cmd.Dir = wtA
+	out, err = cmd.CombinedOutput()
+	assert.Error(t, err, "stash create must fail loudly on an intent-to-add entry")
+	assert.Contains(t, string(out), "not uptodate")
+
+	runGitInPlaceTest(t, wtA, "add", "untracked.txt")
+	sha := gitStdoutTest(t, wtA, "stash", "create", "fully added")
+	require.NotEmpty(t, sha, "a fully added file IS captured")
+	assert.Equal(t, "new work", gitStdoutTest(t, wtA, "cat-file", "-p", sha+":untracked.txt"))
+
+	// Two more guards the recipe's own text depends on, both of which a session
+	// only trips when it pastes the block somewhere slightly different.
+	assertUpdateRefRefusesAnExistingSave(t, wtA, sha)
+	assertCleanNeedsTheRootPathspec(t, wtA)
+}
+
+// assertUpdateRefRefusesAnExistingSave pins the trailing `""` old-value guard in
+// the documented `git update-ref refs/worktree/af-wip "$sha" ""`. Without it, a
+// session that sets work aside twice under the same name silently repoints the
+// ref at the second commit and leaves the first reachable only through fsck.
+func assertUpdateRefRefusesAnExistingSave(t *testing.T, wt, sha string) {
+	t.Helper()
+	const ref = "refs/worktree/af-wip-twice"
+
+	runGitInPlaceTest(t, wt, "update-ref", ref, sha, "")
+	require.Equal(t, sha, gitStdoutTest(t, wt, "rev-parse", ref))
+
+	second := gitStdoutTest(t, wt, "rev-parse", "HEAD")
+	require.NotEqual(t, sha, second)
+	cmd := exec.Command("git", "update-ref", ref, second, "")
+	cmd.Dir = wt
+	out, err := cmd.CombinedOutput()
+	assert.Error(t, err, "a second save under a taken name must be refused, not silently overwrite")
+	assert.Contains(t, string(out), "already exists")
+	assert.Equal(t, sha, gitStdoutTest(t, wt, "rev-parse", ref),
+		"the first save must still be reachable under its name")
+}
+
+// assertCleanNeedsTheRootPathspec pins why the recipe cleans with `:/` rather
+// than `.`. The two halves are asymmetric: `git stash create` records the whole
+// worktree, while `git checkout -- .` only restores paths below the current
+// directory. Run from a subdirectory, the bare form hands back a tree that reads
+// as clean where it isn't, and the next build or commit picks up the leftovers.
+func assertCleanNeedsTheRootPathspec(t *testing.T, wt string) {
+	t.Helper()
+	sub := filepath.Join(wt, "sub")
+	require.NoError(t, os.MkdirAll(sub, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "inner.txt"), []byte("base\n"), 0644))
+	runGitInPlaceTest(t, wt, "add", "-A")
+	runGitInPlaceTest(t, wt, "commit", "-m", "add a subdirectory")
+
+	require.NoError(t, os.WriteFile(filepath.Join(wt, "a.txt"), []byte("base\nroot edit\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "inner.txt"), []byte("base\nsub edit\n"), 0644))
+	require.NotEmpty(t, gitStdoutTest(t, wt, "stash", "create", "both levels"),
+		"create records the whole worktree, not just the cwd")
+
+	// gitStdoutTest trims, so porcelain's leading unstaged column reads as "M
+	// a.txt" here. One line, so this also pins that the sub/ edit WAS cleaned —
+	// the bare pathspec cleans what is under the cwd and nothing above it.
+	runGitInPlaceTest(t, sub, "checkout", "--", ".")
+	assert.Equal(t, "M a.txt", gitStdoutTest(t, wt, "status", "--porcelain"),
+		"`checkout -- .` from a subdirectory leaves the root edit behind")
+
+	runGitInPlaceTest(t, sub, "checkout", "--", ":/")
+	assert.Empty(t, gitStdoutTest(t, wt, "status", "--porcelain"),
+		"`checkout -- :/` cleans from the repo root, which is what the recipe documents")
+}


### PR DESCRIPTION
## What

The regression test #2801 asked for, plus the answer to the question it asked
alongside it. Second and last PR for that issue; #2808 shipped the documentation
first because it protects the running fleet immediately.

## The test the issue asked for, and the one adjustment

#2801 specified: two worktrees of one repo, stash in A, pop in B, assert B does
not receive A's content — "that test will fail on the current tree, which is the
point."

It would fail on every tree, forever. **af cannot make that assertion true.**
git-worktree(1) names `refs/bisect`, `refs/worktree`, and `refs/rewritten` as the
only unshared namespaces under `refs/`; `refs/stash` is not among them, and the
complete set of `stash.*` config keys is `showIncludeUntracked`, `showPatch`, and
`showStat` — all three only change how `git stash show` prints. There is no
`stash.ref` to set. Details and the mechanism I built and rejected are in the
issue.

So the test pins the hazard rather than a fix, which makes it a docs-consistency
gate: **if it ever fails, the prohibition in `CLAUDE.md` is obsolete and should
be deleted along with the test.** Its failure message says exactly that.

## Three tests

Both worktrees come from af's own `Setup()` — the same call the daemon makes when
a session is created — not a hand-rolled `git worktree add`. The claim under test
is about what an af *session* gets, and a test that built its own worktrees would
keep passing after af moved sessions onto something that does not share refs.

- **`TestSessionWorktreesShareOneStashStack`** — B stashes, A stashes, B pops and
  receives **A's** work. A's entry is consumed; B's own is still on the stack,
  now labelled `On b`; A can see B's entry. One stack, both sessions.
- **`TestStashCreateWithWorktreeRefIsPerWorktree`** — guards the substitute the
  docs now tell every session to use. `stash create` adds nothing to
  `refs/stash`, and the same `refs/worktree/af-wip` name resolves to a different
  commit in each worktree. Both are git behaviour this repo depends on and does
  not own; if either breaks, the documented recipe becomes as dangerous as the
  thing it replaced.
- **`TestStashCreateEdgeCasesFailLoudly`** — pins every way the recipe can bite a
  session that pastes it. Each could destroy the work the recipe exists to
  protect if it failed quietly: a clean tree records nothing (empty sha, so
  `update-ref` refuses with `not a valid SHA1` instead of creating a ref to
  nowhere), untracked files are not captured, a half-added `git add -N` file
  fails with `Entry … not uptodate`, a second save under a taken ref name is
  refused by the empty old-value guard rather than orphaning the first, and
  cleaning with a bare `.` from a subdirectory leaves everything above it dirty
  while `:/` does not.

  The last two are here because Codex found them on #2808, against the recipe
  rather than the code: `stash create` records the whole worktree while
  `checkout -- .` only restores below the cwd, so from a subdirectory the recipe
  handed back a tree that read as clean and wasn't. #2808 now passes `""` to
  `update-ref` and cleans with `:/`; these assertions are what keep the two files
  telling the same story.

That last test is not hypothetical. The first draft of the recipe in #2808 ran
`git checkout -- .` unconditionally after `git stash create`, and an empty sha
means *either* a clean tree *or* a failure — so on the `add -N` path it cleaned a
tree whose work had never been recorded. This test is what stops that from
reappearing.

## Watched failing first

Every assertion, by mutation — a test that passes before the change under test is
testing the wrong thing:

| Mutation | What broke |
|---|---|
| both stashes in the same worktree | `should not contain "B session work"`, `does not contain "B work"` — the test detects cross-worktree leakage, not any pop |
| `refs/worktree/af-wip` → `refs/af-wip` | `A's refs/af-wip must still be A's commit after B wrote the same ref name` |
| `stash create` → `stash push` | `Should be empty, but was stash@{0}: On test/stash-sess-a: A wip` |
| `add -N` → `add` | `An error is expected but got nil` |
| drop the `""` old-value guard | `a second save under a taken name must be refused` — and `the first save must still be reachable under its name` |
| clean with `:/` where the bare form is under test | the leftover disappears, so the pathspec-scope assertion fires |

## Verification

Local gates on the pushed head `57ab1183`: `golangci-lint`, `gofmt -l .`,
`go build ./...`, `deadcode -test ./...`, `scripts/lint-file-length.sh`,
`make test-container`.

Both git versions af runs on were checked directly, because these tests assert on
git's behaviour and its error strings: `2.43.0` on the host and `2.39.5` in
`agent-factory-testbox` (bookworm). The theft reproduces identically on both, and
both error strings the tests match are byte-identical across them.

Nothing here touches production code — af never invokes `git stash` anywhere, and
this does not add a writer to the contended stack, per the issue's constraint.

Closes #2801

🤖 Generated with [Claude Code](https://claude.com/claude-code)