### PR TITLE
fix(tui): repair four chrome defects on the status bar, overlays, and separators

### DIFF
--- a/app/clause_separator_test.go
+++ b/app/clause_separator_test.go
@@ -1,0 +1,58 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #2579 Part 2. CLAUDE.md: " · " joins fragments on one line; "—" sets off a
+// clause. Four sites used the fragment separator for a clause boundary, and in
+// both cases the correct form was visible in the SAME frame, which is what made
+// the inconsistency read as a defect rather than a preference.
+
+// The kill dialog joined two independent sentences with `·` while its very next
+// paragraph set off the same kind of clause with `—`.
+func TestKillConfirmSetsOffItsConsequenceClauseWithADash(t *testing.T) {
+	lines := []string{
+		unmergedSevereLine("dev/todo-core", 1, ""),
+		unmergedSevereLine("dev/todo-core", 3, "main"),
+	}
+	for _, line := range lines {
+		assert.Contains(t, line, "— this cannot be undone",
+			"a second sentence is a clause, not another fragment on the line")
+		assert.NotContains(t, line, "· this cannot be undone")
+	}
+}
+
+// The pane header flattened `instance · tab — selected: instance · tab` into
+// four indistinguishable fragments. That trailing clause is the ONLY signal
+// that the workspace is not showing the row under the cursor, so nothing
+// marking where the pane's identity ends actively costs comprehension. The
+// preview arm set the same relationship off with parentheses — a third form —
+// and scroll mode appended its own with `·`; all three now read alike.
+func TestPaneHeaderSetsOffItsClausesWithADash(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+	beta := h.store.GetInstanceByTitle("beta")
+
+	pressKey(t, h, "s")
+	paneA := h.store.OpenPanes()[0]
+	require.Same(t, alpha, paneA.Instance())
+
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	require.Same(t, beta, h.store.GetSelectedInstance())
+
+	view := h.View()
+	assert.Contains(t, view, "Preview beta · ◆ Agent — original alpha · ◆ Agent",
+		"the preview's origin is a clause, not a parenthetical aside")
+
+	h.cancelPanePreview(false)
+	view = h.View()
+	assert.Contains(t, view, "alpha · ◆ Agent — selected: beta · ◆ Agent",
+		"the clause boundary must be a dash so the identity and the clause read apart")
+	assert.NotContains(t, view, "· selected: ",
+		"the selection clause must not read as another identity fragment")
+}

--- a/app/error_details_test.go
+++ b/app/error_details_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/configagent"
+	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,4 +33,90 @@ func TestErrorDetailsOverlayShowsFullTruncatedError(t *testing.T) {
 	assert.Contains(t, rendered, "Last error")
 	assert.Contains(t, rendered, "https://example.invalid/pr/987",
 		"full fallback data must be recoverable from the details overlay")
+}
+
+// TestErrorDetailsSurvivesTheNoticeVisualTimeout is #2618. `E details` is the
+// only in-app way to read a notice the status bar clipped, and it used to stop
+// working 3 seconds later — at exactly the moment the clipped text left the
+// screen. The one case the affordance exists for was the one case it could not
+// serve. The notice now outlives its render.
+func TestErrorDetailsSurvivesTheNoticeVisualTimeout(t *testing.T) {
+	h := newTestHome(t)
+	resizeHome(h, 80, 24)
+
+	msg := "no clipboard tool found (install xclip/wl-clipboard, or pbcopy on macOS); PR URL: https://example.invalid/pr/987"
+	require.NotNil(t, h.handleError(errors.New(msg)))
+	require.Contains(t, h.errBox.String(), "E details", "precondition: the notice is up and clipped")
+
+	// The 3s visual timeout fires.
+	_, _ = h.Update(hideErrMsg{noticeID: h.transientNoticeID})
+	require.Empty(t, h.errBox.FullError(), "the bar must stop rendering the expired notice")
+
+	_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("E")})
+	require.Equal(t, stateHelp, h.state, "E must still open the notice after it left the screen")
+	require.NotNil(t, h.textOverlay)
+	assert.Contains(t, h.textOverlay.Render(), "https://example.invalid/pr/987",
+		"the half the bar clipped is the whole point of the affordance")
+}
+
+// A notice that was RETRACTED — not merely expired — must not stay reachable:
+// it stopped being true, so re-opening it would show the user something af has
+// already taken back.
+func TestErrorDetailsDoesNotResurrectARetractedNotice(t *testing.T) {
+	h := newTestHome(t)
+	resizeHome(h, 80, 24)
+	t.Cleanup(SetConfigAgentSpawnerForTest(func(configagent.Mode, string) (string, string, error) { return "af-config-1", "", nil }))
+
+	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'C'}}, keys.KeyConfigAgent)
+	require.NotNil(t, cmd)
+	spawned := cmd().(configAgentSpawnedMsg)
+	require.Contains(t, h.errBox.FullError(), "Starting the config agent", "precondition")
+
+	h.handleConfigAgentSpawned(spawned)
+	require.Empty(t, h.errBox.FullError(), "precondition: the spawn retracts its own notice")
+
+	_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("E")})
+	assert.Equal(t, stateDefault, h.state, "a retracted notice is gone, not merely off screen")
+	assert.Nil(t, h.textOverlay)
+}
+
+// The overlay's title must match what it is showing. af hiding a pane and
+// telling you how to get it back is designed behavior, not a failure, and
+// filing it under "Last error" reports af working as intended as a fault
+// (#2618 / #2575).
+func TestErrorDetailsTitleDistinguishesNoticesFromFailures(t *testing.T) {
+	tests := []struct {
+		name  string
+		raise func(*home) tea.Cmd
+		title string
+	}{
+		{
+			name:  "operation failure",
+			raise: func(h *home) tea.Cmd { return h.handleError(errors.New("git worktree remove failed")) },
+			title: "Last error",
+		},
+		{
+			name:  "declined action",
+			raise: func(h *home) tea.Cmd { return h.handleNotice(errors.New("no PR for this session yet")) },
+			title: "Last notice",
+		},
+		{
+			name:  "success message",
+			raise: func(h *home) tea.Cmd { return h.showTransientMessage("Daemon restarted.") },
+			title: "Last notice",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			resizeHome(h, 80, 24)
+			require.NotNil(t, tc.raise(h))
+
+			_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("E")})
+			require.Equal(t, stateHelp, h.state)
+			require.NotNil(t, h.textOverlay)
+			assert.Contains(t, h.textOverlay.Render(), tc.title)
+		})
+	}
 }

--- a/app/handle_mouse.go
+++ b/app/handle_mouse.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sachiniyer/agent-factory/ui/tree"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 )
 
 // This file is the root mouse router (#1024 R4, RFC §2.5 — closes #1025).
@@ -773,22 +772,4 @@ func keyMsgFromString(s string) (tea.KeyMsg, bool) {
 		return tea.KeyMsg{Type: tea.KeyRunes, Runes: r}, true
 	}
 	return tea.KeyMsg{}, false
-}
-
-// overlayOrigin computes where overlay.PlaceOverlay(0, 0, fg, bg, true) puts
-// fg's top-left: centered on bg (or 0,0 when fg exceeds bg, matching
-// PlaceOverlay's clamp). The overlays register their button zones relative
-// to this origin.
-func overlayOrigin(fg, bg string) layout.Point {
-	fgW, fgH := lipgloss.Width(fg), lipgloss.Height(fg)
-	bgW, bgH := lipgloss.Width(bg), lipgloss.Height(bg)
-	x := (bgW - fgW) / 2
-	y := (bgH - fgH) / 2
-	if x < 0 {
-		x = 0
-	}
-	if y < 0 {
-		y = 0
-	}
-	return layout.Point{X: x, Y: y}
 }

--- a/app/help.go
+++ b/app/help.go
@@ -309,7 +309,7 @@ func (h helpTypeInstanceStart) toContent() string {
 		keyStyle.Render(helpKey(keys.KeyKill))+descStyle.Render("     - Kill (delete) the selected session"),
 		"",
 		headerStyle.Render("Actions:"),
-		firstRunActionLine("enter continue • esc close"),
+		firstRunActionLine("enter continue · esc close"),
 	)
 	return content
 }

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -746,12 +746,20 @@ func newlyAutoHiddenPane(previousVisible, nextVisible, openPanes []*store.OpenPa
 // can own several panes, so "docs hidden" while a second `docs` pane is on
 // screen tells the user something they can see is false (#1997).
 //
-// The reason clause drops the word "terminal" to pay for the tab name: at 80
-// columns the old line already sat one cell under the limit, and the bar
-// truncates from the RIGHT, so a longer line silently eats the recovery hint
-// (#1973). Long instance titles still overflow — nothing can fit an unbounded
-// title — but the fragments are ordered worst-first, so what survives the
-// truncation is the half that matters: which pane went away.
+// The bar truncates from the RIGHT, so the LAST fragment is the one that dies,
+// and that fragment is the recovery hint — the `s` key, which is the cheaper of
+// the two remedies because it needs no resize and is the one a user cannot
+// discover by fiddling. #1973 bought room for it by dropping a word; #1997 then
+// spent that room making the subject a full pane identity, and at 80 columns the
+// line clipped to a dangling "resize wider or…" for even a five-character
+// session name (#2580).
+//
+// So the reason clause is now the thing that pays: it says "too narrow" without
+// counting the panes (the notice already names the one that went), which buys
+// back enough cells for the hint to survive an ordinary title at 80 columns.
+// Long titles still overflow — nothing fits an unbounded title — but the
+// fragments stay ordered worst-first, so what survives is which pane went away,
+// and since #2618 the clipped tail is readable in full with `E details`.
 func (m *home) setPaneAutoHideStatus(p *store.OpenPane, paneCount int) {
 	if p == nil || paneCount <= 1 {
 		return
@@ -760,8 +768,7 @@ func (m *home) setPaneAutoHideStatus(p *store.OpenPane, paneCount int) {
 	if label, ok := paneStatusLabel(p); ok {
 		subject = label + " hidden"
 	}
-	msg := fmt.Sprintf("%s — too narrow for %d panes; resize wider%s",
-		subject, paneCount, paneRecoveryStatusHint())
+	msg := fmt.Sprintf("%s — too narrow; resize%s", subject, paneRecoveryStatusHint())
 	m.pendingPaneAutoHideStatus = msg
 	m.paneAutoHideNoticeID = m.setTransientNotice(errors.New(msg))
 }
@@ -805,14 +812,18 @@ func paneStatusLabel(p *store.OpenPane) (string, bool) {
 	return fmt.Sprintf("%s · %s", p.Instance().Title, label), true
 }
 
+// paneRecoveryStatusHint names the key that brings the pane back without a
+// resize. It drops the filler "use": every cell it costs comes out of its own
+// survival at 80 columns, since it is the last fragment on a bar that truncates
+// from the right (#2580).
 func paneRecoveryStatusHint() string {
 	if key := bindingKeyWithDesc("pane list"); key != "" {
-		return fmt.Sprintf(" or use `%s` pane list", key)
+		return fmt.Sprintf(" or `%s` pane list", key)
 	}
 	if binding, ok := keys.GlobalKeyBindings[keys.KeyOpenPane]; ok {
 		help := binding.Help()
 		if help.Key != "" && help.Desc != "" {
-			return fmt.Sprintf(" or use `%s` %s", help.Key, help.Desc)
+			return fmt.Sprintf(" or `%s` %s", help.Key, help.Desc)
 		}
 	}
 	return ""

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -25,7 +25,10 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case hideErrMsg:
 		if msg.noticeID == m.transientNoticeID {
-			m.errBox.Clear()
+			// Expire, not Clear: the notice leaves the bar but stays readable
+			// through `E details`. Clearing here is what made that key dead 3
+			// seconds after every notice (#2618).
+			m.errBox.Expire()
 		}
 	case previewTickMsg:
 		// While the user is attached to an instance, the preview/terminal

--- a/app/home_view.go
+++ b/app/home_view.go
@@ -15,22 +15,22 @@ import (
 
 func (m *home) handleError(err error) tea.Cmd {
 	log.ErrorLog.Printf("%v", err)
-	return m.showTransientError(err)
+	if err == nil {
+		return nil
+	}
+	return m.clearTransientMessageAfterDelay(m.setTransientFailure(err))
 }
 
 // handleNotice reports why af deliberately declined or redirected a user
 // action. The same transient UI surface carries both notices and failures, but
-// their logs must not: ERROR is reserved for an operation that actually failed.
+// their logs must not — ERROR is reserved for an operation that actually failed
+// — and neither must the details overlay's title (#2618).
 func (m *home) handleNotice(notice error) tea.Cmd {
 	log.InfoLog.Printf("%v", notice)
-	return m.showTransientError(notice)
-}
-
-func (m *home) showTransientError(err error) tea.Cmd {
-	if err == nil {
+	if notice == nil {
 		return nil
 	}
-	return m.clearTransientMessageAfterDelay(m.setTransientNotice(err))
+	return m.clearTransientMessageAfterDelay(m.setTransientNotice(notice))
 }
 
 func (m *home) showTransientMessage(message string) tea.Cmd {
@@ -40,7 +40,18 @@ func (m *home) showTransientMessage(message string) tea.Cmd {
 	return m.clearTransientMessageAfterDelay(m.setTransientNotice(errors.New(message)))
 }
 
+// setTransientNotice raises informational guidance: an action af declined, work
+// it started, a layout decision it made on the user's behalf.
 func (m *home) setTransientNotice(err error) uint64 {
+	m.transientNoticeID++
+	m.errBox.SetNotice(err)
+	return m.transientNoticeID
+}
+
+// setTransientFailure raises a real operation failure. Same bar, same timer —
+// only the category differs, which is what the details overlay titles itself
+// from.
+func (m *home) setTransientFailure(err error) uint64 {
 	m.transientNoticeID++
 	m.errBox.SetError(err)
 	return m.transientNoticeID
@@ -56,12 +67,23 @@ func (m *home) clearTransientMessageAfterDelay(noticeID uint64) tea.Cmd {
 	}
 }
 
+// showErrorDetails opens the last notice in full. It reads the RETAINED notice,
+// not the one currently painted: the bar drops a notice after 3 seconds, and
+// binding `E` to what is still on screen made the key silently dead in exactly
+// the case it exists for — a message the bar had to clip (#2618).
 func (m *home) showErrorDetails() (tea.Model, tea.Cmd) {
-	full := m.errBox.FullError()
+	full, failure := m.errBox.RetainedNotice()
 	if full == "" {
 		return m, nil
 	}
-	m.textOverlay = overlay.NewTextOverlay("Last error\n\n" + full)
+	// af hiding a pane and saying how to get it back is designed behavior. Filing
+	// it under "Last error" would report af working as intended as a fault, which
+	// is the same miscategorization #2575 found in the logs.
+	title := "Last notice"
+	if failure {
+		title = "Last error"
+	}
+	m.textOverlay = overlay.NewTextOverlay(title + "\n\n" + full)
 	m.textOverlayDismissAnyKey = false
 	m.textOverlayScrollable = true
 	m.textOverlayDismissPolicy = nil
@@ -94,7 +116,7 @@ func (m *home) confirmActionWithDetail(message, detail string, action tea.Cmd) t
 			if msg := action(); msg != nil {
 				if err, ok := msg.(error); ok {
 					log.ErrorLog.Printf("confirmation action failed: %v", err)
-					m.setTransientNotice(err)
+					m.setTransientFailure(err)
 				} else {
 					// Stash non-error messages so handleStateConfirm can
 					// forward them into the Bubble Tea event loop.
@@ -182,33 +204,33 @@ func (m *home) View() string {
 		if m.textOverlay == nil {
 			log.ErrorLog.Printf("text overlay is nil")
 		}
-		return overlay.PlaceOverlay(0, 0, m.textOverlay.Render(), mainView, true)
+		return placeOverlay(m.textOverlay.Render(), mainView)
 	} else if m.state == stateConfirm {
 		if m.confirmationOverlay == nil {
 			log.ErrorLog.Printf("confirmation overlay is nil")
 		}
 		fg := m.confirmationOverlay.Render()
 		m.confirmationOverlay.RegisterZones(m.zones, overlayOrigin(fg, mainView))
-		return overlay.PlaceOverlay(0, 0, fg, mainView, true)
+		return placeOverlay(fg, mainView)
 	} else if m.state == stateSearch {
 		if m.searchOverlay == nil {
 			log.ErrorLog.Printf("search overlay is nil")
 		}
 		fg := m.searchOverlay.Render()
 		m.searchOverlay.RegisterZones(m.zones, overlayOrigin(fg, mainView))
-		return overlay.PlaceOverlay(0, 0, fg, mainView, true)
+		return placeOverlay(fg, mainView)
 	} else if m.state == stateSwitchProject {
 		if m.projectPickerOverlay == nil {
 			log.ErrorLog.Printf("project picker overlay is nil")
 		}
-		return overlay.PlaceOverlay(0, 0, m.projectPickerOverlay.Render(), mainView, true)
+		return placeOverlay(m.projectPickerOverlay.Render(), mainView)
 	} else if m.state == stateSelectProgram || m.state == stateSelectHandoffAgent || m.state == stateSelectBackend {
 		if m.selectionOverlay == nil {
 			log.ErrorLog.Printf("selection overlay is nil")
 		}
 		fg := m.selectionOverlay.Render()
 		m.selectionOverlay.RegisterZones(m.zones, overlayOrigin(fg, mainView))
-		return overlay.PlaceOverlay(0, 0, fg, mainView, true)
+		return placeOverlay(fg, mainView)
 	} else if m.state == stateSelectTabKind {
 		if m.selectionOverlay == nil {
 			log.ErrorLog.Printf("tab-kind selection overlay is nil")
@@ -216,19 +238,19 @@ func (m *home) View() string {
 		}
 		fg := m.selectionOverlay.Render()
 		m.selectionOverlay.RegisterZones(m.zones, overlayOrigin(fg, mainView))
-		return overlay.PlaceOverlay(0, 0, fg, mainView, true)
+		return placeOverlay(fg, mainView)
 	} else if m.state == statePromptInput {
 		if m.promptOverlay == nil {
 			log.ErrorLog.Printf("prompt overlay is nil")
 			return mainView
 		}
-		return overlay.PlaceOverlay(0, 0, m.promptOverlay.Render(), mainView, true)
+		return placeOverlay(m.promptOverlay.Render(), mainView)
 	} else if m.state == stateHooks {
-		return overlay.PlaceOverlay(0, 0, m.renderHooksOverlay(), mainView, true)
+		return placeOverlay(m.renderHooksOverlay(), mainView)
 	} else if m.state == stateTasks {
-		return overlay.PlaceOverlay(0, 0, m.renderTasksOverlay(), mainView, true)
+		return placeOverlay(m.renderTasksOverlay(), mainView)
 	} else if m.state == stateConfigEditor {
-		return overlay.PlaceOverlay(0, 0, m.renderConfigOverlay(), mainView, true)
+		return placeOverlay(m.renderConfigOverlay(), mainView)
 	}
 
 	return mainView

--- a/app/kill_confirm.go
+++ b/app/kill_confirm.go
@@ -298,7 +298,7 @@ func detachedHeadCommitWarning(worktreePath, branchName string, deleteBranch boo
 		}
 	}
 	return "Detached HEAD points to one or more commits not reachable from any ref that survives cleanup. " +
-		"Killing removes the worktree and permanently orphans them · this cannot be undone.", true
+		"Killing removes the worktree and permanently orphans them — this cannot be undone.", true
 }
 
 func refSurvivesWorktreeCleanup(ref, branchName string, deleteBranch bool) bool {
@@ -366,7 +366,7 @@ func unmergedSevereLine(branchName string, n int, baseLabel string) string {
 	if baseLabel != "" {
 		where = fmt.Sprintf("not on %s and not pushed anywhere", baseLabel)
 	}
-	return fmt.Sprintf("Branch %q has %d %s %s. Killing permanently deletes %s · this cannot be undone.", branchName, n, commitWord, where, pronoun)
+	return fmt.Sprintf("Branch %q has %d %s %s. Killing permanently deletes %s — this cannot be undone.", branchName, n, commitWord, where, pronoun)
 }
 
 // unmergedFailClosedLine mirrors the #815 could-not-verify warning for the

--- a/app/overlay_reserves_status_bar_test.go
+++ b/app/overlay_reserves_status_bar_test.go
@@ -1,0 +1,54 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	xansi "github.com/charmbracelet/x/ansi"
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/stretchr/testify/require"
+)
+
+// TestModalOverlayLeavesTheStatusBarIntact is #2578. The help overlay was
+// composited by centering it over the WHOLE frame, so an overlay tall enough to
+// reach the bottom painted its border straight through the hint row — `D kill`
+// rendered as `D ki`, `? help` as `elp`. The row read as corruption rather than
+// as an overlay, on the one screen a confused user goes to.
+//
+// The assertion is the strongest available: the status-bar rows must be byte-
+// for-byte what they are with no overlay up (the fade only rewrites SGR codes,
+// so stripping ANSI compares exactly the printable cells).
+func TestModalOverlayLeavesTheStatusBarIntact(t *testing.T) {
+	for _, size := range [][2]int{{80, 24}, {100, 30}, {200, 50}} {
+		t.Run(sizeName(size), func(t *testing.T) {
+			h := newTestHome(t)
+			resizeHome(h, size[0], size[1])
+			want := statusBarRows(t, h.View(), size[1])
+
+			_, _ = h.showHelpScreen(helpTypeGeneral{}, nil)
+			require.Equal(t, stateHelp, h.state, "precondition: the help overlay is up")
+			got := statusBarRows(t, h.View(), size[1])
+
+			require.Equal(t, want, got,
+				"the overlay painted over the status bar instead of stopping above it")
+		})
+	}
+}
+
+func sizeName(size [2]int) string {
+	return fmt.Sprintf("%dx%d", size[0], size[1])
+}
+
+// statusBarRows returns the frame's final layout.StatusBarRows lines with ANSI
+// stripped.
+func statusBarRows(t *testing.T, frame string, height int) []string {
+	t.Helper()
+	lines := strings.Split(frame, "\n")
+	require.Len(t, lines, height, "the frame must tile the whole window")
+	rows := make([]string, 0, layout.StatusBarRows)
+	for _, line := range lines[height-layout.StatusBarRows:] {
+		rows = append(rows, xansi.Strip(line))
+	}
+	return rows
+}

--- a/app/pane_autohide_status_test.go
+++ b/app/pane_autohide_status_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 )
@@ -237,8 +238,10 @@ func TestPane_AutoHideStatusNamesDisplacedTab(t *testing.T) {
 			rendered := h.errBox.String()
 			assert.Contains(t, rendered, tc.wantHiddenNamedAs,
 				"the toast names the tab that was actually displaced (#1997)")
-			assert.Contains(t, rendered, "resize wider",
+			assert.Contains(t, rendered, "resize",
 				"naming the tab must not push the recovery hint off the 80-column bar (#1973)")
+			assert.Contains(t, rendered, "`"+keys.GlobalKeyBindings[keys.KeyOpenPane].Help().Key+"`",
+				"nor the key half of it (#2580)")
 		})
 	}
 }
@@ -308,4 +311,48 @@ func TestPane_OpenPaneWindowIsIdempotent(t *testing.T) {
 	second := h.openPaneWindow(alpha, 0)
 	require.Same(t, first, second, "re-opening the same (instance, tab) returns the existing pane")
 	assert.Equal(t, 1, h.store.NumOpenPanes(), "no duplicate pane is appended")
+}
+
+// TestPane_AutoHideStatusKeepsTheRecoveryHintAtEightyColumns is #2580 item 3.
+// The bar truncates from the RIGHT, so the auto-hide notice's LAST fragment is
+// the one that dies — and that fragment is the `s` key, the cheaper of the two
+// remedies (no resize needed, and the only one a user cannot discover by
+// fiddling). #1973 bought room for it by dropping a word; #1997 then spent that
+// room making the subject a full pane identity (`alpha · ◆ Agent` rather than
+// `alpha`), pushing the hint back off the end at the default terminal size.
+//
+// The assertion is on the RENDERED bar, not the composed string: the composed
+// string always held the hint, which is exactly why this regressed unnoticed.
+// `clear-cmd` is the issue's own repro name — nine characters, not a long one.
+func TestPane_AutoHideStatusKeepsTheRecoveryHintAtEightyColumns(t *testing.T) {
+	for _, title := range []string{"alpha", "clear-cmd"} {
+		t.Run(title, func(t *testing.T) {
+			h := newTestHome(t)
+			inst := instanceWithFakeBackend(t, title)
+			inst.AddTabForTest("agent", session.TabKindAgent)
+			inst.AddTabForTest("shell", session.TabKindShell)
+			h.store.AddInstance(inst)
+			h.sidebar.SetSelectedInstance(0)
+			_ = h.selectionChanged()
+			resizeHome(h, 80, 24)
+
+			_, _ = h.openOrFocusPane(inst, 0)
+			_, _ = h.openOrFocusPane(inst, 1)
+			require.Equal(t, 1, len(h.visiblePanes), "precondition: only one pane fits at 80 columns")
+
+			rendered := h.errBox.String()
+			openPaneKey := keys.GlobalKeyBindings[keys.KeyOpenPane].Help().Key
+			require.NotEmpty(t, openPaneKey)
+
+			assert.Contains(t, rendered, title+" · ◆ Agent hidden",
+				"the subject still names the pane that was actually displaced (#1997)")
+			assert.Contains(t, rendered, "resize", "the resize remedy survives")
+			assert.Contains(t, rendered, "`"+openPaneKey+"`",
+				"the key that reopens the pane without a resize must survive the 80-column bar")
+			assert.NotContains(t, rendered, "\u2026",
+				"a notice that fits needs no ellipsis, and a dangling `or…` reads as a fault")
+			assert.NotContains(t, rendered, "E details",
+				"the bar only advertises the details key for a notice it had to clip")
+		})
+	}
 }

--- a/app/pane_duplicate_label_test.go
+++ b/app/pane_duplicate_label_test.go
@@ -31,7 +31,7 @@ func TestPane_NumberJumpDisambiguatesDuplicateTerminalHeaders(t *testing.T) {
 	_, _ = h.handleTabJump(2)
 	require.Equal(t, 1, paneB.Tab())
 	view := h.View()
-	assert.Contains(t, view, "beta · 2 › Terminal · selected: beta · 3 › Terminal",
+	assert.Contains(t, view, "beta · 2 › Terminal — selected: beta · 3 › Terminal",
 		"the pane and tree identities remain distinct after jumping to slot 2")
 
 	_, _ = h.handleTabJump(3)

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -197,14 +197,14 @@ func TestPane_HeaderAnnotatesSelectionDivergence(t *testing.T) {
 	require.Same(t, alpha, paneA.Instance(), "selection must not retarget explicit panes")
 
 	view := h.View()
-	assert.Contains(t, view, "Preview beta · ◆ Agent (original alpha · ◆ Agent)",
+	assert.Contains(t, view, "Preview beta · ◆ Agent — original alpha · ◆ Agent",
 		"preview header must reconcile transient target vs original pane")
-	assert.NotContains(t, view, "alpha · ◆ Agent · selected: beta · ◆ Agent",
+	assert.NotContains(t, view, "alpha · ◆ Agent — selected: beta · ◆ Agent",
 		"selected divergence is hidden while preview owns the render binding")
 
 	h.cancelPanePreview(false)
 	view = h.View()
-	assert.Contains(t, view, "alpha · ◆ Agent · selected: beta · ◆ Agent",
+	assert.Contains(t, view, "alpha · ◆ Agent — selected: beta · ◆ Agent",
 		"canceling preview restores the #1289 selected row vs shown content invariant")
 }
 
@@ -226,7 +226,7 @@ func TestPanePreviewPaintsLastCaptureWhileRefreshing(t *testing.T) {
 	_ = h.selectionChanged()
 
 	view := h.View()
-	assert.Contains(t, view, "Preview beta · ◆ Agent (original alpha · ◆ Agent)")
+	assert.Contains(t, view, "Preview beta · ◆ Agent — original alpha · ◆ Agent")
 	assert.Contains(t, view, "ALPHA_PREVIEW_CONTENT",
 		"retargeting must paint the last capture instead of blanking while beta loads")
 	assert.NotContains(t, view, "Loading preview…")
@@ -267,7 +267,7 @@ func TestPanePreviewSlowCaptureFallsBackAfterGrace(t *testing.T) {
 	assert.Nil(t, followup)
 
 	view := h.View()
-	assert.Contains(t, view, "Preview beta · ◆ Agent (original alpha · ◆ Agent)")
+	assert.Contains(t, view, "Preview beta · ◆ Agent — original alpha · ◆ Agent")
 	assert.Contains(t, view, "Loading preview…",
 		"a capture that does not arrive must stop showing another session's pane")
 	assert.NotContains(t, view, "ALPHA_PREVIEW_CONTENT")
@@ -376,7 +376,7 @@ func TestPanePreviewFastScrollLatestWins(t *testing.T) {
 
 	require.IsType(t, panesRefreshedMsg{}, refreshPaneBindingCmd(w, beta, 0, betaSeq)())
 	view := h.View()
-	assert.Contains(t, view, "Preview gamma · ◆ Agent (original alpha · ◆ Agent)")
+	assert.Contains(t, view, "Preview gamma · ◆ Agent — original alpha · ◆ Agent")
 	assert.Contains(t, view, "ALPHA_PREVIEW_CONTENT",
 		"a late capture for beta must leave the last painted frame in place")
 	assert.NotContains(t, view, "BETA_PREVIEW_CONTENT",
@@ -384,7 +384,7 @@ func TestPanePreviewFastScrollLatestWins(t *testing.T) {
 
 	require.IsType(t, panesRefreshedMsg{}, refreshPaneBindingCmd(w, gamma, 0, gammaSeq)())
 	view = h.View()
-	assert.Contains(t, view, "Preview gamma · ◆ Agent (original alpha · ◆ Agent)")
+	assert.Contains(t, view, "Preview gamma · ◆ Agent — original alpha · ◆ Agent")
 	assert.Contains(t, view, "GAMMA_PREVIEW_CONTENT")
 	assert.NotContains(t, view, "BETA_PREVIEW_CONTENT")
 	assert.Same(t, alpha, paneA.Instance(), "latest-wins preview must still be transient")
@@ -449,7 +449,7 @@ func TestPanePreviewTabRowCommitsSameInstanceTerminal(t *testing.T) {
 	assert.Same(t, alpha, h.panePreviewTxn.target.instance)
 	assert.Equal(t, 1, h.panePreviewTxn.target.tab)
 	assert.Equal(t, 0, paneA.Tab(), "preview remains transient until commit")
-	assert.Contains(t, h.View(), "Preview alpha · › Terminal (original alpha · ◆ Agent)")
+	assert.Contains(t, h.View(), "Preview alpha · › Terminal — original alpha · ◆ Agent")
 
 	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
 
@@ -514,7 +514,7 @@ func TestPanePreviewInstanceRowUsesSelectedTerminalTab(t *testing.T) {
 	assert.Same(t, beta, h.panePreviewTxn.target.instance)
 	assert.Equal(t, 1, h.panePreviewTxn.target.tab,
 		"preview target must match the selected/action (instance, tab), not default to Agent")
-	assert.Contains(t, h.View(), "Preview beta · › Terminal (original alpha · ◆ Agent)")
+	assert.Contains(t, h.View(), "Preview beta · › Terminal — original alpha · ◆ Agent")
 	assert.NotContains(t, h.View(), "Preview beta · ◆ Agent")
 }
 
@@ -621,7 +621,7 @@ func TestPanePreviewSplitHideDoesNotStickInPanePreview(t *testing.T) {
 	require.Same(t, beta, h.store.GetSelectedInstance())
 	require.Equal(t, layout.RegionTree, h.ring.Active(), "tree navigation owns focus during preview")
 	require.NotNil(t, h.panePreviewTxn)
-	require.Contains(t, h.View(), "Preview beta · › Terminal (original alpha · ◆ Agent)")
+	require.Contains(t, h.View(), "Preview beta · › Terminal — original alpha · ◆ Agent")
 
 	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("S")}, keys.KeySplitPane)
 	require.NotNil(t, cmd)
@@ -644,7 +644,7 @@ func TestPanePreviewSplitHideDoesNotStickInPanePreview(t *testing.T) {
 	require.Nil(t, h.panePreviewTxn, "hiding the split target must not recreate its preview")
 	assert.Equal(t, layout.PaneRegion(paneA.ID()), h.ring.Active(), "focus lands on the surviving pane")
 	view := h.View()
-	assert.Contains(t, view, "alpha · ◆ Agent · selected: beta ·",
+	assert.Contains(t, view, "alpha · ◆ Agent — selected: beta ·",
 		"the survivor keeps the #1289 selected-vs-shown header")
 	assert.NotContains(t, view, "Preview", "the hidden split pane must not leave a transient preview")
 
@@ -712,7 +712,7 @@ func TestPanePreviewEscCancelsToOwnerPane(t *testing.T) {
 	assert.Equal(t, 0, paneA.Tab())
 	assert.Equal(t, layout.PaneRegion(paneA.ID()), h.ring.Active())
 	view := h.View()
-	assert.Contains(t, view, "alpha · ◆ Agent · selected: beta · ◆ Agent")
+	assert.Contains(t, view, "alpha · ◆ Agent — selected: beta · ◆ Agent")
 	assert.NotContains(t, view, "Preview")
 }
 
@@ -941,7 +941,7 @@ func TestPane_NumberJumpAnnotatesSelectedTabDivergence(t *testing.T) {
 	assert.Equal(t, 1, paneB.Tab(), "focused beta pane jumps to tab 2")
 	assert.Equal(t, 0, h.store.ActiveTab(), "pane-focused jump must not retarget the sidebar selection")
 	view := h.View()
-	assert.Contains(t, view, "beta · › Terminal · selected: beta · ◆ Agent",
+	assert.Contains(t, view, "beta · › Terminal — selected: beta · ◆ Agent",
 		"pane header shows the jumped tab and the still-selected tree tab")
 	assert.Contains(t, view, "1 ◆ Agent *", "sidebar active-tab marker stays on the selected tab")
 }
@@ -1142,7 +1142,7 @@ func TestPane_AutoHideShowsTransientStatus(t *testing.T) {
 
 	require.Equal(t, 2, h.store.NumOpenPanes(), "the second pane still opens")
 	assert.Equal(t, []string{"beta"}, visibleTitles(h), "width pressure hides alpha and shows beta")
-	assert.Equal(t, "alpha · ◆ Agent hidden — too narrow for 2 panes; resize wider or use `s` open pane",
+	assert.Equal(t, "alpha · ◆ Agent hidden — too narrow; resize or `s` open pane",
 		h.errBox.FullError())
 }
 

--- a/app/render.go
+++ b/app/render.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/overlay"
 )
 
 // View render helpers extracted from app.go (#1145): overlay frame sizing and
@@ -306,4 +307,50 @@ func (m *home) renderProjectsRule() string {
 		return ""
 	}
 	return splitDividerStyle.Render(strings.Repeat("─", r.W))
+}
+
+// overlayOrigin computes where a modal's top-left lands on the frame: centered
+// on the frame, then lifted just far enough that its last row clears the status
+// bar. The overlays register their button zones relative to this origin, and
+// placeOverlay composites at it, so the two can never disagree about where the
+// modal is.
+//
+// The lift is #2578. PlaceOverlay's own centering measures the WHOLE frame, so a
+// modal tall enough to reach the bottom painted its border straight through the
+// hint row and cut the hints mid-word — `D kill` rendered as `D ki`, `? help` as
+// `elp`. The row read as corruption rather than as an overlay, on the help
+// screen, which is where a confused user goes.
+//
+// It is a clamp rather than "center within the region above the bar" on purpose:
+// only a modal that would actually collide moves. Every short modal keeps the
+// exact position it has always had, so the fix costs nothing anywhere it was not
+// needed.
+func overlayOrigin(fg, bg string) layout.Point {
+	fgW, fgH := lipgloss.Width(fg), lipgloss.Height(fg)
+	bgW, bgH := lipgloss.Width(bg), lipgloss.Height(bg)
+	y := centerOffset(bgH - fgH)
+	// A modal too tall to clear the bar even at the top of the frame keeps the
+	// old centering: showing it matters more than the hint row, and PlaceOverlay
+	// clamps a negative offset back anyway.
+	if highest := bgH - layout.StatusBarRows - fgH; highest >= 0 && y > highest {
+		y = highest
+	}
+	return layout.Point{X: centerOffset(bgW - fgW), Y: y}
+}
+
+// centerOffset halves the slack, never going negative — matching PlaceOverlay's
+// own clamp for a foreground wider or taller than its background.
+func centerOffset(slack int) int {
+	if slack <= 0 {
+		return 0
+	}
+	return slack / 2
+}
+
+// placeOverlay composites a modal onto the frame at overlayOrigin. Every modal
+// branch in View goes through it so none can reintroduce #2578 by calling
+// PlaceOverlay's centering directly.
+func placeOverlay(fg, bg string) string {
+	origin := overlayOrigin(fg, bg)
+	return overlay.PlaceOverlay(origin.X, origin.Y, fg, bg, false)
 }

--- a/app/tui_state_test.go
+++ b/app/tui_state_test.go
@@ -149,7 +149,7 @@ func TestTUIViewStateRestoredPanesAutoHideShowsStatus(t *testing.T) {
 	require.Equal(t, 1, h.lastLayout.PaneCount())
 	require.Equal(t, 2, h.store.NumOpenPanes(), "auto-hide retains both bindings")
 	assert.Empty(t, h.restoredPaneBaseline, "the sized relayout consumes the baseline")
-	assert.Contains(t, h.errBox.FullError(), "hidden — too narrow for 2 panes",
+	assert.Contains(t, h.errBox.FullError(), "hidden — too narrow",
 		"a pane hidden on the first post-restore relayout must still surface the status (#1535)")
 }
 

--- a/ui/err.go
+++ b/ui/err.go
@@ -11,7 +11,23 @@ import (
 
 type ErrBox struct {
 	height, width int
-	err           error
+	// err is what the bar RENDERS. It goes nil when the notice's visual timer
+	// expires (Expire) or when the action that raised it takes it back (Clear).
+	err error
+	// retained is the most recent notice, kept alive past its visual expiry so
+	// `E details` can still open it (#2618). Retraction drops it as well: a
+	// notice that stopped being TRUE must not stay reachable, while one that
+	// merely stopped being VISIBLE must.
+	//
+	// Retaining it is the whole point of the affordance. `E` exists for a
+	// message too long for the bar, and it used to go dead 3 seconds later — at
+	// exactly the moment the clipped half left the screen — so the one case it
+	// was built for was the one case it could not serve.
+	retained error
+	// retainedIsFailure records whether the retained notice reported a real
+	// failure (handleError) or informational guidance (handleNotice / a success
+	// message), which is what the details overlay titles itself from.
+	retainedIsFailure bool
 }
 
 var errStyle = lipgloss.NewStyle().Foreground(activeTheme.Error)
@@ -20,12 +36,36 @@ func NewErrBox() *ErrBox {
 	return &ErrBox{}
 }
 
-func (e *ErrBox) SetError(err error) {
+// SetError shows a real operation failure.
+func (e *ErrBox) SetError(err error) { e.set(err, true) }
+
+// SetNotice shows informational guidance: an action af deliberately declined or
+// redirected, or something it did on the user's behalf. Same bar, different
+// category — see retainedIsFailure.
+func (e *ErrBox) SetNotice(err error) { e.set(err, false) }
+
+func (e *ErrBox) set(err error, failure bool) {
 	e.err = err
+	if err == nil {
+		return
+	}
+	e.retained = err
+	e.retainedIsFailure = failure
 }
 
+// Expire stops rendering the notice when its visual timer runs out, leaving it
+// readable through `E details`.
+func (e *ErrBox) Expire() {
+	e.err = nil
+}
+
+// Clear RETRACTS the notice: the caller is saying it is no longer true (a
+// "Starting…" that finished, narrow-width guidance the resize resolved), so it
+// leaves no trace behind for `E details` to reopen.
 func (e *ErrBox) Clear() {
 	e.err = nil
+	e.retained = nil
+	e.retainedIsFailure = false
 }
 
 func (e *ErrBox) SetSize(width, height int) {
@@ -33,11 +73,23 @@ func (e *ErrBox) SetSize(width, height int) {
 	e.height = height
 }
 
+// FullError is the notice currently ON the bar, sanitized. Empty once it
+// expires or is retracted.
 func (e *ErrBox) FullError() string {
 	if e.err == nil {
 		return ""
 	}
 	return sanitizeError(e.err.Error())
+}
+
+// RetainedNotice is the most recent notice that has not been retracted, whether
+// or not the bar is still showing it, plus whether it reported a failure. This
+// is what `E details` opens (#2618).
+func (e *ErrBox) RetainedNotice() (text string, failure bool) {
+	if e.retained == nil {
+		return "", false
+	}
+	return sanitizeError(e.retained.Error()), e.retainedIsFailure
 }
 
 func (e *ErrBox) String() string {

--- a/ui/hooks_pane.go
+++ b/ui/hooks_pane.go
@@ -200,11 +200,11 @@ func (h *HooksPane) String() string {
 	b.WriteString("\n")
 	if h.hasFocus {
 		if h.editing || h.adding {
-			b.WriteString(hintStyle.Render("enter save • esc cancel"))
+			b.WriteString(hintStyle.Render("enter save · esc cancel"))
 		} else {
-			hint := "n add • enter edit • D delete • esc back"
+			hint := "n add · enter edit · D delete · esc back"
 			if h.width > 0 && lipgloss.Width(hint) > h.width {
-				hint = "n add • enter • esc back"
+				hint = "n add · enter · esc back"
 			}
 			b.WriteString(hintStyle.Render(hint))
 		}

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/sachiniyer/agent-factory/ui/layout/zones"
 
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -510,9 +511,13 @@ func centerStart(box, content int) int {
 
 // hintDropOrder lists the options that may be dropped when the hint row is
 // wider than the status bar, least valuable first; options in the same inner
-// slice drop together (a lone "ctrl+d preview scroll" without its ctrl+u twin
-// reads like a bug). The full instance row is wider than common terminals, so
-// something has to go — and before this priority existed the CLAMP
+// slice drop together, because half of a pair is not a hint anyone can act on.
+// For the scroll pair that is now structural as well as editorial: the two
+// render as one chip (hintPairs), so dropping one alone would leave a chip
+// naming a key the row is no longer offering.
+//
+// The full instance row is wider than common terminals, so something has to go
+// — and before this priority existed the CLAMP
 // decided, silently cutting the RIGHT edge, i.e. `? help` and `q quit` first:
 // exactly the hints a lost user needs (#1083 play-test). New, help, quit, and
 // kill are deliberately absent from this list: `n new` is the tree-focus
@@ -625,10 +630,24 @@ type hintSpan struct {
 	x, w int
 }
 
+// hintPairs are adjacent options the row renders as ONE chip, keyed by the
+// leading option. Both bindings in a pair carry the identical description, so
+// printing each on its own spent 44 cells saying one thing twice —
+// `ctrl+u preview scroll · ctrl+d preview scroll` — in a row that sheds hints by
+// width (#2580). The chip is `ctrl+u/ctrl+d preview scroll`, the form the help
+// overlay already uses for this pair.
+//
+// The glyphs come from the effective bindings rather than a pinned helpLabel:
+// helpLabel covers only the DEFAULT binding by design, so a [keys] rebind of
+// scroll_up would have shown a label naming a key that no longer scrolls.
+var hintPairs = map[keys.KeyName]keys.KeyName{
+	keys.KeyShiftUp: keys.KeyShiftDown,
+}
+
 // renderHints renders the option row, skipping dropped options, and reports
 // each rendered hint's cell extent for the click zones. Separators follow
-// group membership of the options actually rendered: a bullet within a group,
-// a vertical bar between groups.
+// group membership of the options actually rendered: a middle dot within a
+// group, a vertical bar between groups.
 func (m *Menu) renderHints(drop map[keys.KeyName]bool) (string, []hintSpan) {
 	groupOf := func(i int) int {
 		for gi, g := range m.groups {
@@ -648,11 +667,21 @@ func (m *Menu) renderHints(drop map[keys.KeyName]bool) (string, []hintSpan) {
 	}
 	prevGroup := -1
 	first := true
+	skip := -1
 	for i, k := range m.options {
-		if drop[k] {
+		if drop[k] || i == skip {
 			continue
 		}
 		binding := keys.GlobalKeyBindings[k]
+
+		// A pair collapses only when its partner is the very next option, still
+		// rendered, and in the same group — otherwise the chip would claim a key
+		// the row is not actually offering.
+		partner, paired := hintPairs[k]
+		if paired {
+			paired = i+1 < len(m.options) && m.options[i+1] == partner &&
+				!drop[partner] && groupOf(i) == groupOf(i+1)
+		}
 
 		var (
 			localActionStyle = actionGroupStyle
@@ -678,24 +707,50 @@ func (m *Menu) renderHints(drop map[keys.KeyName]bool) (string, []hintSpan) {
 		first = false
 		prevGroup = group
 
-		start := col
+		keyText, descText := localKeyStyle, localDescStyle
 		if inActionGroup {
-			write(localActionStyle.Render(binding.Help().Key))
-			write(" ")
-			write(localActionStyle.Render(binding.Help().Desc))
-		} else {
-			write(localKeyStyle.Render(binding.Help().Key))
-			write(" ")
-			write(localDescStyle.Render(binding.Help().Desc))
+			keyText, descText = localActionStyle, localActionStyle
 		}
+
+		start := col
+		if paired {
+			// Each key claims the cells of its OWN glyph, so collapsing the pair
+			// costs neither of them its click target and a click still presses
+			// the key printed under the pointer. The shared description belongs
+			// to both and is claimed by neither.
+			partnerBinding := keys.GlobalKeyBindings[partner]
+			write(keyText.Render(binding.Help().Key))
+			spans = appendHintSpan(spans, binding, start, col-start)
+			write(keyText.Render("/"))
+			partnerStart := col
+			write(keyText.Render(partnerBinding.Help().Key))
+			spans = appendHintSpan(spans, partnerBinding, partnerStart, col-partnerStart)
+			write(" ")
+			write(descText.Render(binding.Help().Desc))
+			skip = i + 1
+			continue
+		}
+
+		write(keyText.Render(binding.Help().Key))
+		write(" ")
+		write(descText.Render(binding.Help().Desc))
 		// KeyJumpTab's "1-9" chip names nine keys, not one action — it gets
 		// no click zone. Everything else is clickable by its primary key.
 		if k != keys.KeyJumpTab {
-			if bkeys := binding.Keys(); len(bkeys) > 0 {
-				spans = append(spans, hintSpan{key: bkeys[0], x: start, w: col - start})
-			}
+			spans = appendHintSpan(spans, binding, start, col-start)
 		}
 	}
 
 	return menuStyle.Render(s.String()), spans
+}
+
+// appendHintSpan records a clickable extent for a binding, keyed by its primary
+// key string — what a click on those cells "presses". A binding with no keys
+// registers nothing rather than a zone that presses "".
+func appendHintSpan(spans []hintSpan, binding key.Binding, x, w int) []hintSpan {
+	bkeys := binding.Keys()
+	if len(bkeys) == 0 {
+		return spans
+	}
+	return append(spans, hintSpan{key: bkeys[0], x: x, w: w})
 }

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -5,10 +5,12 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
+	xansi "github.com/charmbracelet/x/ansi"
 
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
 )
 
 // readyUIInstance builds an actionable Ready-status instance for ui-package
@@ -572,5 +574,77 @@ func TestMenuNarrowPaneFocusDoesNotShowHideWithoutOpen(t *testing.T) {
 	out := m.String()
 	if strings.Contains(out, "hide pane") && !strings.Contains(out, "open pane") {
 		t.Fatalf("narrow pane footer must not show hide without the recovery/open action:\n%s", out)
+	}
+}
+
+// TestMenuCollapsesTheScrollPairIntoOneHint is #2580 item 1. Both scroll
+// bindings carry the identical desc "preview scroll", so the row spent 44 cells
+// saying one thing twice — `ctrl+u preview scroll · ctrl+d preview scroll` — in
+// a row that sheds hints by width. The pair renders as one chip, the form the
+// help overlay already uses for it.
+func TestMenuCollapsesTheScrollPairIntoOneHint(t *testing.T) {
+	m := NewMenu()
+	m.SetInstance(readyUIInstance())
+	m.SetScrollAvailable(true)
+	m.SetSize(200, 1)
+
+	out := xansi.Strip(m.String())
+	if got := strings.Count(out, "preview scroll"); got != 1 {
+		t.Fatalf("the scroll description renders %d times, want 1:\n%s", got, out)
+	}
+	if !strings.Contains(out, "ctrl+u/ctrl+d preview scroll") {
+		t.Fatalf("the pair must render as one chip:\n%s", out)
+	}
+}
+
+// The chip's key glyphs come from the effective bindings, so a [keys] rebind
+// shows through — the reason this is a renderer pairing rather than a pinned
+// helpLabel, which only covers the default binding.
+func TestMenuScrollChipFollowsRebinds(t *testing.T) {
+	t.Cleanup(func() {
+		if err := keys.ApplyOverrides(nil); err != nil {
+			t.Fatalf("restoring default keymap: %v", err)
+		}
+	})
+	if err := keys.ApplyOverrides(map[string][]string{
+		"scroll_up":   {"ctrl+b"},
+		"scroll_down": {"ctrl+f"},
+	}); err != nil {
+		t.Fatalf("ApplyOverrides: %v", err)
+	}
+
+	m := NewMenu()
+	m.SetInstance(readyUIInstance())
+	m.SetScrollAvailable(true)
+	m.SetSize(200, 1)
+
+	out := xansi.Strip(m.String())
+	if !strings.Contains(out, "ctrl+b/ctrl+f preview scroll") {
+		t.Fatalf("the chip must name the effective bindings:\n%s", out)
+	}
+}
+
+// Collapsing the pair must not cost either key its click target: the cells
+// under each glyph still press that key.
+func TestMenuScrollChipKeepsBothClickZones(t *testing.T) {
+	m := NewMenu()
+	reg := zones.NewRegistry()
+	m.SetZoneRegistry(reg)
+	m.SetOrigin(layout.Point{})
+	m.SetInstance(readyUIInstance())
+	m.SetScrollAvailable(true)
+	m.SetSize(200, 1)
+
+	reg.Reset()
+	line := strings.Split(xansi.Strip(m.String()), "\n")[0]
+
+	for _, want := range []string{"ctrl+u", "ctrl+d"} {
+		r, ok := reg.Find(zones.StatusHint(want))
+		if !ok {
+			t.Fatalf("no click zone for %q; got %v", want, reg.IDs())
+		}
+		if got := cellSlice(line, r.X, r.X+r.W); got != want {
+			t.Fatalf("the %q zone covers %q, want the key's own glyph", want, got)
+		}
 	}
 }

--- a/ui/overlay/confirmationOverlay.go
+++ b/ui/overlay/confirmationOverlay.go
@@ -359,7 +359,7 @@ func refusalNotices(short int) []string {
 func (c *ConfirmationOverlay) instruction(compact bool) string {
 	bold := lipgloss.NewStyle().Bold(true).Render
 	if compact {
-		return bold(c.ConfirmKey) + " confirm • " +
+		return bold(c.ConfirmKey) + " confirm · " +
 			bold(c.CancelKey) + "/" + bold("esc") + " cancel"
 	}
 	confirmKeys := bold(c.ConfirmKey)

--- a/ui/overlay/projectPickerOverlay.go
+++ b/ui/overlay/projectPickerOverlay.go
@@ -235,7 +235,7 @@ func (p *ProjectPickerOverlay) Render() string {
 			lines = append(lines, truncateOverlayLine(errStyle.Render("  "+p.addErr), cw))
 		}
 		lines = append(lines, "")
-		hint := "enter add • esc back"
+		hint := "enter add · esc back"
 		lines = append(lines, truncateOverlayLine(hintStyle.Render(hint), cw))
 		return finishRender(style, fit, textRect, lines)
 	}
@@ -258,9 +258,9 @@ func (p *ProjectPickerOverlay) Render() string {
 	}
 
 	lines = append(lines, "")
-	hint := "j/k navigate • enter switch • esc cancel"
+	hint := "j/k navigate · enter switch · esc cancel"
 	if lipgloss.Width(hint) > cw {
-		hint = "j/k • enter • esc"
+		hint = "j/k · enter · esc"
 	}
 	lines = append(lines, truncateOverlayLine(hintStyle.Render(hint), cw))
 

--- a/ui/overlay/promptOverlay.go
+++ b/ui/overlay/promptOverlay.go
@@ -151,9 +151,9 @@ func (p *PromptOverlay) Render() string {
 	lines = append(lines, strings.Split(p.textarea.View(), "\n")...)
 	lines = append(lines, "")
 
-	hint := "enter newline • tab done • ctrl+c cancel"
+	hint := "enter newline · tab done · ctrl+c cancel"
 	if lipgloss.Width(hint) > textRect.W {
-		hint = "tab done • ctrl+c cancel"
+		hint = "tab done · ctrl+c cancel"
 	}
 	lines = append(lines, truncateOverlayLine(hintStyle.Render(hint), textRect.W))
 

--- a/ui/overlay/searchOverlay.go
+++ b/ui/overlay/searchOverlay.go
@@ -390,9 +390,9 @@ func (s *SearchOverlay) Render() string {
 	if !plan.compact {
 		lines = append(lines, "")
 	}
-	hint := "↑/↓ navigate • enter select • esc close"
+	hint := "↑/↓ navigate · enter select · esc close"
 	if plan.compact || lipgloss.Width(hint) > plan.contentWidth {
-		hint = "↑/↓ nav • enter • esc close"
+		hint = "↑/↓ nav · enter · esc close"
 	}
 	lines = append(lines, truncateOverlayLine(hintStyle.Render(hint), plan.contentWidth))
 

--- a/ui/projects.go
+++ b/ui/projects.go
@@ -229,7 +229,10 @@ func projectsSwitchHint() string { return "· enter switch" }
 func (p *ProjectsPane) titleLine(name string, nameStyle lipgloss.Style) string {
 	w := p.rect.W
 	const shortName = " Projects "
-	hint := " " + projectsSwitchHint() + " "
+	// No leading pad: every `name` passed in already ends with a space, exactly
+	// as the Automations header's does, and adding another produced the double
+	// space the two headers showed side by side in one frame (#2580).
+	hint := projectsSwitchHint() + " "
 	if runewidth.StringWidth(name+hint) <= w {
 		return nameStyle.Render(name) + projectsHintStyle.Render(hint)
 	}

--- a/ui/projects_test.go
+++ b/ui/projects_test.go
@@ -181,3 +181,23 @@ func TestProjectsPaneEmptyShowsPlaceholder(t *testing.T) {
 	_, ok := p.SelectedProject()
 	assert.False(t, ok, "an empty section resolves no selected project")
 }
+
+// TestProjectsHeaderSpacingMatchesAutomations is #2580 item 2. The Projects
+// name carried a trailing space AND its hint carried a leading one, so the
+// header rendered a double space before the `·` while the Automations header
+// one line above it rendered a single space — the drift visible in one frame,
+// side by side.
+func TestProjectsHeaderSpacingMatchesAutomations(t *testing.T) {
+	p := newTestProjects(testProjectRows())
+	p.SetRect(layout.Rect{X: 0, Y: 0, W: 40, H: 8})
+	header := stripANSI(strings.Split(p.String(), "\n")[0])
+
+	assert.Contains(t, header, "Projects (3) · enter switch",
+		"exactly one space before the separator")
+	assert.NotContains(t, header, "  · ", "no double space before the separator")
+
+	// The compact one-line summary is built through the same titleLine.
+	p.SetCompact(true)
+	compact := stripANSI(strings.Split(p.String(), "\n")[0])
+	assert.NotContains(t, compact, "  · ", "the compact summary doubles up the same way")
+}

--- a/ui/schedule_picker.go
+++ b/ui/schedule_picker.go
@@ -620,13 +620,13 @@ func (p *schedulePicker) chip(cell scheduleCell, text string) string {
 func (p *schedulePicker) hint() string {
 	switch p.activeCell() {
 	case cellRaw:
-		return "type cron • ↑/↓ fields • tab next"
+		return "type cron · ↑/↓ fields · tab next"
 	case cellWeekdays:
-		return "←/→ day • space toggle • ↑/↓ fields"
+		return "←/→ day · space toggle · ↑/↓ fields"
 	case cellType, cellMeridiem:
-		return "←/→ change • ↑/↓ fields • tab next"
+		return "←/→ change · ↑/↓ fields · tab next"
 	default:
-		return "type or ←/→ • ↑/↓ fields • tab next"
+		return "type or ←/→ · ↑/↓ fields · tab next"
 	}
 }
 

--- a/ui/separator_convention_test.go
+++ b/ui/separator_convention_test.go
@@ -1,0 +1,117 @@
+package ui
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The repo-wide separator guard (#2579).
+//
+// #2399 converted the shared status-menu renderer from " • " to " · " and wrote
+// the rule down in ui/menu.go. The sweep stopped there: 25 sibling separator
+// sites across 8 files kept rendering a bullet, and the drift was visible SIDE
+// BY SIDE in one frame — press `/` at 80x24 and the search overlay's hint row
+// and the menu row one line below it disagree; open the task manager and one
+// row uses `·` while another two rows down uses `•`.
+//
+// A per-surface assertion cannot prevent that: it only covers the surface
+// somebody remembered to write it for, which is exactly how 25 sites drifted
+// past a green suite. This scans every non-test Go source in the repo instead,
+// so a new hint row cannot join the row of exceptions quietly.
+//
+// A bullet used as a LIST MARKER is correct and stays (`• Git branch: …`,
+// `af reset`'s teardown plan). The rule distinguishes them structurally rather
+// than by an allowlist that would itself rot: a bullet opening a line is a
+// marker, a bullet inside one is a separator.
+func TestNoBulletSeparatorsInUserFacingCopy(t *testing.T) {
+	root := repoRootForConventions(t)
+
+	var violations []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skipConventionDir(d.Name()) && path != root {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		violations = append(violations, bulletSeparatorsIn(t, root, path)...)
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.Empty(t, violations,
+		"a bullet inside a line joins fragments, and CLAUDE.md's separator for that is \" · \" "+
+			"(#2399/#2579). A bullet that OPENS a line is a list marker and is fine:\n%s",
+		strings.Join(violations, "\n"))
+}
+
+func skipConventionDir(name string) bool {
+	switch name {
+	case ".git", "node_modules", "vendor", "dist", "testdata":
+		return true
+	}
+	return false
+}
+
+// bulletSeparatorsIn reports every string literal in one file that uses "•" to
+// join fragments rather than to open a list item. It reads literal VALUES from
+// the AST, so a bullet in a comment (including the ones documenting this very
+// rule) is not a finding.
+func bulletSeparatorsIn(t *testing.T, root, path string) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	require.NoError(t, err, "parse %s", path)
+
+	rel, err := filepath.Rel(root, path)
+	require.NoError(t, err)
+
+	var found []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		lit, ok := n.(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		value, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			// A malformed literal would not compile; nothing to judge.
+			return true
+		}
+		if !strings.Contains(value, "•") {
+			return true
+		}
+		for _, line := range strings.Split(value, "\n") {
+			// A leading bullet is the list marker; anything after it on the same
+			// line is joining fragments.
+			body := strings.TrimPrefix(strings.TrimLeft(line, " \t"), "•")
+			if strings.Contains(body, "•") {
+				found = append(found, "  "+rel+":"+strconv.Itoa(fset.Position(lit.Pos()).Line)+
+					": "+strings.TrimSpace(line))
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func repoRootForConventions(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller could not locate this test file")
+	return filepath.Dir(filepath.Dir(thisFile))
+}

--- a/ui/statusbar_test.go
+++ b/ui/statusbar_test.go
@@ -75,11 +75,12 @@ func TestMenuNarrowWidthKeepsHelpAndQuit(t *testing.T) {
 		assert.Containsf(t, out, "? help", "width %d: help must survive", w)
 	}
 
-	// At a roomy width nothing is dropped: the scroll hints still render, and
+	// At a roomy width nothing is dropped: both scroll keys still render, and
 	// their copy scopes the binding to AF's preview rather than attached input.
+	// The pair shares one chip (#2580) — the description said the same thing
+	// twice when each key printed its own.
 	m.SetSize(200, 1)
-	assert.Contains(t, m.String(), "ctrl+u preview scroll", "no drops at full width")
-	assert.Contains(t, m.String(), "ctrl+d preview scroll", "no drops at full width")
+	assert.Contains(t, m.String(), "ctrl+u/ctrl+d preview scroll", "no drops at full width")
 	assert.Contains(t, m.String(), "q quit")
 }
 

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -596,17 +596,26 @@ func (w *TabbedWindow) BeginScrollFill() {
 // only place the pane's tab is named inside the pane (the tab bar is gone), so
 // duplicate labels include their 1-based jump slot (#2150); the highlight
 // doubles as the pane's focus indicator.
+//
+// Every clause hanging off that identity — the preview's origin, the diverging
+// tree selection, scroll mode — is set off with "—", and only the fragments
+// INSIDE each identity are joined with " · " (#2579). All three used to pick a
+// different mark for the same relationship, and with two sessions whose tab
+// labels match, `alpha · ◆ Agent · selected: beta · ◆ Agent` flattened into four
+// indistinguishable fragments. That clause is the only signal that the
+// workspace is not showing the row under the cursor, so it has to read at a
+// glance.
 func (w *TabbedWindow) renderHeader(width int) string {
 	var text string
 	if w.preview != nil && w.preview.instance != nil {
 		inst := w.preview.instance
 		label := tabLabelFor(inst, w.preview.tab)
-		text = fmt.Sprintf(" Preview %s · %s (original %s) ", inst.Title, label, w.preview.original)
+		text = fmt.Sprintf(" Preview %s · %s — original %s ", inst.Title, label, w.preview.original)
 	} else if inst := w.boundInstance(); inst != nil {
 		label := tabLabelFor(inst, w.activeTab())
 		text = fmt.Sprintf(" %s · %s ", inst.Title, label)
 		if w.selectionHint != "" {
-			text = fmt.Sprintf(" %s · %s · selected: %s ", inst.Title, label, w.selectionHint)
+			text = fmt.Sprintf(" %s · %s — selected: %s ", inst.Title, label, w.selectionHint)
 		}
 	} else {
 		text = " no session selected "
@@ -615,7 +624,7 @@ func (w *TabbedWindow) renderHeader(width int) string {
 		// Scroll mode is pane chrome, not terminal history. Keeping this cue in
 		// the header prevents an AF-owned footer row from consuming the first
 		// scroll gesture or changing the child's history coordinates (#2192).
-		text = strings.TrimSuffix(text, " ") + " · Scroll · Esc exits "
+		text = strings.TrimSuffix(text, " ") + " — Scroll · Esc exits "
 	}
 	style := paneHeaderStyle
 	switch {

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -599,7 +599,7 @@ func (s *TaskPane) renderListMode() string {
 			if programLabel == "" {
 				programLabel = programDefaultLabel
 			}
-			detail := fmt.Sprintf("      %s • last: %s", programLabel, lastRun)
+			detail := fmt.Sprintf("      %s · last: %s", programLabel, lastRun)
 			if tsk.LastRunStatus != "" {
 				// The full errored summary already has its own line above;
 				// keep this column short.
@@ -643,13 +643,13 @@ func (s *TaskPane) renderListMode() string {
 	}
 
 	if s.hasFocus {
-		hint := "↑/↓ select • n new • enter edit • r run now • x toggle • D delete • esc back"
-		short := "r run now • ↑/↓ • n new • enter • esc"
+		hint := "↑/↓ select · n new · enter edit · r run now · x toggle · D delete · esc back"
+		short := "r run now · ↑/↓ · n new · enter · esc"
 		// A watch task can't be manually run (#1758): drop "r run now" so the
 		// hint never advertises an action that always fails.
 		if s.selectedTaskIsWatch() {
-			hint = "↑/↓ select • n new • enter edit • x toggle • D delete • esc back"
-			short = "↑/↓ • n new • enter • esc"
+			hint = "↑/↓ select · n new · enter edit · x toggle · D delete · esc back"
+			short = "↑/↓ · n new · enter · esc"
 		}
 		if s.width > 0 && lipgloss.Width(hint) > s.width {
 			hint = short

--- a/ui/task_pane_edit.go
+++ b/ui/task_pane_edit.go
@@ -377,25 +377,25 @@ func (s *TaskPane) renderEditMode() string {
 	b.WriteString("\n")
 	quitHint := configuredQuitHelp() + " quit"
 	if s.creating {
-		hint := "tab/shift+tab fields • enter create • esc cancel • " + quitHint
+		hint := "tab/shift+tab fields · enter create · esc cancel · " + quitHint
 		if s.width > 0 && lipgloss.Width(hint) > s.width {
-			hint = "tab fields • enter • esc cancel • " + quitHint
+			hint = "tab fields · enter · esc cancel · " + quitHint
 		}
 		b.WriteString(hintStyle.Render(fitLine(hint, s.width)))
 	} else {
-		hint := "tab/shift+tab fields • enter save"
+		hint := "tab/shift+tab fields · enter save"
 		if s.width > 0 && lipgloss.Width(hint) > s.width {
-			hint = "tab fields • enter save"
+			hint = "tab fields · enter save"
 		}
 		b.WriteString(hintStyle.Render(fitLine(hint, s.width)))
 		b.WriteString("\n")
-		actions := "r run now • x toggle • D delete • esc list • " + quitHint
-		short := "r run • x toggle • D del • esc • " + quitHint
+		actions := "r run now · x toggle · D delete · esc list · " + quitHint
+		short := "r run · x toggle · D del · esc · " + quitHint
 		// A watch task can't be manually run (#1758): drop "r run" so the
 		// editor never advertises an action that always fails.
 		if s.selectedTaskIsWatch() {
-			actions = "x toggle • D delete • esc list • " + quitHint
-			short = "x toggle • D del • esc • " + quitHint
+			actions = "x toggle · D delete · esc list · " + quitHint
+			short = "x toggle · D del · esc · " + quitHint
 		}
 		if s.width > 0 && lipgloss.Width(actions) > s.width {
 			actions = short


### PR DESCRIPTION
Four issues that all land on the same three surfaces — the status bar, the modal
compositor, and the hint rows — so they ship together. #2618 and #2578 are real
bugs and lead.

## #2618 — `E details` stops working 3s after a notice appears

`E` is the only in-app way to read a notice the bar clipped, and it went dead at
exactly the moment the clipped text left the screen: the 3s timeout called
`errBox.Clear()`, and `showErrorDetails` bailed on an empty box. **The one case
the affordance exists for was the one case it could not serve.**

`ErrBox` now separates the notice it *renders* from the one it *retains*:

| | renders | reachable by `E` |
| --- | --- | --- |
| `Expire()` — the 3s visual timer | no | **yes** |
| `Clear()` — a retraction | no | no |

The distinction is load-bearing. `Clear()` is used where af takes a notice
*back* — the config-agent "Starting…" that finished, the narrow-width guidance a
resize resolved — and a notice that stopped being **true** must not stay
reachable, while one that merely stopped being **visible** must.
`TestErrorDetailsDoesNotResurrectARetractedNotice` pins that half; it passed
before and after, so the fix cannot have bought `E` by resurrecting retractions.

The overlay also stops titling everything "Last error". af hiding a pane and
telling you how to get it back is designed behavior; filing it under an error
reports af working as intended as a fault — the same miscategorization #2575
found in the logs. `handleError` / `handleNotice` already split for log levels;
that existing distinction now picks the title too.

## #2578 — help overlay's bottom border paints through the footer

`PlaceOverlay`'s centering measures the **whole frame**, so a modal tall enough
to reach the bottom composited its border over the hint row — `D kill` rendered
as `D ki`, `? help` as `elp`. It read as corruption, on the help screen.

`overlayOrigin` now lifts a modal just far enough for its last row to clear the
status bar, and every `View` branch composites through one `placeOverlay` helper
that shares that origin with the click-zone registration — so the two cannot
disagree about where a modal is, and no branch can reintroduce the bug by
calling `PlaceOverlay`'s centering directly (there is now exactly one caller).

It is a **clamp**, not "center in the region above the bar". I wrote the latter
first and it moved every short modal up a row, which broke two unrelated tests —
correctly, since it was changing modals that never had the problem. Only a modal
that would actually collide moves now.

## #2579 — separator drift after #2399

#2399 converted the shared menu renderer to `" · "` and 25 sibling sites kept
rendering `•`, visible **side by side in one frame**: press `/` and the overlay
hint and the menu row one line below it disagree.

Converted — and guarded. A source scan over every non-test Go file now fails on
a bullet used to *join* fragments, so the next hint row cannot drift past a green
suite the way these 25 did. A bullet **opening** a line is a list marker and
still passes (`• Git branch: …`, `af reset`'s teardown plan): a structural rule
rather than an allowlist that would itself rot. The guard found exactly the
issue's sites and spared exactly the list markers it called out of scope.

**Part 2** — four sites used `" · "` where CLAUDE.md calls for `—`:

- `app/kill_confirm.go` joined two independent sentences with `·` while the next
  paragraph of the *same dialog* used `—` correctly.
- The pane header flattened `alpha · ◆ Agent · selected: beta · ◆ Agent` into
  four indistinguishable fragments — and that clause is the *only* signal the
  workspace is not showing the row under your cursor. All three header forms
  (preview origin, selection, scroll mode) now set their clause off the same
  way; the preview arm's parentheses were the third form the issue flagged.

## #2580 — three chrome nits

1. **Duplicated hint.** The menu row spent 44 cells printing one description
   twice: `ctrl+u preview scroll · ctrl+d preview scroll`. The pair renders as
   one chip — `ctrl+u/ctrl+d preview scroll`, the form the help overlay already
   uses. Not via `helpLabel` as the issue suggested: `helpLabel` covers only the
   **default** binding by design, so a `[keys]` rebind of `scroll_up` would have
   shown a label naming a key that no longer scrolls. The glyphs come from the
   effective bindings instead, and **each key keeps a click zone over its own
   glyph** so collapsing costs neither its click target.
2. **Double space.** The Projects name ends with a space and its hint began with
   one. Now matches Automations. Side benefit: at the 22-column rail minimum the
   reclaimed cell keeps the `· enter switch` affordance that used to be cut.
3. **Clipped recovery hint.** The notice clipped to a dangling `resize wider
   or…` at 80 columns — for a *five*-character session name. The bar truncates
   from the right, so the fragment that died was the `s` key: the cheaper remedy
   (no resize) and the only one a user cannot find by fiddling. The reason clause
   now pays instead of the hint — it says "too narrow" without counting panes the
   notice has already named — which fits an ordinary title at 80 columns.
   Unbounded titles still overflow, as the existing comment concedes; since #2618
   the tail is at least readable with `E`.

## Verification

Every test was watched failing against `master` first. Two notes on that:

- `TestPane_AutoHideStatusKeepsTheRecoveryHintAtEightyColumns` asserts on the
  **rendered bar**, not the composed string. The composed string always held the
  hint — which is exactly why this regressed unnoticed through #1973 → #1997.
- The `•` guard is a source scan rather than per-surface assertions, because
  per-surface assertions are what 25 sites already drifted past.

Driven on a real 80x24 and 200x50 TUI in the playtest container, not only in
tests:

```
# #2578 — menu row intact under the help overlay (was painted through)
╰────────────────────────────────────────────────────────────╯──────────────────╯
      n new · N new remote │ / search │ ? help · q quit

# #2580 item 1
… ↵ interact · o attach · ctrl+u/ctrl+d preview scroll │ t new tab · …

# #2580 item 2 — identical spacing, one frame apart
.Automations.(0).·.m.manage
.Projects.(1).·.enter.switch

# #2580 item 3 — whole at 80 cols, with the issue's own 9-char name
clear-cmd · › Terminal hidden — too narrow; resize or `s` open pane

# #2618 — issue repro step 4: wait >3s, then press E (used to do nothing)
### 6s later, notice line: []
│  Last notice                                   │
│  clear-cmd · › Terminal hidden — too narrow;   │
│  resize or `s` open pane                       │

# #2579 Part 1 — the issue's own side-by-side frame, now agreeing
│  ↑/↓ navigate · enter select · esc close                   │
     n new · D kill │ t new tab · w close tab · 1-9 jump │ ? help · q quit
```

## Gate

All six on the pushed head `1673d5de`: `golangci-lint run --timeout=3m --fast`,
`gofmt -l .` (empty), `go build ./...`, `make test-container`, `deadcode -test
./...` (empty), `scripts/lint-file-length.sh`. No web changes, so no bundle
rebuild.

Closes #2618
Closes #2578
Closes #2579
Closes #2580

-- Captain Claude
