### PR TITLE
docs: correct the Codex gate queries (pagination, resolution, reply route)

### DIFF
--- a/.claude/skills/gate-pr.md
+++ b/.claude/skills/gate-pr.md
@@ -43,16 +43,29 @@ from `app/detail-app` may auto-merge once the gates are clean.
    # a) a verdict for THIS head. The body carries "Reviewed commit: `abc1234…`",
    #    an abbreviation that must prefix $head. Codex posts it as a review on
    #    some PRs and as an issue comment on others, so read both.
-   gh api repos/sachiniyer/agent-factory/pulls/<n>/reviews \
+   gh api --paginate repos/sachiniyer/agent-factory/pulls/<n>/reviews \
      --jq '.[] | select(.user.login=="chatgpt-codex-connector[bot]") | "\(.submitted_at)\n\(.body)"'
-   gh api repos/sachiniyer/agent-factory/issues/<n>/comments \
+   gh api --paginate repos/sachiniyer/agent-factory/issues/<n>/comments \
      --jq '.[] | select(.user.login=="chatgpt-codex-connector[bot]") | "\(.created_at)\n\(.body)"'
 
-   # b) live inline findings — a null .line is stale, already fixed
-   gh api repos/sachiniyer/agent-factory/pulls/<n>/comments \
-     --jq '.[] | select(.user.login=="chatgpt-codex-connector[bot]" and .line != null and .in_reply_to_id == null)
-                 | "\(.id) \(.path):\(.line)\n\(.body)"'
+   # b) live inline findings, minus the ones an allowed reply already cleared —
+   #    the same subtraction auto-gate.js makes, so this can never block a PR
+   #    the workflow would merge. A null .line is stale, already fixed.
+   gh api --paginate repos/sachiniyer/agent-factory/pulls/<n>/comments | jq -s 'add
+     | ([ .[] | select(.in_reply_to_id
+                       and (.user.login | test("^(sachiniyer|app-detail-app)"))
+                       and (.body | test("RESOLVED|ACCEPTED|\\[gate-ack\\]")))
+              | .in_reply_to_id ] | unique) as $cleared
+     | .[] | select(.user.login == "chatgpt-codex-connector[bot]"
+                    and .line and (.in_reply_to_id | not)
+                    and (.id | IN($cleared[]) | not))
+     | "\(.id) \(.path):\(.line)\n\(.body)"'
    ```
+
+   `--paginate` is not optional. A page is 30 comments, and `gh api` fetches one
+   page without it — so a finding on page 2 reads as "no findings", which is the
+   single wrong answer this step must never produce. `auto-gate.js` paginates
+   these same lists (`github.paginate`, `per_page: 100`).
 
    Require all three:
 
@@ -76,9 +89,14 @@ from `app/detail-app` may auto-merge once the gates are clean.
    hang off that comment id:
 
    ```bash
-   gh api repos/sachiniyer/agent-factory/pulls/comments/<comment-id>/replies \
+   gh api repos/sachiniyer/agent-factory/pulls/<n>/comments/<comment-id>/replies \
      -f body='RESOLVED — <what changed, or why this is wrong>'
    ```
+
+   The PR number belongs in that path. `pulls/comments/<id>/replies` — the shape
+   the review-comment objects themselves are fetched from — is not a route, and
+   answers `404 Not Found` while looking like a posted reply if you do not read
+   the response.
 
    If a finding is valid, route it back to the authoring session and stop. Do
    not merge a PR with a valid unresolved finding.

--- a/.claude/skills/gate-pr.md
+++ b/.claude/skills/gate-pr.md
@@ -38,23 +38,29 @@ from `app/detail-app` may auto-merge once the gates are clean.
    hand, so a manual merge cannot be looser than the automated one.
 
    ```bash
-   head="$(gh pr view <n> --json headRefOid -q .headRefOid)"; echo "head=$head"
+   head="$(gh pr view <n> --json headRefOid -q .headRefOid)"
+   echo "head=$head committed=$(gh api repos/sachiniyer/agent-factory/commits/$head --jq .commit.committer.date)"
 
-   # a) a verdict for THIS head. The body carries "Reviewed commit: `abc1234…`",
-   #    an abbreviation that must prefix $head. Codex posts it as a review on
-   #    some PRs and as an issue comment on others, so read both.
-   gh api --paginate repos/sachiniyer/agent-factory/pulls/<n>/reviews \
-     --jq '.[] | select(.user.login=="chatgpt-codex-connector[bot]") | "\(.submitted_at)\n\(.body)"'
-   gh api --paginate repos/sachiniyer/agent-factory/issues/<n>/comments \
-     --jq '.[] | select(.user.login=="chatgpt-codex-connector[bot]") | "\(.created_at)\n\(.body)"'
+   # a) every Codex verdict, NEWEST FIRST. The body carries "Reviewed commit:
+   #    `abc1234…`", an abbreviation that must prefix $head. Codex posts a
+   #    verdict as a review on some PRs and as an issue comment on others, and
+   #    can post several for one head — auto-gate.js merges both kinds into one
+   #    list and judges only the newest matching artifact, so read them in that
+   #    order rather than as two separate streams.
+   { gh api --paginate repos/sachiniyer/agent-factory/pulls/<n>/reviews
+     gh api --paginate repos/sachiniyer/agent-factory/issues/<n>/comments
+   } | jq -s -r 'add
+     | map(select(.user.login == "chatgpt-codex-connector[bot]"))
+     | sort_by(.updated_at // .submitted_at // .created_at) | reverse
+     | .[] | "=== \(.updated_at // .submitted_at // .created_at)\n\(.body)"'
 
    # b) live inline findings, minus the ones an allowed reply already cleared —
    #    the same subtraction auto-gate.js makes, so this can never block a PR
    #    the workflow would merge. A null .line is stale, already fixed.
-   gh api --paginate repos/sachiniyer/agent-factory/pulls/<n>/comments | jq -s 'add
+   gh api --paginate repos/sachiniyer/agent-factory/pulls/<n>/comments | jq -s -r 'add
      | ([ .[] | select(.in_reply_to_id
-                       and (.user.login | test("^(sachiniyer|app-detail-app)"))
-                       and (.body | test("RESOLVED|ACCEPTED|\\[gate-ack\\]")))
+                       and (.user.login | IN("sachiniyer", "app-detail-app", "app-detail-app[bot]"))
+                       and ((.body | test("\\b(?:RESOLVED|ACCEPTED)\\b")) or (.body | contains("[gate-ack]"))))
               | .in_reply_to_id ] | unique) as $cleared
      | .[] | select(.user.login == "chatgpt-codex-connector[bot]"
                     and .line and (.in_reply_to_id | not)
@@ -67,15 +73,23 @@ from `app/detail-app` may auto-merge once the gates are clean.
    single wrong answer this step must never produce. `auto-gate.js` paginates
    these same lists (`github.paginate`, `per_page: 100`).
 
+   Every filter above mirrors `auto-gate.js` exactly, in both directions: an
+   author is an exact login (a `sachiniyer-…` account is not `sachiniyer`), and
+   a marker is a whole word (`UNRESOLVED — sent back` contains `RESOLVED` and
+   must not clear anything). Looser than the workflow lets a live finding
+   through; stricter blocks a PR the workflow would merge. Neither is acceptable.
+
    Require all three:
 
-   - **A verdict that names this head.** Its `Reviewed commit:` must match
-     `headRefOid` and it must be newer than the head commit. An older verdict
-     read different bytes. Silence is not a pass: an unreviewed PR and a clean
-     one are byte-identical through the findings API, so (b) means nothing until
-     (a) holds. If nothing has posted, comment `@codex review this PR` and wait —
-     hours is normal. A `reached your Codex usage limits for code reviews` reply
-     is *not* a verdict.
+   - **A verdict that names this head.** Its `Reviewed commit:` must prefix
+     `headRefOid`, and its timestamp must be newer than the head commit's — the
+     `committed=` value printed above, which is why it is printed. An older
+     verdict read different bytes. Judge the **newest** matching artifact; an
+     older one it superseded is not the gate. Silence is not a pass: an
+     unreviewed PR and a clean one are byte-identical through the findings API,
+     so (b) means nothing until (a) holds. If nothing has posted, comment
+     `@codex review this PR` and wait — hours is normal. A `reached your Codex
+     usage limits for code reviews` reply is *not* a verdict.
    - **No `P0`–`P3` in that verdict body.** Findings usually live inline, but
      Codex does sometimes file one in the body with zero inline comments.
    - **Zero unresolved live inline findings.** These are independent of the
@@ -84,9 +98,10 @@ from `app/detail-app` may auto-merge once the gates are clean.
      inline query overrides the verdict, never the other way round.
 
    Clear a finding by replying **in-thread**, from `sachiniyer` or
-   `app-detail-app`, with `RESOLVED` or `ACCEPTED` and what changed or why the
-   finding is wrong. A top-level PR comment does not clear it — the reply has to
-   hang off that comment id:
+   `app-detail-app`, with `RESOLVED`, `ACCEPTED`, or `[gate-ack]` — all three
+   clear it (`hasResolutionMarker`) — plus what changed or why the finding is
+   wrong. A top-level PR comment does not clear it; the reply has to hang off
+   that comment id:
 
    ```bash
    gh api repos/sachiniyer/agent-factory/pulls/<n>/comments/<comment-id>/replies \


### PR DESCRIPTION
## Summary

Codex filed three P2s on #2799, the PR that rewrote `gate-pr` step 3 onto the
Codex review. All three were real and all three were against the *commands the
step prescribes*. They never landed: clearing them in-thread satisfied
`auto-gate.js`, which squash-merged #2799 minutes before the fix commit existed.
So `master` shipped step 3 with every one of them still in it, and an agent
following it today can wave through a PR that has live findings.

Each was reproduced rather than taken on the reviewer's word.

### 1. `gh api` reads one page

`gh api .../pulls/<n>/comments` returns the first 30 comments without
`--paginate`. A finding on page 2 produces an empty result — i.e. **"no
findings"**, the single wrong answer this step must never give.
`.github/scripts/auto-gate.js` paginates the same lists (`github.paginate`,
`per_page: 100`), so the hand gate was looser than the automated one on exactly
the PRs that need it most.

Both queries now use `--paginate`, and the step says why it is not optional.

### 2. The reply route 404s

The step told the operator to clear a finding with
`pulls/comments/<comment-id>/replies`. That is the shape review comments are
*fetched* from, not a route:

```
$ gh api -X POST repos/sachiniyer/agent-factory/pulls/comments/3716067572/replies -f body=probe
{"message": "Not Found", ...}
```

The real endpoint is
`POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies`.
The three `RESOLVED` replies on #2799 were posted with the corrected form, which
is the proof it works — and the step now says the PR number belongs in the path,
because the wrong form fails silently for anyone who does not read the response.

### 3. Cleared findings counted as unresolved

The findings query dropped every reply and then listed every top-level finding,
so one already answered `RESOLVED`/`ACCEPTED` by an allowed author still read as
outstanding. `auto-gate.js` subtracts those ids (`resolvedByAllowedReply`); the
query now makes the same subtraction.

The error was in the safe direction — it blocks PRs the workflow would merge —
but a step that reports resolved findings as outstanding trains its reader to
skim the list, which is how the unsafe direction arrives.

## Verification

Run against #2799's own findings, which is the only fixture that proves both
halves:

```
# before the RESOLVED replies — corrected query lists all three
3716067567 .claude/skills/gate-pr.md:54
3716067572 .claude/skills/gate-pr.md:80
3716067579 .claude/skills/gate-pr.md:54

# after the replies — corrected query is empty, while the query on master
# still reports 3
$ gh api --paginate .../pulls/2799/comments | jq -s 'add | …'      -> (empty)
$ gh api .../pulls/2799/comments --jq '[…in_reply_to_id == null]|length'  -> 3
```

Required gates, on the pushed head `8fc3294f722e32612357e2e75531f7207b0e2488`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (empty)
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`

Closes #2822