### PR TITLE
fix(daemon): make handoff settlement durable so a delivered mission cannot run twice

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -803,6 +803,19 @@ func (m *Manager) persistInstance(repoID string, instance *session.Instance) {
 //
 // LOCK CONTRACT (#2106): inherits persistInstance's — never call it with m.mu held.
 func (m *Manager) persistAndPublishInstance(repoID string, instance *session.Instance) {
+	if err := m.persistAndPublishInstanceErr(repoID, instance); err != nil {
+		log.WarningLog.Printf("failed to persist instance %q: %v", instance.Title, err)
+	}
+}
+
+// persistAndPublishInstanceErr is persistAndPublishInstance with the write error
+// RETURNED rather than logged, for the caller whose durability gates correctness
+// rather than merely dating a checkpoint: the handoff settlement (#2781, see
+// persistHandoffSettlement). It is the persistInstanceErr/persistInstance pairing
+// one layer up, and the announcement stays unconditional either way — memory has
+// already changed, so every other client must converge on it whether or not disk
+// agreed yet.
+func (m *Manager) persistAndPublishInstanceErr(repoID string, instance *session.Instance) error {
 	repoStartLock := m.startLockForRepo(repoID)
 	repoStartLock.Lock()
 	// Snapshot only AFTER serialization, for the #1917 reason on persistInstanceErr:
@@ -813,9 +826,7 @@ func (m *Manager) persistAndPublishInstance(repoID string, instance *session.Ins
 	err := persistInstanceData(repoID, data)
 	m.publishEvent(agentproto.EventSessionUpdated, data)
 	repoStartLock.Unlock()
-	if err != nil {
-		log.WarningLog.Printf("failed to persist instance %q: %v", instance.Title, err)
-	}
+	return err
 }
 
 // archivePersist is the durable persist ArchiveSession runs at its commit. A

--- a/daemon/handoff_delivery.go
+++ b/daemon/handoff_delivery.go
@@ -49,9 +49,15 @@ func (m *Manager) deliverHandoffMission(delivery handoffDelivery) error {
 		// that lowers it for them. Without it a second window would sit on a
 		// permanently "working" row — the poll skips a fenced session and, once the
 		// fence drops, takes the settled state as its own baseline and reports nothing.
-		m.persistAndPublishInstance(delivery.repoID, delivery.instance)
+		//
+		// It is also durable rather than best-effort: it is what retires the on-disk
+		// delivery obligation, and a lost one makes the next daemon send this mission
+		// again (#2781, see persistHandoffSettlement). Conversation capture still runs
+		// — it describes the incoming runtime, which the failed write does not put in
+		// doubt — and the persist failure is what settle reports.
+		perr := m.persistHandoffSettlement(delivery.repoID, delivery.key, delivery.instance)
 		m.captureAgentConversationAsync(delivery.repoID, delivery.key, delivery.instance, delivery.conversationCapture)
-		return nil
+		return perr
 	}
 
 	serr := task.WaitForReadyAndSendPrompt(context.Background(), delivery.instance, delivery.mission)
@@ -85,6 +91,11 @@ func (m *Manager) deliverHandoffMission(delivery handoffDelivery) error {
 		// the record and pending mission, but make it inert: claiming Running here
 		// turns a startup death into a fake delivery failure and invites commands
 		// into an unconfirmed binding.
+		//
+		// Best-effort is still right for THIS write, unlike settlement's (#2781):
+		// it raises a suppression marker over a mission that was never delivered.
+		// Losing it costs a redundant recovery attempt at worst, never a second
+		// execution of work the agent already did.
 		delivery.instance.MarkStartupStateUnknown()
 		m.persistAndPublishInstance(delivery.repoID, delivery.instance)
 		return fmt.Errorf(

--- a/daemon/handoff_recovery.go
+++ b/daemon/handoff_recovery.go
@@ -38,6 +38,12 @@ type pendingHandoffEntry struct {
 // the publish, a row this loop finishes stays "working" on every open rail until
 // something unrelated republishes it.
 func (m *Manager) ResumePendingHandoffs() {
+	// Repair any settlement write that did not land before scanning for missions
+	// to deliver. A stale obligation on disk is exactly what this pass would
+	// replay after a restart, so retiring it is the same job as finishing one
+	// (#2781).
+	m.flushHandoffSettlements()
+
 	m.mu.Lock()
 	entries := make([]pendingHandoffEntry, 0, len(m.instances))
 	for key, instance := range m.instances {
@@ -94,9 +100,9 @@ func (m *Manager) resumePendingHandoff(entry pendingHandoffEntry, mission string
 		if !entry.instance.ClearPendingHandoffMission(mission) {
 			return fmt.Errorf("pending mission changed while transferring it to limit retry")
 		}
-		m.persistAndPublishInstance(entry.repoID, entry.instance)
+		perr := m.persistHandoffSettlement(entry.repoID, entry.key, entry.instance)
 		m.clearPendingHandoffRetry(entry.repoID, entry.instance)
-		return nil
+		return perr
 	case session.LiveReady:
 		// Positive readiness is the authorization to paste. LiveRunning is not:
 		// startup output and an already-delivered mission both look Running, so
@@ -125,10 +131,16 @@ func (m *Manager) resumePendingHandoff(entry pendingHandoffEntry, mission string
 			if !entry.instance.ClearPendingHandoffMission(mission) {
 				return fmt.Errorf("pending mission changed while parking its usage limit")
 			}
-			m.persistAndPublishInstance(entry.repoID, entry.instance)
+			perr := m.persistHandoffSettlement(entry.repoID, entry.key, entry.instance)
 			m.clearPendingHandoffRetry(entry.repoID, entry.instance)
+			if perr != nil {
+				return errors.Join(err, perr)
+			}
 			return nil
 		}
+		// Best-effort, unlike the settlement writes above (#2781): this raises a
+		// suppression marker over a mission that was never delivered, so losing it
+		// costs another recovery attempt, never a duplicate execution.
 		if op == session.OpReplacing && errors.Is(err, task.ErrAgentReadiness) {
 			entry.instance.MarkStartupStateUnknown()
 			m.persistAndPublishInstance(entry.repoID, entry.instance)
@@ -144,8 +156,11 @@ func (m *Manager) resumePendingHandoff(entry pendingHandoffEntry, mission string
 	if !entry.instance.ClearPendingHandoffMission(mission) {
 		return fmt.Errorf("pending mission changed after delivery")
 	}
-	m.persistAndPublishInstance(entry.repoID, entry.instance)
+	perr := m.persistHandoffSettlement(entry.repoID, entry.key, entry.instance)
 	m.clearPendingHandoffRetry(entry.repoID, entry.instance)
+	if perr != nil {
+		return perr
+	}
 	log.InfoLog.Printf("handoff %q: delivered pending mission", entry.instance.Title)
 	return nil
 }

--- a/daemon/handoff_settle.go
+++ b/daemon/handoff_settle.go
@@ -1,0 +1,85 @@
+package daemon
+
+import (
+	"fmt"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// Handoff settlement is the write that DISCHARGES a delivery obligation, and it
+// is the one persist in this package that may not be best-effort (#2781).
+//
+// PendingHandoffMission on disk is a standing instruction, not a status field: a
+// daemon that starts and finds one reconstructs the replacement fence and sends
+// that exact brief (session.FromInstanceData). That is what makes an interrupted
+// handoff recoverable — and it is what makes a LOST settlement write dangerous,
+// because the marker then outlives a mission the agent already ran. The next
+// daemon delivers it a second time and the session executes the same task twice,
+// with every side effect that implies.
+//
+// persistInstance is therefore the wrong primitive here. Its contract is that a
+// dropped write is a checkpoint "the next poll/tick will re-attempt", but the
+// poll's change detection (persistPollChange) covers liveness and the limit reset
+// time only. Nothing in it looks at PendingHandoffMission, so this divergence is
+// invisible to every later writer and survives until the shutdown checkpoint —
+// which the unclean exit that makes the divergence matter never reaches.
+//
+// So settlement writes are durable AND retried: the failure reaches the caller
+// instead of a log line, and the row joins a retry set the handoff poll drains
+// until the write lands. It announces like every other settlement (#2782) — the
+// fence has come down in memory whether or not disk agreed yet.
+func (m *Manager) persistHandoffSettlement(repoID, key string, instance *session.Instance) error {
+	// persistAndPublishInstanceErr goes through startLockForRepo, which takes m.mu
+	// — the #2106 lock contract, so the bookkeeping below happens after it returns.
+	err := m.persistAndPublishInstanceErr(repoID, instance)
+	owedKey := remoteLossKey(repoID, instance)
+	m.mu.Lock()
+	if err != nil {
+		m.handoffSettleOwed[owedKey] = pendingHandoffEntry{repoID: repoID, key: key, instance: instance}
+	} else {
+		delete(m.handoffSettleOwed, owedKey)
+	}
+	m.mu.Unlock()
+	if err != nil {
+		return fmt.Errorf(
+			"the settled handoff state for %q could not be written to disk "+
+				"(the daemon retries it on its poll; an unclean exit before it lands would redeliver the mission): %w",
+			instance.Title, err)
+	}
+	return nil
+}
+
+// flushHandoffSettlements retries settlement writes that did not land, so a
+// transient failure self-heals within a poll tick instead of leaving a stale
+// delivery obligation on disk for the next daemon to replay. It is driven from
+// ResumePendingHandoffs — the poll pass that already owns handoff durability —
+// and is a no-op in the overwhelmingly common case where no write ever failed.
+func (m *Manager) flushHandoffSettlements() {
+	m.mu.Lock()
+	owed := make([]pendingHandoffEntry, 0, len(m.handoffSettleOwed))
+	for _, entry := range m.handoffSettleOwed {
+		owed = append(owed, entry)
+	}
+	m.mu.Unlock()
+
+	for _, entry := range owed {
+		m.mu.Lock()
+		registered := m.instances[entry.key] == entry.instance
+		if !registered {
+			delete(m.handoffSettleOwed, remoteLossKey(entry.repoID, entry.instance))
+		}
+		m.mu.Unlock()
+		// The row is gone (killed) or a successor took its key. Its record is being
+		// deleted or belongs to another instance now, so writing this snapshot back
+		// would fight whatever removed it — and there is no obligation left to
+		// discharge either way, because a tombstone outranks a pending mission on
+		// load (session.FromInstanceData).
+		if !registered {
+			continue
+		}
+		if err := m.persistHandoffSettlement(entry.repoID, entry.key, entry.instance); err != nil {
+			log.WarningLog.Printf("handoff %q: %v", entry.instance.Title, err)
+		}
+	}
+}

--- a/daemon/handoff_settle_test.go
+++ b/daemon/handoff_settle_test.go
@@ -1,0 +1,216 @@
+package daemon
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+// failSettlementWrite fails exactly one persist for title: the next write that
+// no longer carries a pending mission once an obligation is outstanding — which
+// is the settlement write and nothing else. Writes before it land, and so does
+// every write after it, including the poll's retry, so a test can tell "the
+// settlement never became durable" apart from "nothing was written at all".
+//
+// armed says whether an obligation is outstanding when the hook is installed. A
+// handoff installs it unarmed: the swap persists the row once BEFORE recording
+// the mission, and that write is mission-free too. Seeing the post-swap
+// checkpoint — the write that records the obligation — is what arms it. A test
+// that installs the hook when the mission is already pending starts armed.
+//
+// Returns a func reporting whether the injected failure actually fired; an
+// injection that never runs makes every assertion downstream of it decorative.
+func failSettlementWrite(t *testing.T, title string, failure error, armed bool) func() bool {
+	t.Helper()
+	var mu sync.Mutex
+	fired := false
+	prev := testHookPersistInstanceData
+	t.Cleanup(func() { testHookPersistInstanceData = prev })
+	testHookPersistInstanceData = func(_ string, data session.InstanceData) error {
+		mu.Lock()
+		defer mu.Unlock()
+		if fired || data.Title != title {
+			return nil
+		}
+		if data.PendingHandoffMission != "" {
+			armed = true
+			return nil
+		}
+		if !armed {
+			return nil
+		}
+		fired = true
+		return failure
+	}
+	return func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return fired
+	}
+}
+
+// reloadedHandoffRow materializes the row a restarted daemon would build from a
+// record on disk, and registers it in place of the one this process held.
+//
+// A real load runs session.FromInstanceData, which carries the durable
+// PendingHandoffMission across and reconstructs the OpReplacing fence from it
+// (pinned by session.TestPendingHandoffMissionReconstructsDurableFence) — that
+// reconstruction is precisely what authorizes the recovery pass to deliver. The
+// loader itself cannot run here: for a local session it ends in Instance.Start
+// against real tmux. So this rebuilds the same two durable facts and hands the
+// row to the unmodified production recovery pass, which is where the duplicate
+// delivery would happen.
+func reloadedHandoffRow(t *testing.T, m *Manager, repoID, repoPath string, rec *session.InstanceData, backend session.Backend) *session.Instance {
+	t.Helper()
+	if rec == nil {
+		t.Fatal("no record on disk to reload: the restarted daemon would have no session at all")
+	}
+	inst, err := session.NewInstance(session.InstanceOptions{Title: rec.Title, Path: repoPath, Program: rec.Program})
+	if err != nil {
+		t.Fatalf("NewInstance(reload): %v", err)
+	}
+	inst.SetBackend(backend)
+	inst.SetStartedForTest(true)
+	inst.SetStatusForTest(session.Running)
+	inst.SetTmuxSession(tmux.NewTmuxSession(rec.Title, rec.Program))
+	if rec.PendingHandoffMission != "" {
+		inst.SetPendingHandoffMission(rec.PendingHandoffMission)
+		if err := inst.Transition(session.BeginHandoff()); err != nil {
+			t.Fatalf("reconstruct replacement fence: %v", err)
+		}
+	}
+	m.mu.Lock()
+	m.instances[daemonInstanceKey(repoID, rec.Title)] = inst
+	m.mu.Unlock()
+	return inst
+}
+
+// A handoff mission must be delivered EXACTLY once (#2781).
+//
+// The marker is written to disk BEFORE the readiness wait on purpose: if the
+// daemon dies in that window, the restored row carries an explicit delivery
+// obligation instead of silently claiming an instruction-less agent is fine. The
+// settlement write after a confirmed delivery is the other half of that bargain —
+// it is what retires the obligation.
+//
+// That write used persistInstance, whose failure is logged and dropped, so a
+// failed settlement left the obligation standing over a mission the agent had
+// already run. Nothing downstream repaired it: persistPollChange only writes on a
+// liveness or reset-time change and never inspects PendingHandoffMission, and the
+// whole-state shutdown checkpoint is exactly what an unclean exit skips. The next
+// daemon rebuilt the replacement fence from the stale marker and sent the same
+// brief again — the agent redoing work it had already done, on a branch its first
+// run had already changed.
+//
+// Note which assertion carries the fix. Surfacing the error (the obvious change)
+// makes the FIRST check pass while the mission still gets delivered twice; only
+// retiring the obligation on disk stops the second delivery.
+func TestHandoffSession_SettlementPersistFailureCannotRedeliverTheMission(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &handoffBackend{FakeBackend: session.NewFakeBackend()}
+	inst := registerHandoffSubject(t, manager, repoID, repoPath, "settle-once", backend)
+	inst.SetPrompt("finish the half-applied migration")
+
+	diskFull := errors.New("no space left on device")
+	injected := failSettlementWrite(t, "settle-once", diskFull, false)
+
+	_, err := manager.HandoffSession(HandoffSessionRequest{
+		Title: "settle-once", RepoID: repoID, To: tmux.ProgramGemini,
+	})
+	if !injected() {
+		t.Fatal("no settlement write was ever attempted, so this test exercised nothing")
+	}
+	if err == nil || !errors.Is(err, diskFull) {
+		t.Fatalf("HandoffSession error = %v, want the settlement write failure surfaced (%v): "+
+			"a settlement that never reached disk is not a completed handoff, and reporting success "+
+			"hides an on-disk mission marker that outlives the mission it describes", err, diskFull)
+	}
+
+	_, prompts := backend.snapshot()
+	if len(prompts) != 1 {
+		t.Fatalf("delivered %d prompts during the handoff, want 1", len(prompts))
+	}
+
+	// The daemon's next poll. Its handoff pass owns this obligation, and a
+	// settlement that did not land is the same job as a mission that did not:
+	// finish it before anything can replay it.
+	manager.ResumePendingHandoffs()
+
+	rec := recordFor(t, repoID, "settle-once")
+	if rec == nil || rec.PendingHandoffMission != "" {
+		t.Fatalf("record after the poll = %+v, want no pending mission: the mission was delivered, "+
+			"so leaving its obligation on disk is a standing instruction to deliver it again", rec)
+	}
+
+	// The unclean exit the marker exists for. Rebuild the row from disk exactly as
+	// a restarted daemon would, then run the same recovery pass.
+	reloadedHandoffRow(t, manager, repoID, repoPath, rec, backend)
+	manager.ResumePendingHandoffs()
+
+	_, prompts = backend.snapshot()
+	if len(prompts) != 1 {
+		t.Fatalf("mission delivered %d times (%q), want exactly 1: the settlement write failed, the "+
+			"delivery obligation survived on disk, and the restarted daemon replayed a mission the "+
+			"agent had already executed", len(prompts), prompts)
+	}
+}
+
+// The same obligation, discharged by the recovery pass instead of the handoff
+// itself (#2781). A mission that reaches its agent on a later poll settles
+// through the identical marker-clearing write, so a failure there replays it for
+// the identical reason — and this path has no RPC caller to report the failure
+// to, which is exactly why the retry, not the error return, is what protects it.
+func TestResumePendingHandoffs_SettlementPersistFailureCannotRedeliverTheMission(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	sendErr := errors.New("paste transport failed")
+	backend := &handoffBackend{FakeBackend: session.NewFakeBackend(), sendErr: sendErr}
+	inst := registerHandoffSubject(t, manager, repoID, repoPath, "settle-once-on-retry", backend)
+
+	// Leave the mission pending behind the replacement fence: the paste fails, so
+	// the handoff never settles and the recovery pass inherits the obligation.
+	_, err := manager.HandoffSession(HandoffSessionRequest{
+		Title: "settle-once-on-retry", RepoID: repoID, To: tmux.ProgramGemini,
+	})
+	if !errors.Is(err, task.ErrPromptDelivery) {
+		t.Fatalf("HandoffSession error = %v, want a post-ready prompt-delivery failure", err)
+	}
+	mission := inst.PendingHandoffMission()
+	if mission == "" {
+		t.Fatal("the undelivered mission was not retained; there is no recovery to test")
+	}
+
+	diskFull := errors.New("no space left on device")
+	injected := failSettlementWrite(t, "settle-once-on-retry", diskFull, true)
+	backend.setSendErr(nil)
+
+	manager.ResumePendingHandoffs()
+	if !injected() {
+		t.Fatal("no settlement write was ever attempted, so this test exercised nothing")
+	}
+	if got := inst.PendingHandoffMission(); got != "" {
+		t.Fatalf("recovery left the mission pending in memory (%q) after delivering it", got)
+	}
+
+	// The next poll has to finish what the failed write left open.
+	manager.ResumePendingHandoffs()
+
+	rec := recordFor(t, repoID, "settle-once-on-retry")
+	if rec == nil || rec.PendingHandoffMission != "" {
+		t.Fatalf("record after the following poll = %+v, want no pending mission", rec)
+	}
+
+	reloadedHandoffRow(t, manager, repoID, repoPath, rec, backend)
+	manager.ResumePendingHandoffs()
+
+	_, prompts := backend.snapshot()
+	if len(prompts) != 1 || !strings.Contains(prompts[0], "continuing work") {
+		t.Fatalf("recovery delivered %d prompts (%q), want exactly the one rendered mission: a "+
+			"settlement write lost by the recovery pass replays the mission just as one lost by the "+
+			"handoff itself does", len(prompts), prompts)
+	}
+}

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -223,6 +223,14 @@ type Manager struct {
 	// stable instance identity so a same-title successor cannot inherit an old
 	// retry delay. Guarded by m.mu.
 	handoffRetryDue map[string]time.Time
+	// handoffSettleOwed holds sessions whose handoff SETTLEMENT write failed —
+	// the write that retires the on-disk delivery obligation. Keyed like
+	// handoffRetryDue by stable instance identity. It exists because that write
+	// is the only thing standing between a delivered mission and a second
+	// execution of it after an unclean restart (#2781), and no other writer or
+	// poll would ever repair it; flushHandoffSettlements drains this on the same
+	// poll pass as mission recovery. Guarded by m.mu.
+	handoffSettleOwed map[string]pendingHandoffEntry
 	// remoteLossStates debounces the remote Lost transition (#1794), keyed by
 	// daemon instance key. A remote probe failure is transport-shaped — one
 	// blip fails identically to a dead sandbox — so the poll accumulates
@@ -380,6 +388,7 @@ func newManagerShellForDaemon(cfg *config.Config, transactionID string) (*Manage
 		lostRestoreStates:      make(map[string]*lostRestoreState),
 		limitResumeStates:      make(map[string]*limitResumeState),
 		handoffRetryDue:        make(map[string]time.Time),
+		handoffSettleOwed:      make(map[string]pendingHandoffEntry),
 		remoteLossStates:       make(map[string]*remoteLossState),
 		instanceOpLocks:        make(map[string]*sync.Mutex),
 		pausedPolls:            make(map[string]time.Time),

--- a/daemon/manager_persist.go
+++ b/daemon/manager_persist.go
@@ -40,6 +40,14 @@ func appendInstanceData(repoID string, data session.InstanceData) error {
 	})
 }
 
+// testHookPersistInstanceData runs on every targeted record write, after the
+// storage projection is applied and before any disk I/O, so a test can fail one
+// exact write in isolation. The #2781 duplicate-delivery repro needs the handoff
+// settlement's persist — and only that one — to fail while every other write in
+// the same session stays real. Returns nil in production, and for any write a
+// test does not target.
+var testHookPersistInstanceData = func(string, session.InstanceData) error { return nil }
+
 // persistInstanceData replaces the on-disk record for data.Title in repoID's
 // instances file with data, under the per-repo file lock, leaving every other
 // record untouched. It is the targeted, clobber-safe persist primitive for
@@ -62,6 +70,9 @@ func appendInstanceData(repoID string, data session.InstanceData) error {
 // us).
 func persistInstanceData(repoID string, data session.InstanceData) error {
 	data = data.ForStorage()
+	if err := testHookPersistInstanceData(repoID, data); err != nil {
+		return err
+	}
 	found := false
 	sameTitleDifferentID := false
 	if err := config.UpdateRepoInstances(repoID, func(raw json.RawMessage) (json.RawMessage, error) {


### PR DESCRIPTION
## The bug

A handoff writes `PendingHandoffMission` to disk **before** waiting for the incoming agent's
readiness, on purpose: if the daemon dies in that window, the restored row carries an explicit
delivery obligation instead of silently claiming an instruction-less agent is fine. The
settlement write after a confirmed delivery is the other half of that bargain — it is what
*retires* the obligation.

That write used `persistInstance`, whose failure is logged and dropped. So a failed settlement
left the obligation standing over a mission the agent had **already run**, and nothing
downstream repaired it:

- `persistPollChange` writes only on a liveness or reset-time change, and never inspects
  `PendingHandoffMission` — the divergence is invisible to it;
- the whole-state shutdown checkpoint (`SaveInstances`) would fix it, but that is exactly what
  an unclean exit skips — and an unclean exit is the only way this reaches a restart at all.

The next daemon then rebuilt the replacement fence from the stale marker
(`session.FromInstanceData`) and sent the same brief again. The agent redoes work it has already
done, on a branch its first run already changed.

## The fix

Settlement writes are now **durable and retried**, not best-effort:

- `persistHandoffSettlement` returns the write failure to its caller and enrolls the row in a
  retry set;
- `flushHandoffSettlements` drains that set from `ResumePendingHandoffs` — the poll pass that
  already owns handoff durability — so a transient failure self-heals within a tick instead of
  waiting for a checkpoint the crash never reaches.

Every site that **clears** the marker goes through it: the handoff's own `settle` (commit and
limit-park) and the recovery pass's delivered/limit-parked settlements. The two writes that only
**raise** a startup-unknown suppression marker stay best-effort, and now say why — losing one
costs a redundant recovery attempt, never a second execution.

It composes with #2803, which landed on the same lines while this was in flight: settlement still
publishes `session.updated` under the repo ordering lock. `persistAndPublishInstance` is split
into an `…Err` form for the one caller whose durability gates correctness, mirroring the existing
`persistInstance`/`persistInstanceErr` pairing.

## Why the issue's recommended fix is not enough

The report proposes returning the error from `settle`. That surfaces the failure but leaves the
obligation on disk, so the mission is still delivered twice. The regression test is built to
distinguish the two, and does:

```
# original code — the headline symptom
mission delivered 2 times ([...You are continuing work that is already in progress...] x2),
want exactly 1: the settlement write failed, the delivery obligation survived on disk, and the
restarted daemon replayed a mission the agent had already executed

# with the recommended fix ALONE (persistInstanceErr + return err)
record after the poll = &{... PendingHandoffMission: You are continuing work ...}, want no
pending mission: the mission was delivered, so leaving its obligation on disk is a standing
instruction to deliver it again

# unfixed, first assertion
HandoffSession error = <nil>, want the settlement write failure surfaced (no space left on device)
```

## Verification

Two new tests, both watched failing on `master` before the fix and after the rebase onto the
current head:

- `TestHandoffSession_SettlementPersistFailureCannotRedeliverTheMission` — fails the settlement
  write, runs the daemon's next poll, then materializes the row a restarted daemon would build
  from the record on disk and hands it to the unmodified recovery pass. The mission must be
  delivered exactly once.
- `TestResumePendingHandoffs_SettlementPersistFailureCannotRedeliverTheMission` — the same
  obligation discharged by the recovery pass instead, which has no RPC caller to report the
  failure to. That path is protected by the retry, not by the error return.

`testHookPersistInstanceData` is a new test seam on the write primitive (the
`archivePersist`/`testHookPollBeforePublish` precedent) so exactly one write can fail while every
other write in the same test — including the retry — stays real. Without that, a green test
cannot tell "the settlement never became durable" from "nothing was written at all".

Full local gate on the pushed head `81889dfe`: `golangci-lint run --timeout=3m --fast`,
`gofmt -l .` (empty), `go build ./...`, `make test-container` (whole suite green, `MAKE_EXIT=0`,
`daemon 344s`), `deadcode -test ./...`, `scripts/lint-file-length.sh`.

Closes #2781

🤖 Generated with [Claude Code](https://claude.com/claude-code)
