### PR TITLE
fix(web): keep af's escape modifier out of the app's mouse reports (#2787 follow-up)

### DIFF
--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7547,6 +7547,7 @@ var AttachTerminal = class {
   wheelHint;
   mouseCaptureHintTimer = null;
   mouseOverrideKeyHeld = false;
+  handedOffDrag = false;
   historyWheelRemainder = 0;
   // Incremented only by an actual user scroll input while a peer-owned anchor is
   // pending. Output and resize reflows can move viewportY too, so position deltas
@@ -7574,6 +7575,7 @@ var AttachTerminal = class {
   onWindowFocus = () => this.scheduleVisibleFit();
   onWindowBlur = () => {
     this.mouseOverrideKeyHeld = false;
+    this.endHandedOffDrag();
   };
   onVisibilityChange = () => {
     if (document.visibilityState === "visible") {
@@ -7621,7 +7623,30 @@ var AttachTerminal = class {
     if (!this.applicationOwnsMouse()) {
       return;
     }
+    const handedOff = terminalMouseOverrideHeld(event, this.mouseOverride);
     invertTerminalMouseOverride(event, this.mouseOverride);
+    if (handedOff) {
+      this.beginHandedOffDrag();
+    }
+  };
+  // The rest of a handed-off drag. xterm forwards move/release from DOCUMENT-level
+  // listeners and encodes each event's OWN modifiers into the report, so stripping
+  // only the mousedown would hand a mouse-aware TUI an incoherent sequence: an
+  // unmodified press followed by a Shift/Alt-flagged drag and release. The modifier
+  // is af's escape hatch, not input the user aimed at the application, so it must
+  // not arrive as a modified-click binding.
+  //
+  // STRIPS only, and only while a handed-off drag is in flight. With the modifier
+  // NOT held the drag is a selection, and mouseup must keep its true altKey there:
+  // xterm's alt-click-moves-cursor reads exactly that flag and would otherwise fire
+  // cursor-movement sequences into the PTY on every plain click.
+  onHandedOffDragModifier = (event) => {
+    if (terminalMouseOverrideHeld(event, this.mouseOverride)) {
+      invertTerminalMouseOverride(event, this.mouseOverride);
+    }
+    if (event.type === "mouseup") {
+      this.endHandedOffDrag();
+    }
   };
   handleUserScroll(source) {
     if (this.pendingViewport === null) {
@@ -7662,6 +7687,7 @@ var AttachTerminal = class {
     this.container.removeEventListener("touchmove", this.onTouchMove, true);
     this.container.removeEventListener("pointerdown", this.onPointerDown, true);
     this.container.removeEventListener("mousedown", this.onMouseDownCapture, true);
+    this.endHandedOffDrag();
     this.closeSocket();
     this.term.dispose();
   }
@@ -7671,6 +7697,25 @@ var AttachTerminal = class {
   applicationOwnsWheel() {
     const mode = this.term.modes.mouseTrackingMode;
     return mode !== "none" && mode !== "x10";
+  }
+  /** Tracks the modifier strip on the document for exactly the life of one
+   *  handed-off drag — xterm registers its own forwarders the same way, and events
+   *  can leave this pane mid-drag, so the pane host is not a wide enough net. */
+  beginHandedOffDrag() {
+    if (this.handedOffDrag) {
+      return;
+    }
+    this.handedOffDrag = true;
+    document.addEventListener("mousemove", this.onHandedOffDragModifier, true);
+    document.addEventListener("mouseup", this.onHandedOffDragModifier, true);
+  }
+  endHandedOffDrag() {
+    if (!this.handedOffDrag) {
+      return;
+    }
+    this.handedOffDrag = false;
+    document.removeEventListener("mousemove", this.onHandedOffDragModifier, true);
+    document.removeEventListener("mouseup", this.onHandedOffDragModifier, true);
   }
   showMouseCaptureHint(message) {
     this.mouseCaptureHint.textContent = message;

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "5cb73e76c8eb";
+const VERSION = "3c3e3216c03f";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -1360,8 +1360,26 @@ test("#2681/#2787: application mouse mode selects on a plain drag and keeps a mo
     await p.keyboard.press("Enter");
     await expect(xterm).toHaveClass(/enable-mouse-events/);
 
+    // Sample the baseline only once the terminal has stopped growing. A shell prompt
+    // still landing after this read moves scrollTop by a row for reasons that have
+    // nothing to do with who owns the wheel, and the assertion below would report
+    // that as the wheel having scrolled. Two identical samples, the same idiom as
+    // settledHitTestableTabMenu.
+    let previousTop = Number.NaN;
+    let bottom = 0;
+    await expect
+      .poll(
+        async () => {
+          const top = await viewport.evaluate((el) => el.scrollTop);
+          const stable = top === previousTop;
+          previousTop = top;
+          bottom = top;
+          return stable;
+        },
+        { message: "output must settle before the wheel baseline is sampled", timeout: 10_000 },
+      )
+      .toBe(true);
     inputPayloads.length = 0;
-    const bottom = await viewport.evaluate((el) => el.scrollTop);
     await host.hover();
     await p.mouse.wheel(0, -900);
     await expect.poll(() => inputPayloads.length, { message: "application mouse mode must receive the plain wheel" }).toBeGreaterThan(0);
@@ -1414,6 +1432,22 @@ test("#2681/#2787: application mouse mode selects on a plain drag and keeps a mo
       .poll(() => inputPayloads.length, { message: "Shift+drag must report the button to the mouse-aware application" })
       .toBeGreaterThan(1);
     await expect(selection, "the modifier hands the drag to the app, so it makes no selection").toHaveCount(0);
+
+    // …and it arrives as a PLAIN button. The modifier is af's escape hatch, not
+    // something the user aimed at the application, so it must not reach the app as a
+    // Shift/Alt chord. xterm forwards the rest of a drag from DOCUMENT-level
+    // listeners that encode each event's own modifiers, so press and release can
+    // easily disagree — an incoherent sequence for any TUI with modified-click
+    // bindings. SGR (1006) puts the modifiers in the button field: +4 shift, +8 meta,
+    // +16 ctrl.
+    const buttons = [...inputPayloads.map((bytes) => String.fromCharCode(...bytes)).join("").matchAll(/\x1b\[<(\d+);/g)].map(
+      (m) => Number(m[1]),
+    );
+    expect(buttons.length, "the app must receive both the press and the release").toBeGreaterThan(1);
+    expect(
+      buttons.filter((b) => b & 4),
+      "af's escape modifier must never leak into the app's mouse reports as Shift",
+    ).toEqual([]);
 
     const beforeHistoryScroll = await viewport.evaluate((el) => el.scrollTop);
     inputPayloads.length = 0;

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -120,6 +120,7 @@ export class AttachTerminal {
   private readonly wheelHint: string;
   private mouseCaptureHintTimer: number | null = null;
   private mouseOverrideKeyHeld = false;
+  private handedOffDrag = false;
   private historyWheelRemainder = 0;
   // Incremented only by an actual user scroll input while a peer-owned anchor is
   // pending. Output and resize reflows can move viewportY too, so position deltas
@@ -150,6 +151,9 @@ export class AttachTerminal {
   private readonly onWindowBlur = (): void => {
     // A modifier released in another tab/window never sends this terminal keyup.
     this.mouseOverrideKeyHeld = false;
+    // Nor does a button released there send this window a mouseup, which would
+    // otherwise strand the drag's document listeners until the next release.
+    this.endHandedOffDrag();
   };
   private readonly onVisibilityChange = (): void => {
     if (document.visibilityState === "visible") {
@@ -206,7 +210,32 @@ export class AttachTerminal {
       // modifier keeps its xterm meaning (Shift extends an existing selection).
       return;
     }
+    // Held → this drag is being handed to the application, and the REST of it has
+    // to stay consistent with the press it is about to receive.
+    const handedOff = terminalMouseOverrideHeld(event, this.mouseOverride);
     invertTerminalMouseOverride(event, this.mouseOverride);
+    if (handedOff) {
+      this.beginHandedOffDrag();
+    }
+  };
+  // The rest of a handed-off drag. xterm forwards move/release from DOCUMENT-level
+  // listeners and encodes each event's OWN modifiers into the report, so stripping
+  // only the mousedown would hand a mouse-aware TUI an incoherent sequence: an
+  // unmodified press followed by a Shift/Alt-flagged drag and release. The modifier
+  // is af's escape hatch, not input the user aimed at the application, so it must
+  // not arrive as a modified-click binding.
+  //
+  // STRIPS only, and only while a handed-off drag is in flight. With the modifier
+  // NOT held the drag is a selection, and mouseup must keep its true altKey there:
+  // xterm's alt-click-moves-cursor reads exactly that flag and would otherwise fire
+  // cursor-movement sequences into the PTY on every plain click.
+  private readonly onHandedOffDragModifier = (event: MouseEvent): void => {
+    if (terminalMouseOverrideHeld(event, this.mouseOverride)) {
+      invertTerminalMouseOverride(event, this.mouseOverride);
+    }
+    if (event.type === "mouseup") {
+      this.endHandedOffDrag();
+    }
   };
 
   private handleUserScroll(source: TerminalUserScrollSource): void {
@@ -378,6 +407,7 @@ export class AttachTerminal {
     this.container.removeEventListener("touchmove", this.onTouchMove, true);
     this.container.removeEventListener("pointerdown", this.onPointerDown, true);
     this.container.removeEventListener("mousedown", this.onMouseDownCapture, true);
+    this.endHandedOffDrag();
     this.closeSocket();
     this.term.dispose();
   }
@@ -391,6 +421,27 @@ export class AttachTerminal {
     // DECSET 9/X10 reports button-down only. xterm keeps wheel events for
     // scrollback there; VT200, drag, and any-event modes report wheel input.
     return mode !== "none" && mode !== "x10";
+  }
+
+  /** Tracks the modifier strip on the document for exactly the life of one
+   *  handed-off drag — xterm registers its own forwarders the same way, and events
+   *  can leave this pane mid-drag, so the pane host is not a wide enough net. */
+  private beginHandedOffDrag(): void {
+    if (this.handedOffDrag) {
+      return;
+    }
+    this.handedOffDrag = true;
+    document.addEventListener("mousemove", this.onHandedOffDragModifier, true);
+    document.addEventListener("mouseup", this.onHandedOffDragModifier, true);
+  }
+
+  private endHandedOffDrag(): void {
+    if (!this.handedOffDrag) {
+      return;
+    }
+    this.handedOffDrag = false;
+    document.removeEventListener("mousemove", this.onHandedOffDragModifier, true);
+    document.removeEventListener("mouseup", this.onHandedOffDragModifier, true);
   }
 
   private showMouseCaptureHint(message: string): void {


### PR DESCRIPTION
Follow-up to #2796 (which #2787's fix landed in). The Codex review raised a **P2
on that PR after it had already auto-merged**, so it needs its own change. The
finding is real, and I confirmed the mechanism in the xterm source before acting.

## The leak

#2796 inverts one bit on the `mousedown` to decide "select" vs. "hand this drag to
the application". But xterm forwards the **rest** of a drag from **document-level**
listeners:

```ts
mouseup:   (ev) => { sendEvent(ev); ... },
mousedrag: (ev) => { if (ev.buttons) sendEvent(ev); },
```

…and `sendEvent` encodes each event's own modifiers into the SGR report
(`ctrl: ev.ctrlKey, alt: ev.altKey, shift: ev.shiftKey`). So a user holding
Shift/Option to reach the application produced:

| Event | What the app received |
| --- | --- |
| press | plain button (the mousedown we inverted) |
| drag / release | button **+4 — Shift flagged** |

An incoherent sequence, and to any TUI with modified-click bindings it reads as a
shift-click the user never aimed at it. The modifier is **af's escape hatch**, not
input for the application.

## The fix

Strip the override modifier from move/release too, on document listeners registered
for exactly the life of one handed-off drag (xterm registers its own the same way,
and a drag can leave the pane, so the pane host is not a wide enough net). Cleared on
`mouseup`, on window blur, and in `dispose()`.

It only ever **strips**, never sets — that asymmetry is load-bearing. With the
modifier *not* held the drag is a selection, and `mouseup` must keep its true
`altKey` there: xterm's `alt-click-moves-cursor` reads exactly that flag, so a
synthetic Option would fire cursor-movement sequences into the PTY on every plain
click.

## Verification

**Watched it fail first.** The new assertion decodes the SGR button field of every
forwarded report and asserts none carries the shift bit:

```
Error: af's escape modifier must never leak into the app's mouse reports as Shift
- Expected  - Array []
+ Received  + Array [ 4 ]
```

Clean after the fix. Full `make web-selftest-container`: **128 passed**.

Also in here: the pre-existing wheel-ownership assertion now samples its baseline
only once the terminal has stopped growing. A shell prompt landing between the
sample and the assertion moves `scrollTop` by a row, which that assertion then
reports as the wheel having scrolled — it failed exactly that way twice once
#2796's shell handshake shifted the timing. Two identical samples, the same idiom
as `settledHitTestableTabMenu`. **The assertion itself is unchanged.**

Gate green on this head: `golangci-lint`, `gofmt -l`, `go build ./...`,
`deadcode -test ./...`, `scripts/lint-file-length.sh`, `make test-container`,
the web typecheck + 462 unit tests, and the regenerated `web/dist` bundle committed.

Refs #2787.

Co-Authored-By: Captain Claude <noreply@anthropic.com>
