### PR TITLE
fix(web): scroll the terminal by touch under application mouse mode (#2682)

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -20,6 +20,23 @@
 - The wheel is deliberately **not** inverted: a mouse-aware application still
   receives a plain scroll, and Option/Shift + wheel still scrolls terminal history.
 
+## Scrolling the web terminal on a phone
+
+- **A one-finger drag scrolls the terminal again while an agent owns the mouse.**
+  Claude Code, Codex, and any full-screen TUI enable mouse tracking, and xterm
+  answers by switching its own touch scrolling off — so on a phone the pane stopped
+  at the last screen with no way back into history, which is most of the reason to
+  open one. The drag now moves terminal history itself.
+- A **tap** still reaches the application, so a mouse-driven TUI keeps its clicks.
+  The change above it — a plain *drag* now selects text, with app clicks behind
+  Option/Shift — deliberately stops at the mouse: a phone has no modifier to hold, so
+  applying it to a finger would leave a mouse-driven TUI unreachable there. On touch
+  the two gestures separate without a modifier: the drag scrolls, the tap clicks. A
+  pinch is still the browser's.
+- The escape hint no longer shows for a touch. It names a key to hold — Shift, or
+  Option on macOS — that a phone has no way to press, and the gesture it was there
+  to rescue now works on its own.
+
 ## A healed root agent keeps its conversation
 
 - When the root agent's tmux vanished, the daemon re-created it as a **brand-new

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7317,6 +7317,9 @@ function historyWheelPlan(event, rows, rowHeight, remainder) {
   const lines = Object.is(wholeRows, -0) ? 0 : wholeRows;
   return { lines, remainder: total - lines };
 }
+function touchHistoryScrollPlan(lastY, y, rows, rowHeight, remainder) {
+  return historyWheelPlan({ deltaMode: 0, deltaY: lastY - y }, rows, rowHeight, remainder);
+}
 
 // src/theme.ts
 var THEME_CHOICES = ["auto", "light", "dark"];
@@ -7522,7 +7525,8 @@ var AttachTerminal = class {
     document.addEventListener("visibilitychange", this.onVisibilityChange);
     container.addEventListener("pointerenter", this.onPointerEnter);
     container.addEventListener("wheel", this.onWheel, { capture: true, passive: true });
-    container.addEventListener("touchmove", this.onTouchMove, { capture: true, passive: true });
+    container.addEventListener("touchstart", this.onTouchStart, { capture: true, passive: true });
+    container.addEventListener("touchmove", this.onTouchMove, { capture: true, passive: false });
     container.addEventListener("pointerdown", this.onPointerDown, true);
     container.addEventListener("mousedown", this.onMouseDownCapture, true);
     this.scheduleVisibleFit();
@@ -7549,6 +7553,14 @@ var AttachTerminal = class {
   mouseOverrideKeyHeld = false;
   handedOffDrag = false;
   historyWheelRemainder = 0;
+  // The screen position the current one-finger drag last scrolled from, plus its
+  // sub-row carry. Null whenever no gesture is af's to scroll: none is down, or a
+  // second finger arrived and the browser owns the pinch.
+  touchScrollY = null;
+  touchScrollRemainder = 0;
+  // Whether the gesture in flight came from a finger, read off the pointer event that
+  // precedes the browser's compatibility mouse events (onPointerDown).
+  lastPointerWasTouch = false;
   // Incremented only by an actual user scroll input while a peer-owned anchor is
   // pending. Output and resize reflows can move viewportY too, so position deltas
   // alone do not prove that a user intended to override the saved reading line.
@@ -7598,11 +7610,50 @@ var AttachTerminal = class {
       this.showMouseCaptureHint(this.wheelHint);
     }
   };
-  onTouchMove = () => this.handleUserScroll("touch");
+  // Application mouse mode switches xterm's OWN touch scrolling off — both of its
+  // touch listeners return early while mouse events are active — and nothing takes
+  // over: the finger is on the screen, and the .xterm-viewport holding the scrollback
+  // is that screen's SIBLING, so the browser has no ancestor to pan. A phone
+  // therefore loses scrollback entirely the moment an agent enables mouse tracking,
+  // and unlike the wheel (#2681) it has no modifier to escape with. So af scrolls
+  // history itself here (#2682): the DRAG is terminal-owned, the TAP still reaches
+  // the application — which is why only the move is ever cancelled, never the
+  // touchstart that a tap's compatibility mouse events depend on.
+  onTouchStart = (event) => {
+    const onScrollbar = event.target === this.container.querySelector(".xterm-viewport");
+    this.touchScrollY = event.touches.length === 1 && !onScrollbar ? event.touches[0].clientY : null;
+    this.touchScrollRemainder = 0;
+  };
+  onTouchMove = (event) => {
+    this.handleUserScroll("touch");
+    if (this.touchScrollY === null) {
+      return;
+    }
+    if (event.touches.length !== 1) {
+      this.touchScrollY = null;
+      return;
+    }
+    const last = this.touchScrollY;
+    const y = event.touches[0].clientY;
+    this.touchScrollY = y;
+    if (!this.applicationOwnsMouse()) {
+      return;
+    }
+    const plan = touchHistoryScrollPlan(last, y, this.term.rows, this.rowHeight(), this.touchScrollRemainder);
+    this.touchScrollRemainder = plan.remainder;
+    if (plan.lines !== 0) {
+      this.term.scrollLines(plan.lines);
+    }
+    event.preventDefault();
+  };
   onPointerDown = (event) => {
+    this.lastPointerWasTouch = event.pointerType === "touch";
     const viewport = this.container.querySelector(".xterm-viewport");
     if (event.target === viewport) {
       this.handleUserScroll("scrollbar");
+      return;
+    }
+    if (event.pointerType === "touch") {
       return;
     }
     if (!terminalMouseOverrideHeld(event, this.mouseOverride) && this.applicationOwnsMouse()) {
@@ -7619,8 +7670,15 @@ var AttachTerminal = class {
   // registers its PTY mouseup/mousedrag forwarders inside the mousedown branch this
   // inversion already diverts, and the selection drag that replaces it is driven by
   // document listeners that read no modifier at all.
+  //
+  // Mouse pointers ONLY. The inversion trades a plain click for a selection and hands
+  // the click back behind a modifier — a trade a touch device cannot take, because it
+  // has no modifier to hold, so inverting a tap would leave a phone with NO way to
+  // click a mouse-driven TUI at all. Touch does not need the trade either: its two
+  // gestures already separate without one, the drag scrolling history (#2682) and the
+  // tap staying the click.
   onMouseDownCapture = (event) => {
-    if (!this.applicationOwnsMouse()) {
+    if (!this.applicationOwnsMouse() || this.lastPointerWasTouch) {
       return;
     }
     const handedOff = terminalMouseOverrideHeld(event, this.mouseOverride);
@@ -7684,6 +7742,7 @@ var AttachTerminal = class {
     document.removeEventListener("visibilitychange", this.onVisibilityChange);
     this.container.removeEventListener("pointerenter", this.onPointerEnter);
     this.container.removeEventListener("wheel", this.onWheel, true);
+    this.container.removeEventListener("touchstart", this.onTouchStart, true);
     this.container.removeEventListener("touchmove", this.onTouchMove, true);
     this.container.removeEventListener("pointerdown", this.onPointerDown, true);
     this.container.removeEventListener("mousedown", this.onMouseDownCapture, true);
@@ -7730,13 +7789,17 @@ var AttachTerminal = class {
       this.mouseCaptureHintTimer = null;
     }, 4e3);
   }
+  /** The painted height of one terminal row, which turns a pixel-denominated gesture
+   *  into rows. Falls back to a font-size estimate before the first row exists. */
+  rowHeight() {
+    const renderedRow = this.container.querySelector(".xterm-rows > div");
+    return renderedRow?.getBoundingClientRect().height ?? (this.term.options.fontSize ?? 13) * 1.2;
+  }
   handleHistoryWheel(event) {
     if (!this.applicationOwnsWheel() || !terminalMouseOverrideHeld(event, this.mouseOverride) && !this.mouseOverrideKeyHeld) {
       return true;
     }
-    const renderedRow = this.container.querySelector(".xterm-rows > div");
-    const rowHeight = renderedRow?.getBoundingClientRect().height ?? (this.term.options.fontSize ?? 13) * 1.2;
-    const plan = historyWheelPlan(event, this.term.rows, rowHeight, this.historyWheelRemainder);
+    const plan = historyWheelPlan(event, this.term.rows, this.rowHeight(), this.historyWheelRemainder);
     this.historyWheelRemainder = plan.remainder;
     if (plan.lines !== 0) {
       this.term.scrollLines(plan.lines);

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "3c3e3216c03f";
+const VERSION = "01b1b0cf8c1b";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -37,7 +37,16 @@
 // playwright.config.ts): AF_WEB_BASE_URL and the two seeded session titles
 // AF_WEB_SESSION_A / AF_WEB_SESSION_B. No token is needed.
 
-import { expect, type Browser, type BrowserContext, type Locator, type Page, type Route, test } from "@playwright/test";
+import {
+  expect,
+  type Browser,
+  type BrowserContext,
+  type CDPSession,
+  type Locator,
+  type Page,
+  type Route,
+  test,
+} from "@playwright/test";
 import { decode, Op } from "../src/frame.js";
 
 const SESSION_A = process.env.AF_WEB_SESSION_A ?? "probe-a";
@@ -423,6 +432,36 @@ async function dragTabOntoPaneHitTested(
     },
     { tabText, edge, paneIndex, band: 0.3 }, // EDGE_BAND in split.ts
   );
+}
+
+/**
+ * Drags one finger down the page from `fromY` to `toY`, through CDP's
+ * Input.dispatchTouchEvent — the same call Playwright's own touchscreen.tap makes.
+ *
+ * That routing is the point (#2682). These arrive as TRUSTED touch events at the
+ * browser's gesture pipeline, so Chromium decides who owns the drag exactly as it
+ * does on a phone: whether it pans, whether preventDefault claims it, and whether
+ * compatibility mouse events follow. TouchEvents synthesized in page.evaluate would
+ * prove only that our listeners ran, which is the false pass the issue warns about.
+ * The context must be built with hasTouch, or Chromium ignores these entirely.
+ */
+async function touchDrag(cdp: CDPSession, x: number, fromY: number, toY: number): Promise<void> {
+  const steps = 12;
+  await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ x, y: fromY }] });
+  for (let step = 1; step <= steps; step++) {
+    await cdp.send("Input.dispatchTouchEvent", {
+      type: "touchMove",
+      touchPoints: [{ x, y: fromY + ((toY - fromY) * step) / steps }],
+    });
+  }
+  await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+}
+
+/** Taps once at a point — the gesture that must keep reaching a mouse-aware
+ *  application even when the drag above no longer does. */
+async function touchTap(cdp: CDPSession, x: number, y: number): Promise<void> {
+  await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ x, y }] });
+  await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
 }
 
 /** Points the task modal's schedule picker (#2057) at the "every N minutes" preset.
@@ -1716,6 +1755,142 @@ test("#2337: agent Shift+Enter preserves xterm input effects while shell keeps C
       await resetToAgentTab(p);
     }
     await ctx.close();
+  }
+});
+
+test("#2682 mobile: one finger scrolls the terminal, and keeps doing so under application mouse mode", REAL_FIXTURE, async ({
+  browser,
+}) => {
+  // A phone, not a narrow desktop window. hasTouch/isMobile put Chromium into real
+  // touch emulation, so every gesture below is a trusted touch the browser routes
+  // itself. A resized desktop window keeps delivering wheel events and would pass
+  // this whole test while a real phone stayed stuck — the false pass #2682 names up
+  // front, and the reason there is no unit test standing in for this one.
+  const ctx = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    deviceScaleFactor: 3,
+    hasTouch: true,
+    isMobile: true,
+  });
+  const p = await ctx.newPage();
+  const cdp = await ctx.newCDPSession(p);
+  const inputPayloads: number[][] = [];
+
+  p.on("websocket", (ws) => {
+    if (!ws.url().includes("/v1/sessions/") || !ws.url().includes("/stream")) {
+      return;
+    }
+    ws.on("framesent", ({ payload }) => {
+      const raw = typeof payload === "string" ? new TextEncoder().encode(payload) : new Uint8Array(payload);
+      const frame = decode(raw);
+      if (frame.op === Op.Input) {
+        inputPayloads.push(Array.from(frame.data));
+      }
+    });
+  });
+
+  try {
+    await openTokenless(p);
+    // At this width the rail is an off-canvas drawer, so reaching a terminal at all
+    // goes through the hamburger — the mobile path the report was filed from.
+    await p.locator(".af-nav-toggle").click();
+    await row(p, SESSION_B).click();
+    await expect(p.locator(".af-app.af-nav-open"), "opening a session must close the drawer over it").toHaveCount(0);
+    // Isolated context on B, like the mouse-mode exercise above: this mutates B's tab
+    // roster and restores it in finally, leaving the suite's shared page untouched.
+    await resetToAgentTab(p);
+
+    await createTerminalTab(p);
+    await expect(p.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Terminal", { timeout: 30_000 });
+    const host = await typeableShellTab(p);
+    const xterm = host.locator(".xterm");
+    const viewport = host.locator(".xterm-viewport");
+    const mouseHint = host.locator(".af-mouse-capture-hint");
+    await p.keyboard.type("for i in $(seq 1 200); do printf 'touch-scroll-%s\\n' \"$i\"; done");
+    await p.keyboard.press("Enter");
+    await expect(host).toContainText("touch-scroll-200", { timeout: 20_000 });
+
+    // Aim at the screen — the element a finger actually lands on. The scrollable
+    // .xterm-viewport is its SIBLING, which is the whole reason a browser has nothing
+    // to pan here and why the terminal has to move history itself.
+    const screen = host.locator(".xterm-screen");
+    const screenBox = await screen.boundingBox();
+    expect(screenBox, "the terminal screen must have geometry to drag on").toBeTruthy();
+    const { x, y, width, height } = screenBox as ElementBox;
+    const column = x + width / 2;
+    const dragIntoHistory = (): Promise<void> => touchDrag(cdp, column, y + height * 0.3, y + height * 0.8);
+    const dragTowardNewest = (): Promise<void> => touchDrag(cdp, column, y + height * 0.8, y + height * 0.3);
+
+    // 1. The ordinary shell, where xterm's own touch handling is live. ESTABLISH that
+    //    state rather than assume it: af starts every tmux session with `mouse on`
+    //    (session/tmux/start.go), so a pane can already be tracking before any agent
+    //    runs — which is why this breakage is not exotic. Turning every tracking mode
+    //    off and waiting for xterm to agree is what keeps the two halves distinct, and
+    //    keeps the fix below from quietly taking over the path xterm still owns.
+    await p.keyboard.type("printf '\\033[?1000l\\033[?1002l\\033[?1003l\\033[?1006l'");
+    await p.keyboard.press("Enter");
+    await expect(xterm, "the plain half must run with application mouse tracking OFF").not.toHaveClass(
+      /enable-mouse-events/,
+    );
+    const bottom = await viewport.evaluate((el) => el.scrollTop);
+    expect(bottom, "200 lines of fresh output must leave real scrollback above the view").toBeGreaterThan(0);
+    await dragIntoHistory();
+    await expect
+      .poll(() => viewport.evaluate((el) => el.scrollTop), { message: "a one-finger drag must reach scrollback in a plain shell" })
+      .toBeLessThan(bottom);
+    const parked = await viewport.evaluate((el) => el.scrollTop);
+    await dragTowardNewest();
+    await expect
+      .poll(() => viewport.evaluate((el) => el.scrollTop), { message: "dragging the other way must come back toward the newest output" })
+      .toBeGreaterThan(parked);
+
+    // 2. The report. A full-screen TUI turns mouse tracking on, and xterm answers by
+    //    switching its OWN touch scrolling off (both of its touch listeners return
+    //    early while mouse events are active). Nothing takes over: the finger is on
+    //    the screen, and the scrollable element is not one of its ancestors. Typing
+    //    the mode in returns the viewport to the bottom on its own — xterm scrolls to
+    //    bottom on genuine user input — so the sample below is taken after it settles.
+    await p.keyboard.type("printf '\\033[?1000h\\033[?1006h'");
+    await p.keyboard.press("Enter");
+    await expect(xterm).toHaveClass(/enable-mouse-events/);
+    await expect
+      .poll(() => viewport.evaluate((el) => el.scrollTop), { message: "typing must return the viewport to the newest output" })
+      .toBeGreaterThan(parked);
+
+    inputPayloads.length = 0;
+    const captured = await viewport.evaluate((el) => el.scrollTop);
+    await dragIntoHistory();
+    await expect
+      .poll(() => viewport.evaluate((el) => el.scrollTop), {
+        message: "a one-finger drag must still reach scrollback while an application owns the mouse",
+      })
+      .toBeLessThan(captured);
+    expect(inputPayloads, "the scroll gesture must not ALSO report a drag to the application").toHaveLength(0);
+
+    // The desktop escape is advice a phone cannot take: there is no Shift to hold,
+    // and the gesture it would name just worked.
+    await expect(mouseHint, "a touch pointer must not be told to hold a key it has no way to press").not.toHaveClass(
+      /af-visible/,
+    );
+
+    // 3. A TAP still belongs to the application. That capability is what mouse mode
+    //    was turned on for, and it is what forbids cancelling the touch outright
+    //    rather than only the drag.
+    inputPayloads.length = 0;
+    await touchTap(cdp, column, y + height * 0.5);
+    await expect
+      .poll(() => inputPayloads.length, { message: "a tap must still report a click to the mouse-aware application" })
+      .toBeGreaterThan(0);
+    await expect(mouseHint, "a working tap must not advertise an escape either").not.toHaveClass(/af-visible/);
+  } finally {
+    // The shell holding mouse mode dies with its tab, so nothing has to unwind the
+    // mode itself — and the mouse-report bytes the tap left on its command line go
+    // with it rather than into a later `type()`.
+    try {
+      await resetToAgentTab(p);
+    } finally {
+      await ctx.close();
+    }
   }
 });
 

--- a/web/src/terminal-mouse.test.ts
+++ b/web/src/terminal-mouse.test.ts
@@ -7,6 +7,7 @@ import {
   terminalMouseOverride,
   terminalMouseOverrideFlag,
   terminalMouseOverrideHeld,
+  touchHistoryScrollPlan,
 } from "./terminal-mouse.js";
 
 test("application-mouse escape matches xterm's platform selection modifier", () => {
@@ -61,4 +62,22 @@ test("history wheel converts pixels, lines, and pages without losing trackpad fr
   });
   assert.deepEqual(historyWheelPlan({ deltaY: 3, deltaMode: 1 }, 24, 10, 0), { lines: 3, remainder: 0 });
   assert.deepEqual(historyWheelPlan({ deltaY: -1, deltaMode: 2 }, 24, 10, 0), { lines: -24, remainder: 0 });
+});
+
+test("a touch drag scrolls the way the content follows the finger (#2682)", () => {
+  // Dragging DOWN pulls older output into view: negative lines, like a wheel scrolled
+  // back. Getting this backwards is the one failure a real device shows instantly and
+  // a green unit suite would still call a fix, so pin the direction, not just the
+  // magnitude.
+  assert.deepEqual(touchHistoryScrollPlan(100, 140, 24, 20, 0), { lines: -2, remainder: 0 });
+  assert.deepEqual(touchHistoryScrollPlan(140, 100, 24, 20, 0), { lines: 2, remainder: 0 });
+
+  // A drag is delivered as many small steps, so sub-row motion has to accumulate
+  // across them or a slow scroll never moves at all.
+  const first = touchHistoryScrollPlan(100, 108, 24, 16, 0);
+  assert.deepEqual(first, { lines: 0, remainder: -0.5 });
+  assert.deepEqual(touchHistoryScrollPlan(108, 116, 24, 16, first.remainder), { lines: -1, remainder: 0 });
+
+  // A finger that has not moved must not scroll — and must not report -0 rows.
+  assert.deepEqual(touchHistoryScrollPlan(100, 100, 24, 20, 0), { lines: 0, remainder: 0 });
 });

--- a/web/src/terminal-mouse.ts
+++ b/web/src/terminal-mouse.ts
@@ -85,3 +85,21 @@ export function historyWheelPlan(
   const lines = Object.is(wholeRows, -0) ? 0 : wholeRows;
   return { lines, remainder: total - lines };
 }
+
+/**
+ * Convert one step of a one-finger drag into whole terminal rows (#2682).
+ *
+ * The sign convention is xterm's own: a finger moving UP the screen (clientY
+ * decreasing) scrolls toward the NEWEST output, which is what a positive wheel
+ * deltaY does — so the drag is expressed as that wheel and shares its arithmetic,
+ * including the sub-row remainder that keeps a slow drag moving at all.
+ */
+export function touchHistoryScrollPlan(
+  lastY: number,
+  y: number,
+  rows: number,
+  rowHeight: number,
+  remainder: number,
+): HistoryWheelPlan {
+  return historyWheelPlan({ deltaMode: 0, deltaY: lastY - y }, rows, rowHeight, remainder);
+}

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -56,6 +56,7 @@ import {
   terminalMouseOverride,
   terminalMouseOverrideHeld,
   type TerminalMouseOverride,
+  touchHistoryScrollPlan,
 } from "./terminal-mouse.js";
 import type { StreamEndpoint } from "./stream_endpoint.js";
 import { currentXtermTheme } from "./theme.js";
@@ -122,6 +123,14 @@ export class AttachTerminal {
   private mouseOverrideKeyHeld = false;
   private handedOffDrag = false;
   private historyWheelRemainder = 0;
+  // The screen position the current one-finger drag last scrolled from, plus its
+  // sub-row carry. Null whenever no gesture is af's to scroll: none is down, or a
+  // second finger arrived and the browser owns the pinch.
+  private touchScrollY: number | null = null;
+  private touchScrollRemainder = 0;
+  // Whether the gesture in flight came from a finger, read off the pointer event that
+  // precedes the browser's compatibility mouse events (onPointerDown).
+  private lastPointerWasTouch = false;
   // Incremented only by an actual user scroll input while a peer-owned anchor is
   // pending. Output and resize reflows can move viewportY too, so position deltas
   // alone do not prove that a user intended to override the saved reading line.
@@ -180,14 +189,72 @@ export class AttachTerminal {
       this.showMouseCaptureHint(this.wheelHint);
     }
   };
-  private readonly onTouchMove = (): void => this.handleUserScroll("touch");
+  // Application mouse mode switches xterm's OWN touch scrolling off — both of its
+  // touch listeners return early while mouse events are active — and nothing takes
+  // over: the finger is on the screen, and the .xterm-viewport holding the scrollback
+  // is that screen's SIBLING, so the browser has no ancestor to pan. A phone
+  // therefore loses scrollback entirely the moment an agent enables mouse tracking,
+  // and unlike the wheel (#2681) it has no modifier to escape with. So af scrolls
+  // history itself here (#2682): the DRAG is terminal-owned, the TAP still reaches
+  // the application — which is why only the move is ever cancelled, never the
+  // touchstart that a tap's compatibility mouse events depend on.
+  private readonly onTouchStart = (event: TouchEvent): void => {
+    // Ownership is settled once, at the start of the gesture. A touch whose target is
+    // the viewport itself is a scrollbar drag the browser already handles — the same
+    // discriminator onPointerDown reads below, and taking it over would scroll
+    // BACKWARDS, since a thumb follows the finger while the content opposes it.
+    const onScrollbar = event.target === this.container.querySelector(".xterm-viewport");
+    this.touchScrollY = event.touches.length === 1 && !onScrollbar ? event.touches[0].clientY : null;
+    this.touchScrollRemainder = 0;
+  };
+  private readonly onTouchMove = (event: TouchEvent): void => {
+    this.handleUserScroll("touch");
+    if (this.touchScrollY === null) {
+      return;
+    }
+    if (event.touches.length !== 1) {
+      // A second finger arrived: hand the REST of this gesture to the browser rather
+      // than scrolling by a pinch's motion or by the distance it covered untracked.
+      this.touchScrollY = null;
+      return;
+    }
+    const last = this.touchScrollY;
+    const y = event.touches[0].clientY;
+    this.touchScrollY = y;
+    if (!this.applicationOwnsMouse()) {
+      // xterm's own touch scrolling is live here; tracking the position anyway keeps
+      // a mode change mid-drag from scrolling by everything travelled before it.
+      return;
+    }
+    const plan = touchHistoryScrollPlan(last, y, this.term.rows, this.rowHeight(), this.touchScrollRemainder);
+    this.touchScrollRemainder = plan.remainder;
+    if (plan.lines !== 0) {
+      this.term.scrollLines(plan.lines);
+    }
+    // Claim the pan. Left to the browser it chains out to the document, which toggles
+    // the URL bar, resizes .af-app and refits the terminal mid-gesture (#2493) — and
+    // an uncancelled drag can still synthesize the compatibility mouse events the
+    // application would read as a drag it never got the button press for.
+    event.preventDefault();
+  };
   private readonly onPointerDown = (event: PointerEvent): void => {
+    // A pointer event always precedes its compatibility mouse counterpart — for a tap
+    // the browser fires pointerdown at touch-down and mousedown only after the finger
+    // lifts — so this is what tells onMouseDownCapture below whether the click it is
+    // about to rewrite came from a finger.
+    this.lastPointerWasTouch = event.pointerType === "touch";
     // The xterm screen is a sibling of its scrollable viewport. A pointer whose
     // target is the viewport itself is therefore a scrollbar/track gesture, while
     // an ordinary terminal click targets the screen and keeps the saved anchor.
     const viewport = this.container.querySelector(".xterm-viewport");
     if (event.target === viewport) {
       this.handleUserScroll("scrollbar");
+      return;
+    }
+    // Both halves of the hint are desktop advice a finger cannot take: the drag it
+    // describes scrolls history here rather than selecting (#2682), and there is no
+    // modifier to hold for the app clicks it offers — a tap gives those directly.
+    if (event.pointerType === "touch") {
       return;
     }
     if (!terminalMouseOverrideHeld(event, this.mouseOverride) && this.applicationOwnsMouse()) {
@@ -204,10 +271,19 @@ export class AttachTerminal {
   // registers its PTY mouseup/mousedrag forwarders inside the mousedown branch this
   // inversion already diverts, and the selection drag that replaces it is driven by
   // document listeners that read no modifier at all.
+  //
+  // Mouse pointers ONLY. The inversion trades a plain click for a selection and hands
+  // the click back behind a modifier — a trade a touch device cannot take, because it
+  // has no modifier to hold, so inverting a tap would leave a phone with NO way to
+  // click a mouse-driven TUI at all. Touch does not need the trade either: its two
+  // gestures already separate without one, the drag scrolling history (#2682) and the
+  // tap staying the click.
   private readonly onMouseDownCapture = (event: MouseEvent): void => {
-    if (!this.applicationOwnsMouse()) {
+    if (!this.applicationOwnsMouse() || this.lastPointerWasTouch) {
       // Outside application mouse mode a plain drag already selects, and the
-      // modifier keeps its xterm meaning (Shift extends an existing selection).
+      // modifier keeps its xterm meaning (Shift extends an existing selection). A
+      // touch has no modifier to invert or to hand a drag off with, per the note
+      // above, so it leaves here too.
       return;
     }
     // Held → this drag is being handed to the application, and the REST of it has
@@ -373,7 +449,11 @@ export class AttachTerminal {
     document.addEventListener("visibilitychange", this.onVisibilityChange);
     container.addEventListener("pointerenter", this.onPointerEnter);
     container.addEventListener("wheel", this.onWheel, { capture: true, passive: true });
-    container.addEventListener("touchmove", this.onTouchMove, { capture: true, passive: true });
+    container.addEventListener("touchstart", this.onTouchStart, { capture: true, passive: true });
+    // Capture, so the drag is resolved before xterm's own touch listeners (which sit
+    // on a descendant) see it, and NON-passive, because claiming the pan means
+    // calling preventDefault — a passive listener's is ignored outright.
+    container.addEventListener("touchmove", this.onTouchMove, { capture: true, passive: false });
     container.addEventListener("pointerdown", this.onPointerDown, true);
     container.addEventListener("mousedown", this.onMouseDownCapture, true);
     this.scheduleVisibleFit();
@@ -404,6 +484,7 @@ export class AttachTerminal {
     document.removeEventListener("visibilitychange", this.onVisibilityChange);
     this.container.removeEventListener("pointerenter", this.onPointerEnter);
     this.container.removeEventListener("wheel", this.onWheel, true);
+    this.container.removeEventListener("touchstart", this.onTouchStart, true);
     this.container.removeEventListener("touchmove", this.onTouchMove, true);
     this.container.removeEventListener("pointerdown", this.onPointerDown, true);
     this.container.removeEventListener("mousedown", this.onMouseDownCapture, true);
@@ -458,6 +539,13 @@ export class AttachTerminal {
     }, 4_000);
   }
 
+  /** The painted height of one terminal row, which turns a pixel-denominated gesture
+   *  into rows. Falls back to a font-size estimate before the first row exists. */
+  private rowHeight(): number {
+    const renderedRow = this.container.querySelector<HTMLElement>(".xterm-rows > div");
+    return renderedRow?.getBoundingClientRect().height ?? (this.term.options.fontSize ?? 13) * 1.2;
+  }
+
   private handleHistoryWheel(event: WheelEvent): boolean {
     // Chromium's wheel event can omit modifier flags even while the keyboard key
     // remains down (notably through automation and trackpad momentum). xterm sees
@@ -469,9 +557,7 @@ export class AttachTerminal {
       return true;
     }
 
-    const renderedRow = this.container.querySelector<HTMLElement>(".xterm-rows > div");
-    const rowHeight = renderedRow?.getBoundingClientRect().height ?? (this.term.options.fontSize ?? 13) * 1.2;
-    const plan = historyWheelPlan(event, this.term.rows, rowHeight, this.historyWheelRemainder);
+    const plan = historyWheelPlan(event, this.term.rows, this.rowHeight(), this.historyWheelRemainder);
     this.historyWheelRemainder = plan.remainder;
     if (plan.lines !== 0) {
       this.term.scrollLines(plan.lines);


### PR DESCRIPTION
## Summary

On a phone the terminal pane could not be scrolled at all. It is a **state**, not the layout — the mobile shell, its overflow, and `overscroll-behavior` are all fine:

- xterm binds `touchstart`/`touchmove` on its own element, and **both return early while `areMouseEventsActive`** (`@xterm/xterm` 5.5, `Terminal._bindMouse`). It stops translating a drag into a viewport scroll.
- **Nothing takes over.** The finger lands on `.xterm-screen`, and the scrollable `.xterm-viewport` is that screen's *sibling*, not an ancestor — so the browser has no box to pan either. That sibling relationship is already documented in `terminal.ts` (`onPointerDown` uses it to tell a scrollbar gesture from a terminal one).
- Unlike the wheel escape from #2681, a touch device has **no modifier to hold**.

And this is not an exotic state: `af` starts every tmux session with `mouse on` (`session/tmux/start.go:177`), so tmux itself is a mouse-tracking application in every pane. A phone loses scrollback in the ordinary case, which is what "scrolling is also not working on mobile" meant.

Answering what #2682 asked to establish: the page is not the problem and nothing is chained — with tracking **off**, a one-finger drag scrolls fine (pinned below). The pane does not *consume* touch it should pass through; it *stops handling* touch, and nothing else can. There was no scrollback affordance at all on mobile in that state.

## What changed

`web/src/terminal.ts` gains `touchstart` + `touchmove` capture listeners on the pane host:

- A one-finger drag scrolls terminal history while an application owns the mouse, reusing the wheel path's pixel→row arithmetic (`touchHistoryScrollPlan` → `historyWheelPlan`), sub-row remainder included so a slow drag still moves.
- Ownership is settled **once per gesture**: a pinch and a scrollbar drag stay the browser's (taking the scrollbar over would scroll *backwards* — a thumb follows the finger, the content opposes it). Outside application mouse mode xterm's own handling is untouched.
- `touchmove` is non-passive because claiming the pan means `preventDefault`. Only the **move** is ever cancelled, never the `touchstart` — a tap's compatibility mouse events are how a mouse-aware TUI still gets its clicks.
- `rowHeight()` extracted; the wheel path had the same measurement inline.

Two touch-specific consequences of **#2787 (PR #2796)**, which merged while this was in flight:

- **Its mousedown inversion is not applied to a tap.** The inversion trades a plain click for a selection and hands the click back behind Option/Shift — a trade a finger cannot take. Applied to touch it left a phone with *no* way to click a mouse-driven TUI at all. `onPointerDown` records the pointer type (a pointer event always precedes its compatibility mouse event), and `onMouseDownCapture` skips the inversion for touch. Desktop behaviour is unchanged — #2796's own drag-selects test still passes.
- **The escape hint no longer fires for a touch pointer.** Both halves of it ("Drag selects · Hold Shift for app clicks") name desktop gestures a finger cannot perform.

## Red-first proof

`web/selftest/web-driver.spec.ts` drives **trusted** touch events through CDP `Input.dispatchTouchEvent` — the call Playwright's own `touchscreen.tap` makes — in a `hasTouch`/`isMobile` context, reaching the pane through the mobile drawer. #2682 warns that a narrowed desktop window is a false pass because it still delivers wheel events; synthesizing `TouchEvent`s in `page.evaluate` would be the same false pass one layer down, proving only that our listeners ran.

Against master, with the shipped test:

```
Error: a one-finger drag must still reach scrollback while an application owns the mouse
Expected: < 2754
Received:   2754
```

The half above it — the same drag with tracking explicitly **off** — passes in that same run, so the failure isolates the mode, not the gesture, the geometry, or the harness. After the fix all three halves pass, plus:

- the scroll gesture reports **no** mouse bytes to the application;
- a **tap** still reports a click (this went red on the rebase onto #2796 and green again with the guard — that is how the interaction above was found, not by reading it);
- the hint stays hidden for touch.

`web/src/terminal-mouse.test.ts` pins the pixel→row direction as a unit test, which is what actually gates on master (web-selftest is a signal, not a gate — #2762).

## Harness note

The `#2681` flow was observed losing the front half of a typed command (`/bin/sh: 1: Syntax error: "do" unexpected`), failing 56 lines from the behaviour under test. #2796 landed `typeableShellTab` for exactly that race; this test uses it rather than adding a second helper.

## Verification

- `gofmt -l .` clean · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `deadcode -test ./...` · `scripts/lint-file-length.sh` — all green on the PR head.
- `make web-test` (typecheck + 463 unit tests) green; `make web-build` reproduces the committed bundle exactly.
- The full `web-selftest` suite ran green (128/128) on this change before the rebase, and the `#2681`/`#2682` pair ran green on the rebased tree. No Go sources are touched, so the Go matrix is left to CI.

Closes #2682
