### PR TITLE
fix(daemon): hold a settlement retry off a row inside another operation

### DIFF
--- a/daemon/handoff_settle.go
+++ b/daemon/handoff_settle.go
@@ -78,8 +78,44 @@ func (m *Manager) flushHandoffSettlements() {
 		if !registered {
 			continue
 		}
-		if err := m.persistHandoffSettlement(entry.repoID, entry.key, entry.instance); err != nil {
+		if err := m.flushOneHandoffSettlement(entry); err != nil {
 			log.WarningLog.Printf("handoff %q: %v", entry.instance.Title, err)
 		}
 	}
+}
+
+// flushOneHandoffSettlement retries one owed write, but only while the session
+// is between operations.
+//
+// A retry is a WHOLE-ROW write of live memory, so running it inside another
+// session transaction would checkpoint that transaction's half-built state. A
+// second handoff is the concrete case: it raises OpReplacing and rewrites Program
+// BEFORE it records its own mission marker, and disk strips the transient op — so
+// a retry landing in that window stores the incoming agent as settled with no
+// obligation at all, and a crash before the real checkpoint loses that takeover
+// brief entirely. Trading a duplicated mission for a lost one is not a fix.
+//
+// The per-session op lock is what actually serializes this, because that is the
+// lock every lifecycle operation holds for its whole transaction; the in-flight-op
+// re-check under it is the same fence persistPollChange puts in front of the only
+// other poll-driven whole-row write. TryLock, never Lock: the poll goroutine must
+// not stall behind a slow teardown, and a skipped retry costs nothing — the
+// obligation stays owed for the next tick, and a newer settlement on the same row
+// discharges it outright.
+func (m *Manager) flushOneHandoffSettlement(entry pendingHandoffEntry) error {
+	opLock := m.opLockFor(entry.key)
+	if !opLock.TryLock() {
+		return nil
+	}
+	defer opLock.Unlock()
+
+	// Re-verify under the lock. Registration can change while the lock is acquired,
+	// and an op raised outside it must not be flattened by this write.
+	m.mu.Lock()
+	registered := m.instances[entry.key] == entry.instance
+	m.mu.Unlock()
+	if !registered || entry.instance.GetInFlightOp() != session.OpNone {
+		return nil
+	}
+	return m.persistHandoffSettlement(entry.repoID, entry.key, entry.instance)
 }

--- a/daemon/handoff_settle_test.go
+++ b/daemon/handoff_settle_test.go
@@ -214,3 +214,102 @@ func TestResumePendingHandoffs_SettlementPersistFailureCannotRedeliverTheMission
 			"handoff itself does", len(prompts), prompts)
 	}
 }
+
+// blockingNthSwapBackend parks inside the Nth SwapAgent so a test can hold a
+// handoff transaction open at a chosen point. blockingSwapBackend blocks the
+// FIRST swap and closes its channel unconditionally; this one has to let an
+// earlier handoff through before it stops the next.
+type blockingNthSwapBackend struct {
+	*handoffBackend
+	blockAt int
+	mu      sync.Mutex
+	calls   int
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingNthSwapBackend) SwapAgent(i *session.Instance, plan session.AgentSwapPlan) error {
+	b.mu.Lock()
+	b.calls++
+	block := b.calls == b.blockAt
+	b.mu.Unlock()
+	if block {
+		close(b.entered)
+		<-b.release
+	}
+	return b.handoffBackend.SwapAgent(i, plan)
+}
+
+// A settlement retry must not write while the session is inside another
+// operation (post-merge Codex finding on #2781).
+//
+// The retry is a WHOLE-ROW write of live memory. A second handoff raises
+// OpReplacing and rewrites Program before it records its own mission marker, and
+// disk strips the transient op — so a retry landing in that window persists the
+// incoming agent as SETTLED with no obligation at all. A crash before that
+// handoff's real checkpoint would then lose its takeover brief outright, which
+// trades the duplicate this PR fixes for a silently dropped mission.
+//
+// So the poll holds off while the row is busy and finishes the write once it is
+// free. The obligation is durable in memory; a skipped tick costs nothing.
+func TestFlushHandoffSettlements_HoldsOffWhileTheRowIsInsideAnotherHandoff(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	base := &handoffBackend{FakeBackend: session.NewFakeBackend()}
+	backend := &blockingNthSwapBackend{
+		handoffBackend: base,
+		blockAt:        2,
+		entered:        make(chan struct{}),
+		release:        make(chan struct{}),
+	}
+	registerHandoffSubject(t, manager, repoID, repoPath, "settle-race", backend)
+
+	// First handoff: its settlement write fails, so the row owes one.
+	diskFull := errors.New("no space left on device")
+	injected := failSettlementWrite(t, "settle-race", diskFull, false)
+	if _, err := manager.HandoffSession(HandoffSessionRequest{
+		Title: "settle-race", RepoID: repoID, To: tmux.ProgramGemini,
+	}); !errors.Is(err, diskFull) {
+		t.Fatalf("first HandoffSession error = %v, want the settlement write failure", err)
+	}
+	if !injected() {
+		t.Fatal("no settlement write was ever attempted, so this test exercised nothing")
+	}
+	owed := recordFor(t, repoID, "settle-race")
+	if owed == nil || owed.PendingHandoffMission == "" || owed.Program != tmux.ProgramGemini {
+		t.Fatalf("record after the failed settlement = %+v, want gemini with its mission still pending", owed)
+	}
+
+	// Second handoff, parked inside SwapAgent: the fence is up and Program already
+	// names codex, but this handoff's own mission marker does not exist yet.
+	done := make(chan error, 1)
+	go func() {
+		_, err := manager.HandoffSession(HandoffSessionRequest{
+			Title: "settle-race", RepoID: repoID, To: tmux.ProgramCodex,
+		})
+		done <- err
+	}()
+	<-backend.entered
+
+	// The poll fires in that window.
+	manager.ResumePendingHandoffs()
+
+	mid := recordFor(t, repoID, "settle-race")
+	if mid == nil || mid.Program != owed.Program || mid.PendingHandoffMission != owed.PendingHandoffMission {
+		t.Fatalf("the retry wrote mid-transaction: record = %+v, want it untouched at %q with its mission "+
+			"still pending. Persisting live memory here stores the INCOMING agent as settled with no "+
+			"obligation, so a crash before that handoff's checkpoint loses its takeover brief", mid, owed.Program)
+	}
+
+	close(backend.release)
+	if err := <-done; err != nil {
+		t.Fatalf("second HandoffSession: %v", err)
+	}
+
+	// Once the row is free again the obligation is discharged — by this handoff's
+	// own settlement, or by the next poll's retry if that one also failed.
+	manager.ResumePendingHandoffs()
+	final := recordFor(t, repoID, "settle-race")
+	if final == nil || final.PendingHandoffMission != "" || final.Program != tmux.ProgramCodex {
+		t.Fatalf("record after the transaction finished = %+v, want a settled codex row with no pending mission", final)
+	}
+}


### PR DESCRIPTION
Follow-up to #2828 (which closed #2781). That PR merged on the auto-gate before this finding could
be folded into it, so it ships separately.

## The hole

#2828 made the handoff settlement write durable and added a poll-driven retry for one that failed.
The retry only checked that the instance pointer was still registered — it took no per-session
lock — so it could fire while the same row was inside another transaction.

A second handoff is the concrete case. `HandoffSession` raises `OpReplacing` and rewrites `Program`
in `RecordHandoffSwap` **before** `SetPendingHandoffMission` records the new marker. The retry is a
WHOLE-ROW write of live memory and `ForStorage` strips the transient op, so a write landing in that
window stores the incoming agent as a settled row owing nothing. A crash before that handoff's own
checkpoint then loses its takeover brief outright — trading the duplicated mission #2781 fixed for
a silently dropped one.

`persistPollChange`, the only other poll-driven whole-row write, has guarded against exactly this
since it was written:

```go
if instance.GetInFlightOp() != session.OpNone {
    return
}
```

## The fix

The retry now `TryLock`s the per-session op lock — the lock every lifecycle operation holds for its
whole transaction — and re-checks registration and the in-flight op under it. The op lock is what
actually serializes; a bare op check cannot, because the op can be raised between the check and the
write.

`TryLock`, never `Lock`: the poll goroutine must not stall behind a slow teardown, and a skipped
retry costs nothing. The obligation is durable in memory, the next tick retries, and a newer
settlement on the same row discharges it outright.

## Verification

`TestFlushHandoffSettlements_HoldsOffWhileTheRowIsInsideAnotherHandoff` drives the real window: the
first handoff's settlement write is failed so the row owes one, a second handoff is parked inside
`SwapAgent` (fence up, `Program` already rewritten, its own marker not yet recorded), and the poll
fires there. Watched failing without the guard:

```
--- FAIL: TestFlushHandoffSettlements_HoldsOffWhileTheRowIsInsideAnotherHandoff
    the retry wrote mid-transaction: record = &{... Program:codex ... PendingHandoffMission: ...},
    want it untouched at "gemini" with its mission still pending. Persisting live memory here
    stores the INCOMING agent as settled with no obligation, so a crash before that handoff's
    checkpoint loses its takeover brief
```

It also asserts the obligation is still discharged once the row is free, so the guard cannot pass
by simply never retrying.

`blockingNthSwapBackend` is a new fixture: the existing `blockingSwapBackend` blocks the FIRST swap
and closes its channel unconditionally, and this test has to let an earlier handoff through before
it stops the next one.

## Adjacent site, checked and deliberately not changed

`persistPollChange` is the only other poll-driven whole-row write, and it has the same
check-then-write shape: it tests the in-flight op at the top and re-reads `ToInstanceData()` after
taking the repo start lock, with no op lock between. I looked at whether it carries the same
exposure and concluded it does not, so it is left alone rather than dragged into this PR:

- it writes only when `durableChanged` — a **liveness** or limit-reset-time change — and a handoff
  moves the `inFlightOp` axis, not the liveness one (#1195 split them precisely so they are
  independent), so raising the fence does not by itself arm a poll write;
- for it to write inside the window, the poll would have to independently observe a liveness change
  on that same instance in the same tick.

The settlement retry was different in kind: it had **no** op check at all, and it exists only for a
row whose handoff just failed to settle — the state most correlated with a second handoff arriving.

Adding op-lock acquisition to the one-second poll for every session is a contention change that
would need its own evidence; if it is ever wanted, it should be its own PR.

Gate on the pushed head `3d2fed19`: `gofmt -l .` (empty), `go build ./...`,
`golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh`.
Per the new policy the daemon package's tests are left to CI rather than run on the maintainer's
host — the daemon suite spawns real daemons and touches tmux there.

Closes #2834

🤖 Generated with [Claude Code](https://claude.com/claude-code)