### PR TITLE
fix(web): keep an unsteady tap reaching the app on touch (#2682 follow-up)

### DIFF
--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6906,6 +6906,10 @@ function historyWheelPlan(event, rows, rowHeight, remainder) {
   const lines = Object.is(wholeRows, -0) ? 0 : wholeRows;
   return { lines, remainder: total - lines };
 }
+var TOUCH_SCROLL_SLOP_PX = 8;
+function touchScrollClaimsGesture(originY, y) {
+  return Math.abs(y - originY) >= TOUCH_SCROLL_SLOP_PX;
+}
 function touchHistoryScrollPlan(lastY, y, rows, rowHeight, remainder) {
   return historyWheelPlan({ deltaMode: 0, deltaY: lastY - y }, rows, rowHeight, remainder);
 }
@@ -7147,6 +7151,10 @@ var AttachTerminal = class {
   // second finger arrived and the browser owns the pinch.
   touchScrollY = null;
   touchScrollRemainder = 0;
+  // Where the gesture started, and whether it has since travelled far enough to be a
+  // scroll rather than a tap. Until it has, the touch is left entirely alone.
+  touchScrollOriginY = 0;
+  touchScrollClaimed = false;
   // Whether the gesture in flight came from a finger, read off the pointer event that
   // precedes the browser's compatibility mouse events (onPointerDown).
   lastPointerWasTouch = false;
@@ -7211,7 +7219,9 @@ var AttachTerminal = class {
   onTouchStart = (event) => {
     const onScrollbar = event.target === this.container.querySelector(".xterm-viewport");
     this.touchScrollY = event.touches.length === 1 && !onScrollbar ? event.touches[0].clientY : null;
+    this.touchScrollOriginY = this.touchScrollY ?? 0;
     this.touchScrollRemainder = 0;
+    this.touchScrollClaimed = false;
   };
   onTouchMove = (event) => {
     this.handleUserScroll("touch");
@@ -7227,6 +7237,12 @@ var AttachTerminal = class {
     this.touchScrollY = y;
     if (!this.applicationOwnsMouse()) {
       return;
+    }
+    if (!this.touchScrollClaimed) {
+      if (!touchScrollClaimsGesture(this.touchScrollOriginY, y)) {
+        return;
+      }
+      this.touchScrollClaimed = true;
     }
     const plan = touchHistoryScrollPlan(last, y, this.term.rows, this.rowHeight(), this.touchScrollRemainder);
     this.touchScrollRemainder = plan.remainder;

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "4c4fe8d61ae9";
+const VERSION = "95457d946d91";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -445,8 +445,7 @@ async function dragTabOntoPaneHitTested(
  * prove only that our listeners ran, which is the false pass the issue warns about.
  * The context must be built with hasTouch, or Chromium ignores these entirely.
  */
-async function touchDrag(cdp: CDPSession, x: number, fromY: number, toY: number): Promise<void> {
-  const steps = 12;
+async function touchDrag(cdp: CDPSession, x: number, fromY: number, toY: number, steps = 12): Promise<void> {
   await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ x, y: fromY }] });
   for (let step = 1; step <= steps; step++) {
     await cdp.send("Input.dispatchTouchEvent", {
@@ -1888,6 +1887,22 @@ test("#2682 mobile: one finger scrolls the terminal, and keeps doing so under ap
     await expect(mouseHint, "a touch pointer must not be told to hold a key it has no way to press").not.toHaveClass(
       /af-visible/,
     );
+
+    // The SLOW drag, whose first move lands inside the tap threshold and is therefore
+    // the one move the terminal deliberately does not cancel. It has to end up in the
+    // same place as the fast one: scrolling history, and reporting nothing — a
+    // gesture that both scrolled and clicked would fire a TUI's button under a finger
+    // that was only reading. The drag above cannot see this; its first step is
+    // already past the threshold, so it exercises the cancelled-from-the-start path.
+    inputPayloads.length = 0;
+    const beforeSlow = await viewport.evaluate((el) => el.scrollTop);
+    await touchDrag(cdp, column, y + height * 0.35, y + height * 0.75, 40);
+    await expect
+      .poll(() => viewport.evaluate((el) => el.scrollTop), {
+        message: "a slow drag must reach scrollback too, not only a flick",
+      })
+      .toBeLessThan(beforeSlow);
+    expect(inputPayloads, "a slow scroll must not ALSO deliver a click to the application").toHaveLength(0);
 
     // 3. A TAP still belongs to the application. That capability is what mouse mode
     //    was turned on for, and it is what forbids cancelling the touch outright

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -457,10 +457,26 @@ async function touchDrag(cdp: CDPSession, x: number, fromY: number, toY: number)
   await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
 }
 
-/** Taps once at a point — the gesture that must keep reaching a mouse-aware
- *  application even when the drag above no longer does. */
+/**
+ * Taps once at a point — the gesture that must keep reaching a mouse-aware
+ * application even when the drag above no longer does.
+ *
+ * The tap CARRIES A FEW PIXELS OF MOVEMENT, because a real finger does. That jitter
+ * is the entire difference between a tap the terminal has to pass through and a
+ * scroll it has to claim, and it is invisible to a tap synthesized as a bare
+ * down-up: claiming a touch means cancelling it, and a cancelled touch fires no
+ * compatibility mouse events, so a tap held slightly unsteady would silently stop
+ * reaching the application while a perfectly still one kept working.
+ */
 async function touchTap(cdp: CDPSession, x: number, y: number): Promise<void> {
   await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ x, y }] });
+  // Several small steps rather than one, because they are what a wobble really looks
+  // like and what a naive implementation accumulates: each is a fraction of a row on
+  // its own, so only the running total ever reaches one. Their sum stays under the
+  // scroll threshold, which is what makes this a tap and not a short drag.
+  for (const step of [2, 4, 6]) {
+    await cdp.send("Input.dispatchTouchEvent", { type: "touchMove", touchPoints: [{ x, y: y + step }] });
+  }
   await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
 }
 
@@ -1875,12 +1891,28 @@ test("#2682 mobile: one finger scrolls the terminal, and keeps doing so under ap
 
     // 3. A TAP still belongs to the application. That capability is what mouse mode
     //    was turned on for, and it is what forbids cancelling the touch outright
-    //    rather than only the drag.
+    //    rather than only the drag — including the unsteady tap that carries a few
+    //    pixels of movement, which is what a real finger produces and what a
+    //    cancel-every-move handler would swallow.
     inputPayloads.length = 0;
+    const beforeTap = await viewport.evaluate((el) => el.scrollTop);
     await touchTap(cdp, column, y + height * 0.5);
     await expect
       .poll(() => inputPayloads.length, { message: "a tap must still report a click to the mouse-aware application" })
       .toBeGreaterThan(0);
+    // …and that wobble must not ALSO have been read as a scroll. The direction is
+    // what carries the meaning, not the exact value: reading the wobble as a scroll
+    // pulls older output in, which only ever DECREASES scrollTop, while the reported
+    // click legitimately increases it — xterm scrolls to the bottom on user input
+    // whenever the view sits above it, and a mouse report reaches the PTY through
+    // exactly that path (CoreMouseService.triggerMouseEvent →
+    // CoreService.triggerDataEvent(…, wasUserInput) → onRequestScrollToBottom). An
+    // equality here would therefore fail on the fix working, and would also inherit
+    // the row-of-new-output fragility documented in #2816.
+    expect(
+      await viewport.evaluate((el) => el.scrollTop),
+      "a tap's wobble must never scroll back into history",
+    ).toBeGreaterThanOrEqual(beforeTap);
     await expect(mouseHint, "a working tap must not advertise an escape either").not.toHaveClass(/af-visible/);
   } finally {
     // The shell holding mouse mode dies with its tab, so nothing has to unwind the

--- a/web/src/terminal-mouse.test.ts
+++ b/web/src/terminal-mouse.test.ts
@@ -7,7 +7,9 @@ import {
   terminalMouseOverride,
   terminalMouseOverrideFlag,
   terminalMouseOverrideHeld,
+  TOUCH_SCROLL_SLOP_PX,
   touchHistoryScrollPlan,
+  touchScrollClaimsGesture,
 } from "./terminal-mouse.js";
 
 test("application-mouse escape matches xterm's platform selection modifier", () => {
@@ -80,4 +82,22 @@ test("a touch drag scrolls the way the content follows the finger (#2682)", () =
 
   // A finger that has not moved must not scroll — and must not report -0 rows.
   assert.deepEqual(touchHistoryScrollPlan(100, 100, 24, 20, 0), { lines: 0, remainder: 0 });
+});
+
+test("a tap's wobble is not a scroll, in either direction (#2682)", () => {
+  // Claiming a gesture cancels the touch, and a cancelled touch fires no
+  // compatibility mouse events — so this threshold is what keeps an unsteady tap
+  // delivering its click to a mouse-aware application instead of silently doing
+  // nothing. Both directions, because a finger drifts either way.
+  assert.equal(touchScrollClaimsGesture(200, 203), false);
+  assert.equal(touchScrollClaimsGesture(200, 197), false);
+  assert.equal(touchScrollClaimsGesture(200, 200 + TOUCH_SCROLL_SLOP_PX - 1), false);
+
+  // At the threshold the gesture is a scroll — the same distance at which the
+  // browser would start one itself, so the two can never both act on it.
+  assert.equal(touchScrollClaimsGesture(200, 200 + TOUCH_SCROLL_SLOP_PX), true);
+  assert.equal(touchScrollClaimsGesture(200, 200 - TOUCH_SCROLL_SLOP_PX), true);
+
+  // Under one terminal row, or a real scroll would visibly lag the finger.
+  assert.ok(TOUCH_SCROLL_SLOP_PX < 13 * 1.2);
 });

--- a/web/src/terminal-mouse.ts
+++ b/web/src/terminal-mouse.ts
@@ -87,6 +87,28 @@ export function historyWheelPlan(
 }
 
 /**
+ * How far a finger must travel before a gesture counts as a scroll rather than a
+ * tap, in CSS pixels.
+ *
+ * This threshold is not comfort, it is a capability. Scrolling the terminal by touch
+ * means cancelling the touchmove, and a cancelled touch fires no compatibility mouse
+ * events — so treating the first pixel of jitter as a scroll silently costs a
+ * mouse-aware application the click that an unsteady tap should have delivered.
+ *
+ * 8px is Chromium's own touch slop, which is also the distance at which the browser
+ * would start scrolling on its own. Claiming at the same point is what keeps the two
+ * from overlapping: below it neither the browser nor af moves anything, and above it
+ * af has already taken the gesture. It stays under one terminal row, so a real scroll
+ * still begins within half a line of the finger.
+ */
+export const TOUCH_SCROLL_SLOP_PX = 8;
+
+/** Whether a one-finger gesture has travelled far enough to be a scroll. */
+export function touchScrollClaimsGesture(originY: number, y: number): boolean {
+  return Math.abs(y - originY) >= TOUCH_SCROLL_SLOP_PX;
+}
+
+/**
  * Convert one step of a one-finger drag into whole terminal rows (#2682).
  *
  * The sign convention is xterm's own: a finger moving UP the screen (clientY

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -57,6 +57,7 @@ import {
   terminalMouseOverrideHeld,
   type TerminalMouseOverride,
   touchHistoryScrollPlan,
+  touchScrollClaimsGesture,
 } from "./terminal-mouse.js";
 import type { StreamEndpoint } from "./stream_endpoint.js";
 import { currentXtermTheme } from "./theme.js";
@@ -128,6 +129,10 @@ export class AttachTerminal {
   // second finger arrived and the browser owns the pinch.
   private touchScrollY: number | null = null;
   private touchScrollRemainder = 0;
+  // Where the gesture started, and whether it has since travelled far enough to be a
+  // scroll rather than a tap. Until it has, the touch is left entirely alone.
+  private touchScrollOriginY = 0;
+  private touchScrollClaimed = false;
   // Whether the gesture in flight came from a finger, read off the pointer event that
   // precedes the browser's compatibility mouse events (onPointerDown).
   private lastPointerWasTouch = false;
@@ -199,13 +204,15 @@ export class AttachTerminal {
   // the application — which is why only the move is ever cancelled, never the
   // touchstart that a tap's compatibility mouse events depend on.
   private readonly onTouchStart = (event: TouchEvent): void => {
-    // Ownership is settled once, at the start of the gesture. A touch whose target is
-    // the viewport itself is a scrollbar drag the browser already handles — the same
-    // discriminator onPointerDown reads below, and taking it over would scroll
+    // Eligibility is settled once, at the start of the gesture. A touch whose target
+    // is the viewport itself is a scrollbar drag the browser already handles — the
+    // same discriminator onPointerDown reads below, and taking it over would scroll
     // BACKWARDS, since a thumb follows the finger while the content opposes it.
     const onScrollbar = event.target === this.container.querySelector(".xterm-viewport");
     this.touchScrollY = event.touches.length === 1 && !onScrollbar ? event.touches[0].clientY : null;
+    this.touchScrollOriginY = this.touchScrollY ?? 0;
     this.touchScrollRemainder = 0;
+    this.touchScrollClaimed = false;
   };
   private readonly onTouchMove = (event: TouchEvent): void => {
     this.handleUserScroll("touch");
@@ -225,6 +232,16 @@ export class AttachTerminal {
       // xterm's own touch scrolling is live here; tracking the position anyway keeps
       // a mode change mid-drag from scrolling by everything travelled before it.
       return;
+    }
+    if (!this.touchScrollClaimed) {
+      if (!touchScrollClaimsGesture(this.touchScrollOriginY, y)) {
+        // Still within a tap's wobble. Leaving the event ALONE is the point: claiming
+        // it would cancel the touch, and a cancelled touch fires no compatibility
+        // mouse events — so an unsteady tap would stop reaching the application while
+        // a perfectly still one kept working.
+        return;
+      }
+      this.touchScrollClaimed = true;
     }
     const plan = touchHistoryScrollPlan(last, y, this.term.rows, this.rowHeight(), this.touchScrollRemainder);
     this.touchScrollRemainder = plan.remainder;


### PR DESCRIPTION
## Summary

Follow-up to #2832, which gave the web terminal a one-finger scroll while an application owns the mouse. Codex raised a **P2** on that PR **three minutes after the Auto Gate had already merged it** — the same post-merge gap that produced #2829 — so the fix lands here. The finding is real, and I confirmed the mechanism before acting.

Claiming a touch gesture means calling `preventDefault()` on the `touchmove`. #2832 called it on **every** touchmove in that state, including one that scrolled nothing:

```ts
const plan = touchHistoryScrollPlan(last, y, ...);   // may be lines: 0
…
event.preventDefault();                              // claimed regardless
```

Per the Touch Events spec, cancelling `touchstart` **or the first `touchmove`** of a touch point suppresses **all** compatibility mouse events for that sequence. A real finger does not hold still, so a tap that wobbled two or three pixels emitted a touchmove, had its touch cancelled, and delivered no `mousedown`/`mouseup`/`click` to xterm — nothing reached the PTY.

A perfectly steady tap kept working. That is what makes it worth a follow-up rather than a nit: on a phone the TUI's own UI would appear to respond *intermittently*, which reads as flakiness rather than as a bug with a cause.

## Fix

Claim the gesture only once the finger has travelled a scroll's worth — **Chromium's own touch slop, 8 CSS px**. That number is not comfort-tuning: it is the distance at which the browser itself would start scrolling, so af and the browser can never both act on one gesture. Below it the event is left completely alone (no scroll, no `preventDefault`); above it the gesture stays af's for the rest of its life, so a slow drag cannot oscillate. It is under one terminal row, so a real scroll still begins within half a line of the finger.

## Why the tests missed it

`touchTap` synthesized a bare down-up with **no `touchmove` at all** — the one kind of tap this defect cannot affect. The assertion "a tap must still report a click to the mouse-aware application" therefore passed while the gesture it stands for was broken. It now carries jitter, and additionally asserts that the jitter does **not** scroll the view.

`touchScrollClaimsGesture` is unit-tested (both directions, the boundary, and that the slop stays under a row), which is what actually gates on master — web-selftest is a signal, not a gate (#2762).

## Verification

- `gofmt -l .` clean · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `deadcode -test ./...` · `scripts/lint-file-length.sh` — green on this head.
- `make web-test`: typecheck + 464 unit tests green; `make web-build` reproduces the committed bundle.
- Per the current policy this PR does not run containerized suites locally; CI's `Web selftest` job exercises the jittery-tap and drag assertions in a real Chromium against a real daemon.

Closes #2839
Refs #2682
