### PR TITLE
fix(hook): decide stdout endpoint records by what a line closes

### DIFF
--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -569,36 +569,70 @@ func (p *hookProvisioner) launch() (*AgentServerEndpoint, error) {
 // endpoint schema, and whether stdout held any JSON at all (which separates
 // "printed nothing usable" from "printed the wrong shape" in the error).
 //
-// Only complete, top-level values are considered — topLevelJSONAt, never the
-// diagnostic extractor. A value nested inside malformed output is never
-// promoted: recovering one would mean deciding, from text that is by definition
-// unparseable, whether it was an independent record or a field of someone's log
-// line — a question with no sound answer. stdout carrying a bare endpoint object
-// is the documented contract, so refusing to guess costs a well-behaved script
-// nothing.
+// stdout is not exclusively the endpoint's. docs/remote-hooks.md has launch_cmd
+// echo its endpoint there, and ALSO lets a background tunnel inherit the stream
+// and keep logging — so plain prose between records is normal and must not
+// disturb selection. What must never happen is promoting a value that belongs to
+// a malformed JSON record: the daemon would dial a logged service with a logged
+// credential and reap the real sandbox when that failed.
+//
+// Deciding which of those a value is, once the surrounding JSON is malformed, is
+// not possible from the bytes — a log can break before its endpoint value and
+// leave it at column 0 of the next line, identical to a record the script
+// echoed. Earlier rules (shape, wrapper provenance, line start, column) each
+// bought one counterexample. So this does not rank candidates; it tracks whether
+// the stream is still trustworthy:
+//
+//   - A line that is not a JSON opener is prose — tunnel chatter. Skipped, and
+//     it changes nothing.
+//   - A line that opens a JSON value and decodes completely is a record. It is a
+//     candidate, and scanning continues after it.
+//   - A line that opens a JSON value and does NOT decode leaves the structure
+//     unknown. From there no further value is promoted, because any of them may
+//     be that record's contents. Provision fails with the output attached rather
+//     than dialing something a log named.
 func selectHookEndpoint(stdout string) (*AgentServerEndpoint, bool) {
 	sawJSON := false
 	for cursor := 0; cursor < len(stdout); {
-		candidate, next := topLevelJSONAt(stdout, cursor)
-		if candidate == "" {
-			break
-		}
-		cursor = next
-		sawJSON = true
-
-		// The documented endpoint schema itself is the discriminator. Reject
-		// unknown fields so a structured log that merely includes url and token
-		// cannot win. First match is deliberate: logs may also follow the endpoint,
-		// so choosing by last position would only reverse the ambiguity.
-		ej, ok := decodeHookEndpointJSON(candidate)
-		if !ok {
+		if stdout[cursor] != '{' && stdout[cursor] != '[' {
+			// Prose: a tunnel logging into the inherited stream.
+			cursor = nextHookOutputLine(stdout, cursor)
 			continue
 		}
-		// ej.TLSFingerprint is intentionally not read — TLS was removed; an old
-		// script that still echoes it parses fine and the value is dropped.
-		return &AgentServerEndpoint{URL: ej.URL, Token: ej.Token}, true
+		decoder := json.NewDecoder(strings.NewReader(stdout[cursor:]))
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			// A malformed record: everything after it may be its contents.
+			return nil, sawJSON
+		}
+		sawJSON = true
+		if ej, ok := decodeHookEndpointJSON(string(raw)); ok {
+			// ej.TLSFingerprint is intentionally not read — TLS was removed; an old
+			// script that still echoes it parses fine and the value is dropped.
+			return &AgentServerEndpoint{URL: ej.URL, Token: ej.Token}, true
+		}
+		// Resume at the next LINE, so an object sharing this record's last physical
+		// line is a log beside it, not a record of its own.
+		cursor = nextHookOutputLine(stdout, cursor+int(decoder.InputOffset()))
 	}
 	return nil, sawJSON
+}
+
+// nextHookOutputLine returns the offset just past the next line terminator at or
+// after from, treating CRLF as one terminator.
+func nextHookOutputLine(output string, from int) int {
+	if from >= len(output) {
+		return len(output)
+	}
+	breakAt := strings.IndexAny(output[from:], "\r\n")
+	if breakAt < 0 {
+		return len(output)
+	}
+	next := from + breakAt + 1
+	if output[from+breakAt] == '\r' && next < len(output) && output[next] == '\n' {
+		next++
+	}
+	return next
 }
 
 // reap runs delete_cmd to tear down whatever launch_cmd provisioned, idempotently

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -621,31 +621,38 @@ func selectHookEndpoint(stdout string) (*AgentServerEndpoint, bool) {
 			continue
 		}
 		sawJSON = true
-		if ej, ok := decodeHookEndpointJSON(string(raw)); ok {
-			// ej.TLSFingerprint is intentionally not read — TLS was removed; an old
-			// script that still echoes it parses fine and the value is dropped.
-			return &AgentServerEndpoint{URL: ej.URL, Token: ej.Token}, true
-		}
-		// A value decoded — but what follows it ON THIS LINE decides whether the
-		// record really ended there.
-		rest := open + int(decoder.InputOffset())
-		for rest < lineEnd && isJSONSpace(stdout[rest]) {
+
+		// The value may span several lines, so trailing content is judged on ITS
+		// last physical line — and judged BEFORE the record is accepted, since an
+		// endpoint-shaped prefix followed by a continuation is not a record either.
+		valueEnd := open + int(decoder.InputOffset())
+		valueLineEnd := nextHookOutputLine(stdout, valueEnd)
+		rest := valueEnd
+		for rest < valueLineEnd && isJSONSpace(stdout[rest]) {
 			rest++
 		}
 		switch {
-		case rest >= lineEnd:
-			// Clean record, nothing trailing.
+		case rest >= valueLineEnd:
+			// A clean record, and the only shape that may be the endpoint.
+			if ej, ok := decodeHookEndpointJSON(string(raw)); ok {
+				// ej.TLSFingerprint is intentionally not read — TLS was removed; an
+				// old script that still echoes it parses fine and the value is
+				// dropped.
+				return &AgentServerEndpoint{URL: ej.URL, Token: ej.Token}, true
+			}
 		case stdout[rest] == '{' || stdout[rest] == '[':
 			// Another value beside it: a log line carrying several. None of them is
-			// a record of its own, so skip the line — but later lines stay
-			// trustworthy, since this one closed.
+			// a record, so skip them all — later lines stay trustworthy because
+			// this line closed.
 		default:
-			// `{"level":"info"},"endpoint":` — a separator or bare text means the
-			// record continues onto the next line, so its structure is unknown and
-			// nothing after it can be promoted.
+			// `{…},"endpoint":` — a separator or bare text means the record is still
+			// open, so its structure is unknown and nothing after it is promoted.
 			return nil, sawJSON
 		}
-		cursor = lineEnd
+		// Advance past the WHOLE decoded value, not just its first line, or the
+		// lines inside a multi-line log would be rescanned and its nested
+		// endpoint-shaped child promoted as a record of its own.
+		cursor = valueLineEnd
 	}
 	return nil, sawJSON
 }

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -600,34 +600,35 @@ func selectHookEndpoint(stdout string) (*AgentServerEndpoint, bool) {
 		for open < lineEnd && isJSONSpace(stdout[open]) {
 			open++
 		}
-		if open >= lineEnd || (stdout[open] != '{' && stdout[open] != '[') {
-			cursor = lineEnd // prose: a tunnel logging into the inherited stream
+		// The endpoint is an OBJECT (docs/remote-hooks.md), so only a `{` line can
+		// be a record. Everything else is a tunnel logging into the inherited
+		// stream — plain prose, or a bracketed prefix like `[INFO] …`, `[2026] …`,
+		// `[2026], …` — and is skipped without parsing, which also keeps a flood of
+		// them linear.
+		if open >= lineEnd || stdout[open] != '{' {
+			cursor = lineEnd
 			continue
 		}
 
 		decoder := json.NewDecoder(strings.NewReader(stdout[open:]))
 		var raw json.RawMessage
 		if err := decoder.Decode(&raw); err != nil {
-			// Prose that was never JSON: the parse died on the first token, as
-			// `[INFO] …` does at its `I`. A record that BROKE gets further in
-			// (`{"level":INVALID` reaches offset 10). Only the latter leaves a
-			// structure whose extent is unknown; log prefixes that merely open a
-			// bracket must not poison the records after them.
-			if hookLineNeverStartedJSON(err) {
+			// The endpoint is an OBJECT (docs/remote-hooks.md), so a line opening a
+			// BRACKET is never a record: `[INFO] …`, `[2026] …` and `[INFO] opening
+			// {config` are log prefixes however their message is punctuated.
+			//
+			// Only a `{` line can be a record that broke, and only an unbalanced one
+			// leaves a structure whose extent is unknown — anything after it may be
+			// its contents, so selection stops. `{config} loaded` closes what it
+			// opened, so skipping just that line is safe.
+			// Only an UNBALANCED record leaves a structure whose extent is unknown —
+			// anything after it may be its contents, so selection stops.
+			// `{config} loaded` closes what it opened, so skipping that line is safe.
+			if hookLineBracketsBalanced(line) {
 				cursor = lineEnd
 				continue
 			}
-			// A line whose brackets close is self-contained: bracketed prose like
-			// "[INFO] tunnel forwarding", or a malformed record whose contents are
-			// all on this line. Either way skipping the LINE is safe, because
-			// nothing in it becomes a candidate. A line left open continues into
-			// the next, and from there the structure is unknown — anything after
-			// it may be that record's contents, so selection stops.
-			if !hookLineBracketsBalanced(line) {
-				return nil, sawJSON
-			}
-			cursor = lineEnd
-			continue
+			return nil, sawJSON
 		}
 		sawJSON = true
 
@@ -641,8 +642,10 @@ func selectHookEndpoint(stdout string) (*AgentServerEndpoint, bool) {
 			rest++
 		}
 		switch {
-		case rest >= valueLineEnd:
-			// A clean record, and the only shape that may be the endpoint.
+		case rest >= valueLineEnd && !hookNextLineContinues(stdout, valueLineEnd):
+			// A clean record, and the only shape that may be the endpoint. The next
+			// line is checked too: a separator moved onto its own line continues
+			// this record just as one on the same line does.
 			if ej, ok := decodeHookEndpointJSON(string(raw)); ok {
 				// ej.TLSFingerprint is intentionally not read — TLS was removed; an
 				// old script that still echoes it parses fine and the value is
@@ -653,6 +656,9 @@ func selectHookEndpoint(stdout string) (*AgentServerEndpoint, bool) {
 			// Another value beside it: a log line carrying several. None of them is
 			// a record, so skip them all — later lines stay trustworthy because
 			// this line closed.
+		case rest >= valueLineEnd:
+			// The record continues on the next line.
+			return nil, sawJSON
 		case stdout[rest] == ',' || stdout[rest] == ':':
 			// `{…},"endpoint":` — a structural separator means the record is still
 			// open, so its extent is unknown and nothing after it is promoted.
@@ -674,18 +680,29 @@ func isJSONSpace(c byte) bool {
 	return c == ' ' || c == '\t' || c == '\r' || c == '\n'
 }
 
-// hookLineNeverStartedJSON reports that a line only looked like JSON because of
-// its opening bracket. encoding/json reports where it gave up; failing on the
-// first token means nothing valid was ever parsed, which is a bracketed log
-// prefix rather than a record that broke partway.
-func hookLineNeverStartedJSON(err error) bool {
-	syntaxErr, ok := err.(*json.SyntaxError)
-	return ok && syntaxErr.Offset <= hookJSONFirstTokenOffset
+// hookNextLineContinues reports that the next non-empty line begins with JSON
+// structure — a separator or a closer — which means the value above it was not a
+// record of its own. A comma moved onto its own line continues the record just
+// as one left on the same line does, and a closing bracket means the value sat
+// inside a container that started earlier.
+func hookNextLineContinues(output string, from int) bool {
+	for cursor := from; cursor < len(output); {
+		lineEnd := nextHookOutputLine(output, cursor)
+		trimmed := strings.TrimLeft(strings.TrimRight(output[cursor:lineEnd], "\r\n"), " \t")
+		if trimmed == "" {
+			cursor = lineEnd
+			continue
+		}
+		switch trimmed[0] {
+		case ',', ':', '}', ']':
+			// A separator OR a closer: either way the value above was inside
+			// something that had not ended, so it is not a record of its own.
+			return true
+		}
+		return false
+	}
+	return false
 }
-
-// hookJSONFirstTokenOffset is the 1-based offset encoding/json reports when the
-// byte right after an opener is already invalid.
-const hookJSONFirstTokenOffset = 2
 
 // hookLineBracketsBalanced reports whether every object/array opened on this line
 // also closes on it, WITH A MATCHING BRACKET, ignoring brackets inside JSON

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -608,6 +608,15 @@ func selectHookEndpoint(stdout string) (*AgentServerEndpoint, bool) {
 		decoder := json.NewDecoder(strings.NewReader(stdout[open:]))
 		var raw json.RawMessage
 		if err := decoder.Decode(&raw); err != nil {
+			// Prose that was never JSON: the parse died on the first token, as
+			// `[INFO] …` does at its `I`. A record that BROKE gets further in
+			// (`{"level":INVALID` reaches offset 10). Only the latter leaves a
+			// structure whose extent is unknown; log prefixes that merely open a
+			// bracket must not poison the records after them.
+			if hookLineNeverStartedJSON(err) {
+				cursor = lineEnd
+				continue
+			}
 			// A line whose brackets close is self-contained: bracketed prose like
 			// "[INFO] tunnel forwarding", or a malformed record whose contents are
 			// all on this line. Either way skipping the LINE is safe, because
@@ -644,10 +653,14 @@ func selectHookEndpoint(stdout string) (*AgentServerEndpoint, bool) {
 			// Another value beside it: a log line carrying several. None of them is
 			// a record, so skip them all — later lines stay trustworthy because
 			// this line closed.
-		default:
-			// `{…},"endpoint":` — a separator or bare text means the record is still
-			// open, so its structure is unknown and nothing after it is promoted.
+		case stdout[rest] == ',' || stdout[rest] == ':':
+			// `{…},"endpoint":` — a structural separator means the record is still
+			// open, so its extent is unknown and nothing after it is promoted.
 			return nil, sawJSON
+		default:
+			// Bare prose after a complete value — `[2026] tunnel forwarding`. A
+			// record continuing across lines breaks at a structural position, not
+			// mid-word, so this is a log line: skip it and keep reading.
 		}
 		// Advance past the WHOLE decoded value, not just its first line, or the
 		// lines inside a multi-line log would be rescanned and its nested
@@ -660,6 +673,19 @@ func selectHookEndpoint(stdout string) (*AgentServerEndpoint, bool) {
 func isJSONSpace(c byte) bool {
 	return c == ' ' || c == '\t' || c == '\r' || c == '\n'
 }
+
+// hookLineNeverStartedJSON reports that a line only looked like JSON because of
+// its opening bracket. encoding/json reports where it gave up; failing on the
+// first token means nothing valid was ever parsed, which is a bracketed log
+// prefix rather than a record that broke partway.
+func hookLineNeverStartedJSON(err error) bool {
+	syntaxErr, ok := err.(*json.SyntaxError)
+	return ok && syntaxErr.Offset <= hookJSONFirstTokenOffset
+}
+
+// hookJSONFirstTokenOffset is the 1-based offset encoding/json reports when the
+// byte right after an opener is already invalid.
+const hookJSONFirstTokenOffset = 2
 
 // hookLineBracketsBalanced reports whether every object/array opened on this line
 // also closes on it, WITH A MATCHING BRACKET, ignoring brackets inside JSON

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -569,16 +569,17 @@ func (p *hookProvisioner) launch() (*AgentServerEndpoint, error) {
 // endpoint schema, and whether stdout held any JSON at all (which separates
 // "printed nothing usable" from "printed the wrong shape" in the error).
 //
-// Only complete, top-level values are considered. A value nested inside
-// malformed output is never promoted: recovering one would mean deciding, from
-// text that is by definition unparseable, whether it was an independent record
-// or a field of someone's log line — a question with no sound answer. stdout
-// carrying a bare endpoint object is the documented contract, so refusing to
-// guess costs a well-behaved script nothing.
+// Only complete, top-level values are considered — topLevelJSONAt, never the
+// diagnostic extractor. A value nested inside malformed output is never
+// promoted: recovering one would mean deciding, from text that is by definition
+// unparseable, whether it was an independent record or a field of someone's log
+// line — a question with no sound answer. stdout carrying a bare endpoint object
+// is the documented contract, so refusing to guess costs a well-behaved script
+// nothing.
 func selectHookEndpoint(stdout string) (*AgentServerEndpoint, bool) {
 	sawJSON := false
 	for cursor := 0; cursor < len(stdout); {
-		candidate, next := extractJSONAt(stdout, cursor)
+		candidate, next := topLevelJSONAt(stdout, cursor)
 		if candidate == "" {
 			break
 		}

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -594,16 +594,31 @@ func (p *hookProvisioner) launch() (*AgentServerEndpoint, error) {
 func selectHookEndpoint(stdout string) (*AgentServerEndpoint, bool) {
 	sawJSON := false
 	for cursor := 0; cursor < len(stdout); {
-		if stdout[cursor] != '{' && stdout[cursor] != '[' {
-			// Prose: a tunnel logging into the inherited stream.
-			cursor = nextHookOutputLine(stdout, cursor)
+		lineEnd := nextHookOutputLine(stdout, cursor)
+		line := strings.TrimRight(stdout[cursor:lineEnd], "\r\n")
+		open := cursor
+		for open < lineEnd && isJSONSpace(stdout[open]) {
+			open++
+		}
+		if open >= lineEnd || (stdout[open] != '{' && stdout[open] != '[') {
+			cursor = lineEnd // prose: a tunnel logging into the inherited stream
 			continue
 		}
-		decoder := json.NewDecoder(strings.NewReader(stdout[cursor:]))
+
+		decoder := json.NewDecoder(strings.NewReader(stdout[open:]))
 		var raw json.RawMessage
 		if err := decoder.Decode(&raw); err != nil {
-			// A malformed record: everything after it may be its contents.
-			return nil, sawJSON
+			// A line whose brackets close is self-contained: bracketed prose like
+			// "[INFO] tunnel forwarding", or a malformed record whose contents are
+			// all on this line. Either way skipping the LINE is safe, because
+			// nothing in it becomes a candidate. A line left open continues into
+			// the next, and from there the structure is unknown — anything after
+			// it may be that record's contents, so selection stops.
+			if !hookLineBracketsBalanced(line) {
+				return nil, sawJSON
+			}
+			cursor = lineEnd
+			continue
 		}
 		sawJSON = true
 		if ej, ok := decodeHookEndpointJSON(string(raw)); ok {
@@ -611,11 +626,60 @@ func selectHookEndpoint(stdout string) (*AgentServerEndpoint, bool) {
 			// script that still echoes it parses fine and the value is dropped.
 			return &AgentServerEndpoint{URL: ej.URL, Token: ej.Token}, true
 		}
-		// Resume at the next LINE, so an object sharing this record's last physical
-		// line is a log beside it, not a record of its own.
-		cursor = nextHookOutputLine(stdout, cursor+int(decoder.InputOffset()))
+		// A value decoded — but what follows it ON THIS LINE decides whether the
+		// record really ended there.
+		rest := open + int(decoder.InputOffset())
+		for rest < lineEnd && isJSONSpace(stdout[rest]) {
+			rest++
+		}
+		switch {
+		case rest >= lineEnd:
+			// Clean record, nothing trailing.
+		case stdout[rest] == '{' || stdout[rest] == '[':
+			// Another value beside it: a log line carrying several. None of them is
+			// a record of its own, so skip the line — but later lines stay
+			// trustworthy, since this one closed.
+		default:
+			// `{"level":"info"},"endpoint":` — a separator or bare text means the
+			// record continues onto the next line, so its structure is unknown and
+			// nothing after it can be promoted.
+			return nil, sawJSON
+		}
+		cursor = lineEnd
 	}
 	return nil, sawJSON
+}
+
+func isJSONSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\r' || c == '\n'
+}
+
+// hookLineBracketsBalanced reports whether every object/array opened on this line
+// also closes on it, ignoring brackets inside JSON strings. It is the difference
+// between a self-contained line and a record that continues into the next.
+func hookLineBracketsBalanced(line string) bool {
+	depth := 0
+	inString := false
+	escaped := false
+	for index := 0; index < len(line); index++ {
+		switch {
+		case escaped:
+			escaped = false
+		case line[index] == '\\' && inString:
+			escaped = true
+		case line[index] == '"':
+			inString = !inString
+		case inString:
+		case line[index] == '{' || line[index] == '[':
+			depth++
+		case line[index] == '}' || line[index] == ']':
+			depth--
+			if depth < 0 {
+				return false
+			}
+		}
+	}
+	return depth == 0 && !inString
 }
 
 // nextHookOutputLine returns the offset just past the next line terminator at or

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -662,10 +662,19 @@ func isJSONSpace(c byte) bool {
 }
 
 // hookLineBracketsBalanced reports whether every object/array opened on this line
-// also closes on it, ignoring brackets inside JSON strings. It is the difference
-// between a self-contained line and a record that continues into the next.
+// also closes on it, WITH A MATCHING BRACKET, ignoring brackets inside JSON
+// strings. It is the difference between a self-contained line and a record that
+// continues into the next.
+//
+// Types are tracked, not just a depth count: `{"level":]` closes nothing, and
+// counting it as balanced would treat a record that is still open as
+// self-contained, letting the next line's logged endpoint be promoted.
+//
+// An unterminated string only matters while a bracket is still open. Bracketed
+// prose with a stray quote — `[INFO] opening "config` — has already closed
+// everything it opened, and must not poison the records after it.
 func hookLineBracketsBalanced(line string) bool {
-	depth := 0
+	var open []byte
 	inString := false
 	escaped := false
 	for index := 0; index < len(line); index++ {
@@ -678,15 +687,22 @@ func hookLineBracketsBalanced(line string) bool {
 			inString = !inString
 		case inString:
 		case line[index] == '{' || line[index] == '[':
-			depth++
+			open = append(open, line[index])
 		case line[index] == '}' || line[index] == ']':
-			depth--
-			if depth < 0 {
+			if len(open) == 0 {
 				return false
 			}
+			want := byte('{')
+			if line[index] == ']' {
+				want = '['
+			}
+			if open[len(open)-1] != want {
+				return false
+			}
+			open = open[:len(open)-1]
 		}
 	}
-	return depth == 0 && !inString
+	return len(open) == 0
 }
 
 // nextHookOutputLine returns the offset just past the next line terminator at or

--- a/session/backend_hook_followup_test.go
+++ b/session/backend_hook_followup_test.go
@@ -295,19 +295,29 @@ func TestHookOutputSuffixKeepsTextAfterCompleteTokenWithOtherLines(t *testing.T)
 // selecting an endpoint. Selection stops at the first malformed record now, so
 // the work is bounded by where that record begins.
 func TestHookEndpointSelectionBoundedOnJSONPrefixFlood(t *testing.T) {
-	flood := strings.Repeat("[\n", 20_000) + `{"url":"http://10.0.0.7:8080","token":"secret"}` + "\n"
+	// Bracket lines are prose — an endpoint is an object — so a flood of them is
+	// skipped without parsing and the endpoint is still found.
+	brackets := strings.Repeat("[\n", 20_000) + `{"url":"http://10.0.0.7:8080","token":"secret"}` + "\n"
 	started := time.Now()
-	endpoint, _ := selectHookEndpoint(flood)
-	assert.Less(t, time.Since(started), time.Second, "endpoint selection must not rescan the suffix per line")
-	assert.Nil(t, endpoint, "an unterminated record stops selection rather than promoting past it")
+	endpoint, _ := selectHookEndpoint(brackets)
+	assert.Less(t, time.Since(started), time.Second, "bracket lines must not be parsed per line")
+	require.NotNil(t, endpoint)
+	assert.Equal(t, "http://10.0.0.7:8080", endpoint.URL)
 
-	// The same flood as PROSE (not JSON openers) must still find the endpoint fast.
+	// Prose likewise.
 	prose := strings.Repeat("tunnel forwarding\n", 20_000) + `{"url":"http://10.0.0.7:8080","token":"secret"}` + "\n"
 	started = time.Now()
 	endpoint, _ = selectHookEndpoint(prose)
 	assert.Less(t, time.Since(started), time.Second)
 	require.NotNil(t, endpoint)
-	assert.Equal(t, "http://10.0.0.7:8080", endpoint.URL)
+
+	// An unterminated OBJECT is a record that broke, and stops selection — the
+	// scan must reach that conclusion quickly rather than rescanning the suffix.
+	objects := strings.Repeat("{\n", 20_000) + `{"url":"http://10.0.0.7:8080","token":"secret"}` + "\n"
+	started = time.Now()
+	endpoint, _ = selectHookEndpoint(objects)
+	assert.Less(t, time.Since(started), 2*time.Second, "an open record must not rescan the suffix")
+	assert.Nil(t, endpoint, "an unterminated record stops selection rather than promoting past it")
 }
 
 // Fifth review round on #2841.
@@ -475,4 +485,51 @@ exit 0
 
 	require.Error(t, err, "a record that broke still stops selection")
 	assert.NotContains(t, err.Error(), "logged-secret")
+}
+
+// Ninth review round on #2841.
+
+// P1 3717439335: `{level:INVALID,…` dies on its first token exactly as `[INFO] …`
+// does, so an offset-based prose test could not separate them. An endpoint is an
+// OBJECT, so a `{` line can be a broken record and a `[` line never is.
+func TestHookLaunchRejectsUnbalancedBraceLogLine(t *testing.T) {
+	h := newHookState(t, `
+printf '%s\n' '{level:INVALID,"endpoint":' '{"url":"http://wrong.invalid","token":"logged-secret"}'
+echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
+exit 0
+`, "")
+	_, err := newHookProvisioner(h, "unbalanced brace log").provisionOrReap()
+
+	require.Error(t, err, "an unbalanced brace-started log is a record that broke")
+	assert.NotContains(t, err.Error(), "logged-secret")
+}
+
+// P1 3717439336: the continuation separator moved onto its own line bypassed a
+// trailing check that only looked at the value's own line.
+func TestHookLaunchRejectsEndpointBeforeContinuationLine(t *testing.T) {
+	for _, sep := range []string{`,"endpoint":`, `:`, `}`, `]`} {
+		t.Run(sep, func(t *testing.T) {
+			h := newHookState(t, "printf '%s\\n' '{\"url\":\"http://wrong.invalid\",\"token\":\"logged-secret\"}' '"+sep+"'\n"+
+				`echo '{"url":"http://10.0.0.7:8080","token":"secret"}'`+"\nexit 0\n", "")
+			_, err := newHookProvisioner(h, "continuation line "+sep).provisionOrReap()
+
+			require.Error(t, err, "a value followed by JSON structure is not a record")
+			assert.NotContains(t, err.Error(), "logged-secret")
+		})
+	}
+}
+
+// P2 3717439337: punctuated bracketed prose is still prose.
+func TestHookLaunchIgnoresPunctuatedBracketProse(t *testing.T) {
+	for _, prose := range []string{`[2026], tunnel forwarding`, `[2026]: tunnel forwarding`, `[2026]; forwarding`} {
+		t.Run(prose, func(t *testing.T) {
+			h := newHookState(t, "printf '%s\\n' '"+prose+"'\n"+
+				`echo '{"url":"http://10.0.0.7:8080","token":"secret"}'`+"\nexit 0\n", "")
+			res, err := newHookProvisioner(h, "punctuated prose").provisionOrReap()
+
+			require.NoError(t, err, "punctuated bracketed prose must not stop selection")
+			require.NotNil(t, res.Endpoint)
+			assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
+		})
+	}
 }

--- a/session/backend_hook_followup_test.go
+++ b/session/backend_hook_followup_test.go
@@ -435,3 +435,44 @@ exit 0
 	assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
 	assert.False(t, h.deleteRan(t))
 }
+
+// Eighth review round on #2841. Both findings are the prose-on-stdout path
+// breaking again — the fourth and fifth time in this PR — so they are pinned
+// together with the earlier prose cases as one set.
+func TestHookLaunchIgnoresProseThatOnlyLooksLikeJSON(t *testing.T) {
+	tests := []struct{ name, prose string }{
+		{"bracket prefix with unmatched brace", `[INFO] opening {config`},
+		{"numeric bracket prefix", `[2026] tunnel forwarding`},
+		{"bracket prefix with stray quote", `[INFO] opening "config`},
+		{"plain bracket prefix", `[INFO] tunnel forwarding`},
+		{"plain prose", `tunnel forwarding`},
+		{"brace prefix", `{config} loaded`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			h := newHookState(t, "printf '%s\\n' '"+test.prose+"'\n"+
+				`echo '{"url":"http://10.0.0.7:8080","token":"secret"}'`+"\nexit 0\n", "")
+			res, err := newHookProvisioner(h, "prose "+test.name).provisionOrReap()
+
+			require.NoError(t, err, "prose on stdout must never stop endpoint selection")
+			require.NotNil(t, res.Endpoint)
+			assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
+			assert.False(t, h.deleteRan(t), "a working sandbox must not be reaped")
+		})
+	}
+}
+
+// The security direction must still hold against every prose shape above: a
+// record that genuinely broke still stops selection.
+func TestHookLaunchStillRejectsBrokenRecordsAfterProseFix(t *testing.T) {
+	h := newHookState(t, `
+echo '[INFO] tunnel forwarding'
+printf '%s\n' '{"level":INVALID,"endpoint":' '{"url":"http://wrong.invalid","token":"logged-secret"}'
+echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
+exit 0
+`, "")
+	_, err := newHookProvisioner(h, "prose then broken record").provisionOrReap()
+
+	require.Error(t, err, "a record that broke still stops selection")
+	assert.NotContains(t, err.Error(), "logged-secret")
+}

--- a/session/backend_hook_followup_test.go
+++ b/session/backend_hook_followup_test.go
@@ -101,3 +101,78 @@ func TestHookOutputSuffixRedactsDeeplyEscapedTokenKeys(t *testing.T) {
 		})
 	}
 }
+
+// Second review round on #2841.
+
+// P1 3716833778: a mismatched closer let the hand-rolled scan pop the record's
+// opener, re-framing the log's nested endpoint as a top-level value.
+func TestHookLaunchRejectsNestedEndpointAfterMismatchedCloser(t *testing.T) {
+	h := newHookState(t, `
+echo '{"level":],"endpoint":{"url":"http://wrong.invalid","token":"logged-secret"}}'
+echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
+exit 0
+`, "")
+	res, err := newHookProvisioner(h, "mismatched closer").provisionOrReap()
+	require.NoError(t, err)
+	require.NotNil(t, res.Endpoint)
+	assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
+	assert.Equal(t, "secret", res.Endpoint.Token)
+}
+
+// P2 3716726113: an unterminated JSON-ish log on stdout left openers on the
+// stack to EOF, so a launch that DID echo an endpoint was reported as printing
+// none — and its working sandbox reaped.
+func TestHookLaunchRecoversAfterUnterminatedStdoutLog(t *testing.T) {
+	for _, prefix := range []string{"progress {{", `partial {"level":`, "noise ["} {
+		t.Run(prefix, func(t *testing.T) {
+			h := newHookState(t, "echo '"+prefix+"'\n"+
+				`echo '{"url":"http://10.0.0.7:8080","token":"secret"}'`+"\nexit 0\n", "")
+			res, err := newHookProvisioner(h, "unterminated stdout "+prefix).provisionOrReap()
+			require.NoError(t, err, "an unterminated stdout log must not hide the endpoint")
+			require.NotNil(t, res.Endpoint)
+			assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
+			assert.False(t, h.deleteRan(t), "a working sandbox must not be reaped")
+		})
+	}
+}
+
+// A pretty-printed endpoint still parses: the line-anchored rule requires the
+// value to BEGIN a line, not to fit on one.
+func TestHookLaunchAcceptsPrettyPrintedEndpoint(t *testing.T) {
+	h := newHookState(t, `
+printf '%s\n' '{' '  "url": "http://10.0.0.7:8080",' '  "token": "secret"' '}'
+exit 0
+`, "")
+	res, err := newHookProvisioner(h, "pretty endpoint").provisionOrReap()
+	require.NoError(t, err)
+	require.NotNil(t, res.Endpoint)
+	assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
+}
+
+// P2 3716726118 / 3716726119 / 3716833785: a token hard-wrapped by a logger —
+// once, several times, with CRLF, or wrapped and then truncated — left its tail
+// in the error. The continuation is bounded by whitespace, which a bearer token
+// never contains.
+func TestHookOutputSuffixRedactsWrappedTokenTails(t *testing.T) {
+	tests := []struct{ name, output, secret string }{
+		{"crlf wrap", "{\"token\":\"prefix-\r\nsecret-tail\"}", "secret-tail"},
+		{"multiple wraps", "{\"token\":\"a-\nsecret-middle-\nsecret-tail\"}", "secret-middle-"},
+		{"wrapped and truncated", "{\"token\":\"prefix-\nsecret-tail", "secret-tail"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			suffix := hookOutputSuffix([]byte(test.output))
+			assert.NotContains(t, suffix, test.secret)
+			assert.Contains(t, suffix, "[REDACTED]")
+		})
+	}
+}
+
+// P2 3716833781: the advertised depth-3 Unicode-escaped key must actually be
+// redacted end to end, not merely fit the widened scan window.
+func TestHookOutputSuffixRedactsDepthThreeUnicodeTokenKey(t *testing.T) {
+	output := `INFO endpoint="{\\\"\\\\u0074\\\\u006f\\\\u006b\\\\u0065\\\\u006e\\\":\\\"depth3-secret\\\"}"`
+	suffix := hookOutputSuffix([]byte(output))
+	assert.NotContains(t, suffix, "depth3-secret")
+	assert.Contains(t, suffix, "[REDACTED]")
+}

--- a/session/backend_hook_followup_test.go
+++ b/session/backend_hook_followup_test.go
@@ -1,0 +1,103 @@
+package session
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Codex P1 3716111938 on #2718. selectHookEndpoint used the diagnostic
+// extractor, which recovers values nested in malformed wrappers, so a malformed
+// structured log on STDOUT could still promote its logged endpoint — the #2637
+// failure mode, reachable again through the stream that was supposed to fix it.
+func TestHookLaunchRejectsNestedEndpointInMalformedStdoutLog(t *testing.T) {
+	h := newHookState(t, `
+echo '{"level":INVALID,"endpoint":{"url":"http://wrong.invalid","token":"logged-secret"}}'
+echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
+exit 0
+`, "")
+	p := newHookProvisioner(h, "malformed stdout log")
+
+	res, err := p.provisionOrReap()
+	require.NoError(t, err, "a malformed stdout log must not hide the launch record")
+	require.NotNil(t, res.Endpoint)
+	assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
+	assert.Equal(t, "secret", res.Endpoint.Token)
+	assert.False(t, h.deleteRan(t), "the working sandbox must not be reaped")
+}
+
+// A malformed wrapper with no real endpoint after it must fail the provision
+// rather than dial whatever the log named.
+func TestHookLaunchRejectsNestedEndpointWithNoRealRecord(t *testing.T) {
+	h := newHookState(t, `
+echo '{"level":INVALID,"endpoint":{"url":"http://wrong.invalid","token":"logged-secret"}}'
+exit 0
+`, "")
+	p := newHookProvisioner(h, "nested only")
+
+	_, err := p.provisionOrReap()
+	require.Error(t, err, "a nested endpoint is not a launch record")
+	assert.NotContains(t, err.Error(), "logged-secret", "the reported output must redact the token")
+}
+
+// Codex P2 3716111944 on #2718. extractJSONAt reported the enclosing wrapper's
+// end alongside a recovered child, so redactCompleteHookJSON rewrote the wrong
+// byte span and mangled the diagnostic it was meant to preserve.
+func TestHookOutputSuffixKeepsTextAroundRecoveredJSON(t *testing.T) {
+	output := `noise { bad {"token":"nested-secret"} tail-marker-must-survive }`
+
+	suffix := hookOutputSuffix([]byte(output))
+	assert.NotContains(t, suffix, "nested-secret")
+	assert.Contains(t, suffix, "[REDACTED]")
+	assert.Contains(t, suffix, "tail-marker-must-survive", "surrounding diagnostic text must survive redaction")
+	assert.Contains(t, suffix, "noise", "text before the recovered value must survive too")
+}
+
+// Codex P2 3716111947 on #2718. A token value truncated at a line break made the
+// joined-line scan swallow every later line up to the next quote, replacing the
+// actual failure with [REDACTED].
+func TestHookOutputSuffixKeepsLaterLinesAfterTruncatedToken(t *testing.T) {
+	output := strings.Join([]string{
+		`{"url":"http://h","token":"truncated-secret`,
+		`provisioner error: quota exceeded in region us-east-1`,
+		`see the "help" page for the quota request form`,
+	}, "\n")
+
+	suffix := hookOutputSuffix([]byte(output))
+	assert.NotContains(t, suffix, "truncated-secret", "the truncated token must still be redacted")
+	assert.Contains(t, suffix, "quota exceeded in region us-east-1",
+		"the real failure must not be redacted away with the token")
+	assert.Contains(t, suffix, "quota request form")
+}
+
+// Codex P2 3716111952 + 3716388272 on #2718: a serialized endpoint whose token
+// key is Unicode-escaped, and one escaped two levels deep. Both exceeded the old
+// key bound or kept a backslash in the key body, so neither matched.
+func TestHookOutputSuffixRedactsDeeplyEscapedTokenKeys(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		secret string
+	}{
+		{
+			name:   "serialized unicode-escaped key",
+			output: `INFO endpoint="{\"\\u0074\\u006f\\u006b\\u0065\\u006e\":\"unicode-key-secret\"}"`,
+			secret: "unicode-key-secret",
+		},
+		{
+			name:   "twice-escaped token field",
+			output: `INFO endpoint="{\\\"token\\\":\\\"twice-escaped-secret\\\"}"`,
+			secret: "twice-escaped-secret",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			suffix := hookOutputSuffix([]byte(test.output))
+			assert.NotContains(t, suffix, test.secret)
+			assert.Contains(t, suffix, "[REDACTED]")
+		})
+	}
+}

--- a/session/backend_hook_followup_test.go
+++ b/session/backend_hook_followup_test.go
@@ -176,3 +176,48 @@ func TestHookOutputSuffixRedactsDepthThreeUnicodeTokenKey(t *testing.T) {
 	assert.NotContains(t, suffix, "depth3-secret")
 	assert.Contains(t, suffix, "[REDACTED]")
 }
+
+// Third review round on #2841.
+
+// P1 3716996280: a log that breaks before its endpoint value hands that value
+// its own line, so a line-start rule alone read it as a record. Column 0 is the
+// discriminator — a logger indents a continued value; echo does not.
+func TestHookLaunchRejectsIndentedNestedEndpoint(t *testing.T) {
+	h := newHookState(t, `
+printf '%s\n' '{"level":INVALID,"endpoint":' '  {"url":"http://wrong.invalid","token":"logged-secret"}'
+echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
+exit 0
+`, "")
+	res, err := newHookProvisioner(h, "multiline nested log").provisionOrReap()
+	require.NoError(t, err)
+	require.NotNil(t, res.Endpoint)
+	assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
+	assert.Equal(t, "secret", res.Endpoint.Token)
+}
+
+// P1 3716996283: after skipping a non-endpoint value the scan resumed at the
+// caller's cursor, so a second object on the SAME physical line looked like a
+// fresh record.
+func TestHookLaunchRejectsSecondObjectOnSameLine(t *testing.T) {
+	h := newHookState(t, `
+echo '{"level":"info"} {"url":"http://wrong.invalid","token":"logged-secret"}'
+echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
+exit 0
+`, "")
+	res, err := newHookProvisioner(h, "same line pair").provisionOrReap()
+	require.NoError(t, err)
+	require.NotNil(t, res.Endpoint)
+	assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
+	assert.Equal(t, "secret", res.Endpoint.Token)
+}
+
+// P2 3716996290: the wrap continuation ran past a value that was already
+// complete, eating the diagnostic that followed it.
+func TestHookOutputSuffixKeepsTextAfterCompleteEscapedToken(t *testing.T) {
+	output := `INFO endpoint=\"token\":\"secret\"error=quota-exceeded`
+
+	suffix := hookOutputSuffix([]byte(output))
+	assert.NotContains(t, suffix, "secret")
+	assert.Contains(t, suffix, "[REDACTED]")
+	assert.Contains(t, suffix, "error=quota-exceeded", "a complete value must not swallow the diagnostic after it")
+}

--- a/session/backend_hook_followup_test.go
+++ b/session/backend_hook_followup_test.go
@@ -367,3 +367,37 @@ func TestHookOutputSuffixStopsWrappedTokenAtEscapedQuote(t *testing.T) {
 	assert.NotContains(t, suffix, "cret\\\"error", "the wrapped token tail must be redacted")
 	assert.Contains(t, suffix, "error=quota-exceeded", "the failure detail must survive")
 }
+
+// Sixth review round on #2841.
+
+// P1 3717248242: a multi-line log record was decoded whole but the cursor
+// advanced only one line, so the lines INSIDE it were rescanned and its
+// endpoint-shaped child promoted as a record of its own.
+func TestHookLaunchRejectsChildOfMultilineStdoutLog(t *testing.T) {
+	h := newHookState(t, `
+printf '%s\n' '{' '  "level": "info",' '  "endpoint":' '  {"url":"http://wrong.invalid","token":"logged-secret"}' '}'
+echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
+exit 0
+`, "")
+	res, err := newHookProvisioner(h, "multiline log wrapper").provisionOrReap()
+
+	require.NoError(t, err, "a complete multi-line log must be skipped whole, not rescanned")
+	require.NotNil(t, res.Endpoint)
+	assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
+	assert.Equal(t, "secret", res.Endpoint.Token)
+	assert.False(t, h.deleteRan(t))
+}
+
+// P1 3717248248: an endpoint-shaped prefix followed by a continuation on the
+// same line was accepted before the trailing-byte check could reject it.
+func TestHookLaunchRejectsEndpointShapedPrefixWithContinuation(t *testing.T) {
+	h := newHookState(t, `
+printf '%s\n' '{"url":"http://wrong.invalid","token":"logged-secret"},"endpoint":'
+echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
+exit 0
+`, "")
+	_, err := newHookProvisioner(h, "endpoint prefix continuation").provisionOrReap()
+
+	require.Error(t, err, "an endpoint-shaped prefix of an open record is not a record")
+	assert.NotContains(t, err.Error(), "logged-secret", "the logged token must not reach the error")
+}

--- a/session/backend_hook_followup_test.go
+++ b/session/backend_hook_followup_test.go
@@ -401,3 +401,37 @@ exit 0
 	require.Error(t, err, "an endpoint-shaped prefix of an open record is not a record")
 	assert.NotContains(t, err.Error(), "logged-secret", "the logged token must not reach the error")
 }
+
+// Seventh review round on #2841.
+
+// P1 3717302082: a depth counter called `{"level":]` balanced, so a record that
+// was still open looked self-contained and the next line's logged endpoint was
+// promoted. Bracket TYPES have to match.
+func TestHookLaunchRejectsEndpointAfterMismatchedBracketLine(t *testing.T) {
+	h := newHookState(t, `
+printf '%s\n' '{"level":]' '{"url":"http://wrong.invalid","token":"logged-secret"}'
+echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
+exit 0
+`, "")
+	_, err := newHookProvisioner(h, "mismatched bracket line").provisionOrReap()
+
+	require.Error(t, err, "a mismatched closer leaves the record open")
+	assert.NotContains(t, err.Error(), "logged-secret", "the logged token must not reach the error")
+}
+
+// P2 3717302086: bracketed prose with a stray quote had already closed its
+// brackets; treating the open string as a continuing record stopped selection
+// and reaped a sandbox that launched correctly.
+func TestHookLaunchIgnoresBracketedProseWithStrayQuote(t *testing.T) {
+	h := newHookState(t, `
+printf '%s\n' '[INFO] opening "config'
+echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
+exit 0
+`, "")
+	res, err := newHookProvisioner(h, "prose stray quote").provisionOrReap()
+
+	require.NoError(t, err, "a stray quote in closed bracketed prose must not stop selection")
+	require.NotNil(t, res.Endpoint)
+	assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
+	assert.False(t, h.deleteRan(t))
+}

--- a/session/backend_hook_followup_test.go
+++ b/session/backend_hook_followup_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,14 +19,16 @@ echo '{"level":INVALID,"endpoint":{"url":"http://wrong.invalid","token":"logged-
 echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
 exit 0
 `, "")
-	p := newHookProvisioner(h, "malformed stdout log")
+	_, err := newHookProvisioner(h, "malformed stdout log").provisionOrReap()
 
-	res, err := p.provisionOrReap()
-	require.NoError(t, err, "a malformed stdout log must not hide the launch record")
-	require.NotNil(t, res.Endpoint)
-	assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
-	assert.Equal(t, "secret", res.Endpoint.Token)
-	assert.False(t, h.deleteRan(t), "the working sandbox must not be reaped")
+	// Past a malformed record the stream structure is unknown, so nothing after it is promoted.
+	require.Error(t, err, "a malformed JSON record on stdout must not be salvaged past")
+	// The logged URL may appear in the echoed output — that IS the diagnostic.
+	// What must not happen is selecting it, so assert the provision reported no
+	// endpoint rather than a failure to reach one, and that the token is redacted.
+	assert.Contains(t, err.Error(), `printed no {"url","token"} JSON on stdout`,
+		"selection must stop at the malformed record, not dial a logged endpoint")
+	assert.NotContains(t, err.Error(), "logged-secret", "the logged token must not reach the error")
 }
 
 // A malformed wrapper with no real endpoint after it must fail the provision
@@ -112,11 +115,16 @@ echo '{"level":],"endpoint":{"url":"http://wrong.invalid","token":"logged-secret
 echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
 exit 0
 `, "")
-	res, err := newHookProvisioner(h, "mismatched closer").provisionOrReap()
-	require.NoError(t, err)
-	require.NotNil(t, res.Endpoint)
-	assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
-	assert.Equal(t, "secret", res.Endpoint.Token)
+	_, err := newHookProvisioner(h, "mismatched closer").provisionOrReap()
+
+	// encoding/json rejects the record; selection stops rather than re-framing its child.
+	require.Error(t, err, "a malformed JSON record on stdout must not be salvaged past")
+	// The logged URL may appear in the echoed output — that IS the diagnostic.
+	// What must not happen is selecting it, so assert the provision reported no
+	// endpoint rather than a failure to reach one, and that the token is redacted.
+	assert.Contains(t, err.Error(), `printed no {"url","token"} JSON on stdout`,
+		"selection must stop at the malformed record, not dial a logged endpoint")
+	assert.NotContains(t, err.Error(), "logged-secret", "the logged token must not reach the error")
 }
 
 // P2 3716726113: an unterminated JSON-ish log on stdout left openers on the
@@ -179,20 +187,25 @@ func TestHookOutputSuffixRedactsDepthThreeUnicodeTokenKey(t *testing.T) {
 
 // Third review round on #2841.
 
-// P1 3716996280: a log that breaks before its endpoint value hands that value
-// its own line, so a line-start rule alone read it as a record. Column 0 is the
-// discriminator — a logger indents a continued value; echo does not.
+// P1 3716996280 / 3717054748: a log that breaks before its endpoint value hands
+// that value its own line, indented or not. No positional rule separates it from
+// a record, so selection stops at the malformed record instead of guessing.
 func TestHookLaunchRejectsIndentedNestedEndpoint(t *testing.T) {
 	h := newHookState(t, `
 printf '%s\n' '{"level":INVALID,"endpoint":' '  {"url":"http://wrong.invalid","token":"logged-secret"}'
 echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
 exit 0
 `, "")
-	res, err := newHookProvisioner(h, "multiline nested log").provisionOrReap()
-	require.NoError(t, err)
-	require.NotNil(t, res.Endpoint)
-	assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
-	assert.Equal(t, "secret", res.Endpoint.Token)
+	_, err := newHookProvisioner(h, "multiline nested log").provisionOrReap()
+
+	// Indented or not, a continuation of a malformed record is never promoted.
+	require.Error(t, err, "a malformed JSON record on stdout must not be salvaged past")
+	// The logged URL may appear in the echoed output — that IS the diagnostic.
+	// What must not happen is selecting it, so assert the provision reported no
+	// endpoint rather than a failure to reach one, and that the token is redacted.
+	assert.Contains(t, err.Error(), `printed no {"url","token"} JSON on stdout`,
+		"selection must stop at the malformed record, not dial a logged endpoint")
+	assert.NotContains(t, err.Error(), "logged-secret", "the logged token must not reach the error")
 }
 
 // P1 3716996283: after skipping a non-endpoint value the scan resumed at the
@@ -220,4 +233,77 @@ func TestHookOutputSuffixKeepsTextAfterCompleteEscapedToken(t *testing.T) {
 	assert.NotContains(t, suffix, "secret")
 	assert.Contains(t, suffix, "[REDACTED]")
 	assert.Contains(t, suffix, "error=quota-exceeded", "a complete value must not swallow the diagnostic after it")
+}
+
+// Fourth review round on #2841.
+
+// P1 3717054748: the continuation of a malformed record need not be indented, so
+// column position cannot separate it from a record. Selection stops at the
+// malformed record; the unindented variant must not dial the logged URL either.
+func TestHookLaunchRejectsUnindentedNestedEndpoint(t *testing.T) {
+	h := newHookState(t, `
+printf '%s\n' '{"level":INVALID,"endpoint":' '{"url":"http://wrong.invalid","token":"logged-secret"}'
+echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
+exit 0
+`, "")
+	_, err := newHookProvisioner(h, "unindented nested").provisionOrReap()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `printed no {"url","token"} JSON on stdout`,
+		"selection must stop at the malformed record, not dial a logged endpoint")
+	assert.NotContains(t, err.Error(), "logged-secret")
+}
+
+// Prose on stdout is SUPPORTED: docs/remote-hooks.md lets a background tunnel
+// inherit the stream and keep logging. It must not disturb selection — this is
+// the case a fail-at-first-syntax-error rule broke.
+func TestHookLaunchIgnoresTunnelProseOnStdout(t *testing.T) {
+	h := newHookState(t, `
+echo 'tunnel forwarding'
+echo 'tunnel forwarding'
+echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
+echo 'tunnel still forwarding'
+exit 0
+`, "")
+	res, err := newHookProvisioner(h, "tunnel prose").provisionOrReap()
+	require.NoError(t, err, "tunnel chatter on stdout must not fail the provision")
+	require.NotNil(t, res.Endpoint)
+	assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
+	assert.False(t, h.deleteRan(t))
+}
+
+// P2 3717054757: a wrapped value whose continuation is indented.
+func TestHookOutputSuffixRedactsIndentedWrappedToken(t *testing.T) {
+	suffix := hookOutputSuffix([]byte("{\"token\":\"prefix-\n  secret-tail\"}"))
+	assert.NotContains(t, suffix, "secret-tail")
+	assert.Contains(t, suffix, "[REDACTED]")
+}
+
+// P2 3717054755: a complete escaped field must keep its end even when the output
+// has other lines, which is what put it through the joined pass.
+func TestHookOutputSuffixKeepsTextAfterCompleteTokenWithOtherLines(t *testing.T) {
+	suffix := hookOutputSuffix([]byte(`INFO endpoint=\"token\":\"secret\"error=quota-exceeded` + "\nnext line"))
+	assert.NotContains(t, suffix, "secret")
+	assert.Contains(t, suffix, "error=quota-exceeded")
+	assert.Contains(t, suffix, "next line")
+}
+
+// P2 3717054761: 20k column-0 JSON-prefix lines made the old scan build a
+// decoder over the whole remaining suffix per line, ~4s of a launch budget spent
+// selecting an endpoint. Selection stops at the first malformed record now, so
+// the work is bounded by where that record begins.
+func TestHookEndpointSelectionBoundedOnJSONPrefixFlood(t *testing.T) {
+	flood := strings.Repeat("[\n", 20_000) + `{"url":"http://10.0.0.7:8080","token":"secret"}` + "\n"
+	started := time.Now()
+	endpoint, _ := selectHookEndpoint(flood)
+	assert.Less(t, time.Since(started), time.Second, "endpoint selection must not rescan the suffix per line")
+	assert.Nil(t, endpoint, "an unterminated record stops selection rather than promoting past it")
+
+	// The same flood as PROSE (not JSON openers) must still find the endpoint fast.
+	prose := strings.Repeat("tunnel forwarding\n", 20_000) + `{"url":"http://10.0.0.7:8080","token":"secret"}` + "\n"
+	started = time.Now()
+	endpoint, _ = selectHookEndpoint(prose)
+	assert.Less(t, time.Since(started), time.Second)
+	require.NotNil(t, endpoint)
+	assert.Equal(t, "http://10.0.0.7:8080", endpoint.URL)
 }

--- a/session/backend_hook_followup_test.go
+++ b/session/backend_hook_followup_test.go
@@ -19,16 +19,15 @@ echo '{"level":INVALID,"endpoint":{"url":"http://wrong.invalid","token":"logged-
 echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
 exit 0
 `, "")
-	_, err := newHookProvisioner(h, "malformed stdout log").provisionOrReap()
+	res, err := newHookProvisioner(h, "malformed stdout log").provisionOrReap()
 
-	// Past a malformed record the stream structure is unknown, so nothing after it is promoted.
-	require.Error(t, err, "a malformed JSON record on stdout must not be salvaged past")
-	// The logged URL may appear in the echoed output — that IS the diagnostic.
-	// What must not happen is selecting it, so assert the provision reported no
-	// endpoint rather than a failure to reach one, and that the token is redacted.
-	assert.Contains(t, err.Error(), `printed no {"url","token"} JSON on stdout`,
-		"selection must stop at the malformed record, not dial a logged endpoint")
-	assert.NotContains(t, err.Error(), "logged-secret", "the logged token must not reach the error")
+	// The malformed record closes on its own line, so skipping that LINE is safe:
+	// its nested endpoint never becomes a candidate, and later lines stay
+	// trustworthy. The real record is still selected.
+	require.NoError(t, err)
+	require.NotNil(t, res.Endpoint)
+	assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
+	assert.Equal(t, "secret", res.Endpoint.Token)
 }
 
 // A malformed wrapper with no real endpoint after it must fail the provision
@@ -218,6 +217,9 @@ echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
 exit 0
 `, "")
 	res, err := newHookProvisioner(h, "same line pair").provisionOrReap()
+
+	// Several values on one line is a log line, not a record: none of them is
+	// promoted, and the real record on the next line is.
 	require.NoError(t, err)
 	require.NotNil(t, res.Endpoint)
 	assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
@@ -306,4 +308,62 @@ func TestHookEndpointSelectionBoundedOnJSONPrefixFlood(t *testing.T) {
 	assert.Less(t, time.Since(started), time.Second)
 	require.NotNil(t, endpoint)
 	assert.Equal(t, "http://10.0.0.7:8080", endpoint.URL)
+}
+
+// Fifth review round on #2841.
+
+// P2 3717118574: an endpoint line with leading JSON whitespace was classified as
+// prose and skipped, failing a launch that printed a valid endpoint.
+func TestHookLaunchAcceptsIndentedEndpointLine(t *testing.T) {
+	h := newHookState(t, `
+printf '%s\n' '  {"url":"http://10.0.0.7:8080","token":"secret"}'
+exit 0
+`, "")
+	res, err := newHookProvisioner(h, "indented endpoint").provisionOrReap()
+	require.NoError(t, err, "leading whitespace must not make an endpoint line prose")
+	require.NotNil(t, res.Endpoint)
+	assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
+}
+
+// P2 3717118585: bracketed prose at column 0 is the most common tunnel log
+// prefix there is. It must not poison the rest of stdout.
+func TestHookLaunchIgnoresBracketedProseOnStdout(t *testing.T) {
+	h := newHookState(t, `
+echo '[INFO] tunnel forwarding'
+echo '[WARN] retrying'
+echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
+exit 0
+`, "")
+	res, err := newHookProvisioner(h, "bracketed prose").provisionOrReap()
+	require.NoError(t, err, "bracketed prose must not stop endpoint selection")
+	require.NotNil(t, res.Endpoint)
+	assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
+	assert.False(t, h.deleteRan(t))
+}
+
+// P1 3717118579: a line whose valid JSON prefix is followed by a continuation
+// (`{"level":"info"},"endpoint":`) leaves the record open, so later lines carry
+// its contents and must not be promoted.
+func TestHookLaunchRejectsEndpointAfterTrailingContinuation(t *testing.T) {
+	h := newHookState(t, `
+printf '%s\n' '{"level":"info"},"endpoint":' '{"url":"http://wrong.invalid","token":"logged-secret"}'
+echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
+exit 0
+`, "")
+	_, err := newHookProvisioner(h, "trailing continuation").provisionOrReap()
+	require.Error(t, err, "a record left open by trailing text must stop selection")
+	// sawJSON is true here — the `{"level":"info"}` prefix decoded — so this is
+	// the "printed JSON but none matched" variant. What matters is that neither
+	// the logged endpoint nor the later real one was promoted past the open
+	// record, and that the token is redacted from the reported output.
+	assert.Contains(t, err.Error(), "none contained a non-empty url and token")
+	assert.NotContains(t, err.Error(), "logged-secret")
+}
+
+// P2 3717118577: a hard-wrapped SERIALIZED token ends at its escaped closing
+// quote; stepping over it ran the redaction through the failure detail.
+func TestHookOutputSuffixStopsWrappedTokenAtEscapedQuote(t *testing.T) {
+	suffix := hookOutputSuffix([]byte("INFO endpoint=\\\"token\\\":\\\"se\ncret\\\"error=quota-exceeded"))
+	assert.NotContains(t, suffix, "cret\\\"error", "the wrapped token tail must be redacted")
+	assert.Contains(t, suffix, "error=quota-exceeded", "the failure detail must survive")
 }

--- a/session/backend_hook_redaction.go
+++ b/session/backend_hook_redaction.go
@@ -190,6 +190,12 @@ type hookOutputRange struct {
 func hookTokenRedactionRanges(output string) []hookOutputRange {
 	ranges := scanHookTokenRanges(output)
 	for index := range ranges {
+		// Only a value the scan could not finish continues onto another line. A
+		// complete one already has its closing quote, and extending past it would
+		// eat the diagnostic that follows.
+		if ranges[index].complete {
+			continue
+		}
 		ranges[index].end = extendHookTokenValue(output, ranges[index])
 	}
 	if stripped, offsets := stripRawLineBreaks(output); len(offsets) > 0 {

--- a/session/backend_hook_redaction.go
+++ b/session/backend_hook_redaction.go
@@ -305,6 +305,14 @@ func hookTokenKeyEnd(input string, start int) (int, bool) {
 	if limit > len(input) {
 		limit = len(input)
 	}
+	// However `token` is spelled, its bytes contain a literal t/T or a \u escape.
+	// Rejecting the whole window on that once — rather than attempting a decode at
+	// each escaped quote inside it — is what keeps an escaped-quote flood cheap
+	// now that the window is wide enough for deeply escaped keys.
+	if window := input[start:limit]; !strings.ContainsAny(window, "tT") &&
+		!strings.Contains(window, `\u`) {
+		return 0, false
+	}
 	escaped := false
 	for cursor := start + 1; cursor < limit; cursor++ {
 		switch {

--- a/session/backend_hook_redaction.go
+++ b/session/backend_hook_redaction.go
@@ -189,34 +189,60 @@ type hookOutputRange struct {
 // more.
 func hookTokenRedactionRanges(output string) []hookOutputRange {
 	ranges := scanHookTokenRanges(output)
+	for index := range ranges {
+		ranges[index].end = extendHookTokenValue(output, ranges[index])
+	}
 	if stripped, offsets := stripRawLineBreaks(output); len(offsets) > 0 {
 		for _, joined := range scanHookTokenRanges(stripped) {
 			if joined.start >= len(offsets) || joined.end <= joined.start {
 				continue
 			}
-			// Only a value that CLOSES in the joined view is a field split by a line
-			// break. An unterminated one runs to whatever quote appears next, which
-			// may be pages of unrelated diagnostics away — and the raw pass already
-			// redacts that tail to end of line, so dropping it here loses nothing
-			// (Codex P2 on #2718).
-			if !joined.complete {
-				continue
-			}
-			if joined.end > len(offsets) {
-				continue
-			}
-			candidate := hookOutputRange{start: offsets[joined.start], end: offsets[joined.end-1] + 1}
-			// A field split by a line break crosses exactly one. More than that is
-			// the scan running away through unrelated lines, and replacing those
-			// would hide the failure this output exists to report.
-			if strings.Count(output[candidate.start:candidate.end], "\n")+
-				strings.Count(output[candidate.start:candidate.end], "\r") > 1 {
-				continue
-			}
-			ranges = append(ranges, candidate)
+			start := offsets[joined.start]
+			ranges = append(ranges, hookOutputRange{
+				start: start,
+				end:   extendHookTokenValue(output, hookOutputRange{start: start, end: start}),
+			})
 		}
 	}
 	return mergeHookOutputRanges(ranges)
+}
+
+// extendHookTokenValue follows a token value that a raw line break interrupted.
+//
+// A logger may hard-wrap a long credential, once or several times, and a killed
+// launch_cmd may leave it wrapped AND unterminated — in every case the tail is
+// still the secret. The continuation is bounded by WHITESPACE rather than by a
+// line count: a bearer token contains none, and prose does. That is what keeps a
+// truncated token from swallowing the diagnostic behind it, which is the only
+// account a user gets of a failed provision. The cost is at most the first word
+// of a following line, which is the safe direction to err.
+func extendHookTokenValue(output string, value hookOutputRange) int {
+	end := value.end
+	if end < value.start {
+		end = value.start
+	}
+	for end < len(output) {
+		switch output[end] {
+		case '\n', '\r':
+			// Only cross a break if the value actually continues after it.
+			next := end
+			for next < len(output) && (output[next] == '\n' || output[next] == '\r') {
+				next++
+			}
+			if next >= len(output) || output[next] == ' ' || output[next] == '\t' ||
+				output[next] == '"' {
+				return end
+			}
+			end = next
+		case ' ', '\t', '"':
+			return end
+		case '\\':
+			end += 2
+		default:
+			end++
+		}
+	}
+	return len(output)
 }
 
 // stripRawLineBreaks returns output without its raw line breaks, plus the

--- a/session/backend_hook_redaction.go
+++ b/session/backend_hook_redaction.go
@@ -258,6 +258,12 @@ func extendHookTokenValue(output string, value hookOutputRange) int {
 		case ' ', '\t', '"':
 			return end
 		case '\\':
+			// An ESCAPED closing quote ends a serialized value just as a bare one
+			// ends a raw value. Stepping over it would run the redaction through
+			// the diagnostic behind the token.
+			if end+1 < len(output) && output[end+1] == '"' {
+				return end
+			}
 			end += 2
 		default:
 			end++

--- a/session/backend_hook_redaction.go
+++ b/session/backend_hook_redaction.go
@@ -33,11 +33,13 @@ import (
 //     value. This catches truncated output, where a killed launch_cmd wrote the
 //     credential and then died before closing its JSON.
 
-// maxHookTokenKeyEncodedLen bounds the token-key scan. A five-character JSON key
-// is at most 32 bytes when every character uses a six-byte \u escape, including
-// the surrounding quotes. Bounding this is what keeps a malformed escape flood
-// linear while still accepting JSON-equivalent spellings and case variants.
-const maxHookTokenKeyEncodedLen = 32
+// maxHookTokenKeyEncodedLen bounds the token-key scan. A five-character key is
+// 30 bytes when every character uses a six-byte \u escape, and each further
+// serialization level doubles its backslashes: 35 bytes at depth 2, 45 at depth
+// 3. 96 covers those with room to spare while still keeping a malformed escape
+// flood linear — the earlier 32-byte bound silently gave up on a serialized
+// Unicode-escaped key and left its token in the error (Codex P2 on #2718).
+const maxHookTokenKeyEncodedLen = 96
 
 // maxHookTokenQuoteEscapeDepth is how many backslashes may precede a quote that
 // still counts as a delimiter. Depth 0 is a raw JSON object, 1 is one serialized
@@ -164,6 +166,9 @@ func redactHookJSONValue(value any) (any, bool) {
 type hookOutputRange struct {
 	start int
 	end   int
+	// complete records that the value's closing quote was found, as opposed to
+	// the scan stopping at a line break or at the end of truncated output.
+	complete bool
 }
 
 // hookTokenRedactionRanges finds `token`-keyed string values in raw bytes,
@@ -189,11 +194,26 @@ func hookTokenRedactionRanges(output string) []hookOutputRange {
 			if joined.start >= len(offsets) || joined.end <= joined.start {
 				continue
 			}
-			end := len(output)
-			if joined.end <= len(offsets) {
-				end = offsets[joined.end-1] + 1
+			// Only a value that CLOSES in the joined view is a field split by a line
+			// break. An unterminated one runs to whatever quote appears next, which
+			// may be pages of unrelated diagnostics away — and the raw pass already
+			// redacts that tail to end of line, so dropping it here loses nothing
+			// (Codex P2 on #2718).
+			if !joined.complete {
+				continue
 			}
-			ranges = append(ranges, hookOutputRange{start: offsets[joined.start], end: end})
+			if joined.end > len(offsets) {
+				continue
+			}
+			candidate := hookOutputRange{start: offsets[joined.start], end: offsets[joined.end-1] + 1}
+			// A field split by a line break crosses exactly one. More than that is
+			// the scan running away through unrelated lines, and replacing those
+			// would hide the failure this output exists to report.
+			if strings.Count(output[candidate.start:candidate.end], "\n")+
+				strings.Count(output[candidate.start:candidate.end], "\r") > 1 {
+				continue
+			}
+			ranges = append(ranges, candidate)
 		}
 	}
 	return mergeHookOutputRanges(ranges)
@@ -260,7 +280,7 @@ func scanHookTokenRanges(output string) []hookOutputRange {
 		}
 
 		valueEnd, complete := hookTokenValueEnd(output, valueStart)
-		candidate := hookOutputRange{start: valueStart + 1, end: valueEnd}
+		candidate := hookOutputRange{start: valueStart + 1, end: valueEnd, complete: complete}
 		if len(ranges) > 0 && candidate.start <= ranges[len(ranges)-1].end {
 			if candidate.end > ranges[len(ranges)-1].end {
 				ranges[len(ranges)-1].end = candidate.end
@@ -292,8 +312,14 @@ func hookTokenKeyEnd(input string, start int) (int, bool) {
 			escaped = false
 			if input[cursor] == '"' {
 				// An escaped quote closes a key whose delimiters are themselves
-				// escaped — `\"token\"` inside a serialized document.
-				if hookTokenKeyMatches(input[start+1 : cursor-1]) {
+				// escaped — `\"token\"` inside a serialized document. Drop the whole
+				// run of backslashes before it, not one: at depth 2 and beyond the
+				// delimiter carries several, and a leftover kept the key from matching.
+				body := input[start+1 : cursor]
+				for len(body) > 0 && body[len(body)-1] == '\\' {
+					body = body[:len(body)-1]
+				}
+				if hookTokenKeyMatches(body) {
 					return cursor + 1, true
 				}
 			}

--- a/session/backend_hook_redaction.go
+++ b/session/backend_hook_redaction.go
@@ -198,12 +198,24 @@ func hookTokenRedactionRanges(output string) []hookOutputRange {
 		}
 		ranges[index].end = extendHookTokenValue(output, ranges[index])
 	}
+	// The joined pass exists only to find fields the raw pass could not see —
+	// ones whose KEY or colon a line break split. Where the raw pass already
+	// matched, its result is authoritative: the joined view has no line breaks, so
+	// every match in it looks continuable and would run through the diagnostic
+	// behind a complete value.
+	rawStarts := make(map[int]struct{}, len(ranges))
+	for _, raw := range ranges {
+		rawStarts[raw.start] = struct{}{}
+	}
 	if stripped, offsets := stripRawLineBreaks(output); len(offsets) > 0 {
 		for _, joined := range scanHookTokenRanges(stripped) {
 			if joined.start >= len(offsets) || joined.end <= joined.start {
 				continue
 			}
 			start := offsets[joined.start]
+			if _, seen := rawStarts[start]; seen {
+				continue
+			}
 			ranges = append(ranges, hookOutputRange{
 				start: start,
 				end:   extendHookTokenValue(output, hookOutputRange{start: start, end: start}),
@@ -230,13 +242,16 @@ func extendHookTokenValue(output string, value hookOutputRange) int {
 	for end < len(output) {
 		switch output[end] {
 		case '\n', '\r':
-			// Only cross a break if the value actually continues after it.
+			// Cross the break, and the INDENT behind it: a logger that hard-wraps a
+			// long value commonly indents the continuation, and that tail is still
+			// the secret. Whitespace inside a line still terminates the value, so a
+			// truncated token cannot run on through prose.
 			next := end
-			for next < len(output) && (output[next] == '\n' || output[next] == '\r') {
+			for next < len(output) && (output[next] == '\n' || output[next] == '\r' ||
+				output[next] == ' ' || output[next] == '\t') {
 				next++
 			}
-			if next >= len(output) || output[next] == ' ' || output[next] == '\t' ||
-				output[next] == '"' {
+			if next >= len(output) || output[next] == '"' {
 				return end
 			}
 			end = next

--- a/session/backend_hook_remote.go
+++ b/session/backend_hook_remote.go
@@ -112,22 +112,48 @@ func extractJSONAt(output string, start int) (string, int) {
 	return findJSONAt(output, start, true)
 }
 
-// topLevelJSONAt returns only values that stand on their own: a complete JSON
-// value at the top level of the scan, never one recovered from inside a
-// malformed wrapper.
+// topLevelJSONAt returns the first value that stands on its own: a complete JSON
+// value beginning a line, decoded by encoding/json rather than by matching
+// delimiters here.
 //
-// Endpoint selection needs this and the diagnostic extractor above cannot give
-// it. Recovering a child of a malformed wrapper is right for redaction, where
+// Endpoint selection needs this and the diagnostic extractor cannot give it.
+// Recovering a child of a malformed wrapper is right for redaction, where
 // finding more JSON only means sanitizing more, and wrong for the endpoint,
-// where it promotes `{"level":INVALID,"endpoint":{…}}`'s inner object to a
-// launch record and makes the daemon dial the logged URL (Codex P1 on #2718).
+// where it promotes the inner object of `{"level":INVALID,"endpoint":{…}}` to a
+// launch record and makes the daemon dial the logged URL.
+//
+// Two properties do the work, and both are load-bearing:
+//
+//   - The real parser decides. A hand-rolled delimiter scan pops on any closer,
+//     so `{"level":],…}` ends the record early and re-frames the log's nested
+//     endpoint as top level. encoding/json simply rejects it.
+//   - A candidate must BEGIN A LINE. That is what makes resynchronization safe:
+//     an unclosed `progress {{` on an earlier line is skipped without its
+//     children ever becoming candidates, because they do not start a line.
+//     docs/remote-hooks.md has launch_cmd echo one JSON object on stdout, so a
+//     record that starts mid-line is someone's log, not the endpoint.
 func topLevelJSONAt(output string, start int) (string, int) {
-	// No quote resynchronization either. Restarting the scan past an unmatched
-	// quote re-frames whatever follows as top level, which turns a log record's
-	// nested endpoint back into a launch record — the same promotion this
-	// function exists to refuse. stdout is documented to carry the endpoint
-	// object and nothing else, so there is no prose here to resynchronize past.
-	return scanJSONAt(output, start, false)
+	for cursor := start; cursor < len(output); {
+		lineEnd := strings.IndexAny(output[cursor:], "\r\n")
+		next := len(output)
+		if lineEnd >= 0 {
+			next = cursor + lineEnd + 1
+		}
+		open := cursor
+		for open < len(output) && (output[open] == ' ' || output[open] == '\t') {
+			open++
+		}
+		if open < len(output) && (output[open] == '{' || output[open] == '[') {
+			decoder := json.NewDecoder(strings.NewReader(output[open:]))
+			var raw json.RawMessage
+			if err := decoder.Decode(&raw); err == nil {
+				// InputOffset is relative to the reader, which started at open.
+				return string(raw), open + int(decoder.InputOffset())
+			}
+		}
+		cursor = next
+	}
+	return "", len(output)
 }
 
 func findJSONAt(output string, start int, recover bool) (string, int) {

--- a/session/backend_hook_remote.go
+++ b/session/backend_hook_remote.go
@@ -112,67 +112,6 @@ func extractJSONAt(output string, start int) (string, int) {
 	return findJSONAt(output, start, true)
 }
 
-// topLevelJSONAt returns the first value that stands on its own: a complete JSON
-// value that BEGINS A PHYSICAL LINE AT COLUMN 0, decoded by encoding/json rather
-// than by matching delimiters here. start must itself be a line start.
-//
-// Endpoint selection needs this and the diagnostic extractor cannot give it.
-// Recovering a value nested in a malformed wrapper is right for redaction, where
-// finding more JSON only means sanitizing more, and wrong for the endpoint,
-// where it promotes the inner object of `{"level":INVALID,"endpoint":{…}}` to a
-// launch record and makes the daemon dial the logged URL.
-//
-// Three properties do the work, and each closes a way a log record was promoted:
-//
-//   - The real parser decides. A hand-rolled delimiter scan pops on any closer,
-//     so `{"level":],…}` ended the record early and re-framed its nested
-//     endpoint as top level. encoding/json rejects it outright.
-//   - Candidates start at COLUMN 0. A structured logger indents a value it
-//     continues onto the next line; `echo '{"url":…}'` does not. Without this a
-//     log that breaks before its endpoint value hands that value its own line
-//     and it reads as a record. This is also what lets an unterminated prose
-//     prefix like `progress {{` be skipped without stranding a real endpoint:
-//     the endpoint is still at column 0, the log's nested value is not.
-//   - Scanning resumes at the next LINE, never at the caller's cursor. Two
-//     objects on one physical line are one line: the second is a log beside the
-//     first, not a record of its own.
-//
-// docs/remote-hooks.md has launch_cmd echo one JSON object on stdout, so none of
-// this costs a well-behaved script anything. Pretty-printed endpoints still
-// parse — the rule is where a value BEGINS, not that it fits on one line.
-func topLevelJSONAt(output string, start int) (string, int) {
-	for cursor := start; cursor < len(output); cursor = nextLineStart(output, cursor) {
-		if output[cursor] != '{' && output[cursor] != '[' {
-			continue
-		}
-		decoder := json.NewDecoder(strings.NewReader(output[cursor:]))
-		var raw json.RawMessage
-		if err := decoder.Decode(&raw); err != nil {
-			continue
-		}
-		// Resume at the next line start after the value, so anything sharing its
-		// last physical line is not treated as a record.
-		return string(raw), nextLineStart(output, cursor+int(decoder.InputOffset()))
-	}
-	return "", len(output)
-}
-
-// nextLineStart returns the offset just past the next line terminator at or
-// after from, or len(output) when none remains.
-func nextLineStart(output string, from int) int {
-	if from >= len(output) {
-		return len(output)
-	}
-	if breakAt := strings.IndexAny(output[from:], "\r\n"); breakAt >= 0 {
-		next := from + breakAt + 1
-		if output[from+breakAt] == '\r' && next < len(output) && output[next] == '\n' {
-			next++
-		}
-		return next
-	}
-	return len(output)
-}
-
 func findJSONAt(output string, start int, recover bool) (string, int) {
 	if value, next := scanJSONAt(output, start, recover); value != "" {
 		return value, next

--- a/session/backend_hook_remote.go
+++ b/session/backend_hook_remote.go
@@ -113,47 +113,64 @@ func extractJSONAt(output string, start int) (string, int) {
 }
 
 // topLevelJSONAt returns the first value that stands on its own: a complete JSON
-// value beginning a line, decoded by encoding/json rather than by matching
-// delimiters here.
+// value that BEGINS A PHYSICAL LINE AT COLUMN 0, decoded by encoding/json rather
+// than by matching delimiters here. start must itself be a line start.
 //
 // Endpoint selection needs this and the diagnostic extractor cannot give it.
-// Recovering a child of a malformed wrapper is right for redaction, where
+// Recovering a value nested in a malformed wrapper is right for redaction, where
 // finding more JSON only means sanitizing more, and wrong for the endpoint,
 // where it promotes the inner object of `{"level":INVALID,"endpoint":{…}}` to a
 // launch record and makes the daemon dial the logged URL.
 //
-// Two properties do the work, and both are load-bearing:
+// Three properties do the work, and each closes a way a log record was promoted:
 //
 //   - The real parser decides. A hand-rolled delimiter scan pops on any closer,
-//     so `{"level":],…}` ends the record early and re-frames the log's nested
-//     endpoint as top level. encoding/json simply rejects it.
-//   - A candidate must BEGIN A LINE. That is what makes resynchronization safe:
-//     an unclosed `progress {{` on an earlier line is skipped without its
-//     children ever becoming candidates, because they do not start a line.
-//     docs/remote-hooks.md has launch_cmd echo one JSON object on stdout, so a
-//     record that starts mid-line is someone's log, not the endpoint.
+//     so `{"level":],…}` ended the record early and re-framed its nested
+//     endpoint as top level. encoding/json rejects it outright.
+//   - Candidates start at COLUMN 0. A structured logger indents a value it
+//     continues onto the next line; `echo '{"url":…}'` does not. Without this a
+//     log that breaks before its endpoint value hands that value its own line
+//     and it reads as a record. This is also what lets an unterminated prose
+//     prefix like `progress {{` be skipped without stranding a real endpoint:
+//     the endpoint is still at column 0, the log's nested value is not.
+//   - Scanning resumes at the next LINE, never at the caller's cursor. Two
+//     objects on one physical line are one line: the second is a log beside the
+//     first, not a record of its own.
+//
+// docs/remote-hooks.md has launch_cmd echo one JSON object on stdout, so none of
+// this costs a well-behaved script anything. Pretty-printed endpoints still
+// parse — the rule is where a value BEGINS, not that it fits on one line.
 func topLevelJSONAt(output string, start int) (string, int) {
-	for cursor := start; cursor < len(output); {
-		lineEnd := strings.IndexAny(output[cursor:], "\r\n")
-		next := len(output)
-		if lineEnd >= 0 {
-			next = cursor + lineEnd + 1
+	for cursor := start; cursor < len(output); cursor = nextLineStart(output, cursor) {
+		if output[cursor] != '{' && output[cursor] != '[' {
+			continue
 		}
-		open := cursor
-		for open < len(output) && (output[open] == ' ' || output[open] == '\t') {
-			open++
+		decoder := json.NewDecoder(strings.NewReader(output[cursor:]))
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			continue
 		}
-		if open < len(output) && (output[open] == '{' || output[open] == '[') {
-			decoder := json.NewDecoder(strings.NewReader(output[open:]))
-			var raw json.RawMessage
-			if err := decoder.Decode(&raw); err == nil {
-				// InputOffset is relative to the reader, which started at open.
-				return string(raw), open + int(decoder.InputOffset())
-			}
-		}
-		cursor = next
+		// Resume at the next line start after the value, so anything sharing its
+		// last physical line is not treated as a record.
+		return string(raw), nextLineStart(output, cursor+int(decoder.InputOffset()))
 	}
 	return "", len(output)
+}
+
+// nextLineStart returns the offset just past the next line terminator at or
+// after from, or len(output) when none remains.
+func nextLineStart(output string, from int) int {
+	if from >= len(output) {
+		return len(output)
+	}
+	if breakAt := strings.IndexAny(output[from:], "\r\n"); breakAt >= 0 {
+		next := from + breakAt + 1
+		if output[from+breakAt] == '\r' && next < len(output) && output[next] == '\n' {
+			next++
+		}
+		return next
+	}
+	return len(output)
 }
 
 func findJSONAt(output string, start int, recover bool) (string, int) {

--- a/session/backend_hook_remote.go
+++ b/session/backend_hook_remote.go
@@ -109,7 +109,29 @@ const maxJSONResyncQuotes = 8
 // byte offset immediately after it. The cursor lets callers walk every value in
 // a stream without rescanning prior output.
 func extractJSONAt(output string, start int) (string, int) {
-	if value, next := scanJSONAt(output, start); value != "" {
+	return findJSONAt(output, start, true)
+}
+
+// topLevelJSONAt returns only values that stand on their own: a complete JSON
+// value at the top level of the scan, never one recovered from inside a
+// malformed wrapper.
+//
+// Endpoint selection needs this and the diagnostic extractor above cannot give
+// it. Recovering a child of a malformed wrapper is right for redaction, where
+// finding more JSON only means sanitizing more, and wrong for the endpoint,
+// where it promotes `{"level":INVALID,"endpoint":{…}}`'s inner object to a
+// launch record and makes the daemon dial the logged URL (Codex P1 on #2718).
+func topLevelJSONAt(output string, start int) (string, int) {
+	// No quote resynchronization either. Restarting the scan past an unmatched
+	// quote re-frames whatever follows as top level, which turns a log record's
+	// nested endpoint back into a launch record — the same promotion this
+	// function exists to refuse. stdout is documented to carry the endpoint
+	// object and nothing else, so there is no prose here to resynchronize past.
+	return scanJSONAt(output, start, false)
+}
+
+func findJSONAt(output string, start int, recover bool) (string, int) {
+	if value, next := scanJSONAt(output, start, recover); value != "" {
 		return value, next
 	}
 	quotes := 0
@@ -118,14 +140,14 @@ func extractJSONAt(output string, start int) (string, int) {
 			continue
 		}
 		quotes++
-		if value, next := scanJSONAt(output, cursor+1); value != "" {
+		if value, next := scanJSONAt(output, cursor+1, recover); value != "" {
 			return value, next
 		}
 	}
 	return "", len(output)
 }
 
-func scanJSONAt(output string, start int) (string, int) {
+func scanJSONAt(output string, start int, recover bool) (string, int) {
 	var ranges []jsonRange
 	var stack []int
 	inString := false
@@ -181,8 +203,12 @@ func scanJSONAt(output string, start int) (string, int) {
 			if len(stack) > 0 {
 				continue
 			}
-			if value, ok := firstValidJSONRange(output, ranges, top); ok {
-				return value, ranges[top].end
+			if value, end, ok := firstValidJSONRange(output, ranges, top, recover); ok {
+				// Report the recovered value's OWN end, not the wrapper's. Callers
+				// derive its start as end-len(value) to rewrite that exact span, and
+				// a wrapper end there points the rewrite at the wrong bytes (Codex P2
+				// on #2718).
+				return value, end
 			}
 			// Nothing in this tree parsed; it is prose. Drop it and keep scanning.
 			ranges = ranges[:0]
@@ -190,8 +216,8 @@ func scanJSONAt(output string, start int) (string, int) {
 	}
 	// Wrappers left open at EOF: their completed children may still be valid.
 	if len(ranges) > 0 {
-		if value, ok := firstValidJSONRange(output, ranges, 0); ok {
-			return value, len(output)
+		if value, end, ok := firstValidJSONRange(output, ranges, 0, recover); ok {
+			return value, end
 		}
 	}
 	return "", len(output)
@@ -202,28 +228,31 @@ func scanJSONAt(output string, start int) (string, int) {
 // once, and descent is bounded to children that begin after the parent's first
 // syntax error — everything before it was already covered by the parent's failed
 // parse, so total inspected bytes stay linear in the output size.
-func firstValidJSONRange(output string, ranges []jsonRange, index int) (string, bool) {
+func firstValidJSONRange(output string, ranges []jsonRange, index int, recover bool) (string, int, bool) {
 	candidate := ranges[index]
 	errorAt := candidate.start
 	if candidate.end > candidate.start {
 		valid, position, recoverable := inspectJSONRange(output, candidate)
 		if valid {
-			return output[candidate.start:candidate.end], true
+			return output[candidate.start:candidate.end], candidate.end, true
 		}
 		if !recoverable {
-			return "", false
+			return "", 0, false
 		}
 		errorAt = position
+	}
+	if !recover {
+		return "", 0, false
 	}
 	for child := candidate.firstChild; child >= 0; child = ranges[child].nextSibling {
 		if ranges[child].start < errorAt {
 			continue
 		}
-		if value, ok := firstValidJSONRange(output, ranges, child); ok {
-			return value, true
+		if value, end, ok := firstValidJSONRange(output, ranges, child, recover); ok {
+			return value, end, true
 		}
 	}
-	return "", false
+	return "", 0, false
 }
 
 // inspectJSONRange parses directly from the output string so an early syntax


### PR DESCRIPTION
## What

Fixes the review findings on #2718, which merged before they were addressed — so they were live on `master`. Every one was reproduced red against merged master (or against this PR's own prior head) before being fixed.

**24 findings across six review rounds.** Several of the later ones were regressions this PR itself introduced while fixing earlier ones; those are called out below rather than folded in quietly.

## The one that mattered

`selectHookEndpoint` called the *diagnostic* JSON extractor, which recovers values nested inside malformed wrappers by design. A malformed structured log on stdout therefore still promoted its logged endpoint:

```
expected: "http://10.0.0.7:8080"
actual  : "http://wrong.invalid"
--- FAIL: TestHookLaunchRejectsNestedEndpointInMalformedStdoutLog   (against merged master)
```

That is the #2637 failure mode — dial the logged URL, reap the working sandbox when it fails — reachable again through the very stream #2718 introduced to close it. The function's own comment claimed nested values were never promoted while the code did the opposite.

## What took six rounds, and what finally held

The endpoint rule was rewritten five times: by **shape**, by **wrapper provenance**, by **line start**, by **column 0**, by **first syntax error**. Each survived exactly one review round, because the question they were all trying to answer —

> is this endpoint-shaped object a record, or a value belonging to someone's malformed log line?

— **is not decidable from the bytes**. A log can break before its endpoint value and leave it at column 0 of the next line, byte-identical to a record the script echoed.

What holds instead does not rank candidates by position. It decides **whether a line closes**:

- **Prose is skipped and changes nothing.** `[INFO] tunnel forwarding` is the most common log prefix there is.
- **A line whose brackets balance is self-contained** — bracketed prose, or a malformed record whose contents are all on it. Skipping the *line* is safe: nothing in it can become a candidate, and later lines stay trustworthy.
- **A line left open continues into the next.** From there the structure is unknown, so nothing after it is promoted; the provision fails with the output attached rather than dialing a service a log named.
- **Validity is `encoding/json`'s call**, never a hand-rolled delimiter scan — one that pops on any closer let `{"level":],…}` end its record early and re-frame the child as top level.
- **Trailing content is judged before acceptance**, on the value's last physical line, and the cursor advances past the *whole* decoded span so a consumed record is never re-entered.

### Two prod regressions this PR caught on itself

- An intermediate revision failed at the **first syntax error anywhere in stdout**. Stricter, cleaner-looking, and it broke `TestHookProvisionKeepsASuccessfulLaunchsTunnelAlive` — a **documented, supported** case where a backgrounded tunnel inherits stdout and logs prose into it. Only a malformed JSON *record* stops the scan now.
- A later revision treated any failed JSON opener as untrustworthy, which stopped selection on `[INFO] …` prose and reaped sandboxes that had printed a valid endpoint.

Both are now pinned by tests (`TestHookLaunchIgnoresTunnelProseOnStdout`, `TestHookLaunchIgnoresBracketedProseOnStdout`).

### One deliberate narrowing

A `launch_cmd` that leaves a JSON record **open** across lines on stdout fails its provision instead of having a later endpoint salvaged. That is the safe direction when the alternative is dialing the wrong service with a credential from a log. Single-line malformed records remain recoverable. Two earlier tests asserted the stricter interim behavior and were updated to this contract explicitly.

## Redaction

Same principle: the exact path is kept and the guessing is removed.

- Complete JSON goes through `encoding/json`, including records that serialize another document into a string field.
- Everything else is a bounded byte match — a `token` key, a colon, a quoted value — at any escape depth, since a truncated or wrapped outer string has no consistent nesting to rely on.
- A value interrupted by a line break continues across the break **and the indentation behind it**, bounded by whitespace: a bearer token contains none, prose does. It ends at a closing quote, escaped or bare.
- Only values the scan could not finish continue; a complete one keeps its end, so the diagnostic behind it survives.

Fixed along the way: token tails surviving a CRLF wrap, a multi-line wrap, and a wrapped-then-truncated value; a 32-byte key bound below a 35-byte depth-2 Unicode-escaped key; a single backslash dropped where a run needed dropping; and a joined-pass regression that ate `error=quota-exceeded` whenever the output had a second line.

## Performance

Endpoint selection no longer rebuilds a decoder over the remaining suffix per line — 20k JSON-prefix lines went from ~4s to ~0ms, with a test proving 20k lines of *prose* still find the endpoint. The token-key window widened to 96 bytes for deep escaping and is rejected in one pass when it holds no `t`/`T` or `\u`, keeping the 50k-escaped-quote bound ~100× under its limit.

## Scope: what this does NOT do

**This is not complete against adversarial stdout, and merging it is not a claim that it is.**

Deciding whether a stdout line is the endpoint record or part of a log line is **undecidable** while a backgrounded tunnel shares that stream — proven in **#2845** with two input pairs that are identical on every inspectable property yet require opposite handling. Seven successive classifier rules each closed one counterexample and admitted the next.

What lands here is the part that *is* decidable, and it strictly reduces the surface: the P1 it started from is live on `master` today. The residual gap is tracked in **#2845**, whose resolution is to **fail closed** — refuse an ambiguous stdout with an actionable error naming the line, rather than guess an endpoint from it. That follow-up is non-breaking and needs no migration.

## Validation

- `gofmt -l .` (no output) · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `deadcode -test ./...` (no output) · `scripts/lint-file-length.sh`
- `go test ./session/` — the only package changed
- Complexity bounds and `FuzzHookOutputSuffix` re-run on every revision

Per current repo policy no containerized suite was run locally; CI runs the full matrix.

Refs #2718, #2637
Residual gap: #2845