### PR TITLE
fix(hook): refuse an ambiguous stdout instead of guessing the endpoint

### DIFF
--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -98,6 +98,8 @@ credential value in argv or endpoint JSON.
 - `url` (**required**) — the `af agent-server`'s base URL (`http://host:port` or `ws://host:port`), reachable from the daemon. It must be plain HTTP — a `wss://`/`https://` URL is rejected (af serves no TLS).
 - `token` (**required**) — the bearer token the server printed on startup.
 
+> **If af cannot tell your endpoint from a log line, it refuses the launch.** A backgrounded tunnel may share stdout with the endpoint, and some log shapes are genuinely indistinguishable from a record — `[INVALID,` opening a log array looks exactly like `[INFO] opening {config`. Rather than guess (and risk dialing a URL and bearer token taken from a log line), af fails the provision and names the line it could not classify. The fix is one redirect: send the tunnel's output to `/dev/null` or a file so stdout carries only the endpoint JSON. See [#2845](https://github.com/sachiniyer/agent-factory/issues/2845).
+
 These values are the `af agent-server` startup banner (`addr`/`token`). A legacy `tls_fingerprint` field is accepted-and-ignored, so an old script keeps parsing, but it does nothing — drop it. Keep non-JSON output on stderr — af reads the endpoint from **stdout only**, and it must be a complete top-level object with no fields beyond those above, so a structured log that happens to carry `url` and `token` is never mistaken for it. If `launch_cmd` fails in any way after it has started, af runs `delete_cmd` to reap whatever it may have provisioned — see [`delete_cmd` runs on any failed launch](#delete_cmd-runs-on-any-failed-launch).
 
 ### `delete_cmd`

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -553,9 +553,20 @@ func (p *hookProvisioner) launch() (*AgentServerEndpoint, error) {
 			hookOutputSuffix(out.Combined()))
 	}
 
-	endpoint, sawJSON := selectHookEndpoint(string(out.Stdout))
+	endpoint, sawJSON, ambiguous := selectHookEndpoint(string(out.Stdout))
 	if endpoint != nil {
 		return endpoint, nil
+	}
+	if ambiguous != nil {
+		// Refuse rather than guess. Picking wrong here means dialing a URL and
+		// bearer token lifted from a log line, so the operator gets the line and
+		// the one-line fix instead of a silent wrong endpoint (#2845).
+		return nil, fmt.Errorf("launch_cmd (%s) printed a line on stdout that could be its endpoint "+
+			"or a log line, and af will not guess between them: %s\n"+
+			"Give the endpoint stdout to itself — redirect the tunnel's output "+
+			"(>/dev/null 2>&1, or to a file) — see docs/remote-hooks.md%s",
+			p.hooks.LaunchCmd, strings.TrimSpace(redactHookOutputTokens(ambiguous.line)),
+			hookOutputSuffix(out.Combined()))
 	}
 	if !sawJSON {
 		return nil, fmt.Errorf("launch_cmd (%s) exited 0 but printed no {\"url\",\"token\"} JSON on stdout "+
@@ -591,7 +602,35 @@ func (p *hookProvisioner) launch() (*AgentServerEndpoint, error) {
 //     unknown. From there no further value is promoted, because any of them may
 //     be that record's contents. Provision fails with the output attached rather
 //     than dialing something a log named.
-func selectHookEndpoint(stdout string) (*AgentServerEndpoint, bool) {
+//
+// hookAmbiguousStdout reports a stdout line that could be either the endpoint
+// record or part of a log line. af refuses to choose between them: see #2845 for
+// why no rule can, and hookOutputSuffix redacts the line before it is reported.
+type hookAmbiguousStdout struct {
+	line string
+}
+
+// selectHookEndpoint returns the endpoint from stdout, whether stdout held any
+// JSON at all, and — when it cannot tell a record from log prose — the line that
+// made it ambiguous.
+//
+// It never guesses. Whether a line is the endpoint the script echoed or part of
+// a tunnel's log is UNDECIDABLE while both share stdout, which
+// docs/remote-hooks.md permits: #2845 records two input pairs that are identical
+// on every inspectable property yet require opposite handling. Guessing "prose"
+// on a record means dialing a URL and bearer token taken from a log line, so
+// where the answer is not determined this refuses and says which line to fix.
+//
+// What remains decidable is still decided:
+//
+//   - A line that is not an object opener is a tunnel logging into the inherited
+//     stream, and is skipped without parsing.
+//   - An object that decodes cleanly, with nothing but whitespace after it and
+//     no structural continuation on the next line, is a record — the only shape
+//     that may be the endpoint.
+//   - An object line whose brackets close is self-contained: skipping it is safe
+//     because nothing in it can become a candidate.
+func selectHookEndpoint(stdout string) (*AgentServerEndpoint, bool, *hookAmbiguousStdout) {
 	sawJSON := false
 	for cursor := 0; cursor < len(stdout); {
 		lineEnd := nextHookOutputLine(stdout, cursor)
@@ -600,108 +639,75 @@ func selectHookEndpoint(stdout string) (*AgentServerEndpoint, bool) {
 		for open < lineEnd && isJSONSpace(stdout[open]) {
 			open++
 		}
-		// The endpoint is an OBJECT (docs/remote-hooks.md), so only a `{` line can
-		// be a record. Everything else is a tunnel logging into the inherited
-		// stream — plain prose, or a bracketed prefix like `[INFO] …`, `[2026] …`,
-		// `[2026], …` — and is skipped without parsing, which also keeps a flood of
-		// them linear.
-		if open >= lineEnd || stdout[open] != '{' {
+		if open >= lineEnd || (stdout[open] != '{' && stdout[open] != '[') {
+			// Plain prose from a tunnel sharing the stream.
 			cursor = lineEnd
 			continue
+		}
+		if stdout[open] == '[' {
+			// A bracket line is prose when it closes — `[INFO] tunnel forwarding` —
+			// and UNDECIDABLE when it does not: `[INVALID,` opens a log array whose
+			// elements must never be promoted, and `[INFO] opening {config` is
+			// chatter, and the two are identical here (#2845, pair 1).
+			if hookLineBracketsBalanced(line) {
+				cursor = lineEnd
+				continue
+			}
+			return nil, sawJSON, &hookAmbiguousStdout{line: line}
 		}
 
 		decoder := json.NewDecoder(strings.NewReader(stdout[open:]))
 		var raw json.RawMessage
 		if err := decoder.Decode(&raw); err != nil {
-			// The endpoint is an OBJECT (docs/remote-hooks.md), so a line opening a
-			// BRACKET is never a record: `[INFO] …`, `[2026] …` and `[INFO] opening
-			// {config` are log prefixes however their message is punctuated.
-			//
-			// Only a `{` line can be a record that broke, and only an unbalanced one
-			// leaves a structure whose extent is unknown — anything after it may be
-			// its contents, so selection stops. `{config} loaded` closes what it
-			// opened, so skipping just that line is safe.
-			// Only an UNBALANCED record leaves a structure whose extent is unknown —
-			// anything after it may be its contents, so selection stops.
-			// `{config} loaded` closes what it opened, so skipping that line is safe.
-			if hookLineBracketsBalanced(line) {
+			// A malformed object that closes on its line is self-contained; one left
+			// open could enclose everything after it, and nothing distinguishes that
+			// from a script that simply printed a broken line.
+			if hookLineBracketsBalanced(line) && !hookNextLineContinues(stdout, lineEnd) {
 				cursor = lineEnd
 				continue
 			}
-			return nil, sawJSON
+			return nil, sawJSON, &hookAmbiguousStdout{line: line}
 		}
 		sawJSON = true
 
-		// The value may span several lines, so trailing content is judged on ITS
-		// last physical line — and judged BEFORE the record is accepted, since an
-		// endpoint-shaped prefix followed by a continuation is not a record either.
 		valueEnd := open + int(decoder.InputOffset())
 		valueLineEnd := nextHookOutputLine(stdout, valueEnd)
 		rest := valueEnd
 		for rest < valueLineEnd && isJSONSpace(stdout[rest]) {
 			rest++
 		}
-		switch {
-		case rest >= valueLineEnd && !hookNextLineContinues(stdout, valueLineEnd):
-			// A clean record, and the only shape that may be the endpoint. The next
-			// line is checked too: a separator moved onto its own line continues
-			// this record just as one on the same line does.
+		if rest >= valueLineEnd {
+			if hookNextLineContinues(stdout, valueLineEnd) {
+				// A separator or closer opening the next line either continues this
+				// record or is a tunnel's chatter — `,"endpoint":` versus
+				// `] tunnel closed` (#2845, pair 2).
+				return nil, sawJSON, &hookAmbiguousStdout{line: line}
+			}
 			if ej, ok := decodeHookEndpointJSON(string(raw)); ok {
 				// ej.TLSFingerprint is intentionally not read — TLS was removed; an
 				// old script that still echoes it parses fine and the value is
 				// dropped.
-				return &AgentServerEndpoint{URL: ej.URL, Token: ej.Token}, true
+				return &AgentServerEndpoint{URL: ej.URL, Token: ej.Token}, true, nil
 			}
-		case stdout[rest] == '{' || stdout[rest] == '[':
-			// Another value beside it: a log line carrying several. None of them is
-			// a record, so skip them all — later lines stay trustworthy because
-			// this line closed.
-		case rest >= valueLineEnd:
-			// The record continues on the next line.
-			return nil, sawJSON
-		case stdout[rest] == ',' || stdout[rest] == ':':
-			// `{…},"endpoint":` — a structural separator means the record is still
-			// open, so its extent is unknown and nothing after it is promoted.
-			return nil, sawJSON
-		default:
-			// Bare prose after a complete value — `[2026] tunnel forwarding`. A
-			// record continuing across lines breaks at a structural position, not
-			// mid-word, so this is a log line: skip it and keep reading.
+			cursor = valueLineEnd
+			continue
 		}
-		// Advance past the WHOLE decoded value, not just its first line, or the
-		// lines inside a multi-line log would be rescanned and its nested
-		// endpoint-shaped child promoted as a record of its own.
-		cursor = valueLineEnd
+		if stdout[rest] == '{' || stdout[rest] == '[' {
+			// Several values on one line is a log line, not a record — unless the
+			// trailing one is itself an opener that never closes, which leaves the
+			// same unknown extent as any open record.
+			if hookLineBracketsBalanced(line) {
+				cursor = valueLineEnd
+				continue
+			}
+		}
+		return nil, sawJSON, &hookAmbiguousStdout{line: line}
 	}
-	return nil, sawJSON
+	return nil, sawJSON, nil
 }
 
 func isJSONSpace(c byte) bool {
 	return c == ' ' || c == '\t' || c == '\r' || c == '\n'
-}
-
-// hookNextLineContinues reports that the next non-empty line begins with JSON
-// structure — a separator or a closer — which means the value above it was not a
-// record of its own. A comma moved onto its own line continues the record just
-// as one left on the same line does, and a closing bracket means the value sat
-// inside a container that started earlier.
-func hookNextLineContinues(output string, from int) bool {
-	for cursor := from; cursor < len(output); {
-		lineEnd := nextHookOutputLine(output, cursor)
-		trimmed := strings.TrimLeft(strings.TrimRight(output[cursor:lineEnd], "\r\n"), " \t")
-		if trimmed == "" {
-			cursor = lineEnd
-			continue
-		}
-		switch trimmed[0] {
-		case ',', ':', '}', ']':
-			// A separator OR a closer: either way the value above was inside
-			// something that had not ended, so it is not a record of its own.
-			return true
-		}
-		return false
-	}
-	return false
 }
 
 // hookLineBracketsBalanced reports whether every object/array opened on this line
@@ -748,8 +754,30 @@ func hookLineBracketsBalanced(line string) bool {
 	return len(open) == 0
 }
 
-// nextHookOutputLine returns the offset just past the next line terminator at or
-// after from, treating CRLF as one terminator.
+// hookNextLineContinues reports that the next non-empty line begins with JSON
+// structure — a separator or a closer — which means the value above it was not a
+// record of its own. A comma moved onto its own line continues the record just
+// as one left on the same line does, and a closing bracket means the value sat
+// inside a container that started earlier.
+func hookNextLineContinues(output string, from int) bool {
+	for cursor := from; cursor < len(output); {
+		lineEnd := nextHookOutputLine(output, cursor)
+		trimmed := strings.TrimLeft(strings.TrimRight(output[cursor:lineEnd], "\r\n"), " \t")
+		if trimmed == "" {
+			cursor = lineEnd
+			continue
+		}
+		switch trimmed[0] {
+		case ',', ':', '}', ']':
+			// A separator OR a closer: either way the value above was inside
+			// something that had not ended, so it is not a record of its own.
+			return true
+		}
+		return false
+	}
+	return false
+}
+
 func nextHookOutputLine(output string, from int) int {
 	if from >= len(output) {
 		return len(output)

--- a/session/backend_hook_failclosed_test.go
+++ b/session/backend_hook_failclosed_test.go
@@ -1,0 +1,113 @@
+package session
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #2845: whether a stdout line is the endpoint record or a tunnel's log is
+// undecidable while both share the stream. af refuses rather than guessing,
+// because guessing "prose" on a record dials a URL and bearer token taken from
+// a log line.
+
+// Both pairs from #2845 must REFUSE — that is the point: they are the inputs no
+// rule can classify, so neither member may be resolved by picking.
+func TestHookLaunchRefusesAmbiguousStdout(t *testing.T) {
+	tests := []struct {
+		name  string
+		lines []string
+	}{
+		{"pair 1: open log array", []string{`[INVALID,`, `{"url":"http://wrong.invalid","token":"logged-secret"}`}},
+		{"pair 1: bracket prose with open brace", []string{`[INFO] opening {config`}},
+		{"pair 2: separator on its own line", []string{`{"url":"http://wrong.invalid","token":"logged-secret"}`, `,"endpoint":`}},
+		{"pair 2: closer on its own line", []string{`{"url":"http://wrong.invalid","token":"logged-secret"}`, `] tunnel closed`}},
+		{"open object record", []string{`{"level":INVALID,"endpoint":`, `{"url":"http://wrong.invalid","token":"logged-secret"}`}},
+		{"balanced malformed then continuation", []string{`{level:INVALID}`, `,"endpoint":`, `{"url":"http://wrong.invalid","token":"logged-secret"}`}},
+		{"trailing opener that never closes", []string{`{"level":"info"} {"level":INVALID,"endpoint":`, `{"url":"http://wrong.invalid","token":"logged-secret"}`}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			script := "printf '%s\\n'"
+			for _, line := range test.lines {
+				script += " '" + line + "'"
+			}
+			script += "\n" + `echo '{"url":"http://10.0.0.7:8080","token":"secret"}'` + "\nexit 0\n"
+			h := newHookState(t, script, "")
+
+			_, err := newHookProvisioner(h, "ambiguous "+test.name).provisionOrReap()
+			require.Error(t, err, "ambiguous stdout must be refused, never resolved by guessing")
+
+			// Actionable: name the line, and give the one-line fix.
+			assert.Contains(t, err.Error(), "af will not guess between them")
+			assert.Contains(t, err.Error(), ">/dev/null 2>&1",
+				"the refusal must tell the operator how to fix it")
+			assert.Contains(t, err.Error(), "docs/remote-hooks.md")
+			assert.NotContains(t, err.Error(), "logged-secret",
+				"the refusal must not leak a token from the ambiguous output")
+		})
+	}
+}
+
+// Refusing must stay narrow: an unambiguous launch is untouched, including one
+// whose tunnel shares stdout with well-formed chatter.
+func TestHookLaunchStillAcceptsUnambiguousStdout(t *testing.T) {
+	tests := []struct {
+		name  string
+		lines []string
+	}{
+		{"endpoint alone", []string{`{"url":"http://10.0.0.7:8080","token":"secret"}`}},
+		{"tunnel prose around it", []string{`tunnel forwarding`, `{"url":"http://10.0.0.7:8080","token":"secret"}`, `tunnel still forwarding`}},
+		{"bracketed log prefixes", []string{`[INFO] tunnel forwarding`, `[WARN] retrying`, `{"url":"http://10.0.0.7:8080","token":"secret"}`}},
+		{"numeric bracket prefix", []string{`[2026] tunnel forwarding`, `{"url":"http://10.0.0.7:8080","token":"secret"}`}},
+		{"self-contained log record", []string{`{"level":"info","msg":"up"}`, `{"url":"http://10.0.0.7:8080","token":"secret"}`}},
+		{"balanced malformed line", []string{`{config} loaded`, `{"url":"http://10.0.0.7:8080","token":"secret"}`}},
+		{"indented endpoint", []string{`  {"url":"http://10.0.0.7:8080","token":"secret"}`}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			script := "printf '%s\\n'"
+			for _, line := range test.lines {
+				script += " '" + line + "'"
+			}
+			script += "\nexit 0\n"
+			h := newHookState(t, script, "")
+
+			res, err := newHookProvisioner(h, "clear "+test.name).provisionOrReap()
+			require.NoError(t, err, "an unambiguous launch must not be refused")
+			require.NotNil(t, res.Endpoint)
+			assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
+			assert.Equal(t, "secret", res.Endpoint.Token)
+			assert.False(t, h.deleteRan(t), "a working sandbox must not be reaped")
+		})
+	}
+}
+
+// A pretty-printed endpoint spans lines and is still unambiguous.
+func TestHookLaunchAcceptsPrettyPrintedEndpointUnderFailClosed(t *testing.T) {
+	h := newHookState(t, `
+printf '%s\n' '{' '  "url": "http://10.0.0.7:8080",' '  "token": "secret"' '}'
+exit 0
+`, "")
+	res, err := newHookProvisioner(h, "pretty").provisionOrReap()
+	require.NoError(t, err)
+	require.NotNil(t, res.Endpoint)
+	assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
+}
+
+// The refusal names the offending line so the operator knows what to redirect.
+func TestHookLaunchRefusalNamesTheAmbiguousLine(t *testing.T) {
+	h := newHookState(t, `
+echo '[INFO] opening {config'
+echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
+exit 0
+`, "")
+	_, err := newHookProvisioner(h, "named line").provisionOrReap()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "[INFO] opening {config", "the refusal must quote the line it could not classify")
+	assert.True(t, strings.Contains(err.Error(), "launch_cmd"), "and name the hook that printed it")
+}

--- a/session/backend_hook_followup_test.go
+++ b/session/backend_hook_followup_test.go
@@ -121,8 +121,8 @@ exit 0
 	// The logged URL may appear in the echoed output — that IS the diagnostic.
 	// What must not happen is selecting it, so assert the provision reported no
 	// endpoint rather than a failure to reach one, and that the token is redacted.
-	assert.Contains(t, err.Error(), `printed no {"url","token"} JSON on stdout`,
-		"selection must stop at the malformed record, not dial a logged endpoint")
+	assert.Contains(t, err.Error(), "af will not guess between them",
+		"an ambiguous stdout must be refused, not resolved by guessing")
 	assert.NotContains(t, err.Error(), "logged-secret", "the logged token must not reach the error")
 }
 
@@ -202,8 +202,8 @@ exit 0
 	// The logged URL may appear in the echoed output — that IS the diagnostic.
 	// What must not happen is selecting it, so assert the provision reported no
 	// endpoint rather than a failure to reach one, and that the token is redacted.
-	assert.Contains(t, err.Error(), `printed no {"url","token"} JSON on stdout`,
-		"selection must stop at the malformed record, not dial a logged endpoint")
+	assert.Contains(t, err.Error(), "af will not guess between them",
+		"an ambiguous stdout must be refused, not resolved by guessing")
 	assert.NotContains(t, err.Error(), "logged-secret", "the logged token must not reach the error")
 }
 
@@ -251,8 +251,8 @@ exit 0
 	_, err := newHookProvisioner(h, "unindented nested").provisionOrReap()
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `printed no {"url","token"} JSON on stdout`,
-		"selection must stop at the malformed record, not dial a logged endpoint")
+	assert.Contains(t, err.Error(), "af will not guess between them",
+		"an ambiguous stdout must be refused, not resolved by guessing")
 	assert.NotContains(t, err.Error(), "logged-secret")
 }
 
@@ -299,15 +299,15 @@ func TestHookEndpointSelectionBoundedOnJSONPrefixFlood(t *testing.T) {
 	// skipped without parsing and the endpoint is still found.
 	brackets := strings.Repeat("[\n", 20_000) + `{"url":"http://10.0.0.7:8080","token":"secret"}` + "\n"
 	started := time.Now()
-	endpoint, _ := selectHookEndpoint(brackets)
+	endpoint, _, ambiguous := selectHookEndpoint(brackets)
 	assert.Less(t, time.Since(started), time.Second, "bracket lines must not be parsed per line")
-	require.NotNil(t, endpoint)
-	assert.Equal(t, "http://10.0.0.7:8080", endpoint.URL)
+	assert.Nil(t, endpoint, "unbalanced bracket lines are ambiguous, not prose")
+	assert.NotNil(t, ambiguous, "and af refuses rather than guessing")
 
 	// Prose likewise.
 	prose := strings.Repeat("tunnel forwarding\n", 20_000) + `{"url":"http://10.0.0.7:8080","token":"secret"}` + "\n"
 	started = time.Now()
-	endpoint, _ = selectHookEndpoint(prose)
+	endpoint, _, _ = selectHookEndpoint(prose)
 	assert.Less(t, time.Since(started), time.Second)
 	require.NotNil(t, endpoint)
 
@@ -315,9 +315,10 @@ func TestHookEndpointSelectionBoundedOnJSONPrefixFlood(t *testing.T) {
 	// scan must reach that conclusion quickly rather than rescanning the suffix.
 	objects := strings.Repeat("{\n", 20_000) + `{"url":"http://10.0.0.7:8080","token":"secret"}` + "\n"
 	started = time.Now()
-	endpoint, _ = selectHookEndpoint(objects)
+	endpoint, _, ambiguous = selectHookEndpoint(objects)
 	assert.Less(t, time.Since(started), 2*time.Second, "an open record must not rescan the suffix")
-	assert.Nil(t, endpoint, "an unterminated record stops selection rather than promoting past it")
+	assert.Nil(t, endpoint, "an unterminated record is refused, not promoted past")
+	assert.NotNil(t, ambiguous)
 }
 
 // Fifth review round on #2841.
@@ -366,7 +367,7 @@ exit 0
 	// the "printed JSON but none matched" variant. What matters is that neither
 	// the logged endpoint nor the later real one was promoted past the open
 	// record, and that the token is redacted from the reported output.
-	assert.Contains(t, err.Error(), "none contained a non-empty url and token")
+	assert.Contains(t, err.Error(), "af will not guess between them")
 	assert.NotContains(t, err.Error(), "logged-secret")
 }
 
@@ -451,7 +452,6 @@ exit 0
 // together with the earlier prose cases as one set.
 func TestHookLaunchIgnoresProseThatOnlyLooksLikeJSON(t *testing.T) {
 	tests := []struct{ name, prose string }{
-		{"bracket prefix with unmatched brace", `[INFO] opening {config`},
 		{"numeric bracket prefix", `[2026] tunnel forwarding`},
 		{"bracket prefix with stray quote", `[INFO] opening "config`},
 		{"plain bracket prefix", `[INFO] tunnel forwarding`},


### PR DESCRIPTION
## What

Whether a stdout line is the endpoint record or a tunnel's log is **undecidable** while both share the stream — proven in #2845 with two input pairs that are identical on every inspectable property yet require opposite handling.

This stops guessing. Where the answer is not determined, af **refuses the provision**, quotes the line it could not classify, and gives the one-line fix.

## Why refusing, and not the other two options

The failure is not symmetric:

| Wrong guess | Consequence |
|---|---|
| **record** when it was prose | refuse a launch that worked, reap a live sandbox |
| **prose** when it was a record | **dial a URL and send a bearer token taken from a log line**, then reap the real sandbox when that fails |

The second is the dangerous one — both values are influenceable by anything that can write to the hook's stdout. Refusing is strictly safer than either guess, and unlike making stdout endpoint-only it needs **no breaking change and no migration**.

## The error

```
launch_cmd (./launch.sh) printed a line on stdout that could be its endpoint or a
log line, and af will not guess between them: [INFO] opening {config
Give the endpoint stdout to itself — redirect the tunnel's output
(>/dev/null 2>&1, or to a file) — see docs/remote-hooks.md
```

It names the hook, quotes the offending line, and states the fix. The quoted line goes through token redaction first.

## This stays narrow

Everything decidable is still decided, so unambiguous launches are untouched:

- prose that is not an object opener is skipped **without parsing**;
- a line whose brackets close is self-contained and skipped whole;
- an object that decodes cleanly, with nothing trailing and no structural continuation on the next line, is the endpoint.

Pinned as tests that must still launch: endpoint alone, tunnel prose around it, `[INFO]`/`[WARN]`/`[2026]` prefixes, self-contained log records, `{config} loaded`, an indented endpoint, and a pretty-printed multi-line endpoint.

Pinned as refusals — both #2845 pairs plus the round-ten findings that motivated them:

- `[INVALID,` opening a log array, and `[INFO] opening {config` (pair 1 — indistinguishable, so neither is guessed);
- a separator or a closer on the line after a complete value (pair 2);
- an object record left open, a balanced-but-malformed line followed by a continuation, and a trailing opener that never closes.

## Compatibility

Non-breaking by construction: a script that already keeps stdout clean sees no change, and no documented contract changes. A script whose tunnel emits an ambiguous line trades a silent wrong dial for a loud, fixable refusal. docs/remote-hooks.md gains a note explaining the refusal and the redirect.

The separate question of making stdout endpoint-only remains open for the maintainer; fail-closed does not require it.

## Validation

- `gofmt -l .` (no output) · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `deadcode -test ./...` (no output) · `scripts/lint-file-length.sh`
- `go test ./session/` — the only package changed

Per repo policy no containerized suite was run locally; CI runs the full matrix.

Closes #2845
