### PR TITLE
fix(tui): stop registry mode advertising a create key nothing can honor

### DIFF
--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -316,7 +316,7 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 	// is not even a project. Ahead of that check, this one names the actual
 	// blocker, which is also why nothing below needs a repo-less path anymore.
 	if m.repoRoot == "" {
-		return m, m.handleNotice(errors.New(noActiveProjectNotice(m.projectsFocused())))
+		return m, m.handleNotice(errors.New(noActiveProjectNotice(m.enterPicksAProject(), m.projectsFocused())))
 	}
 	m.pendingProgram = m.program
 	// Every create starts with an empty prompt field and an unchosen backend. The
@@ -420,8 +420,8 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 // KeySetPrompt calls out that hardcoding ctrl+p "would silently drift the day a
 // user rebinds that action". A user who unbound it entirely gets the section
 // instead of a key that does nothing.
-func noActiveProjectNotice(projectsFocused bool) string {
-	return "select a project first — " + switchProjectPickHint(projectsFocused) +
+func noActiveProjectNotice(enterPicks, projectsFocused bool) string {
+	return "select a project first — " + switchProjectPickHint(enterPicks, projectsFocused) +
 		"; af is running with no active project, so there is no repo for this session to live in"
 }
 
@@ -441,17 +441,31 @@ func noActiveProjectNotice(projectsFocused bool) string {
 // the registry-mode empty workspace — so the two cannot drift on wording. What
 // they must NOT share is a single hardcoded key, which is the mistake this
 // signature exists to prevent.
-func switchProjectPickHint(projectsFocused bool) string {
-	if projectsFocused {
+func switchProjectPickHint(enterPicks, projectsFocused bool) string {
+	switch {
+	case enterPicks:
 		// A fixed binding with no configKey: Enter cannot be rebound away from
 		// this, so the word is literal — and it matches the Projects header's own
 		// "· enter switch" rather than the ↵ glyph the help column renders.
 		return "press enter to pick one"
+	case projectsFocused:
+		// Focused on a captive section with no rows: Enter is a no-op
+		// (SelectedProject reports false) and ctrl+p is suppressed, so the only
+		// honest instruction is to leave the section first. Startup no longer
+		// lands here, but a user can still tab in.
+		return "press esc, then " + switchProjectKeyPhrase() + " to add one"
+	default:
+		return switchProjectKeyPhrase() + " to pick one"
 	}
+}
+
+// switchProjectKeyPhrase names the project-switch key, or the section when the
+// action is unbound — still actionable, unlike a key that does nothing.
+func switchProjectKeyPhrase() string {
 	if k := keys.GlobalKeyBindings[keys.KeySwitchProject].Help().Key; k != "" {
-		return fmt.Sprintf("press %s to pick one", k)
+		return fmt.Sprintf("press %s", k)
 	}
-	return "pick one in the Projects section"
+	return "use the Projects section"
 }
 
 // suggestSessionName picks a readable random "adjective-noun" name for the
@@ -494,4 +508,12 @@ func (m *home) clearNamingPlaceholder() {
 // key has to ask.
 func (m *home) projectsFocused() bool {
 	return m.ring.Active() == layout.RegionProjects
+}
+
+// enterPicksAProject reports whether Enter would actually switch projects right
+// now: the captive section must hold the keyboard AND have a row under the
+// cursor. With no rows SelectedProject reports false and handleProjectsFocus
+// consumes Enter as a no-op, so advertising it there is another dead key.
+func (m *home) enterPicksAProject() bool {
+	return m.projectsFocused() && m.projects.HasProjects()
 }

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -420,12 +420,20 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 // user rebinds that action". A user who unbound it entirely gets the section
 // instead of a key that does nothing.
 func noActiveProjectNotice() string {
-	pick := "pick one in the Projects section"
-	if k := keys.GlobalKeyBindings[keys.KeySwitchProject].Help().Key; k != "" {
-		pick = fmt.Sprintf("press %s to pick one", k)
-	}
-	return "select a project first — " + pick +
+	return "select a project first — " + switchProjectPickHint() +
 		"; af is running with no active project, so there is no repo for this session to live in"
+}
+
+// switchProjectPickHint names the action that gives af an active project. It is
+// shared by every surface that has to say so — the create refusal above and the
+// registry-mode empty workspace (#2830) — because a user who reads one and then
+// the other must not be told two different keys. Falls back to naming the
+// section when switch_project is unbound, which is still actionable.
+func switchProjectPickHint() string {
+	if k := keys.GlobalKeyBindings[keys.KeySwitchProject].Help().Key; k != "" {
+		return fmt.Sprintf("press %s to pick one", k)
+	}
+	return "pick one in the Projects section"
 }
 
 // suggestSessionName picks a readable random "adjective-noun" name for the

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/ui"
+	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -315,7 +316,7 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 	// is not even a project. Ahead of that check, this one names the actual
 	// blocker, which is also why nothing below needs a repo-less path anymore.
 	if m.repoRoot == "" {
-		return m, m.handleNotice(errors.New(noActiveProjectNotice()))
+		return m, m.handleNotice(errors.New(noActiveProjectNotice(m.projectsFocused())))
 	}
 	m.pendingProgram = m.program
 	// Every create starts with an empty prompt field and an unchosen backend. The
@@ -419,17 +420,34 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 // KeySetPrompt calls out that hardcoding ctrl+p "would silently drift the day a
 // user rebinds that action". A user who unbound it entirely gets the section
 // instead of a key that does nothing.
-func noActiveProjectNotice() string {
-	return "select a project first — " + switchProjectPickHint() +
+func noActiveProjectNotice(projectsFocused bool) string {
+	return "select a project first — " + switchProjectPickHint(projectsFocused) +
 		"; af is running with no active project, so there is no repo for this session to live in"
 }
 
-// switchProjectPickHint names the action that gives af an active project. It is
-// shared by every surface that has to say so — the create refusal above and the
-// registry-mode empty workspace (#2830) — because a user who reads one and then
-// the other must not be told two different keys. Falls back to naming the
-// section when switch_project is unbound, which is still actionable.
-func switchProjectPickHint() string {
+// switchProjectPickHint names the action that gives af an active project — for
+// the region the user is actually in.
+//
+// The focus argument is the whole point, not a refinement. The Projects section
+// is captive (#1620) and suppresses ctrl+p BY NAME (see handleProjectsFocus), so
+// a hint advertising it while that section holds the keyboard would reproduce
+// #2830 exactly, with a different dead key — and registry mode focuses Projects
+// at startup, which is precisely when this copy is on screen. From there Enter
+// on the cursor row IS the pick, and it is what the section header already
+// advertises. Everywhere else Enter means something else and ctrl+p is the key
+// that works.
+//
+// Shared by every surface that has to say this — the create refusal above and
+// the registry-mode empty workspace — so the two cannot drift on wording. What
+// they must NOT share is a single hardcoded key, which is the mistake this
+// signature exists to prevent.
+func switchProjectPickHint(projectsFocused bool) string {
+	if projectsFocused {
+		// A fixed binding with no configKey: Enter cannot be rebound away from
+		// this, so the word is literal — and it matches the Projects header's own
+		// "· enter switch" rather than the ↵ glyph the help column renders.
+		return "press enter to pick one"
+	}
 	if k := keys.GlobalKeyBindings[keys.KeySwitchProject].Help().Key; k != "" {
 		return fmt.Sprintf("press %s to pick one", k)
 	}
@@ -469,4 +487,11 @@ func (m *home) suggestSessionName(naming *session.Instance) string {
 func (m *home) clearNamingPlaceholder() {
 	m.namingPlaceholder = ""
 	m.sidebar.SetNamingPlaceholder(nil, "")
+}
+
+// projectsFocused reports whether the captive Projects section currently holds
+// the keyboard. Which keys are live depends on it (#1620), so any copy naming a
+// key has to ask.
+func (m *home) projectsFocused() bool {
+	return m.ring.Active() == layout.RegionProjects
 }

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -541,9 +541,10 @@ func newHome(ctx context.Context, program string, repo *config.RepoContext) *hom
 	// surface the user picks a project from, rather than the empty tree. The ring
 	// position survives the first relayout (RegionProjects stays visible), and
 	// there is no saved view state to restore over it (repoID is empty).
-	if repoRoot == "" {
-		h.ring.Focus(layout.RegionProjects)
-	}
+	// Deferred until after refreshSidebarProjects below: focusing this section is
+	// only useful when it HAS a row to pick. With none, it is a captive list where
+	// Enter is a no-op and ctrl+p is suppressed (#1620), so landing there gives a
+	// first-time user a section with no live key at all (#2830).
 	h.syncFocus()
 
 	// Cold-start the projection from the daemon's authoritative Snapshot (#960 PR 6).
@@ -570,6 +571,15 @@ func newHome(ctx context.Context, program string, repo *config.RepoContext) *hom
 	// Populate the sidebar's Projects section from the cross-repo discovery so it
 	// renders (collapsed) at launch with the active project marked.
 	h.refreshSidebarProjects()
+	// In registry mode (launched outside a repo, #2477) the session tree is empty
+	// — there is no active project — so land focus on the Projects section, the
+	// surface the user picks one from. Only when it has rows: see above. The ring
+	// position survives the first relayout (RegionProjects stays visible), and
+	// there is no saved view state to restore over it (repoID is empty).
+	if repoRoot == "" && h.projects.HasProjects() {
+		h.ring.Focus(layout.RegionProjects)
+		h.syncFocus()
+	}
 
 	// Load tasks for sidebar display. Skipped in registry mode (#2477): tasks are
 	// per-project and LoadTasksForCurrentRepo needs a cwd repo, so with no active

--- a/app/home_view.go
+++ b/app/home_view.go
@@ -172,13 +172,20 @@ func (m *home) View() string {
 	cols := []string{rail}
 	if len(m.visiblePanes) == 0 {
 		switch {
-		case m.store.NumInstances() > 0:
-			cols = append(cols, ui.EmptyWorkspace(m.lastLayout.Workspace))
+		// The no-project state outranks the session count. The refresh tick fetches
+		// with an empty repoID, which the daemon answers with the CROSS-REPO
+		// snapshot, so rows from other repos land in the store even though the
+		// launch path skipped exactly that for registry mode — and none of them can
+		// be acted on under an empty active scope. Checked second, the first poll
+		// would replace this hint with "s opens the selected tab" for anyone who
+		// has sessions elsewhere.
 		case m.repoRoot == "":
 			// Registry mode (#2477): no active project, so the blocker is not the
 			// missing sessions but the missing project — and `n` cannot create one
 			// from any focused region here (#2830).
-			cols = append(cols, ui.NoActiveProjectWorkspace(m.lastLayout.Workspace, switchProjectPickHint(m.projectsFocused())))
+			cols = append(cols, ui.NoActiveProjectWorkspace(m.lastLayout.Workspace, switchProjectPickHint(m.enterPicksAProject(), m.projectsFocused())))
+		case m.store.NumInstances() > 0:
+			cols = append(cols, ui.EmptyWorkspace(m.lastLayout.Workspace))
 		default:
 			cols = append(cols, ui.FirstRunWorkspace(m.lastLayout.Workspace))
 		}

--- a/app/home_view.go
+++ b/app/home_view.go
@@ -172,20 +172,26 @@ func (m *home) View() string {
 	cols := []string{rail}
 	if len(m.visiblePanes) == 0 {
 		switch {
-		// The no-project state outranks the session count. The refresh tick fetches
-		// with an empty repoID, which the daemon answers with the CROSS-REPO
-		// snapshot, so rows from other repos land in the store even though the
-		// launch path skipped exactly that for registry mode — and none of them can
-		// be acted on under an empty active scope. Checked second, the first poll
-		// would replace this hint with "s opens the selected tab" for anyone who
-		// has sessions elsewhere.
-		case m.repoRoot == "":
-			// Registry mode (#2477): no active project, so the blocker is not the
-			// missing sessions but the missing project — and `n` cannot create one
-			// from any focused region here (#2830).
-			cols = append(cols, ui.NoActiveProjectWorkspace(m.lastLayout.Workspace, switchProjectPickHint(m.enterPicksAProject(), m.projectsFocused())))
+		// Session count FIRST, and the order is load-bearing. "no panes open" and
+		// "no project selected" answer different questions — why is this area
+		// blank, versus what af is scoped to — and they are not alternatives: a
+		// user who closed their panes has panes to reopen whatever the project
+		// state is, so sending them off to pick a project would be a worse answer
+		// than the one #2830 set out to fix.
+		//
+		// Registry mode CAN hold sessions it cannot act on: the refresh tick
+		// fetches with an empty repoID, which the daemon answers with the
+		// cross-repo snapshot, contradicting the launch path that skips exactly
+		// that. Advertising `s` for a row that would no-op is a real problem, but
+		// a PROJECTION one — those rows should not be in the store — and
+		// re-prioritizing this message would paper over it in the wrong layer.
 		case m.store.NumInstances() > 0:
 			cols = append(cols, ui.EmptyWorkspace(m.lastLayout.Workspace))
+		case m.repoRoot == "":
+			// The empty rail, which is all #2830 is about: no sessions, and no
+			// active project to create one in, so `n` cannot work from any focused
+			// region here (#2477/#2764).
+			cols = append(cols, ui.NoActiveProjectWorkspace(m.lastLayout.Workspace, switchProjectPickHint(m.enterPicksAProject(), m.projectsFocused())))
 		default:
 			cols = append(cols, ui.FirstRunWorkspace(m.lastLayout.Workspace))
 		}

--- a/app/home_view.go
+++ b/app/home_view.go
@@ -171,10 +171,16 @@ func (m *home) View() string {
 	rail := lipgloss.JoinVertical(lipgloss.Left, railParts...)
 	cols := []string{rail}
 	if len(m.visiblePanes) == 0 {
-		if m.store.NumInstances() == 0 {
-			cols = append(cols, ui.FirstRunWorkspace(m.lastLayout.Workspace))
-		} else {
+		switch {
+		case m.store.NumInstances() > 0:
 			cols = append(cols, ui.EmptyWorkspace(m.lastLayout.Workspace))
+		case m.repoRoot == "":
+			// Registry mode (#2477): no active project, so the blocker is not the
+			// missing sessions but the missing project — and `n` cannot create one
+			// from any focused region here (#2830).
+			cols = append(cols, ui.NoActiveProjectWorkspace(m.lastLayout.Workspace, switchProjectPickHint()))
+		default:
+			cols = append(cols, ui.FirstRunWorkspace(m.lastLayout.Workspace))
 		}
 	}
 	for i, p := range m.visiblePanes {

--- a/app/home_view.go
+++ b/app/home_view.go
@@ -178,7 +178,7 @@ func (m *home) View() string {
 			// Registry mode (#2477): no active project, so the blocker is not the
 			// missing sessions but the missing project — and `n` cannot create one
 			// from any focused region here (#2830).
-			cols = append(cols, ui.NoActiveProjectWorkspace(m.lastLayout.Workspace, switchProjectPickHint()))
+			cols = append(cols, ui.NoActiveProjectWorkspace(m.lastLayout.Workspace, switchProjectPickHint(m.projectsFocused())))
 		default:
 			cols = append(cols, ui.FirstRunWorkspace(m.lastLayout.Workspace))
 		}

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -93,6 +93,11 @@ func setPreviewText(inst *session.Instance, text string) {
 
 func TestFirstRunWorkspaceEmptyState(t *testing.T) {
 	h := newTestHome(t)
+	// An ACTIVE project, stated explicitly: newTestHome leaves repoRoot empty,
+	// which since #2830 is registry mode — a different empty state with different
+	// copy, because `n` cannot create anything there. This test is about the
+	// in-repo first run, where advertising `n` is correct.
+	h.repoRoot = t.TempDir()
 	resizeHome(h, 120, 30)
 
 	view := h.View()

--- a/app/registry_mode_create_test.go
+++ b/app/registry_mode_create_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/ui/layout"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -108,8 +110,37 @@ func TestRegistryModeEmptyWorkspaceDoesNotAdvertiseCreate(t *testing.T) {
 		"no focused region in registry mode can honor that promise (#2830)")
 	assert.Contains(t, view, "No project selected",
 		"the empty state must name the actual blocker")
-	assert.Contains(t, view, switchProjectPickHint(),
-		"and it must name the same action, in the same words, as the create refusal")
+	assert.Contains(t, view, "press enter to pick one",
+		"registry mode focuses the captive Projects section, where Enter on the cursor row "+
+			"IS the pick — and where ctrl+p is suppressed by name (#1620)")
+	assert.NotContains(t, view, "ctrl+p",
+		"advertising the project-switch key from the one section that swallows it would "+
+			"reproduce #2830 with a different dead key")
+}
+
+// The same copy from a region where ctrl+p actually works must name ctrl+p.
+// Which key is live depends on focus, so a single hardcoded hint is wrong on one
+// of the two screens whichever key it picks.
+func TestRegistryModeEmptyWorkspaceNamesTheKeyThatWorksWhereFocusIs(t *testing.T) {
+	h := newTestHome(t)
+	h.repoRoot = ""
+	resizeHome(h, 120, 30)
+	h.focusRegion(layout.RegionTree)
+	require.False(t, h.projectsFocused(), "precondition: the captive section does not hold the keyboard")
+
+	view := flatten(h.View())
+
+	assert.Contains(t, view, "press ctrl+p to pick one",
+		"from the tree, ctrl+p reaches the project picker and Enter does not")
+	assert.NotContains(t, view, "press enter to pick one")
+}
+
+// The create refusal is reached by pressing `n`, which only arrives from a
+// region that is NOT the captive Projects section — so it names ctrl+p. Pinned
+// because the two surfaces share a helper and must still be allowed to differ.
+func TestNoActiveProjectNoticeNamesTheKeyForItsFocus(t *testing.T) {
+	assert.Contains(t, noActiveProjectNotice(false), "press ctrl+p to pick one")
+	assert.Contains(t, noActiveProjectNotice(true), "press enter to pick one")
 }
 
 // Inside a repo the ordinary onboarding copy is untouched: `n` works there, so

--- a/app/registry_mode_create_test.go
+++ b/app/registry_mode_create_test.go
@@ -83,3 +83,45 @@ func TestStartNewInstanceWithActiveProjectStillOpensNaming(t *testing.T) {
 	assert.Equal(t, repoDir, h.namingInstance.Path,
 		"the placeholder must target the ACTIVE project's repo root")
 }
+
+// TestRegistryModeEmptyWorkspaceDoesNotAdvertiseCreate is #2830, the other half
+// of the same dead end. #2764 fixed the path where `n` REACHES creation and now
+// refuses with a reason; this covers the path where it never arrives at all.
+//
+// In registry mode newHome lands focus on the Projects section, which is a
+// captive vim-style list that consumes the create verbs on purpose (#1620). So
+// `n` produced no form, no notice, and no repaint — while the workspace beside
+// it read "No sessions yet — press n to create one." The advertised affordance
+// and the live key routing disagreed, and the copy was the half that was wrong.
+//
+// Asserted on the composed frame, not the renderer: the renderer's own behavior
+// is covered in ui, and what regressed here is which renderer the view picks.
+func TestRegistryModeEmptyWorkspaceDoesNotAdvertiseCreate(t *testing.T) {
+	h := newTestHome(t)
+	h.repoRoot = "" // registry mode: launched outside a repo (#2477)
+	resizeHome(h, 120, 30)
+	require.Equal(t, 0, h.store.NumInstances(), "precondition: the rail is empty")
+
+	view := flatten(h.View())
+
+	assert.NotContains(t, view, "press n to create one",
+		"no focused region in registry mode can honor that promise (#2830)")
+	assert.Contains(t, view, "No project selected",
+		"the empty state must name the actual blocker")
+	assert.Contains(t, view, switchProjectPickHint(),
+		"and it must name the same action, in the same words, as the create refusal")
+}
+
+// Inside a repo the ordinary onboarding copy is untouched: `n` works there, so
+// advertising it is correct and this fix must not reach that state.
+func TestNonRegistryModeEmptyWorkspaceStillAdvertisesCreate(t *testing.T) {
+	h := newTestHome(t)
+	h.repoRoot = t.TempDir()
+	resizeHome(h, 120, 30)
+	require.Equal(t, 0, h.store.NumInstances())
+
+	view := flatten(h.View())
+
+	assert.Contains(t, view, "No sessions yet — press n to create one.")
+	assert.NotContains(t, view, "No project selected")
+}

--- a/app/registry_mode_create_test.go
+++ b/app/registry_mode_create_test.go
@@ -146,24 +146,23 @@ func TestRegistryModeEmptyWorkspaceNamesOnlyLiveKeys(t *testing.T) {
 	}
 }
 
-// The no-project state outranks the session count. The refresh tick fetches with
-// an empty repoID, which the daemon answers with the cross-repo snapshot, so rows
-// from other repos reach the store even though the launch path skips exactly that
-// for registry mode — and none of them can be acted on under an empty active
-// scope. Ordered the other way, the first poll replaced this hint with
-// "s opens the selected tab" for anyone who has sessions elsewhere.
-func TestRegistryModeEmptyWorkspaceSurvivesForeignSessionsInTheStore(t *testing.T) {
+// A pane-empty workspace keeps its own message even with no active project.
+// "no panes open" and "no project selected" answer different questions and are
+// not alternatives — collapsing them told a user who had just closed their panes
+// to go pick a project instead of reopening one. Caught in review on this PR.
+func TestPaneEmptyWorkspaceKeepsItsOwnMessageWithoutAProject(t *testing.T) {
 	h := newTestHome(t)
 	h.repoRoot = ""
-	h.store.AddInstance(instanceWithFakeBackend(t, "from-another-repo"))
+	h.store.AddInstance(instanceWithFakeBackend(t, "somewhere"))
 	resizeHome(h, 120, 30)
-	require.Positive(t, h.store.NumInstances(), "precondition: a cross-repo row reached the projection")
+	require.Positive(t, h.store.NumInstances())
+	require.Empty(t, h.visiblePanes, "precondition: sessions exist, no pane is open")
 
 	view := flatten(h.View())
 
-	assert.Contains(t, view, "No project selected",
-		"a session that cannot be acted on must not displace the one hint that unblocks the user")
-	assert.NotContains(t, view, "s opens the selected tab")
+	assert.Contains(t, view, "no panes open", "the pane-empty state owns this message")
+	assert.NotContains(t, view, "No project selected",
+		"#2830 is scoped to the EMPTY rail; it must not reach a workspace that has sessions")
 }
 
 // Inside a repo the ordinary onboarding copy is untouched: `n` works there, so

--- a/app/registry_mode_create_test.go
+++ b/app/registry_mode_create_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 
 	"github.com/stretchr/testify/assert"
@@ -93,60 +94,76 @@ func TestStartNewInstanceWithActiveProjectStillOpensNaming(t *testing.T) {
 // In registry mode newHome lands focus on the Projects section, which is a
 // captive vim-style list that consumes the create verbs on purpose (#1620). So
 // `n` produced no form, no notice, and no repaint — while the workspace beside
-// it read "No sessions yet — press n to create one." The advertised affordance
-// and the live key routing disagreed, and the copy was the half that was wrong.
+// it read "No sessions yet — press n to create one."
 //
-// Asserted on the composed frame, not the renderer: the renderer's own behavior
-// is covered in ui, and what regressed here is which renderer the view picks.
-func TestRegistryModeEmptyWorkspaceDoesNotAdvertiseCreate(t *testing.T) {
-	h := newTestHome(t)
-	h.repoRoot = "" // registry mode: launched outside a repo (#2477)
-	resizeHome(h, 120, 30)
-	// newHome focuses Projects when repoRoot is empty; newTestHome does not
-	// replicate that, and the focus is the whole subject here — which key is live
-	// depends on it. Without this the test measures the tree, where ctrl+p works,
-	// and never reaches the captive section this issue is about.
-	h.focusRegion(layout.RegionProjects)
-	require.True(t, h.projectsFocused(), "precondition: registry mode starts in the captive section")
-	require.Equal(t, 0, h.store.NumInstances(), "precondition: the rail is empty")
+// The table is the point: WHICH key is live depends on the focused region and on
+// whether the section has a row, so a single hardcoded hint is a dead key in one
+// of these states whichever key it names. Two review rounds on this PR were
+// exactly that mistake, twice.
+func TestRegistryModeEmptyWorkspaceNamesOnlyLiveKeys(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		focus      string
+		hasProject bool
+		want       string
+		absent     string
+	}{
+		{
+			// The startup state once a project is registered.
+			name: "projects focused with a row", focus: layout.RegionProjects, hasProject: true,
+			want: "press enter to pick one", absent: "ctrl+p",
+		},
+		{
+			// Enter is a no-op with nothing under the cursor, and ctrl+p is
+			// suppressed here, so the only way forward is out of the section.
+			name: "projects focused with no rows", focus: layout.RegionProjects,
+			want: "press esc, then press ctrl+p to add one", absent: "press enter",
+		},
+		{
+			// From the tree ctrl+p reaches the picker and Enter means something else.
+			name: "tree focused", focus: layout.RegionTree, hasProject: true,
+			want: "press ctrl+p to pick one", absent: "press enter",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			h.repoRoot = "" // registry mode: launched outside a repo (#2477)
+			if tc.hasProject {
+				h.projects.SetProjects([]ui.SidebarProject{{Name: "elsewhere", Root: "/repos/elsewhere"}})
+			}
+			resizeHome(h, 120, 30)
+			h.focusRegion(tc.focus)
+			require.Equal(t, 0, h.store.NumInstances(), "precondition: the rail is empty")
 
-	view := flatten(h.View())
+			view := flatten(h.View())
 
-	assert.NotContains(t, view, "press n to create one",
-		"no focused region in registry mode can honor that promise (#2830)")
-	assert.Contains(t, view, "No project selected",
-		"the empty state must name the actual blocker")
-	assert.Contains(t, view, "press enter to pick one",
-		"registry mode focuses the captive Projects section, where Enter on the cursor row "+
-			"IS the pick — and where ctrl+p is suppressed by name (#1620)")
-	assert.NotContains(t, view, "ctrl+p",
-		"advertising the project-switch key from the one section that swallows it would "+
-			"reproduce #2830 with a different dead key")
+			assert.NotContains(t, view, "press n to create one",
+				"no focused region in registry mode can honor that promise (#2830)")
+			assert.Contains(t, view, "No project selected", "the empty state must name the actual blocker")
+			assert.Contains(t, view, tc.want, "the hint must name a key that is live from here")
+			assert.NotContains(t, view, tc.absent, "and must not name one that is not")
+		})
+	}
 }
 
-// The same copy from a region where ctrl+p actually works must name ctrl+p.
-// Which key is live depends on focus, so a single hardcoded hint is wrong on one
-// of the two screens whichever key it picks.
-func TestRegistryModeEmptyWorkspaceNamesTheKeyThatWorksWhereFocusIs(t *testing.T) {
+// The no-project state outranks the session count. The refresh tick fetches with
+// an empty repoID, which the daemon answers with the cross-repo snapshot, so rows
+// from other repos reach the store even though the launch path skips exactly that
+// for registry mode — and none of them can be acted on under an empty active
+// scope. Ordered the other way, the first poll replaced this hint with
+// "s opens the selected tab" for anyone who has sessions elsewhere.
+func TestRegistryModeEmptyWorkspaceSurvivesForeignSessionsInTheStore(t *testing.T) {
 	h := newTestHome(t)
 	h.repoRoot = ""
+	h.store.AddInstance(instanceWithFakeBackend(t, "from-another-repo"))
 	resizeHome(h, 120, 30)
-	h.focusRegion(layout.RegionTree)
-	require.False(t, h.projectsFocused(), "precondition: the captive section does not hold the keyboard")
+	require.Positive(t, h.store.NumInstances(), "precondition: a cross-repo row reached the projection")
 
 	view := flatten(h.View())
 
-	assert.Contains(t, view, "press ctrl+p to pick one",
-		"from the tree, ctrl+p reaches the project picker and Enter does not")
-	assert.NotContains(t, view, "press enter to pick one")
-}
-
-// The create refusal is reached by pressing `n`, which only arrives from a
-// region that is NOT the captive Projects section — so it names ctrl+p. Pinned
-// because the two surfaces share a helper and must still be allowed to differ.
-func TestNoActiveProjectNoticeNamesTheKeyForItsFocus(t *testing.T) {
-	assert.Contains(t, noActiveProjectNotice(false), "press ctrl+p to pick one")
-	assert.Contains(t, noActiveProjectNotice(true), "press enter to pick one")
+	assert.Contains(t, view, "No project selected",
+		"a session that cannot be acted on must not displace the one hint that unblocks the user")
+	assert.NotContains(t, view, "s opens the selected tab")
 }
 
 // Inside a repo the ordinary onboarding copy is untouched: `n` works there, so
@@ -161,4 +178,13 @@ func TestNonRegistryModeEmptyWorkspaceStillAdvertisesCreate(t *testing.T) {
 
 	assert.Contains(t, view, "No sessions yet — press n to create one.")
 	assert.NotContains(t, view, "No project selected")
+}
+
+// The create refusal is reached by pressing `n`, which cannot arrive from the
+// captive section — so it names ctrl+p. Pinned because the two surfaces share a
+// helper and must still be allowed to name different keys.
+func TestNoActiveProjectNoticeNamesTheKeyForItsFocus(t *testing.T) {
+	assert.Contains(t, noActiveProjectNotice(false, false), "press ctrl+p to pick one")
+	assert.Contains(t, noActiveProjectNotice(true, true), "press enter to pick one")
+	assert.Contains(t, noActiveProjectNotice(false, true), "press esc, then press ctrl+p to add one")
 }

--- a/app/registry_mode_create_test.go
+++ b/app/registry_mode_create_test.go
@@ -102,6 +102,12 @@ func TestRegistryModeEmptyWorkspaceDoesNotAdvertiseCreate(t *testing.T) {
 	h := newTestHome(t)
 	h.repoRoot = "" // registry mode: launched outside a repo (#2477)
 	resizeHome(h, 120, 30)
+	// newHome focuses Projects when repoRoot is empty; newTestHome does not
+	// replicate that, and the focus is the whole subject here — which key is live
+	// depends on it. Without this the test measures the tree, where ctrl+p works,
+	// and never reaches the captive section this issue is about.
+	h.focusRegion(layout.RegionProjects)
+	require.True(t, h.projectsFocused(), "precondition: registry mode starts in the captive section")
 	require.Equal(t, 0, h.store.NumInstances(), "precondition: the rail is empty")
 
 	view := flatten(h.View())

--- a/ui/projects.go
+++ b/ui/projects.go
@@ -185,6 +185,11 @@ func (p *ProjectsPane) HandleMouse(tea.MouseMsg, layout.Point) tea.Cmd { return 
 
 // SelectedProject returns the row under the cursor, or false when the section
 // holds no projects — the row Enter switches to.
+// HasProjects reports whether the section has any row to put a cursor on. With
+// none, Enter is consumed as a no-op (SelectedProject reports false), so nothing
+// may advertise Enter here and nothing should hand the section focus (#2830).
+func (p *ProjectsPane) HasProjects() bool { return len(p.projects) > 0 }
+
 func (p *ProjectsPane) SelectedProject() (SidebarProject, bool) {
 	if len(p.projects) == 0 {
 		return SidebarProject{}, false

--- a/ui/workspace.go
+++ b/ui/workspace.go
@@ -25,6 +25,28 @@ func FirstRunWorkspace(r layout.Rect) string {
 	})
 }
 
+// NoActiveProjectWorkspace renders the zero-session state in registry mode
+// (#2477): af launched outside a repo, with no active project yet.
+//
+// It deliberately does NOT advertise `n`, which FirstRunWorkspace does and this
+// state used to (#2830). In registry mode focus lands on the Projects section,
+// and that section is a captive vim-style list that consumes the create verbs by
+// design (#1620) — so the key did nothing at all, no form and no notice. Reached
+// the long way round, by tabbing to the tree, `n` refuses anyway: a session needs
+// a project to live in (#2764/#2815). The copy was promising an action no focused
+// region could perform.
+//
+// pickHint is supplied by the caller rather than derived here so this line and
+// the refusal notice name the same key in the same words; see the app package's
+// switchProjectPickHint.
+func NoActiveProjectWorkspace(r layout.Rect, pickHint string) string {
+	line := "No project selected"
+	if pickHint != "" {
+		line += " — " + pickHint
+	}
+	return emptyWorkspaceContent(r, []string{line + "."})
+}
+
 func emptyWorkspaceContent(r layout.Rect, lines []string) string {
 	if r.Empty() {
 		return ""

--- a/ui/workspace_test.go
+++ b/ui/workspace_test.go
@@ -27,3 +27,51 @@ func TestFirstRunWorkspacePreservesFrameAtTinySize(t *testing.T) {
 	assert.True(t, strings.HasSuffix(lines[0], "╮"), "top right corner must stay visible")
 	assert.True(t, strings.HasSuffix(lines[len(lines)-1], "╯"), "bottom right corner must stay visible")
 }
+
+// TestNoActiveProjectWorkspaceDoesNotAdvertiseCreate is #2830. Launched outside
+// a repo (registry mode, #2477) af has no active project, focus lands on the
+// Projects section, and that section is a captive list that consumes `n` by
+// design (#1620). Even reached from the tree, `n` refuses: a session needs a
+// project to live in (#2764/#2815). So the zero-session copy advertising `n`
+// was a promise no focused region could keep — the user pressed it and nothing
+// happened at all.
+func TestNoActiveProjectWorkspaceDoesNotAdvertiseCreate(t *testing.T) {
+	lay := layout.Grid{}.Solve(80, 24)
+	out := stripANSI(NoActiveProjectWorkspace(lay.Workspace, "press ctrl+p to pick one"))
+
+	assert.Contains(t, out, "No project selected — press ctrl+p to pick one.",
+		"the empty state must name the one key that moves the user forward")
+	assert.NotContains(t, out, "press n",
+		"advertising create in a mode where no focused region can run it is the bug")
+	assert.NotContains(t, out, "No sessions yet",
+		"the blocker is the missing project, not the missing sessions")
+}
+
+// With no key bound to switch_project the line still has to say something
+// actionable rather than degrade to a bare statement of fact.
+func TestNoActiveProjectWorkspaceWithoutAKeyStillPointsSomewhere(t *testing.T) {
+	lay := layout.Grid{}.Solve(80, 24)
+	out := stripANSI(NoActiveProjectWorkspace(lay.Workspace, "pick one in the Projects section"))
+
+	assert.Contains(t, out, "No project selected — pick one in the Projects section.")
+	assert.NotContains(t, out, "press n")
+}
+
+// The ordinary zero-session state is untouched: inside a repo `n` works, and
+// that is still the right thing to advertise.
+func TestFirstRunWorkspaceStillAdvertisesCreate(t *testing.T) {
+	lay := layout.Grid{}.Solve(80, 24)
+	out := stripANSI(FirstRunWorkspace(lay.Workspace))
+
+	assert.Contains(t, out, "No sessions yet — press n to create one.")
+}
+
+func TestNoActiveProjectWorkspacePreservesFrameAtTinySize(t *testing.T) {
+	lay := layout.Grid{}.Solve(40, 10)
+	out := NoActiveProjectWorkspace(lay.Workspace, "press ctrl+p to pick one")
+
+	requireExactRect(t, out, lay.Workspace, "no-active-project workspace")
+	lines := strings.Split(stripANSI(out), "\n")
+	assert.True(t, strings.HasSuffix(lines[0], "╮"), "top right corner must stay visible")
+	assert.True(t, strings.HasSuffix(lines[len(lines)-1], "╯"), "bottom right corner must stay visible")
+}


### PR DESCRIPTION
## The dead end

Launched outside a git repository — registry mode (#2477) — af has no active
project, `newHome` lands focus on the Projects section, and the workspace read:

```
No sessions yet — press n to create one.
```

Press `n`: **nothing at all.** No form, no notice, no repaint.

The Projects section is a captive vim-style list that consumes the create verbs
by design (#1620) — its doc comment names them as keys deliberately suppressed.
That suppression is correct. The copy was the half that was wrong: it advertised
an affordance the focused region could not honor.

## Which option, and why

Taking **option 1** from the issue, as recommended there.

- **(2) let create fall through from Projects** trades a small copy bug for a
  hole in a considered invariant — a create verb back inside a section that
  deliberately has none.
- **(3) do not focus Projects in registry mode** gives `n` a live route, but only
  to the refusal #2815 added: a session needs a project to live in (#2764), so
  the user still cannot create anything. It also drops the "you are here to pick
  a project" cue #2477 added on purpose.

Registry mode now renders:

```
No project selected — press ctrl+p to pick one.
```

## The part that is not just a string

The hint comes from **one shared helper** with the create refusal
(`switchProjectPickHint`). A user who meets both surfaces must not be told two
different keys, and two independent strings is exactly how that drifts — the
same class as #2579. `noActiveProjectNotice` now reads from it too, so the key
and the wording are single-sourced.

## Scope

Deliberately left: after tabbing to the tree in registry mode the menu row still
shows `n new`. That key now explains itself (#2815), so it is honest if not
ideal — suppressing it needs the menu to learn about `repoRoot`, which is wider
than this issue asked for. Say the word and I will take it separately.

## Tests

In `ui`: the new copy, the no-key-bound fallback, the frame at a tiny size, and
`FirstRunWorkspace` still advertising `n` — the in-repo state this must not
reach. In `app`: which renderer the composed view picks in each mode, asserted on
the frame, plus that the empty state names the *same* hint the refusal does.

## Gate

`gofmt -l .` (empty), `go build ./...`, `golangci-lint run --timeout=3m --fast`,
`deadcode -test ./...` (empty), `scripts/lint-file-length.sh`, and
`go test ./ui/...`. The `app` tests are left to CI — that package spawns real af
daemons and this is the maintainer's live machine.

## Amendments during review

Three rounds, each finding a key or a message that was dead or wrong in a state
the previous round had not considered. Recorded here rather than left in the
history, because the pattern is the point: **which key is live is a function of
(focused region, whether the section has a row)**, and every version that
treated it as one global answer was wrong somewhere.

1. The first cut advertised `ctrl+p` — which `handleProjectsFocus` suppresses by
   name, on the exact screen that shows the copy. It swapped a dead `n` for a
   dead `ctrl+p`.
2. `enter` is a no-op when Projects has no rows (`SelectedProject` reports
   false), so a first-time user with nothing registered still met a dead key.
   Fixed at the source: registry mode now focuses Projects only when it has a
   row to pick, so with none you land on the tree, where `ctrl+p` works and its
   picker offers `enter add`.
3. I briefly re-ordered the empty-state branches so the no-project message
   outranked the session count. That broke `TestPane_OpenHideFlow` on both Linux
   and macOS: a user who closed their panes was told to pick a project instead of
   reopening one. Reverted — "no panes open" and "no project selected" answer
   different questions and are not alternatives.

Round 3 came from a valid finding about registry mode holding cross-repo sessions
it cannot act on. That is real and now filed as **#2864**; it belongs in the
projection — those rows should not be in the store — not in which message the
workspace picks. Fixing it there also fixes the dead `s`/`enter` on those rows,
which no message ordering could.

The tests are now a table over (focus, has-a-row), plus a pin from the other
side: a workspace WITH sessions and no active project keeps "no panes open".

Closes #2830

-- Captain Claude
