### PR TITLE
test(hook): reap the tunnel the test starts, not just the one production spares

### DIFF
--- a/session/backend_hook_reap_test.go
+++ b/session/backend_hook_reap_test.go
@@ -881,6 +881,16 @@ exit 0
 	// runs BEFORE the TempDir removal registered by t.TempDir() above — no writer survives
 	// into os.RemoveAll. launchPgid is populated by provisionOrReap below and read here at
 	// cleanup time.
+	//
+	// This signals, and relies on PID 1 to reap. It cannot wait(2) the tunnel: launch_cmd
+	// backgrounded it and then exited, so the test was never its parent — and it must not
+	// be, because a test-owned server would survive a reap and pass against the very bug
+	// this test exists to catch (see the comment on the script above). Every environment
+	// the suite runs in supplies a reaping init: systemd on dev boxes and CI runners, and
+	// tini in the container harness, which passes --init for exactly this reason
+	// (scripts/testbox.sh). Under a PID 1 that ignores SIGCHLD the killed tunnel would
+	// linger as a defunct entry until that PID 1 exits — no socket, no CPU, and no way
+	// around it from here short of giving the tunnel an owner the test is not allowed to be.
 	t.Cleanup(func() {
 		if p.launchPgid != 0 {
 			_ = syscall.Kill(-p.launchPgid, syscall.SIGKILL)

--- a/session/backend_hook_reap_test.go
+++ b/session/backend_hook_reap_test.go
@@ -868,6 +868,24 @@ exit 0
 	writeHookScript(t, h.delete, fmt.Sprintf(`echo "$name" >> %s/delete-ran.log`, shellsuggest.Arg(dir)))
 
 	p := newHookProvisioner(h, "tunnel holder")
+	// Own the tunnel's lifetime, exactly as TestHookLaunchDoesNotKillBackgroundedChildren
+	// below owns its child's. The production code is right to leave this process alone —
+	// that is the whole claim — but "nothing in the capture path reaps it" is not the same
+	// as "nobody reaps it". Without this the tunnel outlives the test forever: t.TempDir()
+	// removes the directory out from under a python3 that keeps looping and holding a
+	// listening socket, detached, owned by no one (#2842 — 65 of them accumulated on the
+	// dev box, the oldest six days old).
+	//
+	// This cannot weaken the claim: t.Cleanup runs after the test body, so the reachability
+	// assertion has already passed by the time the kill fires. And t.Cleanup is LIFO, so it
+	// runs BEFORE the TempDir removal registered by t.TempDir() above — no writer survives
+	// into os.RemoveAll. launchPgid is populated by provisionOrReap below and read here at
+	// cleanup time.
+	t.Cleanup(func() {
+		if p.launchPgid != 0 {
+			_ = syscall.Kill(-p.launchPgid, syscall.SIGKILL)
+		}
+	})
 	res, err := p.provisionOrReap()
 	require.NoError(t, err, "a launch_cmd that exits 0 with a valid endpoint must succeed")
 	require.NotNil(t, res.Endpoint)


### PR DESCRIPTION
## What

`TestHookProvisionKeepsASuccessfulLaunchsTunnelAlive` leaked one `python3` per run, permanently. 65 had accumulated on the dev box, the oldest six days old; 25 were still alive when I picked this up.

## Why it leaked

The test is *right* that nothing in the capture path may reap the tunnel — that is the claim it exists to make, and the production code correctly leaves it alone. The gap is that **"the capture path does not reap it" is not the same as "somebody reaps it."** `t.TempDir()` removed the directory while a detached `python3` kept looping and holding a listening socket, owned by no one.

## The fix

The mechanism the sibling two functions below already documents: own the child's lifetime with a `t.Cleanup` that kills the launch process group.

```go
t.Cleanup(func() {
    if p.launchPgid != 0 {
        _ = syscall.Kill(-p.launchPgid, syscall.SIGKILL)
    }
})
```

Two ordering properties make this safe, and both are load-bearing:

- `t.Cleanup` runs **after the test body**, so the reachability assertion has already passed before the kill fires — it cannot weaken the claim the test exists to make. The test still passing is itself the proof: had cleanup run first, the `http.Get` would fail.
- `t.Cleanup` is **LIFO**, so it runs *before* the `TempDir` removal registered by `t.TempDir()` above — which is what keeps a live writer out of `os.RemoveAll` (the ENOTEMPTY flake #2548 fixed for the sibling).

## Watched it fail first

On this exact base, master's version versus the fix:

```
unfixed (master)   tunnels before 0 -> after 1     test reports "ok" WHILE leaking
fixed              tunnels before 0 -> after 0
```

A green test that leaks is the whole defect — the suite never had a signal to give. Three consecutive runs of the fixed test hold at zero, and a full `go test ./session/` (46s, all green) leaves no tunnel behind.

## Sibling sweep

Only two other tests in the file spawn a child, and **both already reap**:

- `TestHookLaunchDoesNotKillBackgroundedChildren` — same launch-pgid cleanup, added by #2548
- the stale-pgid test at `:537` — `t.Cleanup(func() { _ = sentinel.Process.Kill() })`

No other backgrounded child in `session/` lacks an owner. Nothing else to fix.

## Box cleanup

The 25 live orphans are reaped. Each was confirmed reparented to init (`ppid=1`) **and** its temp directory already gone, so none could have belonged to a running test. Worth noting my first orphan check was wrong — it tested `/proc/<pid>/cwd`, which is the package directory `go test` ran from, not the temp dir, and reported "0 orphaned" for 25 orphans. The argv path is the one that matters.

## Test plan

- [x] `gofmt -l .` — clean
- [x] `go build ./...` — ok
- [x] `golangci-lint run --timeout=3m --fast` — clean
- [x] `deadcode -test ./...` — clean
- [x] `scripts/lint-file-length.sh` — passed (1177 files)
- [x] `go test ./session/` — green, and leak-free after
- [ ] No containerized suite, per the standing policy; CI runs the matrix

Closes #2842
