### PR TITLE
fix(git): cancel the in-flight hook run before a worktree rebuild restarts it

### DIFF
--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -74,6 +74,9 @@ func (g *GitWorktree) RebuildFromExistingBranch() error {
 		return fmt.Errorf("cannot rebuild worktree %s: branch %s is unavailable: %w", g.worktreePath, g.branchName, err)
 	}
 
+	// Before the checkout is touched, not after: see stopHooks.
+	g.stopHooks()
+
 	branchCreatedByUs := g.branchCreatedByUs
 	if err := g.setupFromExistingBranch(); err != nil {
 		g.branchCreatedByUs = branchCreatedByUs
@@ -81,7 +84,7 @@ func (g *GitWorktree) RebuildFromExistingBranch() error {
 	}
 	g.branchCreatedByUs = branchCreatedByUs
 
-	g.restartHooks()
+	g.startHooks()
 	return nil
 }
 
@@ -108,6 +111,9 @@ func (g *GitWorktree) RebuildFreshFromRecordedBase() error {
 		return fmt.Errorf("cannot fresh rebuild worktree %s: branch %s already exists", g.worktreePath, g.branchName)
 	}
 
+	// Before the remove/add, not after: see stopHooks.
+	g.stopHooks()
+
 	_, _ = g.runGitCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath)
 	_, _ = g.runGitCommand(g.repoPath, "worktree", "prune")
 
@@ -121,38 +127,65 @@ func (g *GitWorktree) RebuildFreshFromRecordedBase() error {
 
 	g.baseCommitSHA = baseCommit
 	g.branchCreatedByUs = true
-	g.restartHooks()
+	g.startHooks()
 	return nil
 }
 
-// restartHooks retires the previous post-worktree hook run before launching one
-// for the rebuilt tree.
+// hookStopTimeout bounds how long a rebuild waits for the previous hook run to
+// actually be gone after cancelling it. Cancellation SIGKILLs the hook's process
+// group, but cmd.Wait can still take up to hookWaitDelay to return when a
+// backgrounded grandchild holds the capture pipe — so this has to exceed that
+// bound to mean anything. It is a bound, not a promise: a rebuild that waited
+// forever would wedge Lost recovery, which is strictly worse than the residual
+// risk of proceeding.
+const hookStopTimeout = 10 * time.Second
+
+// stopHooks retires the previous post-worktree hook run. It MUST be called
+// before the rebuild touches the checkout, and startHooks only after the tree
+// exists again (#2770).
 //
-// A rebuild is the ONLY place a second run can begin on a worktree that already
-// has one, and both halves of this matter (#2770):
+// Recovery reuses the live GitWorktree — respawn calls Rebuild* on
+// i.gitWorktree with no Cleanup() in between — so a hook still running from
+// before the session was Lost is never cancelled by anything else. Starting
+// another one then executes the operator's post_worktree_commands TWICE over the
+// same path. These are provisioning commands (installs, migrations, seeding, a
+// call out to something else), and the duplicate is invisible: hooksDone is
+// overwritten by the new run, so the readiness wait stops tracking the old one.
 //
-//   - Cancelling first. Recovery reuses the live GitWorktree — respawn calls
-//     Rebuild* on i.gitWorktree with no Cleanup() in between — so a hook still
-//     running from before the session was Lost keeps running. Starting another
-//     one then executes the operator's post_worktree_commands TWICE over the same
-//     path. These are provisioning commands (installs, migrations, seeding, a
-//     provisioning call out to something else), and the survivor's relative I/O
-//     fails against the deleted directory while its ABSOLUTE-path work lands in
-//     the tree the rebuild just recreated. It is also invisible: hooksDone is
-//     overwritten by the new run, so the readiness wait stops tracking the old one.
+// The ORDER is the load-bearing part, not just the cancellation. The survivor's
+// relative I/O fails against the deleted directory, but its ABSOLUTE-path work
+// keeps landing wherever it points — so cancelling after the remove/add leaves it
+// writing into the tree the rebuild has already recreated, for however long
+// `worktree add` takes. Cancelling first, and waiting for the run to be gone,
+// is what makes the recreated tree provably untouched by the old run.
 //
-//   - A FRESH context, not the existing one. hooksCancel is permanent — the
-//     cancelled context cannot host the new run, and Cleanup() cancels it too. So
-//     the rebuild would either inherit the cancellation it just issued and start
-//     hooks that return at their first ctx check (a silently unprovisioned tree),
-//     or, after a Cleanup, never provision at all.
-func (g *GitWorktree) restartHooks() {
+// It also installs a FRESH context rather than leaving the cancelled one in
+// place. hooksCancel is permanent, so reusing it would make the new run return
+// at its first context check and leave the tree silently unprovisioned — and
+// Cleanup() cancels the same context, so a rebuild after one would never
+// provision at all.
+func (g *GitWorktree) stopHooks() {
 	if g.hooksCancel != nil {
 		g.hooksCancel()
+	}
+	if g.hooksDone != nil {
+		select {
+		case <-g.hooksDone:
+		case <-time.After(hookStopTimeout):
+			log.WarningLog.Printf("post-worktree hooks for %s did not exit within %s of cancellation; rebuilding anyway",
+				g.worktreePath, hookStopTimeout)
+		}
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	g.hooksCtx = ctx
 	g.hooksCancel = cancel
+}
+
+// startHooks launches the post-worktree hook run for a freshly rebuilt tree, on
+// the context stopHooks installed. Only ever called after a rebuild succeeded:
+// a failed one leaves the previous run's closed channel in place, which readers
+// correctly see as "nothing in flight".
+func (g *GitWorktree) startHooks() {
 	g.hooksDone = RunPostWorktreeHooksAsyncWithEnvironment(g.hooksCtx, g.repoPath, g.worktreePath, g.hookEnvPassthrough)
 }
 

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -81,7 +81,7 @@ func (g *GitWorktree) RebuildFromExistingBranch() error {
 	}
 	g.branchCreatedByUs = branchCreatedByUs
 
-	g.hooksDone = RunPostWorktreeHooksAsyncWithEnvironment(g.hooksCtx, g.repoPath, g.worktreePath, g.hookEnvPassthrough)
+	g.restartHooks()
 	return nil
 }
 
@@ -121,8 +121,39 @@ func (g *GitWorktree) RebuildFreshFromRecordedBase() error {
 
 	g.baseCommitSHA = baseCommit
 	g.branchCreatedByUs = true
-	g.hooksDone = RunPostWorktreeHooksAsyncWithEnvironment(g.hooksCtx, g.repoPath, g.worktreePath, g.hookEnvPassthrough)
+	g.restartHooks()
 	return nil
+}
+
+// restartHooks retires the previous post-worktree hook run before launching one
+// for the rebuilt tree.
+//
+// A rebuild is the ONLY place a second run can begin on a worktree that already
+// has one, and both halves of this matter (#2770):
+//
+//   - Cancelling first. Recovery reuses the live GitWorktree — respawn calls
+//     Rebuild* on i.gitWorktree with no Cleanup() in between — so a hook still
+//     running from before the session was Lost keeps running. Starting another
+//     one then executes the operator's post_worktree_commands TWICE over the same
+//     path. These are provisioning commands (installs, migrations, seeding, a
+//     provisioning call out to something else), and the survivor's relative I/O
+//     fails against the deleted directory while its ABSOLUTE-path work lands in
+//     the tree the rebuild just recreated. It is also invisible: hooksDone is
+//     overwritten by the new run, so the readiness wait stops tracking the old one.
+//
+//   - A FRESH context, not the existing one. hooksCancel is permanent — the
+//     cancelled context cannot host the new run, and Cleanup() cancels it too. So
+//     the rebuild would either inherit the cancellation it just issued and start
+//     hooks that return at their first ctx check (a silently unprovisioned tree),
+//     or, after a Cleanup, never provision at all.
+func (g *GitWorktree) restartHooks() {
+	if g.hooksCancel != nil {
+		g.hooksCancel()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	g.hooksCtx = ctx
+	g.hooksCancel = cancel
+	g.hooksDone = RunPostWorktreeHooksAsyncWithEnvironment(g.hooksCtx, g.repoPath, g.worktreePath, g.hookEnvPassthrough)
 }
 
 func (g *GitWorktree) rebuildBaseCommit() (string, error) {

--- a/session/git/worktree_rebuild_hooks_test.go
+++ b/session/git/worktree_rebuild_hooks_test.go
@@ -1,0 +1,245 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/stretchr/testify/require"
+)
+
+// gatedHookRepo builds a real repo whose single post-worktree hook is a gate: it
+// records that it started, blocks until the test releases it, and only then
+// records that it FINISHED. The completion marker is what a duplicate run is
+// counted by — it is the operator's side effect actually happening, not merely a
+// process existing.
+//
+// The markers are written to ABSOLUTE paths outside the worktree on purpose. A
+// hook that outlives its worktree keeps running with its cwd on a deleted
+// directory, so relative I/O would fail with ENOENT and hide the very thing this
+// measures; absolute-path work is exactly the half that still lands (#2770).
+func gatedHookRepo(t *testing.T) (repoRoot, startedDir, releaseFile, doneDir string) {
+	t.Helper()
+	sandboxHome(t)
+	repoRoot = createGitRepo(t)
+
+	markers := t.TempDir()
+	startedDir = filepath.Join(markers, "started")
+	doneDir = filepath.Join(markers, "done")
+	releaseFile = filepath.Join(markers, "release")
+	require.NoError(t, os.MkdirAll(startedDir, 0o755))
+	require.NoError(t, os.MkdirAll(doneDir, 0o755))
+
+	// $$ is the hook shell's pid, so concurrent runs cannot overwrite each
+	// other's markers — two runs leave two files, which is the whole point.
+	hook := "touch " + startedDir + "/$$; " +
+		"while [ ! -f " + releaseFile + " ]; do sleep 0.05; done; " +
+		"touch " + doneDir + "/$$"
+
+	repoID := config.RepoIDFromRoot(repoRoot)
+	require.NoError(t, config.SaveRepoConfig(repoID, &config.RepoConfig{
+		PostWorktreeCommands: []string{hook},
+	}))
+
+	cfg := config.DefaultConfig()
+	cfg.BranchPrefix = "test/"
+	require.NoError(t, config.SaveConfig(cfg))
+	return repoRoot, startedDir, releaseFile, doneDir
+}
+
+func commitInitial(t *testing.T, repoRoot string) {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repoRoot, "commit", "--allow-empty", "-m", "initial")
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+}
+
+func countMarkers(t *testing.T, dir string) int {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	return len(entries)
+}
+
+// waitForMarkers polls until dir holds at least n entries, and reports whether
+// it got there. Used in both directions: to wait for a hook to really be in
+// flight, and to give a duplicate every chance to appear before ruling it out.
+func waitForMarkers(t *testing.T, dir string, n int, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if countMarkers(t, dir) >= n {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+func closed(ch <-chan struct{}, timeout time.Duration) bool {
+	if ch == nil {
+		return false
+	}
+	select {
+	case <-ch:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+// A rebuild must not leave the previous hook run executing (#2770).
+//
+// Recovery reuses the live GitWorktree: respawn calls RebuildFromExistingBranch
+// on i.gitWorktree with no Cleanup() in between. So a hook still running from
+// before the session was Lost was never cancelled, and the rebuild started a
+// second one over the same path — the operator's post_worktree_commands running
+// TWICE. These are provisioning commands, and the duplicate is invisible:
+// hooksDone is overwritten by the new run, so nothing is tracking the old one.
+//
+// The gate holds both runs open at once so the overlap is a fact rather than a
+// race: with the bug BOTH complete when released.
+func TestRebuildFromExistingBranch_CancelsTheHookRunAlreadyInFlight(t *testing.T) {
+	repoRoot, startedDir, releaseFile, doneDir := gatedHookRepo(t)
+	commitInitial(t, repoRoot)
+
+	gw, _, err := NewGitWorktree(repoRoot, "rebuild-hooks")
+	require.NoError(t, err)
+	require.NoError(t, gw.Setup())
+
+	first := gw.HooksDone()
+	require.NotNil(t, first, "Setup launched no hook run, so there is nothing to duplicate")
+	require.True(t, waitForMarkers(t, startedDir, 1, 10*time.Second),
+		"the first hook never started; the test would prove nothing")
+
+	// The session's worktree vanishes underneath it — the Lost-recovery trigger.
+	require.NoError(t, os.RemoveAll(gw.GetWorktreePath()))
+
+	require.NoError(t, gw.RebuildFromExistingBranch())
+	second := gw.HooksDone()
+	require.NotNil(t, second)
+	require.False(t, first == second, "the rebuild reused the previous run's completion channel")
+
+	// The rebuild must have retired the in-flight run. Its channel closes on
+	// cancellation, so this is the direct question: is the old run still going?
+	require.True(t, closed(first, 10*time.Second),
+		"the hook run from before the rebuild is STILL RUNNING: the rebuild started a second one "+
+			"without cancelling it, so the operator's post_worktree_commands execute twice over this path")
+
+	// Release the gate and let the surviving run finish.
+	require.NoError(t, os.WriteFile(releaseFile, []byte("go"), 0o644))
+	require.True(t, closed(second, 20*time.Second), "the rebuilt worktree's hook run never finished")
+
+	// Give a duplicate every chance to show up before ruling it out: the killed
+	// run would race to its own completion marker the moment the gate opened.
+	if waitForMarkers(t, doneDir, 2, 2*time.Second) {
+		t.Fatalf("post-worktree hooks COMPLETED %d times for one worktree, want 1: the run that was "+
+			"in flight when the worktree vanished was never cancelled, so its side effects landed a "+
+			"second time in the tree the rebuild had just recreated", countMarkers(t, doneDir))
+	}
+	require.Equal(t, 1, countMarkers(t, doneDir), "the rebuilt worktree was left unprovisioned")
+
+	// The fresh context must be live, not the one just cancelled — otherwise the
+	// rebuild "fixes" the duplicate by never provisioning at all.
+	require.Equal(t, 2, countMarkers(t, startedDir),
+		"the rebuild's own hook run never started; it inherited the cancellation it had just issued")
+}
+
+// The same obligation on the fresh-rebuild arm, which recovery falls back to
+// when the recorded branch is gone too. It is a separate function with its own
+// copy of the launch, so a fix applied to only one of them leaves this open.
+func TestRebuildFreshFromRecordedBase_CancelsTheHookRunAlreadyInFlight(t *testing.T) {
+	repoRoot, startedDir, releaseFile, doneDir := gatedHookRepo(t)
+	commitInitial(t, repoRoot)
+
+	gw, branchName, err := NewGitWorktree(repoRoot, "fresh-rebuild-hooks")
+	require.NoError(t, err)
+	require.NoError(t, gw.Setup())
+
+	first := gw.HooksDone()
+	require.NotNil(t, first)
+	require.True(t, waitForMarkers(t, startedDir, 1, 10*time.Second), "the first hook never started")
+
+	// Both the directory and the branch are gone: the fresh-rebuild precondition.
+	require.NoError(t, os.RemoveAll(gw.GetWorktreePath()))
+	out, err := exec.Command("git", "-C", repoRoot, "worktree", "prune").CombinedOutput()
+	require.NoError(t, err, string(out))
+	out, err = exec.Command("git", "-C", repoRoot, "branch", "-D", branchName).CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	require.NoError(t, gw.RebuildFreshFromRecordedBase())
+
+	require.True(t, closed(first, 10*time.Second),
+		"the hook run from before the fresh rebuild is STILL RUNNING: the operator's "+
+			"post_worktree_commands execute twice over this path")
+
+	require.NoError(t, os.WriteFile(releaseFile, []byte("go"), 0o644))
+	require.True(t, closed(gw.HooksDone(), 20*time.Second), "the rebuilt worktree's hook run never finished")
+
+	if waitForMarkers(t, doneDir, 2, 2*time.Second) {
+		t.Fatalf("post-worktree hooks COMPLETED %d times for one worktree, want 1", countMarkers(t, doneDir))
+	}
+	require.Equal(t, 2, countMarkers(t, startedDir),
+		"the fresh rebuild's own hook run never started; it inherited the cancellation it had just issued")
+}
+
+// A rebuild after Cleanup must still provision. Cleanup cancels hooksCtx
+// permanently, so a rebuild that reused it would start hooks that return at
+// their first context check and silently leave the tree unprovisioned — the
+// failure the fresh context in restartHooks exists to prevent. Left un-gated so
+// the hook can complete on its own.
+func TestRebuildAfterCleanup_StillRunsHooks(t *testing.T) {
+	sandboxHome(t)
+	repoRoot := createGitRepo(t)
+	commitInitial(t, repoRoot)
+
+	doneDir := filepath.Join(t.TempDir(), "done")
+	require.NoError(t, os.MkdirAll(doneDir, 0o755))
+	repoID := config.RepoIDFromRoot(repoRoot)
+	require.NoError(t, config.SaveRepoConfig(repoID, &config.RepoConfig{
+		PostWorktreeCommands: []string{"touch " + doneDir + "/$$"},
+	}))
+	cfg := config.DefaultConfig()
+	cfg.BranchPrefix = "test/"
+	require.NoError(t, config.SaveConfig(cfg))
+
+	gw, _, err := NewGitWorktree(repoRoot, "cleanup-then-rebuild")
+	require.NoError(t, err)
+	require.NoError(t, gw.Setup())
+	require.True(t, closed(gw.HooksDone(), 20*time.Second), "the initial hook run never finished")
+
+	state, err := gw.Cleanup()
+	require.NoError(t, err)
+	require.Equal(t, CleanupSettled, state)
+
+	require.NoError(t, gw.RebuildFreshFromRecordedBase())
+	require.True(t, closed(gw.HooksDone(), 20*time.Second), "the rebuilt worktree's hook run never finished")
+	require.True(t, waitForMarkers(t, doneDir, 2, 10*time.Second),
+		"the rebuild ran no hooks: it inherited the context Cleanup had already cancelled, so the "+
+			"recovered worktree is silently unprovisioned")
+}
+
+// Sanity: a worktree whose hooks are still in flight reports them, so the
+// markers above cannot be explained by hooks that never ran at all.
+func TestSetupLaunchesHooksBeforeTheyFinish(t *testing.T) {
+	repoRoot, startedDir, releaseFile, _ := gatedHookRepo(t)
+	commitInitial(t, repoRoot)
+
+	gw, _, err := NewGitWorktree(repoRoot, "in-flight")
+	require.NoError(t, err)
+	require.NoError(t, gw.Setup())
+	t.Cleanup(func() { _ = os.WriteFile(releaseFile, []byte("go"), 0o644) })
+
+	require.True(t, waitForMarkers(t, startedDir, 1, 10*time.Second))
+	require.False(t, closed(gw.HooksDone(), 200*time.Millisecond),
+		"a gated hook reported done while still blocked; the gate is not holding")
+	require.False(t, strings.Contains(gw.GetWorktreePath(), " "), "unexpected path shape")
+}

--- a/session/git/worktree_rebuild_hooks_test.go
+++ b/session/git/worktree_rebuild_hooks_test.go
@@ -243,3 +243,79 @@ func TestSetupLaunchesHooksBeforeTheyFinish(t *testing.T) {
 		"a gated hook reported done while still blocked; the gate is not holding")
 	require.False(t, strings.Contains(gw.GetWorktreePath(), " "), "unexpected path shape")
 }
+
+// The recreated tree must be untouched by the run that preceded it (#2770,
+// post-review finding on the first fix).
+//
+// Cancelling is not enough on its own if it happens AFTER the rebuild: the
+// survivor's relative I/O fails against the deleted directory, but its
+// ABSOLUTE-path work keeps landing wherever it points, so a hook cancelled after
+// `worktree add` has already written provisioning output into the tree the
+// rebuild just created. The window is however long the git surgery takes.
+//
+// The hook here writes its pid into the worktree by absolute path, continuously,
+// exactly as a provisioning command's output would land. The rebuilt tree must
+// carry the NEW run's pid and only that.
+func TestRebuildFromExistingBranch_RecreatedTreeIsUntouchedByThePriorRun(t *testing.T) {
+	sandboxHome(t)
+	repoRoot := createGitRepo(t)
+	commitInitial(t, repoRoot)
+
+	// $$ is the hook shell's pid; the worktree path is resolved by the hook at
+	// run time via $PWD's absolute value captured before any deletion.
+	repoID := config.RepoIDFromRoot(repoRoot)
+	require.NoError(t, config.SaveRepoConfig(repoID, &config.RepoConfig{
+		PostWorktreeCommands: []string{
+			`d="$PWD"; while true; do echo "$$" >> "$d/hook-touched"; sleep 0.01; done`,
+		},
+	}))
+	cfg := config.DefaultConfig()
+	cfg.BranchPrefix = "test/"
+	require.NoError(t, config.SaveConfig(cfg))
+
+	gw, _, err := NewGitWorktree(repoRoot, "tree-untouched")
+	require.NoError(t, err)
+	require.NoError(t, gw.Setup())
+	t.Cleanup(func() { _, _ = gw.Cleanup() })
+
+	worktreePath := gw.GetWorktreePath()
+	touched := filepath.Join(worktreePath, "hook-touched")
+	require.True(t, waitForFile(t, touched, 10*time.Second), "the first hook never wrote into the worktree")
+	oldPID := strings.TrimSpace(strings.Split(strings.TrimSpace(readFile(t, touched)), "\n")[0])
+	require.NotEmpty(t, oldPID)
+
+	// The worktree vanishes — the Lost-recovery trigger. The old hook keeps
+	// running, still pointed at this absolute path.
+	require.NoError(t, os.RemoveAll(worktreePath))
+
+	require.NoError(t, gw.RebuildFromExistingBranch())
+	require.True(t, waitForFile(t, touched, 10*time.Second), "the rebuilt worktree's hook never ran")
+
+	// Let the new run write for a while, then check WHOSE pids are in the tree.
+	time.Sleep(500 * time.Millisecond)
+	for _, line := range strings.Split(strings.TrimSpace(readFile(t, touched)), "\n") {
+		require.NotEqual(t, oldPID, strings.TrimSpace(line),
+			"the hook run from before the rebuild wrote into the RECREATED worktree: it was still "+
+				"alive while the tree was being rebuilt, so the operator's provisioning output landed "+
+				"in the new checkout on top of the run that owns it")
+	}
+}
+
+func waitForFile(t *testing.T, path string, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if data, err := os.ReadFile(path); err == nil && len(strings.TrimSpace(string(data))) > 0 {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(data)
+}


### PR DESCRIPTION
## The bug

Lost-session recovery reuses the **live** `GitWorktree`: `respawn` calls `Rebuild*` on
`i.gitWorktree` with no `Cleanup()` in between (`session/backend_local.go:563,573`). Both rebuild
arms then launched a new hook run on the **same** `hooksCtx` without cancelling the previous one:

```go
g.hooksDone = RunPostWorktreeHooksAsyncWithEnvironment(g.hooksCtx, ...)  // no g.hooksCancel()
```

So a hook still running from before the session was Lost kept running while a second one started
over the same path — the operator's `post_worktree_commands` **executing twice**.

This is a user side effect running twice, not merely a leaked process. Those commands are
provisioning: installs, migrations, seeding, a call out to something else. The survivor's
*relative* I/O fails against the deleted directory, but its **absolute-path** work lands in the
tree the rebuild just recreated. And it is invisible — `hooksDone` is overwritten by the new run,
so the readiness wait stops tracking the old one and nothing ever reports it.

The restore loop is backoff-throttled but retried, so each tick that still finds the worktree
missing is another opportunity to stack a run.

## The fix

Both arms go through `stopHooks` — cancel, wait bounded for the run to actually be gone, install a
**fresh** context — called BEFORE any git surgery, and `startHooks` called only after the tree
exists again.

The **order** is load-bearing, not just the cancellation (Codex caught this on the first revision).
Cancelling after the remove/add leaves the old run alive for the whole rebuild window, and while
its relative I/O fails against the deleted directory, its absolute-path provisioning output keeps
landing wherever it points — which by then is the tree the rebuild has already recreated.

The bounded wait matters too: cancellation SIGKILLs the hook's process group, but `cmd.Wait` can
take up to `hookWaitDelay` to return when a backgrounded grandchild holds the capture pipe, so
"cancelled" is not yet "gone". The bound is 10s and it proceeds on expiry — a rebuild that waited
forever would wedge Lost recovery, which is worse than the residual.

The fresh context is load-bearing, not tidiness. `hooksCancel` is permanent, so keeping the same
context would make the rebuild inherit the cancellation it had just issued — the new hooks would
return at their first `ctx.Done()` check and the recovered worktree would be silently
unprovisioned. `Cleanup()` cancels the same context too, so a rebuild after one would never
provision either. That failure is covered by its own test rather than left implied.

`Setup` is deliberately untouched: it runs once, on a worktree that has no prior run.

## Verification

Reproduced before fixing. The hook is a **gate** — it records that it started, blocks until the
test releases it, then records that it FINISHED — so both runs are held open simultaneously and
the overlap is a fact rather than a race. Completions are counted, not processes: that is the
operator's side effect actually happening. Markers are written to absolute paths outside the
worktree on purpose, because a hook that outlives its worktree would fail relative I/O with ENOENT
and hide the very thing being measured.

On the unfixed code:

```
post-worktree hooks COMPLETED 2 times for one worktree, want 1: the run that was in flight when
the worktree vanished was never cancelled, so its side effects landed a second time in the tree
the rebuild had just recreated

the hook run from before the rebuild is STILL RUNNING: the rebuild started a second one without
cancelling it, so the operator's post_worktree_commands execute twice over this path

the rebuild ran no hooks: it inherited the context Cleanup had already cancelled, so the
recovered worktree is silently unprovisioned
```

Five tests: the two rebuild arms (separate functions with separate launches, so a fix applied to
only one leaves the other open), the after-`Cleanup` case, and a sanity test proving the gate
actually holds a run open — without it, "no duplicate" could be explained by hooks that never ran.
Each duplicate check also asserts the *surviving* run completed and that the rebuild's own run
started, so the guard cannot pass by simply never provisioning.

The fifth pins the ordering, and models the harm rather than the mechanism: the hook writes its pid
into the worktree by absolute path continuously, as provisioning output would, and the rebuilt tree
must carry only the new run's pid. With the cancel moved back after the surgery it fails 3/3 with
`the hook run from before the rebuild wrote into the RECREATED worktree`.

Gate on the pushed head `30342be8`: `gofmt -l .` (empty), `go build ./...`,
`golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh`,
and `go test ./session/git/` (whole package, 23.8s) — a non-daemon package, so it runs locally.
The daemon suite is left to CI per the host policy.

Closes #2770

🤖 Generated with [Claude Code](https://claude.com/claude-code)