### PR TITLE
fix(reap): stop reporting a requested teardown's own processes as leaks (#2765)

### DIFF
--- a/internal/proctree/proctree.go
+++ b/internal/proctree/proctree.go
@@ -282,14 +282,40 @@ func WaitForExits(procs []Process, timeout time.Duration) []Process {
 	}
 }
 
+// ReapOutcome classifies what KillEscalating had to do to one process, and it
+// exists so the CALLER can choose the severity of the line (#2765).
+//
+// KillEscalating is handed a list of processes and told to escalate. It cannot
+// know WHY they are on that list — whether they escaped something that was
+// supposed to contain them, or are simply being destroyed along with the session
+// someone asked it to tear down. That difference is the difference between a
+// finding and a routine step, and the messages below used to answer it anyway by
+// calling every process "leaked". They no longer classify: they report the
+// action, the caller supplies the cause, and severity is the two combined.
+type ReapOutcome int
+
+const (
+	// ReapSignalled: the process was still alive when the grace period ended and
+	// was sent SIGTERM. Routine on a teardown someone asked for; a finding when
+	// the process was supposed to be contained by something it outlived.
+	ReapSignalled ReapOutcome = iota
+	// ReapNeededKill: the process ignored SIGTERM and had to be SIGKILLed.
+	ReapNeededKill
+	// ReapUnkillable: the process survived SIGKILL, or a signal failed for a
+	// reason other than it having already gone away. Abnormal under every
+	// teardown reason there is — an uninterruptible sleep, a wedged mount, a
+	// permission the reaper does not have.
+	ReapUnkillable
+)
+
 // KillEscalating gives procs the grace period to exit on their own, SIGTERMs
 // survivors, waits termWait, SIGKILLs what remains, and returns anything
 // still alive after a final bounded wait (should be empty). Every signal is
 // identity-verified (see Signal) and reported through logf, one line per
-// process. logf may be nil.
-func KillEscalating(procs []Process, grace, termWait time.Duration, logf func(format string, args ...any)) []Process {
+// process, with the ReapOutcome the caller maps to a severity. logf may be nil.
+func KillEscalating(procs []Process, grace, termWait time.Duration, logf func(ReapOutcome, string, ...any)) []Process {
 	if logf == nil {
-		logf = func(string, ...any) {}
+		logf = func(ReapOutcome, string, ...any) {}
 	}
 	survivors := WaitForExits(procs, grace)
 	if len(survivors) == 0 {
@@ -299,9 +325,9 @@ func KillEscalating(procs []Process, grace, termWait time.Duration, logf func(fo
 		err := Signal(p, syscall.SIGTERM)
 		switch {
 		case err == nil:
-			logf("reaping leaked process %d (%s) with SIGTERM: %s", p.PID, p.Comm, Cmdline(p.PID))
+			logf(ReapSignalled, "process %d (%s) was still alive after the grace period; sent SIGTERM: %s", p.PID, p.Comm, Cmdline(p.PID))
 		case !errors.Is(err, ErrIdentityChanged):
-			logf("failed to SIGTERM leaked process %d (%s): %v", p.PID, p.Comm, err)
+			logf(ReapUnkillable, "failed to SIGTERM surviving process %d (%s): %v", p.PID, p.Comm, err)
 		}
 	}
 	survivors = WaitForExits(survivors, termWait)
@@ -309,14 +335,14 @@ func KillEscalating(procs []Process, grace, termWait time.Duration, logf func(fo
 		err := Signal(p, syscall.SIGKILL)
 		switch {
 		case err == nil:
-			logf("leaked process %d (%s) ignored SIGTERM; sent SIGKILL", p.PID, p.Comm)
+			logf(ReapNeededKill, "process %d (%s) ignored SIGTERM; sent SIGKILL", p.PID, p.Comm)
 		case !errors.Is(err, ErrIdentityChanged):
-			logf("failed to SIGKILL leaked process %d (%s): %v", p.PID, p.Comm, err)
+			logf(ReapUnkillable, "failed to SIGKILL surviving process %d (%s): %v", p.PID, p.Comm, err)
 		}
 	}
 	remaining := WaitForExits(survivors, time.Second)
 	for _, p := range remaining {
-		logf("leaked process %d (%s) survived SIGKILL", p.PID, p.Comm)
+		logf(ReapUnkillable, "process %d (%s) survived SIGKILL", p.PID, p.Comm)
 	}
 	return remaining
 }

--- a/internal/proctree/proctree_test.go
+++ b/internal/proctree/proctree_test.go
@@ -227,7 +227,7 @@ func TestKillEscalatingNoWarnOnTOCTOUExit(t *testing.T) {
 	kill = func(pid int, sig syscall.Signal) error { return syscall.ESRCH }
 
 	var logged []string
-	logf := func(format string, args ...any) {
+	logf := func(_ ReapOutcome, format string, args ...any) {
 		logged = append(logged, fmt.Sprintf(format, args...))
 	}
 	// Zero grace so the alive child is treated as a survivor immediately,

--- a/internal/proctree/zombie_test.go
+++ b/internal/proctree/zombie_test.go
@@ -138,7 +138,7 @@ func TestKillEscalatingNoWarnOnZombie(t *testing.T) {
 	p := startZombie(t)
 
 	var lines []string
-	logf := func(format string, args ...any) {
+	logf := func(_ ReapOutcome, format string, args ...any) {
 		lines = append(lines, format)
 	}
 	start := time.Now()

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -668,11 +668,17 @@ func reapWorktreeWriters(worktreePath string) {
 	if len(procs) == 0 {
 		return
 	}
-	proctree.KillEscalating(procs, worktreeReapGrace, worktreeReapTermWait, func(format string, args ...any) {
+	proctree.KillEscalating(procs, worktreeReapGrace, worktreeReapTermWait, func(_ proctree.ReapOutcome, format string, args ...any) {
+		// Every tier stays a WARNING here, and the outcome is deliberately unused
+		// (#2765). This reaper does not run on the requested-teardown side of that
+		// split: it fires only when a process is STILL WRITING into a worktree
+		// after the agent and its tmux session were already torn down, which is the
+		// definition of having escaped its pane tree. There is no routine case.
+		//
 		// worktreePath is a runtime value that may legally contain `%`, so it MUST
 		// be a `%s` ARGUMENT, never spliced into the format string (the #1211 rule
 		// the tmux reaper follows). `format` is KillEscalating's own constant literal.
-		log.WarningLog.Printf("worktree %s: "+format, append([]any{worktreePath}, args...)...)
+		log.WarningLog.Printf("worktree %s: leaked past its session: "+format, append([]any{worktreePath}, args...)...)
 	})
 }
 

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -340,7 +340,9 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 		wg.Add(1)
 		go func(match string, leaked []proctree.Process) {
 			defer wg.Done()
-			reapLeakedProcesses(match, leaked, reapGraceWait, reapTermWait)
+			// These sessions were just killed BY this sweep, on request: their
+			// processes are being destroyed with them, not caught escaping (#2765).
+			reapSessionProcesses(reapOnRequest, match, leaked, reapGraceWait, reapTermWait)
 		}(match, leaked)
 	}
 	wg.Wait()
@@ -360,7 +362,10 @@ func reapVanishedSessionProcesses(match, ownHome string, candidates []proctree.P
 		sweepErr = errors.Join(sweepErr, refreshErr)
 		marked, inspectErr := markedOrphanProcesses(refreshed, match, ownHome)
 		sweepErr = errors.Join(sweepErr, inspectErr)
-		remaining := reapLeakedProcesses(match, marked, reapGraceWait, reapTermWait)
+		// The tmux session is GONE and these processes are still alive carrying its
+		// ownership markers: they outlived the pane tree that was supposed to
+		// contain them. This is the real leak, and the one worth a WARNING (#2765).
+		remaining := reapSessionProcesses(reapEscaped, match, marked, reapGraceWait, reapTermWait)
 		if len(remaining) > 0 {
 			pids := make([]string, 0, len(remaining))
 			for _, process := range remaining {

--- a/session/tmux/close.go
+++ b/session/tmux/close.go
@@ -172,10 +172,14 @@ func (t *TmuxSession) close(waitForProcesses bool) (PaneState, error, closeProce
 	// always gets to finish. CLI kills run daemon-side (KillSession RPC).
 	processes := closeProcessOutcome{captureErr: captureErr}
 	if len(leaked) > 0 {
+		// Close IS the requested teardown (#2765): a caller asked for this session
+		// to die, so every process in its pane tree dying with it is the operation
+		// succeeding, not a leak — most visibly the `af sessions archive --self`
+		// caller, which lives in this very tree and is blocked on this very call.
 		if waitForProcesses {
-			processes.remaining = reapLeakedProcesses(t.sanitizedName, leaked, reapGraceWait, reapTermWait)
+			processes.remaining = reapSessionProcesses(reapOnRequest, t.sanitizedName, leaked, reapGraceWait, reapTermWait)
 		} else {
-			go reapLeakedProcesses(t.sanitizedName, leaked, reapGraceWait, reapTermWait)
+			go reapSessionProcesses(reapOnRequest, t.sanitizedName, leaked, reapGraceWait, reapTermWait)
 		}
 	}
 

--- a/session/tmux/reap.go
+++ b/session/tmux/reap.go
@@ -40,8 +40,11 @@ import (
 // never returned as errors.
 
 var (
-	// reapGraceWait is how long leaked processes get to exit on their own
-	// after kill-session (SIGHUP) before being SIGTERMed. Matches
+	// reapGraceWait is how long a captured process gets to exit on its own
+	// after kill-session (SIGHUP) before being SIGTERMed. "Captured", not
+	// "leaked": most of them are a requested teardown's own pane tree going down
+	// with the session, and only the vanished-session sweep is looking at
+	// processes that escaped one (#2765). Matches
 	// paneExitWait's reasoning: long enough for an agent to flush state,
 	// short enough to bound the sweep. var, not const, so tests can lower it.
 	reapGraceWait = 3 * time.Second
@@ -317,18 +320,75 @@ func selfAndAncestorProcesses(snap map[int]proctree.Process) map[int]bool {
 	return ancestors
 }
 
-// reapLeakedProcesses waits for the captured processes to exit after
+// reapReason says WHY a captured process tree is being reaped. It is the
+// caller's answer and never proctree's: KillEscalating is handed a list and
+// cannot know whether those processes escaped anything (#2765).
+//
+// The distinction is not cosmetic. Every reap used to report every process as
+// "leaked", and the single most reliable way to produce that line was to use the
+// feature exactly as designed — `af sessions archive --self`. A session that
+// archives itself makes the request from INSIDE the pane tree it is asking to
+// tear down, and it is blocked on the very RPC doing the tearing, so it cannot
+// exit within the grace period and is guaranteed to be SIGTERMed. Reaping it is
+// not a leak; it is what "archive this session" MEANS. An operator grepping the
+// log for leaks found their own supported gesture, which is exactly the noise
+// that teaches people to stop reading the log.
+type reapReason struct {
+	// clause names the cause in the log line, so the reader is told which of the
+	// two situations they are looking at rather than left to infer it.
+	clause string
+	// expected is true when a process still alive at SIGTERM time is a normal
+	// consequence of this teardown rather than a finding about it.
+	expected bool
+}
+
+var (
+	// reapOnRequest: someone asked for this session to be destroyed — a kill, an
+	// archive, `af reset`, or the cleanup of a session that failed to start.
+	// Everything in the pane tree is SUPPOSED to die, including the caller that
+	// asked. Only the escalation tiers beyond a plain SIGTERM stay warnable here:
+	// a process ignoring SIGTERM or surviving SIGKILL is abnormal no matter who
+	// asked for the teardown.
+	reapOnRequest = reapReason{clause: "tearing down on request", expected: true}
+	// reapEscaped: the tmux session is already GONE and these processes are still
+	// alive carrying its ownership markers. They outlived the pane tree that was
+	// supposed to contain them — the leak this reaper was built for (#1104), and
+	// the case the WARNING is worth reading.
+	reapEscaped = reapReason{clause: "leaked past its pane tree", expected: false}
+)
+
+// reapSessionProcesses waits for the captured processes to exit after
 // kill-session, then escalates SIGTERM → SIGKILL on survivors (identity
 // verified — see proctree.KillEscalating). Runs synchronously; teardown
 // paths that must stay snappy call it in a goroutine. Every signal is logged
-// per-process.
-func reapLeakedProcesses(sanitizedName string, procs []proctree.Process, grace, termWait time.Duration) []proctree.Process {
-	return proctree.KillEscalating(procs, grace, termWait, func(format string, args ...any) {
-		// sanitizedName is a runtime value that deliberately preserves `%` (see
-		// tmux name sanitization), so it must be a `%s` ARGUMENT — never spliced
-		// into the format string, where its `%` sequences would be interpreted
-		// and corrupt the log (#1211). `format` itself is a constant literal
-		// supplied by KillEscalating, so concatenating it is safe.
-		log.WarningLog.Printf("tmux %s: "+format, append([]any{sanitizedName}, args...)...)
+// per-process, at the severity the reason and the outcome agree on.
+func reapSessionProcesses(reason reapReason, sanitizedName string, procs []proctree.Process, grace, termWait time.Duration) []proctree.Process {
+	return proctree.KillEscalating(procs, grace, termWait, func(outcome proctree.ReapOutcome, format string, args ...any) {
+		logReapOutcome(reason, sanitizedName, outcome, format, args...)
 	})
+}
+
+// logReapOutcome writes one per-process reap line at the severity the reason and
+// the outcome agree on. Split out of the closure above so the mapping is one
+// named thing a test can drive through every tier — including the ones an
+// end-to-end teardown cannot force on demand (a process that ignores SIGTERM,
+// one that survives SIGKILL).
+//
+// Only a plain SIGTERM on a requested teardown is routine. The escalation tiers
+// stay warnable under every reason: a process ignoring SIGTERM or surviving
+// SIGKILL is abnormal regardless of who asked for the teardown, and folding
+// those into the downgrade would trade one kind of unreadable log for another.
+func logReapOutcome(reason reapReason, sanitizedName string, outcome proctree.ReapOutcome, format string, args ...any) {
+	logger := log.WarningLog
+	if reason.expected && outcome == proctree.ReapSignalled {
+		logger = log.InfoLog
+	}
+	// sanitizedName is a runtime value that deliberately preserves `%` (see tmux
+	// name sanitization), so it must be a `%s` ARGUMENT — never spliced into the
+	// format string, where its `%` sequences would be interpreted and corrupt the
+	// log (#1211). The clause goes through the same door: it is a constant today,
+	// and passing it as an argument is what keeps that from becoming load-bearing.
+	// `format` itself is a constant literal supplied by KillEscalating, so
+	// concatenating it is safe.
+	logger.Printf("tmux %s: %s: "+format, append([]any{sanitizedName, reason.clause}, args...)...)
 }

--- a/session/tmux/reap_severity_test.go
+++ b/session/tmux/reap_severity_test.go
@@ -1,0 +1,149 @@
+package tmux
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/internal/proctree"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// captureReapLogs redirects the WARNING and INFO loggers into buffers for the
+// duration of the test and returns readers for both. Severity is the whole
+// subject here, so a test that read only one of them could not tell a line that
+// moved from one that vanished.
+func captureReapLogs(t *testing.T) (warnings, infos func() string) {
+	t.Helper()
+	var warnBuf, infoBuf bytes.Buffer
+	oldWarnOut, oldWarnFlags := log.WarningLog.Writer(), log.WarningLog.Flags()
+	oldInfoOut, oldInfoFlags := log.InfoLog.Writer(), log.InfoLog.Flags()
+	log.WarningLog.SetOutput(&warnBuf)
+	log.WarningLog.SetFlags(0)
+	log.InfoLog.SetOutput(&infoBuf)
+	log.InfoLog.SetFlags(0)
+	t.Cleanup(func() {
+		log.WarningLog.SetOutput(oldWarnOut)
+		log.WarningLog.SetFlags(oldWarnFlags)
+		log.InfoLog.SetOutput(oldInfoOut)
+		log.InfoLog.SetFlags(oldInfoFlags)
+	})
+	return warnBuf.String, infoBuf.String
+}
+
+// TestCloseDoesNotReportRequestedTeardownAsALeak is the regression test for
+// #2765.
+//
+// Close IS the teardown someone asked for. Every process in the pane tree is
+// supposed to die with the session, so a process the reaper has to SIGTERM there
+// is the operation working, not a finding — and the most reliable way to produce
+// one was to use a supported feature exactly as designed: `af sessions archive
+// --self` makes its request from inside the pane tree it is asking to tear down,
+// blocked on the very RPC doing the tearing, so it can never exit within the
+// grace period. Every self-archive named the operator's own command as a "leaked
+// process" at WARNING.
+//
+// The pane child here stands in for that caller: a process in the tree that
+// outlives kill-session's SIGHUP and must be reaped. Against the pre-fix
+// behaviour this logs `WARNING … reaping leaked process N (sleep) with SIGTERM`
+// and the run stops on the assertion below that says a requested teardown must
+// not call its own processes leaked.
+func TestCloseDoesNotReportRequestedTeardownAsALeak(t *testing.T) {
+	testguard.IsolateTmux(t)
+	shrinkReapWaits(t)
+
+	const name = "af_reap-severity-close"
+	escapee := spawnSessionWithEscapee(t, name)
+	require.True(t, proctree.AliveSame(escapee), "escapee must be alive before Close")
+
+	warnings, infos := captureReapLogs(t)
+
+	session := NewTmuxSessionFromSanitizedName(name, "sh")
+	_, closeErr := session.Close()
+	require.NoError(t, closeErr)
+
+	// Close reaps asynchronously, so wait for the reap to actually happen before
+	// reading the logs — otherwise an empty WARNING buffer would pass for the
+	// wrong reason (nothing was reaped yet).
+	require.Eventually(t, func() bool { return !proctree.AliveSame(escapee) },
+		5*time.Second, 25*time.Millisecond,
+		"SIGHUP-immune pane child survived Close — nothing was reaped, so this test proves nothing")
+	// Wait on EITHER buffer, not just INFO: the reap signals before it logs, so
+	// the escapee can be dead a moment before the line lands. Gating on INFO alone
+	// would make the pre-fix behaviour — a line written at WARNING — time out here
+	// reporting "nothing was logged", which is not what went wrong. Waiting for a
+	// line at any severity lets the assertions below name the real defect.
+	require.Eventually(t, func() bool { return infos() != "" || warnings() != "" },
+		5*time.Second, 25*time.Millisecond,
+		"the reap logged nothing at all, at either severity")
+
+	require.NotContains(t, warnings(), "leaked",
+		"a requested teardown reported its own pane processes as leaked — an operator grepping "+
+			"for leaks finds every `af sessions archive --self` they ever ran (#2765)")
+	require.Contains(t, infos(), "tearing down on request",
+		"the reap must still be reported, at INFO, naming why the process was signalled")
+	require.Contains(t, infos(), "tmux "+name+":",
+		"the INFO line must name the session, and pass it as an argument (#1211)")
+	require.NotContains(t, infos(), "%!",
+		"format-string corruption markers must not appear on the INFO path either (#1211)")
+}
+
+// TestVanishedSessionSweepStillReportsALeak is the other half of #2765: the
+// downgrade must not swallow the finding the reaper exists for.
+//
+// Here the tmux session is GONE and a marked helper is still alive — it outlived
+// the pane tree that was supposed to contain it. Nobody asked for that, and it is
+// the case the WARNING is worth reading.
+func TestVanishedSessionSweepStillReportsALeak(t *testing.T) {
+	testguard.IsolateTmux(t)
+	shrinkReapWaits(t)
+
+	const name = "af_reap-severity-vanished"
+	home := t.TempDir()
+	marked := spawnMarkedSessionWithEscapee(t, name, home)
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	warnings, _ := captureReapLogs(t)
+
+	require.NoError(t, CleanupSessions(vanishOnMarkerExecutor(t, name)))
+	require.False(t, proctree.AliveSame(marked),
+		"marked helper survived the sweep — nothing was reaped, so this test proves nothing")
+
+	require.Contains(t, warnings(), "leaked past its pane tree",
+		"a process that outlived its vanished tmux session must still be reported as a leak, at WARNING")
+}
+
+// TestReapReasonSeverityMapping pins the (reason, outcome) → severity table
+// directly, including the tiers an end-to-end test cannot force: a process that
+// ignores SIGTERM or survives SIGKILL is abnormal whoever asked for the teardown,
+// so those must stay at WARNING even on the on-request path.
+func TestReapReasonSeverityMapping(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		reason     reapReason
+		outcome    proctree.ReapOutcome
+		wantOnWarn bool
+	}{
+		{"on-request SIGTERM is routine", reapOnRequest, proctree.ReapSignalled, false},
+		{"on-request ignored SIGTERM is not", reapOnRequest, proctree.ReapNeededKill, true},
+		{"on-request unkillable is not", reapOnRequest, proctree.ReapUnkillable, true},
+		{"escaped SIGTERM is a finding", reapEscaped, proctree.ReapSignalled, true},
+		{"escaped ignored SIGTERM is a finding", reapEscaped, proctree.ReapNeededKill, true},
+		{"escaped unkillable is a finding", reapEscaped, proctree.ReapUnkillable, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			warnings, infos := captureReapLogs(t)
+			logReapOutcome(tc.reason, "af_probe", tc.outcome, "probe line")
+			if tc.wantOnWarn {
+				require.Contains(t, warnings(), "probe line")
+				require.NotContains(t, infos(), "probe line")
+				return
+			}
+			require.Contains(t, infos(), "probe line")
+			require.NotContains(t, warnings(), "probe line")
+		})
+	}
+}

--- a/session/tmux/reap_severity_test.go
+++ b/session/tmux/reap_severity_test.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 	"time"
 
@@ -12,13 +13,36 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 )
 
+// reapLogBuffer is a mutex-guarded log sink. Close reaps in its OWN goroutine,
+// so the poll below reads these buffers while the reaper writes them through the
+// logger. log.Logger serializes its own writes but nothing guards a concurrent
+// READ, and a bytes.Buffer touched from two goroutines is a data race — caught
+// by -race on the macOS gate, not by an ordinary local run. Same shape as the
+// syncBuffer helpers in apiclient and daemon.
+type reapLogBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *reapLogBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *reapLogBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
 // captureReapLogs redirects the WARNING and INFO loggers into buffers for the
 // duration of the test and returns readers for both. Severity is the whole
 // subject here, so a test that read only one of them could not tell a line that
 // moved from one that vanished.
 func captureReapLogs(t *testing.T) (warnings, infos func() string) {
 	t.Helper()
-	var warnBuf, infoBuf bytes.Buffer
+	var warnBuf, infoBuf reapLogBuffer
 	oldWarnOut, oldWarnFlags := log.WarningLog.Writer(), log.WarningLog.Flags()
 	oldInfoOut, oldInfoFlags := log.InfoLog.Writer(), log.InfoLog.Flags()
 	log.WarningLog.SetOutput(&warnBuf)

--- a/session/tmux/reap_test.go
+++ b/session/tmux/reap_test.go
@@ -97,8 +97,14 @@ func TestReapLogsSessionNameLiterally(t *testing.T) {
 
 	// A session name packed with format specifiers — the exact hazard #1211
 	// describes (tmux sanitization preserves `%`).
+	//
+	// reapEscaped, because that reason keeps a plain SIGTERM on WARNING (#2765)
+	// and this test is about the WARNING logger's format-string safety. The
+	// on-request reason routes the same line to INFO and is covered separately in
+	// reap_severity_test.go — including its own #1211 assertion, so neither
+	// severity can drift into splicing the name into the format string.
 	const name = "af_fmt%d%s%n_evil"
-	reapLeakedProcesses(name, []proctree.Process{proc}, time.Millisecond, 300*time.Millisecond)
+	reapSessionProcesses(reapEscaped, name, []proctree.Process{proc}, time.Millisecond, 300*time.Millisecond)
 
 	out := buf.String()
 	require.Contains(t, out, "tmux "+name+":",

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -76,7 +76,9 @@ func (t *TmuxSession) Start(workDir string) error {
 			if cleanupErr != nil {
 				err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)
 			} else if len(leaked) > 0 {
-				go reapLeakedProcesses(t.sanitizedName, leaked, reapGraceWait, reapTermWait)
+				// Start failed and we are tearing the partial session down ourselves;
+				// its processes are going with it by design, not escaping (#2765).
+				go reapSessionProcesses(reapOnRequest, t.sanitizedName, leaked, reapGraceWait, reapTermWait)
 			}
 		}
 		return fmt.Errorf("%w: error starting tmux session: %w", ErrSessionNotStarted, err)


### PR DESCRIPTION
Every reap logged every process it signalled as a `leaked process`, at WARNING. The single most reliable way to produce that line was to use a supported feature exactly as designed:

```
WARNING reap.go:332: tmux af_bc8bf732_DependabotReview-8: reaping leaked process 1036631 (zsh)
  with SIGTERM: … eval 'af sessions archive --self 2>&1 | tail -5' …
```

**The "leaked" process is the caller.** A session that self-archives makes the request from *inside* the pane tree it is asking to tear down, blocked on the very RPC doing the tearing — so it cannot exit within the grace period and is *guaranteed* to be SIGTERMed. Reaping it is not a leak; it is what "archive this session" means. An operator grepping for leaks found their own archives, which is exactly the noise that trains people to stop reading the log.

## The shape

`proctree.KillEscalating` was answering a question it cannot answer. It is handed a list of processes and told to escalate; it has no idea whether they escaped something or are being destroyed along with a session someone asked it to tear down. Its messages now report the **action** and carry a `ReapOutcome` tier, and the **caller supplies the cause** — which is the "available without new plumbing" the issue asked for:

| reason | call sites | plain SIGTERM |
|---|---|---|
| `reapOnRequest` — "tearing down on request" | `Close`, `CloseAndWaitForPaneExit`, the `af reset` sweep, the failed-`Start` cleanup | **INFO** |
| `reapEscaped` — "leaked past its pane tree" | the vanished-session sweep | **WARNING** |
| `reapWorktreeWriters` | a process still writing a worktree after its agent *and* tmux session were torn down | **WARNING** (every tier) |

The fourth `KillEscalating` caller — doctor's `--fix` kill — passes a `nil` logf and never emitted one of these lines at all, so it is unaffected.

**The downgrade is deliberately narrow.** Only a plain SIGTERM on a requested teardown moves. A process that ignores SIGTERM, or survives SIGKILL, is abnormal whoever asked for the teardown, so those stay warnable under *every* reason — folding them in would trade one unreadable log for another. `TestReapReasonSeverityMapping` drives the whole (reason, outcome) table directly, including tiers an end-to-end teardown cannot force on demand.

## Watched it fail first

With the severity split disabled and the old wording restored, driving `Close()` over a pane child that outlives SIGHUP fails the new regression on its substantive assertion:

```
"WARNING:tmux af_reap-severity-close: … reaping leaked process 378876 (sleep) with SIGTERM: sleep 300"
  should not contain "leaked"
```

I also tightened that test while verifying: its readiness guard waited on the INFO buffer alone, so the pre-fix behaviour (a line at WARNING) timed out reporting *"the reap logged nothing at all"* — which is not what goes wrong. It now waits for a line at **either** severity, so the failure names the real defect.

`TestVanishedSessionSweepStillReportsALeak` is the other half: a marked process that outlived a vanished session must still be a WARNING, so the downgrade cannot swallow the finding the reaper exists for. Both end-to-end tests carry a fixture guard that fails if nothing was actually reaped, so neither can pass for the wrong reason.

## The "worth checking while there" item — verified, and the answer is *partly*

The issue asked whether `--self` also produces a spurious entry in `af doctor`'s escaped/orphaned counts, guessing that #2756 covers it. It does not, quite:

- `processLeakMinAge` (1 minute) gates on **process age**, not on how long the process has been orphaned. A `--self` caller is a shell that has lived as long as its session — usually far more than a minute — so the age threshold does **not** exclude it.
- What actually bounds it is the **window**: `reapGraceWait` (3s) + `reapTermWait` (2s) ≈ 5 seconds between kill-session and the caller being gone. A `doctor` scan must land inside it.
- The `(pid, start-id)` revalidation from #2756 is re-checked at report time, so a process that dies mid-scan is dropped. That shrinks the window but cannot close it, because the process is genuinely alive for those seconds.

So a `doctor` run landing inside a ~5s reap window can momentarily list the caller as `orphaned-process`. I have deliberately **not** changed that here: at that instant the statement is true (the session really is dead, the process really is alive), it self-resolves, and suppressing it would need daemon-side "reap in flight" state that doctor does not have. That is a different change from this one, and categorically different from the systematic per-invocation WARNING this PR removes. Happy to file it if you disagree.

## Gate

`gofmt -l .` (empty) · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `deadcode -test ./...` (empty) · `scripts/lint-file-length.sh` · `go test ./internal/proctree/ ./session/tmux/ ./session/git/ ./doctor/` — the four changed packages, all non-daemon. Per the standing instruction no containerized suite was run and nothing under `daemon/` or `app/` was tested on the host; CI covers those.

Closes #2765

🤖 Generated with [Claude Code](https://claude.com/claude-code)
