### PR TITLE
test(hook): prove a re-run reap by how long it blocked, not by what it logged

### DIFF
--- a/session/backend_hook_reap_test.go
+++ b/session/backend_hook_reap_test.go
@@ -100,11 +100,13 @@ mkdir -p '%s'/sandboxes/"$name"
 echo "a VM that bills by the hour" > '%s'/sandboxes/"$name"/resource.txt
 %s
 `, dir, dir, launchBody))
+	// No mkdir before the log line: dir is t.TempDir(), which already exists, and
+	// on the wedged-reap paths that mkdir was a whole fork+exec standing between
+	// the spawn and the only evidence the script ever writes (#2821).
 	writeHookScript(t, h.delete, fmt.Sprintf(`
-mkdir -p '%s'
 echo "$name" >> '%s'/delete-ran.log
 %s
-`, dir, dir, deleteBody))
+`, dir, deleteBody))
 	return h
 }
 
@@ -382,23 +384,48 @@ func TestHookReapTimeoutIsUnknownState(t *testing.T) {
 // then deleted the record and the workspace leaked exactly one poll later, the same
 // leak as master, one tick delayed. A second reap while delete_cmd is still wedged
 // must (i) ACTUALLY re-run delete_cmd and (ii) keep returning the unknown sentinel.
+//
+// (i) is asserted on how long the reap BLOCKED, not on what the script logged,
+// and that is the whole point of #2821. The script's log line was the old proof,
+// and it is not kill-proof: delete_cmd is SIGKILLed at the bound, so on a loaded
+// box the spawn can miss the budget and be killed before its first instruction —
+// leaving no line, and no way for the count to tell "the product latched" from
+// "this box was busy". The two look identical, so the count could only ever
+// produce a false FAIL.
+//
+// Blocking time cannot be destroyed that way. A latch returns the CACHED error
+// with no spawn and no wait, in microseconds; a real re-invocation runs the
+// wedged script into the bound and blocks for it. Load pushes that duration UP,
+// never down, so the assertion is one-sided in the safe direction. It is also the
+// only thing that separates the two here: the error assertions cannot, because
+// the cached error a latch returns IS the unknown-state error.
 func TestHookReapTimeoutIsReRunnable(t *testing.T) {
-	shrinkHookTimeouts(t, 300*time.Millisecond, 300*time.Millisecond)
-	h := newHookState(t, "exit 0\n", "sleep 5\n") // logs one line, then wedges
+	const bound = 300 * time.Millisecond
+	shrinkHookTimeouts(t, bound, bound)
+	h := newHookState(t, "exit 0\n", "sleep 5\n") // wedges until the bound kills it
 	p := newHookProvisioner(h, "re-runnable wedged reap")
 	p.launchStarted = true
 
-	first := p.reap()
+	first, firstTook := timeReap(p)
 	require.True(t, errors.Is(first, ErrWorkspaceStateUnknown), "first timed-out reap must be unknown-state")
-	require.Equal(t, 1, h.deleteRunCount(t), "delete_cmd ran once")
+	require.GreaterOrEqual(t, firstTook, bound,
+		"the first reap must run the wedged delete_cmd into its bound")
 
-	second := p.reap()
+	second, secondTook := timeReap(p)
 	require.Error(t, second,
 		"a second reap while delete_cmd is still wedged must not return nil — a nil would let deleteSessionRecord delete the record and orphan the workspace one poll later")
 	require.True(t, errors.Is(second, ErrWorkspaceStateUnknown),
 		"a re-run timed-out reap must keep returning ErrWorkspaceStateUnknown")
-	require.Equal(t, 2, h.deleteRunCount(t),
-		"the second reap must ACTUALLY re-invoke delete_cmd (the log line count grows), not skip it via a latch")
+	require.GreaterOrEqual(t, secondTook, bound,
+		"the second reap must ACTUALLY re-invoke delete_cmd, not skip it via a latch: it has to block on the still-wedged script for the full bound, where a latch would return the cached error immediately")
+}
+
+// timeReap runs a reap and reports how long it blocked, which is what tells a
+// real invocation apart from a latch — see TestHookReapTimeoutIsReRunnable.
+func timeReap(p *hookProvisioner) (error, time.Duration) {
+	started := time.Now()
+	err := p.reap()
+	return err, time.Since(started)
 }
 
 // TestHookReapAnsweredErrorIsKnownStateAndLatches is the other half: a delete_cmd


### PR DESCRIPTION
## Summary

`TestHookReapTimeoutIsReRunnable` asserted that a wedged `delete_cmd` appends its log line within the same 300ms bound that then SIGKILLs it. Under load the spawn misses that budget and is killed before its first instruction, the line never appears, and the count assertion fires — a false FAIL on a branch whose entire diff was one markdown file. Test-only change.

## Why the count could not be made robust

The evidence is written by the very process the bound kills. So **"the product latched" and "this box was busy" produce the identical observation** — the count did not grow. No amount of polling helps: once the script is SIGKILLed before its `echo`, that line is never coming.

That also rules out the two obvious repairs. Widening the bound leaves the same assumption with a bigger number, and the issue is right that shortening the wedge does nothing because the risk is in the startup, not the wedge.

## What replaced it

**How long the reap BLOCKED**, which the kill cannot destroy:

- a latch returns the cached error with no spawn and no wait;
- a real re-invocation runs the still-wedged script into the bound and blocks for it.

Measured against a reintroduced #2529 latch: **414ns against a 300ms floor**. Load pushes a real invocation further *above* the floor, never below it, so the assertion is one-sided in the safe direction — the opposite of the one it replaces.

## Nothing was weakened

This is the point worth checking, because it looks like a swap of a strong assertion for a weak one. It is not: the error assertions in this test **never** distinguished a latch from a re-invocation, because the cached error a latch returns *is* the `ErrWorkspaceStateUnknown` error. The count was the only thing separating them, and the duration now does that job:

| | old (count) | new (duration) |
|---|---|---|
| reintroduced #2529 latch-on-timeout | caught | caught **6/6** |
| spawn too slow to log (the reported condition) | **fails** — `expected: 1, actual: 0` | passes |

Both rows were run, not reasoned about. The second simulates the exact reported mechanism by delaying the fixture past its own bound, and reproduces the issue's failure shape on the old assertion.

## Also

The shared delete fixture had `mkdir -p '<dir>'` before its log line, where `<dir>` is `t.TempDir()` and already exists — a whole fork+exec sitting between the spawn and the only evidence the script writes. Removed, which shortens that critical path for every hook test rather than just this one.

I checked the siblings the issue flags. The other `shrinkHookTimeouts` tests that use a short *delete* bound (`TestHookReapIsBounded`, `TestHookReapTimeoutIsUnknownState`, `TestHookProvisionFailureWithReapTimeoutPreservesUnknownSentinel`) assert on error semantics and never on the log, and every `deleteRan`/`deleteRunCount` assertion elsewhere is paired with a generous 5s delete bound and a script that exits immediately — including `TestHookReapAnsweredErrorIsKnownStateAndLatches`, whose comment already explains that the generous bound is deliberate for this reason. So this was the only instance of the shape.

## Validation

Cheap gates only, per policy — no container suite, and nothing run against `daemon/` or `app/`:

- `gofmt -l .` (empty), `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...` (empty), `scripts/lint-file-length.sh`
- `go test ./session` — the only package touched — full package green, plus the target test 8/8 and all `Hook` tests green

Closes #2821
