### PR TITLE
fix(web): stop the task modal echoing a Custom cron three times

### DIFF
--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -11041,6 +11041,13 @@ function describe(s) {
       return `Custom: ${s.raw ?? ""}`;
   }
 }
+function previewIsRedundant(s) {
+  const generated = cron(s).trim();
+  if (generated === "") {
+    return true;
+  }
+  return generated === (s.raw ?? "").trim() && describe(s).trim().endsWith(generated);
+}
 function parseCron(expr) {
   const f = fields(expr);
   if (f.length !== 5) {
@@ -11601,6 +11608,7 @@ var SchedulePicker = class {
     const s = this.schedule();
     this.humanLine.textContent = describe(s);
     this.cronOut.value = cron(s);
+    this.previewRow.hidden = previewIsRedundant(s);
   }
 };
 function pad22(n) {

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "525319df5516";
+const VERSION = "101018162d70";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/schedule.test.ts
+++ b/web/src/schedule.test.ts
@@ -19,7 +19,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
-import { SCHEDULE_TYPE_OPTIONS, type Schedule, type ScheduleType, cron, describe, parseCron } from "./schedule.js";
+import { SCHEDULE_TYPE_OPTIONS, type Schedule, type ScheduleType, cron, describe, parseCron, previewIsRedundant } from "./schedule.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
 // web/src → repo-root/schedule/testdata/vectors.json (single source of truth,
@@ -190,4 +190,43 @@ test("weekdays are deduped and ordered Sunday-first regardless of input order", 
   const s: Schedule = { type: "weekly", hour: 9, minute: 0, weekdays: [3, 0, 1, 3] };
   assert.equal(cron(s), "0 9 * * 0,1,3");
   assert.equal(describe(s), "Every week on Sun, Mon, Wed at 9:00 AM");
+});
+
+/**
+ * #2812: with Custom selected, the modal showed the same expression three times
+ * — the field the user types into, the plain-English line ("Custom: 0 0 1 1 *"),
+ * and the read-only "Generated cron". For every preset the pair is the point:
+ * describe() is English and cron() is the generated expression, so the two
+ * differ and reading them together is what lets a user trust what gets saved.
+ * For Custom they collapse onto the input above.
+ *
+ * Derived from the VALUES rather than testing `type === "custom"`, so a future
+ * schedule kind whose preview collapses the same way is covered without another
+ * edit here — and so a change that makes Custom's describe() say something real
+ * turns the preview back on by itself.
+ */
+test("previewIsRedundant hides only a preview that echoes its own input", () => {
+  assert.equal(previewIsRedundant({ type: "custom", raw: "0 0 1 1 *" }), true);
+  assert.equal(previewIsRedundant({ type: "custom", raw: "  0 0 1 1 *  " }), true,
+    "surrounding whitespace does not make an echo informative");
+  assert.equal(previewIsRedundant({ type: "custom", raw: "0 0 1" }), true,
+    "a half-typed expression is still an echo of the field above");
+  assert.equal(previewIsRedundant({ type: "custom", raw: "" }), true,
+    "an empty Custom field has nothing to preview at all");
+  assert.equal(previewIsRedundant({ type: "custom" }), true);
+});
+
+test("previewIsRedundant keeps every preset's preview, which is not an echo", () => {
+  const presets: Schedule[] = [
+    { type: "everyNMinutes", interval: 15 },
+    { type: "everyNHours", interval: 2 },
+    { type: "hourly", minute: 30 },
+    { type: "daily", hour: 9, minute: 0 },
+    { type: "weekly", hour: 9, minute: 0, weekdays: [1, 3] },
+    { type: "monthly", hour: 9, minute: 0, dayOfMonth: 1 },
+  ];
+  for (const s of presets) {
+    assert.equal(previewIsRedundant(s), false, `${s.type} preview carries plain English the inputs do not`);
+    assert.notEqual(describe(s), cron(s), `${s.type}: the two halves must differ for the pairing to be worth showing`);
+  }
 });

--- a/web/src/schedule.ts
+++ b/web/src/schedule.ts
@@ -123,6 +123,32 @@ export function describe(s: Schedule): string {
 }
 
 /**
+ * Reports whether the schedule preview — describe() over cron() — would merely
+ * repeat an expression the form already shows in an editable field (#2812).
+ *
+ * For every preset the pair is the whole point: describe() is plain English and
+ * cron() is the generated expression, so the two differ, and reading them
+ * together is what lets a user trust what is about to be saved. For Custom they
+ * collapse: the user typed the cron, cron() hands it back verbatim and
+ * describe() prefixes it with "Custom: ", so the modal showed one expression
+ * three times.
+ *
+ * Derived from the VALUES rather than testing `type === "custom"`. A schedule
+ * kind added later whose preview collapses the same way is covered with no edit
+ * here, and — the direction that actually matters — if Custom's preview ever
+ * gains a fact the input cannot carry (the TUI shows the next fire time, #2596),
+ * this turns the row back on by itself instead of hiding the new information.
+ */
+export function previewIsRedundant(s: Schedule): boolean {
+  const generated = cron(s).trim();
+  // Nothing to preview at all: an empty Custom field generates no expression.
+  if (generated === "") {
+    return true;
+  }
+  return generated === (s.raw ?? "").trim() && describe(s).trim().endsWith(generated);
+}
+
+/**
  * Best-effort maps a 5-field cron expression back to a structured Schedule. It
  * recognizes exactly the shapes cron() emits — so a task saved by the picker
  * re-opens as its matching preset — plus the Sunday day-of-week alias (7).

--- a/web/src/tasks.ts
+++ b/web/src/tasks.ts
@@ -24,7 +24,7 @@ import { h } from "./dom.js";
 import { asForm, field, modalChrome, type ModalHandle, projectLabel } from "./modals.js";
 import { icon } from "./icon.js";
 import { PROGRAM_REPO_DEFAULT, type ProgramCatalog, type ProgramChoice, programChoices } from "./programs.js";
-import { SCHEDULE_TYPE_OPTIONS, type Schedule, type ScheduleType, cron as scheduleCron, describe as scheduleDescribe, parseCron } from "./schedule.js";
+import { SCHEDULE_TYPE_OPTIONS, type Schedule, type ScheduleType, cron as scheduleCron, describe as scheduleDescribe, parseCron, previewIsRedundant } from "./schedule.js";
 import type { TaskData } from "./types.js";
 
 /** The add-task form's inputs (a subset of task.Task the browser fills; the daemon
@@ -572,8 +572,12 @@ class SchedulePicker {
     }
 
     const s = this.schedule();
+    // Keep the values current even while hidden, so unhiding never flashes a
+    // stale preview from the previously selected type.
     this.humanLine.textContent = scheduleDescribe(s);
     this.cronOut.value = scheduleCron(s);
+    // Custom echoes the field the user is typing into, three times over (#2812).
+    this.previewRow.hidden = previewIsRedundant(s);
   }
 }
 


### PR DESCRIPTION
## The redundancy

Selecting **Custom** showed one expression three times:

| element | value for `0 0 1 1 *` |
| --- | --- |
| `rawInput` — the field the user types into | `0 0 1 1 *` |
| `humanLine` — the plain-English preview | `Custom: 0 0 1 1 *` |
| `cronOut` — the read-only "Generated cron" | `0 0 1 1 *` |

`sync()` hid `intervalRow`/`timeRow`/`weekdayRow`/`domRow`/`rawRow` per type but
never `previewRow`. For every **preset** that is correct: `describe()` is English,
`cron()` is the generated expression, the two differ, and reading them together
is what lets a user trust what is about to be saved. For **Custom** they collapse
onto the field above — `cron()` hands the raw text back verbatim and `describe()`
prefixes it with `Custom: `.

## Which option

**Option 1.** Option 3 (show the next fire time, TUI parity via #2596) is the
right end state, but it needs the evaluation to happen *somewhere*, and both
answers are bigger than this bug:

- **A cron evaluator in the bundle** would be a *second implementation of
  scheduling semantics* to keep in lockstep with robfig. `web/src/schedule.ts`
  today mirrors only `Describe`/`Cron`/`ParseCron` — pure string transforms,
  pinned against shared vectors. An evaluator is a different class of thing, and
  a wrong one would mispredict fire times rather than misprint a label.
- **A `next_run_at` on the API** does not exist yet. It is the better route
  precisely because it keeps one evaluator — worth doing, with its own decision.

Option 2 leaves an empty row as a stable slot; the other per-type rows already
reflow without one, so that is visual noise for no information.

## The part worth reviewing

The predicate is **value-derived**, not `type === "custom"`, and lives in the
pure `schedule` module beside `describe`/`cron` rather than in the DOM:

```ts
export function previewIsRedundant(s: Schedule): boolean {
  const generated = cron(s).trim();
  if (generated === "") return true;          // empty Custom field: nothing to preview
  return generated === (s.raw ?? "").trim() && describe(s).trim().endsWith(generated);
}
```

Two things fall out of that shape. A schedule kind added later whose preview
collapses the same way is covered with no edit here. And — the direction that
actually matters — **if Custom's preview ever gains a fact the input cannot
carry** (option 3's next-run), this turns the row back on by itself rather than
hiding the new information.

## Tests

`web/src/schedule.test.ts`: every Custom shape (typed, padded, half-typed, empty,
absent) is redundant; every preset is not. The preset case also asserts
`describe(s) !== cron(s)` for each — the property that makes showing the pair
worth anything, so if a future edit collapses a preset the way Custom collapsed,
this fails rather than silently hiding that row too.

The unit tests are pure by the repo's convention — the modal's DOM is asserted in
the Playwright selftest, which runs as the `Web selftest` check on this PR.

## Gate

`make web-test` (490 pass, 0 fail — includes `tsc --noEmit`), `make web-build`
with `web/dist` committed, plus `gofmt -l .` (empty), `go build ./...`,
`golangci-lint run --timeout=3m --fast`, `deadcode -test ./...` (empty),
`scripts/lint-file-length.sh`. No containerized suites.

Closes #2812

-- Captain Claude
