### PR TITLE
fix(daemon): bound the kill-tombstone retry and retire one that cannot succeed

### DIFF
--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -212,6 +212,12 @@ type Manager struct {
 	// second concurrent teardown, duplicate operations are rejected, and project
 	// deletion can see a restore claim before the row changes lifecycle state.
 	killsInFlight map[string]struct{}
+
+	// killRetries paces finishUserKill's retry of a retained tombstone, keyed by
+	// daemon instance key. Without it the poll retried every second forever
+	// (#2737). In memory on purpose: a restart re-attempts a retired record once,
+	// which is right when an operator may have fixed the cause in between.
+	killRetries map[string]*session.CleanupRetry
 	// restoresInFlight identifies the subset of killsInFlight entries admitted
 	// by a manual restore. DeleteProject treats these as early blockers because
 	// an archived row has not necessarily changed lifecycle state yet. Keeping
@@ -393,6 +399,7 @@ func newManagerShellForDaemon(cfg *config.Config, transactionID string) (*Manage
 		rootKilledAt:           make(map[string]time.Time),
 		deletedRootRepos:       make(map[string]struct{}),
 		killsInFlight:          make(map[string]struct{}),
+		killRetries:            make(map[string]*session.CleanupRetry),
 		restoresInFlight:       make(map[string]struct{}),
 		lostRestoreStates:      make(map[string]*lostRestoreState),
 		limitResumeStates:      make(map[string]*limitResumeState),

--- a/daemon/rootkill.go
+++ b/daemon/rootkill.go
@@ -101,6 +101,41 @@ func (m *Manager) persistKillTombstone(repoID string, instance *session.Instance
 	return nil
 }
 
+// noteKillRetryFailure books a failed tombstone cleanup against its retry
+// schedule and reports it at the right volume.
+//
+// A cause that may heal backs off and keeps trying, so an outage that ends still
+// recovers without a daemon restart (#1122). A cause that cannot heal by
+// retrying — a cleanup handle missing something no attempt can supply — is
+// retired: it is reported ONCE with what the operator can do, and then left
+// alone instead of relitigating it every poll (#2737). The record is retained
+// either way; retiring stops the retrying, not the retention.
+func (m *Manager) noteKillRetryFailure(key, title string, err error) {
+	m.mu.Lock()
+	retry := m.killRetries[key]
+	if retry == nil {
+		retry = &session.CleanupRetry{}
+		m.killRetries[key] = retry
+	}
+	escalate := retry.RecordFailure(nowFunc(), err)
+	retired, failures := retry.Retired(), retry.Failures()
+	m.mu.Unlock()
+
+	switch {
+	case retired && escalate:
+		log.ErrorLog.Printf("finishing kill of %q: this cleanup cannot be completed by retrying it, so af has stopped trying "+
+			"after %d attempt(s). The record is KEPT so nothing is silently orphaned — resolve the cause and restart the daemon, "+
+			"or kill the session again to retry: %v", title, failures, err)
+	case retired:
+		// Already reported; stay silent rather than repeat it.
+	case escalate:
+		log.ErrorLog.Printf("finishing kill of %q failed %d consecutive times; the cause looks persistent — "+
+			"retrying every %s: %v", title, failures, session.CleanupRetrySettledInterval(), err)
+	default:
+		log.WarningLog.Printf("finishing kill of %q: not deleting the record yet (retrying): %v", title, err)
+	}
+}
+
 // finishUserKill completes the teardown of a session whose record carries the
 // kill-intent tombstone (#1108): the previous KillSession was interrupted by a
 // daemon crash or a teardown error after the tombstone write. Mirrors the tail
@@ -114,6 +149,14 @@ func (m *Manager) finishUserKill(repoID string, instance *session.Instance) {
 	key := daemonInstanceKey(repoID, instance.Title)
 	m.mu.Lock()
 	if _, busy := m.killsInFlight[key]; busy {
+		m.mu.Unlock()
+		return
+	}
+	// Retrying a retained tombstone is paced, and a tombstone that cannot be
+	// completed by retrying is not retried at all. This used to run on every
+	// status poll — once a second, forever, for a cause that could not heal
+	// (#2737).
+	if retry := m.killRetries[key]; retry != nil && !retry.Due(nowFunc()) {
 		m.mu.Unlock()
 		return
 	}
@@ -172,13 +215,16 @@ func (m *Manager) finishUserKill(repoID string, instance *session.Instance) {
 	// workspace. This loop IS the retry.
 	deleted, err := m.deleteSessionRecord(repoID, instance.Title, instance.ID, teardownErr)
 	if err != nil {
-		log.WarningLog.Printf("finishing kill of %q: not deleting the record yet (will retry next poll): %v", instance.Title, err)
+		m.noteKillRetryFailure(key, instance.Title, err)
 		return
 	}
 	if !deleted {
 		log.InfoLog.Printf("finishing kill of %q skipped storage delete: current record has a different instance identity", instance.Title)
 		return
 	}
+	m.mu.Lock()
+	delete(m.killRetries, key)
+	m.mu.Unlock()
 	removed := false
 	m.mu.Lock()
 	if m.instances[key] == instance {

--- a/session/backend_ssh_legacy_tombstone_test.go
+++ b/session/backend_ssh_legacy_tombstone_test.go
@@ -1,0 +1,65 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #2737: a pre-#2704 SSH tombstone recorded no host-key posture, so it restores
+// as strict. When the host was only ever learned in the af-owned accept-new
+// store, the reconnect can never verify it — and the daemon retried that once a
+// second forever. The failure must say it cannot be fixed by retrying so the
+// record is retired instead.
+func TestSSHReapMarksLegacyTombstoneUnusable(t *testing.T) {
+	p := &sshProvisioner{
+		spec:       ProvisionSpec{Title: "legacy-tombstone"},
+		cfg:        configSSHForReapTest(),
+		sessionDir: "/home/remote/.af-sessions/legacy.1234",
+		// hostKeyVerification is EMPTY: the field #2704 added, absent here.
+	}
+	p.reapDial = func() error { return errors.New("ssh: handshake failed: knownhosts: key is unknown") }
+
+	err := p.reap()
+	require.Error(t, err)
+	assert.True(t, CleanupHandleUnusable(err),
+		"a legacy tombstone that cannot verify its host can never be completed by retrying")
+	assert.True(t, TeardownStateUnknown(err),
+		"but the workspace state is still unknown, so the record must still be RETAINED")
+	assert.Contains(t, err.Error(), "known_hosts", "the error must tell the operator what would fix it")
+	assert.Contains(t, err.Error(), "#2704")
+}
+
+// A tombstone that DID record its posture is an ordinary retryable failure: the
+// host may simply be down, and an outage that ends must heal on the next attempt.
+func TestSSHReapKeepsRetryingWhenPostureWasRecorded(t *testing.T) {
+	for _, posture := range []string{"strict", "accept-new"} {
+		t.Run(posture, func(t *testing.T) {
+			p := &sshProvisioner{
+				spec:                ProvisionSpec{Title: "modern-tombstone"},
+				cfg:                 configSSHForReapTest(),
+				sessionDir:          "/home/remote/.af-sessions/modern.1234",
+				hostKeyVerification: posture,
+			}
+			p.reapDial = func() error { return errors.New("dial tcp: connect: connection refused") }
+
+			err := p.reap()
+			require.Error(t, err)
+			assert.False(t, CleanupHandleUnusable(err),
+				"a recorded posture with an unreachable host may heal, so it must keep being retried")
+			assert.True(t, TeardownStateUnknown(err))
+		})
+	}
+}
+
+// The two sentinels compose: retiring stops the retrying, never the retention.
+func TestUnusableHandleStillRetainsTheRecord(t *testing.T) {
+	err := fmt.Errorf("%w: %w", ErrCleanupHandleUnusable,
+		fmt.Errorf("%w: reconnect failed", ErrWorkspaceStateUnknown))
+	assert.True(t, CleanupHandleUnusable(err))
+	assert.True(t, TeardownStateUnknown(err),
+		"deleteSessionRecord must still refuse, so nothing is silently orphaned")
+}

--- a/session/backend_ssh_reap.go
+++ b/session/backend_ssh_reap.go
@@ -65,6 +65,18 @@ func (p *sshProvisioner) reap() error {
 		if err := p.dialForReap(); err != nil {
 			reapErr := fmt.Errorf("%w: backend=ssh: reconnecting to %s to remove remote session dir %q failed: %w",
 				ErrWorkspaceStateUnknown, p.cfg.Host, p.sessionDir, err)
+			if p.hostKeyVerification == "" {
+				// A pre-#2704 tombstone recorded no host-key posture, so it restored
+				// as strict. If the host was only ever learned in the af-owned
+				// accept-new store, this reconnect cannot verify it and no later
+				// attempt will differ — the missing field is not coming back. Mark it
+				// unusable so the daemon retires the record instead of retrying it
+				// once per poll forever (#2737). The workspace state is still unknown,
+				// so the record is retained either way; only the retrying stops.
+				reapErr = fmt.Errorf("%w: %w (this tombstone predates #2704 and recorded no host-key posture, "+
+					"so it is verified strictly; add %s to your known_hosts to let the cleanup finish)",
+					ErrCleanupHandleUnusable, reapErr, p.cfg.Host)
+			}
 			log.WarningLog.Printf("%v", reapErr)
 			return reapErr
 		}

--- a/session/cleanup_retry.go
+++ b/session/cleanup_retry.go
@@ -1,0 +1,109 @@
+package session
+
+import (
+	"time"
+)
+
+// Bounds for retrying a retained record's cleanup. Base doubles per consecutive
+// failure and settles at max, mirroring the root-ensure convention (#1122) so af
+// has one shape for "a bounded operation that keeps failing" rather than a
+// decision per site. Package vars so tests can shorten them.
+var (
+	cleanupRetryBackoffBase = 10 * time.Second
+	cleanupRetryBackoffMax  = 5 * time.Minute
+)
+
+// cleanupRetryEscalationThreshold is the consecutive-failure count at which the
+// cause stops looking transient and earns one ERROR log. Retrying continues at
+// the settled cadence: an outage that ends must still heal on the next attempt,
+// which is exactly what a permanent give-up cost the root agents in #1122.
+const cleanupRetryEscalationThreshold = 6
+
+// CleanupRetry paces the daemon's retry of a retained kill tombstone.
+//
+// Before this, a tombstone whose cleanup could not complete was retried on EVERY
+// status poll — once a second, forever, two log lines per attempt (#2737). That
+// is not resilience: for a cause that cannot heal on its own it is a hot loop
+// burning a user's CPU and log volume with nothing to act on.
+//
+// So two bounds, for the two different kinds of failure:
+//
+//   - A failure that MIGHT heal (an unreachable host, a busy remote) backs off
+//     exponentially to a settled cadence and keeps trying, because an outage that
+//     ends must recover without a daemon restart.
+//   - A failure that CANNOT heal by retrying — a cleanup handle that is
+//     structurally unusable, such as a pre-#2704 SSH tombstone whose host-key
+//     posture was never recorded — is RETIRED. Repeating identical inputs cannot
+//     produce a different answer, so the record stops being retried and is
+//     surfaced once for the operator to act on.
+//
+// The zero value is ready to use. State is in-memory on purpose: a daemon restart
+// re-attempts a retired record once, which is the right behavior when an operator
+// may have fixed the cause (added the host key, restored the remote) in between.
+type CleanupRetry struct {
+	consecutiveFailures int
+	nextAttempt         time.Time
+	escalated           bool
+	retired             bool
+}
+
+// Due reports whether another attempt is allowed now. A retired entry never is.
+func (r *CleanupRetry) Due(now time.Time) bool {
+	if r.retired {
+		return false
+	}
+	return !now.Before(r.nextAttempt)
+}
+
+// Retired reports that this cleanup can never succeed by retrying and has been
+// given up on. It stays true until the entry is dropped (daemon restart) or a
+// caller records a success.
+func (r *CleanupRetry) Retired() bool { return r.retired }
+
+// Failures is the consecutive-failure count, for reporting.
+func (r *CleanupRetry) Failures() int { return r.consecutiveFailures }
+
+// RecordFailure books one failed attempt and schedules the next. It reports
+// whether this failure earns an operator-visible escalation — true exactly once
+// per streak, either when the cause becomes unusable (retire) or when the
+// failure count crosses the threshold.
+func (r *CleanupRetry) RecordFailure(now time.Time, err error) bool {
+	r.consecutiveFailures++
+	if CleanupHandleUnusable(err) {
+		// Nothing about a later attempt differs, so there is no cadence to settle
+		// into — this one is done.
+		r.retired = true
+		if r.escalated {
+			return false
+		}
+		r.escalated = true
+		return true
+	}
+	r.nextAttempt = now.Add(cleanupRetryBackoff(r.consecutiveFailures))
+	if r.consecutiveFailures < cleanupRetryEscalationThreshold || r.escalated {
+		return false
+	}
+	r.escalated = true
+	return true
+}
+
+// RecordSuccess clears the streak, so a cause that healed leaves no backoff
+// behind for the next unrelated failure.
+func (r *CleanupRetry) RecordSuccess() { *r = CleanupRetry{} }
+
+// cleanupRetryBackoff doubles the base per consecutive failure and settles at the
+// max, so a cause that never heals costs one attempt per max interval rather
+// than one per poll.
+func cleanupRetryBackoff(consecutiveFailures int) time.Duration {
+	backoff := cleanupRetryBackoffMax
+	if shift := consecutiveFailures - 1; shift >= 0 && shift < 32 {
+		if b := cleanupRetryBackoffBase << shift; b > 0 && b < backoff {
+			backoff = b
+		}
+	}
+	return backoff
+}
+
+// CleanupRetrySettledInterval is the cadence a never-healing retry settles at,
+// for callers that report it.
+func CleanupRetrySettledInterval() time.Duration { return cleanupRetryBackoffMax }

--- a/session/cleanup_retry_test.go
+++ b/session/cleanup_retry_test.go
@@ -1,0 +1,102 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #2737: a retained tombstone was retried on every status poll — once a second,
+// forever. The pacing is the fix, so pin the cadence rather than just the state.
+func TestCleanupRetryPacesRetriesInsteadOfEveryPoll(t *testing.T) {
+	var retry CleanupRetry
+	now := time.Unix(1_800_000_000, 0)
+
+	require.True(t, retry.Due(now), "the first attempt is always allowed")
+
+	// One failure must stop the next poll a second later from attempting again.
+	retry.RecordFailure(now, errors.New("host unreachable"))
+	assert.False(t, retry.Due(now.Add(time.Second)), "a poll one second later must not retry")
+	assert.False(t, retry.Due(now.Add(cleanupRetryBackoffBase-time.Millisecond)))
+	assert.True(t, retry.Due(now.Add(cleanupRetryBackoffBase)), "the backoff must expire")
+
+	// Backoff doubles and then settles, so a cause that never heals costs one
+	// attempt per settled interval rather than one per poll.
+	var settled CleanupRetry
+	prev := time.Duration(0)
+	for i := 1; i <= 12; i++ {
+		settled.RecordFailure(now, errors.New("still unreachable"))
+		got := cleanupRetryBackoff(i)
+		assert.LessOrEqual(t, got, cleanupRetryBackoffMax, "backoff must never exceed the settled cadence")
+		assert.GreaterOrEqual(t, got, prev, "backoff must not shrink while failures continue")
+		prev = got
+	}
+	assert.Equal(t, cleanupRetryBackoffMax, cleanupRetryBackoff(12), "it must settle at the max, not grow without bound")
+}
+
+// The escalation fires once per streak, not on every failure — the old loop
+// logged two lines every second.
+func TestCleanupRetryEscalatesOnce(t *testing.T) {
+	var retry CleanupRetry
+	now := time.Unix(1_800_000_000, 0)
+
+	escalations := 0
+	for i := 0; i < cleanupRetryEscalationThreshold*3; i++ {
+		if retry.RecordFailure(now, errors.New("still unreachable")) {
+			escalations++
+		}
+		now = now.Add(cleanupRetryBackoffMax)
+	}
+	assert.Equal(t, 1, escalations, "a persistent cause earns exactly one escalation")
+	assert.False(t, retry.Retired(), "a cause that might heal must keep retrying (#1122)")
+}
+
+// A handle that cannot be fixed by retrying is retired, not backed off: repeating
+// identical inputs cannot produce a different answer.
+func TestCleanupRetryRetiresAnUnusableHandle(t *testing.T) {
+	var retry CleanupRetry
+	now := time.Unix(1_800_000_000, 0)
+
+	unusable := fmt.Errorf("%w: %w", ErrCleanupHandleUnusable,
+		fmt.Errorf("%w: reconnecting failed", ErrWorkspaceStateUnknown))
+
+	assert.True(t, retry.RecordFailure(now, unusable), "retiring is worth one report")
+	assert.True(t, retry.Retired())
+	assert.False(t, retry.Due(now), "a retired handle is never due again")
+	assert.False(t, retry.Due(now.Add(24*time.Hour)), "not even much later — no cadence can help it")
+	assert.False(t, retry.RecordFailure(now, unusable), "and it is not reported twice")
+
+	// Retiring must not weaken the retention rule: the workspace state is still
+	// unknown, so the record is still kept.
+	assert.True(t, TeardownStateUnknown(unusable),
+		"an unusable handle still reports unknown workspace state, so the record is retained")
+}
+
+// A cause that heals leaves no backoff behind for the next unrelated failure.
+func TestCleanupRetrySuccessClearsTheStreak(t *testing.T) {
+	var retry CleanupRetry
+	now := time.Unix(1_800_000_000, 0)
+	for i := 0; i < cleanupRetryEscalationThreshold+2; i++ {
+		retry.RecordFailure(now, errors.New("transient"))
+	}
+	require.False(t, retry.Due(now))
+
+	retry.RecordSuccess()
+	assert.True(t, retry.Due(now), "a healed cause starts clean")
+	assert.Zero(t, retry.Failures())
+	assert.False(t, retry.Retired())
+}
+
+// CleanupHandleUnusable must not fire on the ordinary retained-record error, or
+// every transient failure would be retired.
+func TestCleanupHandleUnusableIsNarrow(t *testing.T) {
+	assert.False(t, CleanupHandleUnusable(nil))
+	assert.False(t, CleanupHandleUnusable(errors.New("host unreachable")))
+	assert.False(t, CleanupHandleUnusable(fmt.Errorf("%w: dir removal failed", ErrWorkspaceStateUnknown)),
+		"an unknown workspace state is retried, not retired")
+	assert.True(t, CleanupHandleUnusable(fmt.Errorf("%w: no posture recorded", ErrCleanupHandleUnusable)))
+}

--- a/session/teardown.go
+++ b/session/teardown.go
@@ -171,6 +171,28 @@ var ErrWorkspaceStateUnknown = errors.New("the worktree action was cut off by it
 // It lives here, beside the sentinels, because the teardown choke points are their
 // only producers: teardownTabs raises them, ghostCleanup forwards them, and no
 // other code constructs them. One producer, one predicate, one place to change.
+// ErrCleanupHandleUnusable marks a retained cleanup handle that CANNOT be made
+// to work by retrying it. It is not "the workspace state is unknown" — that is
+// ErrWorkspaceStateUnknown, which is retried precisely because a later attempt
+// may learn more. This is the narrower claim that a later attempt is the same
+// attempt: the handle itself is missing something no retry can supply.
+//
+// The case it was added for is a pre-#2704 SSH kill tombstone (#2737). Those
+// records carry no host-key posture, so they restore as strict; when the host was
+// learned under the af-owned accept-new store, the reconnect can never verify it
+// and the cleanup retried once per second forever. Wrapping that failure lets the
+// daemon retire the record instead of looping on it.
+//
+// It composes with ErrWorkspaceStateUnknown rather than replacing it: the
+// workspace state IS still unknown, so the record must not be deleted — it is
+// only the RETRYING that stops.
+var ErrCleanupHandleUnusable = errors.New("this cleanup handle cannot be completed by retrying it")
+
+// CleanupHandleUnusable reports whether err came from a handle no retry can fix.
+func CleanupHandleUnusable(err error) bool {
+	return errors.Is(err, ErrCleanupHandleUnusable)
+}
+
 func TeardownStateUnknown(err error) bool {
 	return errors.Is(err, ErrPaneMayBeLive) || errors.Is(err, ErrWorkspaceStateUnknown)
 }


### PR DESCRIPTION
## What

A retained kill tombstone was retried on **every status poll** — once a second, forever, two log lines per attempt — for a cause that in the reported case could never heal. The remote sandbox was never cleaned up and the operator got nothing to act on.

Two kinds of failure now get different treatment, because they differ in whether waiting can help.

## A cause that might heal: bounded, but never abandoned

Backs off exponentially from **10s**, settling at **5m**, with a single ERROR log once the streak looks persistent. It keeps retrying forever at that cadence.

That is deliberate. A permanent give-up here is exactly what kept root agents down for hours after the 2026-07-03 tmux outage (#1122): the outage outlasted the fast attempts and recovery then needed a daemon restart. An outage that ends must heal on the next attempt. The bounds mirror `rootEnsureBackoff*` so af has **one shape** for "a bounded operation that keeps failing" rather than a decision per site — the convention question #2737 raises.

Cost drops from ~86,400 attempts/day to ~288.

## A cause that cannot heal: retired

`ErrCleanupHandleUnusable` marks a handle missing something **no attempt can supply**. It is deliberately narrower than `ErrWorkspaceStateUnknown`, which is retried precisely because a later attempt may learn more.

The SSH reap raises it for the #2737 record: a pre-#2704 tombstone recorded no host-key posture, so it restores as `strict` and can never verify a host learned in the af-owned `accept-new` store. Repeating identical inputs cannot produce a different answer, so it is reported **once** — with the operator's fix, adding the host to `known_hosts` — and then left alone.

### Retiring stops the retrying, never the retention

An unusable handle still carries `ErrWorkspaceStateUnknown`, so `deleteSessionRecord` still refuses and **nothing is silently orphaned**. The record stays as the operator's handle on the remote workspace. This is asserted directly (`TestUnusableHandleStillRetainsTheRecord`), because a "give up" that quietly deleted the record would trade a hot loop for a leaked sandbox.

Retry state is in-memory, so a daemon restart re-attempts a retired record once — right when an operator may have fixed the cause in between.

## Detection

The issue asks for the affected population. Measured read-only on this box:

```
instances.json files scanned: 11
ssh cleanup handles found:    0
  of which LEGACY (no host_key_verification): 0
kill tombstones (user_killed) found: 0
```

**Zero affected records here**, consistent with the issue's expectation that this daemon has restarted since #2565. The population elsewhere cannot be determined from this box.

## Why not the migration (option 4)

The issue floats inferring `accept-new` from presence in the af-owned store, and asks that the reasoning be verified rather than assumed. This PR does not take it: presence in that store is evidence the key was *learned* under `accept-new`, but the store is shared across sessions and hosts can be re-keyed, so presence today is not proof about the posture at provision time for this record. Bounding and retiring needs no such inference and cannot silently weaken a posture. The migration remains available as a separate, evidence-checked change.

## Tests

All in `session/`, the non-daemon package changed:

- pacing — a poll one second later must not retry; backoff doubles, never shrinks, settles at the max;
- escalation fires exactly once per streak, and a might-heal cause is never retired;
- an unusable handle is retired, never due again, reported once — and still reports unknown workspace state;
- success clears the streak;
- `CleanupHandleUnusable` is narrow: plain errors and `ErrWorkspaceStateUnknown` are *not* retired;
- the real #2737 shape: a legacy SSH tombstone's failed reconnect is marked unusable, while `strict` and `accept-new` postures with an unreachable host keep retrying.

## Validation

- `gofmt -l .` (no output) · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `deadcode -test ./...` (no output) · `scripts/lint-file-length.sh`
- `go test ./session/`

Per repo policy no containerized suite was run locally, and `./daemon/...` was not tested on this host; CI runs the full matrix.

Closes #2737
