### PR TITLE
fix(web): hold type-ahead instead of dropping it while the socket connects (#2811)

### DIFF
--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6866,6 +6866,54 @@ function decode(raw) {
   }
 }
 
+// src/pending_input.ts
+var DEFAULT_MAX_PENDING_INPUT_BYTES = 64 * 1024;
+var PendingInput = class {
+  constructor(maxBytes = DEFAULT_MAX_PENDING_INPUT_BYTES) {
+    this.maxBytes = maxBytes;
+  }
+  frames = [];
+  queued = 0;
+  /** Holds one frame. Returns false when the cap refused it — nothing was stored,
+   *  and everything already queued is untouched. */
+  push(frame) {
+    if (frame.length === 0) {
+      return true;
+    }
+    if (this.queued + frame.length > this.maxBytes) {
+      return false;
+    }
+    this.frames.push(frame);
+    this.queued += frame.length;
+    return true;
+  }
+  /** Hands back every held frame IN THE ORDER IT WAS TYPED and empties the queue.
+   *  Order is the contract: this is a byte stream, so a reordered flush would
+   *  corrupt the command line exactly as a dropped prefix does. */
+  drain() {
+    const out = this.frames;
+    this.frames = [];
+    this.queued = 0;
+    return out;
+  }
+  /** Discards everything held. Used when the PTY this input was meant for is gone
+   *  (exit or dispose), where delivering it later would type into a different
+   *  program than the user was looking at. */
+  clear() {
+    this.frames = [];
+    this.queued = 0;
+  }
+  /** Bytes currently held — the cap's accounting, exposed for tests and callers
+   *  that want to report pressure. */
+  get bytes() {
+    return this.queued;
+  }
+  /** Frames currently held. */
+  get length() {
+    return this.frames.length;
+  }
+};
+
 // src/terminal-geometry.ts
 function hasVisibleTerminalGeometry(host, proposed) {
   return host.width > 0 && host.height > 0 && !!proposed && proposed.rows > 0 && proposed.cols > 0;
@@ -7147,6 +7195,9 @@ var AttachTerminal = class {
   term;
   fit;
   enc = new TextEncoder();
+  // Type-ahead: what was typed while the socket was down, replayed on open
+  // (#2811). Held here rather than dropped in send().
+  pendingInput = new PendingInput();
   ro;
   io;
   ws = null;
@@ -7346,6 +7397,7 @@ var AttachTerminal = class {
    *  disconnects the observer, and disposes xterm (freeing its DOM/renderer). */
   dispose() {
     this.stopped = true;
+    this.pendingInput.clear();
     if (this.mouseCaptureHintTimer !== null) {
       window.clearTimeout(this.mouseCaptureHintTimer);
       this.mouseCaptureHintTimer = null;
@@ -7477,6 +7529,7 @@ var AttachTerminal = class {
       this.exited = false;
       this.cb.onStatus("open");
       this.sendResize(this.term.rows, this.term.cols, true);
+      this.flushPendingInput();
     };
     ws.onmessage = (e) => this.onMessage(e.data);
     ws.onclose = () => this.scheduleReconnect();
@@ -7537,6 +7590,7 @@ var AttachTerminal = class {
       this.applyEchoedSize(msg.rows, msg.cols);
     } else if (msg.type === "exit") {
       this.exited = true;
+      this.pendingInput.clear();
       const code = typeof msg.code === "number" ? msg.code : 0;
       this.term.write(`\r
 \x1B[38;5;244m[agent exited (code ${code})]\x1B[0m\r
@@ -7729,18 +7783,61 @@ var AttachTerminal = class {
       }
     }
   }
+  /** Writes a frame if the socket can carry one right now. Returns whether it
+   *  went out, so the ONE caller whose payload must not be lost — typed input —
+   *  can hold it instead of dropping it (#2811). */
   send(bytes) {
     const ws = this.ws;
     if (ws && ws.readyState === WebSocket.OPEN) {
       ws.send(bytes);
+      return true;
     }
+    return false;
   }
   // --- input & clipboard -----------------------------------------------------
   /** Sends text to the PTY as OpInput — the single input path shared by typed
    *  keys (onData) and the Ctrl+C interrupt (clipboard.ts). UTF-8 encoded so a
-   *  multibyte char reaches the PTY as the same bytes a real terminal would send. */
+   *  multibyte char reaches the PTY as the same bytes a real terminal would send.
+   *
+   *  Anything typed while the socket is not OPEN is HELD, not dropped (#2811).
+   *  That window is open for the whole of every fresh tab — the pane mounts and
+   *  the user can type before the WebSocket finishes connecting — and again for
+   *  every reconnect gap. Dropping there did not merely lose keystrokes: the
+   *  surviving tail of a half-sent command line still reached the shell, so a
+   *  `for i in …; do printf …; done` arrived as `-mode-%s\n' "$i"; done` and left
+   *  the shell at a continuation prompt having run nothing. A real terminal keeps
+   *  type-ahead in the tty queue; this is the same guarantee, one layer up.
+   *
+   *  Resize is deliberately NOT held: onopen re-sends the current size on every
+   *  (re)connect, so a queued resize would be a stale duplicate of a value the
+   *  socket already re-announces. */
   sendInput(text) {
-    this.send(encode(inputFrame(this.enc.encode(text))));
+    const frame = encode(inputFrame(this.enc.encode(text)));
+    if (this.send(frame)) {
+      return;
+    }
+    if (this.stopped || this.exited) {
+      return;
+    }
+    if (!this.pendingInput.push(frame)) {
+      this.flashNotice("Terminal disconnected \u2014 typing was not delivered");
+    }
+  }
+  /** Hands the PTY everything typed while the socket was down, in order, then
+   *  empties the queue. Called from onopen, so it covers the first connect and
+   *  every reconnect alike. A frame that cannot go out even now is put back, so a
+   *  socket that dies mid-flush loses nothing. */
+  flushPendingInput() {
+    const frames = this.pendingInput.drain();
+    for (let i = 0; i < frames.length; i++) {
+      if (this.send(frames[i])) {
+        continue;
+      }
+      for (let j = i; j < frames.length; j++) {
+        this.pendingInput.push(frames[j]);
+      }
+      return;
+    }
   }
   /** Copies text to the system clipboard, never silently. localhost is a secure
    *  context, so navigator.clipboard.writeText works; but if it is missing (a
@@ -7796,9 +7893,13 @@ var AttachTerminal = class {
    *  ancestor. Styled inline so it needs no stylesheet plumbing and no <style>
    *  element under the CSP. */
   flashCopyHint() {
+    this.flashNotice("Copy failed \u2014 clipboard unavailable");
+  }
+  /** The toast itself, for any condition that must not pass silently. */
+  flashNotice(message) {
     try {
       const hint = document.createElement("div");
-      hint.textContent = "Copy failed \u2014 clipboard unavailable";
+      hint.textContent = message;
       hint.setAttribute("role", "alert");
       hint.style.position = "fixed";
       hint.style.bottom = "12px";

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "4b5c5759438b";
+const VERSION = "525319df5516";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -1568,6 +1568,68 @@ test("#2681/#2787: application mouse mode selects on a plain drag and keeps a mo
   }
 });
 
+test("#2811: typing the instant a tab opens loses nothing — type-ahead is held, not dropped", REAL_FIXTURE, async ({
+  browser,
+}) => {
+  // Deliberately does NOT use typeableShellTab(): that helper exists to keep the
+  // OTHER tests off this race, and using it here would test the helper instead of
+  // the product. This types the way a user does — immediately, into a tab that has
+  // only just appeared, with the socket very likely still CONNECTING.
+  //
+  // The old failure mode was not a lost keystroke but a MANGLED command: the
+  // dropped prefix left the surviving tail to reach the shell on its own and run
+  // as something else. So the assertion is that the whole line arrives intact.
+  const ctx = await browser.newContext();
+  const p = await ctx.newPage();
+
+  try {
+    await openTokenless(p);
+    await row(p, SESSION_B).click();
+    await resetToAgentTab(p);
+
+    const host = p.locator(".af-term-host");
+    // No wait for data-term-status here, on purpose: that attribute belongs to the
+    // pane and can still read "open" from the tab we just left while THIS tab's
+    // socket is connecting — which is exactly how the #2796 CI run typed into a
+    // connecting terminal and lost the front of its command.
+    await createTerminalTab(p);
+    await host.click();
+    const marker = "af-2811-typeahead-ok";
+    await p.keyboard.type(`printf '%s\\n' ${marker}`);
+    await p.keyboard.press("Enter");
+
+    // The command must have RUN, which is stronger than the text merely appearing:
+    // its output is a line that contains only the marker, and it can only exist if
+    // every byte of the command line arrived, in order.
+    await expect(host, "type-ahead typed before the socket opened must still reach the shell").toContainText(marker, {
+      timeout: 20_000,
+    });
+    await expect
+      .poll(
+        async () =>
+          (await host.locator(".xterm-rows > div").allInnerTexts()).filter((line) => line.trim() === marker).length,
+        { message: "the command must have executed, not just echoed as a mangled line" },
+      )
+      .toBeGreaterThan(0);
+
+    // …and the shell must be at a fresh prompt rather than parked on a continuation
+    // prompt, which is where a truncated command line strands it.
+    const screen = (await host.locator(".xterm-rows > div").allInnerTexts()).map((l) => l.trimEnd());
+    const lastNonEmpty = [...screen].reverse().find((l) => l.trim() !== "") ?? "";
+    expect(lastNonEmpty.trimStart().startsWith(">"), `shell left at a continuation prompt: ${JSON.stringify(screen.slice(-4))}`).toBe(
+      false,
+    );
+  } finally {
+    try {
+      await resetToAgentTab(p);
+    } finally {
+      await ctx.close();
+    }
+    await row(page, SESSION_A).click();
+    await expect(row(page, SESSION_A)).toHaveClass(/af-row-selected/);
+  }
+});
+
 test("#2787: Cmd+C copies the terminal selection to the system clipboard", REAL_FIXTURE, async ({ browser }) => {
   // The defect this pins is invisible to a unit test, which is how it shipped: the
   // old unit test asserted only that our handler declined Cmd+C, under a NAME that

--- a/web/src/pending_input.test.ts
+++ b/web/src/pending_input.test.ts
@@ -1,0 +1,77 @@
+// Pins the type-ahead queue behind the attach terminal's input path (#2811).
+//
+// The defect this replaces was a silent drop, so these tests assert the two
+// properties whose absence made it silent AND destructive: nothing typed is lost
+// while the socket is down, and what comes back comes back IN ORDER. A queue that
+// preserved bytes but reordered them would corrupt a command line just as badly
+// as the drop did.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { DEFAULT_MAX_PENDING_INPUT_BYTES, PendingInput } from "./pending_input.js";
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+/** Concatenates a drain back into the byte stream the PTY would have received. */
+function stream(frames: Uint8Array[]): string {
+  return frames.map((f) => dec.decode(f)).join("");
+}
+
+test("holds what was typed while the socket is down and replays it IN ORDER", () => {
+  const pending = new PendingInput();
+  // One frame per keystroke, exactly as xterm's onData delivers them.
+  for (const ch of "for i in $(seq 1 80); do") {
+    assert.equal(pending.push(enc.encode(ch)), true);
+  }
+
+  assert.equal(pending.length, 24);
+  const drained = stream(pending.drain());
+  assert.equal(
+    drained,
+    "for i in $(seq 1 80); do",
+    "the command line must survive byte-for-byte — a lost PREFIX is what left the shell at a continuation prompt",
+  );
+  assert.equal(pending.length, 0, "a drain empties the queue so the next flush cannot double-send");
+  assert.equal(pending.bytes, 0);
+});
+
+test("a drain returns nothing when nothing was held", () => {
+  const pending = new PendingInput();
+  assert.deepEqual(pending.drain(), []);
+});
+
+test("an empty frame is not held and is not a refusal", () => {
+  const pending = new PendingInput();
+  assert.equal(pending.push(new Uint8Array()), true);
+  assert.equal(pending.length, 0);
+});
+
+test("the cap refuses the NEWEST frame and keeps every earlier byte intact", () => {
+  const pending = new PendingInput(8);
+  assert.equal(pending.push(enc.encode("12345")), true);
+  assert.equal(pending.push(enc.encode("678")), true, "exactly at the cap still fits");
+  assert.equal(pending.bytes, 8);
+
+  assert.equal(pending.push(enc.encode("9")), false, "over the cap must be refused, not evict the front");
+  assert.equal(stream(pending.drain()), "12345678", "the refusal must not disturb what is already queued");
+});
+
+test("clear drops everything — the PTY it was typed at is gone", () => {
+  const pending = new PendingInput();
+  pending.push(enc.encode("rm -rf /tmp/x"));
+  pending.clear();
+  assert.equal(pending.length, 0);
+  assert.deepEqual(pending.drain(), [], "cleared input must never reach a later PTY");
+  assert.equal(pending.bytes, 0);
+});
+
+test("the default cap is far above any real type-ahead", () => {
+  // Not a magic-number echo: the point is that ordinary typing and an ordinary
+  // paste can never hit the ceiling, so the refusal path stays reserved for a
+  // socket that is never coming back.
+  assert.ok(DEFAULT_MAX_PENDING_INPUT_BYTES >= 16 * 1024);
+  const pending = new PendingInput();
+  assert.equal(pending.push(enc.encode("x".repeat(8 * 1024))), true, "an 8 KiB paste must be held, not refused");
+});

--- a/web/src/pending_input.ts
+++ b/web/src/pending_input.ts
@@ -1,0 +1,86 @@
+// Type-ahead for the attach terminal's WebSocket (#2811).
+//
+// A real terminal never loses what you typed while it was starting up: the bytes
+// sit in the tty's input queue and the program reads them when it gets there. The
+// web terminal had no such queue. Its send path was:
+//
+//     if (ws && ws.readyState === WebSocket.OPEN) { ws.send(bytes); }
+//
+// …so every keystroke typed before the socket finished connecting was discarded,
+// silently. That window is not exotic — it is open for the whole of every fresh
+// tab (the pane mounts, then the socket connects) and again for every reconnect
+// gap. What it produces is worse than a dropped keystroke: the SURVIVING tail of
+// a half-sent command line reaches the shell on its own, so
+// `for i in $(seq 1 80); do printf 'mouse-mode-%s\n' "$i"; done` arrives as
+// `-mode-%s\n' "$i"; done` and leaves the shell sitting at a continuation prompt
+// having run nothing. That exact corruption was captured in CI on #2796.
+//
+// This is the queue that was missing. It is deliberately DUMB — it holds opaque
+// frames, in order, and hands them back on demand — so the socket lifecycle stays
+// terminal.ts's business and this stays unit-testable without a DOM.
+
+/** The default ceiling on buffered input, in bytes. Real type-ahead is a command
+ *  line or a paste; 64 KiB is orders of magnitude beyond that, so the cap only
+ *  ever engages on a socket that is never coming back (or a runaway sender) —
+ *  where the alternative is growing without bound for the life of the page. */
+export const DEFAULT_MAX_PENDING_INPUT_BYTES = 64 * 1024;
+
+/**
+ * An ordered, bounded hold for outbound input frames.
+ *
+ * When the cap is reached, the NEWEST frame is refused rather than evicting the
+ * oldest. That direction is the whole point: a command line is only meaningful
+ * from its first byte, and dropping the front is precisely the corruption this
+ * exists to prevent — a truncated tail that still executes is far more dangerous
+ * than input that never arrives. push() reports the refusal so the caller can
+ * say so out loud instead of losing it quietly a second time.
+ */
+export class PendingInput {
+  private frames: Uint8Array[] = [];
+  private queued = 0;
+
+  constructor(private readonly maxBytes: number = DEFAULT_MAX_PENDING_INPUT_BYTES) {}
+
+  /** Holds one frame. Returns false when the cap refused it — nothing was stored,
+   *  and everything already queued is untouched. */
+  push(frame: Uint8Array): boolean {
+    if (frame.length === 0) {
+      return true; // nothing to hold; not a refusal
+    }
+    if (this.queued + frame.length > this.maxBytes) {
+      return false;
+    }
+    this.frames.push(frame);
+    this.queued += frame.length;
+    return true;
+  }
+
+  /** Hands back every held frame IN THE ORDER IT WAS TYPED and empties the queue.
+   *  Order is the contract: this is a byte stream, so a reordered flush would
+   *  corrupt the command line exactly as a dropped prefix does. */
+  drain(): Uint8Array[] {
+    const out = this.frames;
+    this.frames = [];
+    this.queued = 0;
+    return out;
+  }
+
+  /** Discards everything held. Used when the PTY this input was meant for is gone
+   *  (exit or dispose), where delivering it later would type into a different
+   *  program than the user was looking at. */
+  clear(): void {
+    this.frames = [];
+    this.queued = 0;
+  }
+
+  /** Bytes currently held — the cap's accounting, exposed for tests and callers
+   *  that want to report pressure. */
+  get bytes(): number {
+    return this.queued;
+  }
+
+  /** Frames currently held. */
+  get length(): number {
+    return this.frames.length;
+  }
+}

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -41,6 +41,7 @@ import { type IMarker, type ITheme, Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { handleClipboardKeydown } from "./clipboard.js";
 import { decode, encode, inputFrame, Op, resizeFrame } from "./frame.js";
+import { PendingInput } from "./pending_input.js";
 import {
   hasVisibleTerminalGeometry,
   shouldRefitVisibleTerminal,
@@ -104,6 +105,9 @@ export class AttachTerminal {
   private readonly term: Terminal;
   private readonly fit: FitAddon;
   private readonly enc = new TextEncoder();
+  // Type-ahead: what was typed while the socket was down, replayed on open
+  // (#2811). Held here rather than dropped in send().
+  private readonly pendingInput = new PendingInput();
   private readonly ro: ResizeObserver;
   private readonly io: IntersectionObserver;
 
@@ -480,6 +484,7 @@ export class AttachTerminal {
    *  disconnects the observer, and disposes xterm (freeing its DOM/renderer). */
   dispose(): void {
     this.stopped = true;
+    this.pendingInput.clear();
     if (this.mouseCaptureHintTimer !== null) {
       window.clearTimeout(this.mouseCaptureHintTimer);
       this.mouseCaptureHintTimer = null;
@@ -640,6 +645,9 @@ export class AttachTerminal {
       // Push our current size on (re)connect so a server that came up after us, or
       // a resize we did while disconnected, is reflected. The echo reconciles it.
       this.sendResize(this.term.rows, this.term.cols, true);
+      // …then hand over anything typed before this socket existed. After the size
+      // so a full-screen program sizes itself before the keystrokes arrive.
+      this.flushPendingInput();
     };
 
     ws.onmessage = (e) => this.onMessage(e.data);
@@ -716,6 +724,9 @@ export class AttachTerminal {
       this.applyEchoedSize(msg.rows, msg.cols);
     } else if (msg.type === "exit") {
       this.exited = true;
+      // Whatever is still held was typed at a PTY that has now exited; delivering
+      // it to anything later would type into a program the user never saw.
+      this.pendingInput.clear();
       const code = typeof msg.code === "number" ? msg.code : 0;
       this.term.write(`\r\n\x1b[38;5;244m[agent exited (code ${code})]\x1b[0m\r\n`);
       this.cb.onStatus("exited");
@@ -932,20 +943,73 @@ export class AttachTerminal {
     }
   }
 
-  private send(bytes: Uint8Array): void {
+  /** Writes a frame if the socket can carry one right now. Returns whether it
+   *  went out, so the ONE caller whose payload must not be lost — typed input —
+   *  can hold it instead of dropping it (#2811). */
+  private send(bytes: Uint8Array): boolean {
     const ws = this.ws;
     if (ws && ws.readyState === WebSocket.OPEN) {
       ws.send(bytes);
+      return true;
     }
+    return false;
   }
 
   // --- input & clipboard -----------------------------------------------------
 
   /** Sends text to the PTY as OpInput — the single input path shared by typed
    *  keys (onData) and the Ctrl+C interrupt (clipboard.ts). UTF-8 encoded so a
-   *  multibyte char reaches the PTY as the same bytes a real terminal would send. */
+   *  multibyte char reaches the PTY as the same bytes a real terminal would send.
+   *
+   *  Anything typed while the socket is not OPEN is HELD, not dropped (#2811).
+   *  That window is open for the whole of every fresh tab — the pane mounts and
+   *  the user can type before the WebSocket finishes connecting — and again for
+   *  every reconnect gap. Dropping there did not merely lose keystrokes: the
+   *  surviving tail of a half-sent command line still reached the shell, so a
+   *  `for i in …; do printf …; done` arrived as `-mode-%s\n' "$i"; done` and left
+   *  the shell at a continuation prompt having run nothing. A real terminal keeps
+   *  type-ahead in the tty queue; this is the same guarantee, one layer up.
+   *
+   *  Resize is deliberately NOT held: onopen re-sends the current size on every
+   *  (re)connect, so a queued resize would be a stale duplicate of a value the
+   *  socket already re-announces. */
   private sendInput(text: string): void {
-    this.send(encode(inputFrame(this.enc.encode(text))));
+    const frame = encode(inputFrame(this.enc.encode(text)));
+    if (this.send(frame)) {
+      return;
+    }
+    if (this.stopped || this.exited) {
+      // No socket is coming: this terminal is disposed or its PTY exited. Holding
+      // would grow for the life of the page and could only ever be delivered to a
+      // program the user never typed at.
+      return;
+    }
+    if (!this.pendingInput.push(frame)) {
+      // Refused by the cap — a socket that is not coming back. Say so rather than
+      // losing it quietly a second time, which is the whole defect this fixes.
+      this.flashNotice("Terminal disconnected — typing was not delivered");
+    }
+  }
+
+  /** Hands the PTY everything typed while the socket was down, in order, then
+   *  empties the queue. Called from onopen, so it covers the first connect and
+   *  every reconnect alike. A frame that cannot go out even now is put back, so a
+   *  socket that dies mid-flush loses nothing. */
+  private flushPendingInput(): void {
+    const frames = this.pendingInput.drain();
+    for (let i = 0; i < frames.length; i++) {
+      if (this.send(frames[i])) {
+        continue;
+      }
+      // The socket died mid-flush. Put this frame back AND everything after it,
+      // in order, so the next open resumes exactly where this stopped — requeuing
+      // only the failed one would drop the rest of the command line, which is the
+      // very corruption being fixed.
+      for (let j = i; j < frames.length; j++) {
+        this.pendingInput.push(frames[j]);
+      }
+      return;
+    }
   }
 
   /** Copies text to the system clipboard, never silently. localhost is a secure
@@ -1007,9 +1071,14 @@ export class AttachTerminal {
    *  ancestor. Styled inline so it needs no stylesheet plumbing and no <style>
    *  element under the CSP. */
   private flashCopyHint(): void {
+    this.flashNotice("Copy failed — clipboard unavailable");
+  }
+
+  /** The toast itself, for any condition that must not pass silently. */
+  private flashNotice(message: string): void {
     try {
       const hint = document.createElement("div");
-      hint.textContent = "Copy failed — clipboard unavailable";
+      hint.textContent = message;
       hint.setAttribute("role", "alert");
       hint.style.position = "fixed";
       hint.style.bottom = "12px";


### PR DESCRIPTION
Typing into a just-created web terminal tab lost the first keystrokes. I filed this
while fixing #2787 and deliberately left the mechanism **open** rather than guess,
so this PR answers the question first and then fixes what it found.

Closes #2811

## It is not the daemon

The issue asked whether the daemon accepts `OpInput` for a tab whose program has
not spawned and drops it. It does not, and the spawn path is why:

`AddShellTab` runs `shellTmux.Start(worktreePath)` **to completion before** appending
the tab to `i.Tabs` (`session/tab_spawn.go`). So by the time a tab id resolves at
all, `ensureBrokerByID` finds a live tmux, `send-keys -H` lands in the pane, and the
pty buffers type-ahead exactly as a tty is supposed to. **A daemon-side buffer would
not have fixed this — those bytes never reached the daemon.**

## It is the client

`web/src/terminal.ts`:

```ts
private send(bytes: Uint8Array): void {
  const ws = this.ws;
  if (ws && ws.readyState === WebSocket.OPEN) { ws.send(bytes); }
}
```

Anything handed to that while the socket is still `CONNECTING` is discarded on the
floor, with no error and no feedback. That window is open for the whole of every
fresh tab — the pane mounts, *then* the socket connects — and again for every
reconnect gap.

**What makes it destructive rather than merely lossy is that the loss is a PREFIX.**
The surviving tail of a half-sent command line still reaches the shell and runs as
something else. The #2796 CI run captured precisely that:

```
for i in $(seq 1 80); do printf 'mouse-mode-%s\n' "$i"; done     ← typed
                              -mode-%s\n' "$i"; done             ← what the shell got
```

…leaving the shell parked at a continuation prompt having run nothing. That is a
real-browser reproduction of this bug, from CI, before I knew what it was.

## The fix

`PendingInput` — an ordered, bounded (64 KiB) hold for outbound input frames, drained
from `onopen` after the size re-announce, so it covers the first connect and every
reconnect alike. Three decisions worth stating:

- **It refuses the NEWEST frame at the cap, never evicting the oldest.** Dropping the
  front is the exact corruption this exists to prevent; a truncated tail that still
  executes is more dangerous than input that never arrives. A refusal raises a
  visible notice rather than losing it quietly a second time.
- **Order is the contract.** This is a byte stream, so a reordered flush corrupts a
  command line just as badly as a dropped prefix. A socket that dies mid-flush
  requeues the failed frame *and everything after it*.
- **Input is discarded only where it can no longer mean anything** — a PTY that has
  exited, or a disposed terminal — because delivering it later would type into a
  program the user never saw. Resize is not held at all: `onopen` already re-announces
  the current size, so a queued one would be a stale duplicate.

## Verification

**Watched it fail first.** `pending_input.test.ts` was run against a `PendingInput`
carrying today's shipped semantics (accept the frame, store nothing):

```
not ok 1 - holds what was typed while the socket is down and replays it IN ORDER
not ok 4 - the cap refuses the NEWEST frame and keeps every earlier byte intact
# pass 4  # fail 2
```

Both pass against the real implementation; 494 web unit tests green.

**Browser-level**, `#2811: typing the instant a tab opens loses nothing` in
`web-driver.spec.ts` types immediately into a brand-new tab — deliberately *not*
using the `typeableShellTab()` helper, which exists to keep other tests off this
race and would test the helper instead of the product. It asserts the command
actually **ran** (a line whose entire content is the marker, which can only exist if
every byte arrived in order) and that the shell is not left on a continuation prompt.
CI runs the web selftest on `web/` changes.

Local gate per the current policy — cheap checks only, no containerized suites, and
no `go test` against `./daemon/...` or `./app/...`: `gofmt -l .` clean, `go build
./...` ok, `golangci-lint --fast` ok, `deadcode -test ./...` clean,
`scripts/lint-file-length.sh` passed, web typecheck + 494 unit tests, and the
regenerated `web/dist` bundle committed.

Co-Authored-By: Captain Claude <noreply@anthropic.com>
