### PR TITLE
fix(upgrade): stop an in-place install from clobbering a live upgrade transaction

### DIFF
--- a/commands/autoupdate.go
+++ b/commands/autoupdate.go
@@ -154,7 +154,13 @@ func autoUpdateForChannel(channel string, checkTimeout, downloadBudget time.Dura
 			return fmt.Errorf("failed to resolve executable path: %w", err)
 		}
 
-		if err := config.AtomicWriteFile(resolvedPath, binary, 0755); err != nil {
+		// The guarded swap (#2212). The launch path has no override: an
+		// unattended installer must never be the thing that clobbers a live
+		// upgrade transaction, and there is no human here to weigh it. In
+		// practice autoUpdateOnLaunch has already stood down before we get this
+		// far; this is the backstop that makes the interlock a property of the
+		// write rather than of remembering to check.
+		if err := writeExecutableInPlace(resolvedPath, binary, false, ""); err != nil {
 			throttleFailure(latestTag)
 			return fmt.Errorf("failed to write new binary: %w", err)
 		}

--- a/commands/autoupdate_launch.go
+++ b/commands/autoupdate_launch.go
@@ -77,6 +77,17 @@ func autoUpdateOnLaunch(cfg *config.Config) {
 		log.InfoLog.Printf("auto-update: stdout is not a terminal; skipping")
 		return
 	}
+	// Stand down while a daemon upgrade transaction owns the executable
+	// (#2212). Checked here, before the throttle cache is even opened, so a
+	// launch during an upgrade neither consumes the shared 6h window nor spends
+	// a download on a swap the interlock would refuse. Silent by design: like
+	// every other skip on this path, it must not print at, block, or fail a
+	// launch the user asked for.
+	if active := activeUpgradeOwningExecutable(); active != nil {
+		log.InfoLog.Printf("auto-update: daemon upgrade to %s in progress (transaction %s, phase %s); skipping the launch-time install",
+			active.ToVersion, active.ID, active.Phase)
+		return
+	}
 
 	channel := config.UpdateChannelStable
 	if cfg != nil && cfg.UpdateChannel != "" {

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/internal/autoupdate"
 	"github.com/sachiniyer/agent-factory/log"
@@ -87,6 +86,8 @@ func init() {
 		"Install the channel's latest release even if it is older than the current binary (e.g. switching from preview back to stable)")
 	upgradeCmd.Flags().BoolVar(&upgradeNoRestart, "no-restart", false,
 		"Leave the running daemon alone (af upgrade restarts it by default so the new binary takes effect)")
+	upgradeCmd.Flags().BoolVar(&upgradeIgnoreActiveUpgrade, ignoreActiveUpgradeFlag, false,
+		"Install even while a daemon upgrade transaction is in progress (this can leave that upgrade unable to roll back)")
 }
 
 var upgradeCmd = &cobra.Command{
@@ -203,6 +204,15 @@ func shouldUpgrade(latestTag, current, channel string, allowDowngrade bool) (pro
 // Cobra. out carries the result; errOut carries anything that means the user
 // is not running the version they just installed.
 func runUpgrade(out, errOut io.Writer, downloadURL string, noRestart bool) error {
+	// Refuse before spending a download on a swap we are not going to perform.
+	// writeExecutableInPlace below is the actual guard; this only buys the user a
+	// faster, cheaper refusal (#2212).
+	if !upgradeIgnoreActiveUpgrade {
+		if active := activeUpgradeOwningExecutable(); active != nil {
+			return &blockedInPlaceInstallError{active: active, flag: "--" + ignoreActiveUpgradeFlag}
+		}
+	}
+
 	binary, err := downloadBinaryFn(downloadURL, downloadTimeout)
 	if err != nil {
 		return err
@@ -219,7 +229,11 @@ func runUpgrade(out, errOut io.Writer, downloadURL string, noRestart bool) error
 		return fmt.Errorf("failed to resolve executable path: %w", err)
 	}
 
-	if err := config.AtomicWriteFile(resolvedPath, binary, 0755); err != nil {
+	if err := writeExecutableInPlace(resolvedPath, binary, upgradeIgnoreActiveUpgrade, "--"+ignoreActiveUpgradeFlag); err != nil {
+		var blocked *blockedInPlaceInstallError
+		if errors.As(err, &blocked) {
+			return err
+		}
 		return fmt.Errorf("failed to write new binary: %w", err)
 	}
 

--- a/commands/upgrade_interlock.go
+++ b/commands/upgrade_interlock.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/upgradetxn"
@@ -67,6 +69,11 @@ type activeUpgrade struct {
 	ID        string
 	ToVersion string
 	Phase     string
+	// artifact is set only for a transaction discovered beside the executable
+	// rather than through this home's journal: its home, version, and phase are
+	// unknown, but the staged binary proves it exists and names it for a user
+	// who needs to clear a leftover.
+	artifact string
 }
 
 // blockedInPlaceInstallError is returned when an in-place swap is refused. It
@@ -84,6 +91,12 @@ func (e *blockedInPlaceInstallError) Error() string {
 		"a daemon upgrade to %s is in progress (transaction %s, phase %s); installing over it would destroy the rollback that upgrade depends on",
 		e.active.ToVersion, e.active.ID, e.active.Phase,
 	)
+	if e.active.artifact != "" {
+		msg = fmt.Sprintf(
+			"a daemon upgrade is staging over this executable (transaction %s, preserved binary %s); it belongs to another agent-factory home, and installing over it would destroy the rollback that upgrade depends on",
+			e.active.ID, e.active.artifact,
+		)
+	}
 	if e.flag == "" {
 		return msg
 	}
@@ -165,6 +178,44 @@ func isTerminalUpgradePhase(phase upgradetxn.Phase) bool {
 	}
 }
 
+// foreignUpgradeStagingOver reports a transaction staging over this exact
+// executable regardless of which AF home owns it, or nil when none is.
+//
+// One `af` binary can serve many AF homes (AGENT_FACTORY_HOME), but a
+// transaction is home-scoped while the executable is not. So
+// `AGENT_FACTORY_HOME=/tmp/other af upgrade` would look in /tmp/other, find no
+// journal, and happily rename over the very binary the default home's
+// transaction is preserving — destroying a rollback it never knew existed.
+// There is no registry of AF homes to consult, but there does not need to be:
+// upgradetxn stages its preserved and candidate binaries NEXT TO the executable
+// (binaryArtifactPaths), so the executable's own directory is the one place
+// every home's transaction is visible.
+//
+// Read with ReadDir and a literal prefix rather than filepath.Glob: an
+// executable whose name contains a glob metacharacter would otherwise silently
+// match the wrong set, and this decides whether to overwrite a binary.
+func foreignUpgradeStagingOver(resolvedPath string) *activeUpgrade {
+	dir := filepath.Dir(resolvedPath)
+	prefix := "." + filepath.Base(resolvedPath) + ".af-upgrade-"
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		// Cannot enumerate: inconclusive, and inconclusive never blocks.
+		return nil
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, ".previous") {
+			continue
+		}
+		id := strings.TrimSuffix(strings.TrimPrefix(name, prefix), ".previous")
+		if id == "" {
+			continue
+		}
+		return &activeUpgrade{ID: id, artifact: filepath.Join(dir, name)}
+	}
+	return nil
+}
+
 // writeExecutableInPlace is the ONE guarded in-place binary swap. Both installers
 // go through it, so the interlock cannot be bypassed by adding a call site — the
 // entrypoint checks elsewhere exist to give a better message and to skip a
@@ -174,7 +225,13 @@ func isTerminalUpgradePhase(phase upgradetxn.Phase) bool {
 // because an unoverridable auto-upgrade safeguard is its own hazard.
 func writeExecutableInPlace(resolvedPath string, binary []byte, override bool, flag string) error {
 	swap := func() error {
-		if active := activeUpgradeOwningExecutable(); active != nil {
+		active := activeUpgradeOwningExecutable()
+		if active == nil {
+			// Nothing in THIS home. The executable is shared across homes, so
+			// ask the executable itself before overwriting it.
+			active = foreignUpgradeStagingOver(resolvedPath)
+		}
+		if active != nil {
 			if !override {
 				return &blockedInPlaceInstallError{active: active, flag: flag}
 			}
@@ -201,8 +258,33 @@ func writeExecutableInPlace(resolvedPath string, binary []byte, override bool, f
 		log.WarningLog.Printf("upgrade interlock: cannot resolve the agent-factory home to take the upgrade lock; installing unlocked: %v", err)
 		return swap()
 	}
-	if err := upgradetxn.WithInstallLock(home, swap); err != nil {
-		return err
+
+	// A FAILURE TO TAKE THE LOCK MUST NEVER BLOCK THE INSTALL. Broken lock
+	// storage — <home>/upgrade left as a file or symlink, or a directory that
+	// cannot be read — says nothing about whether a transaction exists, and
+	// returning that error here would be worse than the hazard this guard exists
+	// to prevent: `af upgrade` permanently refusing, on every invocation, with
+	// --ignore-active-upgrade powerless because the override lives inside the
+	// swap that never runs. The journal check inside swap still applies, so the
+	// unlocked path is today's behaviour plus a real guard, not a bypass.
+	//
+	// swapRan is what separates "the lock could not be taken" from "the swap
+	// itself failed" — WithInstallLock returns fn's error too, so the error alone
+	// cannot tell them apart, and mistaking a refusal for a lock failure would
+	// install exactly what the guard just declined.
+	swapRan := false
+	var swapErr error
+	lockErr := upgradetxn.WithInstallLock(home, func() error {
+		swapRan = true
+		swapErr = swap()
+		return swapErr
+	})
+	if swapRan {
+		if lockErr != nil && swapErr == nil {
+			log.WarningLog.Printf("upgrade interlock: installed, but releasing the upgrade lock failed: %v", lockErr)
+		}
+		return swapErr
 	}
-	return nil
+	log.WarningLog.Printf("upgrade interlock: cannot take the upgrade lock, so this install is not serialised against a daemon upgrade: %v", lockErr)
+	return swap()
 }

--- a/commands/upgrade_interlock.go
+++ b/commands/upgrade_interlock.go
@@ -1,0 +1,171 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/upgradetxn"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// The two-installer interlock (#2212).
+//
+// Two mechanisms replace the same on-disk executable:
+//
+//  1. IN PLACE — `af upgrade` and launch-time auto-update. AtomicWriteFile over
+//     the resolved executable, then restart the daemon. No journal, no
+//     probation, no rollback.
+//  2. TRANSACTIONAL — the daemon's activation path (internal/upgradetxn): an
+//     fsynced journal, a preserved previous binary, probation, validated
+//     activation, and guarded rollback.
+//
+// An in-place swap that lands mid-transaction writes the canonical path with no
+// awareness of the transaction, destroying the rollback that transaction exists
+// to guarantee — the failure #2212 calls the worst on the whole upgrade path,
+// and strictly worse than not having a daemon-owned upgrade at all.
+//
+// WHICH mechanism wins is still an open product decision on the issue (A: the
+// transactional path is the single writer whenever a daemon owns the home;
+// B: the daemon defers to the in-place installer; C: leave both and add mutual
+// exclusion). This file does not pick one. It builds the floor ALL THREE need
+// and that none of them can be safe without: the in-place writer never clobbers
+// a live transaction. Landing it before activation means the reconciliation
+// slice gets to be about policy rather than about safety.
+//
+// Nothing creates a transaction yet, so on every real box today this resolves to
+// "no journal → proceed" and behaviour is unchanged. That is pinned by a test.
+
+// ignoreActiveUpgradeFlag is the `af upgrade` escape hatch. Named for what it
+// ignores rather than a bare --force, so the thing being overridden is visible
+// in the command the user types.
+const ignoreActiveUpgradeFlag = "ignore-active-upgrade"
+
+// upgradeIgnoreActiveUpgrade is that flag's value. A package var, like
+// upgradeAllowDowngrade, so adding it churns no runUpgrade call site.
+var upgradeIgnoreActiveUpgrade bool
+
+// loadUpgradeJournal is the seam over the real journal loader. A journal that
+// upgradetxn.Load accepts can only be produced by a real Prepare — it is
+// validated against the preserved binaries, their digests, and the recovery lock
+// on disk — so hand-forging one per phase is not possible. The seam lets the
+// POLICY below (which phases block, what unreadable evidence means) be tested
+// exhaustively, while one test drives a genuinely Prepare'd transaction through
+// the production path to prove the seam is wired to the real loader.
+var loadUpgradeJournal = func(home string) (upgradetxn.Journal, error) {
+	txn, err := upgradetxn.Load(home)
+	if err != nil {
+		return upgradetxn.Journal{}, err
+	}
+	return txn.Journal(), nil
+}
+
+// activeUpgrade describes a daemon upgrade transaction that currently owns this
+// home's executable. Nil means an in-place swap may proceed.
+type activeUpgrade struct {
+	ID        string
+	ToVersion string
+	Phase     string
+}
+
+// blockedInPlaceInstallError is returned when an in-place swap is refused. It
+// names the override, because a refusal a user cannot get past is not a
+// safeguard — it is a brick.
+type blockedInPlaceInstallError struct {
+	active *activeUpgrade
+	// flag is the command-line escape hatch, empty on paths that have none
+	// (launch-time auto-update, which skips silently rather than refusing).
+	flag string
+}
+
+func (e *blockedInPlaceInstallError) Error() string {
+	msg := fmt.Sprintf(
+		"a daemon upgrade to %s is in progress (transaction %s, phase %s); installing over it would destroy the rollback that upgrade depends on",
+		e.active.ToVersion, e.active.ID, e.active.Phase,
+	)
+	if e.flag == "" {
+		return msg
+	}
+	return msg + fmt.Sprintf(". Wait for it to finish, or re-run with %s to install anyway", e.flag)
+}
+
+// activeUpgradeOwningExecutable reports the transaction that currently owns this
+// home's executable, or nil when an in-place swap may proceed.
+//
+// The polarity is deliberate and is the whole design of this function: it blocks
+// ONLY on a positive, readable, non-terminal transaction. Everything else
+// proceeds.
+//
+//   - No home, no journal, or ErrNoActiveTransaction — proceed. This is every
+//     box today.
+//   - A journal in a TERMINAL phase (committed, rolled_back, aborted) — proceed.
+//     Those phases are cleanup only; the activation is decided and there is no
+//     rollback left to corrupt.
+//   - A journal that cannot be read or validated — proceed, loudly. This is the
+//     case worth arguing about, so: refusing on unreadable evidence would let one
+//     corrupt file disable `af upgrade` permanently, and `af doctor` has no
+//     upgrade-transaction repair to send the user to. That is an unoverridable
+//     block produced by an inference, which is the shape this repo has been bitten
+//     by before. It is also the empirically wrong guess: a live transaction writes
+//     a valid fsynced journal, so a corrupt one much more often means a broken
+//     install that needs `af upgrade` to work than a live actor to protect.
+func activeUpgradeOwningExecutable() *activeUpgrade {
+	home, err := config.GetConfigDir()
+	if err != nil {
+		log.WarningLog.Printf("upgrade interlock: cannot resolve the agent-factory home; proceeding: %v", err)
+		return nil
+	}
+	if _, err := os.Stat(home); errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	journal, err := loadUpgradeJournal(home)
+	if errors.Is(err, upgradetxn.ErrNoActiveTransaction) {
+		return nil
+	}
+	if err != nil {
+		log.WarningLog.Printf("upgrade interlock: cannot read the daemon upgrade journal; proceeding with the in-place install: %v", err)
+		return nil
+	}
+	if isTerminalUpgradePhase(journal.Phase) {
+		return nil
+	}
+	return &activeUpgrade{
+		ID:        journal.ID,
+		ToVersion: journal.ToVersion,
+		Phase:     string(journal.Phase),
+	}
+}
+
+// isTerminalUpgradePhase reports whether the transaction has already decided its
+// outcome, leaving only cleanup. rollback_failed is deliberately NOT terminal:
+// it is the circuit-breaker state that retains every recovery artifact, so it is
+// exactly when an unwitting overwrite does the most damage.
+func isTerminalUpgradePhase(phase upgradetxn.Phase) bool {
+	switch phase {
+	case upgradetxn.PhaseCommitted, upgradetxn.PhaseRolledBack, upgradetxn.PhaseAborted:
+		return true
+	default:
+		return false
+	}
+}
+
+// writeExecutableInPlace is the ONE guarded in-place binary swap. Both installers
+// go through it, so the interlock cannot be bypassed by adding a call site — the
+// entrypoint checks elsewhere exist to give a better message and to skip a
+// pointless download, not to be the guard.
+//
+// override is the caller's explicit "install anyway"; it is honoured, and logged,
+// because an unoverridable auto-upgrade safeguard is its own hazard.
+func writeExecutableInPlace(resolvedPath string, binary []byte, override bool, flag string) error {
+	if active := activeUpgradeOwningExecutable(); active != nil {
+		if !override {
+			return &blockedInPlaceInstallError{active: active, flag: flag}
+		}
+		log.WarningLog.Printf(
+			"upgrade interlock: overridden — installing in place while daemon upgrade transaction %s (phase %s) is active; its rollback may no longer be usable",
+			active.ID, active.Phase,
+		)
+	}
+	return config.AtomicWriteFile(resolvedPath, binary, 0755)
+}

--- a/commands/upgrade_interlock.go
+++ b/commands/upgrade_interlock.go
@@ -130,6 +130,21 @@ func activeUpgradeOwningExecutable() *activeUpgrade {
 	if isTerminalUpgradePhase(journal.Phase) {
 		return nil
 	}
+	// A valid journal is not proof there is still a rollback to protect.
+	// upgradetxn.Load validates the recorded paths, digests, and lock metadata —
+	// not the artifact contents — so a half-cleaned or failed transaction can
+	// leave a loadable journal whose preserved previous binary is gone. Blocking
+	// then protects nothing and only stands between the user and a working
+	// `af upgrade`, which is the one thing they have left. Downgrade to "proceed"
+	// only on a POSITIVE observation that the artifact is absent; an inconclusive
+	// stat keeps the block, which is overridable.
+	if _, err := os.Stat(journal.PreviousBinaryPath); errors.Is(err, os.ErrNotExist) {
+		log.WarningLog.Printf(
+			"upgrade interlock: daemon upgrade transaction %s (phase %s) has no preserved previous binary at %s; its rollback is already impossible, so the in-place install proceeds",
+			journal.ID, journal.Phase, journal.PreviousBinaryPath,
+		)
+		return nil
+	}
 	return &activeUpgrade{
 		ID:        journal.ID,
 		ToVersion: journal.ToVersion,
@@ -158,14 +173,36 @@ func isTerminalUpgradePhase(phase upgradetxn.Phase) bool {
 // override is the caller's explicit "install anyway"; it is honoured, and logged,
 // because an unoverridable auto-upgrade safeguard is its own hazard.
 func writeExecutableInPlace(resolvedPath string, binary []byte, override bool, flag string) error {
-	if active := activeUpgradeOwningExecutable(); active != nil {
-		if !override {
-			return &blockedInPlaceInstallError{active: active, flag: flag}
+	swap := func() error {
+		if active := activeUpgradeOwningExecutable(); active != nil {
+			if !override {
+				return &blockedInPlaceInstallError{active: active, flag: flag}
+			}
+			log.WarningLog.Printf(
+				"upgrade interlock: overridden — installing in place while daemon upgrade transaction %s (phase %s) is active; its rollback may no longer be usable",
+				active.ID, active.Phase,
+			)
 		}
-		log.WarningLog.Printf(
-			"upgrade interlock: overridden — installing in place while daemon upgrade transaction %s (phase %s) is active; its rollback may no longer be usable",
-			active.ID, active.Phase,
-		)
+		return config.AtomicWriteFile(resolvedPath, binary, 0755)
 	}
-	return config.AtomicWriteFile(resolvedPath, binary, 0755)
+
+	// Check and write under the transaction preparation lock, so the two cannot
+	// interleave. Checking and then writing is a time-of-check-to-time-of-use
+	// window on its own: a transaction published in between is invisible to a
+	// check that already passed, and the swap lands underneath it. upgradetxn's
+	// Prepare takes this same lock and snapshots the running executable inside
+	// it, so holding it here is what makes the interlock airtight rather than
+	// merely likely.
+	home, err := config.GetConfigDir()
+	if err != nil {
+		// No home to lock against. Proceeding matches the rest of this file's
+		// polarity — an install must not be blocked by evidence we cannot read —
+		// and an unresolvable home means there is no journal to race anyway.
+		log.WarningLog.Printf("upgrade interlock: cannot resolve the agent-factory home to take the upgrade lock; installing unlocked: %v", err)
+		return swap()
+	}
+	if err := upgradetxn.WithInstallLock(home, swap); err != nil {
+		return err
+	}
+	return nil
 }

--- a/commands/upgrade_interlock_test.go
+++ b/commands/upgrade_interlock_test.go
@@ -221,11 +221,19 @@ func TestWriteExecutableInPlace_OverrideInstallsAnyway(t *testing.T) {
 	require.Equal(t, "new binary", string(on), "an explicit override must install")
 }
 
-// `af upgrade` refuses before spending a download, and the refusal names the
-// override.
+// The path a maintainer actually runs: `af upgrade` on a box where a daemon is
+// serving. It must refuse before spending a download, name the override, and —
+// the thing that actually matters — leave the executable it is running on
+// untouched.
 func TestRunUpgrade_RefusesDuringALiveTransaction(t *testing.T) {
 	upgradeHome(t)
 	stubUpgradeJournal(t, journalAt(upgradetxn.PhaseDaemonStopped), nil)
+
+	installed := filepath.Join(t.TempDir(), "af")
+	require.NoError(t, os.WriteFile(installed, []byte("the binary in use"), 0o755))
+	originalExec := osExecutableFn
+	osExecutableFn = func() (string, error) { return installed, nil }
+	t.Cleanup(func() { osExecutableFn = originalExec })
 
 	downloaded := false
 	originalDownload := downloadBinaryFn
@@ -244,6 +252,41 @@ func TestRunUpgrade_RefusesDuringALiveTransaction(t *testing.T) {
 	require.Contains(t, err.Error(), "upgrade-abc123")
 	require.Contains(t, err.Error(), "--"+ignoreActiveUpgradeFlag)
 	require.False(t, downloaded, "the refusal must come before the download, not after it")
+
+	on, readErr := os.ReadFile(installed)
+	require.NoError(t, readErr)
+	require.Equal(t, "the binary in use", string(on),
+		"af upgrade must not clobber the executable while a transaction owns it")
+}
+
+// The other half, and the more important one for a box where `af upgrade` is run
+// often: with no transaction in flight, `af upgrade` installs exactly as it
+// always has. The interlock must be invisible on the path people actually use.
+func TestRunUpgrade_InstallsNormallyWithNoTransaction(t *testing.T) {
+	upgradeHome(t)
+
+	installed := filepath.Join(t.TempDir(), "af")
+	require.NoError(t, os.WriteFile(installed, []byte("old binary"), 0o755))
+	originalExec := osExecutableFn
+	osExecutableFn = func() (string, error) { return installed, nil }
+	t.Cleanup(func() { osExecutableFn = originalExec })
+
+	originalDownload := downloadBinaryFn
+	downloadBinaryFn = func(string, time.Duration) ([]byte, error) {
+		return []byte("new binary"), nil
+	}
+	t.Cleanup(func() { downloadBinaryFn = originalDownload })
+
+	originalIgnore := upgradeIgnoreActiveUpgrade
+	upgradeIgnoreActiveUpgrade = false
+	t.Cleanup(func() { upgradeIgnoreActiveUpgrade = originalIgnore })
+
+	require.NoError(t, runUpgrade(io.Discard, io.Discard, "http://example.invalid/af.tar.gz", true))
+
+	on, err := os.ReadFile(installed)
+	require.NoError(t, err)
+	require.Equal(t, "new binary", string(on),
+		"with no transaction the in-place upgrade must behave exactly as before")
 }
 
 // The launch path stands down without touching the shared throttle window or

--- a/commands/upgrade_interlock_test.go
+++ b/commands/upgrade_interlock_test.go
@@ -406,3 +406,155 @@ func TestWriteExecutableInPlace_HoldsThePreparationLockAgainstPrepare(t *testing
 	require.NoError(t, err)
 	require.Equal(t, "new binary", string(on), "and the swap completes once the lock is free")
 }
+
+// Broken lock storage must never block an install. <home>/upgrade left as a file
+// says nothing about whether a transaction exists, and refusing here would make
+// `af upgrade` fail on every invocation with --ignore-active-upgrade powerless,
+// because the override lives inside the swap that never runs.
+func TestWriteExecutableInPlace_BrokenLockStorageStillInstalls(t *testing.T) {
+	home := upgradeHome(t)
+	// Not a directory: WithInstallLock cannot take a lock under it.
+	require.NoError(t, os.WriteFile(filepath.Join(home, "upgrade"), []byte("not a directory"), 0o644))
+
+	target := filepath.Join(t.TempDir(), "af")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0o755))
+
+	require.NoError(t, writeExecutableInPlace(target, []byte("new binary"), false, "--"+ignoreActiveUpgradeFlag),
+		"broken lock storage must not stand between a user and their upgrade")
+
+	on, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, "new binary", string(on))
+}
+
+// ...but the journal check still applies on that unlocked path. Failing to take
+// the lock is not a bypass of the guard, only of the serialisation.
+func TestWriteExecutableInPlace_BrokenLockStorageStillRefusesALiveTransaction(t *testing.T) {
+	home := upgradeHome(t)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "upgrade"), []byte("not a directory"), 0o644))
+	stubUpgradeJournal(t, journalAt(t, upgradetxn.PhaseCandidateValidating), nil)
+
+	target := filepath.Join(t.TempDir(), "af")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0o755))
+
+	err := writeExecutableInPlace(target, []byte("new binary"), false, "--"+ignoreActiveUpgradeFlag)
+	var blocked *blockedInPlaceInstallError
+	require.ErrorAs(t, err, &blocked, "an unlockable install must still honour the journal")
+
+	on, readErr := os.ReadFile(target)
+	require.NoError(t, readErr)
+	require.Equal(t, "old binary", string(on))
+}
+
+// The override has to work on the unlocked path too, or the escape hatch is
+// exactly as unreachable as the bug this fixes.
+func TestWriteExecutableInPlace_BrokenLockStorageHonoursTheOverride(t *testing.T) {
+	home := upgradeHome(t)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "upgrade"), []byte("not a directory"), 0o644))
+	stubUpgradeJournal(t, journalAt(t, upgradetxn.PhaseCandidateValidating), nil)
+
+	target := filepath.Join(t.TempDir(), "af")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0o755))
+
+	require.NoError(t, writeExecutableInPlace(target, []byte("new binary"), true, "--"+ignoreActiveUpgradeFlag))
+
+	on, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, "new binary", string(on))
+}
+
+// Taking the lock must not restyle a directory the installer did not create. An
+// AF home pointed at a broad user directory would otherwise have a routine
+// `af upgrade` change the mode of an unrelated upgrade/ folder.
+func TestWriteExecutableInPlace_LeavesAnExistingUpgradeDirectoryUntouched(t *testing.T) {
+	home := upgradeHome(t)
+	existing := filepath.Join(home, "upgrade")
+	require.NoError(t, os.Mkdir(existing, 0o755))
+	keep := filepath.Join(existing, "user-file")
+	require.NoError(t, os.WriteFile(keep, []byte("mine"), 0o644))
+
+	target := filepath.Join(t.TempDir(), "af")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0o755))
+	require.NoError(t, writeExecutableInPlace(target, []byte("new binary"), false, "--"+ignoreActiveUpgradeFlag))
+
+	info, err := os.Stat(existing)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o755), info.Mode().Perm(),
+		"an in-place upgrade must not chmod a directory it did not create")
+
+	contents, err := os.ReadFile(keep)
+	require.NoError(t, err)
+	require.Equal(t, "mine", string(contents))
+}
+
+// One `af` binary can serve many AF homes, but a transaction is home-scoped
+// while the executable is not. An upgrade run under a DIFFERENT home would find
+// no journal of its own and rename over the very binary another home's
+// transaction is preserving. upgradetxn stages its artifacts next to the
+// executable, so the executable's own directory is where every home's
+// transaction is visible.
+func TestWriteExecutableInPlace_RefusesAnotherHomesStagedUpgrade(t *testing.T) {
+	upgradeHome(t) // this home has no transaction at all
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "af")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0o755))
+	// What upgradetxn.binaryArtifactPaths stages beside the executable.
+	staged := filepath.Join(dir, ".af.af-upgrade-upgrade-otherhome.previous")
+	require.NoError(t, os.WriteFile(staged, []byte("preserved by another home"), 0o755))
+
+	err := writeExecutableInPlace(target, []byte("new binary"), false, "--"+ignoreActiveUpgradeFlag)
+	var blocked *blockedInPlaceInstallError
+	require.ErrorAs(t, err, &blocked,
+		"a transaction staged over this executable by another home must still block the swap")
+	require.Contains(t, err.Error(), "upgrade-otherhome")
+	require.Contains(t, err.Error(), staged, "the message must name the artifact so a leftover can be cleared")
+
+	on, readErr := os.ReadFile(target)
+	require.NoError(t, readErr)
+	require.Equal(t, "old binary", string(on))
+}
+
+// The override still applies to the cross-home case — including for a leftover
+// artifact from an interrupted cleanup, which is the realistic way a user meets
+// this block.
+func TestWriteExecutableInPlace_OverrideBeatsAnotherHomesStagedUpgrade(t *testing.T) {
+	upgradeHome(t)
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "af")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".af.af-upgrade-upgrade-leftover.previous"), []byte("x"), 0o755))
+
+	require.NoError(t, writeExecutableInPlace(target, []byte("new binary"), true, "--"+ignoreActiveUpgradeFlag))
+
+	on, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, "new binary", string(on))
+}
+
+// Only artifacts belonging to THIS executable count. A sibling binary's upgrade,
+// or an unrelated dotfile, must not block.
+func TestForeignUpgradeStagingOver_OnlyMatchesThisExecutable(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "af")
+	require.NoError(t, os.WriteFile(target, []byte("binary"), 0o755))
+
+	for _, name := range []string{
+		".other.af-upgrade-upgrade-abc.previous", // a different executable
+		".af.af-upgrade-upgrade-abc.candidate",   // the candidate, not the rollback input
+		".af.af-upgrade-.previous",               // no transaction id
+		"af.af-upgrade-upgrade-abc.previous",     // not the dotted prefix
+		"unrelated",
+	} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644))
+	}
+
+	require.Nil(t, foreignUpgradeStagingOver(target),
+		"only a preserved-previous artifact for THIS executable may block it")
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".af.af-upgrade-upgrade-real.previous"), []byte("x"), 0o755))
+	found := foreignUpgradeStagingOver(target)
+	require.NotNil(t, found)
+	require.Equal(t, "upgrade-real", found.ID)
+}

--- a/commands/upgrade_interlock_test.go
+++ b/commands/upgrade_interlock_test.go
@@ -1,0 +1,273 @@
+package commands
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/upgradetxn"
+	"github.com/stretchr/testify/require"
+)
+
+var errNotAValidJournal = errors.New("validate active upgrade journal: invalid")
+
+// stubUpgradeJournal points the interlock's loader seam at a fixed journal, so
+// each phase's policy is testable. upgradetxn.Load validates a journal against
+// the preserved binaries, their digests, and the recovery lock on disk, so a
+// journal per phase cannot be hand-forged — only Prepare produces a valid one.
+// TestActiveUpgrade_ReadsARealPreparedTransaction covers the real loader, so the
+// seam cannot drift away from it unnoticed.
+func stubUpgradeJournal(t *testing.T, journal upgradetxn.Journal, err error) {
+	t.Helper()
+	original := loadUpgradeJournal
+	loadUpgradeJournal = func(string) (upgradetxn.Journal, error) { return journal, err }
+	t.Cleanup(func() { loadUpgradeJournal = original })
+}
+
+func journalAt(phase upgradetxn.Phase) upgradetxn.Journal {
+	return upgradetxn.Journal{ID: "upgrade-abc123", ToVersion: "1.0.300", Phase: phase}
+}
+
+func upgradeHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	resolved, err := config.GetConfigDir()
+	require.NoError(t, err)
+	return resolved
+}
+
+// The universal case on every box today: no transaction has ever been created,
+// so the interlock is invisible and the in-place installers behave exactly as
+// before. If this regresses, the interlock has started blocking real upgrades.
+func TestActiveUpgrade_NoJournalAllowsTheInstall(t *testing.T) {
+	upgradeHome(t)
+	require.Nil(t, activeUpgradeOwningExecutable(),
+		"with no upgrade transaction the in-place installer must be unaffected")
+}
+
+// The real loader, against a genuinely Prepare'd transaction — proof that the
+// seam above is wired to production and that a real journal blocks.
+func TestActiveUpgrade_ReadsARealPreparedTransaction(t *testing.T) {
+	home := upgradeHome(t)
+	executable := filepath.Join(t.TempDir(), "af")
+	require.NoError(t, os.WriteFile(executable, []byte("previous-af-binary"), 0o755))
+
+	id := "upgrade-" + strings.Repeat("a", 32)
+	_, err := upgradetxn.Prepare(upgradetxn.Plan{
+		ID:             id,
+		HomeDir:        home,
+		ExecutablePath: executable,
+		FromVersion:    "1.0.100",
+		ToVersion:      "1.0.300",
+		Candidate:      []byte("candidate-af-binary"),
+		Daemon: upgradetxn.DaemonSnapshot{
+			WasRunning: true,
+			BootID:     "boot",
+			Owner:      upgradetxn.DaemonOwner{Kind: upgradetxn.SupervisionAdHoc},
+		},
+		RecoveryJob: upgradetxn.RecoveryJob{Kind: upgradetxn.RecoveryJobDetached},
+	})
+	require.NoError(t, err, "the test needs a real, valid transaction to be meaningful")
+
+	active := activeUpgradeOwningExecutable()
+	require.NotNil(t, active, "a real prepared transaction must block an in-place swap")
+	require.Equal(t, id, active.ID)
+	require.Equal(t, "1.0.300", active.ToVersion)
+	require.Equal(t, string(upgradetxn.PhasePrepared), active.Phase)
+}
+
+// Every phase where an activation is still in flight must block: a swap there
+// destroys the rollback the transaction depends on.
+func TestActiveUpgrade_InFlightPhasesBlockTheInstall(t *testing.T) {
+	for _, phase := range []upgradetxn.Phase{
+		upgradetxn.PhasePrepared,
+		upgradetxn.PhaseSupervisorReady,
+		upgradetxn.PhaseDaemonStopping,
+		upgradetxn.PhaseDaemonStopped,
+		upgradetxn.PhaseCandidateInstalled,
+		upgradetxn.PhaseCandidateStarting,
+		upgradetxn.PhaseCandidateValidating,
+		upgradetxn.PhaseRollingBack,
+		upgradetxn.PhaseRollbackRestored,
+		upgradetxn.PhasePreviousStarting,
+		upgradetxn.PhasePreviousValidating,
+		// Not terminal, and the one that matters most: rollback_failed is the
+		// circuit-breaker state that retains every recovery artifact, so it is
+		// exactly when an unwitting overwrite does the most damage.
+		upgradetxn.PhaseRollbackFailed,
+	} {
+		t.Run(string(phase), func(t *testing.T) {
+			upgradeHome(t)
+			stubUpgradeJournal(t, journalAt(phase), nil)
+
+			active := activeUpgradeOwningExecutable()
+			require.NotNil(t, active, "phase %s is in flight and must block an install", phase)
+			require.Equal(t, "upgrade-abc123", active.ID)
+			require.Equal(t, string(phase), active.Phase)
+		})
+	}
+}
+
+// Terminal phases are cleanup only — the activation is already decided and there
+// is no rollback left to corrupt — so they must not block. Blocking here would
+// strand `af upgrade` behind a journal nobody is going to act on.
+func TestActiveUpgrade_TerminalPhasesAllowTheInstall(t *testing.T) {
+	for _, phase := range []upgradetxn.Phase{
+		upgradetxn.PhaseCommitted,
+		upgradetxn.PhaseRolledBack,
+		upgradetxn.PhaseAborted,
+	} {
+		t.Run(string(phase), func(t *testing.T) {
+			upgradeHome(t)
+			stubUpgradeJournal(t, journalAt(phase), nil)
+			require.Nil(t, activeUpgradeOwningExecutable(),
+				"phase %s is cleanup only and must not block an install", phase)
+		})
+	}
+}
+
+// The polarity that matters. A journal that cannot be read or validated must NOT
+// block: refusing on unreadable evidence would let one corrupt file disable
+// `af upgrade` permanently, with no upgrade-transaction repair in `af doctor` to
+// send the user to — an unoverridable block produced by an inference.
+func TestActiveUpgrade_UnreadableJournalAllowsTheInstall(t *testing.T) {
+	t.Run("real corrupt journal on disk", func(t *testing.T) {
+		home := upgradeHome(t)
+		dir := filepath.Join(home, "upgrade")
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "active.json"), []byte("{not json"), 0o644))
+
+		require.Nil(t, activeUpgradeOwningExecutable(),
+			"a corrupt journal must not permanently disable af upgrade")
+	})
+
+	t.Run("journal fails validation", func(t *testing.T) {
+		upgradeHome(t)
+		stubUpgradeJournal(t, upgradetxn.Journal{}, errNotAValidJournal)
+		require.Nil(t, activeUpgradeOwningExecutable(),
+			"an unvalidatable journal is inconclusive, not proof of a live upgrade")
+	})
+}
+
+// A missing home is not a live transaction.
+func TestActiveUpgrade_MissingHomeAllowsTheInstall(t *testing.T) {
+	home := upgradeHome(t)
+	require.NoError(t, os.RemoveAll(home))
+	require.Nil(t, activeUpgradeOwningExecutable())
+}
+
+// The guarded writer is the actual interlock: both installers go through it, so
+// it must refuse rather than write when a transaction is live.
+func TestWriteExecutableInPlace_RefusesDuringALiveTransaction(t *testing.T) {
+	upgradeHome(t)
+	stubUpgradeJournal(t, journalAt(upgradetxn.PhaseCandidateStarting), nil)
+
+	target := filepath.Join(t.TempDir(), "af")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0o755))
+
+	err := writeExecutableInPlace(target, []byte("new binary"), false, "--"+ignoreActiveUpgradeFlag)
+	require.Error(t, err)
+
+	var blocked *blockedInPlaceInstallError
+	require.ErrorAs(t, err, &blocked)
+	require.Contains(t, err.Error(), "upgrade-abc123")
+	require.Contains(t, err.Error(), "--"+ignoreActiveUpgradeFlag,
+		"a refusal must name its override; a block a user cannot get past is a brick")
+
+	on, readErr := os.ReadFile(target)
+	require.NoError(t, readErr)
+	require.Equal(t, "old binary", string(on), "the executable must be untouched")
+}
+
+// And it must actually write when nothing owns the executable — otherwise every
+// test above would pass on a writer that refuses unconditionally.
+func TestWriteExecutableInPlace_WritesWhenNoTransactionIsActive(t *testing.T) {
+	upgradeHome(t)
+
+	target := filepath.Join(t.TempDir(), "af")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0o755))
+
+	require.NoError(t, writeExecutableInPlace(target, []byte("new binary"), false, "--"+ignoreActiveUpgradeFlag))
+
+	on, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, "new binary", string(on))
+
+	info, err := os.Stat(target)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o755), info.Mode().Perm(), "the swapped binary must stay executable")
+}
+
+// The override is honoured. An interlock a user cannot get past would be its own
+// hazard — a safeguard must not be the thing that strands someone on a broken
+// binary.
+func TestWriteExecutableInPlace_OverrideInstallsAnyway(t *testing.T) {
+	upgradeHome(t)
+	stubUpgradeJournal(t, journalAt(upgradetxn.PhaseCandidateValidating), nil)
+
+	target := filepath.Join(t.TempDir(), "af")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0o755))
+
+	require.NoError(t, writeExecutableInPlace(target, []byte("new binary"), true, "--"+ignoreActiveUpgradeFlag))
+
+	on, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, "new binary", string(on), "an explicit override must install")
+}
+
+// `af upgrade` refuses before spending a download, and the refusal names the
+// override.
+func TestRunUpgrade_RefusesDuringALiveTransaction(t *testing.T) {
+	upgradeHome(t)
+	stubUpgradeJournal(t, journalAt(upgradetxn.PhaseDaemonStopped), nil)
+
+	downloaded := false
+	originalDownload := downloadBinaryFn
+	downloadBinaryFn = func(string, time.Duration) ([]byte, error) {
+		downloaded = true
+		return []byte("new binary"), nil
+	}
+	t.Cleanup(func() { downloadBinaryFn = originalDownload })
+
+	originalIgnore := upgradeIgnoreActiveUpgrade
+	upgradeIgnoreActiveUpgrade = false
+	t.Cleanup(func() { upgradeIgnoreActiveUpgrade = originalIgnore })
+
+	err := runUpgrade(io.Discard, io.Discard, "http://example.invalid/af.tar.gz", true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "upgrade-abc123")
+	require.Contains(t, err.Error(), "--"+ignoreActiveUpgradeFlag)
+	require.False(t, downloaded, "the refusal must come before the download, not after it")
+}
+
+// The launch path stands down without touching the shared throttle window or
+// spending a download — and never blocks or errors at the launch.
+func TestAutoUpdateOnLaunch_StandsDownDuringALiveTransaction(t *testing.T) {
+	home := upgradeHome(t)
+	stubUpgradeJournal(t, journalAt(upgradetxn.PhaseCandidateStarting), nil)
+
+	checked := false
+	originalFetch := fetchLatestReleaseTagFn
+	fetchLatestReleaseTagFn = func(string, time.Duration) (string, error) {
+		checked = true
+		return "v1.0.400", nil
+	}
+	t.Cleanup(func() { fetchLatestReleaseTagFn = originalFetch })
+
+	originalTTY := stdoutIsTTYFn
+	stdoutIsTTYFn = func() bool { return true }
+	t.Cleanup(func() { stdoutIsTTYFn = originalTTY })
+
+	autoUpdateOnLaunch(&config.Config{AutoUpdate: true, UpdateChannel: config.UpdateChannelStable})
+
+	require.False(t, checked, "a launch during an upgrade must not even resolve a release")
+	_, err := os.Stat(filepath.Join(home, "last_update_check"))
+	require.True(t, os.IsNotExist(err),
+		"standing down must not consume the shared 6h window; the next launch re-evaluates")
+}

--- a/commands/upgrade_interlock_test.go
+++ b/commands/upgrade_interlock_test.go
@@ -29,8 +29,20 @@ func stubUpgradeJournal(t *testing.T, journal upgradetxn.Journal, err error) {
 	t.Cleanup(func() { loadUpgradeJournal = original })
 }
 
-func journalAt(phase upgradetxn.Phase) upgradetxn.Journal {
-	return upgradetxn.Journal{ID: "upgrade-abc123", ToVersion: "1.0.300", Phase: phase}
+// journalAt builds a journal whose preserved previous binary really exists —
+// that artifact is what the interlock protects, and a journal without it is a
+// transaction with no rollback left (see
+// TestActiveUpgrade_MissingRollbackArtifactAllowsTheInstall).
+func journalAt(t *testing.T, phase upgradetxn.Phase) upgradetxn.Journal {
+	t.Helper()
+	previous := filepath.Join(t.TempDir(), ".af-upgrade-previous")
+	require.NoError(t, os.WriteFile(previous, []byte("preserved previous binary"), 0o755))
+	return upgradetxn.Journal{
+		ID:                 "upgrade-abc123",
+		ToVersion:          "1.0.300",
+		Phase:              phase,
+		PreviousBinaryPath: previous,
+	}
 }
 
 func upgradeHome(t *testing.T) string {
@@ -104,7 +116,7 @@ func TestActiveUpgrade_InFlightPhasesBlockTheInstall(t *testing.T) {
 	} {
 		t.Run(string(phase), func(t *testing.T) {
 			upgradeHome(t)
-			stubUpgradeJournal(t, journalAt(phase), nil)
+			stubUpgradeJournal(t, journalAt(t, phase), nil)
 
 			active := activeUpgradeOwningExecutable()
 			require.NotNil(t, active, "phase %s is in flight and must block an install", phase)
@@ -125,7 +137,7 @@ func TestActiveUpgrade_TerminalPhasesAllowTheInstall(t *testing.T) {
 	} {
 		t.Run(string(phase), func(t *testing.T) {
 			upgradeHome(t)
-			stubUpgradeJournal(t, journalAt(phase), nil)
+			stubUpgradeJournal(t, journalAt(t, phase), nil)
 			require.Nil(t, activeUpgradeOwningExecutable(),
 				"phase %s is cleanup only and must not block an install", phase)
 		})
@@ -155,6 +167,36 @@ func TestActiveUpgrade_UnreadableJournalAllowsTheInstall(t *testing.T) {
 	})
 }
 
+// A loadable journal is not proof there is still a rollback to protect.
+// upgradetxn.Load validates recorded paths, digests, and lock metadata — not the
+// artifact contents — so a half-cleaned or failed transaction can leave a journal
+// that loads while its preserved previous binary is gone. Blocking then protects
+// nothing and only stands between the user and a working `af upgrade`.
+func TestActiveUpgrade_MissingRollbackArtifactAllowsTheInstall(t *testing.T) {
+	upgradeHome(t)
+	journal := journalAt(t, upgradetxn.PhaseCandidateValidating)
+	require.NoError(t, os.Remove(journal.PreviousBinaryPath))
+	stubUpgradeJournal(t, journal, nil)
+
+	require.Nil(t, activeUpgradeOwningExecutable(),
+		"with the preserved previous binary gone the rollback is already impossible; blocking protects nothing")
+}
+
+// But only a POSITIVE absence downgrades the block. An inconclusive stat is not
+// evidence the artifact is gone, and the block it keeps is overridable anyway.
+func TestActiveUpgrade_InconclusiveArtifactStatKeepsTheBlock(t *testing.T) {
+	upgradeHome(t)
+	journal := journalAt(t, upgradetxn.PhaseCandidateValidating)
+	// A path whose parent is a regular file: stat fails ENOTDIR, not ErrNotExist.
+	blocked := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(blocked, []byte("x"), 0o644))
+	journal.PreviousBinaryPath = filepath.Join(blocked, "previous")
+	stubUpgradeJournal(t, journal, nil)
+
+	require.NotNil(t, activeUpgradeOwningExecutable(),
+		"an inconclusive stat must not be read as a missing rollback artifact")
+}
+
 // A missing home is not a live transaction.
 func TestActiveUpgrade_MissingHomeAllowsTheInstall(t *testing.T) {
 	home := upgradeHome(t)
@@ -166,7 +208,7 @@ func TestActiveUpgrade_MissingHomeAllowsTheInstall(t *testing.T) {
 // it must refuse rather than write when a transaction is live.
 func TestWriteExecutableInPlace_RefusesDuringALiveTransaction(t *testing.T) {
 	upgradeHome(t)
-	stubUpgradeJournal(t, journalAt(upgradetxn.PhaseCandidateStarting), nil)
+	stubUpgradeJournal(t, journalAt(t, upgradetxn.PhaseCandidateStarting), nil)
 
 	target := filepath.Join(t.TempDir(), "af")
 	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0o755))
@@ -209,7 +251,7 @@ func TestWriteExecutableInPlace_WritesWhenNoTransactionIsActive(t *testing.T) {
 // binary.
 func TestWriteExecutableInPlace_OverrideInstallsAnyway(t *testing.T) {
 	upgradeHome(t)
-	stubUpgradeJournal(t, journalAt(upgradetxn.PhaseCandidateValidating), nil)
+	stubUpgradeJournal(t, journalAt(t, upgradetxn.PhaseCandidateValidating), nil)
 
 	target := filepath.Join(t.TempDir(), "af")
 	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0o755))
@@ -227,7 +269,7 @@ func TestWriteExecutableInPlace_OverrideInstallsAnyway(t *testing.T) {
 // untouched.
 func TestRunUpgrade_RefusesDuringALiveTransaction(t *testing.T) {
 	upgradeHome(t)
-	stubUpgradeJournal(t, journalAt(upgradetxn.PhaseDaemonStopped), nil)
+	stubUpgradeJournal(t, journalAt(t, upgradetxn.PhaseDaemonStopped), nil)
 
 	installed := filepath.Join(t.TempDir(), "af")
 	require.NoError(t, os.WriteFile(installed, []byte("the binary in use"), 0o755))
@@ -293,7 +335,7 @@ func TestRunUpgrade_InstallsNormallyWithNoTransaction(t *testing.T) {
 // spending a download — and never blocks or errors at the launch.
 func TestAutoUpdateOnLaunch_StandsDownDuringALiveTransaction(t *testing.T) {
 	home := upgradeHome(t)
-	stubUpgradeJournal(t, journalAt(upgradetxn.PhaseCandidateStarting), nil)
+	stubUpgradeJournal(t, journalAt(t, upgradetxn.PhaseCandidateStarting), nil)
 
 	checked := false
 	originalFetch := fetchLatestReleaseTagFn
@@ -313,4 +355,54 @@ func TestAutoUpdateOnLaunch_StandsDownDuringALiveTransaction(t *testing.T) {
 	_, err := os.Stat(filepath.Join(home, "last_update_check"))
 	require.True(t, os.IsNotExist(err),
 		"standing down must not consume the shared 6h window; the next launch re-evaluates")
+}
+
+// The interlock's check and write must be atomic against a transaction publish.
+// Checking and then writing is a time-of-check-to-time-of-use window on its own:
+// a transaction published in between is invisible to a check that already
+// passed. Both sides take upgradetxn's preparation lock, so this proves the
+// installer actually holds it — a Prepare racing the swap blocks until the swap
+// is done, rather than interleaving with it.
+func TestWriteExecutableInPlace_HoldsThePreparationLockAgainstPrepare(t *testing.T) {
+	home := upgradeHome(t)
+
+	target := filepath.Join(t.TempDir(), "af")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0o755))
+
+	// Hold the same lock a Prepare would, then prove the swap cannot proceed
+	// while it is held.
+	holding := make(chan struct{})
+	release := make(chan struct{})
+	held := make(chan error, 1)
+	go func() {
+		held <- upgradetxn.WithInstallLock(home, func() error {
+			close(holding)
+			<-release
+			return nil
+		})
+	}()
+	<-holding
+
+	done := make(chan error, 1)
+	go func() {
+		done <- writeExecutableInPlace(target, []byte("new binary"), false, "--"+ignoreActiveUpgradeFlag)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("the in-place swap proceeded while the preparation lock was held; check and write are not serialised against Prepare")
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	on, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, "old binary", string(on), "nothing may be written while the lock is held")
+
+	close(release)
+	require.NoError(t, <-held)
+	require.NoError(t, <-done)
+
+	on, err = os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, "new binary", string(on), "and the swap completes once the lock is free")
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2359,6 +2359,7 @@ af upgrade [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `--allow-downgrade` |  | Install the channel's latest release even if it is older than the current binary (e.g. switching from preview back to stable) |
+| `--ignore-active-upgrade` |  | Install even while a daemon upgrade transaction is in progress (this can leave that upgrade unable to roll back) |
 | `--no-restart` |  | Leave the running daemon alone (af upgrade restarts it by default so the new binary takes effect) |
 
 **Global flags**

--- a/internal/upgradetxn/install_lock.go
+++ b/internal/upgradetxn/install_lock.go
@@ -3,6 +3,7 @@ package upgradetxn
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 )
 
@@ -43,8 +44,8 @@ func WithInstallLock(homeDir string, fn func() error) (retErr error) {
 		return fmt.Errorf("validate upgrade home: %w", err)
 	}
 	root := upgradeRoot(home)
-	if err := ensureDurableDirectory(home, root, transactionDirMode); err != nil {
-		return fmt.Errorf("prepare upgrade root: %w", err)
+	if err := ensureLockRoot(root); err != nil {
+		return err
 	}
 	lock, err := acquireFileLock(filepath.Join(root, preparationLockName), false)
 	if err != nil {
@@ -54,4 +55,34 @@ func WithInstallLock(homeDir string, fn func() error) (retErr error) {
 		retErr = errors.Join(retErr, releaseFileLock(lock))
 	}()
 	return fn()
+}
+
+// ensureLockRoot makes the upgrade root usable as a lock location WITHOUT
+// restyling it. Prepare hardens the directory it creates for a transaction; an
+// in-place installer only needs somewhere to take the lock, and it must not
+// chmod a directory it did not create. That distinction matters because this now
+// runs on every in-place upgrade: an AF home pointed at a broad user directory
+// would otherwise have a routine `af upgrade` silently change the mode of an
+// unrelated `upgrade/` folder.
+//
+// An existing directory is used exactly as it is. Only a directory this call
+// creates is secured. Anything that is not a directory — a file, a symlink — is
+// an error, and the caller's contract is to log it and install unlocked rather
+// than let broken lock storage stand between a user and their upgrade.
+func ensureLockRoot(path string) error {
+	err := validateDirectoryNoSymlink(path)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if mkErr := os.Mkdir(path, transactionDirMode); mkErr != nil {
+		if !errors.Is(mkErr, os.ErrExist) {
+			return fmt.Errorf("create upgrade lock root %s: %w", path, mkErr)
+		}
+	} else if chErr := os.Chmod(path, transactionDirMode); chErr != nil {
+		return fmt.Errorf("secure new upgrade lock root %s: %w", path, chErr)
+	}
+	return validateDirectoryNoSymlink(path)
 }

--- a/internal/upgradetxn/install_lock.go
+++ b/internal/upgradetxn/install_lock.go
@@ -1,0 +1,57 @@
+package upgradetxn
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+)
+
+// preparationLockName is the single lock that serialises publishing a
+// transaction against an in-place binary swap. Named once so Prepare and
+// WithInstallLock cannot drift onto different files and silently stop
+// excluding each other.
+const preparationLockName = "prepare.lock"
+
+// WithInstallLock runs fn while holding the SAME preparation lock Prepare takes,
+// so an in-place binary swap and a transaction publish cannot interleave (#2212).
+//
+// Two mechanisms replace the same executable: the in-place installers
+// (`af upgrade`, launch-time auto-update) and this transactional path. Checking
+// for an active transaction and then writing the binary is a
+// time-of-check-to-time-of-use window on its own — a transaction published in
+// between is invisible to a check that already passed, and the swap lands
+// underneath it. Serialising both through one lock is what closes that window,
+// and it is why Prepare snapshots the running executable inside the lock rather
+// than before it.
+//
+// It is also why Prepare snapshots the running executable INSIDE this lock. An
+// in-place installer takes the same lock around its swap, so reading the
+// executable outside it would let a transaction preserve pre-swap bytes as its
+// "previous" binary while newer bytes sit on disk — and a later rollback would
+// then silently undo that install.
+//
+// The lock blocks rather than failing: an installer that arrives mid-preparation
+// should wait out a bounded, seconds-long publish, not refuse. Callers that must
+// not block are the ones that should be reading the journal instead.
+//
+// Like Prepare, this materialises the upgrade root if it is absent — taking a
+// lock requires a file to take it on. That is a write, so this belongs on paths
+// that are already mutating (an install), never on a read-only probe.
+func WithInstallLock(homeDir string, fn func() error) (retErr error) {
+	home, err := canonicalExistingDir(homeDir)
+	if err != nil {
+		return fmt.Errorf("validate upgrade home: %w", err)
+	}
+	root := upgradeRoot(home)
+	if err := ensureDurableDirectory(home, root, transactionDirMode); err != nil {
+		return fmt.Errorf("prepare upgrade root: %w", err)
+	}
+	lock, err := acquireFileLock(filepath.Join(root, preparationLockName), false)
+	if err != nil {
+		return fmt.Errorf("lock upgrade preparation: %w", err)
+	}
+	defer func() {
+		retErr = errors.Join(retErr, releaseFileLock(lock))
+	}()
+	return fn()
+}

--- a/internal/upgradetxn/transaction.go
+++ b/internal/upgradetxn/transaction.go
@@ -301,6 +301,21 @@ func Prepare(stablePlan Plan) (_ *Transaction, retErr error) {
 	}
 	recoveryNonce := hex.EncodeToString(nonceBytes)
 
+	root := upgradeRoot(home)
+	if err := ensureDurableDirectory(home, root, transactionDirMode); err != nil {
+		return nil, fmt.Errorf("prepare upgrade root: %w", err)
+	}
+
+	preparationLock, err := acquireFileLock(filepath.Join(root, preparationLockName), false)
+	if err != nil {
+		return nil, fmt.Errorf("lock upgrade preparation: %w", err)
+	}
+	defer func() {
+		retErr = errors.Join(retErr, releaseFileLock(preparationLock))
+	}()
+
+	// Snapshot the running executable under the preparation lock, never before
+	// it — see WithInstallLock for why that ordering is load-bearing (#2212).
 	executable, err := canonicalExistingFile(stablePlan.ExecutablePath)
 	if err != nil {
 		return nil, fmt.Errorf("validate running executable: %w", err)
@@ -319,19 +334,6 @@ func Prepare(stablePlan Plan) (_ *Transaction, retErr error) {
 	if digest(previousBinary) == digest(stablePlan.Candidate) {
 		return nil, errors.New("candidate binary is byte-identical to the previous binary")
 	}
-
-	root := upgradeRoot(home)
-	if err := ensureDurableDirectory(home, root, transactionDirMode); err != nil {
-		return nil, fmt.Errorf("prepare upgrade root: %w", err)
-	}
-
-	preparationLock, err := acquireFileLock(filepath.Join(root, "prepare.lock"), false)
-	if err != nil {
-		return nil, fmt.Errorf("lock upgrade preparation: %w", err)
-	}
-	defer func() {
-		retErr = errors.Join(retErr, releaseFileLock(preparationLock))
-	}()
 
 	activePath := activeJournalPath(home)
 	if _, err := os.Lstat(activePath); err == nil {

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -1709,6 +1709,7 @@
       "af token show --json": "cli.json-envelope",
       "af upgrade --allow-downgrade": "install.upgrade",
       "af upgrade --help": "meta.discovery",
+      "af upgrade --ignore-active-upgrade": "install.upgrade",
       "af upgrade --no-restart": "install.upgrade",
       "af version --help": "meta.discovery"
     }


### PR DESCRIPTION
## What

Two mechanisms replace the same on-disk executable:

1. **In place** — `af upgrade` and launch-time auto-update: `AtomicWriteFile` over the resolved executable, then restart the daemon. No journal, no probation, no rollback.
2. **Transactional** — the daemon's activation path (`internal/upgradetxn`): an fsynced journal, a preserved previous binary, probation, validated activation, guarded rollback.

An in-place swap that lands mid-transaction writes the canonical path with no awareness of the transaction, destroying the rollback that transaction exists to guarantee. #2212 names this the worst failure on the whole upgrade path — strictly worse than having no daemon-owned upgrade at all. It is latent only because nothing creates a transaction yet, and it would not be visible in the diff of the slice that changes that.

## This does not pick the winner — it builds the floor all three options need

Which mechanism wins is still open on #2212: **A** transactional is the single writer whenever a daemon owns the home, **B** the daemon defers to the in-place installer, **C** leave both and add mutual exclusion. I have not guessed at it.

But **all three require the same thing**: the in-place writer must not clobber a live transaction. Option C *is* that floor; A and B add policy on top. So it can land now, and the reconciliation slice then gets to be about policy rather than about safety.

## The design is the polarity

`writeExecutableInPlace` is the one guarded swap both installers go through, so the interlock is a property of the write rather than of remembering to check. The entrypoint checks exist only for a better message and to skip a pointless download.

Check and write are held under **`upgradetxn`'s own preparation lock**, so they cannot interleave with a transaction publish. `Prepare` already took that lock, so the installer just had to participate — and `Prepare`'s snapshot of the running executable moved inside it, since reading outside would let a transaction preserve pre-swap bytes while newer bytes sat on disk.

It blocks **only on a positive, readable, non-terminal transaction**:

| State | Result | Why |
|---|---|---|
| No journal | proceed | Every box today. Behaviour unchanged, pinned by a test. |
| In-flight phase | **block** | A swap here destroys the rollback. |
| `rollback_failed` | **block** | Deliberately not terminal — it retains every recovery artifact, so an overwrite does the most damage here. |
| `committed` / `rolled_back` / `aborted` | proceed | Cleanup only; the activation is decided and there is no rollback left to corrupt. |
| Unreadable / unvalidatable journal | proceed, loudly | See below. |
| Valid journal, preserved previous binary **positively absent** | proceed, loudly | The rollback is already impossible, so blocking protects nothing. |
| A preserved-previous artifact staged beside the executable by **another AF home** | **block** | One binary serves many homes; a home-scoped journal cannot see them all. |
| The interlock's own lock cannot be taken | proceed, loudly | Broken lock storage must never block an upgrade — see below. |

**The unreadable case is the one worth arguing about.** Refusing on unreadable evidence would let one corrupt file disable `af upgrade` permanently — and `af doctor` has no upgrade-transaction repair to send the user to (I checked: `doctor/` does not import `upgradetxn`, so the "run af doctor --fix" pointer other upgrade messages use would be a remedy that does not exist). That is an unoverridable block produced by an inference, which is the shape this repo has been bitten by before. It is also the empirically wrong guess: a live transaction writes a valid fsynced journal, so a corrupt one much more often means a broken install that needs `af upgrade` to work than a live actor to protect.

## Never unoverridable

`af upgrade --ignore-active-upgrade` installs anyway, and the refusal message names it. A refusal a user cannot get past is not a safeguard but a brick. The override is logged, since it may leave that upgrade unable to roll back.

The launch path deliberately has **no** override: an unattended installer must never be the thing that clobbers a live transaction, and there is no human there to weigh it. It stands down silently — before the throttle cache is even opened, so a launch during an upgrade neither consumes the shared 6h window nor spends a download — and never blocks, prints at, or fails the launch.

## Verification

Every load-bearing branch was **mutation-tested** — implementation broken, test watched go red, then restored:

| Mutation | Test that caught it |
| --- | --- |
| writer guard removed | `WriteExecutableInPlace_RefusesDuringALiveTransaction` |
| terminal phases treated as in-flight | `ActiveUpgrade_TerminalPhasesAllowTheInstall` |
| `rollback_failed` treated as terminal | `ActiveUpgrade_InFlightPhasesBlockTheInstall` |
| unreadable journal blocks | `ActiveUpgrade_UnreadableJournalAllowsTheInstall` |
| override ignored | `WriteExecutableInPlace_OverrideInstallsAnyway` |
| `af upgrade` early check removed | `RunUpgrade_RefusesDuringALiveTransaction` |
| launch-path gate removed | `AutoUpdateOnLaunch_StandsDownDuringALiveTransaction` |
| installer skips the preparation lock | `WriteExecutableInPlace_HoldsThePreparationLockAgainstPrepare` |
| missing rollback artifact still blocks | `ActiveUpgrade_MissingRollbackArtifactAllowsTheInstall` |
| inconclusive artifact stat read as absence | `ActiveUpgrade_InconclusiveArtifactStatKeepsTheBlock` |
| lock failure returns the error (the brick) | `WriteExecutableInPlace_BrokenLockStorageStillInstalls` |
| unlocked path skips the journal check | `WriteExecutableInPlace_BrokenLockStorageStillRefusesALiveTransaction` |
| lock root chmods an existing directory | `WriteExecutableInPlace_LeavesAnExistingUpgradeDirectoryUntouched` |
| cross-home check removed | `WriteExecutableInPlace_RefusesAnotherHomesStagedUpgrade` |
| artifact prefix match loosened | `ForeignUpgradeStagingOver_OnlyMatchesThisExecutable` |

`upgradetxn.Load` validates a journal against the preserved binaries, their digests, and the recovery lock on disk, so a journal per phase cannot be hand-forged — only `Prepare` produces a valid one. Phase policy is therefore tested through a loader seam, and `ActiveUpgrade_ReadsARealPreparedTransaction` drives a genuinely `Prepare`d transaction through the production path so the seam cannot drift from the real loader unnoticed.

Local gate green: `gofmt -l .` (empty), `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh`, plus the `commands` upgrade/auto-update tests. `docs/reference/cli.md` regenerated with `scripts/gen-docs.sh` for the new flag. No daemon-package tests were run on the host, and no containerized suite — CI runs the matrix.

## Review round

Codex filed two P2s, both confirmed in code before fixing and both fixed in `0d3e36a8`:

1. **Check-then-write is a TOCTOU window.** Correct. The fix was smaller than reported — `Prepare` already takes a `prepare.lock`, so the installer only had to participate (`upgradetxn.WithInstallLock`, sharing one `preparationLockName` const so the two cannot drift onto different files). Wiring it surfaced something the report did not name: `Prepare` read the running executable *before* acquiring its own lock, so a swap in that gap would have left the transaction preserving pre-swap bytes and a later rollback silently undoing the user's `af upgrade`. That snapshot now happens inside the lock.
2. **A loadable journal is not proof a rollback survives.** Confirmed: `validateTransactionStorage` checks only the transaction directory, never the `.af-upgrade-*` binaries, so a half-cleaned transaction blocked `af upgrade` while protecting nothing. Now downgraded on a positive absence of the preserved previous binary; an inconclusive stat keeps the block.

`internal/upgradetxn`'s suite is green with the reordering. `transaction.go` reached the 1000-line limit, so the ordering rationale lives with `WithInstallLock` — where the invariant belongs — rather than being grandfathered.

### Second round

Three more P2s, all confirmed in code and all fixed in `244000b6`:

3. **The interlock could brick the installer.** `<home>/upgrade` left as a file made `WithInstallLock` error, and that error returned *before* the write — on every invocation, with `--ignore-active-upgrade` powerless because the override lives inside the swap that never ran. Exactly the unoverridable block this PR claims not to create. A lock failure now logs and installs unlocked; a `swapRan` flag separates "could not lock" from "the swap refused", so the fallback costs the serialisation, never the guard.
4. **Taking the lock chmodded directories it did not create.** `ensureDurableDirectory` chmods an *existing* directory, and the installer now reaches it on every upgrade. The lock root is used as found; only a directory this code creates is secured.
5. **The guard could not see other homes.** A transaction is home-scoped, the executable is not. My first read was that cross-home discovery needed a registry that does not exist — checking beat assuming: `binaryArtifactPaths` stages the preserved and candidate binaries *next to the executable*, so the executable's own directory is where every home's transaction is visible.

**What is deliberately not claimed:** finding 5 closes the cross-home *check*, not cross-home *serialisation*. A different home's `Prepare` racing the window between its own lock and staging its artifacts is still unserialised, because the lock is per-home. That needs an executable-keyed lock `Prepare` also takes — a change to the engine's locking model, unreachable until activation exists, and [recorded on #2212 as a prerequisite for the activation slice](https://github.com/sachiniyer/agent-factory/issues/2212). A cross-home lock without the discovery that shipped would have serialised against a transaction the installer still could not see and then written anyway — a false sense of safety.

## Scope

Inert on every real box today: nothing creates a transaction, so this resolves to "no journal → proceed" everywhere. It does not enable activation, does not touch the throttle, and does not change `autoUpdateOnLaunch`'s behaviour when no upgrade is in flight.

Closes #2858

Prerequisite for the remaining #2212 work: the activation wiring plus the A/B/C reconciliation, and R4's destructive forward-then-rollback integration. This PR carries no closing keyword for that epic — it is one slice of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
