### PR TITLE
fix(web): copy on every route, on every layout, and stop stealing devtools (#2831)

### DIFF
--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6745,6 +6745,13 @@ var import_addon_fit = __toESM(require_addon_fit(), 1);
 var import_xterm = __toESM(require_xterm(), 1);
 
 // src/clipboard.ts
+function chordIsLetter(ev, letter, code) {
+  const typed = ev.key.toLowerCase();
+  if (typed.length === 1 && typed >= "a" && typed <= "z") {
+    return typed === letter;
+  }
+  return ev.code === code;
+}
 var ETX = "";
 var LF = "\n";
 function handleClipboardKeydown(ev, deps) {
@@ -6756,7 +6763,7 @@ function handleClipboardKeydown(ev, deps) {
     deps.sendUserInput(LF);
     return false;
   }
-  if (ev.metaKey && !ev.ctrlKey && !ev.altKey && !ev.shiftKey && ev.key.toLowerCase() === "c") {
+  if (ev.metaKey && !ev.ctrlKey && !ev.altKey && !ev.shiftKey && chordIsLetter(ev, "c", "KeyC")) {
     if (!deps.hasSelection()) {
       return true;
     }
@@ -6767,17 +6774,12 @@ function handleClipboardKeydown(ev, deps) {
   if (ev.metaKey || ev.altKey || !ev.ctrlKey) {
     return true;
   }
-  const key = ev.key.toLowerCase();
-  if (key === "v") {
+  if (chordIsLetter(ev, "v", "KeyV")) {
     return false;
   }
-  if (key === "c") {
+  if (chordIsLetter(ev, "c", "KeyC")) {
     if (ev.shiftKey) {
-      ev.preventDefault();
-      if (deps.hasSelection()) {
-        deps.copy(deps.getSelection());
-      }
-      return false;
+      return true;
     }
     if (deps.hasSelection()) {
       ev.preventDefault();
@@ -6789,6 +6791,22 @@ function handleClipboardKeydown(ev, deps) {
     deps.sendInput(ETX);
     return false;
   }
+  return true;
+}
+function handleTerminalCopy(ev, deps) {
+  if (!deps.hasSelection()) {
+    return false;
+  }
+  const text = deps.getSelection();
+  if (text === "") {
+    return false;
+  }
+  ev.preventDefault();
+  if (ev.clipboardData) {
+    ev.clipboardData.setData("text/plain", text);
+    return true;
+  }
+  deps.copy(text);
   return true;
 }
 
@@ -7190,6 +7208,7 @@ var AttachTerminal = class {
     container.addEventListener("touchmove", this.onTouchMove, { capture: true, passive: false });
     container.addEventListener("pointerdown", this.onPointerDown, true);
     container.addEventListener("mousedown", this.onMouseDownCapture, true);
+    container.addEventListener("copy", this.onCopy);
     this.scheduleVisibleFit();
   }
   term;
@@ -7322,6 +7341,16 @@ var AttachTerminal = class {
     }
     event.preventDefault();
   };
+  /** Every browser-initiated copy over the terminal (#2831) — the chord, macOS
+   *  Edit → Copy, right-click → Copy, assistive tech. The decision is in
+   *  clipboard.ts; this only supplies xterm's selection and the fallback ladder. */
+  onCopy = (event) => {
+    handleTerminalCopy(event, {
+      hasSelection: () => this.term.hasSelection(),
+      getSelection: () => this.term.getSelection(),
+      copy: (text) => this.copyToClipboard(text)
+    });
+  };
   onPointerDown = (event) => {
     this.lastPointerWasTouch = event.pointerType === "touch";
     const viewport = this.container.querySelector(".xterm-viewport");
@@ -7423,6 +7452,7 @@ var AttachTerminal = class {
     this.container.removeEventListener("touchmove", this.onTouchMove, true);
     this.container.removeEventListener("pointerdown", this.onPointerDown, true);
     this.container.removeEventListener("mousedown", this.onMouseDownCapture, true);
+    this.container.removeEventListener("copy", this.onCopy);
     this.endHandedOffDrag();
     this.closeSocket();
     this.term.dispose();

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "101018162d70";
+const VERSION = "f75ced45391a";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/clipboard.test.ts
+++ b/web/src/clipboard.test.ts
@@ -11,7 +11,14 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { type ClipboardDeps, type ClipboardKeyEvent, handleClipboardKeydown } from "./clipboard.js";
+import {
+  type ClipboardDeps,
+  type ClipboardKeyEvent,
+  handleClipboardKeydown,
+  handleTerminalCopy,
+  type TerminalCopyDeps,
+  type TerminalCopyEvent,
+} from "./clipboard.js";
 import { decode, inputFrame, Op, encode } from "./frame.js";
 
 const ETX = "\x03";
@@ -172,33 +179,29 @@ test("Ctrl+C with NO selection sends \\x03 on the wire and copies nothing", () =
 
 // --- Ctrl+Shift+C: explicit always-copy, never interrupts ---------------------
 
-test("Ctrl+Shift+C copies the selection and never sends \\x03", () => {
-  const r = rig({ selection: "abc" });
-  const ret = handleClipboardKeydown(
-    keyEvent({ key: "C", ctrlKey: true, shiftKey: true }, r.markPrevented),
-    r.deps,
-  );
+test("Ctrl+Shift+C is left entirely to the browser's devtools (#2831)", () => {
+  // It used to be an explicit always-copy with a preventDefault. But Ctrl+Shift+C is
+  // inspect-element on Linux and Windows, exactly as Cmd+Shift+C is on macOS — which
+  // the Cmd branch already refused to claim for that reason. Claiming one and sparing
+  // the other protected devtools for macOS users only.
+  //
+  // `true` is safe here, and that was measured rather than assumed: against real
+  // xterm in Chromium, Ctrl+Shift+C emits nothing on onData (the ctrl+letter mapping
+  // does not apply with shift held) and xterm leaves the event uncancelled. So there
+  // is no keymap to suppress and the browser still gets its shortcut.
+  for (const selection of ["sel", ""]) {
+    const r = rig({ selection });
+    const ret = handleClipboardKeydown(
+      keyEvent({ key: "C", code: "KeyC", ctrlKey: true, shiftKey: true }, r.markPrevented),
+      r.deps,
+    );
 
-  assert.equal(ret, false);
-  assert.deepEqual(r.clipboard, ["abc"]);
-  assert.equal(wireInput(r.wire), "", "an explicit copy must never interrupt");
-  assert.equal(r.prevented(), 1);
-  assert.equal(r.cleared(), 0, "Ctrl+Shift+C keeps the selection — it is the 'keep selecting' gesture");
+    assert.equal(ret, true, `selection=${JSON.stringify(selection)}`);
+    assert.equal(r.prevented(), 0, "the browser must still see the event to open devtools");
+    assert.equal(wireInput(r.wire), "", "nothing may reach the PTY on a devtools keypress");
+    assert.deepEqual(r.clipboard, [], "copying belongs to Ctrl+C, Cmd+C and the copy event now");
+  }
 });
-
-test("Ctrl+Shift+C with NO selection is a no-op (no copy, no interrupt)", () => {
-  const r = rig({ selection: "" });
-  const ret = handleClipboardKeydown(
-    keyEvent({ key: "C", ctrlKey: true, shiftKey: true }, r.markPrevented),
-    r.deps,
-  );
-
-  assert.equal(ret, false, "still claims the key so it never falls through to \\x03");
-  assert.deepEqual(r.clipboard, []);
-  assert.equal(wireInput(r.wire), "", "explicit copy is never an interrupt, even with nothing selected");
-});
-
-// --- Paste: defer to xterm's native (browser-trusted) paste -------------------
 
 test("Ctrl+V defers to native paste: suppresses xterm's \\x16, sends nothing itself, no preventDefault", () => {
   const r = rig({ selection: "" });
@@ -224,14 +227,12 @@ test("Ctrl+Shift+V also defers to native paste without preventDefault", () => {
 
 // --- macOS Cmd+C: copy a selection, otherwise stay out of the way -------------
 //
-// The previous version of this block was named "Cmd+C is NOT claimed (macOS browser
-// copies before xterm)" and asserted only that the handler returned true — trivially
-// true of ANY unclaimed key. The name asserted an ENVIRONMENT fact nothing checked,
-// and it was false: xterm paints its own selection overlay instead of making a DOM
-// selection, so the browser's native copy wrote nothing (#2787). Each test below now
-// asserts exactly what its name claims, and the browser half — that a real Cmd+C
-// really does land in the system clipboard — is pinned by the Playwright case in
-// web/selftest/web-driver.spec.ts, because no unit test can see it.
+// #2831 asked whether the copy EVENT could replace this chord. Measured in Chromium:
+// it cannot. The event fires for the PLATFORM copy chord only, so on Linux
+// `Control+c` dispatches one and `Meta+c` does not — dropping this branch would
+// regress Cmd+C wherever Meta is not the copy modifier, and leave the remaining path
+// untested on the platform CI runs. handleTerminalCopy is an addition, not a
+// replacement, and these stay.
 
 test("Cmd+C WITH a selection copies it through the same never-silent ladder as Ctrl+C", () => {
   const r = rig({ selection: "sel" });
@@ -244,6 +245,17 @@ test("Cmd+C WITH a selection copies it through the same never-silent ladder as C
   assert.equal(r.cleared(), 0, "Cmd+C keeps the selection — it has no interrupt to fall through to");
 });
 
+test("Cmd+C copies on a non-Latin layout too (#2831)", () => {
+  const r = rig({ selection: "sel" });
+  const ret = handleClipboardKeydown(
+    keyEvent({ key: "с", code: "KeyC", metaKey: true }, r.markPrevented),
+    r.deps,
+  );
+
+  assert.equal(ret, false);
+  assert.deepEqual(r.clipboard, ["sel"], "a Cyrillic layout must copy on Cmd+C as well as Ctrl+C");
+});
+
 test("Cmd+C with NO selection is left untouched and NEVER interrupts", () => {
   const r = rig({ selection: "" });
   const ret = handleClipboardKeydown(keyEvent({ key: "c", metaKey: true }, r.markPrevented), r.deps);
@@ -254,26 +266,20 @@ test("Cmd+C with NO selection is left untouched and NEVER interrupts", () => {
   assert.equal(r.prevented(), 0);
 });
 
-test("Cmd+Shift+C and Cmd+Alt+C stay with the browser (its devtools shortcuts)", () => {
-  for (const modifiers of [{ shiftKey: true }, { altKey: true }]) {
+test("Cmd+Shift+C, Cmd+Alt+C and Cmd+V stay with the browser", () => {
+  for (const init of [
+    { key: "c", shiftKey: true },
+    { key: "c", altKey: true },
+    { key: "v" },
+  ]) {
     const r = rig({ selection: "sel" });
-    const ret = handleClipboardKeydown(
-      keyEvent({ key: "c", metaKey: true, ...modifiers }, r.markPrevented),
-      r.deps,
-    );
+    const ret = handleClipboardKeydown(keyEvent({ ...init, metaKey: true }, r.markPrevented), r.deps);
 
-    assert.equal(ret, true, JSON.stringify(modifiers));
-    assert.deepEqual(r.clipboard, [], `only the BARE Cmd+C is ours: ${JSON.stringify(modifiers)}`);
-    assert.equal(wireInput(r.wire), "", JSON.stringify(modifiers));
-    assert.equal(r.prevented(), 0, JSON.stringify(modifiers));
+    assert.equal(ret, true, JSON.stringify(init));
+    assert.deepEqual(r.clipboard, [], `only the BARE Cmd+C is ours: ${JSON.stringify(init)}`);
+    assert.equal(wireInput(r.wire), "", JSON.stringify(init));
+    assert.equal(r.prevented(), 0, JSON.stringify(init));
   }
-});
-
-test("Cmd+V is NOT claimed (native paste path untouched)", () => {
-  const r = rig({});
-  const ret = handleClipboardKeydown(keyEvent({ key: "v", metaKey: true }, r.markPrevented), r.deps);
-  assert.equal(ret, true);
-  assert.equal(r.prevented(), 0);
 });
 
 // --- The keydown-only guard: a gesture is handled once, not per key phase ------
@@ -304,4 +310,140 @@ test("a plain key and other Ctrl combos fall through untouched", () => {
     assert.equal(wireInput(r.wire), "");
     assert.equal(r.prevented(), 0);
   }
+});
+
+// --- Layout independence (#2831) ----------------------------------------------
+//
+// `ev.key` is the layout-mapped character, `ev.code` the physical key. Matching on
+// `key` alone reproduced the original silent failure for anyone on a non-Latin
+// layout; matching on `code` alone would break Dvorak, where the physical C
+// position types "j" and Ctrl+J is a real control code. So: `key` when it is a
+// Latin letter, `code` only when it cannot be.
+
+test("Ctrl+C copies on a Cyrillic layout, where key is 'с' (U+0441) not 'c'", () => {
+  const r = rig({ selection: "sel" });
+  const ret = handleClipboardKeydown(
+    keyEvent({ key: "с", code: "KeyC", ctrlKey: true }, r.markPrevented),
+    r.deps,
+  );
+
+  assert.equal(ret, false);
+  assert.deepEqual(r.clipboard, ["sel"], "a Cyrillic layout must copy, not fall through silently");
+  assert.equal(wireInput(r.wire), "");
+});
+
+test("Ctrl+C still INTERRUPTS on a non-Latin layout when nothing is selected", () => {
+  const r = rig({ selection: "" });
+  const ret = handleClipboardKeydown(
+    keyEvent({ key: "ψ", code: "KeyC", ctrlKey: true }, r.markPrevented),
+    r.deps,
+  );
+
+  assert.equal(ret, false);
+  assert.equal(wireInput(r.wire), ETX, "the runaway-agent reflex must survive the layout too");
+});
+
+test("Ctrl+V defers to native paste on a non-Latin layout", () => {
+  const r = rig({});
+  const ret = handleClipboardKeydown(
+    keyEvent({ key: "м", code: "KeyV", ctrlKey: true }, r.markPrevented),
+    r.deps,
+  );
+  assert.equal(ret, false, "xterm's \\x16 must still be suppressed");
+  assert.equal(r.prevented(), 0, "and the browser's trusted paste must still fire");
+});
+
+test("a Latin layout is matched by the TYPED letter, so Dvorak's Ctrl+J stays Ctrl+J", () => {
+  // On Dvorak the key at the physical C position types "j". Ctrl+J is LF — a real
+  // terminal control code — so `code === "KeyC"` must NOT win over a Latin `key`.
+  const r = rig({ selection: "sel" });
+  const ret = handleClipboardKeydown(
+    keyEvent({ key: "j", code: "KeyC", ctrlKey: true }, r.markPrevented),
+    r.deps,
+  );
+
+  assert.equal(ret, true, "Ctrl+J is the application's, not ours");
+  assert.deepEqual(r.clipboard, [], "typing J must never copy");
+  assert.equal(r.prevented(), 0);
+});
+
+test("the letter the user TYPED wins: Dvorak Ctrl+C copies though its code is KeyI", () => {
+  const r = rig({ selection: "sel" });
+  const ret = handleClipboardKeydown(
+    keyEvent({ key: "c", code: "KeyI", ctrlKey: true }, r.markPrevented),
+    r.deps,
+  );
+
+  assert.equal(ret, false);
+  assert.deepEqual(r.clipboard, ["sel"]);
+});
+
+test("an event with no code at all still works on a Latin layout", () => {
+  // `code` is optional: a synthetic event may omit it entirely.
+  const r = rig({ selection: "sel" });
+  const ret = handleClipboardKeydown(keyEvent({ key: "c", ctrlKey: true }, r.markPrevented), r.deps);
+  assert.equal(ret, false);
+  assert.deepEqual(r.clipboard, ["sel"]);
+});
+
+// --- The copy EVENT: every route, not just the chord (#2831) ------------------
+
+/** A copy-event rig: records what would be written into the system clipboard via
+ *  clipboardData, and what fell back to the never-silent ladder. */
+function copyRig(opts: { selection?: string; withClipboardData?: boolean }) {
+  const written: Array<[string, string]> = [];
+  const ladder: string[] = [];
+  let prevented = 0;
+  const selection = opts.selection ?? "";
+  const deps: TerminalCopyDeps = {
+    hasSelection: () => selection !== "",
+    getSelection: () => selection,
+    copy: (t) => ladder.push(t),
+  };
+  const ev: TerminalCopyEvent = {
+    clipboardData:
+      opts.withClipboardData === false
+        ? null
+        : {
+            setData: (format, data) => {
+              written.push([format, data]);
+            },
+          },
+    preventDefault: () => {
+      prevented++;
+    },
+  };
+  return { ev, deps, written, ladder, prevented: () => prevented };
+}
+
+test("a copy over a terminal selection writes it into clipboardData", () => {
+  // This is the whole point of #2831: the browser fires `copy` for the chord AND
+  // for macOS Edit -> Copy, right-click -> Copy and assistive tech, so one handler
+  // covers routes no key chord ever saw.
+  const r = copyRig({ selection: "hello world" });
+  const handled = handleTerminalCopy(r.ev, r.deps);
+
+  assert.equal(handled, true);
+  assert.deepEqual(r.written, [["text/plain", "hello world"]]);
+  assert.equal(r.prevented(), 1, "without preventDefault the browser overwrites us with its empty selection");
+  assert.deepEqual(r.ladder, [], "clipboardData is the permission-free path; no ladder needed");
+});
+
+test("a copy with NO terminal selection is left entirely alone", () => {
+  // Ordinary page text (an error message, a session title) must still copy.
+  const r = copyRig({ selection: "" });
+  const handled = handleTerminalCopy(r.ev, r.deps);
+
+  assert.equal(handled, false);
+  assert.deepEqual(r.written, []);
+  assert.equal(r.prevented(), 0, "preventDefault here would break copying the rest of the page");
+});
+
+test("a copy event with no clipboardData falls back to the never-silent ladder", () => {
+  const r = copyRig({ selection: "sel", withClipboardData: false });
+  const handled = handleTerminalCopy(r.ev, r.deps);
+
+  assert.equal(handled, true);
+  assert.deepEqual(r.ladder, ["sel"], "the copy must not be silently dropped");
+  assert.equal(r.prevented(), 1);
 });

--- a/web/src/clipboard.ts
+++ b/web/src/clipboard.ts
@@ -31,11 +31,40 @@ export interface ClipboardKeyEvent {
    *  on "keydown" so a gesture is handled once, not three times. */
   type: string;
   key: string;
+  /** The PHYSICAL key, layout-independent by definition ("KeyC" wherever the C key
+   *  sits). Optional because a synthetic event may omit it; see chordIsLetter. */
+  code?: string;
   ctrlKey: boolean;
   metaKey: boolean;
   shiftKey: boolean;
   altKey: boolean;
   preventDefault(): void;
+}
+
+/**
+ * Does this event carry the given Latin letter as a CHORD key, on any layout?
+ *
+ * `ev.key` is the layout-mapped character and `ev.code` is the physical key, and
+ * neither alone is right (#2831):
+ *
+ *   - `key` alone breaks every non-Latin layout. On Cyrillic the C key reports
+ *     `key: "с"` (U+0441) and on Greek `"ψ"`; neither equals "c", so the gesture
+ *     went unclaimed and the user got the original silent failure.
+ *   - `code` alone breaks re-arranged Latin layouts. On Dvorak the key at the
+ *     physical C position types "j", and Ctrl+J is a real terminal control code
+ *     (LF) — claiming it as copy would break input to fix a layout nobody was on.
+ *
+ * So: trust `key` whenever it IS a Latin letter (every Latin layout, including
+ * Dvorak and Colemak, where the letter the user typed is the letter they meant),
+ * and fall back to the physical `code` only when it is not (the non-Latin layouts,
+ * where `key` cannot express the chord at all).
+ */
+function chordIsLetter(ev: ClipboardKeyEvent, letter: string, code: string): boolean {
+  const typed = ev.key.toLowerCase();
+  if (typed.length === 1 && typed >= "a" && typed <= "z") {
+    return typed === letter;
+  }
+  return ev.code === code;
 }
 
 /** The side-effecting capabilities the decision drives. terminal.ts supplies real
@@ -126,6 +155,15 @@ export function handleClipboardKeydown(ev: ClipboardKeyEvent, deps: ClipboardDep
   //   - no selection → untouched. Cmd+C is not an interrupt on macOS, so this path
   //     must never emit \x03.
   //
+  // #2831 asked whether handleTerminalCopy below could REPLACE this chord, since the
+  // browser fires `copy` for the chord as well as for the menu routes. Measured in
+  // Chromium, it cannot: the copy event fires for the PLATFORM copy chord only, so on
+  // Linux `Control+c` dispatches one and `Meta+c` does not. Dropping this branch would
+  // therefore trade a path verified on every platform for one that is unverifiable on
+  // the platform CI runs, and would regress Cmd+C wherever Meta is not the copy
+  // modifier. handleTerminalCopy is an ADDITION that covers the routes no chord
+  // reaches; the chords below stay.
+  //
   // The selection is deliberately KEPT. Clearing exists on Ctrl+C so a second press
   // falls through to the interrupt; Cmd+C has no interrupt to fall through to, so
   // clearing would just be a surprising selection loss.
@@ -133,7 +171,13 @@ export function handleClipboardKeydown(ev: ClipboardKeyEvent, deps: ClipboardDep
   // Bare only: Cmd+Shift+C is the browser's inspect-element toggle, and Cmd+Alt+C
   // devtools too — claiming those would trade one broken shortcut for another.
   // Cmd+V stays untouched; its trusted-paste path already works.
-  if (ev.metaKey && !ev.ctrlKey && !ev.altKey && !ev.shiftKey && ev.key.toLowerCase() === "c") {
+  if (
+    ev.metaKey &&
+    !ev.ctrlKey &&
+    !ev.altKey &&
+    !ev.shiftKey &&
+    chordIsLetter(ev, "c", "KeyC")
+  ) {
     if (!deps.hasSelection()) {
       return true;
     }
@@ -146,25 +190,35 @@ export function handleClipboardKeydown(ev: ClipboardKeyEvent, deps: ClipboardDep
     return true;
   }
 
-  const key = ev.key.toLowerCase();
-
-  if (key === "v") {
+  if (chordIsLetter(ev, "v", "KeyV")) {
     // Defer to xterm's native (browser-trusted) paste for both Ctrl+V and
     // Ctrl+Shift+V. Returning false suppresses xterm's Ctrl+V→\x16 keymap; NOT
     // calling preventDefault lets the browser's `paste` event flow to xterm.
     return false;
   }
 
-  if (key === "c") {
+  if (chordIsLetter(ev, "c", "KeyC")) {
     if (ev.shiftKey) {
-      // Ctrl+Shift+C — explicit, unambiguous copy. Copies a selection if present,
-      // a no-op otherwise; never interrupts. The selection is deliberately LEFT
-      // intact: this is the "just copy, I want to keep selecting" gesture.
-      ev.preventDefault();
-      if (deps.hasSelection()) {
-        deps.copy(deps.getSelection());
-      }
-      return false;
+      // Ctrl+Shift+C is the INSPECT-ELEMENT shortcut on Linux and Windows, exactly
+      // as Cmd+Shift+C is on macOS — and the Cmd branch above already refuses to
+      // claim it, on the grounds that doing so "would trade one broken shortcut for
+      // another". This branch used to claim it anyway with a preventDefault, so the
+      // #2787 fix protected devtools for macOS users while keeping it broken for
+      // everyone else (#2831). The two branches now agree, and this returns `true`
+      // exactly as that one does.
+      //
+      // `true` (not the `false` Ctrl+V uses) because xterm needs no suppressing
+      // here. Measured against real xterm in Chromium: Ctrl+Shift+C emits NOTHING
+      // on onData — the ctrl+letter→control-byte mapping does not apply with shift
+      // held, unlike bare Ctrl+C which emits \x03 — and xterm leaves the event
+      // uncancelled, so the browser still gets its shortcut. There is nothing to
+      // suppress and nothing to preventDefault; the honest answer is "not our
+      // gesture".
+      //
+      // Copy is not lost with it: Ctrl+C over a selection still copies, Cmd+C still
+      // copies on macOS, and handleTerminalCopy covers the routes that reach the
+      // terminal as a `copy` event instead of a chord.
+      return true;
     }
     // Ctrl+C — a present selection means "copy it" (the terminal convention), so
     // copy and do NOT interrupt.
@@ -188,4 +242,63 @@ export function handleClipboardKeydown(ev: ClipboardKeyEvent, deps: ClipboardDep
   }
 
   return true; // not our gesture
+}
+
+/** The subset of a DOM ClipboardEvent the copy decision reads. A real
+ *  ClipboardEvent satisfies it structurally; tests construct plain objects. */
+export interface TerminalCopyEvent {
+  /** null when the platform gives no synchronous write surface — see the fallback. */
+  clipboardData: { setData(format: string, data: string): void } | null;
+  preventDefault(): void;
+}
+
+/** What the copy decision needs from the terminal. A strict subset of ClipboardDeps
+ *  — no wire access at all, because copying can never send input. */
+export interface TerminalCopyDeps {
+  hasSelection(): boolean;
+  getSelection(): string;
+  /** The never-silent ladder in terminal.ts, used only when the event carries no
+   *  clipboardData to write into. */
+  copy(text: string): void;
+}
+
+/**
+ * Put xterm's selection on the clipboard for ANY copy the browser initiates (#2831).
+ *
+ * This is the single copy path, and it is deliberately event-shaped rather than
+ * chord-shaped. The browser fires `copy` for Cmd+C, for Ctrl+C on Linux/Windows,
+ * for macOS Edit → Copy, for right-click → Copy, and for assistive technology that
+ * copies without synthesizing a keydown. Before this, only the chords worked, so
+ * every menu route failed the same silent way the original bug did: the browser
+ * copied `document.getSelection()`, xterm had no DOM selection, nothing landed on
+ * the clipboard, and no handler of ours ran to say so.
+ *
+ * Writing into `event.clipboardData` is what makes this work without a permission
+ * prompt: inside a trusted `copy` event the write is synchronous and always allowed,
+ * unlike navigator.clipboard.writeText.
+ *
+ * Returns whether the selection was written, so a caller (and a test) can tell the
+ * handled case from the deliberate pass-through.
+ */
+export function handleTerminalCopy(ev: TerminalCopyEvent, deps: TerminalCopyDeps): boolean {
+  // No terminal selection ⇒ not ours. Leave the event completely alone so a copy
+  // aimed at ordinary page text (an error message, a session title) still works.
+  if (!deps.hasSelection()) {
+    return false;
+  }
+  const text = deps.getSelection();
+  if (text === "") {
+    return false;
+  }
+  // Ours either way: preventDefault stops the browser writing its own EMPTY document
+  // selection over what we are about to put there.
+  ev.preventDefault();
+  if (ev.clipboardData) {
+    ev.clipboardData.setData("text/plain", text);
+    return true;
+  }
+  // No clipboardData (older/unusual embedders): fall back to the never-silent ladder
+  // rather than dropping the copy, so a failure still surfaces a visible hint.
+  deps.copy(text);
+  return true;
 }

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -39,7 +39,7 @@
 import { FitAddon } from "@xterm/addon-fit";
 import { type IMarker, type ITheme, Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
-import { handleClipboardKeydown } from "./clipboard.js";
+import { handleClipboardKeydown, handleTerminalCopy } from "./clipboard.js";
 import { decode, encode, inputFrame, Op, resizeFrame } from "./frame.js";
 import { PendingInput } from "./pending_input.js";
 import {
@@ -257,6 +257,16 @@ export class AttachTerminal {
     // an uncancelled drag can still synthesize the compatibility mouse events the
     // application would read as a drag it never got the button press for.
     event.preventDefault();
+  };
+  /** Every browser-initiated copy over the terminal (#2831) — the chord, macOS
+   *  Edit → Copy, right-click → Copy, assistive tech. The decision is in
+   *  clipboard.ts; this only supplies xterm's selection and the fallback ladder. */
+  private readonly onCopy = (event: ClipboardEvent): void => {
+    handleTerminalCopy(event, {
+      hasSelection: () => this.term.hasSelection(),
+      getSelection: () => this.term.getSelection(),
+      copy: (text) => this.copyToClipboard(text),
+    });
   };
   private readonly onPointerDown = (event: PointerEvent): void => {
     // A pointer event always precedes its compatibility mouse counterpart — for a tap
@@ -477,6 +487,9 @@ export class AttachTerminal {
     container.addEventListener("touchmove", this.onTouchMove, { capture: true, passive: false });
     container.addEventListener("pointerdown", this.onPointerDown, true);
     container.addEventListener("mousedown", this.onMouseDownCapture, true);
+    // Bubbles from xterm's focused helper textarea, so this one listener catches
+    // the copy chord AND every menu/context-menu copy aimed at the terminal (#2831).
+    container.addEventListener("copy", this.onCopy);
     this.scheduleVisibleFit();
   }
 
@@ -510,6 +523,7 @@ export class AttachTerminal {
     this.container.removeEventListener("touchmove", this.onTouchMove, true);
     this.container.removeEventListener("pointerdown", this.onPointerDown, true);
     this.container.removeEventListener("mousedown", this.onMouseDownCapture, true);
+    this.container.removeEventListener("copy", this.onCopy);
     this.endHandedOffDrag();
     this.closeSocket();
     this.term.dispose();


### PR DESCRIPTION
## Summary

Closes the three holes Sachin's audit found in the shipped #2787 clipboard fix.
Item 4 (touch has no copy path) is deliberately left alone — the issue puts it
with #2682, and it is its own piece of work.

## 1. Copy was keydown-only, so menu and right-click copy failed silently

Everything routed through `handleClipboardKeydown`, so copy only ever worked when
it arrived as a **key event**. macOS Edit → Copy, right-click → Copy, and
assistive technology that copies without synthesizing a keydown each failed
exactly the way the original bug did — the browser copies `document.getSelection()`,
xterm has no DOM selection, nothing lands on the clipboard, and no handler of ours
ran to say so.

`handleTerminalCopy` now writes xterm's selection into `event.clipboardData` from a
`copy` listener on the terminal element. Inside a trusted copy event that write is
synchronous and permission-free, unlike `navigator.clipboard.writeText`.

**It is an addition, not the replacement the issue proposed — and that is a
measured correction, not a preference.** The issue argued the listener could
replace the chord handlers outright. I probed real Chromium before believing it:

| route | fires a `copy` event? |
| --- | --- |
| `Control+c` (Linux) | ✅ yes — even with no DOM selection |
| `Meta+c` (Linux) | ❌ **no** — Meta is Super here, not the copy modifier |
| `execCommand("copy")`, no DOM selection | ❌ no dispatch to the element |

The copy event fires for the **platform** copy chord only. Dropping the `Cmd+C`
branch would therefore have regressed Cmd+C wherever Meta is not the copy modifier,
traded a path verified on every platform for one unverifiable on the platform CI
runs, and turned the existing #2787 Playwright case (which presses `Meta+c` on a
Linux runner) red. So the chords stay and the listener covers what they cannot
reach. No double-copy is possible: we `preventDefault` on exactly the paths where
we copy ourselves, which suppresses the event.

## 2. The letter match was keyboard-layout dependent

`ev.key` is the layout-mapped character, so the C key reports `"с"` (U+0441) on
Cyrillic and `"ψ"` on Greek — neither equals `"c"`, so the gesture went unclaimed
and the user got the original silent failure. This affected `Ctrl+C`, `Cmd+C` and
`Ctrl+V` alike.

Fixed with `ev.code`, but **guarded rather than blanket**. `code` alone would break
Dvorak, where the key at the physical C position types `"j"` — and `Ctrl+J` is a
real terminal control code (LF), so claiming it as copy would break input to fix a
layout nobody was on. The rule: trust `key` whenever it **is** a Latin letter (every
Latin layout, Dvorak and Colemak included, where the letter typed is the letter
meant), and fall back to the physical `code` only when it cannot be.

## 3. `Ctrl+Shift+C` stole the devtools shortcut

The Cmd branch deliberately spares `Cmd+Shift+C` because claiming it "would trade
one broken shortcut for another". The Ctrl branch claimed the identical
inspect-element shortcut on Linux/Windows anyway, so the fix protected devtools for
macOS users and kept breaking it for everyone else. It now returns `true`, exactly
as the Cmd branch does.

**`true` rather than `false` was measured, and it corrected me.** My first draft
returned `false` with a comment asserting that xterm maps `Ctrl+Shift+C` to the
interrupt byte like `Ctrl+C`, so a bare `true` would fire an interrupt at the agent
on every devtools keypress. Probing real xterm in Chromium showed that is false:

| chord | xterm emitted on `onData` | left the event cancellable? |
| --- | --- | --- |
| `Control+Shift+C` | nothing | yes — `defaultPrevented` false, so the browser still gets its shortcut |
| `Control+c` | the interrupt byte | consumed by xterm |

The ctrl+letter mapping does not apply with shift held, so there is no keymap to
suppress and nothing to preventDefault. `true` is the honest answer, and the wrong
rationale is gone from the comment.

Copy is not lost with the gesture: `Ctrl+C` over a selection still copies, `Cmd+C`
still copies, and the copy event covers the rest.

## Verification

`make web-test` — **496 pass, 0 fail**.

Every behaviour change is pinned by a test **watched failing against the old code**,
not merely observed green:

| mutation | tests that went red |
| --- | --- |
| revert the layout guard to the old `key`-only match | the 3 non-Latin cases (Cyrillic copy, non-Latin interrupt, non-Latin paste) |
| match on `code` only | 9, including the Dvorak `Ctrl+J` guard |
| re-claim `Ctrl+Shift+C` | the devtools case |
| re-claim `Cmd+C` as a chord | the Cmd+C case |
| stop writing `clipboardData` | both copy-event cases |

The two browser facts this change rests on were probed against real Chromium and
real xterm locally, rather than assumed — the tables above are that output. No
containerized suite was run.

**On browser coverage:** I did not add a Playwright case for the copy listener,
because on Linux there is no honest way to drive it — the chord that would reach it
is claimed by the keydown path, and a synthetic `ClipboardEvent` is untrusted so its
`clipboardData` never reaches the real clipboard. Asserting on one would have been
theatre. The existing #2787 case still covers the `Cmd+C` chord end to end and keeps
passing, since that branch is unchanged apart from the layout guard.

## Gate

`gofmt -l .` (empty) · `go build ./...` · `golangci-lint --fast` ·
`deadcode -test ./...` · `scripts/lint-file-length.sh` · `make web-test` (496 pass).
No Go package changed, so no Go tests were run; no containerized suite was run.
`make web-build` ran and the regenerated bundle is committed.

Closes #2831
