### PR TITLE
feat(tasks): give a task's spawned sessions a declared lifecycle

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -703,6 +703,7 @@ func init() {
 	tasksAddCmd.Flags().StringVar(&taskAddWatchCmdFlag, "watch-cmd", "", "Long-running watch command; each stdout line triggers the task (exactly one of --cron / --watch-cmd)")
 	tasksAddCmd.Flags().StringVar(&taskAddTargetSessionFlag, "target-session", "", "Deliver the prompt into this session (auto-created if missing); empty creates a new session per run")
 	tasksAddCmd.Flags().IntVar(&taskAddMaxConcurrentRunsFlag, "max-concurrent-runs", 0, "Cap how many sessions this watch task may have in flight at once; excess events are queued in order instead of spawning runs, subject to the durable queue's retention limits (0 = unlimited; --watch-cmd tasks without --target-session only)")
+	tasksAddCmd.Flags().StringVar(&taskAddOnCompleteFlag, "on-complete", "", "What happens to the session a run spawns once it finishes: keep (default, leaves it in place), archive (restorable, but retains its whole worktree), or kill (reclaims the worktree and prunes the session's branch). Not for --target-session tasks, whose session is meant to be reused")
 	tasksAddCmd.Flags().StringVar(&taskAddProgramFlag, "program", "", "Program to run (one of: "+tmux.SupportedProgramsString()+"; defaults to config default)")
 	tasksAddCmd.MarkFlagRequired("name")
 
@@ -719,6 +720,7 @@ func init() {
 	tasksUpdateCmd.Flags().StringVar(&taskUpdateWatchCmdFlag, "watch-cmd", "", "New watch command (clears cron)")
 	tasksUpdateCmd.Flags().StringVar(&taskUpdateTargetSessionFlag, "target-session", "", "New target session; pass an empty value to revert to a new session per run")
 	tasksUpdateCmd.Flags().IntVar(&taskUpdateMaxConcurrentRunsFlag, "max-concurrent-runs", 0, "New in-flight session cap for this watch task; pass 0 to revert to unlimited")
+	tasksUpdateCmd.Flags().StringVar(&taskUpdateOnCompleteFlag, "on-complete", "", "New spawned-session lifecycle: keep, archive, or kill; pass keep to revert to leaving sessions in place")
 	tasksUpdateCmd.Flags().StringVar(&taskUpdateProjectPathFlag, "project-path", "", "Move the task to this git repository (distinct from --repo, which scopes its current project)")
 	tasksUpdateCmd.Flags().StringVar(&taskUpdateEnabledFlag, "enabled", "", "Enable or disable the task (true/false)")
 	tasksUpdateCmd.Flags().StringVar(&taskUpdateProgramFlag, "program", "", "New program to run (one of: "+tmux.SupportedProgramsString()+"; leave unset to keep the current one)")

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -164,6 +164,7 @@ var (
 	taskAddWatchCmdFlag          string
 	taskAddTargetSessionFlag     string
 	taskAddMaxConcurrentRunsFlag int
+	taskAddOnCompleteFlag        string
 	taskAddProgramFlag           string
 )
 
@@ -235,6 +236,7 @@ var tasksAddCmd = &cobra.Command{
 			WatchCmd:          strings.TrimSpace(taskAddWatchCmdFlag),
 			TargetSession:     taskAddTargetSessionFlag,
 			MaxConcurrentRuns: taskAddMaxConcurrentRunsFlag,
+			OnComplete:        taskAddOnCompleteFlag,
 			ProjectPath:       repo.Root,
 			Program:           program,
 			Enabled:           true,
@@ -417,6 +419,7 @@ var (
 	taskUpdateWatchCmdFlag          string
 	taskUpdateTargetSessionFlag     string
 	taskUpdateMaxConcurrentRunsFlag int
+	taskUpdateOnCompleteFlag        string
 	taskUpdateProjectPathFlag       string
 	taskUpdateEnabledFlag           string
 	taskUpdateProgramFlag           string
@@ -545,6 +548,12 @@ var tasksUpdateCmd = &cobra.Command{
 		// control socket because TaskUpdate round-trips through JSON (#1700).
 		if cmd.Flags().Changed("max-concurrent-runs") {
 			patch.MaxConcurrentRuns = intPtr(taskUpdateMaxConcurrentRunsFlag)
+		}
+		// --on-complete keep is a meaningful value (revert to the default), not
+		// "unchanged", so this gates on the flag being passed for the same reason
+		// the two above do (#2595).
+		if cmd.Flags().Changed("on-complete") {
+			patch.OnComplete = strPtr(taskUpdateOnCompleteFlag)
 		}
 		// --repo authorizes the task against its CURRENT project. Keep the new
 		// binding separate so a caller can say `--repo old --project-path new`

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -206,6 +206,13 @@ type Manager struct {
 	// effect on the next daemon start" contract — a re-added project's root
 	// materializes on restart, not mid-run). Guarded by m.mu.
 	deletedRootRepos map[string]struct{}
+	// deferredTaskLifecycle parks a task's declared on_complete verb (#2595) for a
+	// session whose run finished while a TUI was attached, mapping the session's
+	// daemon key to the stable id of the session that finished. The paused poll
+	// path spends the completion edge without being able to act on it (tearing
+	// down under a live attach is what the pause prevents), so the intent waits
+	// here and the first unpaused tick drains it. Guarded by m.mu.
+	deferredTaskLifecycle map[string]string
 	// killsInFlight marks sessions (by daemon instance key) with an exclusive
 	// lifecycle operation in progress (kill/archive/restore). The status poll's
 	// finish-kill pass for tombstoned records (#1108) therefore never runs a

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -257,6 +257,7 @@ func (m *Manager) pollLeaseActiveLocked(repoID, title, id string, now time.Time)
 func (m *Manager) observeTaskRunWhilePaused(repoID, key string, instance *session.Instance) {
 	before := instance.GetLiveness()
 	beforeReset, _ := instance.LimitResetAt()
+	taskRunWasActive := instance.TaskRunActive()
 	epoch := instance.StateEpoch() // see refreshInstanceStatus (#2135)
 	obs, err := instance.AgentServer().Snapshot()
 	// Whatever happened, no loss episode survives an attach (see above).
@@ -276,6 +277,10 @@ func (m *Manager) observeTaskRunWhilePaused(repoID, key string, instance *sessio
 	// never conclude death. The attach already answers that question.
 	m.resolveIdleLiveness(instance, obs.Content, epoch)
 	m.persistPollChange(repoID, instance, before, beforeReset, projectionChanged)
+	// The run may have just ended here, on the one path that cannot act on it: the
+	// attach owns this session's tmux. Park the declared lifecycle so the first
+	// unpaused tick applies it, instead of losing the edge entirely (#2595).
+	m.deferTaskSessionLifecycleWhilePaused(repoID, instance, taskRunWasActive)
 }
 
 // RefreshStatuses recomputes every started instance's status the way the TUI
@@ -553,6 +558,9 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 	// state it reacts to is durable, so a teardown can never outrun the record of
 	// why it happened.
 	m.applyTaskSessionLifecycleOnRunEnd(repoID, instance, taskRunWasActive)
+	// And drain a lifecycle owed from a run that finished while this session was
+	// attached, now that it is being polled normally again.
+	m.applyDeferredTaskSessionLifecycle(repoID, instance)
 }
 
 // SaveInstances writes the manager's authoritative in-memory instances to disk

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -300,6 +300,9 @@ func (m *Manager) RefreshStatuses() {
 		repoID, _ := splitDaemonInstanceKey(key)
 		entries = append(entries, entry{repoID: repoID, instance: inst})
 	}
+	// Reclaim lifecycle intents whose session is gone, in the same hold that
+	// already has the instance map (#2595).
+	m.sweepDeferredTaskLifecycleLocked()
 	m.mu.Unlock()
 
 	// Drop debounce state for sessions that are gone or replaced, colocated with

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -443,6 +443,11 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 	as := instance.AgentServer()
 	before := instance.GetLiveness()
 	beforeReset, _ := instance.LimitResetAt()
+	// The task run's own in-flight marker, captured beside the liveness it will be
+	// compared against. Reading it here rather than deriving it later is what makes
+	// the completion edge observable: taskRunActive flips true→false exactly once,
+	// inside a Transition below, and nothing else in the tick reports it (#2595).
+	taskRunWasActive := instance.TaskRunActive()
 	// Snapshot dismisses a pending trust prompt then reads the pane in one probe
 	// (the exact order the poll used to run CheckAndHandleTrustPrompt then
 	// HasUpdated). Content is the capture handed back so the idle branch runs the
@@ -542,6 +547,12 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 
 	// Persist a liveness OR usage-limit reset-time change (#1146); see limit.go.
 	m.persistPollChange(repoID, instance, before, beforeReset, projectionChanged)
+
+	// The run this session was spawned for may have just finished on the idle edge
+	// above. Apply the owning task's declared lifecycle (#2595) — last, after the
+	// state it reacts to is durable, so a teardown can never outrun the record of
+	// why it happened.
+	m.applyTaskSessionLifecycleOnRunEnd(repoID, instance, taskRunWasActive)
 }
 
 // SaveInstances writes the manager's authoritative in-memory instances to disk

--- a/daemon/task_session_lifecycle.go
+++ b/daemon/task_session_lifecycle.go
@@ -105,6 +105,26 @@ func (m *Manager) deferTaskSessionLifecycleWhilePaused(repoID string, instance *
 	m.mu.Unlock()
 }
 
+// sweepDeferredTaskLifecycle drops parked intents whose session is gone or has
+// been replaced.
+//
+// An intent is drained by a normal poll of the session that owes it, so a session
+// killed (by the user, or with its project) while one is parked would never come
+// back to collect — and the entry would sit in the map for the daemon's lifetime.
+// That is the same reclamation the paused-poll lease sweep does for the same
+// reason, and leaking a map entry inside the change that exists to stop leaks
+// would be a poor joke.
+//
+// Runs under m.mu, from the same snapshot hold RefreshStatuses already takes.
+func (m *Manager) sweepDeferredTaskLifecycleLocked() {
+	for key, owedID := range m.deferredTaskLifecycle {
+		inst := m.instances[key]
+		if inst == nil || inst.ID != owedID {
+			delete(m.deferredTaskLifecycle, key)
+		}
+	}
+}
+
 // applyDeferredTaskSessionLifecycle drains an intent parked while the session was
 // attached, once it is being polled normally again.
 //

--- a/daemon/task_session_lifecycle.go
+++ b/daemon/task_session_lifecycle.go
@@ -137,5 +137,5 @@ func (m *Manager) runTaskSessionLifecycle(repoID, title, taskID, verb string) {
 		log.WarningLog.Printf("task %s: could not %s session %q after its run finished: %v", taskID, verb, title, err)
 		return
 	}
-	log.InfoLog.Printf("task %s: %sd session %q after its run finished (on_complete=%s)", taskID, verb, title, verb)
+	log.InfoLog.Printf("task %s: applied on_complete=%s to session %q after its run finished", taskID, verb, title)
 }

--- a/daemon/task_session_lifecycle.go
+++ b/daemon/task_session_lifecycle.go
@@ -23,28 +23,37 @@ import (
 // runEndedIntoIdle reports whether this tick is the moment a task run finished
 // with its session sitting idle and healthy.
 //
-// Both halves are load-bearing:
+// Three conditions, each excluding a different way the run marker can clear
+// without a run having completed:
 //
-//   - the run marker went true→false on THIS tick. taskRunActive flips once and
+//   - the marker went true→false on THIS tick. taskRunActive flips once and
 //     permanently, so this can fire at most once per session — a session cannot be
 //     archived twice, and a session a user later adopts and works in is never
 //     revisited. That is the difference between an edge and a standing predicate,
 //     and it is why this is not a sweep: "task session whose run has ended" stays
 //     true forever, including for the session someone is typing into right now.
 //
-//   - the session settled into LiveReady. taskRunActive also clears on paths that
-//     are NOT a completed run: CommitArchive ends it (already archived — nothing to
-//     do), and a startup that settles terminal-unknown ends it without the session
-//     ever having run. That last one matters most: the daemon deliberately RETAINS
-//     an uncertain create's record so an operator can inspect the workspace it may
-//     have left behind (keepUncertainCreate), and reaping it here would destroy
-//     exactly what that retention exists to preserve.
+//   - the session settled into LiveReady. CommitArchive also ends a run, and that
+//     session is already archived with nothing left to do.
 //
-// The idle edge itself is session.runEndsOnIdleEdge — a transition INTO Ready from
-// somewhere else — so pairing "the run ended" with "we are now Ready" identifies it
-// without this package having to re-derive the edge.
+//   - startup did not settle terminal-unknown. This one is checked explicitly
+//     even though the poll cannot currently deliver such a session here, and the
+//     explicitness is the point. MarkStartupStateUnknown clears taskRunActive
+//     DIRECTLY — not through a transition — and leaves liveness untouched, so an
+//     uncertain create sits at LiveReady with its run marker clear and satisfies
+//     both conditions above. What actually keeps it away from this function today
+//     is refreshInstanceStatus's `!instance.Started()` early return, since the
+//     same call also clears started. That is a correct outcome resting on a
+//     distant, unrelated line: the daemon RETAINS an uncertain create's record so
+//     an operator can inspect the workspace it may have left behind
+//     (keepUncertainCreate), and reaping it would destroy exactly what that
+//     retention exists to preserve. Stating the condition here means a future
+//     refactor of the poll's early returns cannot silently authorize that.
 func runEndedIntoIdle(instance *session.Instance, taskRunWasActive bool) bool {
 	if !taskRunWasActive || instance.TaskRunActive() {
+		return false
+	}
+	if instance.StartupStateUnknown() {
 		return false
 	}
 	return instance.GetLiveness() == session.LiveReady

--- a/daemon/task_session_lifecycle.go
+++ b/daemon/task_session_lifecycle.go
@@ -1,0 +1,141 @@
+package daemon
+
+import (
+	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+// Task-spawned session lifecycle (#2595).
+//
+// A cron task with no target session creates one session per fire, and af had no
+// policy for what became of it. The run finished, the agent went idle, and the
+// session then held its tmux session and its git worktree forever — four a day on
+// the maintainer's box, until 12 of 17 live sessions were finished runs. The only
+// thing standing between a schedule and unbounded growth was prose in the prompt
+// ("finally, run af sessions archive --self"), which nothing enforces and
+// `af tasks list` cannot show.
+//
+// The verb now lives on the task (task.OnComplete), and this is where it is
+// applied.
+
+// runEndedIntoIdle reports whether this tick is the moment a task run finished
+// with its session sitting idle and healthy.
+//
+// Both halves are load-bearing:
+//
+//   - the run marker went true→false on THIS tick. taskRunActive flips once and
+//     permanently, so this can fire at most once per session — a session cannot be
+//     archived twice, and a session a user later adopts and works in is never
+//     revisited. That is the difference between an edge and a standing predicate,
+//     and it is why this is not a sweep: "task session whose run has ended" stays
+//     true forever, including for the session someone is typing into right now.
+//
+//   - the session settled into LiveReady. taskRunActive also clears on paths that
+//     are NOT a completed run: CommitArchive ends it (already archived — nothing to
+//     do), and a startup that settles terminal-unknown ends it without the session
+//     ever having run. That last one matters most: the daemon deliberately RETAINS
+//     an uncertain create's record so an operator can inspect the workspace it may
+//     have left behind (keepUncertainCreate), and reaping it here would destroy
+//     exactly what that retention exists to preserve.
+//
+// The idle edge itself is session.runEndsOnIdleEdge — a transition INTO Ready from
+// somewhere else — so pairing "the run ended" with "we are now Ready" identifies it
+// without this package having to re-derive the edge.
+func runEndedIntoIdle(instance *session.Instance, taskRunWasActive bool) bool {
+	if !taskRunWasActive || instance.TaskRunActive() {
+		return false
+	}
+	return instance.GetLiveness() == session.LiveReady
+}
+
+// applyTaskSessionLifecycleOnRunEnd applies the owning task's on_complete verb to
+// a session whose run just finished. A no-op for every session that is not a
+// task-spawned one whose run ended on this tick, and for the default keep — which
+// is what makes this invisible to every task written before #2595.
+//
+// It runs on the poll goroutine but hands the actual teardown to a separate one:
+// ArchiveSession relocates a worktree and KillSession removes one, both of which
+// can take seconds on a large tree, and RefreshStatuses walks every session in
+// series. Blocking here would stall liveness polling for every other session
+// behind one teardown.
+func (m *Manager) applyTaskSessionLifecycleOnRunEnd(repoID string, instance *session.Instance, taskRunWasActive bool) {
+	if !runEndedIntoIdle(instance, taskRunWasActive) {
+		return
+	}
+	taskID := instance.TaskID
+	if taskID == "" {
+		return
+	}
+	title := instance.Title
+	verb, err := m.taskSessionLifecycle(repoID, taskID)
+	if err != nil {
+		// An unreadable or unscopable task store is not permission to tear a
+		// session down. Keep it — the conservative outcome, and the same one an
+		// older daemon produced — and say so once, on the tick that could not
+		// decide. A later run's completion asks again.
+		log.WarningLog.Printf("could not read the session lifecycle for task %s (session %q): %v; leaving the session in place",
+			taskID, title, err)
+		return
+	}
+	if verb == task.OnCompleteKeep {
+		return
+	}
+	go m.runTaskSessionLifecycle(repoID, title, taskID, verb)
+}
+
+// taskSessionLifecycle resolves the on_complete verb for one task in a repo.
+// A task that no longer exists yields keep: its sessions outlive it, and deleting
+// a task must not retroactively authorize destroying the work its runs produced.
+func (m *Manager) taskSessionLifecycle(repoID, taskID string) (string, error) {
+	tasks, bindingUpdates, err := loadTasksForRepoID(repoID)
+	// Publish before propagating, for the reason loadEnabledTaskTargets documents:
+	// the load commits backfilled bindings durably even when it then returns a
+	// scope error, and nothing else republishes them.
+	for _, updated := range bindingUpdates {
+		m.publishEvent(agentproto.EventTaskUpdated, updated)
+	}
+	if err != nil {
+		return "", err
+	}
+	for _, t := range tasks {
+		if t.ID == taskID {
+			return t.SessionLifecycle(), nil
+		}
+	}
+	return task.OnCompleteKeep, nil
+}
+
+// runTaskSessionLifecycle performs the teardown on its own goroutine.
+//
+// It reuses ArchiveSession/KillSession rather than reaching for the primitives
+// underneath, so a task-driven teardown is the SAME operation a user's
+// `af sessions archive` is: the same killsInFlight + op-lock serialization
+// (#2779), the same refusal when a task still targets the session, the same
+// events. A policy that tore down sessions through a private path would be a
+// second lifecycle implementation, and the two would drift.
+func (m *Manager) runTaskSessionLifecycle(repoID, title, taskID, verb string) {
+	var err error
+	switch verb {
+	case task.OnCompleteArchive:
+		_, _, err = m.ArchiveSession(ArchiveSessionRequest{Title: title, RepoID: repoID})
+	case task.OnCompleteKill:
+		_, err = m.KillSession(KillSessionRequest{Title: title, RepoID: repoID})
+	default:
+		// Unreachable: ValidateTrigger refuses an unknown verb on write, and
+		// SessionLifecycle canonicalizes. Log rather than guess — picking a verb
+		// here would be inventing destructive intent from a value nothing accepted.
+		log.WarningLog.Printf("task %s declares an unknown on_complete %q; leaving session %q in place", taskID, verb, title)
+		return
+	}
+	if err != nil {
+		// Failing to reap is not a failure of the RUN, which already succeeded, so
+		// this never touches the task's last-run status. The session stays where it
+		// is and stays visible, which is the recoverable outcome; a user can finish
+		// the teardown by hand.
+		log.WarningLog.Printf("task %s: could not %s session %q after its run finished: %v", taskID, verb, title, err)
+		return
+	}
+	log.InfoLog.Printf("task %s: %sd session %q after its run finished (on_complete=%s)", taskID, verb, title, verb)
+}

--- a/daemon/task_session_lifecycle.go
+++ b/daemon/task_session_lifecycle.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"time"
+
 	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
@@ -19,6 +21,21 @@ import (
 //
 // The verb now lives on the task (task.OnComplete), and this is where it is
 // applied.
+
+// killSessionForLifecycle is the kill a declared teardown performs. A package var
+// so a test can assert WHICH session the deferred goroutine names — the stale-id
+// retarget it guards against is invisible if the only observable is that some
+// session went away. Production points it at the real RPC and never reassigns it.
+var killSessionForLifecycle = func(m *Manager, req KillSessionRequest) error {
+	_, err := m.KillSession(req)
+	return err
+}
+
+// taskLifecycleHookWait bounds how long a declared teardown waits for a session's
+// post_worktree_commands to finish before giving up and leaving it in place. Long
+// enough for an ordinary build/install hook, short enough that a hung one leaks a
+// session rather than a goroutine.
+const taskLifecycleHookWait = 10 * time.Minute
 
 // runEndedIntoIdle reports whether this tick is the moment a task run finished
 // with its session sitting idle and healthy.
@@ -59,6 +76,69 @@ func runEndedIntoIdle(instance *session.Instance, taskRunWasActive bool) bool {
 	return instance.GetLiveness() == session.LiveReady
 }
 
+// deferTaskSessionLifecycleWhilePaused records that a run finished on the PAUSED
+// poll path, so its declared lifecycle is applied once the attach ends.
+//
+// A run can finish while a TUI is attached full-screen: observeTaskRunWhilePaused
+// settles the agent idle on the backstop tick, which ends the run and clears the
+// marker there. The completion edge is then spent, and the ordinary hook — which
+// only runs on the unpaused path — never sees it, so a declared archive/kill was
+// skipped PERMANENTLY and the session leaked despite the policy. That is the exact
+// failure #2595 exists to fix, reached through the one door the fix did not cover.
+//
+// Applying it inline instead is not the answer: the pause exists because the
+// attached client owns the tmux server for the attach's duration, and tearing the
+// session down under it is what the pause is there to prevent. So the intent is
+// parked and drained on the first unpaused tick.
+func (m *Manager) deferTaskSessionLifecycleWhilePaused(repoID string, instance *session.Instance, taskRunWasActive bool) {
+	if !runEndedIntoIdle(instance, taskRunWasActive) || instance.TaskID == "" {
+		return
+	}
+	key := daemonInstanceKey(repoID, instance.Title)
+	m.mu.Lock()
+	if m.deferredTaskLifecycle == nil {
+		m.deferredTaskLifecycle = make(map[string]string)
+	}
+	// Keyed by session id, not by the map key alone: a kill and a same-titled
+	// re-create would otherwise inherit the original's owed teardown.
+	m.deferredTaskLifecycle[key] = instance.ID
+	m.mu.Unlock()
+}
+
+// applyDeferredTaskSessionLifecycle drains an intent parked while the session was
+// attached, once it is being polled normally again.
+//
+// It re-checks that the session is STILL the one that finished and still idle. A
+// user who attached, read the result, and then set the session working again has
+// adopted it — that work is theirs, not the task's, and the same rule the edge
+// enforces has to hold across the deferral.
+func (m *Manager) applyDeferredTaskSessionLifecycle(repoID string, instance *session.Instance) {
+	if instance.TaskID == "" {
+		return
+	}
+	key := daemonInstanceKey(repoID, instance.Title)
+	m.mu.Lock()
+	owedID, owed := m.deferredTaskLifecycle[key]
+	if owed {
+		delete(m.deferredTaskLifecycle, key)
+	}
+	m.mu.Unlock()
+	if !owed {
+		return
+	}
+	if owedID != instance.ID || instance.GetLiveness() != session.LiveReady || instance.TaskRunActive() {
+		// Either a different session now holds this title, or the user picked the
+		// work back up during the attach. Drop the intent rather than carrying it
+		// forward: a verb owed to a finished run must not land on new work.
+		return
+	}
+	// The run genuinely ended and nothing has happened since, so this is the same
+	// decision the edge would have made — taken now that the attach has released
+	// the session. taskRunWasActive is passed as true because the edge it names
+	// already happened, on the paused tick that parked this intent.
+	m.applyTaskSessionLifecycleOnRunEnd(repoID, instance, true)
+}
+
 // applyTaskSessionLifecycleOnRunEnd applies the owning task's on_complete verb to
 // a session whose run just finished. A no-op for every session that is not a
 // task-spawned one whose run ended on this tick, and for the default keep — which
@@ -77,7 +157,15 @@ func (m *Manager) applyTaskSessionLifecycleOnRunEnd(repoID string, instance *ses
 	if taskID == "" {
 		return
 	}
+	// Capture the STABLE ID here, not just the title. The teardown below runs
+	// later on another goroutine, and ArchiveSession/KillSession fall back to
+	// {Title, RepoID} only when ID is empty — so a title-only request lets a kill
+	// and a same-titled re-create in the gap retarget the reap onto the
+	// REPLACEMENT session. That is the unstable-identity verb class, and #2779 was
+	// the last time a lifecycle op keyed on a title reached the wrong worktree.
+	sessionID := instance.ID
 	title := instance.Title
+	hooksDone := instance.PostWorktreeHooksDone()
 	verb, err := m.taskSessionLifecycle(repoID, taskID)
 	if err != nil {
 		// An unreadable or unscopable task store is not permission to tear a
@@ -91,7 +179,7 @@ func (m *Manager) applyTaskSessionLifecycleOnRunEnd(repoID string, instance *ses
 	if verb == task.OnCompleteKeep {
 		return
 	}
-	go m.runTaskSessionLifecycle(repoID, title, taskID, verb)
+	go m.runTaskSessionLifecycle(repoID, sessionID, title, taskID, verb, hooksDone)
 }
 
 // taskSessionLifecycle resolves the on_complete verb for one task in a repo.
@@ -124,13 +212,37 @@ func (m *Manager) taskSessionLifecycle(repoID, taskID string) (string, error) {
 // (#2779), the same refusal when a task still targets the session, the same
 // events. A policy that tore down sessions through a private path would be a
 // second lifecycle implementation, and the two would drift.
-func (m *Manager) runTaskSessionLifecycle(repoID, title, taskID, verb string) {
+//
+// Both requests carry the stable id, so a session killed and re-created under the
+// same title between the completion edge and this call cannot be reaped in the
+// original's place — the resolver only falls back to {Title, RepoID} when ID is
+// empty.
+func (m *Manager) runTaskSessionLifecycle(repoID, sessionID, title, taskID, verb string, hooksDone <-chan struct{}) {
+	// post_worktree_commands can still be running: the agent's readiness and the
+	// hook run are deliberately concurrent (task.WaitForReady does not charge a
+	// slow build hook against the startup budget), so a short task can finish while
+	// its own provisioning is mid-flight. Archiving would MOVE the worktree out
+	// from under those hooks and killing would REMOVE it, so wait for them.
+	//
+	// Bounded, because this must not become a way for a hung hook to wedge the
+	// reap forever — the same reasoning the concurrency cap gives for not waiting
+	// on hooks to release a slot. On timeout the session is left in place and says
+	// why, which is the recoverable outcome.
+	if hooksDone != nil {
+		select {
+		case <-hooksDone:
+		case <-time.After(taskLifecycleHookWait):
+			log.WarningLog.Printf("task %s: post-worktree hooks for session %q have run for over %s; leaving the session in place rather than tearing down a worktree they may still be writing to",
+				taskID, title, taskLifecycleHookWait)
+			return
+		}
+	}
 	var err error
 	switch verb {
 	case task.OnCompleteArchive:
-		_, _, err = m.ArchiveSession(ArchiveSessionRequest{Title: title, RepoID: repoID})
+		_, _, err = m.ArchiveSession(ArchiveSessionRequest{ID: sessionID, Title: title, RepoID: repoID})
 	case task.OnCompleteKill:
-		_, err = m.KillSession(KillSessionRequest{Title: title, RepoID: repoID})
+		err = killSessionForLifecycle(m, KillSessionRequest{ID: sessionID, Title: title, RepoID: repoID})
 	default:
 		// Unreachable: ValidateTrigger refuses an unknown verb on write, and
 		// SessionLifecycle canonicalizes. Log rather than guess — picking a verb

--- a/daemon/task_session_lifecycle_test.go
+++ b/daemon/task_session_lifecycle_test.go
@@ -261,3 +261,118 @@ func TestTaskSessionLifecycle_IgnoresSessionsNoTaskSpawned(t *testing.T) {
 	manager.mu.Unlock()
 	assert.True(t, stillRegistered, "a user's own session is never task-reaped")
 }
+
+// TestTaskSessionLifecycle_BindsTheTeardownToTheStableID is the stale-identity
+// guard. The teardown runs later on a goroutine, and ArchiveSession/KillSession
+// fall back to {Title, RepoID} only when ID is empty — so a title-only request
+// would let a kill plus a same-titled re-create in that gap retarget the reap
+// onto the REPLACEMENT session. #2779 was the last time a lifecycle op keyed on
+// a title reached the wrong worktree.
+func TestTaskSessionLifecycle_BindsTheTeardownToTheStableID(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst := registerTaskSpawnedSession(t, manager, repoID, repoPath, "nightly", "task-kill")
+	stubTaskLifecycle(t, "task-kill", task.OnCompleteKill)
+
+	var gotID, gotTitle string
+	prev := killSessionForLifecycle
+	killSessionForLifecycle = func(m *Manager, req KillSessionRequest) error {
+		gotID, gotTitle = req.ID, req.Title
+		return nil
+	}
+	t.Cleanup(func() { killSessionForLifecycle = prev })
+
+	was := endRunOnIdleEdge(t, inst)
+	manager.applyTaskSessionLifecycleOnRunEnd(repoID, inst, was)
+
+	require.Eventually(t, func() bool { return gotID != "" }, 20*time.Second, 25*time.Millisecond)
+	assert.Equal(t, inst.ID, gotID, "the teardown must name the session that actually finished")
+	assert.Equal(t, "nightly", gotTitle)
+}
+
+// TestTaskSessionLifecycle_DeferredWhileAttached is the paused-path gap: a run
+// can finish while a TUI is attached, and that path spends the completion edge
+// without being able to act on it. Losing the edge there skipped the declared
+// policy permanently — the exact leak #2595 exists to fix, through the one door
+// the first cut did not cover.
+func TestTaskSessionLifecycle_DeferredWhileAttached(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst := registerTaskSpawnedSession(t, manager, repoID, repoPath, "nightly", "task-archive")
+	stubTaskLifecycle(t, "task-archive", task.OnCompleteArchive)
+
+	was := endRunOnIdleEdge(t, inst)
+	manager.deferTaskSessionLifecycleWhilePaused(repoID, inst, was)
+
+	// Nothing happens while the intent is parked.
+	time.Sleep(150 * time.Millisecond)
+	require.Equal(t, session.LiveReady, inst.GetLiveness(), "the attach must not be torn down under")
+
+	manager.applyDeferredTaskSessionLifecycle(repoID, inst)
+	require.Eventually(t, func() bool {
+		return inst.GetLiveness() == session.LiveArchived
+	}, 20*time.Second, 25*time.Millisecond, "the owed lifecycle must be applied once the attach ends")
+}
+
+// TestTaskSessionLifecycle_DeferredIntentDropsWhenTheUserAdoptsTheSession: the
+// rule the edge enforces has to survive the deferral. A user who attached, read
+// the result, and set the session working again has adopted it.
+func TestTaskSessionLifecycle_DeferredIntentDropsWhenTheUserAdoptsTheSession(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst := registerTaskSpawnedSession(t, manager, repoID, repoPath, "nightly", "task-kill")
+	stubTaskLifecycle(t, "task-kill", task.OnCompleteKill)
+
+	was := endRunOnIdleEdge(t, inst)
+	manager.deferTaskSessionLifecycleWhilePaused(repoID, inst, was)
+
+	// The user picks the work back up during the attach.
+	inst.SetStatusForTest(session.Running)
+	manager.applyDeferredTaskSessionLifecycle(repoID, inst)
+
+	time.Sleep(200 * time.Millisecond)
+	manager.mu.Lock()
+	_, present := manager.instances[daemonInstanceKey(repoID, "nightly")]
+	manager.mu.Unlock()
+	assert.True(t, present, "work a user started is theirs, not the task's")
+
+	// And the intent is spent, so returning to idle does not reap it later.
+	inst.SetStatusForTest(session.Ready)
+	manager.applyDeferredTaskSessionLifecycle(repoID, inst)
+	time.Sleep(200 * time.Millisecond)
+	manager.mu.Lock()
+	_, stillPresent := manager.instances[daemonInstanceKey(repoID, "nightly")]
+	manager.mu.Unlock()
+	assert.True(t, stillPresent, "a dropped intent must not resurface")
+}
+
+// TestTaskSessionLifecycle_WaitsForPostWorktreeHooks: post_worktree_commands run
+// concurrently with the agent (task.WaitForReady deliberately does not charge a
+// slow build hook against the startup budget), so a short task can finish while
+// its own provisioning is mid-flight. Archiving MOVES that worktree and killing
+// REMOVES it, either of which pulls the ground out from under a running hook.
+func TestTaskSessionLifecycle_WaitsForPostWorktreeHooks(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst := registerTaskSpawnedSession(t, manager, repoID, repoPath, "nightly", "task-kill")
+	stubTaskLifecycle(t, "task-kill", task.OnCompleteKill)
+
+	hooks := make(chan struct{})
+	reaped := make(chan struct{})
+	prev := killSessionForLifecycle
+	killSessionForLifecycle = func(m *Manager, req KillSessionRequest) error {
+		close(reaped)
+		return nil
+	}
+	t.Cleanup(func() { killSessionForLifecycle = prev })
+
+	go manager.runTaskSessionLifecycle(repoID, inst.ID, "nightly", "task-kill", task.OnCompleteKill, hooks)
+
+	select {
+	case <-reaped:
+		t.Fatal("the teardown ran while post-worktree hooks were still in flight")
+	case <-time.After(300 * time.Millisecond):
+	}
+	close(hooks)
+	select {
+	case <-reaped:
+	case <-time.After(20 * time.Second):
+		t.Fatal("the teardown never ran after the hooks finished")
+	}
+}

--- a/daemon/task_session_lifecycle_test.go
+++ b/daemon/task_session_lifecycle_test.go
@@ -172,7 +172,6 @@ func TestRunEndedIntoIdle(t *testing.T) {
 	// one, which is the shape an uncertain create leaves behind.
 	inst.SetStatusForTest(session.Loading)
 	assert.False(t, runEndedIntoIdle(inst, true), "only a session that settled idle may be reaped")
-	_ = repoID
 }
 
 // TestTaskSessionLifecycle_UnreadableTaskStoreKeepsTheSession: a lookup that

--- a/daemon/task_session_lifecycle_test.go
+++ b/daemon/task_session_lifecycle_test.go
@@ -273,10 +273,13 @@ func TestTaskSessionLifecycle_BindsTheTeardownToTheStableID(t *testing.T) {
 	inst := registerTaskSpawnedSession(t, manager, repoID, repoPath, "nightly", "task-kill")
 	stubTaskLifecycle(t, "task-kill", task.OnCompleteKill)
 
-	var gotID, gotTitle string
+	// A channel, not shared vars: the seam runs on the teardown goroutine while the
+	// assertion runs on the test's, so plain fields would be a data race (-race
+	// catches it) and the handoff is what publishes the write.
+	got := make(chan KillSessionRequest, 1)
 	prev := killSessionForLifecycle
 	killSessionForLifecycle = func(m *Manager, req KillSessionRequest) error {
-		gotID, gotTitle = req.ID, req.Title
+		got <- req
 		return nil
 	}
 	t.Cleanup(func() { killSessionForLifecycle = prev })
@@ -284,9 +287,13 @@ func TestTaskSessionLifecycle_BindsTheTeardownToTheStableID(t *testing.T) {
 	was := endRunOnIdleEdge(t, inst)
 	manager.applyTaskSessionLifecycleOnRunEnd(repoID, inst, was)
 
-	require.Eventually(t, func() bool { return gotID != "" }, 20*time.Second, 25*time.Millisecond)
-	assert.Equal(t, inst.ID, gotID, "the teardown must name the session that actually finished")
-	assert.Equal(t, "nightly", gotTitle)
+	select {
+	case req := <-got:
+		assert.Equal(t, inst.ID, req.ID, "the teardown must name the session that actually finished")
+		assert.Equal(t, "nightly", req.Title)
+	case <-time.After(20 * time.Second):
+		t.Fatal("the declared teardown never ran")
+	}
 }
 
 // TestTaskSessionLifecycle_DeferredWhileAttached is the paused-path gap: a run

--- a/daemon/task_session_lifecycle_test.go
+++ b/daemon/task_session_lifecycle_test.go
@@ -1,0 +1,234 @@
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+	sessiongit "github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+// registerTaskSpawnedSession is registerArchivable for a session a TASK created:
+// same real worktree and manager registration, but attributed to taskID and left
+// mid-run (LiveRunning) so the completion edge can still be driven.
+//
+// The TaskID must go through NewInstance rather than being poked in afterwards —
+// taskRunActive is derived from it at construction and is the whole subject here.
+func registerTaskSpawnedSession(t *testing.T, m *Manager, repoID, repoPath, title, taskID string) *session.Instance {
+	t.Helper()
+	wtPath := filepath.Join(filepath.Dir(repoPath), "wt-"+sanitizeArchiveTitle(title))
+	branch := "af/" + sanitizeArchiveTitle(title)
+	out, err := exec.Command("git", "-C", repoPath, "worktree", "add", "-b", branch, wtPath).CombinedOutput()
+	require.NoError(t, err, string(out))
+	require.NoError(t, os.WriteFile(filepath.Join(wtPath, "dirty.txt"), []byte("uncommitted"), 0644))
+
+	gw, err := sessiongit.NewGitWorktreeFromStorage(repoPath, wtPath, title, branch, "", false, true)
+	require.NoError(t, err)
+
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title: title, Path: repoPath, Program: "claude", TaskID: taskID,
+	})
+	require.NoError(t, err)
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetGitWorktreeForTest(gw)
+	inst.SetStartedForTest(true)
+	// Mid-run: the agent is working, so the run has not ended and the idle edge
+	// below is a real transition INTO Ready rather than a no-op.
+	inst.SetStatusForTest(session.Running)
+
+	seedDiskInstance(t, repoID, title, repoPath)
+	m.mu.Lock()
+	m.instances[daemonInstanceKey(repoID, title)] = inst
+	m.mu.Unlock()
+
+	require.True(t, inst.TaskRunActive(), "precondition: a task-spawned session starts with its run in flight")
+	return inst
+}
+
+// stubTaskLifecycle points the task lookup at a fixed policy for repoID, so these
+// tests exercise the lifecycle decision without standing up a task store.
+func stubTaskLifecycle(t *testing.T, taskID, onComplete string) {
+	t.Helper()
+	prev := loadTasksForRepoID
+	loadTasksForRepoID = func(string) ([]task.Task, []task.Task, error) {
+		return []task.Task{{ID: taskID, OnComplete: onComplete}}, nil, nil
+	}
+	t.Cleanup(func() { loadTasksForRepoID = prev })
+}
+
+// endRunOnIdleEdge drives the transition that ends a task run: the agent settling
+// idle. It is the same ObserveLiveness edge the status poll uses, so these tests
+// exercise the real completion signal rather than poking taskRunActive.
+func endRunOnIdleEdge(t *testing.T, inst *session.Instance) bool {
+	t.Helper()
+	was := inst.TaskRunActive()
+	require.NoError(t, inst.Transition(session.ObserveLiveness(session.LiveReady)))
+	require.False(t, inst.TaskRunActive(), "the idle edge must end the run")
+	return was
+}
+
+// TestTaskSessionLifecycle_KeepLeavesTheFinishedSessionAlone is the compatibility
+// case, and the one that matters most: every task written before #2595 declares
+// nothing, and a finished run must still leave its session exactly where it was.
+func TestTaskSessionLifecycle_KeepLeavesTheFinishedSessionAlone(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst := registerTaskSpawnedSession(t, manager, repoID, repoPath, "nightly", "task-keep")
+
+	for _, verb := range []string{"", task.OnCompleteKeep} {
+		stubTaskLifecycle(t, "task-keep", verb)
+		was := inst.TaskRunActive()
+		manager.applyTaskSessionLifecycleOnRunEnd(repoID, inst, was)
+	}
+	was := endRunOnIdleEdge(t, inst)
+	stubTaskLifecycle(t, "task-keep", "")
+	manager.applyTaskSessionLifecycleOnRunEnd(repoID, inst, was)
+
+	// Nothing is dispatched, so a short settle is enough to prove no teardown ran.
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, session.LiveReady, inst.GetLiveness(), "an undeclared policy must leave the session live")
+	manager.mu.Lock()
+	_, stillRegistered := manager.instances[daemonInstanceKey(repoID, "nightly")]
+	manager.mu.Unlock()
+	assert.True(t, stillRegistered)
+}
+
+// TestTaskSessionLifecycle_ArchiveArchivesTheFinishedSession is the headline
+// behavior of #2595: the leak the issue reports stops accumulating.
+func TestTaskSessionLifecycle_ArchiveArchivesTheFinishedSession(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst := registerTaskSpawnedSession(t, manager, repoID, repoPath, "nightly", "task-archive")
+	stubTaskLifecycle(t, "task-archive", task.OnCompleteArchive)
+
+	was := endRunOnIdleEdge(t, inst)
+	manager.applyTaskSessionLifecycleOnRunEnd(repoID, inst, was)
+
+	require.Eventually(t, func() bool {
+		return inst.GetLiveness() == session.LiveArchived
+	}, 20*time.Second, 25*time.Millisecond, "the finished run's session must be archived")
+
+	// Archived, not destroyed: the record survives so the run stays restorable.
+	assert.NotNil(t, recordFor(t, repoID, "nightly"), "an archived session keeps its durable record")
+}
+
+// TestTaskSessionLifecycle_KillRemovesTheFinishedSession covers the other verb.
+// It exists as its own case because the archive/kill choice is the actual product
+// decision here — archive retains the worktree, kill reclaims it (#2573).
+func TestTaskSessionLifecycle_KillRemovesTheFinishedSession(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst := registerTaskSpawnedSession(t, manager, repoID, repoPath, "nightly", "task-kill")
+	stubTaskLifecycle(t, "task-kill", task.OnCompleteKill)
+
+	was := endRunOnIdleEdge(t, inst)
+	manager.applyTaskSessionLifecycleOnRunEnd(repoID, inst, was)
+
+	require.Eventually(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		_, present := manager.instances[daemonInstanceKey(repoID, "nightly")]
+		return !present
+	}, 20*time.Second, 25*time.Millisecond, "the finished run's session must be removed")
+}
+
+// TestTaskSessionLifecycle_OnlyFiresOnTheIdleEdge pins the predicate that keeps
+// this from becoming a sweep. A session whose run ended long ago — the state a
+// user may since have adopted and be working in — must never be revisited.
+func TestTaskSessionLifecycle_OnlyFiresOnTheIdleEdge(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst := registerTaskSpawnedSession(t, manager, repoID, repoPath, "nightly", "task-archive")
+	stubTaskLifecycle(t, "task-archive", task.OnCompleteArchive)
+
+	endRunOnIdleEdge(t, inst)
+	// A later tick observes the same finished session, but the edge is behind it:
+	// taskRunWasActive is false because the run had already ended.
+	manager.applyTaskSessionLifecycleOnRunEnd(repoID, inst, false)
+
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, session.LiveReady, inst.GetLiveness(),
+		"a session whose run ended on an earlier tick must not be torn down by a later one")
+}
+
+// TestRunEndedIntoIdle covers the predicate directly, including the case that
+// protects an uncertain create: the run marker also clears when startup settles
+// terminal-unknown, and that session must never be reaped.
+func TestRunEndedIntoIdle(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst := registerTaskSpawnedSession(t, manager, repoID, repoPath, "nightly", "task-x")
+
+	assert.False(t, runEndedIntoIdle(inst, true), "a run still in flight has not ended")
+	assert.False(t, runEndedIntoIdle(inst, false), "nor has one the caller never saw active")
+
+	endRunOnIdleEdge(t, inst)
+	assert.True(t, runEndedIntoIdle(inst, true), "ended + Ready is the completion edge")
+	assert.False(t, runEndedIntoIdle(inst, false), "the edge needs the run to have been active")
+
+	// Not Ready: the run marker is clear but the session is not a healthy idle
+	// one, which is the shape an uncertain create leaves behind.
+	inst.SetStatusForTest(session.Loading)
+	assert.False(t, runEndedIntoIdle(inst, true), "only a session that settled idle may be reaped")
+	_ = repoID
+}
+
+// TestTaskSessionLifecycle_UnreadableTaskStoreKeepsTheSession: a lookup that
+// cannot answer is not permission to tear anything down.
+func TestTaskSessionLifecycle_UnreadableTaskStoreKeepsTheSession(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst := registerTaskSpawnedSession(t, manager, repoID, repoPath, "nightly", "task-boom")
+
+	prev := loadTasksForRepoID
+	loadTasksForRepoID = func(string) ([]task.Task, []task.Task, error) {
+		return nil, nil, assert.AnError
+	}
+	t.Cleanup(func() { loadTasksForRepoID = prev })
+
+	was := endRunOnIdleEdge(t, inst)
+	manager.applyTaskSessionLifecycleOnRunEnd(repoID, inst, was)
+
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, session.LiveReady, inst.GetLiveness(),
+		"an unreadable task store must leave the session in place")
+}
+
+// TestTaskSessionLifecycle_DeletedTaskKeepsItsSessions: sessions outlive the task
+// that made them, and removing a task must not retroactively authorize destroying
+// the work its runs produced.
+func TestTaskSessionLifecycle_DeletedTaskKeepsItsSessions(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst := registerTaskSpawnedSession(t, manager, repoID, repoPath, "nightly", "task-gone")
+
+	prev := loadTasksForRepoID
+	loadTasksForRepoID = func(string) ([]task.Task, []task.Task, error) {
+		return nil, nil, nil // the task is no longer in the store
+	}
+	t.Cleanup(func() { loadTasksForRepoID = prev })
+
+	was := endRunOnIdleEdge(t, inst)
+	manager.applyTaskSessionLifecycleOnRunEnd(repoID, inst, was)
+
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, session.LiveReady, inst.GetLiveness())
+}
+
+// TestTaskSessionLifecycle_IgnoresSessionsNoTaskSpawned: a session a user made by
+// hand has no TaskID, so no policy can reach it however it settles.
+func TestTaskSessionLifecycle_IgnoresSessionsNoTaskSpawned(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, _ := registerArchivable(t, manager, repoID, repoPath, "mine")
+	stubTaskLifecycle(t, "", task.OnCompleteKill)
+
+	assert.False(t, inst.TaskRunActive(), "precondition: a hand-made session has no run")
+	manager.applyTaskSessionLifecycleOnRunEnd(repoID, inst, true)
+
+	time.Sleep(200 * time.Millisecond)
+	assert.NotEqual(t, session.LiveArchived, inst.GetLiveness())
+	manager.mu.Lock()
+	_, stillRegistered := manager.instances[daemonInstanceKey(repoID, "mine")]
+	manager.mu.Unlock()
+	assert.True(t, stillRegistered, "a user's own session is never task-reaped")
+}

--- a/daemon/task_session_lifecycle_test.go
+++ b/daemon/task_session_lifecycle_test.go
@@ -168,10 +168,32 @@ func TestRunEndedIntoIdle(t *testing.T) {
 	assert.True(t, runEndedIntoIdle(inst, true), "ended + Ready is the completion edge")
 	assert.False(t, runEndedIntoIdle(inst, false), "the edge needs the run to have been active")
 
-	// Not Ready: the run marker is clear but the session is not a healthy idle
-	// one, which is the shape an uncertain create leaves behind.
-	inst.SetStatusForTest(session.Loading)
+	// Not idle: the run marker is clear but the agent is working again, so this is
+	// not a finished run sitting quiet.
+	inst.SetStatusForTest(session.Running)
 	assert.False(t, runEndedIntoIdle(inst, true), "only a session that settled idle may be reaped")
+}
+
+// TestRunEndedIntoIdle_ExcludesAnUncertainCreate is the case that caught a wrong
+// claim in review: session.Loading decomposes to LiveReady, and more importantly
+// MarkStartupStateUnknown clears taskRunActive DIRECTLY while leaving liveness
+// alone — so an uncertain create satisfies "run ended" and "is LiveReady" both.
+//
+// The daemon retains that record deliberately so an operator can inspect the
+// workspace the create may have left behind (keepUncertainCreate). The poll's
+// !Started() early return keeps it away from the lifecycle hook today, but the
+// predicate must refuse it on its own rather than resting on a distant line.
+func TestRunEndedIntoIdle_ExcludesAnUncertainCreate(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst := registerTaskSpawnedSession(t, manager, repoID, repoPath, "uncertain", "task-x")
+
+	inst.MarkStartupStateUnknown()
+	require.False(t, inst.TaskRunActive(), "precondition: the marker clears without a completed run")
+	require.Equal(t, session.LiveReady, inst.GetLiveness(),
+		"precondition: liveness is untouched, which is what makes this indistinguishable on the first two conditions")
+
+	assert.False(t, runEndedIntoIdle(inst, true),
+		"a create whose startup outcome was never established is not a finished run")
 }
 
 // TestTaskSessionLifecycle_UnreadableTaskStoreKeepsTheSession: a lookup that

--- a/daemon/task_session_lifecycle_test.go
+++ b/daemon/task_session_lifecycle_test.go
@@ -383,3 +383,56 @@ func TestTaskSessionLifecycle_WaitsForPostWorktreeHooks(t *testing.T) {
 		t.Fatal("the teardown never ran after the hooks finished")
 	}
 }
+
+// TestTaskSessionLifecycle_ParkedIntentIsReclaimedWhenTheSessionGoes: an intent
+// is drained by a normal poll of the session that owes it, so a session killed
+// while one is parked would never come back to collect. Leaking a map entry
+// inside the change that exists to stop leaks is not acceptable, and it is the
+// same reclamation the paused-poll lease sweep performs.
+func TestTaskSessionLifecycle_ParkedIntentIsReclaimedWhenTheSessionGoes(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst := registerTaskSpawnedSession(t, manager, repoID, repoPath, "nightly", "task-archive")
+	stubTaskLifecycle(t, "task-archive", task.OnCompleteArchive)
+
+	was := endRunOnIdleEdge(t, inst)
+	manager.deferTaskSessionLifecycleWhilePaused(repoID, inst, was)
+
+	key := daemonInstanceKey(repoID, "nightly")
+	manager.mu.Lock()
+	_, parked := manager.deferredTaskLifecycle[key]
+	manager.mu.Unlock()
+	require.True(t, parked, "precondition: the intent is parked")
+
+	// The session goes away without ever being polled again.
+	manager.mu.Lock()
+	delete(manager.instances, key)
+	manager.sweepDeferredTaskLifecycleLocked()
+	_, stillParked := manager.deferredTaskLifecycle[key]
+	manager.mu.Unlock()
+	assert.False(t, stillParked, "an intent whose session is gone must be reclaimed")
+}
+
+// TestTaskSessionLifecycle_ParkedIntentIsReclaimedOnTitleReuse: the map is keyed
+// by daemon instance key, which is a title — so a same-titled replacement must
+// not inherit the original's owed teardown.
+func TestTaskSessionLifecycle_ParkedIntentIsReclaimedOnTitleReuse(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst := registerTaskSpawnedSession(t, manager, repoID, repoPath, "nightly", "task-kill")
+	stubTaskLifecycle(t, "task-kill", task.OnCompleteKill)
+
+	was := endRunOnIdleEdge(t, inst)
+	manager.deferTaskSessionLifecycleWhilePaused(repoID, inst, was)
+
+	// A different session now holds the title.
+	replacement, err := session.NewInstance(session.InstanceOptions{
+		Title: "nightly", Path: repoPath, Program: "claude", TaskID: "task-kill",
+	})
+	require.NoError(t, err)
+	key := daemonInstanceKey(repoID, "nightly")
+	manager.mu.Lock()
+	manager.instances[key] = replacement
+	manager.sweepDeferredTaskLifecycleLocked()
+	_, stillParked := manager.deferredTaskLifecycle[key]
+	manager.mu.Unlock()
+	assert.False(t, stillParked, "a replacement session must not inherit the original's owed teardown")
+}

--- a/daemon/task_session_lifecycle_test.go
+++ b/daemon/task_session_lifecycle_test.go
@@ -187,6 +187,14 @@ func TestRunEndedIntoIdle_ExcludesAnUncertainCreate(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	inst := registerTaskSpawnedSession(t, manager, repoID, repoPath, "uncertain", "task-x")
 
+	// The production shape, which the shared fixture deliberately is not: a create
+	// whose session was born LiveReady and whose agent never ran. The fixture opens
+	// mid-run (LiveRunning) so the idle EDGE is drivable, so put it back to the
+	// state MarkStartupStateUnknown actually finds. SetStatusForTest writes the
+	// axes directly rather than transitioning, so this does not end the run itself.
+	inst.SetStatusForTest(session.Ready)
+	require.True(t, inst.TaskRunActive(), "precondition: the run is still marked in flight")
+
 	inst.MarkStartupStateUnknown()
 	require.False(t, inst.TaskRunActive(), "precondition: the marker clears without a completed run")
 	require.Equal(t, session.LiveReady, inst.GetLiveness(),

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2078,6 +2078,7 @@ af tasks add [flags]
 | `--cron` | `string` | Cron expression (exactly one of --cron / --watch-cmd) |
 | `--max-concurrent-runs` | `int` | Cap how many sessions this watch task may have in flight at once; excess events are queued in order instead of spawning runs, subject to the durable queue's retention limits (0 = unlimited; --watch-cmd tasks without --target-session only) (default `0`) |
 | `--name` | `string` | Task name (required) |
+| `--on-complete` | `string` | What happens to the session a run spawns once it finishes: keep (default, leaves it in place), archive (restorable, but retains its whole worktree), or kill (reclaims the worktree and prunes the session's branch). Not for --target-session tasks, whose session is meant to be reused |
 | `--program` | `string` | Program to run (one of: claude, codex, aider, gemini, amp, opencode, devin; defaults to config default) |
 | `--prompt` | `string` | Prompt to send (required for --cron tasks; --watch-cmd tasks default to the emitted line, with {{line}} substituted when present) |
 | `--target-session` | `string` | Deliver the prompt into this session (auto-created if missing); empty creates a new session per run |
@@ -2227,6 +2228,7 @@ af tasks update <id> [flags]
 | `--enabled` | `string` | Enable or disable the task (true/false) |
 | `--max-concurrent-runs` | `int` | New in-flight session cap for this watch task; pass 0 to revert to unlimited (default `0`) |
 | `--name` | `string` | New task name |
+| `--on-complete` | `string` | New spawned-session lifecycle: keep, archive, or kill; pass keep to revert to leaving sessions in place |
 | `--program` | `string` | New program to run (one of: claude, codex, aider, gemini, amp, opencode, devin; leave unset to keep the current one) |
 | `--project-path` | `string` | Move the task to this git repository (distinct from --repo, which scopes its current project) |
 | `--prompt` | `string` | New prompt |

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -26,6 +26,7 @@ Tasks live in `~/.agent-factory/tasks.json`. Manage them via `af tasks` (JSON CL
 | `watch_cmd` | Event trigger — long-running command; each stdout line fires the task (exactly one of `cron_expr` / `watch_cmd`) |
 | `target_session` | Deliver into this session by title (auto-created if missing). Empty = create a new session per fire |
 | `max_concurrent_runs` | Cap on how many sessions this watch task may have in flight at once. `0` (the default) = unlimited. Excess events are queued in order and delivered as sessions finish, rather than spawning more runs (subject to the durable queue's retention limits). Watch tasks with an empty `target_session` only (see [Limiting concurrent sessions](#limiting-concurrent-sessions)) |
+| `on_complete` | What happens to a session this task spawned once its run finishes: `keep` (the default — leave it in place), `archive`, or `kill`. Rejected on a `target_session` task, whose session exists to be reused (see [What happens to a run's session](#what-happens-to-a-runs-session)) |
 | `project_path` | Repo the task operates on; also the watch script's working directory |
 | `repo_id` | The owning project's id, resolved once when the task is bound and retained. Derived, not editable — it is recomputed only when `project_path` changes. It exists so that deleting the recorded directory cannot strand the task outside its own project; rows created before this field fall back to resolving `project_path` |
 | `program` | Agent to run (`claude`, `codex`, `aider`, `gemini`, `amp`, `opencode`, `devin`). Empty = configured `default_program` |
@@ -35,6 +36,8 @@ Tasks live in `~/.agent-factory/tasks.json`. Manage them via `af tasks` (JSON CL
 A task with both triggers set is always invalid. An enabled task must have exactly one; a disabled task with neither is tolerated as a draft. An enabled cron task must carry a non-empty prompt — there is no event line to fall back to. Watch tasks are exempt (empty prompt defaults to the emitted line). Disabled drafts are tolerated regardless of prompt.
 
 `max_concurrent_runs` is rejected on a cron task or one with a `target_session` set, rather than stored and ignored: overlapping cron fires already coalesce, and deliveries into a single target session already serialize, so there would be nothing for the cap to bound.
+
+`on_complete` is rejected on a task with a `target_session` for the same class of reason: that session is one long-lived session you named so runs could share it, and archiving or killing it after every run would destroy the thing the target exists to reuse.
 
 An **all-whitespace** `target_session` means the same thing as an empty one — create a session per fire — and is stored as empty. A session title is otherwise kept **exactly** as written, including any leading or trailing spaces: titles are matched byte-for-byte at delivery, so a task targeting `" build "` keeps looking for `" build "` and is never silently re-pointed at `"build"`.
 
@@ -104,6 +107,66 @@ How it behaves:
 
 Pick the cap from what a run actually costs. If each event triggers an expensive post-worktree build, a low cap keeps the machine usable; if runs are cheap, leave it unlimited and let the 10/min rate limit be the only bound.
 
+## What happens to a run's session
+
+A task with no `target_session` creates **a new session per run**. Until `on_complete`
+existed, af had no policy for what became of it: the run finished, the agent went idle,
+and the session then held its tmux session and its git worktree indefinitely. A daily
+cron task leaked one session a day, forever, and the only thing standing between a
+schedule and unbounded growth was a line of prose in the prompt asking the agent to
+archive itself — which nothing enforced and `af tasks list` could not show.
+
+`on_complete` moves that decision onto the task, where it is declared once and visible:
+
+```bash
+af tasks add --name "Docs drift audit" --prompt "Audit the docs" \
+  --cron "17 6 * * *" --on-complete kill
+```
+
+| Value | What happens when the run finishes |
+|---|---|
+| `keep` | Nothing. The session stays live and idle. **The default**, and exactly what every task did before this field existed |
+| `archive` | The session is archived — inert and restorable, and it keeps its full worktree |
+| `kill` | The session is permanently deleted, reclaiming its worktree and pruning the branch it owned |
+
+**Choosing between `archive` and `kill` is the real decision, and af does not make it
+for you.** Archiving is restorable, but an archived worktree is retained whole —
+gitignored build output included — until someone prunes it by hand, so a daily task set
+to `archive` trades a session leak for a disk one. Killing reclaims that space and prunes
+the session's own branch, which is the right trade when the run's output already lives
+somewhere durable: a pushed branch, or a merged PR. A run you might need to read
+afterwards wants `archive`; a run whose result is already in git usually wants `kill`.
+
+That is why the default is `keep` rather than either verb — af will not silently reap a
+session, and an existing task's behavior does not change when you upgrade.
+
+How it behaves:
+
+- **It fires on the run's completion edge**, the same moment `max_concurrent_runs`
+  releases a slot: the agent has gone idle and the session is sitting healthy. It is not
+  a background sweep over old sessions, which matters because "a task session whose run
+  has finished" stays true forever — including for a session you have since adopted and
+  are working in yourself. Once a run's completion has passed, that session is never
+  revisited.
+- **A session you took over is yours.** If you prompt a finished run's session, the work
+  is not the task's, and no policy applies to it.
+- **A session created outside a task is never touched**, whatever the tasks in that
+  project declare.
+- **A failed teardown leaves the session in place** and logs. The run itself already
+  succeeded, so a failure to reap never marks the run failed; finish it by hand with
+  `af sessions archive`/`kill` if you want to.
+- **If the policy cannot be read** — an unreadable task store, or a task deleted since
+  the run started — the session is kept. Removing a task does not retroactively
+  authorize destroying the work its runs produced.
+- **A session the daemon is unsure about is kept.** A create whose startup outcome was
+  never established is deliberately retained so you can inspect the workspace it may have
+  left behind; that is not a completed run and is never reaped.
+
+Not covered here: pruning worktrees that are *already* archived (#2573), and the
+`--keep-runs N` / idle-TTL shapes floated on #2595. Both need a standing sweep over
+sessions whose runs have ended, which is exactly the shape that can reap a session
+someone has adopted; `on_complete` is edge-triggered and cannot.
+
 ### Watch-task status
 
 The TUI Tasks pane shows each watch task's supervision state, derived from the persisted fields:
@@ -138,10 +201,10 @@ Versions before #791 installed one systemd timer / launchd plist **per task** (`
 
 ```bash
 af tasks list [--all]
-af tasks add --name <n> --prompt <p> --cron "0 9 * * *" [--target-session <title>] [--program <agent>]
-af tasks add --name <n> --watch-cmd <cmd> [--prompt "… {{line}} …"] [--target-session <title>] [--max-concurrent-runs <n>]
+af tasks add --name <n> --prompt <p> --cron "0 9 * * *" [--target-session <title>] [--on-complete keep|archive|kill] [--program <agent>]
+af tasks add --name <n> --watch-cmd <cmd> [--prompt "… {{line}} …"] [--target-session <title>] [--max-concurrent-runs <n>] [--on-complete keep|archive|kill]
 af tasks get <id>
-af tasks update <id> [--cron …|--watch-cmd …] [--prompt …] [--target-session …] [--max-concurrent-runs <n>] [--project-path <repo>] [--program <agent>] [--enabled true|false]
+af tasks update <id> [--cron …|--watch-cmd …] [--prompt …] [--target-session …] [--max-concurrent-runs <n>] [--on-complete keep|archive|kill] [--project-path <repo>] [--program <agent>] [--enabled true|false]
 af tasks restart <id>          # enabled watch tasks only; reloads an edited script
 af tasks trigger <id>          # cron tasks only
 af tasks remove <id>
@@ -149,7 +212,7 @@ af tasks remove <id>
 
 Every subcommand is scoped to one project — the current directory's, or the one `--repo` names — so `tasks list` shows this project's tasks (`--all` spans every project) and an id belonging to another project is refused rather than acted on. `tasks add` binds the task to the resolved project and reports it as `project_path`. On `tasks update`, `--repo` authorizes the task in its current project while `--project-path` moves it to a new project and working directory. See [Project scoping](cli.md#project-scoping) for the full contract.
 
-On `update`, setting one trigger clears the other (switching watch→cron requires a prompt when the resulting cron task is enabled). `--target-session ""` explicitly reverts to create-per-run; omitting the flag leaves it untouched. `--max-concurrent-runs 0` explicitly reverts to unlimited; omitting the flag leaves the current cap untouched. `--program` accepts the same agent enum as `tasks add`; omitting it keeps the task's current program.
+On `update`, setting one trigger clears the other (switching watch→cron requires a prompt when the resulting cron task is enabled). `--target-session ""` explicitly reverts to create-per-run; omitting the flag leaves it untouched. `--max-concurrent-runs 0` explicitly reverts to unlimited; omitting the flag leaves the current cap untouched. `--on-complete keep` explicitly reverts to leaving sessions in place; omitting the flag leaves the current policy untouched. `--program` accepts the same agent enum as `tasks add`; omitting it keeps the task's current program.
 
 ## Examples
 

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -1310,6 +1310,24 @@
       "notes": "A watch-task concurrency cap (task.Task/TaskUpdate.MaxConcurrentRuns) added on master. The CLI sets it via --max-concurrent-runs; the TUI task form and web do not expose it. Same class as the other task-edit gaps: the TUI can edit tasks (so this is a missing FIELD, #1935-adjacent) and the web cannot edit tasks at all (#1935). Niche enough that whether the UIs should surface it is an owner call. Not filed pending that."
     },
     {
+      "id": "task.on-complete",
+      "title": "Declare what happens to a task run's session when it finishes",
+      "tui": {
+        "status": "no",
+        "pointer": ""
+      },
+      "web": {
+        "status": "no",
+        "pointer": ""
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/api.go af tasks add/update --on-complete"
+      },
+      "verdict": "unclear",
+      "notes": "The spawned-session lifecycle verb (task.Task/TaskUpdate.OnComplete, #2595): keep/archive/kill applied when a run finishes. The CLI sets it via --on-complete; the TUI task form and web do not expose it. Exactly the task.max-concurrent-runs shape — the TUI can edit tasks so this is a missing FIELD (#1935-adjacent), and the web cannot edit tasks at all (#1935). Whether the UIs should surface it is the same owner call, so it is recorded here rather than filed. The DEFAULT (keep) is the historical behavior, so a surface that cannot set it still produces correct tasks — which is why this is a field gap and not a broken create."
+    },
+    {
       "id": "session.tab.rename",
       "title": "Rename a tab",
       "tui": {
@@ -1710,7 +1728,9 @@
       "af upgrade --allow-downgrade": "install.upgrade",
       "af upgrade --help": "meta.discovery",
       "af upgrade --no-restart": "install.upgrade",
-      "af version --help": "meta.discovery"
+      "af version --help": "meta.discovery",
+      "af tasks add --on-complete": "task.on-complete",
+      "af tasks update --on-complete": "task.on-complete"
     }
   },
   "field_coverage": {
@@ -1853,6 +1873,9 @@
           },
           "task.repo_id": {
             "ok": "Daemon-resolved at bind time (#1893): task.RepoID is sha256 of the main repo root, computed by the daemon when the task binds to a project, never a client input — like created_at/last_run_at."
+          },
+          "task.on_complete": {
+            "gap": "task.on-complete"
           }
         }
       },
@@ -1893,6 +1916,9 @@
           },
           "expect.project_path": {
             "ok": "A CLI-side compare-and-swap guard (#1891): api/tasks.go enforceTaskScope authorizes a task mutation against the project the CLI resolved via --repo, so a stale id cannot hit a task that moved projects. The TUI and web operate within an already-selected project and set no expectation — it is the stateless CLI's safety mechanism, not a user option."
+          },
+          "update.on_complete": {
+            "gap": "task.on-complete"
           }
         }
       },
@@ -2005,6 +2031,9 @@
         },
         "expect.project_path": {
           "ok": "A CLI-side compare-and-swap guard (#1891): api/tasks.go enforceTaskScope authorizes a task mutation against the project the CLI resolved via --repo, so a stale id cannot hit a task that moved projects. The TUI and web operate within an already-selected project and set no expectation — it is the stateless CLI's safety mechanism, not a user option."
+        },
+        "update.on_complete": {
+          "gap": "task.on-complete"
         }
       },
       "AddTask": {
@@ -2019,6 +2048,9 @@
         },
         "task.repo_id": {
           "ok": "Daemon-resolved at bind time (#1893): task.RepoID is sha256 of the main repo root, computed by the daemon when the task binds to a project, never a client input — like created_at/last_run_at."
+        },
+        "task.on_complete": {
+          "gap": "task.on-complete"
         }
       },
       "RemoveTask": {

--- a/task/on_complete.go
+++ b/task/on_complete.go
@@ -1,0 +1,64 @@
+package task
+
+import "strings"
+
+// Spawned-session lifecycle (#2595).
+//
+// A task with no target session creates one session per run, and af had no policy
+// for what became of it: the run finished, the agent went idle, and the session
+// held its tmux session and its git worktree indefinitely. The only thing standing
+// between a schedule and unbounded growth was prose in the prompt asking the agent
+// to archive itself — unenforced, and invisible to `af tasks list`.
+//
+// Task.OnComplete is the declaration; daemon/task_session_lifecycle.go applies it.
+
+// The three lifecycle verbs a task can declare for the sessions it spawns
+// (#2595). Stored lowercase; empty on disk means OnCompleteKeep.
+const (
+	// OnCompleteKeep leaves the session exactly where the run left it. The
+	// historical behavior, and the default, so no existing task changes.
+	OnCompleteKeep = "keep"
+	// OnCompleteArchive archives the session when its run finishes: restorable,
+	// but its worktree — gitignored build output included — is retained until
+	// someone prunes it by hand (#2573).
+	OnCompleteArchive = "archive"
+	// OnCompleteKill permanently deletes the session when its run finishes,
+	// reclaiming the worktree and pruning the session's owned branch. Right for a
+	// run whose output already lives somewhere durable, such as a pushed branch.
+	OnCompleteKill = "kill"
+)
+
+// OnCompleteValues lists the accepted verbs in the order surfaces should offer
+// them: least destructive first, so a picker's default lands on the safe one.
+func OnCompleteValues() []string {
+	return []string{OnCompleteKeep, OnCompleteArchive, OnCompleteKill}
+}
+
+// CanonicalOnComplete puts a stored or user-supplied verb into canonical form.
+// Empty and whitespace both mean keep, so a legacy row and an explicit "keep"
+// are the same policy and neither has to be special-cased downstream.
+func CanonicalOnComplete(v string) string {
+	trimmed := strings.ToLower(strings.TrimSpace(v))
+	if trimmed == "" {
+		return OnCompleteKeep
+	}
+	return trimmed
+}
+
+// canonicalizeOnComplete normalizes the stored verb on every write, mirroring
+// canonicalizeTargetSession. It stores "" for keep rather than the literal word
+// so an untouched task's JSON is byte-identical to what it was before this field
+// existed — the omitempty on the field is only half of that guarantee.
+func (t *Task) canonicalizeOnComplete() {
+	if CanonicalOnComplete(t.OnComplete) == OnCompleteKeep {
+		t.OnComplete = ""
+		return
+	}
+	t.OnComplete = CanonicalOnComplete(t.OnComplete)
+}
+
+// SessionLifecycle reports the verb to apply to a session this task spawned,
+// once that session's run has finished. Always one of the OnComplete* constants.
+func (t Task) SessionLifecycle() string {
+	return CanonicalOnComplete(t.OnComplete)
+}

--- a/task/on_complete_test.go
+++ b/task/on_complete_test.go
@@ -245,3 +245,46 @@ func TestTaskUpdateOnCompleteSurvivesGob(t *testing.T) {
 	require.NotNil(t, decoded.OnComplete, "a patch reverting to the default must survive the control socket")
 	assert.Equal(t, "", *decoded.OnComplete)
 }
+
+// TestUpdateTaskAddingATargetSessionDropsAnInapplicableVerb is the retargeting
+// case. A per-run task that declares on_complete would otherwise merge with a
+// newly-added target_session into a record ValidateTrigger rejects, so ordinary
+// retargeting would fail from every surface that does not expose the field — and
+// force a CLI user to know to pass --on-complete keep alongside.
+//
+// It mirrors the max_concurrent_runs rule exactly: an unpatched, now-inapplicable
+// field is dropped by the shared merge.
+func TestUpdateTaskAddingATargetSessionDropsAnInapplicableVerb(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", dir)
+
+	require.NoError(t, AddTask(Task{
+		ID: "abc", CronExpr: "0 3 * * *", Prompt: "p",
+		ProjectPath: dir, Program: "claude", Enabled: true, OnComplete: OnCompleteArchive,
+	}))
+
+	target := "shared"
+	updated, err := UpdateTask("abc", TaskUpdate{TargetSession: &target}, ProjectExpectation{})
+	require.NoError(t, err, "retargeting a task must not be blocked by a verb the new shape cannot carry")
+	assert.Equal(t, "shared", updated.TargetSession)
+	assert.Empty(t, updated.OnComplete, "the inapplicable lifecycle is dropped, not left to fail validation")
+}
+
+// TestUpdateTaskExplicitVerbWithATargetSessionStillErrors: dropping is only for
+// a field the caller did NOT mention. Asking for both in one patch is a
+// contradiction and must still surface as one rather than being silently ignored.
+func TestUpdateTaskExplicitVerbWithATargetSessionStillErrors(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", dir)
+
+	require.NoError(t, AddTask(Task{
+		ID: "abc", CronExpr: "0 3 * * *", Prompt: "p",
+		ProjectPath: dir, Program: "claude", Enabled: true,
+	}))
+
+	target := "shared"
+	verb := OnCompleteKill
+	_, err := UpdateTask("abc", TaskUpdate{TargetSession: &target, OnComplete: &verb}, ProjectExpectation{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "target_session")
+}

--- a/task/on_complete_test.go
+++ b/task/on_complete_test.go
@@ -1,0 +1,247 @@
+package task
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCanonicalOnComplete pins the normalization every surface relies on: empty
+// and "keep" are the SAME policy, so nothing downstream has to special-case a
+// legacy row, and case/whitespace from a CLI flag never reaches storage.
+func TestCanonicalOnComplete(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want string
+	}{
+		{"", OnCompleteKeep},
+		{"   ", OnCompleteKeep},
+		{"keep", OnCompleteKeep},
+		{"archive", OnCompleteArchive},
+		{"  ARCHIVE ", OnCompleteArchive},
+		{"Kill", OnCompleteKill},
+		{"nope", "nope"}, // preserved verbatim so validation can name it back
+	} {
+		assert.Equal(t, tc.want, CanonicalOnComplete(tc.in), "CanonicalOnComplete(%q)", tc.in)
+	}
+}
+
+// TestValidateTriggerOnComplete is the admission half of #2595.
+func TestValidateTriggerOnComplete(t *testing.T) {
+	cases := []struct {
+		name    string
+		task    Task
+		wantErr string
+	}{
+		{
+			name: "unset is the default and always valid",
+			task: Task{ID: "t1", CronExpr: "0 3 * * *", Prompt: "p", Enabled: true},
+		},
+		{
+			name: "explicit keep is valid",
+			task: Task{ID: "t2", CronExpr: "0 3 * * *", Prompt: "p", Enabled: true, OnComplete: "keep"},
+		},
+		{
+			name: "archive on a cron task is the headline case",
+			task: Task{ID: "t3", CronExpr: "0 3 * * *", Prompt: "p", Enabled: true, OnComplete: "archive"},
+		},
+		{
+			name: "kill on a cron task is valid",
+			task: Task{ID: "t4", CronExpr: "0 3 * * *", Prompt: "p", Enabled: true, OnComplete: "kill"},
+		},
+		{
+			name: "a watch task that spawns per event may declare one",
+			task: Task{ID: "t5", WatchCmd: "tail -f log", Enabled: true, OnComplete: "kill"},
+		},
+		{
+			// The session a target task names is the thing it exists to REUSE;
+			// reaping it after each run destroys exactly that.
+			name:    "archive with a target session is refused",
+			task:    Task{ID: "t6", WatchCmd: "tail -f log", TargetSession: "shared", Enabled: true, OnComplete: "archive"},
+			wantErr: "target_session",
+		},
+		{
+			name:    "kill with a target session is refused",
+			task:    Task{ID: "t7", CronExpr: "0 3 * * *", Prompt: "p", TargetSession: "shared", Enabled: true, OnComplete: "kill"},
+			wantErr: "target_session",
+		},
+		{
+			// keep IS the target task's behavior, so it must not be refused —
+			// otherwise reverting a task to the default would fail.
+			name: "keep with a target session is fine",
+			task: Task{ID: "t8", CronExpr: "0 3 * * *", Prompt: "p", TargetSession: "shared", Enabled: true, OnComplete: "keep"},
+		},
+		{
+			name:    "an unknown verb is refused and named back",
+			task:    Task{ID: "t9", CronExpr: "0 3 * * *", Prompt: "p", Enabled: true, OnComplete: "delete"},
+			wantErr: `unknown on_complete "delete"`,
+		},
+		{
+			name: "a disabled draft may still carry a verb",
+			task: Task{ID: "t10", CronExpr: "0 3 * * *", OnComplete: "archive"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.task.ValidateTrigger()
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// TestOnCompleteUnknownVerbNamesTheAcceptedOnes: a rejection that does not say
+// what IS accepted makes the user guess, and there are exactly three answers.
+func TestOnCompleteUnknownVerbNamesTheAcceptedOnes(t *testing.T) {
+	err := Task{ID: "t", CronExpr: "0 3 * * *", Prompt: "p", Enabled: true, OnComplete: "purge"}.ValidateTrigger()
+	require.Error(t, err)
+	for _, verb := range OnCompleteValues() {
+		assert.Contains(t, err.Error(), verb, "the refusal must offer %q", verb)
+	}
+}
+
+// TestSessionLifecycleReadsThroughTheDefault: callers ask the task, not the raw
+// field, so a legacy row and an explicit keep are indistinguishable to them.
+func TestSessionLifecycleReadsThroughTheDefault(t *testing.T) {
+	assert.Equal(t, OnCompleteKeep, Task{}.SessionLifecycle())
+	assert.Equal(t, OnCompleteKeep, Task{OnComplete: "  "}.SessionLifecycle())
+	assert.Equal(t, OnCompleteArchive, Task{OnComplete: "Archive"}.SessionLifecycle())
+}
+
+// TestAddTaskStoresKeepAsAbsent is the compatibility guarantee that makes this
+// field safe to ship: a task that does not opt in must serialize EXACTLY as it
+// did before the field existed, so an older af reading the same tasks.json sees
+// no new key and a diff of the store shows nothing.
+func TestAddTaskStoresKeepAsAbsent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", dir)
+
+	for i, in := range []string{"", "keep", "  KEEP  "} {
+		t.Run("stored as absent: "+strconv.Quote(in), func(t *testing.T) {
+			created, err := AddTaskChecked(Task{
+				ID:          fmt.Sprintf("id%d", i),
+				CronExpr:    "0 3 * * *",
+				Prompt:      "p",
+				ProjectPath: dir,
+				Program:     "claude",
+				Enabled:     false,
+				OnComplete:  in,
+			}, nil)
+			require.NoError(t, err)
+			assert.Empty(t, created.OnComplete, "keep must be stored as the zero value")
+
+			raw, err := os.ReadFile(filepath.Join(dir, "tasks.json"))
+			require.NoError(t, err)
+			assert.NotContains(t, string(raw), "on_complete",
+				"a task that did not opt in must not gain a new key on disk")
+		})
+	}
+}
+
+// TestAddTaskStoresAnExplicitVerbCanonically: an opted-in task DOES carry the
+// key, lowercased and trimmed, so the daemon never has to normalize at read time.
+func TestAddTaskStoresAnExplicitVerbCanonically(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", dir)
+
+	created, err := AddTaskChecked(Task{
+		ID:          "abc",
+		CronExpr:    "0 3 * * *",
+		Prompt:      "p",
+		ProjectPath: dir,
+		Program:     "claude",
+		Enabled:     false,
+		OnComplete:  "  Archive ",
+	}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, OnCompleteArchive, created.OnComplete)
+
+	stored, err := LoadTasks()
+	require.NoError(t, err)
+	require.Len(t, stored, 1)
+	assert.Equal(t, OnCompleteArchive, stored[0].OnComplete,
+		"the canonical verb must be what a reader gets back")
+}
+
+// TestUpdateTaskPatchesOnComplete covers the round trip that matters for a
+// pointer patch field: setting a verb, and reverting to the default. "keep" is a
+// real value to patch back to, which is why TaskUpdate.OnComplete is a *string —
+// a plain string could not tell "revert" from "leave alone".
+func TestUpdateTaskPatchesOnComplete(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", dir)
+
+	err := AddTask(Task{
+		ID: "abc", CronExpr: "0 3 * * *", Prompt: "p",
+		ProjectPath: dir, Program: "claude", Enabled: false,
+	})
+	require.NoError(t, err)
+
+	set := OnCompleteKill
+	updated, err := UpdateTask("abc", TaskUpdate{OnComplete: &set}, ProjectExpectation{})
+	require.NoError(t, err)
+	assert.Equal(t, OnCompleteKill, updated.OnComplete)
+
+	// An unrelated patch must not disturb it.
+	name := "renamed"
+	updated, err = UpdateTask("abc", TaskUpdate{Name: &name}, ProjectExpectation{})
+	require.NoError(t, err)
+	assert.Equal(t, OnCompleteKill, updated.OnComplete, "an unrelated patch must not clear the verb")
+
+	revert := OnCompleteKeep
+	updated, err = UpdateTask("abc", TaskUpdate{OnComplete: &revert}, ProjectExpectation{})
+	require.NoError(t, err)
+	assert.Empty(t, updated.OnComplete, "reverting to keep must return the row to its default shape")
+}
+
+// TestUpdateTaskRejectsAnUnknownVerb: the patch path runs the same validation as
+// the create path, so a bad value cannot be introduced by an update either.
+func TestUpdateTaskRejectsAnUnknownVerb(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", dir)
+
+	err := AddTask(Task{
+		ID: "abc", CronExpr: "0 3 * * *", Prompt: "p",
+		ProjectPath: dir, Program: "claude", Enabled: true,
+	})
+	require.NoError(t, err)
+
+	bad := "shred"
+	_, err = UpdateTask("abc", TaskUpdate{OnComplete: &bad}, ProjectExpectation{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown on_complete")
+}
+
+// TestTaskUpdateIsEmptyCountsOnComplete: a patch carrying ONLY this field must
+// not be mistaken for a no-op, or `af tasks update --on-complete kill` would
+// validate and write nothing.
+func TestTaskUpdateIsEmptyCountsOnComplete(t *testing.T) {
+	assert.True(t, TaskUpdate{}.IsEmpty())
+	verb := OnCompleteArchive
+	assert.False(t, TaskUpdate{OnComplete: &verb}.IsEmpty())
+}
+
+// TestTaskUpdateOnCompleteSurvivesGob is the #1700 trap: the control socket
+// gob-encodes the patch, and gob elides a pointer to a zero value — so a
+// *string pointing at "" would decode back as nil and silently drop the patch.
+// TaskUpdate round-trips through JSON to keep the nil-vs-set distinction, and
+// "keep" canonicalizes from "" so this is exactly the reverting patch.
+func TestTaskUpdateOnCompleteSurvivesGob(t *testing.T) {
+	empty := ""
+	encoded, err := TaskUpdate{OnComplete: &empty}.GobEncode()
+	require.NoError(t, err)
+
+	var decoded TaskUpdate
+	require.NoError(t, decoded.GobDecode(encoded))
+	require.NotNil(t, decoded.OnComplete, "a patch reverting to the default must survive the control socket")
+	assert.Equal(t, "", *decoded.OnComplete)
+}

--- a/task/task.go
+++ b/task/task.go
@@ -71,8 +71,28 @@ type Task struct {
 	// ValidateTrigger): a target_session task delivers into one session, so its
 	// deliveries already serialize, and overlapping cron fires already coalesce on
 	// RunTask's per-task lock. omitempty + additive: no tasks schema bump.
-	MaxConcurrentRuns int    `json:"max_concurrent_runs,omitempty"`
-	ProjectPath       string `json:"project_path"`
+	MaxConcurrentRuns int `json:"max_concurrent_runs,omitempty"`
+	// OnComplete is what happens to a session this task SPAWNED once its run
+	// finishes (#2595). Empty — the default — means OnCompleteKeep, so every task
+	// written before this field existed behaves exactly as it always has.
+	//
+	// The problem it solves is that a per-run session had no lifecycle at all: a
+	// daily cron task produced one session per fire, each finished its work, went
+	// idle, and then held a tmux session and a git worktree forever. The only
+	// thing standing between a schedule and unbounded growth was prose in the
+	// prompt ("finally, run af sessions archive --self"), which nothing enforces
+	// and which `af tasks list` cannot show. This moves the decision onto the
+	// task, where it is declared once and visible.
+	//
+	// Both non-keep verbs are offered because the choice between them is the
+	// actual decision, not an implementation detail: archive keeps the session
+	// restorable but retains its whole worktree — gitignored build output
+	// included — indefinitely, while kill reclaims that disk and prunes the
+	// session's owned branch. A run whose output already landed in a pushed
+	// branch or a PR usually wants kill; a run that might need inspecting wants
+	// archive. af must not pick for the user, so the default does neither.
+	OnComplete  string `json:"on_complete,omitempty"`
+	ProjectPath string `json:"project_path"`
 	// RepoID is the owning project's repo ID, resolved ONCE at bind time and
 	// retained. It is derived, never patchable — AddTask sets it and UpdateTask
 	// recomputes it when ProjectPath changes.
@@ -196,6 +216,19 @@ func (t Task) ValidateTrigger() error {
 		if CanonicalTargetSession(t.TargetSession) != "" {
 			return fmt.Errorf("task %s sets both max_concurrent_runs and target_session; deliveries into one session already serialize, so drop the cap or drop the target session", t.ID)
 		}
+	}
+	// on_complete governs a session this task SPAWNED, so it is meaningful only
+	// where the task spawns one (#2595). Rejecting it elsewhere follows the cap's
+	// precedent above for the same reason: a setting that reads as enforced but
+	// silently does nothing is the gotcha class this repo designs away.
+	switch onComplete := t.SessionLifecycle(); onComplete {
+	case OnCompleteKeep:
+	case OnCompleteArchive, OnCompleteKill:
+		if CanonicalTargetSession(t.TargetSession) != "" {
+			return fmt.Errorf("task %s sets both on_complete=%s and target_session; a target session is one long-lived session you named for reuse, and %sing it after every run would destroy the thing the target exists to reuse — drop on_complete, or drop the target session to get a session per run", t.ID, onComplete, onComplete)
+		}
+	default:
+		return fmt.Errorf("task %s has an unknown on_complete %q; use one of %s", t.ID, t.OnComplete, strings.Join(OnCompleteValues(), ", "))
 	}
 	return nil
 }
@@ -326,6 +359,7 @@ func AddTaskChecked(t Task, validate func(Task) error) (Task, error) {
 	// stored — a whitespace-only target session must not validate as "no target
 	// session" and then behave as one at delivery time (#1892).
 	t.canonicalizeTargetSession()
+	t.canonicalizeOnComplete()
 	if err := t.ValidateTrigger(); err != nil {
 		return Task{}, err
 	}
@@ -602,10 +636,15 @@ type TaskUpdate struct {
 	// because 0 is a meaningful value ("unlimited"), not "unchanged" — the same
 	// nil-vs-zero distinction Enabled and TargetSession rely on, and the reason
 	// this type needs the JSON gob codec below.
-	MaxConcurrentRuns *int    `json:"max_concurrent_runs,omitempty"`
-	ProjectPath       *string `json:"project_path,omitempty"`
-	Program           *string `json:"program,omitempty"`
-	Enabled           *bool   `json:"enabled,omitempty"`
+	MaxConcurrentRuns *int `json:"max_concurrent_runs,omitempty"`
+	// OnComplete patches the spawned-session lifecycle verb (#2595). A pointer for
+	// the same reason as MaxConcurrentRuns: "keep" is a meaningful value to patch
+	// BACK to, and a plain string could not tell "revert to keep" from "leave it
+	// alone".
+	OnComplete  *string `json:"on_complete,omitempty"`
+	ProjectPath *string `json:"project_path,omitempty"`
+	Program     *string `json:"program,omitempty"`
+	Enabled     *bool   `json:"enabled,omitempty"`
 }
 
 // GobEncode/GobDecode route TaskUpdate through JSON on the net/rpc gob control
@@ -632,6 +671,7 @@ func (u *TaskUpdate) GobDecode(data []byte) error {
 func (u TaskUpdate) IsEmpty() bool {
 	return u.Name == nil && u.Prompt == nil && u.CronExpr == nil &&
 		u.WatchCmd == nil && u.TargetSession == nil && u.MaxConcurrentRuns == nil &&
+		u.OnComplete == nil &&
 		u.ProjectPath == nil && u.Program == nil && u.Enabled == nil
 }
 
@@ -657,6 +697,9 @@ func (u TaskUpdate) apply(t Task) Task {
 	if u.MaxConcurrentRuns != nil {
 		t.MaxConcurrentRuns = *u.MaxConcurrentRuns
 	}
+	if u.OnComplete != nil {
+		t.OnComplete = *u.OnComplete
+	}
 	if u.ProjectPath != nil {
 		t.ProjectPath = *u.ProjectPath
 	}
@@ -677,6 +720,7 @@ func (u TaskUpdate) apply(t Task) Task {
 	// write now canonicalizes what it is about to store, so the record cannot
 	// persist a value the two sides would read differently.
 	t.canonicalizeTargetSession()
+	t.canonicalizeOnComplete()
 	// Drop a cap the merged record can no longer carry, unless this patch set it
 	// explicitly (#1892). A partial patch that only moves the trigger or the
 	// delivery mode — which is every non-CLI writer, since DiffTask sends just the
@@ -784,6 +828,13 @@ func DiffTask(old, cur Task) TaskUpdate {
 	}
 	if cur.MaxConcurrentRuns != old.MaxConcurrentRuns {
 		u.MaxConcurrentRuns = &cur.MaxConcurrentRuns
+	}
+	// Included before any editor offers it (#2595). An unchanged field patches
+	// nothing either way, so this is inert today — but a differ that silently
+	// omits a user-editable field is the #1700 clobber waiting to be reintroduced
+	// the moment a surface starts editing it.
+	if cur.OnComplete != old.OnComplete {
+		u.OnComplete = &cur.OnComplete
 	}
 	if cur.ProjectPath != old.ProjectPath {
 		u.ProjectPath = &cur.ProjectPath

--- a/task/task.go
+++ b/task/task.go
@@ -734,6 +734,15 @@ func (u TaskUpdate) apply(t Task) Task {
 	if u.MaxConcurrentRuns == nil {
 		t.clearInapplicableCap()
 	}
+	// Same rule, same reason, for the spawned-session lifecycle (#2595): adding a
+	// target_session to a per-run task that declares on_complete would otherwise
+	// merge into a record ValidateTrigger rejects, so ordinary retargeting would
+	// fail from every surface that does not expose the field — and force a CLI user
+	// to know to pass --on-complete keep alongside. An explicitly-patched verb is
+	// left alone so a contradictory request still surfaces as an error.
+	if u.OnComplete == nil {
+		t.clearInapplicableOnComplete()
+	}
 	return t
 }
 
@@ -755,6 +764,22 @@ func (t Task) capApplies() bool {
 func (t *Task) clearInapplicableCap() {
 	if t.MaxConcurrentRuns > 0 && !t.capApplies() {
 		t.MaxConcurrentRuns = 0
+	}
+}
+
+// onCompleteApplies reports whether this task's shape can carry a spawned-session
+// lifecycle: it governs a session the task CREATED, so it is meaningful only when
+// the task creates one. A target-session task delivers into a session the user
+// named for reuse, which is not the task's to reap.
+func (t Task) onCompleteApplies() bool {
+	return CanonicalTargetSession(t.TargetSession) == ""
+}
+
+// clearInapplicableOnComplete drops a stale lifecycle verb from a task whose
+// shape can no longer carry one.
+func (t *Task) clearInapplicableOnComplete() {
+	if t.SessionLifecycle() != OnCompleteKeep && !t.onCompleteApplies() {
+		t.OnComplete = ""
 	}
 }
 


### PR DESCRIPTION
A cron task with no target session creates **a session per run**, and af had no
policy for what became of it. The run finished, the agent went idle, and the
session then held its tmux session and its git worktree indefinitely — four a day
on the maintainer's box, until **12 of 17 live sessions were finished cron runs**
and the live-session list was mostly leak rather than work.

The only thing standing between a schedule and unbounded growth was prose in the
prompt asking the agent to archive itself. Nothing enforces it, `af tasks list`
cannot show whether a task does it, and a self-archiving session can never report
the result — the daemon SIGTERMs the caller as part of the teardown it asked for.

## The design call

Task-level **`on_complete`: `keep` (default) · `archive` · `kill`**.

```bash
af tasks add --name "Docs drift audit" --prompt "Audit the docs" \
  --cron "17 6 * * *" --on-complete kill
```

**Default `keep` is exactly today's behavior.** The field is `omitempty` *and*
canonicalizes `keep` to `""`, so an existing task's row on disk is byte-identical
after this lands and an older `af` reading the same `tasks.json` sees no new key.
Nothing is silently reaped; opting in is a deliberate act.

**Both non-keep verbs are offered because choosing between them is the actual
decision**, which is the point the issue thread lands on. Archive keeps the
session restorable but retains its *whole* worktree — gitignored build output
included — until someone prunes it by hand, so a daily task set to `archive`
trades a session leak for a disk one (#2573). Kill reclaims that space and prunes
the session's own branch, which is right when the run's output already lives in a
pushed branch or a merged PR. af must not pick for the user, so the default does
neither.

## Why an edge, not a sweep

Enforcement fires on the run's **completion edge** — the same `taskRunActive`
true→false transition the concurrency cap already releases a slot on — rather
than on a standing predicate.

That distinction is the safety property, and it is why `--keep-runs N` and the
idle-TTL shapes floated on the issue are deliberately **not** here. *"A task
session whose run has ended"* stays true forever, including for the session you
adopted after the run and are typing into right now; any sweep over that
predicate eventually reaps live work. `taskRunActive` flips once and permanently,
so this can fire at most once per session and never revisits one.

## Everything unprovable keeps the session

- an unreadable or unscopable task store
- a task **deleted** since the run started — removing a task must not
  retroactively authorize destroying what its runs produced
- a create whose startup outcome was never established (the daemon retains that
  record deliberately so an operator can inspect the workspace it may have left;
  its run marker clears too, which is why the predicate also requires the session
  to have settled **idle and healthy**)
- a session no task spawned
- a teardown that fails — the run already succeeded, so this never marks the run
  failed; the session stays visible and can be finished by hand

Refused with `target_session`, mirroring the `max_concurrent_runs` rule: that
session is one long-lived session you named so runs could share it, and reaping
it after every run destroys the thing the target exists to reuse.

Teardown goes through `ArchiveSession`/`KillSession`, so a task-driven reap is the
*same* operation `af sessions archive` is — same `killsInFlight` + op-lock
serialization (#2779), same refusals, same events — rather than a second
lifecycle implementation that would drift.

## Surfaces

CLI `--on-complete` on `tasks add`/`update`, and it rides `af tasks list`
automatically (the command emits the full task record). The TUI task form and web
do not expose it yet — recorded in `parity/inventory.json` as `task.on-complete`,
the same shape as the existing `task.max-concurrent-runs` gap, since whether the
UIs should surface it is an owner call. `DiffTask` carries the field already, so a
future TUI field cannot silently drop it (#1700).

## Verification

Per the standing policy: cheap local checks + `go test` on the non-daemon packages
this touches; no containerized suites, and nothing run against `./daemon/...`.

- `gofmt -l .` (empty), `go build ./...`, `golangci-lint --fast`,
  `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean.
  `task/task.go` crossed the 1000-line limit, so the new code is split into
  `task/on_complete.go` rather than grandfathered.
- `go test ./task/ ./api/ ./parity/` — green. The parity gate caught the new
  CLI-only flag on its own and is satisfied by the inventory entry above.
- `daemon/task_session_lifecycle_test.go` covers keep/archive/kill, the
  edge-not-sweep property, the unreadable-store and deleted-task paths, and a
  session no task spawned. Left to CI, which runs the full matrix.

## Review round: four P2s, all real, all fixed

Codex found four defects in the first cut. Each was verified against the code
before acting, and each was genuine:

1. **The deferred teardown was keyed on the title.** It runs later on a
   goroutine, and `ArchiveSession`/`KillSession` fall back to `{Title, RepoID}`
   only when `ID` is empty — so a kill plus a same-titled re-create in that gap
   would retarget the reap onto the **replacement** session. This is the same
   unstable-identity class as #2779. Both requests now carry `instance.ID`,
   captured at the completion edge.

2. **A run that finished while a TUI was attached lost its policy permanently.**
   `observeTaskRunWhilePaused` settles the agent idle on its backstop tick, which
   spends the completion edge on the one path that cannot act on it — the attach
   owns that session's tmux, which is what the pause exists to protect. The edge
   was simply gone, so `archive`/`kill` was skipped forever and the session
   leaked *despite* a declared lifecycle: the exact failure this issue is about,
   through the one door the first cut did not cover. The intent is now parked and
   drained on the first unpaused tick, re-checking that it is still the same
   session and still idle — a user who picked the work back up during the attach
   has adopted it, and that rule has to survive the deferral.

3. **Adding a `target_session` to a task that declared `on_complete` failed
   validation.** The merged record tripped the new conflict rule, so ordinary
   retargeting broke from every surface that does not expose the field, and a CLI
   user would have had to know to pass `--on-complete keep` alongside. Now
   dropped by the shared merge exactly as an inapplicable `max_concurrent_runs`
   already is — with an explicitly-patched verb still erroring, so a
   contradictory request is never silently ignored.

4. **The teardown could run while `post_worktree_commands` were still going.**
   Hook execution and agent readiness are deliberately concurrent
   (`task.WaitForReady` does not charge a slow build hook against the startup
   budget), so a short task can finish while its own provisioning is mid-flight —
   and archive MOVES that worktree while kill REMOVES it. Now waits on
   `PostWorktreeHooksDone()`, bounded at 10 minutes so a hung hook leaks a session
   rather than a goroutine.

Each has a regression test.

## CI also caught two of my test assumptions

Worth recording, since one of them was load-bearing. `TestRunEndedIntoIdle`
failed because I claimed the predicate's `LiveReady` condition excluded a create
whose startup settled terminal-unknown. It does not:
`MarkStartupStateUnknown` clears `taskRunActive` **directly**, not through a
transition, and leaves liveness untouched. The behavior was still correct — the
poll's `!instance.Started()` early return keeps such a session away — but the
protection rested on a distant, unrelated line while the comment claimed the
predicate did it. Now checked explicitly.

Closes #2595

🤖 Generated with [Claude Code](https://claude.com/claude-code)