### PR TITLE
fix(daemon): retire only a cause that is actually permanent, and pace every path

### DIFF
--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -55,6 +55,10 @@ func (m *Manager) KillSession(req KillSessionRequest) (session.InstanceData, err
 	defer func() {
 		m.mu.Lock()
 		delete(m.killsInFlight, key)
+		// An explicit kill supersedes any finishUserKill schedule for this session,
+		// including a retired one — that is the "kill it again to retry" the
+		// retirement log points the operator at (#2737).
+		delete(m.killRetries, key)
 		m.mu.Unlock()
 	}()
 

--- a/daemon/rootkill.go
+++ b/daemon/rootkill.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"fmt"
 	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
@@ -101,6 +102,16 @@ func (m *Manager) persistKillTombstone(repoID string, instance *session.Instance
 	return nil
 }
 
+// forgetKillRetry drops a session's retry state. The schedule describes ONE
+// tombstone, so it must not outlive it: the key is repo+title, and a later
+// session reusing that title — a recreated root agent especially — would
+// otherwise inherit a retired entry and never be finished at all.
+func (m *Manager) forgetKillRetry(key string) {
+	m.mu.Lock()
+	delete(m.killRetries, key)
+	m.mu.Unlock()
+}
+
 // noteKillRetryFailure books a failed tombstone cleanup against its retry
 // schedule and reports it at the right volume.
 //
@@ -193,7 +204,11 @@ func (m *Manager) finishUserKill(repoID string, instance *session.Instance) {
 	// passed the check just before the tombstone became visible. Both happen before
 	// record deletion so an unknown outcome keeps the stable-id retry handle.
 	if err := m.stopVSCodeForInstance(key, instance.ID); err != nil {
-		log.WarningLog.Printf("finishing kill of %q: VS Code editor teardown remains unknown; retaining the record for the next poll: %v", instance.Title, err)
+		// Paced like the record-delete failure below: a persistent editor cleanup
+		// failure is the same once-per-poll hot loop this scheduler exists to bound
+		// (#2737), just reached by a different return.
+		m.noteKillRetryFailure(key, instance.Title,
+			fmt.Errorf("VS Code editor teardown remains unknown: %w", err))
 		return
 	}
 
@@ -207,7 +222,8 @@ func (m *Manager) finishUserKill(repoID string, instance *session.Instance) {
 	// bounded teardown does not need a daemon restart to converge (#1917).
 	teardownErr := instance.Kill()
 	if err := m.stopVSCodeForInstance(key, instance.ID); err != nil {
-		log.WarningLog.Printf("finishing kill of %q: could not confirm the VS Code editor stopped; retaining the record for the next poll: %v", instance.Title, err)
+		m.noteKillRetryFailure(key, instance.Title,
+			fmt.Errorf("could not confirm the VS Code editor stopped: %w", err))
 		return
 	}
 	// Through the one choke point (#1917): it refuses while the teardown's outcome
@@ -222,9 +238,7 @@ func (m *Manager) finishUserKill(repoID string, instance *session.Instance) {
 		log.InfoLog.Printf("finishing kill of %q skipped storage delete: current record has a different instance identity", instance.Title)
 		return
 	}
-	m.mu.Lock()
-	delete(m.killRetries, key)
-	m.mu.Unlock()
+	m.forgetKillRetry(key)
 	removed := false
 	m.mu.Lock()
 	if m.instances[key] == instance {

--- a/session/backend_ssh_legacy_tombstone_test.go
+++ b/session/backend_ssh_legacy_tombstone_test.go
@@ -7,31 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
-
-// #2737: a pre-#2704 SSH tombstone recorded no host-key posture, so it restores
-// as strict. When the host was only ever learned in the af-owned accept-new
-// store, the reconnect can never verify it — and the daemon retried that once a
-// second forever. The failure must say it cannot be fixed by retrying so the
-// record is retired instead.
-func TestSSHReapMarksLegacyTombstoneUnusable(t *testing.T) {
-	p := &sshProvisioner{
-		spec:       ProvisionSpec{Title: "legacy-tombstone"},
-		cfg:        configSSHForReapTest(),
-		sessionDir: "/home/remote/.af-sessions/legacy.1234",
-		// hostKeyVerification is EMPTY: the field #2704 added, absent here.
-	}
-	p.reapDial = func() error { return errors.New("ssh: handshake failed: knownhosts: key is unknown") }
-
-	err := p.reap()
-	require.Error(t, err)
-	assert.True(t, CleanupHandleUnusable(err),
-		"a legacy tombstone that cannot verify its host can never be completed by retrying")
-	assert.True(t, TeardownStateUnknown(err),
-		"but the workspace state is still unknown, so the record must still be RETAINED")
-	assert.Contains(t, err.Error(), "known_hosts", "the error must tell the operator what would fix it")
-	assert.Contains(t, err.Error(), "#2704")
-}
 
 // A tombstone that DID record its posture is an ordinary retryable failure: the
 // host may simply be down, and an outage that ends must heal on the next attempt.
@@ -62,4 +39,69 @@ func TestUnusableHandleStillRetainsTheRecord(t *testing.T) {
 	assert.True(t, CleanupHandleUnusable(err))
 	assert.True(t, TeardownStateUnknown(err),
 		"deleteSessionRecord must still refuse, so nothing is silently orphaned")
+}
+
+// Review finding on #2855: a legacy tombstone whose reconnect fails for a
+// TRANSIENT reason must not be retired. Retiring on any dial error turns a host
+// outage into a permanent stop, which is the failure #1122 is about — only the
+// unknown-host-key signal proves the missing posture is what blocks the cleanup.
+func TestSSHReapKeepsRetryingLegacyTombstoneOnTransientDialFailure(t *testing.T) {
+	transient := []struct {
+		name string
+		err  error
+	}{
+		{"connection refused", errors.New("dial tcp 10.0.0.9:22: connect: connection refused")},
+		{"timeout", errors.New("dial tcp 10.0.0.9:22: i/o timeout")},
+		{"dns failure", errors.New("dial tcp: lookup remote.invalid: no such host")},
+		{"auth failure", errors.New("ssh: unable to authenticate")},
+	}
+	for _, test := range transient {
+		t.Run(test.name, func(t *testing.T) {
+			p := &sshProvisioner{
+				spec:       ProvisionSpec{Title: "legacy-transient"},
+				cfg:        configSSHForReapTest(),
+				sessionDir: "/home/remote/.af-sessions/legacy.1234",
+			}
+			p.reapDial = func() error { return test.err }
+
+			err := p.reap()
+			require.Error(t, err)
+			assert.False(t, CleanupHandleUnusable(err),
+				"a transient reconnect failure may heal, so a legacy record must keep being retried")
+			assert.True(t, TeardownStateUnknown(err))
+		})
+	}
+}
+
+// The permanent case is specifically knownhosts' "host not present" signal.
+func TestSSHReapRetiresLegacyTombstoneOnUnknownHostKey(t *testing.T) {
+	p := &sshProvisioner{
+		spec:       ProvisionSpec{Title: "legacy-unknown-host"},
+		cfg:        configSSHForReapTest(),
+		sessionDir: "/home/remote/.af-sessions/legacy.1234",
+	}
+	p.reapDial = func() error { return &knownhosts.KeyError{} }
+
+	err := p.reap()
+	require.Error(t, err)
+	assert.True(t, CleanupHandleUnusable(err),
+		"an unrecorded posture plus an unverifiable host can never be completed by retrying")
+	assert.True(t, TeardownStateUnknown(err), "and the record is still retained")
+	assert.Contains(t, err.Error(), "known_hosts", "the error must tell the operator what would fix it")
+	assert.Contains(t, err.Error(), "#2704")
+}
+
+// A key MISMATCH is not the same claim: the host is present and its key changed,
+// which is a security event to surface, not a missing-field record to retire.
+func TestSSHReapDoesNotRetireLegacyTombstoneOnKeyMismatch(t *testing.T) {
+	p := &sshProvisioner{
+		spec:       ProvisionSpec{Title: "legacy-mismatch"},
+		cfg:        configSSHForReapTest(),
+		sessionDir: "/home/remote/.af-sessions/legacy.1234",
+	}
+	p.reapDial = func() error { return &knownhosts.KeyError{Want: []knownhosts.KnownKey{{}}} }
+
+	err := p.reap()
+	require.Error(t, err)
+	assert.False(t, CleanupHandleUnusable(err), "a changed host key is not a missing-posture record")
 }

--- a/session/backend_ssh_reap.go
+++ b/session/backend_ssh_reap.go
@@ -65,14 +65,18 @@ func (p *sshProvisioner) reap() error {
 		if err := p.dialForReap(); err != nil {
 			reapErr := fmt.Errorf("%w: backend=ssh: reconnecting to %s to remove remote session dir %q failed: %w",
 				ErrWorkspaceStateUnknown, p.cfg.Host, p.sessionDir, err)
-			if p.hostKeyVerification == "" {
+			if p.hostKeyVerification == "" && isUnknownHostKeyError(err) {
 				// A pre-#2704 tombstone recorded no host-key posture, so it restored
-				// as strict. If the host was only ever learned in the af-owned
-				// accept-new store, this reconnect cannot verify it and no later
-				// attempt will differ — the missing field is not coming back. Mark it
+				// as strict, and this host is not in the strict store — the missing
+				// field is not coming back, so no later attempt differs. Mark it
 				// unusable so the daemon retires the record instead of retrying it
 				// once per poll forever (#2737). The workspace state is still unknown,
 				// so the record is retained either way; only the retrying stops.
+				//
+				// ONLY on the unknown-host-key signal. A timeout or a refused
+				// connection on the same legacy record says nothing about the posture
+				// and may heal on its own, and retiring those would turn a host
+				// outage into a permanent stop — the failure #1122 is about.
 				reapErr = fmt.Errorf("%w: %w (this tombstone predates #2704 and recorded no host-key posture, "+
 					"so it is verified strictly; add %s to your known_hosts to let the cleanup finish)",
 					ErrCleanupHandleUnusable, reapErr, p.cfg.Host)

--- a/session/cleanup_retry.go
+++ b/session/cleanup_retry.go
@@ -45,6 +45,7 @@ type CleanupRetry struct {
 	nextAttempt         time.Time
 	escalated           bool
 	retired             bool
+	retirementReported  bool
 }
 
 // Due reports whether another attempt is allowed now. A retired entry never is.
@@ -73,9 +74,13 @@ func (r *CleanupRetry) RecordFailure(now time.Time, err error) bool {
 		// Nothing about a later attempt differs, so there is no cadence to settle
 		// into — this one is done.
 		r.retired = true
-		if r.escalated {
+		// Report the RETIREMENT even if a backoff escalation already fired: those
+		// say opposite things. "retrying every 5m" told the operator af was still
+		// working on it; this says it has stopped and needs them.
+		if r.retirementReported {
 			return false
 		}
+		r.retirementReported = true
 		r.escalated = true
 		return true
 	}

--- a/session/cleanup_retry_test.go
+++ b/session/cleanup_retry_test.go
@@ -100,3 +100,27 @@ func TestCleanupHandleUnusableIsNarrow(t *testing.T) {
 		"an unknown workspace state is retried, not retired")
 	assert.True(t, CleanupHandleUnusable(fmt.Errorf("%w: no posture recorded", ErrCleanupHandleUnusable)))
 }
+
+// Review finding on #2855: a cleanup that backs off, escalates, and only THEN
+// turns out to be unusable must still report the retirement. "retrying every 5m"
+// and "af has stopped" say opposite things, and the operator acted on the first.
+func TestCleanupRetryReportsRetirementAfterAnEscalation(t *testing.T) {
+	var retry CleanupRetry
+	now := time.Unix(1_800_000_000, 0)
+
+	escalations := 0
+	for i := 0; i < cleanupRetryEscalationThreshold; i++ {
+		if retry.RecordFailure(now, errors.New("host unreachable")) {
+			escalations++
+		}
+		now = now.Add(cleanupRetryBackoffMax)
+	}
+	require.Equal(t, 1, escalations, "the backoff escalation fires once")
+	require.False(t, retry.Retired())
+
+	unusable := fmt.Errorf("%w: posture never recorded", ErrCleanupHandleUnusable)
+	assert.True(t, retry.RecordFailure(now, unusable),
+		"discovering the cause is permanent must be reported even after a backoff escalation")
+	assert.True(t, retry.Retired())
+	assert.False(t, retry.RecordFailure(now, unusable), "but only once")
+}


### PR DESCRIPTION
## What

#2855 merged at 06:12:30, two minutes after its review landed at 06:10:12 and before the fixes could be pushed. **Four review findings are therefore live on `master`**, one of which inverts that PR's own premise. This lands the fixes that were already written and gate-verified against it.

## The serious one

`backend_ssh_reap.go` on master wraps **every** failed reconnect on a legacy tombstone as `ErrCleanupHandleUnusable`:

```go
if p.hostKeyVerification == "" {          // master today
```

So a refused connection or a timeout retires the record after **one** poll. #2855's own body argues at length — citing #1122 — that a cause which might heal must never be given up on, and then does exactly that: a host outage becomes a permanent stop, and the remote sandbox is never cleaned up until an operator restarts the daemon or re-kills the session.

The guard the code already had is the fix:

```go
if p.hostKeyVerification == "" && isUnknownHostKeyError(err) {
```

Only knownhosts' "host not present" signal proves the *missing posture* is what blocks the cleanup. A timeout says nothing about posture. A key **mismatch** does not retire either — `Want` is non-empty there, the host is present and its key changed, which is a security event to surface rather than a missing-field record to abandon.

## The other three

- **Retirement after a backoff escalation went unreported**, because the escalation flag was already set. "Retrying every 5m" and "af has stopped, act on this" say opposite things, and the operator had acted on the first. Retirement is tracked separately and always earns one report.
- **The retry schedule outlived its session.** Keyed by repo+title and cleared only when `finishUserKill` deleted the row, a retired entry could be inherited by a later session reusing that title — a recreated root agent especially — which would then never be finished at all: a worse stuck state than the hot loop #2737 set out to fix. `KillSession` clears it too, which also makes the retirement log's "kill the session again to retry" true; it was not.
- **Two early returns bypassed the scheduler.** A persistent VS Code teardown failure kept the exact once-per-poll loop #2737 exists to bound, reached by a different return. A retry budget covering one of three exits is not a budget.

## Tests

In `session/`, the non-daemon package changed:

- `TestSSHReapKeepsRetryingLegacyTombstoneOnTransientDialFailure` — refused / timeout / DNS / auth all keep retrying;
- `TestSSHReapRetiresLegacyTombstoneOnUnknownHostKey` — the one case that retires;
- `TestSSHReapDoesNotRetireLegacyTombstoneOnKeyMismatch`;
- `TestCleanupRetryReportsRetirementAfterAnEscalation`.

## Validation

- `gofmt -l .` (no output) · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `deadcode -test ./...` (no output) · `scripts/lint-file-length.sh`
- `go test ./session/`

No containerized suite; `./daemon/...` not tested on this host, per policy.

Refs #2737, #2855
