### PR TITLE
fix(git): preserve source modes on the cross-device worktree copy

### DIFF
--- a/session/git/worktree_archive_test.go
+++ b/session/git/worktree_archive_test.go
@@ -1290,3 +1290,42 @@ func TestMoveDirCrossDevice_CrossDeviceModesMatchSameDeviceRename(t *testing.T) 
 	assert.Equal(t, collectTreeDescription(t, renamedDest), collectTreeDescription(t, copiedDest),
 		"the cross-device copy must land the same permissions the same-device rename does")
 }
+
+// TestMoveWorktree_ArchiveRestoreRoundTripPreservesModes drives #2869 through
+// the public primitives rather than the copier underneath them, because the
+// promise that broke is a user-facing one: archive a session, restore it, and
+// get your files back as they were. Both legs take the cross-device fallback,
+// which is what a real user gets whenever $AF_HOME and the repo sit on
+// different filesystems.
+//
+// PRE-FIX both legs tightened the tree by the umask instead of preserving it,
+// and restore never recovered what archive had dropped: an executable 0755 hook
+// reached the archive as 0700 and came back 0700.
+func TestMoveWorktree_ArchiveRestoreRoundTripPreservesModes(t *testing.T) {
+	withUmask(t, 0077)
+	previousFast := worktreeMoveFast
+	worktreeMoveFast = func(*GitWorktree, string, string) error {
+		return errors.New("forced fast-path failure (simulating EXDEV)")
+	}
+	t.Cleanup(func() { worktreeMoveFast = previousFast })
+	previousRename := renamePath
+	renamePath = func(_, _ string) error { return syscall.EXDEV }
+	t.Cleanup(func() { renamePath = previousRename })
+
+	gw, _, srcPath := archiveTestWorktree(t)
+	hook := filepath.Join(srcPath, "hook.sh")
+	require.NoError(t, os.WriteFile(hook, []byte("#!/bin/sh\ntrue\n"), 0600))
+	require.NoError(t, os.Chmod(hook, 0755))
+	require.NoError(t, os.Chmod(filepath.Join(srcPath, "dirty.txt"), 0664))
+	beforeArchive := collectTreeDescription(t, srcPath)
+
+	archived := filepath.Join(testguard.CanonicalTempDir(t), "archived", "repoid", "arch")
+	require.NoError(t, gw.MoveWorktree(archived))
+	assert.Equal(t, beforeArchive, collectTreeDescription(t, archived),
+		"the archived copy must be mode-identical to the worktree it took")
+
+	restored := filepath.Join(testguard.CanonicalTempDir(t), "restored", "arch")
+	require.NoError(t, gw.RestoreWorktreeTo(restored))
+	assert.Equal(t, beforeArchive, collectTreeDescription(t, restored),
+		"a restored session must come back with the modes it had, executable hooks included")
+}

--- a/session/git/worktree_archive_test.go
+++ b/session/git/worktree_archive_test.go
@@ -1260,3 +1260,33 @@ func TestMoveDirCrossDevice_LongLeafFitsPrivateNames(t *testing.T) {
 	assert.FileExists(t, filepath.Join(dest, "tracked.txt"))
 	assert.NoDirExists(t, src)
 }
+
+// TestMoveDirCrossDevice_CrossDeviceModesMatchSameDeviceRename pins the #2869
+// divergence itself. moveDirCrossDevice has two implementations of one promise:
+// rename(2) when src and dest share a device, and a byte copy when they do not.
+// A rename preserves modes for free, so the copy is the only path that can drift
+// — and it did, because mkdirat/openat subtract the umask. Which filesystem the
+// archive root happens to live on must not decide the permissions a session's
+// files come back with, so the two paths are asserted against each other rather
+// than against a hand-written expectation.
+func TestMoveDirCrossDevice_CrossDeviceModesMatchSameDeviceRename(t *testing.T) {
+	withUmask(t, 0077)
+	workspace := t.TempDir()
+	renamedSource := filepath.Join(workspace, "renamed-src")
+	copiedSource := filepath.Join(workspace, "copied-src")
+	writeModeProbeTree(t, renamedSource)
+	writeModeProbeTree(t, copiedSource)
+
+	renamedDest := filepath.Join(workspace, "renamed-dest")
+	require.NoError(t, moveDirCrossDevice(renamedSource, renamedDest),
+		"same-device move must take the rename fast path")
+
+	originalRename := renamePath
+	renamePath = func(_, _ string) error { return syscall.EXDEV }
+	t.Cleanup(func() { renamePath = originalRename })
+	copiedDest := filepath.Join(workspace, "copied-dest")
+	require.NoError(t, moveDirCrossDevice(copiedSource, copiedDest))
+
+	assert.Equal(t, collectTreeDescription(t, renamedDest), collectTreeDescription(t, copiedDest),
+		"the cross-device copy must land the same permissions the same-device rename does")
+}

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -17,11 +17,13 @@ import (
 
 // copyTree recursively copies the directory rooted at src to dest, preserving
 // regular files (contents + permission bits), subdirectories, and symlinks
-// (copied as links, never followed). Traversal stays anchored to open directory
-// descriptors: a worktree process can replace any pathname after it is
-// inspected, so every source open is nonblocking and no-follow, and every
-// destination node is created exclusively. This is only reached on the
-// cross-device fallback.
+// (copied as links, never followed). Permission bits are restored explicitly
+// after each node is created rather than left to the mode passed at creation,
+// because that mode is subtracted by the process umask — see preserveSourceMode.
+// Traversal stays anchored to open directory descriptors: a worktree process can
+// replace any pathname after it is inspected, so every source open is
+// nonblocking and no-follow, and every destination node is created exclusively.
+// This is only reached on the cross-device fallback.
 func copyTree(src, dest string) error {
 	copied, err := copyTreeWithIdentities(src, dest)
 	if copied != nil {
@@ -198,6 +200,12 @@ func copyTreeWithIdentities(src, dest string) (*copiedTreeIdentities, error) {
 		return nil, errors.Join(err, cleanupErr)
 	}
 	destinationIdentity, err := identityFromFile(destination)
+	if err == nil {
+		// The whole copy is anchored to this descriptor, so it is also where the
+		// root's mode belongs. Every child mode is restored the same way, at the
+		// point its own descriptor is confirmed.
+		err = preserveSourceMode(int(destination.Fd()), sourceInfo.Mode(), dest, "directory")
+	}
 	if err != nil {
 		cleanupErr := removeCreatedDirectory(destParent, destParentPath, destName, createdIdentity)
 		_ = destination.Close()
@@ -369,6 +377,11 @@ func copyDirectoryEntry(
 	if !destinationIdentity.same(openedIdentity) {
 		return created, fmt.Errorf("cannot move worktree across filesystems: destination directory %s changed after it was created", destinationPath)
 	}
+	// Only now: the descriptor has just been confirmed to be the node this
+	// process created, which is what makes chmodding it safe.
+	if err := preserveSourceMode(int(destinationChild.Fd()), sourceInfo.Mode(), destinationPath, "directory"); err != nil {
+		return created, err
+	}
 	return created, nil
 }
 
@@ -407,6 +420,36 @@ func copySymlinkEntry(
 		return created, fmt.Errorf("cannot move worktree across filesystems: destination symlink %s changed while it was copied", destinationPath)
 	}
 	return created, nil
+}
+
+// preserveSourceMode restores a source node's permission bits on the descriptor
+// that owns its copy.
+//
+// mkdirat(2) and openat(2) subtract the process umask from the mode they are
+// handed, so creating a node "with the source's mode" is not the same as giving
+// it the source's mode: under the common umask 0022 a 0777 directory lands 0755,
+// and under 0077 an executable 0755 hook lands 0700. The same-device half of
+// this move is a rename(2), which preserves modes exactly — so every bit the
+// umask removes here is one move behaving two different ways depending on which
+// filesystem the archive root happens to sit on, and an archive that no longer
+// restores what it took (#2869).
+//
+// It chmods a descriptor rather than a name because this copier's entire premise
+// is that a worktree process can replace any pathname mid-copy: fchmodat() would
+// apply the source's mode to whatever node holds the name by the time it runs.
+// Callers pass a descriptor only after confirming it is the node they created.
+//
+// Setuid, setgid and sticky bits sit outside Perm() and are not carried over,
+// which is the behavior this copier has always had. Symlinks are skipped
+// entirely: Linux ignores their mode bits and offers no fchmod for them.
+func preserveSourceMode(destinationFD int, sourceMode os.FileMode, destinationPath, kind string) error {
+	if err := unix.Fchmod(destinationFD, uint32(sourceMode.Perm())); err != nil {
+		return fmt.Errorf(
+			"cannot move worktree across filesystems: failed to preserve mode %#o on destination %s %s: %w",
+			sourceMode.Perm(), kind, destinationPath, err,
+		)
+	}
+	return nil
 }
 
 func copiedDirectoryHasChildren(directory *copiedDirectory) bool {
@@ -490,6 +533,14 @@ func copyRegularFileAtWithIdentity(
 		return created, err
 	}
 	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return created, err
+	}
+	// After the contents, not before: openat() created this file no wider than
+	// the source (a umask only clears bits), so widening it back is the last
+	// step, once there is nothing half-written left to expose. The already-open
+	// descriptor keeps its write access regardless of the new mode.
+	if err := preserveSourceMode(outFD, info.Mode(), destinationPath, "file"); err != nil {
 		_ = out.Close()
 		return created, err
 	}

--- a/session/git/worktree_copy_tree_test.go
+++ b/session/git/worktree_copy_tree_test.go
@@ -1,6 +1,8 @@
 package git
 
 import (
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -265,4 +267,109 @@ func assertNamedPipeDestinationFailsPromptly(t *testing.T, fifo string, copyFn f
 			t.Fatalf("HUNG: copy blocked opening destination named pipe %s and did not return after bounded cleanup", fifo)
 		}
 	}
+}
+
+// TestCopyTree_PreservesModesTheUmaskWouldAlter is the #2869 regression. The
+// destination nodes are created with mkdirat(2)/openat(2), and both subtract the
+// process umask from the mode they are handed — so the copier silently tightened
+// exactly the permissions its doc comment promises to preserve, while the
+// same-device rename(2) path kept them verbatim. The existing coverage above
+// missed it because 0755 dirs and 0640 files survive a typical umask 0022
+// untouched; every probe here is a mode a umask does alter.
+func TestCopyTree_PreservesModesTheUmaskWouldAlter(t *testing.T) {
+	withUmask(t, 0077)
+	src := filepath.Join(t.TempDir(), "src")
+	want := writeModeProbeTree(t, src)
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	require.NoError(t, copyTree(src, dest))
+
+	assert.Equal(t, want, collectTreeDescription(t, dest),
+		"the cross-device copy must reproduce the source modes, not the umask's opinion of them")
+}
+
+// withUmask sets the process umask for the duration of one test. The umask is
+// process-wide, so this is only confined to the calling test because nothing in
+// this package calls t.Parallel().
+func withUmask(t *testing.T, mask int) {
+	t.Helper()
+	original := syscall.Umask(mask)
+	t.Cleanup(func() { syscall.Umask(original) })
+}
+
+// writeModeProbeTree builds a fixture whose permission bits a umask does alter,
+// and returns the description collectTreeDescription must produce for a faithful
+// copy of it.
+//
+// Every node is chmod'd explicitly after it is created because os.Mkdir and
+// os.WriteFile subtract the umask themselves: without the chmod the fixture
+// would be born already tightened, the copy would match it, and the assertion
+// would pass vacuously — which is how this bug survived its own test.
+func writeModeProbeTree(t *testing.T, root string) map[string]string {
+	t.Helper()
+	directories := map[string]os.FileMode{
+		".":   0750, // a group-shared worktree: umask 0077 drops group access
+		"sub": 0777,
+	}
+	files := map[string]os.FileMode{
+		"run.sh":         0755, // an executable hook: umask 0077 drops group/other +x
+		"shared.txt":     0664,
+		"sub/secret.key": 0600, // control: no umask widens, so this one must not move
+	}
+	require.NoError(t, os.Mkdir(root, 0700))
+	require.NoError(t, os.Mkdir(filepath.Join(root, "sub"), 0700))
+	for relative := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(root, relative), []byte(relative), 0600))
+	}
+	require.NoError(t, os.Symlink("run.sh", filepath.Join(root, "link")))
+
+	want := map[string]string{"link": "symlink -> run.sh"}
+	for relative, mode := range files {
+		require.NoError(t, os.Chmod(filepath.Join(root, relative), mode))
+		want[relative] = fmt.Sprintf("file %04o", mode)
+	}
+	// Directories last: the root drops to 0750 here, and the writes above need
+	// it traversable while they run.
+	for relative, mode := range directories {
+		require.NoError(t, os.Chmod(filepath.Join(root, relative), mode))
+		want[relative] = fmt.Sprintf("dir %04o", mode)
+	}
+	return want
+}
+
+// collectTreeDescription renders a tree as relative path → type and permission
+// bits, so a mismatch reports every node at once instead of the first one.
+// Symlinks are described by their target: their own mode bits are not portable
+// (Linux fixes them at 0777, other kernels apply the umask) and nothing reads
+// them, so asserting on those would pin the platform rather than the copier.
+func collectTreeDescription(t *testing.T, root string) map[string]string {
+	t.Helper()
+	described := map[string]string{}
+	require.NoError(t, filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		switch {
+		case info.Mode()&os.ModeSymlink != 0:
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			described[relative] = "symlink -> " + target
+		case info.IsDir():
+			described[relative] = fmt.Sprintf("dir %04o", info.Mode().Perm())
+		default:
+			described[relative] = fmt.Sprintf("file %04o", info.Mode().Perm())
+		}
+		return nil
+	}))
+	return described
 }


### PR DESCRIPTION
## The bug

An archive is supposed to be restorable and *identical*. Only one of the two move paths behaved that way.

`moveDirCrossDevice` has two implementations of one promise:

- **same device** — `rename(2)`, which carries permission bits verbatim
- **cross device** — a byte copy, which creates every node with `mkdirat(2)` / `openat(2)`

Both of those syscalls **subtract the process umask** from the mode they are handed, so the mode the copier asked for was never the mode it got. Under the common umask `0022` a `0777` directory landed `0755`; under `0077` an executable `0755` hook came back `0700` — no longer executable for anyone but the owner, and a group-shared `0770` worktree came back `0700`.

Which filesystem `$AF_HOME` happens to sit on decided the answer, silently. It applies to **both directions of the round trip**: `MoveWorktree` (archive) and `RestoreWorktreeTo` (restore) share `relocateWorktreeTo`, so an archive→restore cycle across a device boundary tightened modes twice and never restored them. The copier's own doc comment has promised "preserves file contents, modes, and symlinks" since the path was introduced.

## The fix

Restore the source mode explicitly after each node is created, at all three creation sites (staging root, subdirectories, regular files).

Two deliberate choices:

- **chmod a descriptor, not a name.** This copier's entire premise is that a worktree process can replace any pathname mid-copy — the file is built around descriptor-anchored traversal with identity validation at every step. The `fchmodat()`-by-name form suggested in the issue would apply the source's mode to whatever node holds the name by the time it runs. `preserveSourceMode` takes an fd, and callers only pass one after confirming it is the node this process created (for subdirectories, immediately after the existing `destinationIdentity.same(openedIdentity)` check).
- **files are chmodded after their contents, not before.** A umask only ever *clears* bits, so `openat()` created the file no wider than the source; widening it back is therefore the last step, once there is nothing half-written left to expose. The already-open descriptor keeps its write access regardless of the new mode.

Symlinks are untouched — Linux ignores their mode bits and offers no `fchmod` for them. Setuid/setgid/sticky sit outside `Perm()` and are still not carried over, unchanged from before.

## Tests

Both tests **fail on master and pass with the fix**. Measured on master before the change:

```
expected: {".":"dir 0750", "run.sh":"file 0755", "shared.txt":"file 0664", "sub":"dir 0777", "sub/secret.key":"file 0600"}
actual  : {".":"dir 0700", "run.sh":"file 0700", "shared.txt":"file 0600", "sub":"dir 0700", "sub/secret.key":"file 0600"}
```

- `TestCopyTree_PreservesModesTheUmaskWouldAlter` — the copier against a fixture of modes a umask does alter.
- `TestMoveDirCrossDevice_CrossDeviceModesMatchSameDeviceRename` — runs the *same* fixture through both halves of `moveDirCrossDevice` and asserts they agree. The divergence is the bug, so this pins the two paths against each other rather than against a hand-written expectation.

Two things the fixture does on purpose, because the pre-existing test passed throughout this bug's life and it is worth not repeating that:

- Every node is `chmod`'d **explicitly after creation**, because `os.Mkdir`/`os.WriteFile` subtract the umask too. Without that the fixture would be born already tightened, the copy would match it, and the assertion would pass vacuously.
- `sub/secret.key` at `0600` is a **control**: no umask widens, so a fix that blanket-rewrote modes would move it. It must not move.

- `TestMoveWorktree_ArchiveRestoreRoundTripPreservesModes` — drives the **public primitives** (`MoveWorktree` then `RestoreWorktreeTo`), both legs on the cross-device fallback, and asserts the whole tree is mode-identical at all three points. This is the promise a user actually relies on rather than the mechanism under it. Pre-fix it reported the archived hook at `0700` and restore never recovered it:

```
archived hook.sh = file 0700
expected: {".":"dir 0700", ".git":"file 0600", "dirty.txt":"file 0664", "hook.sh":"file 0755"}
actual  : {".":"dir 0700", ".git":"file 0600", "dirty.txt":"file 0600", "hook.sh":"file 0700"}
```

The existing `TestCopyTree_PreservesModesAndSymlinks` gave false confidence because `0755` dirs and `0640` files survive umask `0022` untouched.

## Verification

`gofmt -l .` clean · `go build ./...` · `golangci-lint run --fast` · `deadcode -test ./...` · `scripts/lint-file-length.sh` · `go test ./session/git/` (full package, green — 21s).

## Not in scope

While probing this I confirmed a **separate, pre-existing** bug: a source subdirectory without owner-write (e.g. `0555`) makes the cross-device copy fail outright — `failed to create destination file …: permission denied` — because the directory is created at its final mode and then populated. It reproduces identically on master and on this branch (this change neither causes nor worsens it; a umask can only clear bits, so restoring the source mode can only ever widen what was created). Fixing it means deferring mode application until each subtree is complete, which is a restructure of the copier's mode handling, so it gets its own issue rather than riding along here.

Closes #2869
