### PR TITLE
fix(daemon): key per-session retry state by stable id, not by title

### DIFF
--- a/daemon/handoff_recovery.go
+++ b/daemon/handoff_recovery.go
@@ -166,7 +166,7 @@ func (m *Manager) resumePendingHandoff(entry pendingHandoffEntry, mission string
 }
 
 func (m *Manager) pendingHandoffRetryAllowed(repoID string, instance *session.Instance) bool {
-	key := remoteLossKey(repoID, instance)
+	key := stableSessionKey(repoID, instance)
 	now := nowFunc()
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -179,6 +179,6 @@ func (m *Manager) pendingHandoffRetryAllowed(repoID string, instance *session.In
 
 func (m *Manager) clearPendingHandoffRetry(repoID string, instance *session.Instance) {
 	m.mu.Lock()
-	delete(m.handoffRetryDue, remoteLossKey(repoID, instance))
+	delete(m.handoffRetryDue, stableSessionKey(repoID, instance))
 	m.mu.Unlock()
 }

--- a/daemon/handoff_settle.go
+++ b/daemon/handoff_settle.go
@@ -33,7 +33,7 @@ func (m *Manager) persistHandoffSettlement(repoID, key string, instance *session
 	// persistAndPublishInstanceErr goes through startLockForRepo, which takes m.mu
 	// — the #2106 lock contract, so the bookkeeping below happens after it returns.
 	err := m.persistAndPublishInstanceErr(repoID, instance)
-	owedKey := remoteLossKey(repoID, instance)
+	owedKey := stableSessionKey(repoID, instance)
 	m.mu.Lock()
 	if err != nil {
 		m.handoffSettleOwed[owedKey] = pendingHandoffEntry{repoID: repoID, key: key, instance: instance}
@@ -67,7 +67,7 @@ func (m *Manager) flushHandoffSettlements() {
 		m.mu.Lock()
 		registered := m.instances[entry.key] == entry.instance
 		if !registered {
-			delete(m.handoffSettleOwed, remoteLossKey(entry.repoID, entry.instance))
+			delete(m.handoffSettleOwed, stableSessionKey(entry.repoID, entry.instance))
 		}
 		m.mu.Unlock()
 		// The row is gone (killed) or a successor took its key. Its record is being

--- a/daemon/kill_commit_test.go
+++ b/daemon/kill_commit_test.go
@@ -186,7 +186,7 @@ func TestRestoreLostSessions_ObservedAliveThenDied_StartsFreshEpisode(t *testing
 	inst := registerStarted(t, manager, repoID, repoPath, "long-lived", backend, true, session.Lost)
 	zeroRestoreBackoff(t)
 
-	key := daemonInstanceKey(repoID, "long-lived")
+	key := stableSessionKey(repoID, inst)
 	manager.RestoreLostSessions() // recovers; arms the confirmation
 	if got := backend.recoverCalls(); got != 1 {
 		t.Fatalf("recover calls = %d, want 1", got)

--- a/daemon/limitresume.go
+++ b/daemon/limitresume.go
@@ -44,9 +44,21 @@ var (
 	limitResumeBackoffMax  = 5 * time.Minute
 )
 
-// limitResumeState is the per-session auto-resume retry state, keyed by daemon
-// instance key and guarded by Manager.mu (the loop runs on the poll goroutine;
-// tests drive ResumeLimitedSessions directly). parkedAt anchors the
+// limitResumeState is the per-session auto-resume retry state, keyed by
+// stableSessionKey — the stable instance id, NOT the repo/title daemon key
+// (#2876) — and guarded by Manager.mu (the loop runs on the poll goroutine;
+// tests drive ResumeLimitedSessions directly).
+//
+// Every field below describes ONE runtime: when THIS session was first seen
+// parked, how many times IT has been resumed, when ITS next attempt is allowed.
+// A title is a slot that outlives its occupant, so filing the episode under one
+// handed it to the next session to take that name — and here that is worse than
+// an inflated counter, because nextAttempt is a GATE. A successor moving into a
+// title whose predecessor was mid-backoff was not resumed at all until the
+// discarded session's backoff expired, with nothing logged. Same rule and same
+// reason as lostRestoreState (#2868); see stableSessionKey.
+//
+// parkedAt anchors the
 // no-parseable-reset-time fallback interval (the first tick the session was seen
 // parked); nextAttempt is the backoff gate that ALSO survives the brief non-limit
 // window between resumeFromLimit clearing the limit and the next poll re-detecting
@@ -82,9 +94,21 @@ func (m *Manager) ResumeLimitedSessions() {
 	now := nowFunc()
 	m.mu.Lock()
 	entries := make([]entry, 0, len(m.instances))
+	// live is the set of stable identities whose episode still describes a
+	// resumable runtime. Built here rather than indexing m.instances directly
+	// because the state is keyed by stable id, not by the repo/title map key
+	// (#2876) — and because presence in that map is not the same question: an
+	// ARCHIVED or never-started row is still in it under the same id while being
+	// permanently ineligible for resume (resumeLimitedSession requires started +
+	// LiveLimitReached), so its episode describes something that will never run
+	// again. Same rule as RestoreLostSessions and sweepRemoteLossStates.
+	live := make(map[string]struct{}, len(m.instances))
 	for key, inst := range m.instances {
 		repoID, _ := splitDaemonInstanceKey(key)
 		entries = append(entries, entry{key: key, repoID: repoID, instance: inst})
+		if inst.Started() && inst.GetLiveness() != session.LiveArchived {
+			live[stableSessionKey(repoID, inst)] = struct{}{}
+		}
 	}
 	// Drop retry state for sessions that are gone, or that have stayed OUT of
 	// LimitReached past their backoff window (a resume that stuck — the episode
@@ -93,17 +117,25 @@ func (m *Manager) ResumeLimitedSessions() {
 	// resumeFromLimit clearing the limit and the next poll re-detecting the
 	// banner, and keeping the state there is what throttles an immediate
 	// re-limit instead of restarting it at attempt zero.
+	//
+	// That retention is exactly why the identity keying below is load-bearing
+	// rather than tidy (#2876). "Inside its backoff window" is the one state this
+	// sweep will not clear, so a title freed mid-backoff — the common case, since
+	// a user kills a session precisely when its agent is stuck at a wall — handed
+	// the next session to take that name a gate it could not see or clear.
 	for key, inst := range m.instances {
-		st := m.limitResumeStates[key]
+		repoID, _ := splitDaemonInstanceKey(key)
+		stateKey := stableSessionKey(repoID, inst)
+		st := m.limitResumeStates[stateKey]
 		if st == nil {
 			continue
 		}
 		if inst.GetLiveness() != session.LiveLimitReached && !now.Before(st.nextAttempt) {
-			delete(m.limitResumeStates, key)
+			delete(m.limitResumeStates, stateKey)
 		}
 	}
 	for key := range m.limitResumeStates {
-		if _, live := m.instances[key]; !live {
+		if _, ok := live[key]; !ok {
 			delete(m.limitResumeStates, key)
 		}
 	}
@@ -131,7 +163,12 @@ func (m *Manager) resumeLimitedSession(key, repoID string, inst *session.Instanc
 		return
 	}
 
+	// Two keys, deliberately, exactly as restoreLostSession carries them. `key`
+	// (repo/title) addresses the SLOT — killsInFlight, the per-session op lock, the
+	// m.instances re-read below. stateKey addresses this SESSION's stable identity,
+	// which is what a resume episode is about (#2876).
 	now := nowFunc()
+	stateKey := stableSessionKey(repoID, inst)
 	m.mu.Lock()
 	if _, killing := m.killsInFlight[key]; killing {
 		m.mu.Unlock()
@@ -145,10 +182,10 @@ func (m *Manager) resumeLimitedSession(key, repoID string, inst *session.Instanc
 		m.mu.Unlock()
 		return
 	}
-	st := m.limitResumeStates[key]
+	st := m.limitResumeStates[stateKey]
 	if st == nil {
 		st = &limitResumeState{parkedAt: now}
-		m.limitResumeStates[key] = st
+		m.limitResumeStates[stateKey] = st
 	}
 	// due = when this session first becomes eligible. With a parsed reset time it
 	// is reset + grace (a reset already in the past yields a due in the past →

--- a/daemon/limitresume_test.go
+++ b/daemon/limitresume_test.go
@@ -142,7 +142,7 @@ func TestResumeLimitedSessions_ArchivedClearsTimer(t *testing.T) {
 	advance := withFrozenClock(t)
 	base := nowFunc()
 	manager, repoID, inst, backend := newAutoResumeManager(t, "", true, "archived work", base.Add(time.Hour))
-	key := daemonInstanceKey(repoID, "limited")
+	key := stableSessionKey(repoID, inst)
 
 	// First pass (before due) creates the retry state.
 	manager.ResumeLimitedSessions()
@@ -196,8 +196,8 @@ func TestResumeLimitedSessions_NoResetTimeFallback(t *testing.T) {
 // surface-only — never auto-resumed no matter how much time passes.
 func TestResumeLimitedSessions_NoResetNoIntervalNeverResumes(t *testing.T) {
 	advance := withFrozenClock(t)
-	manager, repoID, _, backend := newAutoResumeManager(t, "", true, "orphan work", time.Time{}) // zero reset, no interval
-	key := daemonInstanceKey(repoID, "limited")
+	manager, repoID, inst, backend := newAutoResumeManager(t, "", true, "orphan work", time.Time{}) // zero reset, no interval
+	key := stableSessionKey(repoID, inst)
 
 	for i := 0; i < 5; i++ {
 		advance(24 * time.Hour)

--- a/daemon/limitresume_title_reuse_test.go
+++ b/daemon/limitresume_title_reuse_test.go
@@ -1,0 +1,155 @@
+package daemon
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The #2876 regression lock, the usage-limit sibling of #2868: an auto-resume
+// retry episode belongs to ONE runtime, and a later session that merely reuses
+// the title must not inherit it.
+//
+// This one bites harder than #2868 did, because the inherited field is a GATE
+// rather than a counter. limitResumeState.nextAttempt is consulted as "nothing
+// may fire before this", so a successor that moves into a title whose predecessor
+// was mid-backoff is not merely slow to be resumed — it is not resumed AT ALL
+// until the discarded session's backoff expires, and nothing is logged. A user
+// watching a fresh session sit parked at a usage-limit wall sees the auto-resume
+// feature simply not work.
+//
+// Why the sweep does not catch it: an entry is dropped only once the session has
+// left LiveLimitReached AND its backoff has elapsed. During a backoff the second
+// clause is false by construction, and the reap loop below it keys off
+// m.instances, which a same-titled successor repopulates.
+
+// newTitleReuseLimitManager builds the auto-resume fixture and also hands back the
+// repo path, so a SECOND session can be registered under the same title later —
+// which newAutoResumeManager, built for single-session tests, cannot do.
+func newTitleReuseLimitManager(t *testing.T) (*Manager, string, string, *session.Instance, *limitResumeBackend) {
+	t.Helper()
+	manager, repoID, repoPath := newStatusTestManager(t)
+	manager.cfg.LimitAutoResume = true
+	backend := &limitResumeBackend{FakeBackend: session.NewFakeBackend(), alive: true}
+	inst := registerStarted(t, manager, repoID, repoPath, "limited", backend, true, session.Running)
+	inst.Prompt = "old work"
+	inst.SetLimitReached(nowFunc()) // reset already in the past
+	return manager, repoID, repoPath, inst, backend
+}
+
+// limitEpisodeAttempts reports the attempt count of every auto-resume episode the
+// manager holds, sorted. Key-agnostic for the same reason trackedEpisodes is (see
+// lostrestore_title_reuse_test.go): which key an episode is filed under is the
+// thing under test, so a by-key lookup would fail against the unfixed build as a
+// missing precondition rather than as inherited state.
+func limitEpisodeAttempts(m *Manager) []int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	attempts := make([]int, 0, len(m.limitResumeStates))
+	for _, st := range m.limitResumeStates {
+		attempts = append(attempts, st.attempts)
+	}
+	slices.Sort(attempts)
+	return attempts
+}
+
+// parkSuccessor registers a second session under the same title the predecessor
+// held, parked at a usage-limit wall whose window has already elapsed — so it is
+// due for auto-resume immediately, and any delay it suffers is inherited.
+func parkSuccessor(t *testing.T, m *Manager, repoID, repoPath, title string) (*session.Instance, *limitResumeBackend) {
+	t.Helper()
+	backend := &limitResumeBackend{FakeBackend: session.NewFakeBackend(), alive: true}
+	inst := registerStarted(t, m, repoID, repoPath, title, backend, true, session.Running)
+	inst.Prompt = "the successor's own work"
+	inst.SetLimitReached(nowFunc().Add(-time.Hour))
+	return inst, backend
+}
+
+// assertSuccessorResumesOnItsOwnSchedule is the user-visible assertion: the new
+// session is auto-resumed on ITS due time, and the episode recording that is its
+// own first attempt — not a continuation of a discarded session's backoff.
+func assertSuccessorResumesOnItsOwnSchedule(t *testing.T, m *Manager, backend *limitResumeBackend) {
+	t.Helper()
+	if _, _, prompts := backend.snapshot(); len(prompts) != 1 {
+		t.Fatalf("the NEW session was resumed %d time(s), want exactly 1: its own limit window had "+
+			"elapsed, so auto-resume was due — it was gated behind the backoff of a session the user "+
+			"already discarded, because the episode was filed under the reused TITLE rather than the "+
+			"stable instance id (#2876)", len(prompts))
+	}
+	if attempts := limitEpisodeAttempts(m); !slices.Equal(attempts, []int{1}) {
+		t.Fatalf("tracked auto-resume episodes = %v, want exactly one with one attempt: the successor "+
+			"must start its own episode, and the discarded session's must not outlive it (#2876)", attempts)
+	}
+}
+
+// TestResumeLimitedSessions_KilledThenTitleReused_ResumesOnOwnSchedule drives the
+// reported cycle: parked at a limit -> auto-resume fires and arms a backoff ->
+// user kills the session -> a new session takes the freed title and parks at a
+// limit of its own. The new session must be resumed when ITS window elapses.
+func TestResumeLimitedSessions_KilledThenTitleReused_ResumesOnOwnSchedule(t *testing.T) {
+	advance := withFrozenClock(t)
+	manager, repoID, repoPath, old, oldBackend := newTitleReuseLimitManager(t)
+
+	// One auto-resume fires and arms the exponential backoff.
+	advance(limitResumeGrace + time.Second)
+	manager.ResumeLimitedSessions()
+	if _, _, prompts := oldBackend.snapshot(); len(prompts) != 1 {
+		t.Fatalf("precondition: the predecessor must be resumed once, got %d", len(prompts))
+	}
+	if attempts := limitEpisodeAttempts(manager); !slices.Equal(attempts, []int{1}) {
+		t.Fatalf("precondition: tracked episodes = %v, want exactly one with one attempt", attempts)
+	}
+
+	// The user kills it WHILE that backoff is still running — which is exactly when
+	// the entry cannot be swept, since the sweep requires the backoff to have
+	// elapsed before it will drop one.
+	manager.mu.Lock()
+	delete(manager.instances, daemonInstanceKey(repoID, "limited"))
+	manager.mu.Unlock()
+
+	replacement, freshBackend := parkSuccessor(t, manager, repoID, repoPath, "limited")
+	if replacement.ID == old.ID {
+		t.Fatal("precondition: a new session must mint a new stable id")
+	}
+
+	// Still inside the predecessor's 10s backoff.
+	advance(time.Second)
+	manager.ResumeLimitedSessions()
+	assertSuccessorResumesOnItsOwnSchedule(t, manager, freshBackend)
+}
+
+// TestResumeLimitedSessions_ArchivedThenTitleReused_ResumesOnOwnSchedule is the
+// other route to a free title: reuse-archived-name RENAMES the archived row and
+// leaves it in the manager map, so the successor moves into a key whose episode
+// nothing reaped.
+func TestResumeLimitedSessions_ArchivedThenTitleReused_ResumesOnOwnSchedule(t *testing.T) {
+	advance := withFrozenClock(t)
+	manager, repoID, repoPath, old, oldBackend := newTitleReuseLimitManager(t)
+
+	advance(limitResumeGrace + time.Second)
+	manager.ResumeLimitedSessions()
+	if _, _, prompts := oldBackend.snapshot(); len(prompts) != 1 {
+		t.Fatalf("precondition: the predecessor must be resumed once, got %d", len(prompts))
+	}
+
+	// Archived and renamed out of the way, as renameArchivedForReuseLocked does.
+	if err := old.Transition(session.ObserveLiveness(session.LiveArchived)); err != nil {
+		t.Fatalf("archive transition: %v", err)
+	}
+	old.SetStartedForTest(false)
+	if err := old.SetTitle("limited-1"); err != nil {
+		t.Fatalf("rename archived: %v", err)
+	}
+	manager.mu.Lock()
+	delete(manager.instances, daemonInstanceKey(repoID, "limited"))
+	manager.instances[daemonInstanceKey(repoID, "limited-1")] = old
+	manager.mu.Unlock()
+
+	_, freshBackend := parkSuccessor(t, manager, repoID, repoPath, "limited")
+
+	advance(time.Second)
+	manager.ResumeLimitedSessions()
+	assertSuccessorResumesOnItsOwnSchedule(t, manager, freshBackend)
+}

--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -71,6 +71,17 @@ var errRestoreDiedBeforeConfirm = errors.New("the re-spawned agent exited before
 // lostRestoreState is the per-session retry state. Guarded by Manager.mu (the
 // loop runs on the daemon poll goroutine; tests drive RestoreLostSessions
 // directly).
+//
+// It is filed under stableSessionKey — the session's stable ID — and NOT under
+// the repo/title daemon key (#2868). Everything below describes ONE runtime: how
+// many times THIS agent failed to come back, which worktree of ITS went missing,
+// how far ITS observation counter had advanced when it was last respawned. A
+// title is a slot that outlives its occupant, so filing an episode under one
+// hands the next occupant its predecessor's history: kill or archive a session
+// that failed four restores, create another with the same title, and the new
+// session's very first hiccup is charged as failure five and waits minutes for a
+// retry it should have gotten in ten seconds. Same rule and same reason as
+// remoteLossState; see stableSessionKey.
 type lostRestoreState struct {
 	consecutiveFailures int
 	nextAttempt         time.Time
@@ -123,9 +134,21 @@ func (m *Manager) RestoreLostSessions() {
 	}
 	m.mu.Lock()
 	entries := make([]entry, 0, len(m.instances))
+	// live is the set of stable identities whose retry episode still describes a
+	// restorable runtime. Built here rather than reusing m.instances directly
+	// because the state is keyed by stable ID, not by the repo/title map key
+	// (#2868) — and because presence in that map is not the same question:
+	// an ARCHIVED or never-started row is still in it under the same ID, but its
+	// runtime was deliberately torn down, so its failure history describes
+	// something that no longer exists and no poll will ever confirm it alive. Same
+	// rule, same reason, as sweepRemoteLossStates.
+	live := make(map[string]struct{}, len(m.instances))
 	for key, inst := range m.instances {
 		repoID, _ := splitDaemonInstanceKey(key)
 		entries = append(entries, entry{key: key, repoID: repoID, instance: inst})
+		if inst.Started() && inst.GetLiveness() != session.LiveArchived {
+			live[stableSessionKey(repoID, inst)] = struct{}{}
+		}
 	}
 	// Drop retry state for sessions that are gone or no longer Lost (healed,
 	// killed, or replaced) so the map never grows unbounded.
@@ -139,11 +162,13 @@ func (m *Manager) RestoreLostSessions() {
 	// confirmation, the state is kept until confirmBy passes, so a death inside
 	// that window still lands on the attempt that caused it.
 	for key, inst := range m.instances {
-		st := m.lostRestoreStates[key]
+		repoID, _ := splitDaemonInstanceKey(key)
+		stateKey := stableSessionKey(repoID, inst)
+		st := m.lostRestoreStates[stateKey]
 		if st == nil || inst.GetStatus() == session.Lost {
 			continue
 		}
-		if st.awaitingConfirm && !m.observedAliveSinceSpawnLocked(key, inst, st) {
+		if st.awaitingConfirm && !m.observedAliveSinceSpawnLocked(repoID, inst, st) {
 			// Not Lost, but nothing has ANSWERED yet either. A row can read non-Lost
 			// for reasons that are not proof of life — a poll that has not run at this
 			// interval, or a remote inside its 60s loss grace — so keep the history
@@ -154,10 +179,10 @@ func (m *Manager) RestoreLostSessions() {
 		// now stayed non-Lost past the settle interval: CONFIRMED ALIVE. Only here
 		// is the backoff history provably about a runtime that no longer exists,
 		// which is the one condition under which forgetting it is safe.
-		delete(m.lostRestoreStates, key)
+		delete(m.lostRestoreStates, stateKey)
 	}
 	for key := range m.lostRestoreStates {
-		if _, live := m.instances[key]; !live {
+		if _, ok := live[key]; !ok {
 			delete(m.lostRestoreStates, key)
 		}
 	}
@@ -244,15 +269,23 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 		return
 	}
 
+	// Two keys, deliberately. `key` is the repo/title daemon key: it addresses the
+	// SLOT, which is what the exclusive-operation gates (killsInFlight, the
+	// per-session op lock, the m.instances re-read) are about. stateKey addresses
+	// this SESSION's stable identity, which is what a failure episode is about
+	// (#2868) — a successor that merely reuses the title is a different runtime and
+	// must not be charged for its predecessor's failures.
+	stateKey := stableSessionKey(repoID, inst)
+
 	m.mu.Lock()
 	if _, killing := m.killsInFlight[key]; killing {
 		m.mu.Unlock()
 		return
 	}
-	st := m.lostRestoreStates[key]
+	st := m.lostRestoreStates[stateKey]
 	if st == nil {
 		st = &lostRestoreState{}
-		m.lostRestoreStates[key] = st
+		m.lostRestoreStates[stateKey] = st
 	}
 	// Reaching here means the session is Lost. If a restore was still awaiting
 	// confirmation AND its settle window has not elapsed, its replacement runtime
@@ -267,9 +300,9 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 	// the observation, not a deadline: "confirmBy has passed" merely meant time
 	// elapsed, which a long poll interval or the 60s remote grace can outlast while
 	// the runtime was dead the whole time (#1917 round 6).
-	if st.awaitingConfirm && m.observedAliveSinceSpawnLocked(key, inst, st) {
+	if st.awaitingConfirm && m.observedAliveSinceSpawnLocked(repoID, inst, st) {
 		st = &lostRestoreState{}
-		m.lostRestoreStates[key] = st
+		m.lostRestoreStates[stateKey] = st
 	}
 	diedBeforeConfirm := st.awaitingConfirm
 	if diedBeforeConfirm {
@@ -280,7 +313,7 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 	skip := !diedBeforeConfirm && time.Now().Before(st.nextAttempt)
 	m.mu.Unlock()
 	if diedBeforeConfirm {
-		m.lostRestoreFailed(key, st, inst.Title, errRestoreDiedBeforeConfirm)
+		m.lostRestoreFailed(st, inst.Title, errRestoreDiedBeforeConfirm)
 		return
 	}
 	if skip {
@@ -337,10 +370,10 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 		// the answered probe already ended the loss episode, and leaving the stale
 		// count in place across a disk write lets a blip in that window re-mark the
 		// very session we just proved alive.
-		m.clearRemoteLoss(remoteLossKey(repoID, inst))
+		m.clearRemoteLoss(stableSessionKey(repoID, inst))
 		m.persistInstance(repoID, inst)
 		m.mu.Lock()
-		delete(m.lostRestoreStates, key)
+		delete(m.lostRestoreStates, stateKey)
 		m.mu.Unlock()
 		return
 	case probeUnknown:
@@ -404,7 +437,7 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 	log.InfoLog.Printf("restored lost session %q (repo %s): agent re-spawned in its workspace", inst.Title, repoID)
 	// The spawn succeeded — but that is NOT recovery (#1910). Arm the confirmation
 	// window rather than clearing the retry state; see armRestoreConfirmation.
-	m.armRestoreConfirmation(key, repoID, inst)
+	m.armRestoreConfirmation(repoID, inst)
 }
 
 // armRestoreConfirmation marks a session whose recovery spawn just RETURNED SUCCESS
@@ -425,24 +458,31 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 //
 // The entry is created if absent: the manual path may run with no prior automatic
 // attempts on record. Takes m.mu itself; the caller must not already hold it.
-func (m *Manager) armRestoreConfirmation(key, repoID string, inst *session.Instance) {
+//
+// The entry and the observation counter it snapshots are keyed the SAME way — by
+// stable identity — which is the invariant #2868 broke: observedAtSpawn was read
+// from an ID-keyed counter while the state holding it was filed under the title,
+// so a successor's zeroed counter could never advance past a value its
+// predecessor had earned, and the sweep kept a state that belonged to a session
+// the user had already discarded.
+func (m *Manager) armRestoreConfirmation(repoID string, inst *session.Instance) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	key := stableSessionKey(repoID, inst)
 	st := m.lostRestoreStates[key]
 	if st == nil {
 		st = &lostRestoreState{}
 		m.lostRestoreStates[key] = st
 	}
 	st.awaitingConfirm = true
-	st.observedAtSpawn = m.aliveObservations[remoteLossKey(repoID, inst)]
+	st.observedAtSpawn = m.aliveObservations[key]
 }
 
 // observedAliveSinceSpawnLocked reports whether a poll has gotten an ANSWER out of
 // this session's runtime since its last respawn — the definition of "confirmed
 // alive" (#1917 round 6). Caller holds m.mu.
-func (m *Manager) observedAliveSinceSpawnLocked(key string, inst *session.Instance, st *lostRestoreState) bool {
-	repoID, _ := splitDaemonInstanceKey(key)
-	return m.aliveObservations[remoteLossKey(repoID, inst)] > st.observedAtSpawn
+func (m *Manager) observedAliveSinceSpawnLocked(repoID string, inst *session.Instance, st *lostRestoreState) bool {
+	return m.aliveObservations[stableSessionKey(repoID, inst)] > st.observedAtSpawn
 }
 
 // lostRestoreFailed records a failed restore attempt: exponential backoff to
@@ -450,7 +490,7 @@ func (m *Manager) observedAliveSinceSpawnLocked(key string, inst *session.Instan
 // persists — never a permanent give-up (#1128: an outage is indistinguishable
 // from a broken worktree while it lasts; only a later retry can tell). One
 // ERROR at the escalation threshold makes a persistent cause visible.
-func (m *Manager) lostRestoreFailed(key string, st *lostRestoreState, title string, err error) {
+func (m *Manager) lostRestoreFailed(st *lostRestoreState, title string, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	st.consecutiveFailures++
@@ -489,19 +529,24 @@ func lostRestoreBackoff(attempt int) time.Duration {
 // per-session operation gate despite its historical name; treating the manual
 // restore's marker as kill intent would label a vanished worktree
 // "expected_teardown" in the diagnostic emitted for that very restore.
+//
+// `key` is the repo/title daemon key and is used ONLY to ask whether an exclusive
+// operation holds the slot; the episode itself is filed under the session's stable
+// identity, so a title reused by a later session starts from zero (#2868).
 func (m *Manager) recordLostRestoreFailure(key, repoID string, inst *session.Instance, restoreErr error, trigger lostRestoreTrigger) {
+	stateKey := stableSessionKey(repoID, inst)
 	m.mu.Lock()
-	st := m.lostRestoreStates[key]
+	st := m.lostRestoreStates[stateKey]
 	if st == nil {
 		st = &lostRestoreState{}
-		m.lostRestoreStates[key] = st
+		m.lostRestoreStates[stateKey] = st
 	}
 	_, operationInFlight := m.killsInFlight[key]
 	m.mu.Unlock()
 
 	teardownInFlight := operationInFlight && trigger != lostRestoreManual
 	m.logVanishedWorktreeOnce(repoID, st, inst, restoreErr, teardownInFlight)
-	m.lostRestoreFailed(key, st, inst.Title, restoreErr)
+	m.lostRestoreFailed(st, inst.Title, restoreErr)
 }
 
 func (m *Manager) logVanishedWorktreeOnce(repoID string, st *lostRestoreState, inst *session.Instance, restoreErr error, teardownInFlight bool) {

--- a/daemon/lostrestore_confirm_test.go
+++ b/daemon/lostrestore_confirm_test.go
@@ -22,7 +22,7 @@ import (
 // probe got an ANSWER out of the runtime. Tests drive it explicitly because that,
 // not elapsed time, is what confirms a restore (#1917 round 6).
 func observeAlive(m *Manager, repoID string, inst *session.Instance) {
-	m.noteAliveObservation(remoteLossKey(repoID, inst))
+	m.noteAliveObservation(stableSessionKey(repoID, inst))
 }
 
 // diesOnSpawnBackend models the reported agent: its Recover SUCCEEDS — the spawn
@@ -99,10 +99,10 @@ func TestRestoreLostSessions_SpawnSucceedsButRuntimeDies_BacksOff(t *testing.T) 
 func TestRestoreLostSessions_RepeatedImmediateExits_EscalateExponentially(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	backend := &diesOnSpawnBackend{FakeBackend: session.NewFakeBackend()}
-	registerStarted(t, manager, repoID, repoPath, "flapper", backend, true, session.Lost)
+	inst := registerStarted(t, manager, repoID, repoPath, "flapper", backend, true, session.Lost)
 	zeroRestoreBackoff(t) // every pass is due, so the loop is free to hot-loop if it can
 
-	key := daemonInstanceKey(repoID, "flapper")
+	key := stableSessionKey(repoID, inst)
 	// spawn, observe-death, spawn, observe-death, ...
 	for i := 0; i < 6; i++ {
 		manager.RestoreLostSessions()
@@ -137,7 +137,7 @@ func TestRestoreLostSessions_ConfirmedAliveClearsRetryState(t *testing.T) {
 	inst := registerStarted(t, manager, repoID, repoPath, "healthy", backend, true, session.Lost)
 	zeroRestoreBackoff(t)
 
-	key := daemonInstanceKey(repoID, "healthy")
+	key := stableSessionKey(repoID, inst)
 	manager.RestoreLostSessions() // recovers; arms the confirmation window
 
 	manager.mu.Lock()
@@ -189,10 +189,10 @@ func TestRestoreLostSessions_ConfirmedAliveClearsRetryState(t *testing.T) {
 func TestRestoreLostSessions_NeverObservedAlive_BacksOffRegardlessOfElapsedTime(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	backend := &diesOnSpawnBackend{FakeBackend: session.NewFakeBackend()}
-	registerStarted(t, manager, repoID, repoPath, "flapper", backend, true, session.Lost)
+	inst := registerStarted(t, manager, repoID, repoPath, "flapper", backend, true, session.Lost)
 	zeroRestoreBackoff(t)
 
-	key := daemonInstanceKey(repoID, "flapper")
+	key := stableSessionKey(repoID, inst)
 	// Many passes, and NOT ONE observation — exactly what a poll interval longer
 	// than any window, or a remote inside its 60s grace, produces. No clock is
 	// advanced: the point is that time is irrelevant without an answer.
@@ -226,7 +226,7 @@ func TestRestoreLostSessions_ObservationConfirms_NotElapsedTime(t *testing.T) {
 	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
 	inst := registerStarted(t, manager, repoID, repoPath, "healthy", backend, true, session.Lost)
 	zeroRestoreBackoff(t)
-	key := daemonInstanceKey(repoID, "healthy")
+	key := stableSessionKey(repoID, inst)
 
 	manager.RestoreLostSessions() // spawn; awaiting confirmation
 
@@ -282,7 +282,7 @@ func TestRefreshInstanceStatus_SnapshotNilErrorOnDeadSession_IsNotAnObservation(
 	backend := &deadPaneBackend{FakeBackend: session.NewFakeBackend()}
 	inst := registerStarted(t, manager, repoID, repoPath, "corpse", backend, true, session.Running)
 
-	obsKey := remoteLossKey(repoID, inst)
+	obsKey := stableSessionKey(repoID, inst)
 	manager.refreshInstanceStatus(repoID, inst)
 
 	manager.mu.Lock()
@@ -309,7 +309,7 @@ func TestRefreshInstanceStatus_LiveSessionIsObserved(t *testing.T) {
 	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
 	inst := registerStarted(t, manager, repoID, repoPath, "busy", backend, true, session.Running)
 
-	obsKey := remoteLossKey(repoID, inst)
+	obsKey := stableSessionKey(repoID, inst)
 	manager.refreshInstanceStatus(repoID, inst)
 
 	manager.mu.Lock()
@@ -361,7 +361,7 @@ func TestRefreshInstanceStatus_WedgedProbe_IsNotAnObservation(t *testing.T) {
 	backend := &wedgedProbeBackend{FakeBackend: session.NewFakeBackend()}
 	inst := registerStarted(t, manager, repoID, repoPath, "wedged", backend, true, session.Running)
 
-	obsKey := remoteLossKey(repoID, inst)
+	obsKey := stableSessionKey(repoID, inst)
 	manager.refreshInstanceStatus(repoID, inst)
 
 	manager.mu.Lock()

--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -103,7 +103,7 @@ func TestRestoreLostSessions_RecoversLostInstance(t *testing.T) {
 	observeAlive(manager, repoID, inst)
 	manager.RestoreLostSessions()
 	manager.mu.Lock()
-	_, hasState := manager.lostRestoreStates[daemonInstanceKey(repoID, "stranded")]
+	_, hasState := manager.lostRestoreStates[stableSessionKey(repoID, inst)]
 	manager.mu.Unlock()
 	if hasState {
 		t.Fatal("a confirmed-alive recovery must drop the retry state")
@@ -120,7 +120,7 @@ func TestRestoreSession_RecoversLostInstanceOnDemand(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
 	inst := registerStarted(t, manager, repoID, repoPath, "stranded", backend, true, session.Lost)
-	key := daemonInstanceKey(repoID, "stranded")
+	key := stableSessionKey(repoID, inst)
 	manager.mu.Lock()
 	manager.lostRestoreStates[key] = &lostRestoreState{consecutiveFailures: 3}
 	manager.mu.Unlock()
@@ -687,12 +687,14 @@ func TestRestoreLostSessions_StateCleanedForGoneSessions(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	zeroRestoreBackoff(t)
 	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend(), failWith: errors.New("down")}
-	registerStarted(t, manager, repoID, repoPath, "doomed", backend, true, session.Lost)
+	inst := registerStarted(t, manager, repoID, repoPath, "doomed", backend, true, session.Lost)
 
 	manager.RestoreLostSessions()
-	key := daemonInstanceKey(repoID, "doomed")
+	// The episode is filed under the session's stable identity; the manager map
+	// still addresses it by repo/title (#2868).
+	stateKey := stableSessionKey(repoID, inst)
 	manager.mu.Lock()
-	_, hasState := manager.lostRestoreStates[key]
+	_, hasState := manager.lostRestoreStates[stateKey]
 	manager.mu.Unlock()
 	if !hasState {
 		t.Fatal("a failed attempt must record retry state")
@@ -700,12 +702,12 @@ func TestRestoreLostSessions_StateCleanedForGoneSessions(t *testing.T) {
 
 	// The session disappears (user killed it; record + map entry gone).
 	manager.mu.Lock()
-	delete(manager.instances, key)
+	delete(manager.instances, daemonInstanceKey(repoID, "doomed"))
 	manager.mu.Unlock()
 	manager.RestoreLostSessions()
 
 	manager.mu.Lock()
-	_, hasState = manager.lostRestoreStates[key]
+	_, hasState = manager.lostRestoreStates[stateKey]
 	manager.mu.Unlock()
 	if hasState {
 		t.Fatal("retry state for a gone session must be dropped")

--- a/daemon/lostrestore_title_reuse_test.go
+++ b/daemon/lostrestore_title_reuse_test.go
@@ -1,0 +1,231 @@
+package daemon
+
+import (
+	"errors"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The #2868 regression lock: a Lost-restore failure episode belongs to ONE
+// runtime, and a later session that merely reuses the title must not inherit it.
+//
+// The field shape: a session goes Lost, its restores fail four times, the user
+// gives up and kills it, then creates a fresh session with the same name. The new
+// session's very first hiccup was charged as failure five — so it waited minutes
+// for a retry it should have gotten in ten seconds, born broken for reasons
+// belonging to a session the user had already discarded. The cause was keying:
+// lostRestoreStates was filed under the repo/title daemon key, which addresses a
+// SLOT that outlives its occupant, while every other per-runtime map (the
+// remote-loss debounce, aliveObservations, handoff retries) had already been moved
+// to the stable instance id for exactly this reason.
+//
+// Both halves of the cycle are driven here because af offers two ways to free a
+// title and they leave the manager map in different shapes: a kill REMOVES the
+// row, while reuse-archived-name RENAMES it and leaves it in place (see
+// renameArchivedForReuseLocked). A fix that only reaped state for rows that
+// vanished would still hand the archived session's history to its successor.
+
+// failEveryRestoreBackend fails every Recover, which is what an episode of
+// consecutive failures is made of.
+type failEveryRestoreBackend struct {
+	*session.FakeBackend
+	err error
+}
+
+func (b *failEveryRestoreBackend) Recover(*session.Instance) error { return b.err }
+func (b *failEveryRestoreBackend) Type() string                    { return "local" }
+
+// trackedEpisodes summarizes every retry episode the manager holds — the failure
+// counts, sorted, and the furthest-out retry deadline among them.
+//
+// It deliberately names NO key. Which key an episode is filed under is the thing
+// under test, so an assertion that looked one up by key would pass or fail for the
+// wrong reason: against the buggy build it would read a key that build never
+// writes and fail as a missing precondition rather than as an inherited backoff.
+// Asked this way, the same assertion means the same thing on both builds — how
+// many episodes exist and how much each one has accumulated.
+func trackedEpisodes(m *Manager) (failures []int, longestWait time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	failures = make([]int, 0, len(m.lostRestoreStates))
+	for _, st := range m.lostRestoreStates {
+		failures = append(failures, st.consecutiveFailures)
+		if wait := time.Until(st.nextAttempt); wait > longestWait {
+			longestWait = wait
+		}
+	}
+	slices.Sort(failures)
+	return failures, longestWait
+}
+
+// soleEpisode returns the one episode being tracked, failing the test if there is
+// not exactly one. Key-agnostic for the same reason trackedEpisodes is.
+func soleEpisode(t *testing.T, m *Manager) *lostRestoreState {
+	t.Helper()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.lostRestoreStates) != 1 {
+		t.Fatalf("tracked episodes = %d, want exactly 1", len(m.lostRestoreStates))
+	}
+	for _, st := range m.lostRestoreStates {
+		return st
+	}
+	return nil
+}
+
+// accumulateRestoreFailures drives n failed restore passes against a Lost session
+// with the backoff collapsed, then puts the real schedule back so the NEXT
+// failure's retry deadline is a duration a user would actually wait.
+func accumulateRestoreFailures(t *testing.T, m *Manager, n int) {
+	t.Helper()
+	realBase := lostRestoreBackoffBase
+	lostRestoreBackoffBase = 0
+	t.Cleanup(func() { lostRestoreBackoffBase = realBase })
+	for i := 0; i < n; i++ {
+		m.RestoreLostSessions()
+	}
+	lostRestoreBackoffBase = realBase
+
+	failures, _ := trackedEpisodes(m)
+	if !slices.Equal(failures, []int{n}) {
+		t.Fatalf("precondition: after %d failed restores the tracked episodes are %v, want exactly one with %d",
+			n, failures, n)
+	}
+}
+
+// assertNewSessionStartsFresh is the whole point of the fix, asserted twice: once
+// on the counter, and once on the thing the user actually experiences — how long
+// the new session waits before anyone tries to restore it again.
+func assertNewSessionStartsFresh(t *testing.T, m *Manager) {
+	t.Helper()
+	failures, longestWait := trackedEpisodes(m)
+	if !slices.Equal(failures, []int{1}) {
+		t.Fatalf("tracked episodes after the NEW session's FIRST failed restore = %v, want exactly "+
+			"one episode with one failure: the new session inherited the failure history of a session "+
+			"the user already discarded, because the episode was filed under the reused TITLE rather "+
+			"than the stable instance id (#2868)", failures)
+	}
+	// backoff(1) is lostRestoreBackoffBase (10s); backoff(5), the inherited count,
+	// is 160s. Allowing 2x the base keeps this about the escalation rather than
+	// about scheduling precision.
+	if longestWait > 2*lostRestoreBackoffBase {
+		t.Fatalf("the new session waits %s for its next restore attempt, want no more than %s: an "+
+			"inherited episode put it deep into the exponential backoff on its first failure (#2868)",
+			longestWait.Round(time.Second), (2 * lostRestoreBackoffBase).Round(time.Second))
+	}
+}
+
+// TestRestoreLostSessions_KilledThenTitleReused_StartsFreshEpisode drives the
+// reported cycle: Lost -> restores fail -> user kills it -> new session takes the
+// freed title. The new session's first failure must be its first, not the old
+// session's fifth.
+func TestRestoreLostSessions_KilledThenTitleReused_StartsFreshEpisode(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	doomed := &failEveryRestoreBackend{
+		FakeBackend: session.NewFakeBackend(),
+		err:         errors.New("worktree is gone"),
+	}
+	old := registerStarted(t, manager, repoID, repoPath, "recycled", doomed, true, session.Lost)
+	accumulateRestoreFailures(t, manager, 4)
+
+	// The user gives up and kills it: the row leaves the manager map once teardown
+	// commits.
+	manager.mu.Lock()
+	delete(manager.instances, daemonInstanceKey(repoID, "recycled"))
+	manager.mu.Unlock()
+
+	// ...and creates a new session with the same name. Same title, different
+	// session — which is precisely what the stable id exists to tell apart (#1195).
+	fresh := &failEveryRestoreBackend{
+		FakeBackend: session.NewFakeBackend(),
+		err:         errors.New("a transient blip"),
+	}
+	replacement := registerStarted(t, manager, repoID, repoPath, "recycled", fresh, true, session.Lost)
+	if replacement.ID == old.ID {
+		t.Fatal("precondition: a new session must mint a new stable id")
+	}
+
+	manager.RestoreLostSessions()
+
+	// Exactly one episode with exactly one failure: the new session's own. That
+	// single shape carries both halves — nothing was inherited, and the discarded
+	// session's episode was reaped rather than accumulating for the daemon's life.
+	assertNewSessionStartsFresh(t, manager)
+}
+
+// TestRestoreLostSessions_ArchivedThenTitleReused_StartsFreshEpisode is the other
+// way a title comes free, and the harder one: reuse-archived-name RENAMES the
+// archived row and leaves it in the manager map, so the successor moves in under a
+// key whose retry state was never reaped.
+func TestRestoreLostSessions_ArchivedThenTitleReused_StartsFreshEpisode(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	doomed := &failEveryRestoreBackend{
+		FakeBackend: session.NewFakeBackend(),
+		err:         errors.New("worktree is gone"),
+	}
+	old := registerStarted(t, manager, repoID, repoPath, "recycled", doomed, true, session.Lost)
+	accumulateRestoreFailures(t, manager, 4)
+
+	// The user archives it, then creates a new session with the same name.
+	// renameArchivedForReuseLocked frees the title by renaming the archived row and
+	// RE-KEYING it in the manager map — the row stays, under a new key. Modelled
+	// here rather than called: the real helper relocates a worktree and moves a
+	// branch, none of which this episode's keying depends on.
+	if err := old.Transition(session.ObserveLiveness(session.LiveArchived)); err != nil {
+		t.Fatalf("archive transition: %v", err)
+	}
+	old.SetStartedForTest(false)
+	if err := old.SetTitle("recycled-1"); err != nil {
+		t.Fatalf("rename archived: %v", err)
+	}
+	manager.mu.Lock()
+	delete(manager.instances, daemonInstanceKey(repoID, "recycled"))
+	manager.instances[daemonInstanceKey(repoID, "recycled-1")] = old
+	manager.mu.Unlock()
+
+	fresh := &failEveryRestoreBackend{
+		FakeBackend: session.NewFakeBackend(),
+		err:         errors.New("a transient blip"),
+	}
+	registerStarted(t, manager, repoID, repoPath, "recycled", fresh, true, session.Lost)
+
+	manager.RestoreLostSessions()
+	assertNewSessionStartsFresh(t, manager)
+}
+
+// TestRestoreLostSessions_ArchivedMidConfirmation_DropsItsEpisode covers the one
+// case the "no longer Lost" sweep cannot: a restore whose spawn succeeded is held
+// awaiting a liveness OBSERVATION (#1910), and the session is archived before any
+// poll answers. Archiving tears the runtime down, so that observation is never
+// coming — and the row stays in the manager map under its stable id, so presence
+// alone would keep the episode for the daemon's whole life and greet the session
+// with a stale backoff if it were ever restored. Same rule, same reason, as
+// sweepRemoteLossStates: unstarted or Archived is not live.
+func TestRestoreLostSessions_ArchivedMidConfirmation_DropsItsEpisode(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	zeroRestoreBackoff(t)
+	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
+	inst := registerStarted(t, manager, repoID, repoPath, "shelved", backend, true, session.Lost)
+
+	manager.RestoreLostSessions() // recovers; the episode is held awaiting confirmation
+	if !soleEpisode(t, manager).awaitingConfirm {
+		t.Fatal("precondition: a successful respawn must leave the episode awaiting confirmation")
+	}
+
+	// Archived before any poll got an answer out of the new runtime.
+	if err := inst.Transition(session.ObserveLiveness(session.LiveArchived)); err != nil {
+		t.Fatalf("archive transition: %v", err)
+	}
+	inst.SetStartedForTest(false)
+
+	manager.RestoreLostSessions()
+
+	if failures, _ := trackedEpisodes(manager); len(failures) != 0 {
+		t.Fatalf("tracked episodes after archiving = %v, want none: the runtime those failures "+
+			"describe was deliberately torn down, so no poll will ever confirm it alive and clear "+
+			"the entry", failures)
+	}
+}

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -156,7 +156,7 @@ type Manager struct {
 	ghostTaskRuns  map[string]int
 	repoStartLocks map[string]*sync.Mutex
 	// aliveObservations counts POSITIVE liveness observations per session (keyed by
-	// remoteLossKey, so a same-title successor never inherits its predecessor's).
+	// stableSessionKey, so a same-title successor never inherits its predecessor's).
 	// Incremented only where the poll actually gets an answer OUT of a runtime; read
 	// by the Lost-restore loop, which may only clear a session's failure history when
 	// this has advanced past the spawn. Guarded by mu.
@@ -232,8 +232,10 @@ type Manager struct {
 	// ordinary kill/archive operations already in progress.
 	restoresInFlight map[string]struct{}
 	// lostRestoreStates tracks per-session retry state for the Lost-session
-	// restore loop (#1108 PR 2), keyed by daemon instance key — the general
-	// sibling of rootEnsureStates.
+	// restore loop (#1108 PR 2) — the general sibling of rootEnsureStates. Keyed
+	// by stableSessionKey (the stable instance ID), NOT by daemon instance key:
+	// an episode describes one runtime's failures, so a later session that merely
+	// reuses the title must not inherit them (#2868).
 	lostRestoreStates map[string]*lostRestoreState
 	// limitResumeStates tracks per-session retry state for the usage-limit
 	// auto-resume scheduler (#1146 PR3), keyed by daemon instance key — the
@@ -292,7 +294,7 @@ type Manager struct {
 	pausedPolls map[string]time.Time
 	// taskRunProbeDue schedules the backstop observation for a PAUSED session whose
 	// task run is still in flight (#1892). Guarded by pausedMu (the same lock as
-	// pausedPolls) but keyed by remoteLossKey — the stable instance ID — rather
+	// pausedPolls) but keyed by stableSessionKey — the stable instance ID — rather
 	// than the legacy daemon-instance-key lease fallback. An attach suppresses the
 	// liveness probe, and the cap's slot is released
 	// by observing the agent go idle — so without a bounded backstop a user watching

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -238,8 +238,10 @@ type Manager struct {
 	// reuses the title must not inherit them (#2868).
 	lostRestoreStates map[string]*lostRestoreState
 	// limitResumeStates tracks per-session retry state for the usage-limit
-	// auto-resume scheduler (#1146 PR3), keyed by daemon instance key — the
-	// opt-in sibling of lostRestoreStates. Guarded by m.mu.
+	// auto-resume scheduler (#1146 PR3) — the opt-in sibling of lostRestoreStates,
+	// and keyed the same way for the same reason: by stableSessionKey (the stable
+	// instance ID), so a session that merely reuses a title cannot inherit the
+	// backoff gate a discarded predecessor armed (#2876). Guarded by m.mu.
 	limitResumeStates map[string]*limitResumeState
 	// handoffRetryDue throttles recovery of rendered takeover missions
 	// that survived a daemon restart before delivery was confirmed. Keyed by

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -255,10 +255,16 @@ type Manager struct {
 	// poll pass as mission recovery. Guarded by m.mu.
 	handoffSettleOwed map[string]pendingHandoffEntry
 	// remoteLossStates debounces the remote Lost transition (#1794), keyed by
-	// daemon instance key. A remote probe failure is transport-shaped — one
-	// blip fails identically to a dead sandbox — so the poll accumulates
-	// consecutive failures here and only settles Lost once they are durable.
-	// Guarded by m.mu; entries are dropped the moment a probe succeeds.
+	// stableSessionKey — the stable instance ID, which is what every writer and
+	// every clearRemoteLoss call site actually passes. This said "daemon instance
+	// key" until #2868, and being wrong here is not cosmetic: it is the comment a
+	// reader consults when deciding how to key the NEXT per-session map, and
+	// lostRestoreStates is what came of consulting it.
+	//
+	// A remote probe failure is transport-shaped — one blip fails identically to a
+	// dead sandbox — so the poll accumulates consecutive failures here and only
+	// settles Lost once they are durable. Guarded by m.mu; entries are dropped the
+	// moment a probe succeeds.
 	remoteLossStates map[string]*remoteLossState
 	// instanceOpLocks serializes the mutually-exclusive per-session
 	// operations — kill teardown and Lost-recovery — by daemon instance key.

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -77,7 +77,7 @@ func (m *Manager) PauseStatusPoll(repoID, title, id string) {
 // resumes on the next tick rather than waiting out the lease (#1160).
 //
 // It also frees the session's backstop-timer entry (#2015). That entry is keyed
-// by remoteLossKey (the stable instance ID), so an ID-bearing resume can delete
+// by stableSessionKey (the stable instance ID), so an ID-bearing resume can delete
 // it directly. Legacy title-only callers resolve the tracked instance as before.
 // sweepPausedPollState reclaims any entry this cannot (a crashed TUI that never
 // resumes, a session torn down mid-pause), so a lookup miss here is harmless.
@@ -92,7 +92,7 @@ func (m *Manager) ResumeStatusPoll(repoID, title, id string) {
 	m.pausedMu.Unlock()
 }
 
-// taskRunProbeKey resolves the taskRunProbeDue key (remoteLossKey — the stable
+// taskRunProbeKey resolves the taskRunProbeDue key (stableSessionKey — the stable
 // instance ID) for a tracked session, or "" when the session is no longer tracked
 // (already torn down; the sweep drops any orphaned entry). Reads m.instances under
 // m.mu and is never called with pausedMu held, so the two locks stay unnested.
@@ -103,7 +103,7 @@ func (m *Manager) taskRunProbeKey(repoID, title, id string) string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if inst := m.instances[daemonInstanceKey(repoID, title)]; inst != nil {
-		return remoteLossKey(repoID, inst)
+		return stableSessionKey(repoID, inst)
 	}
 	return ""
 }
@@ -141,7 +141,7 @@ func (m *Manager) taskRunBackstopDue(key string) bool {
 //
 // That sibling keys garbage on "session gone", but a session stays live across a
 // detach, so this keys garbage on "not currently paused" instead.
-// taskRunProbeDue is keyed by remoteLossKey (the stable instance ID), while
+// taskRunProbeDue is keyed by stableSessionKey (the stable instance ID), while
 // pausedPolls also admits a legacy title key, so the live set is bridged by
 // walking m.instances. m.mu and pausedMu are taken SEPARATELY, never nested —
 // the poll deliberately keeps them apart so a slow probe under one can't block
@@ -175,7 +175,7 @@ func (m *Manager) sweepPausedPollState() {
 		repoID, _ := splitDaemonInstanceKey(key)
 		pairs = append(pairs, keyPair{
 			repoID: repoID, title: inst.Title, id: inst.ID,
-			probeKey: remoteLossKey(repoID, inst),
+			probeKey: stableSessionKey(repoID, inst),
 		})
 	}
 	m.mu.Unlock()
@@ -369,7 +369,7 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 	// finishUserKill never ran: the tombstone sat unprocessed for the daemon's whole
 	// life, and the error told the user it would be retried automatically. That was
 	// a promise the code did not keep.
-	key := remoteLossKey(repoID, instance)
+	key := stableSessionKey(repoID, instance)
 	if instance.UserKilled() {
 		m.clearRemoteLoss(key)
 		m.finishUserKill(repoID, instance)
@@ -412,7 +412,7 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		// observeTaskRunWhilePaused for why it can end a run but never conclude
 		// death, and taskRunPollBackstop for why this is not a return to per-tick
 		// probing.
-		if instance.TaskRunActive() && m.taskRunBackstopDue(remoteLossKey(repoID, instance)) {
+		if instance.TaskRunActive() && m.taskRunBackstopDue(stableSessionKey(repoID, instance)) {
 			m.observeTaskRunWhilePaused(repoID, key, instance)
 			return
 		}

--- a/daemon/manual_restore_backoff_test.go
+++ b/daemon/manual_restore_backoff_test.go
@@ -36,11 +36,11 @@ import (
 func TestRestoreSession_ImmediateReLossAfterManualRestore_EscalatesNotResets(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	backend := &diesOnSpawnBackend{FakeBackend: session.NewFakeBackend()}
-	registerStarted(t, manager, repoID, repoPath, "flapper", backend, true, session.Lost)
+	inst := registerStarted(t, manager, repoID, repoPath, "flapper", backend, true, session.Lost)
 
 	// The automatic loop has already tried and failed three times: a real backoff
 	// episode is in progress when the user reaches for manual restore.
-	key := daemonInstanceKey(repoID, "flapper")
+	key := stableSessionKey(repoID, inst)
 	manager.mu.Lock()
 	manager.lostRestoreStates[key] = &lostRestoreState{consecutiveFailures: 3}
 	manager.mu.Unlock()
@@ -92,7 +92,7 @@ func TestRestoreSession_LongLivedThenDied_ResetsBackoff(t *testing.T) {
 	inst := registerStarted(t, manager, repoID, repoPath, "long-lived", backend, true, session.Lost)
 	zeroRestoreBackoff(t)
 
-	key := daemonInstanceKey(repoID, "long-lived")
+	key := stableSessionKey(repoID, inst)
 	manager.mu.Lock()
 	manager.lostRestoreStates[key] = &lostRestoreState{consecutiveFailures: 3}
 	manager.mu.Unlock()
@@ -143,9 +143,9 @@ func TestRestoreSession_FailedManualRestoresShareDiagnosticsAndBackoff(t *testin
 		Err:          &os.PathError{Op: "stat", Path: worktreePath, Err: os.ErrNotExist},
 	}
 	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend(), failWith: restoreErr}
-	registerStarted(t, manager, repoID, repoPath, "manual-failure", backend, true, session.Lost)
+	inst := registerStarted(t, manager, repoID, repoPath, "manual-failure", backend, true, session.Lost)
 
-	key := daemonInstanceKey(repoID, "manual-failure")
+	key := stableSessionKey(repoID, inst)
 	manager.mu.Lock()
 	manager.lostRestoreStates[key] = &lostRestoreState{consecutiveFailures: 2}
 	manager.mu.Unlock()

--- a/daemon/remoteloss.go
+++ b/daemon/remoteloss.go
@@ -78,22 +78,34 @@ type remoteLossState struct {
 	firstFailureAt      time.Time
 }
 
-// remoteLossKey identifies the debounce entry for an instance.
+// stableSessionKey is the daemon's key for any state that describes ONE
+// session's runtime rather than one repo/title slot: the remote-loss debounce
+// below, aliveObservations, the Lost-restore retry episode, handoff retry/settle
+// bookkeeping, the paused task-run backstop.
 //
 // It keys on the STABLE INSTANCE ID (#1195), not the repo/title daemon key, so
 // failure state can never outlive the session that earned it. Titles are reused:
-// kill or archive a remote session and create another with the same title, and a
+// kill or archive a session and create another with the same title, and a
 // title-keyed entry would hand the NEW session the OLD one's accumulated
-// failures — one blip would then satisfy the threshold instantly and re-provision
-// a sandbox that had never failed a probe in its life. That is the
-// key-by-title-instead-of-identity class from #1723/#1678/#1738, and the ID is
-// exactly the field #1195 minted to tell "same session" from "title reused".
+// failures. For the debounce that means one blip satisfying the threshold
+// instantly and re-provisioning a sandbox that had never failed a probe in its
+// life; for the Lost-restore episode it means a brand-new session waiting
+// minutes for its first restore because a session the user already discarded
+// failed four times (#2868). That is the key-by-title-instead-of-identity class
+// from #1723/#1678/#1738, and the ID is exactly the field #1195 minted to tell
+// "same session" from "title reused".
+//
+// The ID is what makes a title reuse a DIFFERENT key while a re-provision of the
+// same session keeps the SAME one — which is the distinction every caller here
+// wants, and why the sites that replace a runtime under one identity must retire
+// their own state explicitly (see noteRuntimeReplaced).
 //
 // Legacy records persisted before #1195 carry no ID; they fall back to the
-// daemon key. No remote session can be one of those — the remote runtime landed
-// in #1592, long after — so the fallback only ever serves local sessions, which
-// never enter the debounce at all.
-func remoteLossKey(repoID string, instance *session.Instance) string {
+// daemon key. Nothing materializes an ID-less Instance — FromInstanceData
+// backfills one in memory for exactly this reason, and the daemon load path
+// backfills it durably — so the fallback is a belt-and-braces path, not a live
+// one.
+func stableSessionKey(repoID string, instance *session.Instance) string {
 	if instance.ID != "" {
 		return instance.ID
 	}
@@ -204,7 +216,7 @@ func (m *Manager) noteRuntimeReplaced(repoID string, instance *session.Instance)
 	// predecessor-owned facts together rather than making each caller remember a
 	// second reset site.
 	instance.ClearAgentModelChange()
-	m.clearRemoteLoss(remoteLossKey(repoID, instance))
+	m.clearRemoteLoss(stableSessionKey(repoID, instance))
 }
 
 // sweepRemoteLossStates drops debounce entries that no longer describe anything
@@ -237,7 +249,7 @@ func (m *Manager) sweepRemoteLossStates() {
 			continue // nothing to probe: its entry can never be cleared by an answer
 		}
 		repoID, _ := splitDaemonInstanceKey(key)
-		live[remoteLossKey(repoID, inst)] = struct{}{}
+		live[stableSessionKey(repoID, inst)] = struct{}{}
 	}
 	for key := range m.remoteLossStates {
 		if _, ok := live[key]; !ok {

--- a/daemon/remoteloss.go
+++ b/daemon/remoteloss.go
@@ -100,6 +100,25 @@ type remoteLossState struct {
 // wants, and why the sites that replace a runtime under one identity must retire
 // their own state explicitly (see noteRuntimeReplaced).
 //
+// THE RULE, because this keeps being got wrong one map at a time (#1723, #1678,
+// #1738, #1794, #2868, #2876). Before adding any per-session map to Manager, ask
+// what the entry DESCRIBES:
+//
+//   - A RUNTIME — failures it accumulated, observations of it, work owed to it,
+//     a process it owns: key it here. A title is a slot that outlives its
+//     occupant, so a title-keyed entry is inherited by the next session to take
+//     that name, which is a bug every single time.
+//   - A SLOT — "an exclusive operation is running against this name", "this name
+//     is reserved", the lock that serializes ops on it: key it by
+//     daemonInstanceKey. Being shared with a successor is the entire point, and
+//     these are point-in-time within one operation anyway.
+//
+// If a map is genuinely slot-shaped but its VALUE describes a runtime, the third
+// option is to store the stable id alongside and compare before acting —
+// deferredTaskLifecycle and vscodeSupervisor.servers both do this deliberately,
+// and killRetries instead drops its entry at the very events that free the title.
+// What is never safe is a title key, a runtime-shaped value, and no guard.
+//
 // Legacy records persisted before #1195 carry no ID; they fall back to the
 // daemon key. Nothing materializes an ID-less Instance — FromInstanceData
 // backfills one in memory for exactly this reason, and the daemon load path

--- a/daemon/restore.go
+++ b/daemon/restore.go
@@ -123,10 +123,13 @@ func (m *Manager) restoreLostOrDeadSession(repoID, title string, instance *sessi
 	case probeAlive:
 		log.InfoLog.Printf("not re-provisioning session %q: its sandbox answers as alive, so it was never lost — clearing the Lost mark instead (re-provisioning would orphan it and discard unpushed work)", title)
 		_ = instance.Transition(session.ObserveLiveness(session.LiveRunning))
-		m.clearRemoteLoss(remoteLossKey(repoID, instance))
+		// Both of these are per-runtime state and both are filed under the session's
+		// stable identity, never under the repo/title `key` above (#2868).
+		stateKey := stableSessionKey(repoID, instance)
+		m.clearRemoteLoss(stateKey)
 		m.persistInstance(repoID, instance)
 		m.mu.Lock()
-		delete(m.lostRestoreStates, key)
+		delete(m.lostRestoreStates, stateKey)
 		m.mu.Unlock()
 		return instance.GetWorktreePath(), nil
 	case probeUnknown:
@@ -156,6 +159,6 @@ func (m *Manager) restoreLostOrDeadSession(repoID, title string, instance *sessi
 	// auto path now prevents (#1976). consecutiveFailures is CARRIED; RestoreLostSessions
 	// clears the state once a poll observes the runtime alive, and the auto loop charges
 	// an immediate re-loss against the same episode.
-	m.armRestoreConfirmation(key, repoID, instance)
+	m.armRestoreConfirmation(repoID, instance)
 	return instance.GetWorktreePath(), nil
 }

--- a/daemon/status_probedue_leak_test.go
+++ b/daemon/status_probedue_leak_test.go
@@ -10,7 +10,7 @@ import (
 // registerTaskRun seeds a started, task-run-active instance — the only shape
 // that arms taskRunProbeDue. taskRunActive is derived from TaskID (#1892), so a
 // non-empty TaskID is what distinguishes this from registerStarted's user
-// session. The instance still carries a stable ID (remoteLossKey's basis), which
+// session. The instance still carries a stable ID (stableSessionKey's basis), which
 // is exactly the key the backstop timer is stored under.
 func registerTaskRun(t *testing.T, m *Manager, repoID, repoPath, title string) *session.Instance {
 	t.Helper()
@@ -40,7 +40,7 @@ func probeDueLen(m *Manager) int {
 
 // TestResumeStatusPoll_FreesTaskRunProbeDueEntry is the #2015 fail-first: a clean
 // detach must FREE the backstop-timer entry an attach armed. The map is written
-// by taskRunBackstopDue under remoteLossKey (the stable instance ID), but the
+// by taskRunBackstopDue under stableSessionKey (the stable instance ID), but the
 // buggy ResumeStatusPoll deletes under daemonInstanceKey(repoID,title) — keys
 // that never coincide for an ID-bearing session — so the delete is a no-op and
 // the entry leaks. The map must return to its pre-attach baseline of 0.
@@ -49,7 +49,7 @@ func TestResumeStatusPoll_FreesTaskRunProbeDueEntry(t *testing.T) {
 	inst := registerTaskRun(t, manager, repoID, repoPath, "attached-run")
 
 	if inst.ID == "" {
-		t.Fatal("precondition: a task-run instance must carry a stable ID (remoteLossKey's basis)")
+		t.Fatal("precondition: a task-run instance must carry a stable ID (stableSessionKey's basis)")
 	}
 	if !inst.TaskRunActive() {
 		t.Fatal("precondition: instance must be task-run-active to arm the backstop")

--- a/daemon/status_remote_test.go
+++ b/daemon/status_remote_test.go
@@ -595,7 +595,7 @@ func TestRefreshStatuses_NewSessionDoesNotInheritDebounceState(t *testing.T) {
 	advance(time.Second)
 	manager.RefreshStatuses()
 	manager.mu.Lock()
-	freshState := manager.remoteLossStates[remoteLossKey(repoID, fresh)]
+	freshState := manager.remoteLossStates[stableSessionKey(repoID, fresh)]
 	manager.mu.Unlock()
 	if freshState == nil || freshState.consecutiveFailures != 1 {
 		t.Fatalf("new session failure state = %#v, want a fresh one-failure episode", freshState)

--- a/daemon/vscode_server.go
+++ b/daemon/vscode_server.go
@@ -494,6 +494,14 @@ type vscodeSupervisor struct {
 type vscodeFailure struct {
 	err error
 	at  time.Time
+	// instanceID scopes the cooldown to the session that earned it. The map is
+	// keyed by daemonInstanceKey, which addresses a title slot rather than a
+	// session, so without this a successor reusing that title inside the cooldown
+	// gets its predecessor's spawn error replayed instead of a spawn attempt
+	// (#2868/#2876, the same class one map over). Short-lived and self-healing —
+	// unlike the restore and limit backoffs — but the guard costs one comparison,
+	// and "the window is small" is how a class survives an audit.
+	instanceID string
 }
 
 func newVSCodeSupervisor() *vscodeSupervisor {
@@ -569,7 +577,7 @@ func (v *vscodeSupervisor) reconcilePersistedBeforeSpawn(key, instanceID string)
 	if server != nil && !hasLiveServer {
 		delete(v.servers, key)
 		if !server.ready {
-			v.failures[key] = vscodeFailure{err: errVSCodeStartExited, at: v.now()}
+			v.failures[key] = vscodeFailure{err: errVSCodeStartExited, at: v.now(), instanceID: instanceID}
 		}
 	}
 	v.mu.Unlock()
@@ -654,15 +662,16 @@ func (v *vscodeSupervisor) ensureServerForInstance(key, instanceID, worktree str
 			// and must still respawn at once, so it is deliberately not recorded.
 			if neverReady {
 				v.failures[key] = vscodeFailure{
-					err: errVSCodeStartExited,
-					at:  v.now(),
+					err:        errVSCodeStartExited,
+					at:         v.now(),
+					instanceID: s.instanceID,
 				}
 			}
 		}
 	}
 	// Replay a recent failure instead of respawning, so the notice page's refresh
 	// can't drive a spawn loop against a broken editor.
-	if f, ok := v.failures[key]; ok && v.now().Sub(f.at) < v.cooldown {
+	if f, ok := v.failures[key]; ok && f.instanceID == instanceID && v.now().Sub(f.at) < v.cooldown {
 		return vscodeEndpoint{}, f.err
 	}
 
@@ -675,7 +684,7 @@ func (v *vscodeSupervisor) ensureServerForInstance(key, instanceID, worktree str
 
 	server, err := v.spawnLocked(key, instanceID, binary, worktree)
 	if err != nil {
-		v.failures[key] = vscodeFailure{err: err, at: v.now()}
+		v.failures[key] = vscodeFailure{err: err, at: v.now(), instanceID: instanceID}
 		return vscodeEndpoint{}, err
 	}
 	delete(v.failures, key)


### PR DESCRIPTION
Closes #2868.
Closes #2876.

Two instances of one class, fixed together, plus a third the audit turned up.

## The bug

`lostRestoreStates` holds the Lost-session restore loop's retry episode for one
session: how many consecutive restores failed, when the next attempt is due, how
far the alive-observation counter had advanced at the last respawn, which missing
worktree has already been logged. It was filed under the **repo/title daemon
key** — and a title is a *slot* that outlives its occupant.

So the episode outlived the session that earned it. Kill or archive a session
whose restores have been failing, create another with the same name, and the new
session moves into a slot that still holds its predecessor's history: its very
first hiccup is charged as failure five, and it waits 160 seconds for a retry it
should have gotten in ten. A brand-new session, born broken for reasons belonging
to one the user already discarded.

Both ways of freeing a title reach it, and they leave the manager map in
different shapes:

- **kill** removes the row, then the create puts a new instance under the same key;
- **reuse-archived-name** (`renameArchivedForReuseLocked`) *renames* the archived
  row and leaves it in the map under a new key, so the successor moves into a key
  whose state nothing reaps.

The two halves of the mechanism had already disagreed with each other, which is
what kept the stale entry alive through the sweep: `armRestoreConfirmation` stored
`observedAtSpawn` from `aliveObservations`, which is keyed by **instance ID**,
into a state filed under the **title**. A successor's zeroed counter can never
advance past a value its predecessor earned, so `observedAliveSinceSpawnLocked`
answered "not confirmed yet" forever and the sweep kept the state.

This is the key-by-title-instead-of-identity class from #1723/#1678/#1738.
`remoteLossStates` was moved to the stable id for exactly this reason and carries
a comment saying so; `lostRestoreStates` was left behind.

## The fix

File the episode under `stableSessionKey` — the stable instance id (#1195) — the
way every other per-runtime map in the daemon already is. A re-provision keeps the
same id (same session, new runtime), a title reuse mints a new one, which is
precisely the distinction these maps need.

Three consequences worth naming:

- `restoreLostSession` now carries **two** keys on purpose. `key` (repo/title)
  still addresses the *slot* — `killsInFlight`, the per-session op lock, the
  `m.instances` re-read. `stateKey` addresses the *session*, which is what a
  failure episode is about.
- The sweep's reap loop can no longer index `m.instances` by the state key, so it
  builds a live set of stable ids. That set treats an **unstarted or Archived** row
  as not live — same rule and same reason as `sweepRemoteLossStates`. Archiving
  tears the runtime down, so an episode held awaiting a liveness observation would
  never get one, and the row stays in `m.instances` under the same id: presence
  alone would keep it for the daemon's whole life.
- `remoteLossKey` is renamed to `stableSessionKey`. Six maps now key on it
  (remote-loss debounce, `aliveObservations`, handoff retry/settle, the paused
  task-run backstop, and now this one), and the remote-specific name actively
  misled at the site this PR fixes — the reason to reach for the daemon key
  instead. Pure rename, no behavior.

## Watch it fail first

The regression test landed in its own commit **before** the fix, so CI ran it
against an otherwise-unmodified tree:

- Test-only head (a186aa5b): **RED** — `tracked episodes ... = [5], want exactly
  one episode with one failure`, on both the kill and the archive variant, plus
  the retained-after-archive leak.
- With the fix: green.

The assertions deliberately name no map key. Which key an episode is filed under
is the thing under test, so a by-key lookup would have failed against the buggy
build for the *wrong* reason — reading a key that build never writes, and
reporting a missing precondition instead of an inherited backoff. Asked as "how
many episodes exist and how much has each accumulated", the same assertion means
the same thing on both builds.

The second assertion is the user-visible one: the new session's next-attempt
deadline must be within one backoff base (10s), not the 160s an inherited count
buys.

## #2876, folded in

`limitResumeStates` (usage-limit auto-resume, #1146) had the identical keying,
and it is the **worse** of the two: `nextAttempt` there is a *gate*, not a
counter. A successor moving into a title whose predecessor was mid-backoff was
not merely slow to be resumed — it was **not resumed at all**, silently, until
the discarded session's backoff expired. A user watching a fresh session sit
parked at a usage-limit wall just sees auto-resume not work.

Its sweep could not save it, for a reason that makes the window the common case
rather than a corner: an entry is dropped only once the session has left
`LiveLimitReached` **and** its backoff has elapsed. "Inside its backoff" is
exactly the state that is never cleared — and a user kills a session precisely
when its agent is stuck at a wall.

Same fix, same shape: episode under `stableSessionKey`, repo/title key retained
for the slot-scoped gates, reap by a live set of stable ids.

Its tests followed the same watch-it-fail discipline in their own commit
(`8c57d95e`), and assert the user-visible outcome — the successor's prompt IS
re-delivered when its own window elapses — rather than a counter, because being
silently skipped is what the bug actually does.

## Audit: every per-session map in `daemon/`

#2876 landing on the same day made it clear this is a pattern, not a field, so I
walked all 28 string-keyed `Manager` maps plus the vscode supervisor rather than
fixing one and waiting for the next report. Grouped by verdict:

**Wrongly title-keyed — runtime-shaped state, no guard**

| map | verdict |
| --- | --- |
| `lostRestoreStates` | **fixed here** (#2868) |
| `limitResumeStates` | **fixed here** (#2876) |
| `vscodeSupervisor.failures` | **fixed here** — see below |

The third one is the audit's own find, not a filed report. `vscodeSupervisor.failures`
is title-keyed and its spawn cooldown was replayed *before* any identity
comparison, so a successor reusing a title within `vscodeRespawnCooldown` got its
predecessor's spawn error returned instead of a spawn attempt. The window is 5s
and it self-heals, which is exactly why it would have survived a less mechanical
audit — so it is now scoped to the session that earned it, like its neighbours in
the same struct.

**Already keyed by stable id** — `aliveObservations`, `remoteLossStates`,
`handoffRetryDue`, `handoffSettleOwed`, `taskRunProbeDue`. `remoteLossStates` was
correct in code but its `manager.go` comment *said* "keyed by daemon instance
key" — that is the comment a reader consults when keying the next map, and
`lostRestoreStates` is what came of consulting it. Corrected in `feeceb44`.

**Title-keyed with a deliberate identity guard on the value** — checked each,
all safe (and the shape the vscode fix above now joins):

- `deferredTaskLifecycle` — stores `instance.ID` as the value and refuses to act
  on a mismatch, plus a sweep that drops them.
- `vscodeSupervisor.servers` — `server.instanceID` is compared on both the ensure
  path (`alive && s.instanceID != instanceID`) and teardown.
- `killRetries` — dropped by `forgetKillRetry` on a completed teardown and by any
  explicit `KillSession`, i.e. at the exact events that free the title. Its own
  doc already names this hazard.

**Title-keyed by design** — a title *is* the identity there, and sharing with a
successor is the point: `instances`, `reservedTitles`, `pendingCreates`,
`reservedTmuxNames`, `reservedRemoteNames`, `killsInFlight`, `restoresInFlight`,
`instanceOpLocks`, `targetLocks`, `repoStartLocks`. All are slot-exclusion or
name-reservation, and all are point-in-time within one operation.

**Not session-scoped** — `rootEnsureStates` (config path), `rootKilledAt` /
`deletedRootRepos` / `rootAgent*` / `projectDeletes` (repo id), `reservedTaskRuns`
/ `ghostTaskRuns` (task id), `pendingConversationCaptures` (instance pointer).

**One residual, bounded and left alone** — `pausedPolls` keys by stable id when
the client sends one and falls back to the daemon key only for legacy ID-less
callers. A legacy pause could suppress a successor's poll, but every entry is
lease-bounded (`statusPollLease`) so it self-heals within one lease, and the
resume must match the writer's key — changing it would break pause/resume pairing
for exactly the clients the fallback exists for.

To stop the next one, `stableSessionKey`'s doc now states the rule directly
(runtime → identity, slot → daemon key, slot-shaped-with-runtime-value → store
the id and compare) rather than leaving it to be re-derived per map.
