### PR TITLE
fix(reset): a tmux listing that FAILED is not an empty session set

### DIFF
--- a/commands/reset.go
+++ b/commands/reset.go
@@ -329,8 +329,17 @@ func runReset(cmd *cobra.Command, _ []string) (err error) {
 	}
 
 	// 5. Clean up tmux sessions before deleting the records that name them.
-	if err := cleanupTmuxSessionsFn(); err != nil {
-		return fmt.Errorf("failed to cleanup tmux sessions: %w", err)
+	//    A sweep that could not READ the session set aborts the whole reset
+	//    (#2870), rather than warning and continuing: the listing is what tells
+	//    reset which sessions are live, so proceeding without it deletes
+	//    worktrees and prunes branches with their fate unknown, and a warning is
+	//    no safeguard once the worktree is gone. Same rule as 4b/4d for the
+	//    daemon and planFactoryReset for unreadable records — and nothing
+	//    destructive has run yet, so the abort costs the user one command.
+	if cleanupErr := cleanupTmuxSessionsFn(); cleanupErr != nil {
+		err = fmt.Errorf("failed to cleanup tmux sessions: %w", cleanupErr)
+		fmt.Fprintln(out, "\nNothing was removed: no worktree, branch, session record, or task was touched.")
+		return err
 	}
 	fmt.Fprintln(out, "Tmux sessions have been cleaned up")
 
@@ -554,11 +563,6 @@ func planFactoryReset() (*resetPlan, error) {
 		}
 	}
 
-	// Cross-check the instances/ dir: any repoID directory GetAllInstances did
-	// NOT surface (e.g. an unsupported newer schema version it skipped upstream)
-	// is a record we cannot read. Treat it like a corrupt one — leave it and its
-	// branches intact rather than erasing it wholesale — so an unreadable record
-	// never has its branch orphaned or deleted by guessing.
 	seen := make(map[string]struct{}, len(plan.processedRepoIDs)+len(plan.corruptRepoIDs))
 	for _, id := range plan.processedRepoIDs {
 		seen[id] = struct{}{}
@@ -566,17 +570,11 @@ func planFactoryReset() (*resetPlan, error) {
 	for _, id := range plan.corruptRepoIDs {
 		seen[id] = struct{}{}
 	}
-	if entries, derr := os.ReadDir(filepath.Join(dir, "instances")); derr == nil {
-		for _, e := range entries {
-			if !e.IsDir() {
-				continue
-			}
-			if _, ok := seen[e.Name()]; !ok {
-				log.WarningLog.Printf("reset: leaving repo %s intact: unreadable session records", e.Name())
-				plan.corruptRepoIDs = append(plan.corruptRepoIDs, e.Name())
-			}
-		}
+	unsurfaced, err := unreadableRepoIDs(filepath.Join(dir, "instances"), seen)
+	if err != nil {
+		return nil, err
 	}
+	plan.corruptRepoIDs = append(plan.corruptRepoIDs, unsurfaced...)
 
 	// NOTE: there is deliberately NO current-repo fallback. The pre-#1736 reset
 	// forced the cwd's repo into a bulk worktree cleanup even when it had no AF

--- a/commands/reset_records.go
+++ b/commands/reset_records.go
@@ -1,0 +1,47 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// unreadableRepoIDs cross-checks the on-disk instances/ directory against the
+// repoIDs GetAllInstances actually surfaced, and returns the ones it did not.
+//
+// It is a compensating control, not a nicety: LoadAllRepoInstances SKIPS a
+// per-repo record file it cannot read (an unsupported newer schema version, a
+// permission failure) and returns the rest, so a repo can be absent from its map
+// while its records — and the branches those records describe — are very much
+// still on disk. Reset treats each one it finds here like a corrupt record:
+// leave the repo and its branches intact rather than erasing it wholesale, so an
+// unreadable record never has its branch orphaned or deleted by guessing.
+//
+// Which is exactly why a FAILED read of this directory may not answer "no
+// additional repos" (#2870). That answer silently disables the control, and the
+// wipe then takes the whole instances/ tree including the records nobody could
+// read. A missing directory is a determinate empty — a home with no records has
+// nothing to preserve, and must still be resettable — but anything else fails
+// closed, at plan time, before a single byte is deleted.
+func unreadableRepoIDs(instancesDir string, seen map[string]struct{}) ([]string, error) {
+	entries, err := os.ReadDir(instancesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read stored session records in %s: %w", instancesDir, err)
+	}
+	var unsurfaced []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, ok := seen[e.Name()]; ok {
+			continue
+		}
+		log.WarningLog.Printf("reset: leaving repo %s intact: unreadable session records", e.Name())
+		unsurfaced = append(unsurfaced, e.Name())
+	}
+	return unsurfaced, nil
+}

--- a/commands/reset_tmux_listing_test.go
+++ b/commands/reset_tmux_listing_test.go
@@ -1,0 +1,192 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cmdutil "github.com/sachiniyer/agent-factory/cmd"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+// failingListTmuxOnPath puts a `tmux` earlier on PATH whose `ls` exits 1 with an
+// AMBIGUOUS diagnostic — a reachable socket we are not permitted to talk to, so
+// sessions may well be running behind it. Every other subcommand exits non-zero,
+// so any attempt to continue the sweep fails loudly instead of silently
+// succeeding against a fake.
+func failingListTmuxOnPath(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	script := `#!/bin/sh
+case "$1" in
+ls)
+  echo "error connecting to /tmp/tmux-1000/default (Permission denied)" >&2
+  exit 1
+  ;;
+*)
+  exit 97
+  ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestFactoryReset_RefusesWhenTmuxListingFails is the #2870 end-to-end lock, and
+// the reason it drives the REAL tmux.CleanupSessions instead of a stub: the
+// defect was that a failed read returned nil, so any test that stubs the cleanup
+// out cannot see it. Every other destructive boundary is still faked.
+//
+// `af reset` deletes worktrees, prunes branches, and erases records. It lists
+// tmux sessions first precisely so it knows what is live before it destroys
+// anything — so a listing that FAILED, read as "there are no sessions", hands
+// reset a licence to destroy exactly the work that check exists to protect. The
+// user sees a clean run, not an error.
+func TestFactoryReset_RefusesWhenTmuxListingFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	t.Chdir(t.TempDir())
+
+	repo, liveWT, reusedWT := seedMockRepo(t, home)
+	seedAFState(t, home, repo, liveWT, reusedWT)
+	repoID := config.RepoIDFromRoot(repo)
+	instancesPath := filepath.Join(home, "instances", repoID, "instances.json")
+	recordsBefore, err := os.ReadFile(instancesPath)
+	if err != nil {
+		t.Fatalf("read seeded instances: %v", err)
+	}
+
+	fakeDaemonSeams(t)
+	failingListTmuxOnPath(t)
+	// The real sweep, against a tmux that cannot answer. This is the seam the
+	// bug lived behind.
+	cleanupTmuxSessionsFn = func() error { return tmux.CleanupSessions(cmdutil.MakeExecutor()) }
+
+	out, err := runResetCapture(t)
+	if err == nil {
+		t.Fatalf("runReset returned nil after tmux refused to list sessions — reset proceeded to "+
+			"destroy worktrees, branches, and records with the live session set unknown (#2870).\noutput:\n%s", out)
+	}
+	for _, want := range []string{"could not list tmux sessions", "Permission denied"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q, want it to contain %q so the user can see what was unreadable", err, want)
+		}
+	}
+	if !strings.Contains(out, "Nothing was removed") {
+		t.Errorf("reset output does not tell the user nothing was removed:\n%s", out)
+	}
+	if strings.Contains(out, "Tmux sessions have been cleaned up") {
+		t.Errorf("reset claimed the tmux sweep succeeded:\n%s", out)
+	}
+	if strings.Contains(out, "Factory reset complete") {
+		t.Errorf("reset reported completion after refusing:\n%s", out)
+	}
+
+	// --- Nothing was destroyed ---
+	if _, err := os.Stat(liveWT); err != nil {
+		t.Errorf("live AF worktree %s was removed despite the refusal: %v", liveWT, err)
+	}
+	if _, err := os.Stat(reusedWT); err != nil {
+		t.Errorf("AF worktree %s was removed despite the refusal: %v", reusedWT, err)
+	}
+	for _, branch := range []string{"af-session-1", "af-session-2", "my-feature", "reused-linked", "master"} {
+		if !branchExists(repo, branch) {
+			t.Errorf("branch %s was pruned despite the refusal", branch)
+		}
+	}
+	recordsAfter, err := os.ReadFile(instancesPath)
+	if err != nil {
+		t.Fatalf("session records were erased despite the refusal: %v", err)
+	}
+	if string(recordsAfter) != string(recordsBefore) {
+		t.Errorf("session records changed despite the refusal:\n got %s\nwant %s", recordsAfter, recordsBefore)
+	}
+	tasks, err := task.LoadTasks()
+	if err != nil {
+		t.Fatalf("LoadTasks: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Errorf("tasks after the refusal = %d, want 2 (untouched)", len(tasks))
+	}
+	for _, name := range []string{"archived", "events", "logs", "locks", config.StateFileName} {
+		if _, err := os.Stat(filepath.Join(home, name)); err != nil {
+			t.Errorf("%s was wiped despite the refusal: %v", name, err)
+		}
+	}
+
+	// --- And the refusal is recoverable: with tmux answering, the same home
+	//     still resets cleanly. A fail-closed guard that leaves the user stuck
+	//     would be its own bug.
+	cleanupTmuxSessionsFn = func() error { return nil }
+	if _, err := runResetCapture(t); err != nil {
+		t.Fatalf("re-running reset after the tmux failure cleared: %v", err)
+	}
+	assertGone(t, filepath.Join(home, "instances"))
+	assertGone(t, liveWT)
+}
+
+// TestPlanFactoryReset_UnreadableRecordDirIsNotAnEmptyOne is the sibling read in
+// the same command. planFactoryReset cross-checks <AF_HOME>/instances against
+// the repos GetAllInstances surfaced, because LoadAllRepoInstances SKIPS a repo
+// file it cannot read — the cross-check is what turns a skipped repo into a
+// preserved one, so its branches are not orphaned by a wholesale delete.
+//
+// A failed directory read must therefore not answer "no additional repos": that
+// silently disables the compensating control and lets the wipe take the whole
+// instances/ tree, including records nobody could read.
+//
+// It tests the guard directly rather than through planFactoryReset, and that is
+// deliberate: LoadAllRepoInstances reads the SAME directory a few lines earlier
+// and already fails closed on it, so a whole-command test would abort there and
+// pass with or without this fix — asserting the claim while checking something
+// weaker. Only the window between the two reads reaches this branch, and only
+// this test can prove what happens in it.
+func TestPlanFactoryReset_UnreadableRecordDirIsNotAnEmptyOne(t *testing.T) {
+	seen := map[string]struct{}{"known-repo": {}}
+
+	t.Run("missing directory is a determinate empty", func(t *testing.T) {
+		ids, err := unreadableRepoIDs(filepath.Join(t.TempDir(), "instances"), seen)
+		if err != nil {
+			t.Fatalf("unreadableRepoIDs on a missing dir = %v, want nil: a home with no records "+
+				"has nothing to preserve and must still be resettable", err)
+		}
+		if len(ids) != 0 {
+			t.Errorf("ids = %v, want none", ids)
+		}
+	})
+
+	t.Run("unsurfaced repo is reported", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "instances")
+		mkdir(t, filepath.Join(dir, "known-repo"))
+		mkdir(t, filepath.Join(dir, "skipped-repo"))
+		writeFile(t, filepath.Join(dir, "stray-file"), "not a repo dir")
+		ids, err := unreadableRepoIDs(dir, seen)
+		if err != nil {
+			t.Fatalf("unreadableRepoIDs = %v, want nil", err)
+		}
+		if len(ids) != 1 || ids[0] != "skipped-repo" {
+			t.Errorf("ids = %v, want [skipped-repo]", ids)
+		}
+	})
+
+	t.Run("unreadable directory aborts", func(t *testing.T) {
+		// A regular file where the directory should be: ReadDir fails with
+		// ENOTDIR for every user, root included, so this pins the guard without
+		// depending on file modes.
+		notADir := filepath.Join(t.TempDir(), "instances")
+		writeFile(t, notADir, "")
+		ids, err := unreadableRepoIDs(notADir, seen)
+		if err == nil {
+			t.Fatalf("unreadableRepoIDs on an unreadable dir = (%v, nil) — a failed read was reported "+
+				"as 'no additional repos', which lets the wipe delete records it could not read", ids)
+		}
+		if !strings.Contains(err.Error(), notADir) {
+			t.Errorf("error = %q, want it to name the path that could not be read", err)
+		}
+	})
+}

--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -57,7 +57,18 @@ const (
 )
 
 // listTmuxSessions returns every session name on the current tmux server.
-// A missing server (exit 1) is an empty list, mirroring CleanupSessions.
+//
+// It collapses EVERY failure into an empty list, which is wrong and is tracked
+// as #2874: `tmux ls` exits 1 both for "there is no server" and for "I could not
+// reach the server", so an unreachable socket reads here as "no sessions are
+// live" — and checkOrphanedProcesses turns that into an armed `kill pid N` for
+// every live session's processes. Do not build anything new on this list until
+// it is three-valued.
+//
+// The comment this replaces cited CleanupSessions as the model. That stopped
+// being true in #2870, which made the reset-side listing distinguish tmux's
+// definitive no-server diagnostics from an unreadable one and fail closed;
+// session/tmux has the classifier this needs.
 func listTmuxSessions(ctx *scanContext) []string {
 	out, err := ctx.opts.Exec.Output(exec.Command("tmux", "ls", "-F", "#{session_name}"))
 	if err != nil {

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -135,18 +135,82 @@ func probeSessionStrict(cmdExec cmd.Executor, name string) (exists bool, known b
 // missingTmuxSession recognizes tmux's explicit exact-target absence answer.
 // Exit status 1 alone is ambiguous: wrapper, policy, and unclassified connection
 // failures can return the same status while the named session remains unknown.
-// An explicit no-server diagnostic is also definitive: no session can remain.
+// A definitive no-server answer counts too: no session can remain on a socket
+// that holds no server.
 func missingTmuxSession(err error, name string) bool {
-	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+	diagnostic, ok := tmuxExitOneDiagnostic(err)
+	if !ok {
 		return false
 	}
-	diagnostic := strings.TrimSpace(string(exitErr.Stderr))
-	if diagnostic == "can't find session: "+name {
-		return true
+	return diagnostic == "can't find session: "+name || noTmuxServerDiagnostic(diagnostic)
+}
+
+// tmuxExitOneDiagnostic returns the trimmed stderr of a tmux command that
+// exited with status 1, and whether it did. Only status 1 qualifies: tmux
+// reports both "the thing you asked about is absent" and "I could not reach the
+// server" with it, so the diagnostic is the ONLY thing that separates them, and
+// any other status is a failure mode tmux does not document a diagnostic for.
+func tmuxExitOneDiagnostic(err error) (string, bool) {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+		return "", false
 	}
-	serverSocket, noServer := strings.CutPrefix(diagnostic, "no server running on ")
-	return noServer && strings.TrimSpace(serverSocket) != ""
+	return strings.TrimSpace(string(exitErr.Stderr)), true
+}
+
+// noTmuxServerDiagnostic reports whether a tmux exit-1 diagnostic is tmux's
+// DEFINITIVE "there is no server on this socket" answer — which, for a listing,
+// is the difference between "there are no sessions" and "I could not find out".
+//
+// tmux's client prints the ECONNREFUSED case by name and routes every other
+// connect(2) failure through strerror, so exactly two diagnostics are definitive
+// (both measured against tmux 3.4):
+//
+//   - "no server running on <socket>" — the socket exists and refused us, so
+//     nothing is listening on it. A server that exits leaves its socket file
+//     behind, so this is what a server that has DIED says.
+//   - "error connecting to <socket> (No such file or directory)" — ENOENT: the
+//     socket does not exist, so no server ever created one there. This is the
+//     ordinary answer on a machine with no tmux server, and it is why the set
+//     cannot be narrowed to the line above: doing so would make `af reset`
+//     refuse to run for most users (#2870).
+//
+// Everything else leaves the session set unknown — (Permission denied) and other
+// connect failures, tmux's own socket-directory refusals, a wrapper's exit 1,
+// and an empty diagnostic. A "no server" line that names no socket is not tmux's
+// answer either, so it is not accepted.
+//
+// The strings are matched in tmux's own C locale: tmux calls setlocale only for
+// LC_CTYPE, so strerror stays untranslated regardless of the user's LANG.
+func noTmuxServerDiagnostic(diagnostic string) bool {
+	if socket, refused := strings.CutPrefix(diagnostic, "no server running on "); refused {
+		return strings.TrimSpace(socket) != ""
+	}
+	rest, connectFailure := strings.CutPrefix(diagnostic, "error connecting to ")
+	if !connectFailure {
+		return false
+	}
+	socket, absent := strings.CutSuffix(rest, " (No such file or directory)")
+	return absent && strings.TrimSpace(socket) != ""
+}
+
+// tmuxDiagnosticSuffix renders tmux's stderr as a parenthesized clause for an
+// error message, or "" when there is nothing to render.
+//
+// It exists because an (*exec.ExitError).Error() is only "exit status N": tmux's
+// actual reason — the socket it could not reach and why — lives in Stderr, and
+// an error that omits it tells the user of a REFUSED reset nothing about what to
+// fix. Whitespace is collapsed so a multi-line diagnostic stays one line.
+func tmuxDiagnosticSuffix(err error) string {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return ""
+	}
+	diagnostic := strings.Join(strings.Fields(string(exitErr.Stderr)), " ")
+	if diagnostic == "" {
+		return ""
+	}
+	return " (" + diagnostic + ")"
 }
 
 // exactTarget builds an exact-match `-t` target spec for the named session.
@@ -186,8 +250,23 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 	listTimedOut := listCtx.Err() != nil
 	listCancel()
 
-	// If there's an error and it's because no server is running, that's fine
-	// Exit code 1 typically means no sessions exist
+	// The listing has THREE outcomes and they must never collapse into two
+	// (#2870). `af reset` calls this before it deletes worktrees, prunes
+	// branches, and erases records, so "there are no sessions" is a licence to
+	// destroy — and it may only be issued when tmux actually ANSWERED:
+	//
+	//   listed, and here they are  -> err == nil, fall through and sweep them.
+	//   listed, and there are none -> a definitive no-server diagnostic (or an
+	//                                 empty successful listing); return nil.
+	//   could not list             -> abort. Fail CLOSED, with the underlying
+	//                                 error: a warning here is not a safeguard,
+	//                                 because by the time it is read the
+	//                                 worktree is gone.
+	//
+	// This is the same rule the storage half of the reset already follows — an
+	// unreadable instances.json is preserved rather than treated as an empty
+	// repo (#868/#869) — applied to the one read that was still collapsing
+	// "I could not tell" into "nothing is there".
 	if err != nil {
 		if listTimedOut {
 			// A wedged server has told us NOTHING about what is running, so the
@@ -196,10 +275,14 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 			// success for a reset that swept nothing.
 			return fmt.Errorf("%w: tmux ls after %s", ErrTmuxTimeout, tmuxCommandTimeout)
 		}
-		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
-			return nil // No sessions to clean up
+		if diagnostic, exitOne := tmuxExitOneDiagnostic(err); exitOne && noTmuxServerDiagnostic(diagnostic) {
+			return nil // tmux answered: no server on this socket, so no sessions
 		}
-		return fmt.Errorf("failed to list tmux sessions: %v", err)
+		// Name what was unreadable AND what was therefore not done. tmux writes
+		// its reason to stderr, which the bare error swallows — `exit status 1`
+		// on its own gives the user nothing to act on.
+		return fmt.Errorf("could not list tmux sessions%s; refusing to sweep with the session set "+
+			"unknown — no tmux session was killed: %w", tmuxDiagnosticSuffix(err), err)
 	}
 
 	// Anchor to start-of-line so `af_` embedded in a non-agent session name

--- a/session/tmux/cleanup_list_test.go
+++ b/session/tmux/cleanup_list_test.go
@@ -1,0 +1,257 @@
+package tmux
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/cmd"
+)
+
+// listFailureTmuxOnPath puts a `tmux` earlier on PATH whose `ls` fails with the
+// given exit status and stderr diagnostic. Every OTHER subcommand touches
+// touched and exits non-zero, so a test can assert that a refused listing
+// reached no further tmux command at all — the sweep stopped, it did not
+// merely report.
+func listFailureTmuxOnPath(t *testing.T, touched, diagnostic string, exitCode int) {
+	t.Helper()
+	dir := t.TempDir()
+	script := fmt.Sprintf(`#!/bin/sh
+case "$1" in
+ls)
+  printf '%%s\n' "$LS_DIAGNOSTIC" >&2
+  exit %d
+  ;;
+*)
+  : > "$TOUCHED_MARKER"
+  exit 97
+  ;;
+esac
+`, exitCode)
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("LS_DIAGNOSTIC", diagnostic)
+	t.Setenv("TOUCHED_MARKER", touched)
+}
+
+// TestCleanupSessionsListFailureIsNotAnEmptySessionSet is the #2870 regression
+// lock: `af reset` calls CleanupSessions before it deletes worktrees, branches,
+// and records, so a FAILED listing read as "there are no sessions" licenses the
+// destruction the listing exists to prevent.
+//
+// `tmux ls` exits 1 for BOTH outcomes, so the exit status alone cannot separate
+// them; only the diagnostic can. The table below is measured against tmux 3.4 —
+// every string here is one tmux actually emits — and it pins both directions:
+//
+//   - The two DEFINITIVE absences must still return nil, or `af reset` breaks on
+//     every machine that simply has no tmux server running. That is not a
+//     hypothetical: the socket-absent (ENOENT) line is the everyday no-server
+//     answer, because tmux only prints "no server running on" for a socket it
+//     could reach and be REFUSED by.
+//   - Everything else must abort, and must abort BEFORE any other tmux command
+//     runs.
+func TestCleanupSessionsListFailureIsNotAnEmptySessionSet(t *testing.T) {
+	cases := []struct {
+		name       string
+		diagnostic string
+		exitCode   int
+		wantAbort  bool
+	}{
+		{
+			// A server that exited leaves its socket file behind, so the next
+			// connect is REFUSED. Measured: this is what `tmux ls` says after the
+			// last session dies.
+			name:       "server exited, socket refused",
+			diagnostic: "no server running on /tmp/tmux-1000/default",
+			exitCode:   1,
+		},
+		{
+			// The socket was never created — a machine where tmux has not run.
+			// Measured: this, NOT the line above, is the ordinary "no sessions"
+			// answer, so refusing here would break reset for most users.
+			name:       "socket absent",
+			diagnostic: "error connecting to /tmp/tmux-1000/default (No such file or directory)",
+			exitCode:   1,
+		},
+		{
+			// The reported bug: a reachable socket we are not allowed to talk to.
+			// Sessions may be running; we cannot see them.
+			name:       "permission denied",
+			diagnostic: "error connecting to /tmp/tmux-1000/default (Permission denied)",
+			exitCode:   1,
+			wantAbort:  true,
+		},
+		{
+			name:       "connect timed out",
+			diagnostic: "error connecting to /tmp/tmux-1000/default (Connection timed out)",
+			exitCode:   1,
+			wantAbort:  true,
+		},
+		{
+			// tmux's own socket-directory guards, which never reach connect(2).
+			name:       "socket directory rejected",
+			diagnostic: "directory /tmp/tmux-1000 has unsafe permissions",
+			exitCode:   1,
+			wantAbort:  true,
+		},
+		{
+			name:       "socket directory uncreatable",
+			diagnostic: "couldn't create directory /tmp/x/tmux-1000 (Not a directory)",
+			exitCode:   1,
+			wantAbort:  true,
+		},
+		{
+			// A wrapper or policy shim in front of tmux: same exit status, no
+			// tmux diagnostic at all.
+			name:       "wrapper refusal",
+			diagnostic: "tmux-policy: denied by site policy",
+			exitCode:   1,
+			wantAbort:  true,
+		},
+		{
+			name:       "no diagnostic at all",
+			diagnostic: "",
+			exitCode:   1,
+			wantAbort:  true,
+		},
+		{
+			// A truncated no-server line names no socket, so it is not tmux's
+			// answer — it is a prefix match on nothing.
+			name:       "no-server line naming no socket",
+			diagnostic: "no server running on",
+			exitCode:   1,
+			wantAbort:  true,
+		},
+		{
+			name:       "non-1 exit status",
+			diagnostic: "error connecting to /tmp/tmux-1000/default (No such file or directory)",
+			exitCode:   2,
+			wantAbort:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			touched := filepath.Join(t.TempDir(), "reached-another-tmux-command")
+			listFailureTmuxOnPath(t, touched, tc.diagnostic, tc.exitCode)
+			t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+			err := CleanupSessions(cmd.MakeExecutor())
+
+			if !tc.wantAbort {
+				if err != nil {
+					t.Fatalf("CleanupSessions error = %v, want nil: %q is tmux's definitive "+
+						"no-server answer, so reset must be allowed to proceed", err, tc.diagnostic)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CleanupSessions returned nil for %q — an unreadable session list was "+
+					"reported as an empty one, which lets `af reset` delete worktrees and prune "+
+					"branches with the tmux session set unknown (#2870)", tc.diagnostic)
+			}
+			if !strings.Contains(err.Error(), "could not list tmux sessions") {
+				t.Errorf("error = %q, want it to name the read that failed", err)
+			}
+			if tc.diagnostic != "" && !strings.Contains(err.Error(), tc.diagnostic) {
+				t.Errorf("error = %q, want it to carry tmux's diagnostic %q — `exit status 1` alone "+
+					"tells the user nothing to act on", err, tc.diagnostic)
+			}
+			if _, statErr := os.Stat(touched); !os.IsNotExist(statErr) {
+				t.Errorf("a refused listing went on to run another tmux command (stat %s = %v); "+
+					"the sweep must stop, not continue on an unknown session set", touched, statErr)
+			}
+		})
+	}
+}
+
+// TestCleanupSessionsAcceptsLiveServerWithNoSessions covers the third outcome
+// the two branches above are not: tmux ANSWERED and the answer was empty. A
+// server configured with `exit-empty off` outlives its last session, and `tmux
+// ls` then exits 0 with no output. That is a real empty session set and reset
+// may proceed.
+func TestCleanupSessionsAcceptsLiveServerWithNoSessions(t *testing.T) {
+	dir := t.TempDir()
+	script := "#!/bin/sh\ncase \"$1\" in\nls) exit 0 ;;\n*) exit 97 ;;\nesac\n"
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	if err := CleanupSessions(cmd.MakeExecutor()); err != nil {
+		t.Fatalf("CleanupSessions error = %v, want nil for a successful listing with no sessions", err)
+	}
+}
+
+// TestCleanupSessionsAgainstRealTmuxSocket drives the REAL tmux binary rather
+// than a script, because the fix turns on strings tmux emits and a fake tmux
+// cannot prove those strings are right (#2870: "reproduce it first — an
+// unreachable socket via TMUX_TMPDIR").
+//
+// Both halves matter and neither is redundant with the table above:
+//
+//   - unreachable socket directory -> CleanupSessions must REFUSE.
+//   - readable, empty socket directory (no server) -> it must PROCEED. This is
+//     the half that fails if the definitive-absence set is narrowed to the
+//     "no server running on" line alone, which is what makes it worth the cost
+//     of a real tmux.
+//
+// Nothing here can reach the developer's live server: TMUX is cleared so the
+// ambient session cannot supply a socket, and TMUX_TMPDIR pins resolution
+// inside a throwaway directory.
+func TestCleanupSessionsAgainstRealTmuxSocket(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skipf("tmux is not installed: %v", err)
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the directory mode the unreachable half depends on")
+	}
+
+	// A short base path, not t.TempDir(): the socket path lands in sun_path,
+	// which is 108 bytes.
+	base, err := os.MkdirTemp("", "aftmux")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(base) })
+	sockDir := filepath.Join(base, fmt.Sprintf("tmux-%d", os.Getuid()))
+	if len(filepath.Join(sockDir, "default")) > 100 {
+		t.Skipf("TMPDIR is too long for a unix socket path: %s", sockDir)
+	}
+	if err := os.MkdirAll(sockDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// An ambient $TMUX would hand tmux the REAL server's socket and bypass
+	// TMUX_TMPDIR entirely. Empty is treated as unset by tmux.
+	t.Setenv("TMUX", "")
+	t.Setenv("TMUX_TMPDIR", base)
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	// Readable and empty: no server, definitively. Reset may proceed.
+	if err := CleanupSessions(cmd.MakeExecutor()); err != nil {
+		t.Fatalf("CleanupSessions error = %v, want nil — %s holds no tmux server, so this is a "+
+			"real empty session set and `af reset` must not be blocked by it", err, sockDir)
+	}
+
+	// Unreachable: tmux cannot tell us what is running there.
+	if err := os.Chmod(sockDir, 0); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(sockDir, 0o700) })
+
+	err = CleanupSessions(cmd.MakeExecutor())
+	if err == nil {
+		t.Fatal("CleanupSessions returned nil against an unreachable tmux socket — `af reset` " +
+			"would go on to delete worktrees and prune branches without knowing what is running (#2870)")
+	}
+	if !strings.Contains(err.Error(), "could not list tmux sessions") {
+		t.Errorf("error = %q, want it to name the read that failed", err)
+	}
+}


### PR DESCRIPTION
## The bug

`af reset` sweeps tmux sessions before it deletes worktrees, prunes branches,
and erases records. `CleanupSessions` returned `nil` for **any** `tmux ls` exit
status 1:

```go
if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
	return nil // No sessions to clean up
}
```

tmux uses that status both for "there is no server" and for "I could not reach
the server". So an unreachable socket read as *there are no sessions* — which is
exactly the licence reset needs to destroy the work the listing exists to
protect. The user saw a clean run, not an error.

This is the failed-read-as-empty-result class that #868 fixed on the storage side
of the same command. `planFactoryReset` already surfaces a `GetAllInstances`
error as `failed to read stored sessions` and aborts, and preserves a corrupt
per-repo `instances.json` rather than reading it as an empty repo (#869). The
tmux listing was the read that missed it.

## The fix

Three outcomes, never collapsed:

| outcome | signal | result |
| --- | --- | --- |
| listed, and here they are | exit 0 with output | sweep them |
| listed, and there are none | a definitive no-server diagnostic, or exit 0 with no output | proceed |
| **could not list** | anything else | **abort**, with tmux's own stderr in the message |

It fails **closed** — no warn-and-continue, because a warning on a destructive
path is not a safeguard once the worktree is gone — and reset prints what was
therefore *not* done, so a refusal cannot be mistaken for a completed wipe:

```
failed to cleanup tmux sessions: could not list tmux sessions (error connecting
to /tmp/tmux-1000/default (Permission denied)); refusing to sweep with the
session set unknown — no tmux session was killed: exit status 1

Nothing was removed: no worktree, branch, session record, or task was touched.
```

### Why the recommended fix would have broken `af reset` for most users

The report suggested accepting exit 1 **only** for `no server running on
<socket>`. Measured against tmux 3.4, that is the wrong half. tmux's client
prints the ECONNREFUSED case by name and routes every other `connect(2)` failure
through `strerror`, so:

```
$ tmux -S /tmp/x/nosock ls          # socket never created (ENOENT)
error connecting to /tmp/x/nosock (No such file or directory)
$ tmux -S /tmp/x/dead ls            # server exited, socket file left behind (ECONNREFUSED)
no server running on /tmp/x/dead
```

A tmux server **leaves its socket behind when it exits**, so `no server running
on` is what a *dead* server says. The everyday "this machine has no tmux server"
answer is the ENOENT line — which means narrowing the definitive set to the
`no server running on` line alone would make `af reset` refuse to run on any
machine that simply has no tmux server. Both are accepted; the regression test
pins both directions, and one half of it drives the **real** tmux binary against
a throwaway `TMUX_TMPDIR` precisely because a fake tmux cannot prove these
strings are right.

Everything else stays unknown and aborts: `(Permission denied)`, other connect
failures, tmux's own `directory ... has unsafe permissions` /
`couldn't create directory ...`, a wrapper's exit 1, an empty diagnostic, a
`no server running on` line naming no socket, and any non-1 exit status.

## Adjacent reads audited

Per the triage note — one read getting this wrong means siblings might too.

**Fixed.** `planFactoryReset`'s `instances/` cross-check had the same shape:

```go
if entries, derr := os.ReadDir(filepath.Join(dir, "instances")); derr == nil {
```

A failed read answered *no additional repos*. That silently disables a
compensating control — `LoadAllRepoInstances` **skips** a per-repo record file it
cannot read, and this cross-check is what turns a skipped repo into a preserved
one so its branches are not orphaned by the wholesale `DeleteAllInstances`. It
now fails closed at plan time, before a byte is deleted. Its regression lock
tests the guard directly rather than through `planFactoryReset`, deliberately:
`LoadAllRepoInstances` reads the same directory a few lines earlier and already
fails closed, so a whole-command test would abort there and pass with or without
this fix.

**Already safe, left alone.** `GetAllInstances` aborts (#868) · a corrupt
`instances.json` is preserved, not read as empty (#869) · `RemoveWorktreeDir`
refuses on an unverifiable registration and classifies the failure so the record
is retained (#2110/#2531) · `removeArchivedDirs` and `pruneWorktreeResidue`
return their read error and delete nothing · `retainBlockedInstances` propagates
an unmarshal error · a daemon whose home cannot be verified is left running and
`assertNoLiveDaemon` is the gate, not the report · `autostartUnitServesHome`
refuses to touch a unit it cannot attribute · `pgrepDaemonCandidates`' exit 1 is
POSIX pgrep's documented "no matches" and it fails closed on every other status.

**Found, NOT fixed here — filed as #2874.** `doctor/listTmuxSessions` collapses
every failure into an empty list, and `checkOrphanedProcesses` turns an empty
liveness set into an armed `kill pid N` for every live session's processes, which
`af doctor --fix` then executes. It is a bigger and more dangerous change than
this one (a new FAIL row, four consumers, a rework of `scanContext`), so it gets
its own PR rather than riding along on a reset fix. Its comment cited
`CleanupSessions` as the model — a comment that propagated this defect by
asserting parity with the broken original — and now names the hazard and the
issue instead.

## Tests

Both fail on master, at the assertion that matters:

- `TestCleanupSessionsListFailureIsNotAnEmptySessionSet` — ten measured tmux
  diagnostics, pinning both directions. Also asserts a refused listing runs **no
  further tmux command**: the sweep stops, it does not merely report.
- `TestCleanupSessionsAgainstRealTmuxSocket` — the real tmux binary against a
  throwaway `TMUX_TMPDIR`: readable-and-empty proceeds, mode-000 refuses. `$TMUX`
  is cleared so the ambient session cannot supply a socket.
- `TestCleanupSessionsAcceptsLiveServerWithNoSessions` — the third outcome:
  `exit-empty off` leaves a live server with zero sessions, and that empty
  listing is real.
- `TestFactoryReset_RefusesWhenTmuxListingFails` — end to end through the real
  `tmux.CleanupSessions` (every other boundary faked). On master reset reports
  *Factory reset complete — 3 sessions, 3 worktrees, 2 branches removed* against
  an unreadable session list; with the fix it refuses, and the worktrees,
  branches, records, tasks and state trees are all still there. It then re-runs
  with tmux answering and asserts the reset completes, so the guard cannot leave
  a user stuck.
- `TestPlanFactoryReset_UnreadableRecordDirIsNotAnEmptyOne` — the `instances/`
  cross-check guard.

Local: `gofmt -l .`, `go build ./...`, `golangci-lint --fast`, `deadcode -test`,
`scripts/lint-file-length.sh` all clean; `go test ./commands/ ./session/tmux/
./doctor/` green.

Closes #2870

🤖 Generated with [Claude Code](https://claude.com/claude-code)
