### PR TITLE
fix(auto-gate): a RESOLVED reply is a claim, require the commit as evidence

### DIFF
--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -9,6 +9,11 @@ const REVIEWED_COMMIT_RE = /(?:\*\*Reviewed commit:\*\*|Reviewed commit:)\s*`([0
 // Docs/Deploy is deliberately conditional and is skipped on pull_request runs.
 const ALLOWED_SKIPPED_CHECKS = new Set(["Deploy"]);
 const RESOLUTION_MARKER_RE = /\b(?:RESOLVED|ACCEPTED)\b/;
+// RESOLVED claims a code change was made; ACCEPTED and [gate-ack] claim none is
+// owed. The distinction is load-bearing: only the first implies a commit must
+// exist, so only the first is checked against the head (#2878).
+const FIX_CLAIM_RE = /\bRESOLVED\b/;
+const NO_CHANGE_CLAIM_RE = /\bACCEPTED\b/;
 
 async function evaluate({ github, context, core, prNumber, setOutputs = true }) {
   try {
@@ -521,23 +526,58 @@ async function evaluateCodex({ github, context, number, sha, lastCommitDate }) {
       })
       .map((comment) => comment.in_reply_to_id),
   );
-  const unresolvedFindings = reviewComments.filter((comment) => {
-    if (comment.user?.login !== CODEX_REVIEWER) {
-      return false;
-    }
-    if (comment.in_reply_to_id) {
-      return false;
-    }
-    if (comment.line == null) {
-      return false;
-    }
-    return !resolvedByAllowedReply.has(comment.id);
-  });
+  const isLiveFinding = (comment) =>
+    comment.user?.login === CODEX_REVIEWER && !comment.in_reply_to_id && comment.line != null;
+  const unresolvedFindings = reviewComments.filter(
+    (comment) => isLiveFinding(comment) && !resolvedByAllowedReply.has(comment.id),
+  );
 
   if (unresolvedFindings.length > 0) {
     reasons.push(`${unresolvedFindings.length} unresolved live Codex inline finding(s)`);
   } else {
     notes.push("No unresolved live Codex inline findings");
+  }
+
+  // A RESOLVED reply is a CLAIM; the commit is the evidence. Clearing a finding
+  // fires pull_request_review_comment, which re-runs this gate — so without this
+  // check the merge happens the instant the reply lands, on a head that predates
+  // the fix. That is how #2799, #2718, #2829 and #2839 all merged with real
+  // findings live, the fix commits arriving minutes after the squash (#2878).
+  //
+  // A fix for a finding filed at T cannot exist in a commit made before T. That
+  // is the whole test — necessary, not sufficient, and deliberately not "newer
+  // than the reply": the normal order is fix, push, reply, which leaves the head
+  // older than the reply and would block a correctly fixed PR.
+  const allowedReplies = reviewComments.filter(
+    (comment) => comment.in_reply_to_id && ALLOWED_AUTHORS.has(comment.user?.login || ""),
+  );
+  const claimedFixed = new Set(
+    allowedReplies.filter((c) => FIX_CLAIM_RE.test(c.body || "")).map((c) => c.in_reply_to_id),
+  );
+  const claimedNoChange = new Set(
+    allowedReplies
+      .filter((c) => NO_CHANGE_CLAIM_RE.test(c.body || "") || (c.body || "").includes("[gate-ack]"))
+      .map((c) => c.in_reply_to_id),
+  );
+  const unpushedFixClaims = reviewComments.filter((comment) => {
+    if (!isLiveFinding(comment)) {
+      return false;
+    }
+    // An explicit "no code change is owed" wins: the author asserted the finding
+    // does not apply, and no commit can be demanded for that.
+    if (!claimedFixed.has(comment.id) || claimedNoChange.has(comment.id)) {
+      return false;
+    }
+    const filedAt = parseTimestamp(comment.created_at);
+    // Unparseable timestamps fail closed — an unknown order is not a proven one.
+    return filedAt == null || lastPushTime == null || lastPushTime <= filedAt;
+  });
+
+  if (unpushedFixClaims.length > 0) {
+    reasons.push(
+      `${unpushedFixClaims.length} finding(s) marked RESOLVED with no commit pushed after them; ` +
+        "the head predates the fix they claim",
+    );
   }
 
   return { ok: reasons.length === 0, reasons, notes };

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -278,6 +278,71 @@ test("Codex verdict parsing requires a real verdict and matches its short SHA", 
   assert.equal(__test.reviewedCommitMatchesHead(OTHER_SHA.slice(0, 10), HEAD_SHA), false);
 });
 
+test("RESOLVED does not clear a finding when no commit followed it", async () => {
+  // The #2799 race: finding filed at 01:15 on a head committed at 01:00, author
+  // replies RESOLVED, no push. The claimed fix cannot be in the head.
+  const result = await evaluateGate({
+    headCommittedDate: "2026-07-09T01:00:00Z",
+    reviewComments: [
+      codexFinding({ id: 10, line: 32, createdAt: "2026-07-09T01:15:00Z" }),
+      findingReply({ id: 11, inReplyToId: 10, body: "RESOLVED — fixed it." }),
+    ],
+  });
+
+  assert.equal(result.shouldMerge, false);
+  assert.match(result.reasons.join("\n"), /RESOLVED.*no commit pushed after/);
+});
+
+test("RESOLVED clears a finding once a commit lands after it", async () => {
+  const result = await evaluateGate({
+    headCommittedDate: "2026-07-09T01:18:00Z",
+    issueComments: [codexVerdict(HEAD_SHA, "2026-07-09T01:20:00Z")],
+    reviewComments: [
+      codexFinding({ id: 10, line: 32, createdAt: "2026-07-09T01:15:00Z" }),
+      findingReply({ id: 11, inReplyToId: 10, body: "RESOLVED — fixed it." }),
+    ],
+  });
+
+  assert.equal(result.shouldMerge, true, result.reasons.join("\n"));
+});
+
+test("ACCEPTED needs no commit — it claims no code change is owed", async () => {
+  const result = await evaluateGate({
+    headCommittedDate: "2026-07-09T01:00:00Z",
+    reviewComments: [
+      codexFinding({ id: 10, line: 32, createdAt: "2026-07-09T01:15:00Z" }),
+      findingReply({ id: 11, inReplyToId: 10, body: "ACCEPTED — does not apply here." }),
+    ],
+  });
+
+  assert.equal(result.shouldMerge, true, result.reasons.join("\n"));
+});
+
+test("gate-ack needs no commit either", async () => {
+  const result = await evaluateGate({
+    headCommittedDate: "2026-07-09T01:00:00Z",
+    reviewComments: [
+      codexFinding({ id: 10, line: 32, createdAt: "2026-07-09T01:15:00Z" }),
+      findingReply({ id: 11, inReplyToId: 10, body: "Root accepts this [gate-ack]." }),
+    ],
+  });
+
+  assert.equal(result.shouldMerge, true, result.reasons.join("\n"));
+});
+
+test("a later ACCEPTED exempts a finding an earlier RESOLVED claimed to fix", async () => {
+  const result = await evaluateGate({
+    headCommittedDate: "2026-07-09T01:00:00Z",
+    reviewComments: [
+      codexFinding({ id: 10, line: 32, createdAt: "2026-07-09T01:15:00Z" }),
+      findingReply({ id: 11, inReplyToId: 10, body: "RESOLVED — fixed it." }),
+      findingReply({ id: 12, inReplyToId: 10, body: "ACCEPTED — on reflection it does not apply." }),
+    ],
+  });
+
+  assert.equal(result.shouldMerge, true, result.reasons.join("\n"));
+});
+
 test("gate-ack remains an explicit finding resolution marker", () => {
   assert.equal(__test.hasResolutionMarker("Root accepts this [gate-ack]."), true);
   assert.equal(__test.hasResolutionMarker("accepted in discussion, not marked"), false);
@@ -295,6 +360,7 @@ async function evaluateGate(options = {}) {
 
 function fakeGateGithub({
   headSha = HEAD_SHA,
+  headCommittedDate = "2026-07-09T01:00:00Z",
   isDraft = false,
   state = "OPEN",
   merged = false,
@@ -355,7 +421,7 @@ function fakeGateGithub({
           author: { login: "sachiniyer" },
           labels: { nodes: [] },
           commits: {
-            nodes: [{ commit: { committedDate: "2026-07-09T01:00:00Z" } }],
+            nodes: [{ commit: { committedDate: headCommittedDate } }],
           },
         },
       },
@@ -464,12 +530,12 @@ function codexReview(sha, summary = "Here are some suggestions.", timestamp = "2
   };
 }
 
-function codexFinding({ id, line }) {
+function codexFinding({ id, line, createdAt = "2026-07-09T01:15:00Z" }) {
   return {
     id,
     user: { login: "chatgpt-codex-connector[bot]" },
     body: "P1: this needs attention",
-    created_at: "2026-07-09T01:15:00Z",
+    created_at: createdAt,
     line,
   };
 }


### PR DESCRIPTION

## The race

`auto-gate.js` merged as soon as the unresolved-finding count reached zero, and counted a finding cleared the moment an allowed author replied with a resolution marker. **Nothing checked that the fix was pushed.**

Clearing a finding fires `pull_request_review_comment`, which re-runs the gate — so the merge happened at the instant of the reply, on a head that predated the fix.

## It happened four times last night

- **#2799** — fix commit arrived minutes after the squash, leaving `master` carrying the uncorrected Codex queries that #2822 re-filed and #2824 re-fixed
- **#2718** — a P1 that put a live token-dialing bug on `master`
- **#2829**, **#2839** — same shape

Every one had a real finding, correctly identified, correctly acknowledged, and merged anyway.

## The gate condition

> A finding cleared **only** by a fix-claiming `RESOLVED` requires the head commit to be **newer than the finding**.

A fix for something filed at `T` cannot exist in a commit made before `T`. Necessary, not sufficient, and evaluated from data the gate already fetches — `lastCommitDate` is the same value the verdict-freshness check uses.

Three deliberate choices:

- **`ACCEPTED` and `[gate-ack]` are exempt.** They assert no code change is owed, so no commit can be demanded. An `ACCEPTED` alongside an earlier `RESOLVED` also exempts — a reclassification is the author's to make.
- **The bound is the FINDING, not the reply.** The normal order is fix → push → reply, which leaves the head older than the reply; binding to the reply would block correctly-fixed PRs.
- **An unparseable finding timestamp fails closed.** An unknown order is not a proven one.

It fails safe: the auto-merge is withheld with a reason naming the count, and the author pushes or re-classifies.

## Watched it fail first

```
unmodified auto-gate.js          not ok 20 - RESOLVED does not clear a finding when no commit followed it
with the fix                     25/25 pass
with ONLY the new condition off  not ok 20 again
```

That third run matters: it proves the test is bound to the new condition rather than to something adjacent.

## A coverage hole the race hid behind

The suite had **no end-to-end test of a `RESOLVED` reply clearing a finding at all**. `RESOLVED` appeared only in a `hasResolutionMarker` unit test; every end-to-end resolution test used `ACCEPTED`. And the default fixture's head commit (`01:00:00Z`) already predated its finding (`01:15:00Z`) — the race was the fixture's own state, which is why nothing noticed. Five tests now cover both markers in both orders, and the fixture takes `headCommittedDate` so the ordering is explicit.

`.claude/skills/gate-pr.md` already gates on this for hand-runs (#2739); this makes the gate that actually merges agree with it.

## Test plan

- [x] `node --test .github/scripts/auto-gate.test.js` — 25/25 (was 20)
- [x] `gofmt -l .`, `go build ./...`, `golangci-lint`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean
- [x] No Go package changed, so no `go test`; no container run

Closes #2878