### PR TITLE
docs(config): stop claiming an ssh_config Match af never performs

### DIFF
--- a/config/backend.go
+++ b/config/backend.go
@@ -78,13 +78,20 @@ type SSHConfig struct {
 	// Host is the ssh target (`host` or `host:port`) the session is provisioned
 	// on. Required when the ssh runtime is selected; enforced by the runtime.
 	Host string `json:"host,omitempty" toml:"host,omitempty"`
-	// User is the ssh login user. Optional — empty defers to the ssh client's
-	// default (the current user or an ssh_config Match).
+	// User is the ssh login user. Optional — empty means the daemon's own user
+	// (os/user.Current, else $USER).
+	//
+	// NOT an ssh_config lookup: the runtime connects with the Go
+	// golang.org/x/crypto/ssh client rather than the ssh binary, and never reads
+	// ~/.ssh/config — so no Match block, Host alias, or per-host User applies
+	// here. Every connection parameter af uses is a field of this struct.
 	User string `json:"user,omitempty" toml:"user,omitempty"`
 	// Port is the ssh port. Optional — 0 means the default (22).
 	Port int `json:"port,omitempty" toml:"port,omitempty"`
 	// IdentityFile is the path to the private key used for auth. Optional —
-	// empty defers to the agent/default keys.
+	// empty falls back to ~/.ssh/id_ed25519, ~/.ssh/id_ecdsa, ~/.ssh/id_rsa and
+	// any keys a running ssh-agent holds. Also not an ssh_config IdentityFile
+	// directive, for the reason above.
 	IdentityFile string `json:"identity_file,omitempty" toml:"identity_file,omitempty"`
 	// KnownHosts is the path to the OpenSSH known_hosts file the runtime verifies
 	// the remote's host key against (#1592 Phase 4 PR5). Optional — empty defers


### PR DESCRIPTION
## What

`SSHConfig.User`'s comment said an empty value "defers to the ssh client's default (the current user or **an ssh_config Match**)". af never reads `~/.ssh/config`.

## Evidence

- The runtime connects with `golang.org/x/crypto/ssh`, explicitly so it does not depend on the ssh binary — `session/backend_ssh.go:34-36` states that as a locked decision.
- An empty `ssh.user` resolves through `loginUser()` (`session/backend_ssh.go:560-568`): `user.Current()`, else `$USER`. No ssh_config.
- `authMethods()` (`session/backend_ssh.go:333-341`) hardcodes `~/.ssh/{id_ed25519,id_ecdsa,id_rsa}` and never reads an `IdentityFile` directive.
- #2556 went further and guaranteed af never resolves even a *path* from ssh_config (`backend_ssh.go:460`, `:495`).

`IdentityFile`'s "empty defers to the agent/default keys" was *true* but read the same way — a reader assumes ssh-client defaults, which include ssh_config's `IdentityFile`. It now names the three files `authMethods` actually tries.

## Why it is worth a PR

It is the sentence that makes #2847 — a provisioning hook returning an ssh alias — look half-implemented. Anyone scoping that issue reads this comment and concludes af has ssh_config integration to build on; it has none, and that is a material part of the estimate. Found while settling #2847's host-key risk.

User-facing docs are already honest: `docs/backends.md` and `docs/configuration.md` describe af's own `ssh.host`/`ssh.user` and never promise aliases. Comment-only change — no behavior, no API.

## Validation

- `gofmt -l .` (no output) · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `deadcode -test ./...` · `scripts/lint-file-length.sh`
- `go test ./config/` — the only package touched — green.

Closes #2882