### PR TITLE
fix(tui): stop the registry-mode poll filling the rail with inert sessions

### DIFF
--- a/app/registry_mode_snapshot_test.go
+++ b/app/registry_mode_snapshot_test.go
@@ -1,0 +1,99 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// #2864. Registry mode (launched outside a repo, #2477) has no active project,
+// so newHome deliberately skips the cold-start snapshot: an empty repoID makes
+// the daemon answer with the CROSS-REPO list, and those sessions are not merely
+// irrelevant to an empty scope — they are INERT. Every per-session verb keys on
+// m.repoID and resolveSessionActionTarget requires target.repoID == m.repoID, so
+// each one silently no-ops.
+//
+// The refresh tick then undid that a second later: it fetched with the same
+// empty repoID and reconciled the answer straight into the projection. The rail
+// filled with rows whose `s` and `enter` do nothing — the dead-affordance class
+// #2830 fixed one layer up, arriving here by a different route.
+//
+// Driven through the real Update path with a real snapshotFetchedMsg, because
+// what regressed is the poll's behavior, not a helper's.
+func TestRegistryModeSnapshotPollLeavesTheRailEmpty(t *testing.T) {
+	h := newTestHome(t)
+	pinSnapshotInstanceBuilder(t)
+	h.repoRoot = "" // registry mode: no active project…
+	h.repoID = ""   // …so the daemon reads every fetch as all-repos
+	require.Equal(t, 0, h.store.NumInstances(), "precondition: the rail starts empty")
+
+	h.Update(snapshotFetchedMsg{
+		repoID: "",
+		data:   []session.InstanceData{crossRepoInstance("alpha"), crossRepoInstance("beta")},
+	})
+
+	assert.Equal(t, 0, h.store.NumInstances(),
+		"a cross-repo row the empty scope cannot act on must not reach the projection")
+}
+
+// The poll must keep working normally the moment a project IS active — the guard
+// is about an empty scope, not about polling.
+func TestActiveProjectSnapshotPollStillReconciles(t *testing.T) {
+	h := newTestHome(t)
+	pinSnapshotInstanceBuilder(t)
+	h.repoRoot = t.TempDir()
+	require.NotEmpty(t, h.repoID, "precondition: newTestHome gives an active scope")
+
+	h.Update(snapshotFetchedMsg{
+		repoID: h.repoID,
+		data:   []session.InstanceData{crossRepoInstance("mine")},
+	})
+
+	assert.Equal(t, 1, h.store.NumInstances(),
+		"an active scope still reconciles its own sessions on every poll")
+}
+
+// Alarms are deliberately NOT gated with the sessions. deliveryAlarms reads an
+// empty repoID as every repo the same way, but an alarm is a notification, not a
+// target: it needs no active scope to be worth showing, and suppressing it would
+// hide a real delivery failure from the mode a user is most likely idling in.
+func TestRegistryModeSnapshotPollStillRaisesDeliveryAlarms(t *testing.T) {
+	h := newTestHome(t)
+	pinSnapshotInstanceBuilder(t)
+	h.repoRoot = ""
+	h.repoID = ""
+
+	h.Update(snapshotFetchedMsg{
+		repoID: "",
+		data:   []session.InstanceData{crossRepoInstance("alpha")},
+		alarms: []daemon.DeliveryAlarm{{
+			TaskID: "t1", TaskName: "watcher", TargetSession: "alpha",
+			Pending: 3, Consecutive: 5, Since: time.Now().Add(-time.Hour),
+		}},
+	})
+
+	assert.Equal(t, 0, h.store.NumInstances(), "the sessions are still refused")
+	assert.True(t, h.alarmBanner.Active(),
+		"a delivery failure is worth showing with or without an active project")
+}
+
+// pinSnapshotInstanceBuilder makes materialization deterministic so these tests
+// measure the SCOPE guard and nothing else — a build failure would otherwise
+// leave an empty rail for entirely the wrong reason and read as a pass.
+func pinSnapshotInstanceBuilder(t *testing.T) {
+	t.Helper()
+	t.Cleanup(SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
+		return instanceWithFakeBackend(t, d.Title), nil
+	}))
+}
+
+func crossRepoInstance(title string) session.InstanceData {
+	d := session.InstanceData{Title: title, CreatedAt: time.Now()}
+	d.Worktree.RepoPath = "/repos/elsewhere"
+	return d
+}

--- a/app/sync.go
+++ b/app/sync.go
@@ -311,7 +311,26 @@ func (m *home) handleSnapshot(msg snapshotFetchedMsg) bool {
 		log.WarningLog.Printf("failed to fetch daemon snapshot: %v", msg.err)
 		return false
 	}
-	changed := m.reconcileSnapshot(msg.data)
+	changed := false
+	// An empty active scope owns no sessions, so there is nothing to reconcile
+	// (#2864). The daemon reads an empty repoID as "every repo" — the same
+	// all-repos answer the cold start deliberately refuses in registry mode
+	// (#2477) — and those rows are not merely irrelevant, they are INERT: every
+	// per-session verb keys on m.repoID, and resolveSessionActionTarget requires
+	// target.repoID == m.repoID, so each one silently no-ops. Reconciling them
+	// filled the rail with sessions whose `s` and `enter` do nothing, undoing
+	// newHome's refusal one poll later.
+	//
+	// The alarms below are deliberately NOT gated. deliveryAlarms reads an empty
+	// repoID as every repo too, but an alarm is a notification, not a target: it
+	// needs no active scope to be worth showing, and suppressing it would hide a
+	// real delivery failure from the one mode a user is most likely to be idling
+	// in. The Projects section keeps its own counts from msg.allRepos, which this
+	// does not touch, so the cross-repo view a registry-mode user actually needs
+	// stays live.
+	if m.repoID != "" {
+		changed = m.reconcileSnapshot(msg.data)
+	}
 	if m.applyDeliveryAlarms(msg.alarms) {
 		changed = true
 	}


### PR DESCRIPTION
## The contradiction

`newHome` deliberately skips the cold-start snapshot in registry mode (#2477),
and says why in its own comment:

> Cold-starting here would use an empty repoID, which the daemon answers with the
> CROSS-REPO snapshot — listing sessions the empty active scope cannot act on,
> because every per-session op is keyed to `m.repoID` and would silently no-op
> (`resolveSessionActionTarget` requires `target.repoID == m.repoID`).

The refresh tick then undid that a poll later:

- `fetchSnapshotCmd` captures `repoID := m.repoID` with **no registry guard**
- the tick is armed unconditionally from `Init`
- `handleSnapshot` handed the result straight to `reconcileSnapshot`, no filter

So the rail filled with rows whose `s` and `enter` do nothing. Same
dead-affordance class as #2830, one layer down and arriving by a different
route — and the launch path's refusal was contradicted a second after launch.

This is the actual cause behind the symptom I hit in #2848, where I wrongly tried
to fix it by re-prioritizing a workspace message. That was the wrong layer and it
broke the pane-empty message; this is the right one, and it also fixes the dead
`s`/`enter` on those rows, which no message ordering could.

## The fix

One guard, where the contradiction was: reconcile only with an active scope. The
launch path and the poll now agree.

## What is deliberately NOT changed

**The fetch itself.** Its response also carries the delivery alarms, and
`deliveryAlarms` reads an empty repoID as every repo the same way the session
list does (`if repoID != "" && w.repoID != repoID { continue }`). But an alarm is
a **notification, not a target**: it needs no active scope to be worth showing,
and suppressing it would hide a real delivery failure from the mode a user is
most likely to be idling in. Gating the fetch would have taken the alarms with
it, which is why the guard is on the reconcile rather than the RPC.

**The Projects section.** The issue flagged this as needing a check before
choosing "don't fetch at all", so: it gets its counts from a *separate* all-repos
fetch on the same poll (`msg.allRepos` → `refreshSidebarProjectsFromSnapshot`),
which this does not touch. The cross-repo view a registry-mode user actually
needs stays live while the rail they cannot act on stays empty. That existing
split is why this is one guard rather than a rework.

## Tests

Driven through the real `Update` path with a real `snapshotFetchedMsg`, because
what regressed is the poll's behavior, not a helper's:

- empty scope refuses cross-repo rows
- an active scope still reconciles on every poll — the guard is about scope, not
  about polling
- alarms are raised either way, with the sessions still refused

All three pin the instance builder via `SetInstanceBuilderForTest`, so a
materialization failure cannot leave an empty rail for entirely the wrong reason
and read as a pass.

## Gate

`gofmt -l .` (empty), `go build ./...`, `golangci-lint run --timeout=3m --fast`,
`deadcode -test ./...` (empty), `scripts/lint-file-length.sh`, `go test ./ui/...`.
The `app` tests are left to CI — that package spawns real af daemons and this is
the maintainer's live machine.

Closes #2864

-- Captain Claude
