### PR TITLE
fix(projects): an unreadable project root is present, not gone

### DIFF
--- a/config/project_registry.go
+++ b/config/project_registry.go
@@ -742,11 +742,42 @@ func projectFromRecord(record projectRecord) Project {
 	}
 }
 
+// projectPathExists answers whether the last-known project root is PRESENT, and
+// only a determinate answer may be a "no" (#2885).
+//
+// A stat that failed for any reason other than ErrNotExist — permission denied,
+// an I/O error, a dead network mount — is evidence of NOTHING. Reporting "gone"
+// there puts a false disappearance on the wire: path_exists is the field
+// `af projects list` and every registry client read as "your checkout is still
+// where you left it", so a user is told to go hunting for a repo that never
+// moved. Present-but-unreadable is present.
+//
+// The same rule is already stated by fileExists (config_load.go) and already
+// followed, in THIS file, by projectRootHasCheckoutID and readCheckoutID — both
+// of which take ErrNotExist as determinate and turn every other stat failure
+// into an error rather than a verdict.
+//
+// It also moves the two registration guards that consult this in the safe
+// direction: an ambiguous re-registration is REFUSED rather than allowed to
+// proceed on the strength of a stat nobody could perform.
 func projectPathExists(path string) bool {
 	info, err := os.Stat(path)
-	return err == nil && info.IsDir()
+	if err != nil {
+		return !errors.Is(err, os.ErrNotExist)
+	}
+	return info.IsDir()
 }
 
+// sameProjectPath reports whether two paths name the same directory.
+//
+// A stat failure here also collapses to "not the same", which would be the same
+// hazard as above were it reachable — but it is MASKED, and deliberately left
+// that way (#2885). Its only caller takes the "path changed" branch on false and
+// immediately calls projectRootHasCheckoutID on that same root, which propagates
+// the identical stat failure as an error. So an unreadable root makes the
+// registration FAIL LOUDLY rather than take a wrong branch, which is the outcome
+// a fail-closed rewrite here would produce anyway. Recorded rather than changed,
+// so the next reader does not have to re-derive it.
 func sameProjectPath(left, right string) bool {
 	if filepath.Clean(left) == filepath.Clean(right) {
 		return true

--- a/config/project_registry.go
+++ b/config/project_registry.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"syscall"
 
 	"github.com/sachiniyer/agent-factory/internal/pathutil"
 	"github.com/sachiniyer/agent-factory/log"
@@ -757,13 +758,20 @@ func projectFromRecord(record projectRecord) Project {
 // of which take ErrNotExist as determinate and turn every other stat failure
 // into an error rather than a verdict.
 //
+// ENOTDIR is determinate too, and belongs with ErrNotExist rather than in the
+// fail-closed arm: an ancestor that is a regular file means nothing can exist
+// below it. Go does not map ENOTDIR to ErrNotExist, so special-casing only
+// ErrNotExist would report that path as PRESENT — a fabricated positive, the
+// exact mirror of the bug this function was fixed for (#2889 review).
+//
 // It also moves the two registration guards that consult this in the safe
 // direction: an ambiguous re-registration is REFUSED rather than allowed to
 // proceed on the strength of a stat nobody could perform.
 func projectPathExists(path string) bool {
 	info, err := os.Stat(path)
 	if err != nil {
-		return !errors.Is(err, os.ErrNotExist)
+		determinatelyAbsent := errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOTDIR)
+		return !determinatelyAbsent
 	}
 	return info.IsDir()
 }

--- a/config/project_registry_path_exists_test.go
+++ b/config/project_registry_path_exists_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// PathExists answers ONE question — "is the last-known project root present?" —
+// and the only honest "no" is a determinate one (#2885). A stat that FAILED is
+// evidence of nothing, so reporting "gone" there tells a user their checkout
+// vanished when it is merely unreadable. This is the same rule config_load.go's
+// fileExists states, and the same one projectRootHasCheckoutID/readCheckoutID
+// already follow in this very file.
+
+func TestProjectPathExists_DeterminateAnswers(t *testing.T) {
+	root := t.TempDir()
+
+	dir := filepath.Join(root, "checkout")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	assert.True(t, projectPathExists(dir), "a readable directory is present")
+
+	assert.False(t, projectPathExists(filepath.Join(root, "gone")),
+		"a path that is determinately absent is the one honest false")
+
+	file := filepath.Join(root, "notes.txt")
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0o644))
+	assert.False(t, projectPathExists(file),
+		"a regular file is determinately not a project root")
+}
+
+// The regression this pins: an unreadable root must not be reported as gone.
+func TestProjectPathExists_UnreadableRootIsPresentNotGone(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX directory permissions")
+	}
+	root := t.TempDir()
+	locked := filepath.Join(root, "locked")
+	target := filepath.Join(locked, "checkout")
+	require.NoError(t, os.MkdirAll(target, 0o755))
+	// Remove +x on the PARENT so stat(target) fails with EACCES while target
+	// itself is very much still there.
+	require.NoError(t, os.Chmod(locked, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	// Never assert a negative the environment cannot produce: root bypasses the
+	// DAC check, so under a root test runner this stat SUCCEEDS and the assertion
+	// below would be testing nothing.
+	if _, probe := os.Stat(target); probe == nil {
+		t.Skip("this runner can stat through a 0o000 directory (running as root?), so the denial is unobservable here")
+	}
+
+	assert.True(t, projectPathExists(target),
+		"an unreadable root is PRESENT: a failed stat is evidence of nothing, and answering 'gone' invents a disappearance")
+}

--- a/config/project_registry_path_exists_test.go
+++ b/config/project_registry_path_exists_test.go
@@ -31,6 +31,15 @@ func TestProjectPathExists_DeterminateAnswers(t *testing.T) {
 	require.NoError(t, os.WriteFile(file, []byte("x"), 0o644))
 	assert.False(t, projectPathExists(file),
 		"a regular file is determinately not a project root")
+
+	// ENOTDIR is as determinate as ENOENT and must not be swept into the
+	// fail-closed arm: an ancestor that is a regular file means NOTHING can exist
+	// below it (#2889 review). Go does not map it to ErrNotExist, so a rule that
+	// only special-cases ErrNotExist reports this as present — a fabricated
+	// POSITIVE, the mirror of the bug this function was fixed for.
+	ancestorIsAFile := filepath.Join(root, "notes.txt", "checkout")
+	assert.False(t, projectPathExists(ancestorIsAFile),
+		"a path under a regular-file ancestor cannot exist, and ENOTDIR proves it")
 }
 
 // The regression this pins: an unreadable root must not be reported as gone.


### PR DESCRIPTION
Closes #2885

Proactive audit of every daemon HTTP read route for the three properties #2800's `ListDirectory` was built around — (a) a failed read never returns an empty success, (b) capping is reported not silent, (c) permission-denied is distinguishable from not-found. The routes hold up well; this is the one real defect it turned up.

## The defect

```go
func projectPathExists(path string) bool {
	info, err := os.Stat(path)
	return err == nil && info.IsDir()
}
```

Every stat failure — permission denied, an I/O error, a dead network mount — was reported as **"the path is not there"**. It feeds `Project.PathExists`, i.e. the `path_exists` field of `POST /v1/ListProjects` and of `af projects list`, whose documented contract (`api/projects.go`) is *"whether the last-known path is present"*.

An unreadable directory **is present**. This put a false disappearance on the wire, and "your checkout is gone" is exactly the kind of confident wrong answer a user acts on — rebinding, re-adding, or hunting for a repo that never moved.

## Why it's a slip, not a policy

The rule is already established in this codebase, and in this very file. `projectRootHasCheckoutID` and `readCheckoutID` both take `ErrNotExist` as determinate and turn every other stat failure into an **error** rather than a verdict. And `config_load.go` states it outright:

> `fileExists` reports whether path exists (any stat error other than not-exist — e.g. permission denied — counts as "exists" so a shadowed config.json is still flagged rather than silently assumed gone).

`Project.PathExists`'s own comment scopes only the *identity* axis ("availability, not identity proof") and says nothing about readability, so this was not a documented trade-off.

## The fix

Only a determinate `ErrNotExist` is a "no". Wire type (`bool`) and contract wording unchanged. It also moves the two registration guards that consult it in the safe direction: an ambiguous re-registration is **refused** rather than allowed to proceed on the strength of a stat nobody could perform.

## Adjacent, deliberately not changed

`sameProjectPath` collapses stat errors the same way. Traced through, that is **masked**: its caller takes the "path changed" branch on false and immediately calls `projectRootHasCheckoutID` on the same root, which propagates the identical failure as an error — so an unreadable root already fails the registration *loudly* rather than taking a wrong branch, which is what a fail-closed rewrite would produce anyway. A comment records the analysis instead of changing behavior for no present benefit.

## Verification

**Watched it fail first.** The unreadable-root case is red on master (`Should be true`), green after. It builds the denial by removing `+x` from the *parent* so the target is provably still there, and **skips honestly with a stated reason** if the runner is root and can stat through a `0o000` directory — a negative the environment cannot produce must not be asserted.

`gofmt -l .` (empty), `go build ./...`, `golangci-lint --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh`, no generated-artifact drift, and the full `./config` package (9.1s) — a non-daemon, non-app package, which is the only one I ran per current policy. No containerized suite.

## What the audit cleared

Recorded in #2885 with evidence so it isn't re-derived: `Preview` (distinguishes `Gone`/`TabGone`, and its own comment names this class), `Snapshot` (in-memory, #960), `GetConfig`/`ListTasks`/`ListBackends` (propagate; `ListBackends` threads `cfgErr` rather than rendering a failed load as "unavailable"), the registry walk (ENOENT determinate, everything else propagates), `LoadAllRepoInstances`' per-repo skip (documented, with a compensating control — #868/#2870), and the `cleanOrphanQueues`/vscode socket sweeps (a `ReadDir` failure removes *nothing*, which for a deletion sweep is the fail-closed direction). On (b): no daemon read route truncates silently — the only caps are identifier shortening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
