### PR TITLE
fix(archive): record a restored worktree's new location durably

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -678,16 +678,45 @@ func (m *Manager) restoreArchivedInstance(instance *session.Instance, repoID, ti
 		return "", fmt.Errorf("failed to restore worktree for %q: %w", req.Title, err)
 	}
 
+	// The relocate SUCCEEDED, so the worktree's new location is now certain — and
+	// it exists only in memory, exactly as on the cut-off branch above.
+	// setWorktreeLocation updated g.worktreePath; this write is the only thing that
+	// carries it across a restart, so it takes the error-returning persist for the
+	// reason that branch already spells out (#2880). A restore nothing recorded is
+	// not a completed restore, however live the session is: disk would still say
+	// Archived at an archive path that no longer exists, the next restore would
+	// fail relocate's source-exists guard, and the user's work would sit at a path
+	// nothing durable points at. No poll repairs it — persistPollChange writes on a
+	// liveness/reset change and this row's liveness is already settled — and the
+	// whole-state shutdown checkpoint is what an unclean exit skips.
+	//
+	// Both arms below persist through it. The re-spawn failure is the same
+	// stranding with a Lost row instead of a Running one: the worktree has moved
+	// either way.
+	restoredPath := instance.GetWorktreePath()
+	commitRestore := func() error {
+		if perr := m.persistInstanceErr(repoID, instance); perr != nil {
+			return fmt.Errorf("the worktree for %q was moved back to %s but that location could not be written to disk (%v); "+
+				"nothing durable points at it — move it back or re-register it manually before restarting the daemon",
+				req.Title, restoredPath, perr)
+		}
+		return nil
+	}
+
 	// Worktree is back in place. Re-spawn the agent and flip Running. On a
 	// re-spawn failure RestoreFromArchive leaves the instance started + Lost, so
 	// the Lost-restore loop keeps retrying against the now-restored worktree.
 	if err := instance.RestoreFromArchive(); err != nil {
-		m.persistInstance(repoID, instance)
+		if perr := commitRestore(); perr != nil {
+			return "", fmt.Errorf("%w; its agent also failed to re-spawn: %v", perr, err)
+		}
 		return "", fmt.Errorf("restored worktree for %q but failed to re-spawn its agent (it will be retried): %w", req.Title, err)
 	}
 
 	worktreePath := instance.GetWorktreePath()
-	m.persistInstance(repoID, instance)
+	if perr := commitRestore(); perr != nil {
+		return "", fmt.Errorf("re-spawned the agent for %q, but %w", req.Title, perr)
+	}
 	log.InfoLog.Printf("restored session %q (repo %s): worktree moved back to %s, agent re-spawned", req.Title, repoID, worktreePath)
 	return worktreePath, nil
 }

--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -703,6 +703,21 @@ func (m *Manager) restoreArchivedInstance(instance *session.Instance, repoID, ti
 		return nil
 	}
 
+	// Record the new location NOW, before the respawn — not only after it.
+	// RestoreFromArchive spawns tmux, which can take seconds or time out, and a
+	// daemon that exits anywhere in that window would leave disk naming an archive
+	// path that no longer exists even though every write here succeeded. Moving the
+	// commit ahead of the respawn closes the window to the relocate itself, which
+	// is the shortest it can be.
+	//
+	// It writes a still-Archived row pointing at the restored path, which is
+	// exactly the state the cut-off-relocate branch above persists and is already
+	// covered: a later restore relocates off the occupied path rather than
+	// colliding with itself (RestoreWorktreePath's collision suffix).
+	if perr := commitRestore(); perr != nil {
+		return "", perr
+	}
+
 	// Worktree is back in place. Re-spawn the agent and flip Running. On a
 	// re-spawn failure RestoreFromArchive leaves the instance started + Lost, so
 	// the Lost-restore loop keeps retrying against the now-restored worktree.

--- a/daemon/archive_restore_commit_test.go
+++ b/daemon/archive_restore_commit_test.go
@@ -43,9 +43,9 @@ func TestRestoreArchived_SuccessfulRelocateReportsAFailedPersist(t *testing.T) {
 	require.NoError(t, perr)
 
 	// Fail exactly the restore commit: the write that first carries the RESTORED
-	// location. Everything before it — the archive above, and the relocate's own
-	// git work — is real, so this cannot be confused with a restore that never got
-	// that far.
+	// location, which is the one taken BEFORE the respawn. Everything before it —
+	// the archive above, and the relocate's own git work — is real, so this cannot
+	// be confused with a restore that never got that far.
 	diskFull := errors.New("no space left on device")
 	var mu sync.Mutex
 	fired := false

--- a/daemon/archive_restore_commit_test.go
+++ b/daemon/archive_restore_commit_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,16 +47,30 @@ func TestRestoreArchived_SuccessfulRelocateReportsAFailedPersist(t *testing.T) {
 	// git work — is real, so this cannot be confused with a restore that never got
 	// that far.
 	diskFull := errors.New("no space left on device")
+	var mu sync.Mutex
+	fired := false
 	prev := testHookPersistInstanceData
 	t.Cleanup(func() { testHookPersistInstanceData = prev })
 	testHookPersistInstanceData = func(_ string, data session.InstanceData) error {
-		if data.Title == "worker" && data.Worktree.WorktreePath == restored {
-			return diskFull
+		if data.Title != "worker" || data.Worktree.WorktreePath != restored {
+			return nil
 		}
-		return nil
+		mu.Lock()
+		fired = true
+		mu.Unlock()
+		return diskFull
 	}
 
 	_, _, err = manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
+
+	// Without this, the assertion below fails on the unfixed code whether or not
+	// the seam ever matched — so a later change to what gets written (ForStorage,
+	// a different commit point) could make the whole test vacuous once it is green.
+	mu.Lock()
+	injected := fired
+	mu.Unlock()
+	require.True(t, injected,
+		"the restore commit was never attempted with the restored path, so this test exercised nothing")
 
 	require.Error(t, err,
 		"a restore whose new location was never written reported success: disk still says Archived at "+

--- a/daemon/archive_restore_commit_test.go
+++ b/daemon/archive_restore_commit_test.go
@@ -1,0 +1,79 @@
+package daemon
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+	sessiongit "github.com/sachiniyer/agent-factory/session/git"
+)
+
+// A restore whose new worktree location never reached disk must not report
+// success (#2880).
+//
+// RestoreWorktreeTo moves the bytes and then calls setWorktreeLocation, which
+// updates the path IN MEMORY. The write that follows is the only thing that
+// carries it across a restart, and it used persistInstance — log and continue. A
+// lost write plus an unclean exit therefore reloads the session Archived, bound
+// to an archive directory that no longer exists, while the user's work sits at
+// the restore path with nothing durable pointing at it. The next restore fails
+// relocate's source-exists guard, and no poll repairs the divergence:
+// persistPollChange writes on a liveness/reset change and this row's liveness is
+// already settled.
+//
+// This is the same contract the cut-off-relocate branch in the same function
+// already keeps (TestRestoreArchived_RelocateCutOffReportsAFailedPersist). A
+// relocate that fully SUCCEEDED makes the new location more certain, not less.
+func TestRestoreArchived_SuccessfulRelocateReportsAFailedPersist(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, _ := registerArchivable(t, manager, repoID, repoPath, "worker")
+	inst.SetBackend(&recoverFakeBackend{FakeBackend: session.NewFakeBackend()})
+
+	_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
+	require.NoError(t, err)
+	archivedPath := inst.GetWorktreePath()
+	require.Equal(t, archivedPath, recordFor(t, repoID, "worker").Worktree.WorktreePath,
+		"precondition: the archive location is what is persisted going in")
+
+	restored, perr := sessiongit.RestoreWorktreePath(repoPath, "worker", inst.GetBranch())
+	require.NoError(t, perr)
+
+	// Fail exactly the restore commit: the write that first carries the RESTORED
+	// location. Everything before it — the archive above, and the relocate's own
+	// git work — is real, so this cannot be confused with a restore that never got
+	// that far.
+	diskFull := errors.New("no space left on device")
+	prev := testHookPersistInstanceData
+	t.Cleanup(func() { testHookPersistInstanceData = prev })
+	testHookPersistInstanceData = func(_ string, data session.InstanceData) error {
+		if data.Title == "worker" && data.Worktree.WorktreePath == restored {
+			return diskFull
+		}
+		return nil
+	}
+
+	_, _, err = manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
+
+	require.Error(t, err,
+		"a restore whose new location was never written reported success: disk still says Archived at "+
+			"an archive path that no longer exists, so a restart strands the worktree and every later "+
+			"restore fails the source-exists guard")
+	assert.ErrorContains(t, err, restored,
+		"the error must name where the worktree actually is, so the operator can re-register it")
+	assert.ErrorContains(t, err, diskFull.Error(),
+		"the error must name the write failure, not just the outcome")
+
+	// The premise: the bytes really did move, which is what makes a lost pointer
+	// stranding rather than a harmless retry.
+	assert.True(t, exists(restored), "premise: the relocate placed the worktree at the restore path")
+	assert.False(t, exists(archivedPath), "premise: it is no longer at the archive path")
+
+	// And the record still names the old location — the exact state a restarted
+	// daemon would load. Nothing here can fix that; the error is the only signal
+	// the operator gets, which is why it must not be swallowed.
+	assert.Equal(t, archivedPath, recordFor(t, repoID, "worker").Worktree.WorktreePath,
+		"premise: the failed write left the stale archive path on disk")
+}


### PR DESCRIPTION
Found by the transactional-commit audit; the class sweep is #2883.

## The interleaving

`RestoreArchivedSession` (`daemon/archive.go`):

1. `RestoreArchivedWorktree(dest)` moves the worktree out of the archive root back beside the repo.
   `relocateWorktreeTo` moves the bytes, then `setWorktreeLocation(dest)` updates `g.worktreePath`
   **in memory only**.
2. `RestoreFromArchive()` re-spawns the agent and flips the row live.
3. `m.persistInstance(...)` — best-effort: failure logged and dropped.

Lose that write, then exit uncleanly:

- disk still says `Archived` with `Worktree.WorktreePath` at the **archive** path, which no longer
  exists;
- the row reloads Archived and inert, bound to that dead path;
- the user's work is at `dest` and nothing durable points at it;
- the next restore fails relocate's source-exists guard —
  `cannot relocate worktree: source <archive path> does not exist`.

Nothing repairs it. `persistPollChange` writes only on a liveness or limit-reset change, and after
the restore the poll's before and after are the same settled state. The whole-state shutdown
checkpoint would fix it, and an unclean exit is exactly what skips it.

## Why this one was unambiguous

The `ErrRelocateStateUnknown` branch **in the same function** was already hardened against
precisely this, and says why:

> That new location only exists in memory, and this failure path returns without persisting — so a
> daemon restart would reload the session as Archived pointing at an archive path that is no longer
> there, and every later restore would fail the source-exists guard while the user's work sat at
> dest.
>
> Persist first, then report — and take the error-returning persist, not the log-and-continue one.

Every word applies to the success path, where the relocate having fully succeeded makes the new
location *more* certain. Both arms now take `persistInstanceErr` and report the stranding the way
that branch already does, naming the path the worktree is actually at so the operator can
re-register it.

A restore that could not be recorded is not a completed restore, however live the session is.

## Verification

The daemon suite cannot be run on the maintainer's host, so **fail-first came from CI**: the
test-only commit `42fb88d2` was pushed ahead of the fix and its `Test` job went red with

```
--- FAIL: TestRestoreArchived_SuccessfulRelocateReportsAFailedPersist
    Error:   An error is expected but got nil.
    Messages: a restore whose new location was never written reported success: disk still says
              Archived at an archive path that no longer exists, so a restart strands the worktree
              and every later restore fails the source-exists guard
```

That red alone would not have been enough — on the unfixed code the assertion fails whether or not
the injected write failure ever matched — so the test also asserts the injection **fired**. Without
that it could go vacuously green later if what gets written ever changes (a different commit point,
a `ForStorage` rewrite of the path). It further pins the premise: the bytes really are at the
restore path, gone from the archive path, and the record still names the stale one.

Left alone deliberately: `restoreRemoteSession` (`archive.go:552`) has the same shape with a
different consequence — the branch is on origin either way, so a lost write orphans a sandbox
rather than stranding local work. That needs its own reasoning about double-provisioning and should
not ride along here.

Gate on the pushed head `f543d0b9`: `gofmt -l .` (empty), `go build ./...`,
`golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh`.
Daemon tests left to CI per the host policy.

Closes #2880

🤖 Generated with [Claude Code](https://claude.com/claude-code)