### PR TITLE
fix(web): give each session's VS Code editor its own origin (#2743)

### DIFF
--- a/daemon/editor_origin.go
+++ b/daemon/editor_origin.go
@@ -1,0 +1,138 @@
+package daemon
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// The VS Code editor's PER-SESSION preview origin (#2743).
+//
+// Terminal history — and every other piece of workbench state — crosses between
+// sessions' editors, and the vector is the browser ORIGIN, not the shared user-data
+// directory the issue was first filed against. code-server is VS Code *Web*, which
+// keeps workbench state in the browser's IndexedDB; `vscode-web-state-db-global`
+// holds `terminal.history.entries.commands` and `.dirs` and is NOT workspace-scoped.
+// Because every session's editor is framed on the SPA's one origin, they all share
+// that database, so one session's commands and checkout paths show up in another
+// session's "Run Recent Command". On this box those command lines carry branch names,
+// paths and occasionally tokens, and it looks exactly like the user's own history —
+// so nobody would ever report it.
+//
+// The fix is to stop sharing the origin. That is #1856's machinery, with ONE
+// difference that makes it a separate derivation rather than a flag on the existing
+// one: an editor's origin must be STABLE.
+//
+// WHY A SECOND SECRET. A web tab's origin is HMAC(Manager.previewSecret, sid, tid),
+// and previewSecret is in-memory and rotates on every daemon restart — right for a
+// dev-server preview, which holds nothing worth keeping. An editor holds a great
+// deal: layout, opened editors, and the very terminal history this issue is about,
+// all in origin-scoped IndexedDB. A rotating origin would silently blank all of it on
+// every daemon restart, which is not a fix but a second, quieter data loss. So the
+// editor's origin derives from a secret PERSISTED at 0600 in the af home — the same
+// posture the daemon bearer token already has — and the preview secret keeps its
+// ephemeral lifetime, unchanged. Two secrets because they protect two things with
+// genuinely different lifetimes; collapsing them would mean either weakening the
+// preview posture or destroying editor state.
+//
+// WHY PER SESSION, NOT PER TAB. There is one code-server per session
+// (ensureVSCodeServer keys on daemonInstanceKey(repoID, title)), so a per-TAB origin
+// would put one editor behind two origins with two IndexedDBs — the same process
+// disagreeing with itself about its own state. Per-session is also exactly the
+// boundary the issue asks for: history scoped per session, with the user-data
+// directory still shared so settings and extensions keep carrying across, which is
+// why it is shared in the first place.
+//
+// WHAT THIS DOES NOT COVER, stated rather than discovered: *.localhost resolves to
+// the BROWSER's own loopback, so a remote viewer keeps the shared-origin editor and
+// keeps this leak. Closing it there needs an origin scheme that survives a single
+// forwarded port, which no *.localhost scheme does.
+
+// editorOriginSecretFileName is the persisted HMAC key behind every editor origin.
+// 0600 in the af home, beside daemon-token, and for the same reason: it is bearer
+// material for a surface that must outlive a restart.
+const editorOriginSecretFileName = "editor-origin-secret" //nolint:gosec // file name, not a credential
+
+// editorOriginSecretPath resolves the editor-origin secret's path in the af home.
+func editorOriginSecretPath() (string, error) {
+	dir, err := config.GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, editorOriginSecretFileName), nil
+}
+
+// ensureEditorOriginSecret loads the persisted editor-origin secret, minting it on
+// first use. It mirrors EnsureToken exactly — 0700 directory, file lock, atomic 0600
+// write — because it is the same kind of material with the same durability
+// requirement, and a second hand-rolled implementation is how the two drift.
+//
+// Persistence IS the feature here: the value's whole job is to make an editor's
+// origin the same name tomorrow as it was today, so the browser hands that editor
+// back the IndexedDB it left behind.
+func ensureEditorOriginSecret() (string, error) {
+	path, err := editorOriginSecretPath()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("create editor-origin secret directory: %w", err)
+	}
+	var resolved string
+	err = config.WithFileLock(path, func() error {
+		if secret, lerr := loadEditorOriginSecret(path); lerr == nil {
+			resolved = secret
+			return nil
+		} else if !os.IsNotExist(lerr) {
+			return lerr
+		}
+		secret, gerr := generateToken()
+		if gerr != nil {
+			return gerr
+		}
+		if werr := config.AtomicWriteFile(path, []byte(secret+"\n"), 0o600); werr != nil {
+			return fmt.Errorf("write editor-origin secret: %w", werr)
+		}
+		resolved = secret
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return resolved, nil
+}
+
+// loadEditorOriginSecret reads the secret, treating an empty file as absent so a
+// truncated write is re-minted rather than producing a derivation everyone shares.
+func loadEditorOriginSecret(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	secret := strings.TrimSpace(string(data))
+	if secret == "" {
+		return "", os.ErrNotExist
+	}
+	return secret, nil
+}
+
+// editorOriginLabel derives the DNS label of one SESSION's editor origin. Same shape
+// and alphabet as previewTabHostLabel (so previewHostLabel parses both and one gate
+// covers them), but keyed on the session alone and under the PERSISTED secret — the
+// two properties that make an editor's browser state survive a daemon restart.
+//
+// The "vscode" domain separator keeps this derivation disjoint from the web-tab one
+// even if the two secrets were ever identical, so no session's editor origin can
+// collide with any tab's preview origin.
+func editorOriginLabel(secret, sessionID string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte("vscode"))
+	mac.Write([]byte{0})
+	mac.Write([]byte(sessionID))
+	return previewLabelPrefix + strings.ToLower(previewLabelEncoding.EncodeToString(mac.Sum(nil)[:previewLabelBytes]))
+}

--- a/daemon/editor_origin_test.go
+++ b/daemon/editor_origin_test.go
@@ -1,0 +1,477 @@
+package daemon
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The VS Code editor's per-session, restart-STABLE origin (#2743). code-server is
+// VS Code Web and keeps workbench state in origin-scoped browser IndexedDB
+// (vscode-web-state-db-global holds terminal.history.entries.commands, which is NOT
+// workspace-scoped), so every session's editor sharing the SPA's origin means one
+// session's terminal history is readable in another session's editor.
+
+// TestEditorOrigin_DiffersPerSession is the leak, stated as a property: two sessions
+// must not share an editor origin. The browser partitions IndexedDB by origin, so
+// distinct origins are exactly what stops the history crossing — nothing else in the
+// stack does, and the shared user-data directory (the vector this issue was first
+// filed against) is not involved either way.
+func TestEditorOrigin_DiffersPerSession(t *testing.T) {
+	const secret = "persisted-editor-secret"
+
+	a := editorOriginLabel(secret, "session-a")
+	b := editorOriginLabel(secret, "session-b")
+	require.NotEqual(t, a, b, "two sessions' editors must not share an origin — that IS the leak")
+	require.True(t, isPreviewLabel(a), "an editor label must parse as a preview label, so one gate covers both")
+	require.True(t, isPreviewLabel(b))
+	require.LessOrEqual(t, len(a), 63, "a DNS label may not exceed 63 characters")
+}
+
+// TestEditorOrigin_StableAcrossRestarts is the property that separates a fix from a
+// second, quieter data loss. The web-tab derivation rotates with an in-memory secret;
+// applying that to an editor would blank its layout, its open editors and its
+// terminal history on every daemon restart. The editor's secret is persisted, so the
+// origin — and therefore the IndexedDB the browser hands back — is the same name
+// tomorrow as today.
+func TestEditorOrigin_StableAcrossRestarts(t *testing.T) {
+	home := testguard.SocketTempDir(t)
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	first, err := ensureEditorOriginSecret()
+	require.NoError(t, err)
+	require.NotEmpty(t, first)
+
+	// A second daemon lifetime over the same af home resolves the SAME secret.
+	second, err := ensureEditorOriginSecret()
+	require.NoError(t, err)
+	require.Equal(t, first, second, "the editor-origin secret must persist, or every restart is a wipe")
+	require.Equal(t, editorOriginLabel(first, "s1"), editorOriginLabel(second, "s1"),
+		"a session's editor origin must survive a daemon restart")
+
+	// Contrast, pinned deliberately: the WEB preview secret is ephemeral by design and
+	// keeps that lifetime. Collapsing the two would either weaken the preview posture
+	// or destroy editor state.
+	cfg := config.DefaultConfig()
+	m1, err := NewManager(cfg)
+	require.NoError(t, err)
+	m2, err := NewManager(cfg)
+	require.NoError(t, err)
+	require.NotEqual(t, m1.previewSecret, m2.previewSecret,
+		"the web-preview secret stays per-daemon — this fix must not quietly persist it")
+	require.Equal(t, m1.editorOriginSecret, m2.editorOriginSecret,
+		"the editor secret is the one that persists")
+}
+
+// TestEditorOriginSecret_OnDiskPosture pins how the persisted secret is stored. It is
+// bearer material, so it gets the daemon token's posture: 0600 in the af home. It is
+// on disk ON PURPOSE — that is the whole point — so the test asserts the mode rather
+// than its absence, which is the opposite of the preview secret's contract.
+func TestEditorOriginSecret_OnDiskPosture(t *testing.T) {
+	home := testguard.SocketTempDir(t)
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	secret, err := ensureEditorOriginSecret()
+	require.NoError(t, err)
+	path, err := editorOriginSecretPath()
+	require.NoError(t, err)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm(),
+		"the editor-origin secret is bearer material: same posture as the daemon token")
+	require.Equal(t, filepath.Dir(path), filepath.Clean(home), "it lives in the af home")
+
+	// An empty/truncated file must be re-minted, never used: a shared empty secret
+	// would give every session's editor the SAME origin — the leak, restored.
+	require.NoError(t, os.WriteFile(path, []byte("\n"), 0o600))
+	remade, err := ensureEditorOriginSecret()
+	require.NoError(t, err)
+	require.NotEmpty(t, remade, "an empty secret file must be re-minted, never used as the key")
+	require.NotEqual(t, secret, remade, "and re-minting must produce a new value, not resurrect the old one")
+}
+
+// TestEditorOrigin_MintedPerSessionNotPerTab pins that two vscode tabs in ONE session
+// share one origin. There is one code-server per session, so a per-tab origin would
+// put a single editor behind two IndexedDBs — the same process disagreeing with
+// itself about its own state.
+func TestEditorOrigin_MintedPerSessionNotPerTab(t *testing.T) {
+	const secret = "persisted-editor-secret"
+	require.Equal(t, editorOriginLabel(secret, "s1"), editorOriginLabel(secret, "s1"),
+		"the derivation reads the session alone — no tab id enters it")
+
+	// And it is disjoint from the web-tab derivation even under an identical secret,
+	// so no editor origin can ever collide with a preview origin.
+	require.NotEqual(t, editorOriginLabel(secret, "s1"), previewTabHostLabel(secret, "s1", "t1"))
+	require.NotEqual(t, editorOriginLabel(secret, "s1"), previewTabHostLabel(secret, "s1", ""))
+}
+
+// TestEditorOrigin_MintedForAVSCodeTab drives the real path: a live VS Code tab must
+// mint the PER-SESSION, persisted-secret origin — not the per-tab ephemeral one a web
+// tab gets — and the two kinds in one session must land on different origins.
+//
+// This is what actually closes the leak: the editor stops sharing the SPA's origin,
+// so the browser stops handing every session's editor the same IndexedDB.
+func TestEditorOrigin_MintedForAVSCodeTab(t *testing.T) {
+	upstream := echoUpstream(t, "devserver")
+	m, previewAddr, sessionID, tabIDs := newPreviewOriginFixture(t, upstream.URL)
+	editorTab := addVSCodeTab(t, m, sessionID)
+
+	webOrigin := previewOriginFor(m, sessionID, tabIDs[0])
+	editorOrigin := previewOriginFor(m, sessionID, editorTab)
+	require.NotEmpty(t, webOrigin)
+	require.NotEmpty(t, editorOrigin)
+	require.NotEqual(t, webOrigin, editorOrigin,
+		"an editor and a dev-server preview in one session are different origins")
+
+	editorLabel, ok := previewHostLabel(editorOrigin[len("http://"):])
+	require.True(t, ok)
+	require.Equal(t, editorOriginLabel(m.editorOriginSecret, sessionID), editorLabel,
+		"a vscode tab must use the PER-SESSION derivation under the persisted secret")
+	require.NotEqual(t, previewTabHostLabel(m.previewSecret, sessionID, editorTab), editorLabel,
+		"it must NOT use the per-tab ephemeral derivation — that origin dies on restart")
+
+	// A SECOND vscode tab in the same session resolves to the SAME origin: one
+	// code-server per session, so one origin and one IndexedDB.
+	secondEditor := addVSCodeTab(t, m, sessionID)
+	require.Equal(t, editorOrigin, previewOriginFor(m, sessionID, secondEditor),
+		"two vscode tabs share one editor, so they must share one origin")
+
+	// Fail-safe: with no persisted secret the daemon promises no stable editor origin
+	// and the client keeps today's same-origin mirror. A WEB tab is unaffected.
+	m.editorOriginSecret = ""
+	require.Empty(t, previewOriginFor(m, sessionID, editorTab),
+		"without a persisted secret there is no stable address to promise")
+	require.NotEmpty(t, previewOriginFor(m, sessionID, tabIDs[0]),
+		"a web tab rides the ephemeral secret and is unaffected")
+	_ = previewAddr
+}
+
+// addVSCodeTab adds a VS Code tab to the fixture's session and returns its stable id.
+// Creating one spawns nothing — a vscode tab resolves its editor at proxy time.
+func addVSCodeTab(t *testing.T, m *Manager, sessionID string) string {
+	t.Helper()
+	inst, repoID, title, err := m.resolveStreamSession(sessionID, "")
+	require.NoError(t, err)
+	require.NotNil(t, inst)
+	before := len(inst.GetTabs())
+	_, err = m.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "vscode"})
+	require.NoError(t, err)
+	tabs := inst.GetTabs()
+	require.Len(t, tabs, before+1)
+	id := tabs[before].ID
+	require.NotEmpty(t, id)
+	return id
+}
+
+// TestEditorOrigin_GateAuthenticatesTheEditorOrigin is the round trip the rest of
+// this file did not make, and its absence hid a total functional failure.
+//
+// Minting and deriving were both tested in isolation and both correct, while the
+// GATE re-derived every registered label with the web-tab rule — so an editor origin
+// presented a label that could never match, and the listener answered the framed
+// "address expired" notice instead of the editor. Every unit test still passed: the
+// two halves were each right about themselves and wrong about each other.
+//
+// A vscode target cannot actually be served here (there is no code-server on a test
+// box), and that is what makes the assertion sharp: reaching the editor's OWN
+// failure — the install hint — proves the request got PAST the gate, which is the
+// only thing under test. An "address expired" body would mean it did not.
+func TestEditorOrigin_GateAuthenticatesTheEditorOrigin(t *testing.T) {
+	upstream := echoUpstream(t, "devserver")
+	m, previewAddr, sessionID, tabIDs := newPreviewOriginFixture(t, upstream.URL)
+	editorTab := addVSCodeTab(t, m, sessionID)
+
+	editorOrigin := previewOriginFor(m, sessionID, editorTab)
+	require.NotEmpty(t, editorOrigin, "a live vscode tab must mint an origin")
+	host := editorOrigin[len("http://"):]
+
+	resp := previewHostGet(t, previewHTTPClient(), previewAddr, host, "/")
+	body := readAllString(t, resp)
+	require.NotContains(t, body, "Preview address expired",
+		"the gate must AUTHENTICATE an editor origin — it has to re-derive the label the same way previewOriginFor minted it")
+	require.NotContains(t, body, "unauthorized")
+
+	// Past the gate, it fails on the editor itself, which is the expected outcome on a
+	// box with no code-server. Either notice proves authentication succeeded.
+	require.True(t,
+		strings.Contains(body, "VS Code") || strings.Contains(body, "code-server"),
+		"expected the editor's own notice once authenticated, got: %s", body)
+
+	// And a WEB tab in the same session still authenticates under its own derivation,
+	// so the fork did not simply move the breakage to the other kind.
+	webHost := previewHostOf(t, m, previewAddr, sessionID, tabIDs[0])
+	webResp := previewHostGet(t, previewHTTPClient(), previewAddr, webHost, "/")
+	require.Equal(t, http.StatusOK, webResp.StatusCode)
+	require.Contains(t, readAllString(t, webResp), "server=devserver")
+}
+
+// TestEditorOrigin_SurvivesTheRegisteringTabClosing pins that a session's editor
+// origin does not depend on WHICH vscode tab last asked for it. All of a session's
+// editor tabs share one label, so the registry entry holds the last registrant; if
+// that tab closes while another editor pane stays open, resolving through the stored
+// id would fail on a live editor.
+func TestEditorOrigin_SurvivesTheRegisteringTabClosing(t *testing.T) {
+	upstream := echoUpstream(t, "devserver")
+	m, previewAddr, sessionID, _ := newPreviewOriginFixture(t, upstream.URL)
+	first := addVSCodeTab(t, m, sessionID)
+	second := addVSCodeTab(t, m, sessionID)
+
+	// The SECOND tab registers last, so it owns the shared entry.
+	origin := previewOriginFor(m, sessionID, second)
+	require.NotEmpty(t, origin)
+	require.Equal(t, origin, previewOriginFor(m, sessionID, first), "one label for the session")
+
+	_, repoID, title, err := m.resolveStreamSession(sessionID, "")
+	require.NoError(t, err)
+	inst, _, _, err2 := m.resolveStreamSession(sessionID, "")
+	require.NoError(t, err2)
+	nameOf := ""
+	for _, tb := range inst.GetTabs() {
+		if tb.ID == second {
+			nameOf = tb.Name
+		}
+	}
+	require.NotEmpty(t, nameOf)
+	_, err = m.CloseTab(CloseTabRequest{Title: title, RepoID: repoID, TabName: nameOf})
+	require.NoError(t, err)
+
+	// The first editor tab is still open, so the shared origin must still resolve.
+	resp := previewHostGet(t, previewHTTPClient(), previewAddr, origin[len("http://"):], "/")
+	body := readAllString(t, resp)
+	require.NotContains(t, body, "Preview address expired",
+		"a surviving editor tab must keep the session's origin working after the registrant closed")
+}
+
+// TestEditorOrigin_StabilityFollowsTheActiveListener pins that the ephemeral-port
+// guard reads the listener that is SERVING, not the one config asks for.
+//
+// The two diverge exactly where it hurts: a daemon started on "127.0.0.1:0" whose
+// live change to a fixed port FAILS to bind has already had the fixed value swapped
+// into config, while reconcile deliberately leaves the old random-port listener
+// accepting. Deciding from config there would vend a supposedly stable editor origin
+// on an ephemeral port, and the editor's browser storage would vanish at the next
+// restart — the exact loss the persisted secret exists to prevent, reached by
+// trusting the wrong source.
+// TestEditorOrigin_WithheldOnANetworkBoundListener pins the security half of the
+// editor-origin precondition, which a web tab is deliberately not held to.
+//
+// On the preview listener the host label is the ONLY credential for every peer, and
+// *.localhost resolution buys no protection against an attacker: a remote client just
+// sends `Host: <label>.localhost` to an exposed ip:port. Behind an editor origin is a
+// code-server the daemon spawned with auth disabled — a terminal, so arbitrary code
+// execution as the user — and an editor's label comes from a PERSISTED secret, so it
+// never rotates and one leak is permanent. A web tab's label dies at the next restart
+// and fronts a dev server, which is a far smaller prize.
+//
+// Withholding costs nothing real: per-tab origins are same-machine only by nature, so
+// a network-bound preview listener could never have served a remote viewer an editor.
+func TestEditorOrigin_WithheldOnANetworkBoundListener(t *testing.T) {
+	for _, addr := range []string{"0.0.0.0:8444", ":8444", "192.168.1.10:8444", "[::]:8444"} {
+		require.False(t, editorOriginPortIsSafe(addr),
+			"a network-bound preview listener must not carry an editor origin: %q", addr)
+	}
+	for _, addr := range []string{"127.0.0.1:8444", "localhost:8444", "[::1]:8444"} {
+		require.True(t, editorOriginPortIsSafe(addr), "a loopback fixed port is the supported shape: %q", addr)
+	}
+	// Both conditions are required, not either.
+	require.False(t, editorOriginPortIsSafe("127.0.0.1:0"), "loopback but ephemeral is still refused")
+	require.False(t, editorOriginPortIsSafe(""), "nothing bound is nothing to promise")
+
+	// End to end: a live editor tab on a network-bound listener mints nothing, while
+	// the WEB tab beside it is unaffected — its origin is ephemeral by design and it
+	// fronts a dev server, not a terminal.
+	upstream := echoUpstream(t, "devserver")
+	m, sessionID, _ := newPreviewDaemonWithTabs(t, func(cfg *config.Config) {
+		cfg.PreviewListenAddr = "0.0.0.0:0"
+	}, upstream.URL)
+	editorTab := addVSCodeTab(t, m, sessionID)
+	require.Empty(t, previewOriginFor(m, sessionID, editorTab),
+		"no editor origin on a listener a network peer can reach")
+}
+
+func TestEditorOrigin_StabilityFollowsTheActiveListener(t *testing.T) {
+	require.True(t, previewPortIsEphemeral("127.0.0.1:0"), ":0 lets the kernel re-pick every bind")
+	require.True(t, previewPortIsEphemeral(""), "nothing bound is nothing stable")
+	require.True(t, previewPortIsEphemeral("garbage"))
+	require.False(t, previewPortIsEphemeral("127.0.0.1:8444"), "a fixed port is the whole precondition")
+
+	upstream := echoUpstream(t, "devserver")
+	m, _, sessionID, _ := newPreviewOriginFixture(t, upstream.URL)
+	editorTab := addVSCodeTab(t, m, sessionID)
+
+	// The fixture binds a concrete port, so an editor origin is on offer.
+	require.NotEmpty(t, previewOriginFor(m, sessionID, editorTab))
+	require.False(t, previewPortIsEphemeral(m.activePreviewConfigAddr()))
+
+	// Now ask config for an ephemeral port WITHOUT rebinding, which is the shape a
+	// failed live rebind leaves behind. The active listener still has its fixed port,
+	// so the origin must still be offered — the guard must not follow the request.
+	next := *m.Config()
+	next.PreviewListenAddr = "127.0.0.1:0"
+	m.live.Store(&next)
+	require.Equal(t, "127.0.0.1:0", m.Config().PreviewListenAddr, "config now asks for an ephemeral port")
+	require.False(t, previewPortIsEphemeral(m.activePreviewConfigAddr()),
+		"the SERVING listener still has its fixed port — the guard reads that, not the request")
+	require.NotEmpty(t, previewOriginFor(m, sessionID, editorTab),
+		"an editor origin stays valid while the listener behind it is unchanged")
+}
+
+// TestEditorOrigin_RevokedWhenTheListenerBecomesUnsafe pins that the loopback
+// requirement is enforced where every request passes, not only where the origin was
+// minted. preview_listen_addr applies LIVE, so a loopback listener can become
+// network-bound under a registration that already exists — and bindPreviewLocked
+// swaps the listener without touching the registry. Gating only the mint would leave
+// `Host: <old label>.localhost` authorizing an auth-disabled editor, i.e. a terminal,
+// on the newly exposed port.
+func TestEditorOrigin_RevokedWhenTheListenerBecomesUnsafe(t *testing.T) {
+	upstream := echoUpstream(t, "devserver")
+	m, previewAddr, sessionID, _ := newPreviewOriginFixture(t, upstream.URL)
+	editorTab := addVSCodeTab(t, m, sessionID)
+
+	origin := previewOriginFor(m, sessionID, editorTab)
+	require.NotEmpty(t, origin, "loopback + fixed port: an editor origin is minted")
+	host := origin[len("http://"):]
+	label, ok := previewHostLabel(host)
+	require.True(t, ok)
+	_, registered := m.previewOrigins.lookup(label)
+	require.True(t, registered, "and the registration exists — this is the stale entry under test")
+
+	// The listener goes network-bound live. The registry is deliberately NOT cleared,
+	// which is exactly the condition that made minting-time-only gating insufficient.
+	next := *m.Config()
+	next.PreviewListenAddr = "0.0.0.0:8444"
+	m.live.Store(&next)
+	require.NoError(t, m.webListeners.bindPreviewLocked("0.0.0.0:0"))
+
+	// Bind-new-before-close means the OLD listener is gone, so the request has to go
+	// to the address now serving. Asking the old one would fail at the transport and
+	// prove nothing about the gate — which is exactly how this test first failed.
+	exposedAddr := m.lifecycle.snapshot().listeners.PreviewBoundAddr
+	require.NotEmpty(t, exposedAddr)
+	require.NotEqual(t, previewAddr, exposedAddr, "the listener really moved")
+
+	resp := previewHostGet(t, previewHTTPClient(), exposedAddr, host, "/")
+	body := readAllString(t, resp)
+	require.NotContains(t, body, "server=devserver", "an exposed listener must not serve the editor's origin")
+	require.Contains(t, body, "Preview address expired",
+		"the gate must re-check listener safety per request, not trust the registration")
+}
+
+// TestEditorOrigin_SurvivesADaemonRestartWithoutAReload pins the property the
+// persisted secret exists for. The label is stable across restarts while
+// previewOrigins is in-memory and empty on every boot, so a UI left open across a
+// restart keeps addressing a perfectly valid host the new daemon has not learned.
+// Requiring a manual reload there would defeat the whole point of persisting.
+func TestEditorOrigin_SurvivesADaemonRestartWithoutAReload(t *testing.T) {
+	upstream := echoUpstream(t, "devserver")
+	m, previewAddr, sessionID, _ := newPreviewOriginFixture(t, upstream.URL)
+	editorTab := addVSCodeTab(t, m, sessionID)
+
+	origin := previewOriginFor(m, sessionID, editorTab)
+	require.NotEmpty(t, origin)
+	label, ok := previewHostLabel(origin[len("http://"):])
+	require.True(t, ok)
+
+	// Simulate the new daemon: same persisted secret and sessions, EMPTY registry —
+	// which is precisely what a restart produces.
+	m.previewOrigins = newPreviewOriginRegistry()
+	_, known := m.previewOrigins.lookup(label)
+	require.False(t, known, "the new boot has never seen this label")
+
+	ref, recovered := m.recoverEditorOrigin(label)
+	require.True(t, recovered, "a stable editor label must be resolvable without the per-boot registry")
+	require.Equal(t, sessionID, ref.sessionID)
+	require.Equal(t, session.TabKindVSCode, ref.kind)
+
+	// And it is registered on the way, so the derivation is paid once per boot.
+	_, nowKnown := m.previewOrigins.lookup(label)
+	require.True(t, nowKnown)
+
+	// A label belonging to no session is still refused — recovery is derivation, not
+	// a bypass of the credential.
+	_, bogus := m.recoverEditorOrigin(editorOriginLabel(m.editorOriginSecret, "no-such-session"))
+	require.False(t, bogus)
+	_ = previewAddr
+}
+
+// TestEditorOrigin_UnknownHostIsO1 pins that an unknown preview host costs a map
+// lookup, not a scan. Any peer that can dial the preview listener may invent
+// correctly-shaped af….localhost hosts with no credential, so the miss path must not
+// do per-session work — the version this replaces computed an HMAC per live session
+// WHILE HOLDING the manager's main mutex, which on a box with hundreds of sessions
+// turns a free rejection into O(sessions) work and serializes real session
+// operations behind the flood.
+func TestEditorOrigin_UnknownHostIsO1(t *testing.T) {
+	secret := "persisted"
+	ids := []string{"s1", "s2", "s3"}
+	scans := 0
+	idFn := func() []string {
+		scans++
+		return ids
+	}
+	idx := newEditorLabelIndex()
+
+	// First miss builds the index once.
+	_, ok := idx.lookup("afdoesnotexist", idFn, secret)
+	require.False(t, ok)
+	require.Equal(t, 1, scans)
+
+	// A flood of further unknown hosts must not rebuild: the rate limit holds them to
+	// the cached answer.
+	for i := 0; i < 50; i++ {
+		_, ok := idx.lookup("afinvented", idFn, secret)
+		require.False(t, ok)
+	}
+	require.Equal(t, 1, scans, "an unknown-host flood must not scan per request")
+
+	// A known label still resolves, from the index the first miss built.
+	sid, ok := idx.lookup(editorOriginLabel(secret, "s2"), idFn, secret)
+	require.True(t, ok)
+	require.Equal(t, "s2", sid)
+	require.Equal(t, 1, scans, "and a hit needs no rebuild at all")
+}
+
+// TestEditorOrigin_WarmUpDeniesWithARetryingNotice pins WHICH framed page a denial
+// renders while the daemon is still restoring.
+//
+// The preview listener binds long before RestoreInstances (#829), so an editor iframe
+// can navigate before the daemon has the sessions it needs to recognise the label.
+// That address becomes valid seconds later — so rendering the terminal "expired" page
+// there strands the frame on a document that never re-requests, exactly the failure
+// the recovery path was added to remove.
+func TestEditorOrigin_WarmUpDeniesWithARetryingNotice(t *testing.T) {
+	warming := true
+	gate := &authGate{
+		expectedTokenForRequest: func(*http.Request) (string, error) { return "", nil },
+		presentedToken:          func(*http.Request) string { return "whatever" },
+	}
+	serve := func() *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		servePosture(rec, httptest.NewRequest(http.MethodGet, "/", nil),
+			http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+			requestPosture{gate: gate, previewOrigin: true, previewWarmingUp: func() bool { return warming }})
+		return rec
+	}
+
+	warm := serve()
+	require.Contains(t, warm.Body.String(), "Starting up")
+	require.Contains(t, warm.Body.String(), `http-equiv="refresh"`,
+		"a warm-up denial MUST retry — the address becomes valid when restore finishes")
+	require.NotContains(t, warm.Body.String(), "Preview address expired")
+
+	warming = false
+	restored := serve()
+	require.Contains(t, restored.Body.String(), "Preview address expired")
+	require.NotContains(t, restored.Body.String(), `http-equiv="refresh"`,
+		"once restored, an unrecognised label is terminal — retrying would spin forever")
+}

--- a/daemon/httpauth.go
+++ b/daemon/httpauth.go
@@ -222,6 +222,10 @@ type requestPosture struct {
 	// Zero value false keeps the control-plane behavior, so only the preview
 	// listener opts in.
 	previewOrigin bool
+	// previewWarmingUp reports whether the daemon has not finished restoring. It
+	// only ever matters alongside previewOrigin, and it decides WHICH framed page a
+	// denial renders — see servePosture. Nil means "not warming up".
+	previewWarmingUp func() bool
 }
 
 // servePosture runs the auth + CORS flow for one request against a posture the
@@ -255,13 +259,24 @@ func servePosture(w http.ResponseWriter, r *http.Request, next http.Handler, p r
 	if p.gate != nil && !p.gate.authorize(r) {
 		if p.previewOrigin {
 			// A preview origin's denial is RENDERED IN A PANE, so it must not be the
-			// JSON envelope. The everyday cause is a daemon restart: the secret rotates
-			// and the registry empties, so an iframe left open keeps addressing a host
-			// that no longer names a tab. Say that, and say what fixes it.
+			// JSON envelope. WHICH page depends on whether the address can still become
+			// valid, and getting that backwards strands the frame either way.
 			//
-			// Deliberately NON-retrying: the old address can never become valid again
-			// under the new secret, so a self-refreshing page would spin forever. The
-			// web client mints a fresh origin when it rebuilds the pane.
+			// WARMING UP: the listener binds long before RestoreInstances (#829), so an
+			// editor iframe can navigate while the daemon still has no sessions to
+			// recognise its label by. That address becomes valid the moment restore
+			// finishes, so this must be the RETRYING notice — the expired page never
+			// re-requests, and the frame would sit on it until a manual reload even
+			// though the daemon recovered seconds later.
+			if p.previewWarmingUp != nil && p.previewWarmingUp() {
+				writeTabNoticePage(w, "Starting up",
+					"af is starting up — this tab will load as soon as the daemon has restored its sessions.", true)
+				return
+			}
+			// Otherwise the address really is dead: a web tab's label does not survive
+			// the secret rotating, and an editor label the restored daemon cannot place
+			// names no session it holds. Deliberately NON-retrying — nothing will make
+			// it valid — and the web client mints a fresh origin when it rebuilds.
 			writePreviewExpiredPage(w)
 			return
 		}

--- a/daemon/listener_reload.go
+++ b/daemon/listener_reload.go
@@ -212,7 +212,8 @@ func (wl *webListeners) bindPreviewLocked(addr string) error {
 	policy := previewListenerPolicy(cfg)
 	notice := config.PreviewListenerExposureNotice(cfg)
 	closer, info, err := startTCPListenerWithListen(wl.previewMux, addr, cfg, policy, previewShell, previewOriginAuth(wl.manager),
-		&livePosture{snapshot: wl.manager.Config, policyFromConfig: false, previewOrigin: true}, wl.listenTCP)
+		&livePosture{snapshot: wl.manager.Config, policyFromConfig: false, previewOrigin: true,
+			previewWarmingUp: func() bool { return !wl.manager.Ready() }}, wl.listenTCP)
 	if err != nil {
 		return fmt.Errorf("apply preview_listen_addr %q: %w — daemon still serving preview on %s", addr, err, servingOn(wl.previewConfigAddr))
 	}
@@ -246,6 +247,17 @@ func (wl *webListeners) bindPreviewLocked(addr string) error {
 		log.WarningLog.Printf("%s", notice)
 	}
 	return nil
+}
+
+// previewConfigAddress returns the CONFIG address that produced the preview listener
+// currently serving — not the one config merely asks for. The two diverge exactly
+// when a live rebind FAILED: ApplyConfig has already swapped the requested config in
+// while reconcile left the previous listener accepting, so a decision made from
+// config would describe a listener that does not exist. "" when nothing is bound.
+func (wl *webListeners) previewConfigAddress() string {
+	wl.mu.Lock()
+	defer wl.mu.Unlock()
+	return wl.previewConfigAddr
 }
 
 // close tears down both listeners (daemon shutdown). Errors are joined so one

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/task"
 )
@@ -63,6 +64,21 @@ type Manager struct {
 	// mutex, deliberately: the gate must resolve a request without ever touching a
 	// session lock (#1878's "the proxy must not do the restore's job").
 	previewOrigins *previewOriginRegistry
+
+	// editorOriginSecret is the PERSISTED HMAC key behind a session's VS Code origin
+	// (#2743). Deliberately separate from previewSecret and with the opposite
+	// lifetime: an editor's workbench state (layout, opened editors, terminal
+	// history) lives in origin-scoped browser IndexedDB, so its origin must be the
+	// same name after a daemon restart or that state is silently destroyed. Empty
+	// when it could not be loaded, which withholds editor origins rather than
+	// promising a stable one it cannot keep. Immutable after construction.
+	editorOriginSecret string
+
+	// editorLabels indexes editor host labels back to their sessions so an unknown
+	// preview host is an O(1) rejection. Any peer that can dial the preview listener
+	// can invent correctly-shaped hosts without a credential, so the miss path must
+	// not do per-session work (#2743 review).
+	editorLabels *editorLabelIndex
 
 	// limitDetector is the resolved usage-limit matcher set (#1146), built from
 	// cfg.LimitPatterns (it compiles the override regexes) and reused across poll
@@ -381,6 +397,16 @@ func newManagerShellForDaemon(cfg *config.Config, transactionID string) (*Manage
 	if err != nil {
 		return nil, fmt.Errorf("mint preview secret: %w", err)
 	}
+	// The editor-origin secret is PERSISTED, unlike the one above (#2743): a session's
+	// VS Code origin must survive a daemon restart or the browser hands the editor a
+	// fresh, empty IndexedDB every time. Non-fatal — a daemon that cannot keep this
+	// secret should still start and simply serve editors on the app origin as before,
+	// rather than refusing to run over a preview feature that is off by default.
+	editorSecret, err := ensureEditorOriginSecret()
+	if err != nil {
+		log.WarningLog.Printf("editor preview origins disabled: %v", err)
+		editorSecret = ""
+	}
 	state := config.LoadState()
 	storage, err := session.NewStorage(state, "")
 	if err != nil {
@@ -393,6 +419,8 @@ func newManagerShellForDaemon(cfg *config.Config, transactionID string) (*Manage
 		cfg:                    cfg,
 		previewSecret:          previewSecret,
 		previewOrigins:         newPreviewOriginRegistry(),
+		editorOriginSecret:     editorSecret,
+		editorLabels:           newEditorLabelIndex(),
 		pollReloadCh:           make(chan struct{}, 1),
 		ready:                  make(chan struct{}),
 		lifecycle:              lifecycle,

--- a/daemon/preview_auth_test.go
+++ b/daemon/preview_auth_test.go
@@ -322,7 +322,7 @@ func TestPreviewAuthEndpoint_WithholdsOriginUnlessBound(t *testing.T) {
 			cfg.PreviewListenAddr = ""
 		}, upstream.URL)
 		require.False(t, m.lifecycle.snapshot().listeners.PreviewConfigured)
-		require.True(t, m.hasIframeTab(sid, tabIDs[0]), "the tab is live — only the listener is missing")
+		requireIframeTab(t, m, sid, tabIDs[0], "the tab is live — only the listener is missing")
 		require.Empty(t, fetchPreviewAuthOrigin(t, m, sid, tabIDs[0]),
 			"a disabled preview listener must vend no origin")
 	})
@@ -340,10 +340,27 @@ func TestPreviewAuthEndpoint_WithholdsOriginUnlessBound(t *testing.T) {
 		listeners := m.lifecycle.snapshot().listeners
 		require.True(t, listeners.PreviewConfigured, "the address was configured")
 		require.False(t, listeners.PreviewBound, "the bind failed")
-		require.True(t, m.hasIframeTab(sid, tabIDs[0]), "the tab is live — only the bind failed")
+		requireIframeTab(t, m, sid, tabIDs[0], "the tab is live — only the bind failed")
 		require.Empty(t, fetchPreviewAuthOrigin(t, m, sid, tabIDs[0]),
 			"a configured-but-unbound preview listener must not vend an origin for a dead port")
 	})
+}
+
+// requireIframeTab asserts the (session, tab) pair really is a live iframe tab, so a
+// test that expects an EMPTY origin proves the reason it means to prove rather than
+// passing because the tab was never there.
+// requireIframeTabOK asserts whether (sid, tid) resolves as a live iframe tab, so a
+// test that expects a NEGATIVE proves the reason it means to prove.
+func requireIframeTabOK(t *testing.T, m *Manager, sid, tid string, want bool, msgAndArgs ...any) {
+	t.Helper()
+	_, ok := m.iframeTabKind(sid, tid)
+	require.Equal(t, want, ok, msgAndArgs...)
+}
+
+func requireIframeTab(t *testing.T, m *Manager, sid, tid, msg string) {
+	t.Helper()
+	_, ok := m.iframeTabKind(sid, tid)
+	require.True(t, ok, msg)
 }
 
 // fetchPreviewAuthOrigin calls GET /v1/preview-auth?session=&tab= on m's control

--- a/daemon/preview_origin.go
+++ b/daemon/preview_origin.go
@@ -13,7 +13,9 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
 )
 
@@ -125,6 +127,12 @@ const previewOriginRegistryMax = 1024
 type previewTabRef struct {
 	sessionID string
 	tabID     string
+	// kind records which derivation minted this label, because the gate has to
+	// re-derive it the SAME way to authenticate it. A web tab's label is per-tab
+	// under the ephemeral secret; an editor's is per-session under the persisted
+	// one. Deriving the wrong one yields a value that can never match the presented
+	// host, which fails closed — the editor simply never loads (#2743 review).
+	kind session.TabKind
 }
 
 // previewOriginRegistry maps a minted host label back to its tab. It is the ONLY
@@ -150,13 +158,13 @@ func newPreviewOriginRegistry() *previewOriginRegistry {
 
 // register makes label addressable for (sessionID, tabID), evicting the oldest
 // entries once the cap is exceeded.
-func (p *previewOriginRegistry) register(label, sessionID, tabID string) {
+func (p *previewOriginRegistry) register(label, sessionID, tabID string, kind session.TabKind) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if _, exists := p.byLabel[label]; !exists {
 		p.order = append(p.order, label)
 	}
-	p.byLabel[label] = previewTabRef{sessionID: sessionID, tabID: tabID}
+	p.byLabel[label] = previewTabRef{sessionID: sessionID, tabID: tabID, kind: kind}
 	for len(p.order) > previewOriginRegistryMax {
 		oldest := p.order[0]
 		p.order = p.order[1:]
@@ -247,10 +255,12 @@ func isPreviewLabel(s string) bool {
 	return true
 }
 
-// hasIframeTab reports whether sessionID names a live session holding an IFRAME
-// tab with stable id tabID. It is the registration guard on /v1/preview-auth, and
-// it is deliberately NOT WebTabTarget: resolving a vscode target SPAWNS an editor,
-// which minting an address must never do.
+// iframeTabKind reports the kind of the IFRAME tab with stable id tabID in the live
+// session sessionID, and whether it is one at all. It is the registration guard on
+// /v1/preview-auth AND what selects the origin derivation (a web tab's is per-tab and
+// ephemeral, an editor's is per-session and stable, #2743). It is deliberately NOT
+// WebTabTarget: resolving a vscode target SPAWNS an editor, which minting an address
+// must never do.
 //
 // Resolved under ONE lock (TabTargetByID), the same discipline the proxy uses: an
 // id→ordinal then ordinal→tab pair takes the instance lock twice, and a tab closing
@@ -261,9 +271,9 @@ func isPreviewLabel(s string) bool {
 // resolveStreamSession's refresh would otherwise load a session off disk here — and
 // it fails the safe way: no origin is minted, so the client keeps the same-origin
 // mirror until the daemon has restored.
-func (m *Manager) hasIframeTab(sessionID, tabID string) bool {
+func (m *Manager) iframeTabKind(sessionID, tabID string) (session.TabKind, bool) {
 	if !m.Ready() {
-		return false
+		return 0, false
 	}
 	// The ALREADY-RESTORED map, never resolveStreamSession. That resolver's miss path
 	// runs findSessionByStableID + refreshLocked, i.e. it reads session state off disk
@@ -279,13 +289,197 @@ func (m *Manager) hasIframeTab(sessionID, tabID string) bool {
 	// tab it is currently rendering.
 	instance := m.trackedStreamSession(sessionID)
 	if instance == nil {
-		return false
+		return 0, false
 	}
 	kind, _, ok := instance.TabTargetByID(tabID)
 	if !ok {
-		return false
+		return 0, false
 	}
-	return kind == session.TabKindWeb || kind == session.TabKindVSCode
+	if kind != session.TabKindWeb && kind != session.TabKindVSCode {
+		return 0, false
+	}
+	return kind, true
+}
+
+// recoverEditorOrigin resolves an editor label the registry does not hold, by
+// re-deriving it from the sessions this daemon actually has.
+//
+// It exists because the editor label is deliberately STABLE across restarts — that is
+// the whole of #2743, so the browser hands the editor back its IndexedDB — while
+// previewOrigins is in-memory and empty on every boot. Without this, a UI left open
+// across a daemon restart keeps addressing a perfectly valid host that the new daemon
+// has simply not learned, and the pane shows "Preview address expired" until the user
+// reloads by hand: the restart the persisted secret was meant to survive.
+//
+// The derivation is one HMAC per tracked session, computed only on a registry miss and
+// registered on success, so the cost is paid once per label per boot. It reads the
+// already-restored map and nothing else — no disk, no refresh — for the same reason
+// the mint guard does (#1878): the auth path must never do the restore's job.
+//
+// Only EDITOR labels are recoverable, and only they need to be: a web tab's label is
+// derived from the ephemeral secret, so after a restart it is not merely unregistered
+// but genuinely invalid, and the client re-fetches one.
+func (m *Manager) recoverEditorOrigin(label string) (previewTabRef, bool) {
+	if m.editorOriginSecret == "" || !m.Ready() {
+		return previewTabRef{}, false
+	}
+	sessionID, ok := m.editorLabels.lookup(label, m.trackedSessionIDs, m.editorOriginSecret)
+	if !ok {
+		return previewTabRef{}, false
+	}
+	// The session owns this label, but only a session with a LIVE editor tab has an
+	// origin to serve — otherwise the label names nothing to proxy.
+	tabID, ok := m.liveVSCodeTab(sessionID)
+	if !ok {
+		return previewTabRef{}, false
+	}
+	ref := previewTabRef{sessionID: sessionID, tabID: tabID, kind: session.TabKindVSCode}
+	m.previewOrigins.register(label, sessionID, tabID, session.TabKindVSCode)
+	return ref, true
+}
+
+// trackedSessionIDs snapshots the stable ids of the sessions the daemon holds. It
+// takes the manager lock only for the copy — no hashing, no I/O — so a caller doing
+// per-session work cannot serialize ordinary session operations behind it.
+func (m *Manager) trackedSessionIDs() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ids := make([]string, 0, len(m.instances))
+	for _, inst := range m.instances {
+		if inst != nil && inst.ID != "" {
+			ids = append(ids, inst.ID)
+		}
+	}
+	return ids
+}
+
+// editorLabelIndex maps editor host labels back to their sessions, so a miss costs a
+// map lookup rather than a scan.
+//
+// The scan it replaces was reachable by ANY peer that can dial the preview listener,
+// with no credential: a correctly-shaped `af….localhost` host is free to invent, and
+// each one used to cost an HMAC per live session — computed while holding the
+// manager's main mutex. On a box with hundreds of sessions that turns an O(1)
+// rejection into O(sessions) work AND serializes real session operations behind the
+// flood. Indexing keeps the recovery the persisted label needs while giving an
+// unknown host the O(1) rejection it should always have had.
+//
+// The index is a pure function of (secret, session id set), and the secret is fixed
+// for the process — so it is rebuilt only when a lookup misses AND the rate limit
+// allows, never per request. A session that appears later is picked up on the next
+// rebuild; nothing depends on that timing, because the normal path registers directly
+// through /v1/preview-auth when the client mounts the pane.
+type editorLabelIndex struct {
+	mu        sync.Mutex
+	byLabel   map[string]string
+	lastBuilt time.Time
+}
+
+// editorLabelIndexMinRebuild bounds how often a miss may trigger a rebuild, so a
+// flood of invented hosts cannot turn every request into a scan.
+const editorLabelIndexMinRebuild = time.Second
+
+func newEditorLabelIndex() *editorLabelIndex {
+	return &editorLabelIndex{byLabel: map[string]string{}}
+}
+
+func (x *editorLabelIndex) lookup(label string, ids func() []string, secret string) (string, bool) {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	if sid, ok := x.byLabel[label]; ok {
+		return sid, true
+	}
+	if !x.lastBuilt.IsZero() && time.Since(x.lastBuilt) < editorLabelIndexMinRebuild {
+		return "", false
+	}
+	x.lastBuilt = time.Now()
+	rebuilt := make(map[string]string, len(x.byLabel))
+	for _, id := range ids() {
+		rebuilt[editorOriginLabel(secret, id)] = id
+	}
+	x.byLabel = rebuilt
+	sid, ok := rebuilt[label]
+	return sid, ok
+}
+
+// liveVSCodeTab returns the stable id of any live VS Code tab in sessionID. There is
+// one editor per session, so every vscode tab addresses the same code-server and any
+// of them will do — which is the point: a shared per-session origin must not depend
+// on one particular tab still existing.
+func (m *Manager) liveVSCodeTab(sessionID string) (string, bool) {
+	if !m.Ready() {
+		return "", false
+	}
+	// The restored map, for the same reason iframeTabKind uses it: this runs on EVERY
+	// editor sub-resource request, and resolveStreamSession's miss path reads session
+	// state off disk. A miss here means the session is gone, which is an answer, not a
+	// reason to go looking on disk (#2948).
+	instance := m.trackedStreamSession(sessionID)
+	if instance == nil {
+		return "", false
+	}
+	for _, tab := range instance.GetTabs() {
+		if tab.Kind == session.TabKindVSCode && tab.ID != "" {
+			return tab.ID, true
+		}
+	}
+	return "", false
+}
+
+// previewPortIsEphemeral reports whether a preview_listen_addr asks the kernel to
+// pick the port (":0"). Such a port changes on every bind, and an origin is
+// scheme+host+PORT — so no label, however stable, yields a stable origin there.
+//
+// It takes the ACTIVE listener's config address, never the requested one. The two
+// diverge precisely when it matters: a daemon started on "127.0.0.1:0" whose live
+// change to a fixed port FAILS to bind has already had the fixed value swapped into
+// config while the old random-port listener keeps serving. Reading config there would
+// vend a supposedly stable editor origin on an ephemeral port, and the editor's
+// browser storage would vanish at the next restart or successful rebind — the exact
+// loss the persisted secret exists to prevent, arrived at by trusting the wrong
+// source. An empty address is ephemeral by the same logic: nothing is bound, so
+// nothing is stable.
+func previewPortIsEphemeral(activeAddr string) bool {
+	if activeAddr == "" {
+		return true
+	}
+	_, port, err := net.SplitHostPort(activeAddr)
+	return err != nil || port == "" || port == "0"
+}
+
+// editorOriginPortIsSafe reports whether the ACTIVE preview listener may carry an
+// EDITOR origin. Two conditions, and a web tab is held to neither.
+//
+//  1. Not ephemeral. An origin is scheme+host+PORT, so a port the kernel re-picks
+//     every bind cannot carry the stable origin an editor's browser state depends on.
+//  2. LOOPBACK-BOUND. This is the security half, and the editor is where it starts to
+//     matter. On this listener the host label is the ONLY credential for every peer,
+//     and *.localhost resolution is irrelevant to an attacker: a remote client can
+//     simply send `Host: <label>.localhost` to an exposed ip:port. What sits behind an
+//     editor origin is a code-server the daemon spawned with auth disabled — a
+//     terminal, i.e. arbitrary code execution as the user — and unlike a web tab's
+//     label, an editor's is derived from a PERSISTED secret, so it never rotates and
+//     one leak (editor content, a log, a screenshot, browser history) is permanent.
+//     A dev server behind a web-tab origin is a far smaller prize with a credential
+//     that dies at the next restart.
+//
+// Withholding costs nothing real: per-tab origins are same-machine only by nature, so
+// a network-bound preview listener was never going to serve a remote viewer an editor
+// anyway. The client falls back to the same-origin mirror, which is what a remote
+// viewer already uses.
+func editorOriginPortIsSafe(activeAddr string) bool {
+	return !previewPortIsEphemeral(activeAddr) && config.IsLoopbackListenAddr(activeAddr)
+}
+
+// activePreviewConfigAddr is the config address behind the preview listener that is
+// actually serving. It falls back to the requested config only when there is no
+// listener owner at all (tests that construct a bare Manager), where the two cannot
+// disagree because nothing has bound.
+func (m *Manager) activePreviewConfigAddr() string {
+	if m.webListeners == nil {
+		return m.Config().PreviewListenAddr
+	}
+	return m.webListeners.previewConfigAddress()
 }
 
 // previewOriginFor returns the browser-facing origin of one tab's preview —
@@ -318,11 +512,37 @@ func previewOriginFor(m *Manager, sessionID, tabID string) string {
 	if err != nil || port == "" {
 		return ""
 	}
-	if !m.hasIframeTab(sessionID, tabID) {
+	kind, ok := m.iframeTabKind(sessionID, tabID)
+	if !ok {
 		return ""
 	}
-	label := previewTabHostLabel(m.previewSecret, sessionID, tabID)
-	m.previewOrigins.register(label, sessionID, tabID)
+	// An editor origin promises STABILITY, and browser storage is partitioned by
+	// scheme, host AND PORT — so a stable label on an ephemeral port is not a stable
+	// origin. With preview_listen_addr = "127.0.0.1:0" the kernel picks a new port
+	// every bind, which would move the editor to a fresh origin (and a fresh, empty
+	// IndexedDB) on every daemon restart: exactly the data loss the persisted secret
+	// exists to prevent, reintroduced one layer down. Withhold instead, so the client
+	// keeps the same-origin mirror rather than being promised durability af cannot
+	// deliver. Web tabs are unaffected — their origins are ephemeral by design.
+	if kind == session.TabKindVSCode && !editorOriginPortIsSafe(m.activePreviewConfigAddr()) {
+		return ""
+	}
+	// The derivation forks on the tab kind, and the fork is the whole of #2743.
+	//
+	// A WEB tab gets a per-TAB label under the ephemeral secret: two previews of the
+	// same session are separate untrusted apps and must not read each other, and a
+	// preview holds nothing worth surviving a restart.
+	//
+	// A VSCODE tab gets a per-SESSION label under the PERSISTED secret. Per-session
+	// because there is one code-server per session, so a per-tab origin would put one
+	// editor behind two IndexedDBs; persisted because the editor's workbench state —
+	// including the terminal history this fixes — is origin-scoped, and a rotating
+	// origin would blank it on every daemon restart.
+	label := m.expectedOriginLabel(previewTabRef{sessionID: sessionID, tabID: tabID, kind: kind})
+	if label == "" {
+		return "" // no persisted secret ⇒ no stable editor origin to promise
+	}
+	m.previewOrigins.register(label, sessionID, tabID, kind)
 	return "http://" + label + previewHostSuffix + ":" + port
 }
 
@@ -343,15 +563,50 @@ func previewOriginAuth(m *Manager) *tcpListenerAuth {
 			}
 			ref, ok := m.previewOrigins.lookup(label)
 			if !ok {
+				// A label the registry does not hold may still be a legitimate editor
+				// origin this daemon simply has not learned yet — see recoverEditorOrigin.
+				ref, ok = m.recoverEditorOrigin(label)
+				if !ok {
+					return "", nil
+				}
+			}
+			// Re-check the listener's safety HERE, not only where the origin was minted.
+			// preview_listen_addr applies live, so a loopback listener can become
+			// network-bound under a registration that already exists — and
+			// bindPreviewLocked swaps the listener without touching the registry. Gating
+			// only the mint would leave `Host: <old label>.localhost` authorizing an
+			// auth-disabled editor on the newly exposed port. The gate is the one place
+			// every request must pass, so the check belongs here where it cannot be
+			// outrun by a config change (#2743 review).
+			if ref.kind == session.TabKindVSCode && !editorOriginPortIsSafe(m.activePreviewConfigAddr()) {
 				return "", nil
 			}
-			return previewTabHostLabel(m.previewSecret, ref.sessionID, ref.tabID), nil
+			// Re-derive by the SAME rule that minted it. A single derivation here would
+			// fail closed for the other kind — and fail closed invisibly, since the
+			// symptom is the framed "address expired" notice rather than an error.
+			return m.expectedOriginLabel(ref), nil
 		},
 		presented: func(r *http.Request) string {
 			label, _ := previewHostLabel(r.Host)
 			return label
 		},
 	}
+}
+
+// expectedOriginLabel re-derives the host label a registered tab's origin must
+// present. It is the authenticating half of previewOriginFor and MUST stay in step
+// with it: the two derivations are keyed on different things (a web tab on
+// (sid, tid) under the ephemeral secret, an editor on the session alone under the
+// persisted one), so a mismatch is not an error anyone sees — it is a gate that
+// silently refuses a correctly-minted origin.
+func (m *Manager) expectedOriginLabel(ref previewTabRef) string {
+	if ref.kind == session.TabKindVSCode {
+		if m.editorOriginSecret == "" {
+			return ""
+		}
+		return editorOriginLabel(m.editorOriginSecret, ref.sessionID)
+	}
+	return previewTabHostLabel(m.previewSecret, ref.sessionID, ref.tabID)
 }
 
 // newPreviewMux is the handler mounted on the preview listener. There is exactly
@@ -398,6 +653,9 @@ func (cs *controlServer) previewOriginHandler(w http.ResponseWriter, r *http.Req
 	}
 	ref, ok := cs.manager.previewOrigins.lookup(label)
 	if !ok {
+		ref, ok = cs.manager.recoverEditorOrigin(label)
+	}
+	if !ok {
 		// Not reachable through the gate, which denies an unregistered label first and
 		// renders the SAME page (servePosture's previewOrigin branch). Kept as the
 		// fail-closed floor for any future wiring that reaches this handler directly:
@@ -419,9 +677,23 @@ func (cs *controlServer) previewOriginHandler(w http.ResponseWriter, r *http.Req
 		writeHTTPError(w, r, http.StatusBadRequest, errors.New("invalid web tab path"))
 		return
 	}
+	tabID := ref.tabID
+	if ref.kind == session.TabKindVSCode {
+		// Every vscode tab of a session shares ONE label, so the registry entry holds
+		// whichever tab registered last. If that tab is closed while another editor
+		// pane stays open, the shared origin would resolve through a dead tab id and
+		// fail until the survivor remounted. The editor is a SESSION-level resource,
+		// so resolve it that way: any live vscode tab of this session addresses it.
+		live, ok := cs.manager.liveVSCodeTab(ref.sessionID)
+		if !ok {
+			writePreviewExpiredPage(w)
+			return
+		}
+		tabID = live
+	}
 	cs.serveWebTabRoute(w, r, webTabRoute{
 		sessionID: ref.sessionID,
-		tabID:     ref.tabID,
+		tabID:     tabID,
 		// Empty: the tab owns the origin ROOT, so there is no prefix to mirror under.
 		// Every prefix-aware rewrite (cookie Path, Location, Refresh) degenerates to
 		// the identity here, which is precisely what "the app owns its origin" means.

--- a/daemon/preview_origin_test.go
+++ b/daemon/preview_origin_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/session"
 )
 
 // TestPreviewListener_NeverEmitsCORSAllowOrigin is the load-bearing isolation test
@@ -124,7 +125,13 @@ func newPreviewDaemonWithTabs(t *testing.T, tune func(*config.Config), targets .
 
 	cfg := config.DefaultConfig()
 	cfg.ListenAddr = "127.0.0.1:0"
-	cfg.PreviewListenAddr = "127.0.0.1:0"
+	// A CONCRETE preview port, not ":0". Editor origins are withheld on an ephemeral
+	// port on purpose — an origin is scheme+host+PORT, so a port the kernel re-picks
+	// every bind cannot carry the stable origin an editor's browser state depends on.
+	// A test that wants to exercise editor origins therefore has to configure the port
+	// a real operator would; grabbing a free one keeps that faithful without pinning a
+	// fixed number that concurrent tests would collide on.
+	cfg.PreviewListenAddr = grabFreeLoopbackAddr(t)
 	if tune != nil {
 		tune(cfg)
 	}
@@ -698,7 +705,7 @@ func TestPreviewOriginRegistry_CapEvictsOldest(t *testing.T) {
 	first := previewTabHostLabel("secret", "s", "t0")
 	for i := 0; i <= previewOriginRegistryMax; i++ {
 		tid := fmt.Sprintf("t%d", i)
-		reg.register(previewTabHostLabel("secret", "s", tid), "s", tid)
+		reg.register(previewTabHostLabel("secret", "s", tid), "s", tid, session.TabKindWeb)
 	}
 	_, ok := reg.lookup(first)
 	require.False(t, ok, "the oldest entry must be evicted once the cap is exceeded")
@@ -706,13 +713,13 @@ func TestPreviewOriginRegistry_CapEvictsOldest(t *testing.T) {
 	newest := previewTabHostLabel("secret", "s", fmt.Sprintf("t%d", previewOriginRegistryMax))
 	ref, ok := reg.lookup(newest)
 	require.True(t, ok, "the newest entry must survive")
-	require.Equal(t, previewTabRef{sessionID: "s", tabID: fmt.Sprintf("t%d", previewOriginRegistryMax)}, ref)
+	require.Equal(t, previewTabRef{sessionID: "s", tabID: fmt.Sprintf("t%d", previewOriginRegistryMax), kind: session.TabKindWeb}, ref)
 
 	// Re-registering an existing label must not grow the order list (or the cap would
 	// evict live entries every time a pane remounted).
 	reg2 := newPreviewOriginRegistry()
 	for i := 0; i < 5; i++ {
-		reg2.register("same-label", "s", "t")
+		reg2.register("same-label", "s", "t", session.TabKindWeb)
 	}
 	require.Len(t, reg2.order, 1, "re-registering the same label must not append a duplicate")
 }
@@ -817,14 +824,14 @@ func TestPreviewAuth_DoesNotRefreshOnUnknownSession(t *testing.T) {
 	m, _, sessionID, tabIDs := newPreviewOriginFixture(t, upstream.URL)
 
 	// A live tab still validates through the tracked map.
-	require.True(t, m.hasIframeTab(sessionID, tabIDs[0]))
+	requireIframeTabOK(t, m, sessionID, tabIDs[0], true)
 
 	// Unknown ids answer false, and do so from memory. resolveStreamSession is the
 	// refreshing path; trackedStreamSession is the one this must use.
 	for _, id := range []string{"no-such-session", "", "af-" + sessionID, sessionID + "x"} {
-		require.False(t, m.hasIframeTab(id, tabIDs[0]), "unknown session %q must not validate", id)
+		requireIframeTabOK(t, m, id, tabIDs[0], false, "unknown session %q must not validate", id)
 		require.Nil(t, m.trackedStreamSession(id), "and must not be resolvable from the tracked map")
 	}
 	// A known session with an unknown tab is equally a miss, with no refresh either.
-	require.False(t, m.hasIframeTab(sessionID, "no-such-tab"))
+	requireIframeTabOK(t, m, sessionID, "no-such-tab", false)
 }

--- a/daemon/tcpserver.go
+++ b/daemon/tcpserver.go
@@ -197,6 +197,9 @@ type livePosture struct {
 	// Zero value false keeps the control listener's behavior, and it is inert for the
 	// agent-server (static posture, no livePosture at all).
 	previewOrigin bool
+	// previewWarmingUp reports whether the daemon is still restoring, so a denial on
+	// the preview origin can render the RETRYING notice instead of the terminal one.
+	previewWarmingUp func() bool
 }
 
 // startTCPListener binds the plain-HTTP TCP listener on addr and serves mux
@@ -290,7 +293,7 @@ func startTCPListenerWithListen(mux http.Handler, addr string, cfg *config.Confi
 				// The preview origin answers no cross-origin reader, ever — see previewOrigin.
 				cors = nil
 			}
-			return requestPosture{gate: g, cors: cors, previewOrigin: live.previewOrigin}
+			return requestPosture{gate: g, cors: cors, previewOrigin: live.previewOrigin, previewWarmingUp: live.previewWarmingUp}
 		})
 	} else {
 		gate := &authGate{

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,25 @@
 # Release Notes
 
+## One session's terminal history no longer shows up in another session's editor
+
+- **A confidentiality fix.** code-server is VS Code *Web*, and it keeps its integrated
+  terminal history in the **browser's** storage, under a key that is global rather than
+  per-workspace. Because every session's editor was framed on the same origin, they all
+  shared one store — so *Terminal: Run Recent Command* in one session offered **another
+  session's commands**, and *Go to Recent Directory* offered another session's checkout.
+  Command lines routinely carry branch names, paths and occasionally secrets, and the
+  entries look exactly like your own, so this was unlikely to ever be reported as a bug.
+- Setting `preview_listen_addr` now gives **each session's editor its own origin**, which
+  is what makes the browser keep those stores apart. The origin is **stable across daemon
+  restarts** (an editor's layout and history live behind it, so a rotating name would
+  wipe them), derived from a 0600 secret in the af home.
+- **The shared user-data directory is untouched** — settings, extensions and themes still
+  carry across sessions, which is the reason it is shared.
+- Two things to expect: **existing editor state does not migrate** (it is the shared store
+  being fixed, so layout and history start empty once), and this is **same-machine only** —
+  a remote viewer keeps the shared-origin editor. See
+  [Web UI → per-tab preview origins](web.md#per-tab-preview-origins).
+
 ## Breaking: a remote hook's `launch_cmd` owns stdout
 
 - **`launch_cmd`'s stdout now carries its `{"url","token"}` endpoint JSON and

--- a/docs/web.md
+++ b/docs/web.md
@@ -617,6 +617,43 @@ What to know before turning it on:
 - **It is off by default.** No second port opens unless you set the key, and a bind
   conflict is logged and skipped, never fatal.
 
+#### VS Code tabs get one too — per session
+
+A **VS Code tab** moves onto a per-**session** origin, not a per-tab one: there is one
+editor per session, so both of a session's editors sit on the same origin and share one
+state store, as they should.
+
+This is a **confidentiality fix, not an ergonomics one**. code-server is VS Code *Web*,
+which keeps workbench state in the browser's IndexedDB — and its terminal history
+(`terminal.history.entries.commands`) is **global, not workspace-scoped**. On one shared
+origin that means one session's *Terminal: Run Recent Command* offers **another
+session's commands**, and *Go to Recent Directory* offers another session's checkout.
+Those command lines carry branch names, paths and sometimes secrets, and it looks
+exactly like your own history, so it never gets reported. Giving each session's editor
+its own origin is what partitions that store.
+
+Two consequences worth knowing:
+
+- **Editor origins require a LOOPBACK, fixed preview port.** With
+  `preview_listen_addr` bound to a network interface (or to an ephemeral `:0`), web
+  tabs still get per-tab origins but **editors do not** — they stay on the same-origin
+  mirror. On that listener the hostname is the only credential, and a remote client can
+  simply send `Host: <label>.localhost` to the exposed port; behind an editor origin is
+  a code-server running with auth disabled, i.e. a terminal. Since per-tab origins are
+  same-machine only anyway, a network bind could never have served a remote viewer an
+  editor, so nothing is lost by refusing.
+- **A session's editor origin is stable across daemon restarts**, unlike a web tab's.
+  It has to be: the editor's layout, open editors and history live behind that origin,
+  so a rotating name would wipe them on every restart. It is derived from a secret kept
+  at `~/.agent-factory/editor-origin-secret` (0600, the same posture as the daemon
+  token). Delete that file and every session's editor starts fresh.
+- **Existing editor state does not migrate.** Turning `preview_listen_addr` on moves
+  editors to new origins, so layout and history start empty once. That old state is the
+  shared store this fixes, so leaving it behind is the point.
+
+The shared **user-data directory is untouched** — settings, extensions and themes still
+carry across every session's editor, which is why af shares it in the first place.
+
 !!! note "Previews over a token-protected listener"
     Over a **token-protected** network listener, iframe sub-resource requests on the
     mirror path are kept authorized via a path-scoped cookie (see

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -10832,6 +10832,7 @@ var SplitView = class {
       return;
     }
     const webProxied = proxied && !isVSCode;
+    const mayUsePreviewOrigin = proxied && realId !== "";
     const probePath = webProxied ? webProxyPath(sessionId, realId, target, null) : "";
     let disposed = false;
     let probeSeq = 0;
@@ -10869,7 +10870,7 @@ var SplitView = class {
         previewSrcOnce = null;
       }
       if (previewSrcOnce === null) {
-        previewSrcOnce = webProxied && !this.archived && canUsePreviewOrigin(window.location) ? fetchPreviewOrigin(sessionId, realId, this.token ?? "").then(async (origin) => {
+        previewSrcOnce = mayUsePreviewOrigin && !this.archived && canUsePreviewOrigin(window.location) ? fetchPreviewOrigin(sessionId, realId, this.token ?? "").then(async (origin) => {
           if (origin === "") {
             return "";
           }

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "0f4eddd54454";
+const VERSION = "2d44be716b3a";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -7746,6 +7746,160 @@ test("icons: the Lucide subset is inline, accessible, and currentColor-themed at
   );
 });
 
+test("vscode tab (#2743): one session's editor state is readable in another's on the shared origin, and is NOT once each session has its own", REAL_FIXTURE, async () => {
+  // The leak and the fix, in one run, driven rather than reasoned about.
+  //
+  // code-server is VS Code Web and keeps workbench state — including
+  // `terminal.history.entries.commands` in `vscode-web-state-db-global`, which is NOT
+  // workspace-scoped — in ORIGIN-scoped browser storage. So the question is entirely
+  // "do two sessions' editors share an origin", and the honest way to answer it is to
+  // write a value in one session's editor and try to read it from the other's.
+  //
+  // localStorage stands in for IndexedDB deliberately: both are partitioned by the
+  // same origin rule, and the fake code-server this fixture runs has no real terminal
+  // to generate history with. What is under test is the PARTITION, not VS Code.
+  const afBin = process.env.AF_BIN;
+  const mockRepo = process.env.AF_MOCK_REPO;
+  const previewPort = process.env.AF_WEB_PREVIEW_PORT;
+  test.skip(!afBin || !mockRepo || !previewPort, "set only by web-selftest-entry.sh");
+  const { execFileSync } = await import("node:child_process");
+  const af = (...args: string[]): void => {
+    execFileSync(afBin as string, ["--repo", mockRepo as string, ...args], { stdio: "pipe" });
+  };
+
+  // Two sessions of its OWN, created out of band and killed in the finally. The
+  // seeded fixture sessions are permuted, archived and consumed by earlier tests in
+  // file order — probe-b is archived by the time this runs, and "cannot add a tab to
+  // an archived session" is not a fact about origins. A test whose subject is
+  // cross-SESSION isolation has to own both sessions outright.
+  //
+  // The names avoid the fixture's substring rule (no seeded name contains these, and
+  // these contain none), so the rail's hasText lookups cannot cross-match.
+  const SA = "probe-2743-alpha";
+  const SB = "probe-2743-beta";
+  const setPreview = (value: string): void => {
+    execFileSync(afBin as string, ["config", "set", "preview_listen_addr", value], { stdio: "pipe" });
+  };
+
+  const PROBE_KEY = "af-2743-probe";
+  const PROBE_VALUE = "AF_EDITOR_STATE_ALPHA_7b21e";
+
+  /** Opens `session`'s vscode tab, waits for the editor to render, and returns the
+   *  frame plus the origin it landed on. */
+  const openEditor = async (session: string): Promise<{ origin: string; frameUrl: string }> => {
+    await row(page, session).click();
+    await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+    await page.locator(".af-tabbar").locator(".af-tab", { hasText: "editor" }).click();
+    const frame = page.locator(".af-term-host .af-pane-host iframe.af-webframe");
+    await expect(frame).toHaveCount(1, { timeout: 15_000 });
+    await expect(page.frameLocator(".af-webframe").locator("#marker")).toHaveText(VSCODE_MARKER, {
+      timeout: 30_000,
+    });
+    const src = (await frame.getAttribute("src")) ?? "";
+    return { origin: new URL(src, page.url()).origin, frameUrl: src };
+  };
+
+  /** Runs fn inside the editor frame of the CURRENTLY open pane, handing it the probe
+   *  key/value pair (a frame callback is serialized, so it can close over nothing). */
+  const inEditor = <T>(origin: string, fn: (kv: [string, string]) => T): Promise<T> => {
+    const f = page.frames().find((fr) => fr.url().startsWith(origin) && fr !== page.mainFrame());
+    expect(f, `an editor frame on ${origin} should be attached`).toBeTruthy();
+    return f!.evaluate(fn, [PROBE_KEY, PROBE_VALUE] as [string, string]);
+  };
+
+  // create then WAIT: `sessions create` can return before the record is resolvable,
+  // and tab-create against a half-created session fails. The entry script polls the
+  // same way for the same reason.
+  const afOk = (...args: string[]): boolean => {
+    try {
+      af(...args);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  for (const s of [SA, SB]) {
+    af("sessions", "create", "--name", s, "--program", "claude");
+    await expect.poll(() => afOk("sessions", "get", s), { timeout: 60_000 }).toBe(true);
+    af("sessions", "tab-create", s, "--kind", "vscode", "--name", "editor");
+  }
+
+  try {
+    // The rail learns about out-of-band sessions through the events plane, but a
+    // reload is the deterministic way to be sure both rows are present before the
+    // assertions start.
+    await page.reload();
+    await expect(row(page, SA)).toHaveCount(1, { timeout: 30_000 });
+    await expect(row(page, SB)).toHaveCount(1, { timeout: 30_000 });
+
+    // ---- 1. THE LEAK, on today's shared origin (preview_listen_addr unset) --------
+    const a0 = await openEditor(SA);
+    expect(a0.frameUrl, "with no preview listener the editor is on the SPA's own origin").toMatch(
+      /^\/v1\/webtab\//,
+    );
+    await inEditor(a0.origin, ([k, v]) => window.localStorage.setItem(k, v));
+
+    const b0 = await openEditor(SB);
+    expect(b0.origin, "both editors share the SPA origin today — that IS the bug").toBe(a0.origin);
+    const leaked = await inEditor(b0.origin, ([k]) => window.localStorage.getItem(k));
+    expect(
+      leaked,
+      "session B's editor reads session A's state on the shared origin — the #2743 leak, reproduced",
+    ).toBe(PROBE_VALUE);
+
+    // ---- 2. THE FIX: a per-session origin ----------------------------------------
+    setPreview(`127.0.0.1:${previewPort}`);
+    await page.reload();
+
+    const a1 = await openEditor(SA);
+    const b1 = await openEditor(SB);
+    const originRe = new RegExp(`^http://af[a-z2-7]{32}\\.localhost:${previewPort}$`);
+    expect(a1.origin, "session A's editor moves to its own origin").toMatch(originRe);
+    expect(b1.origin, "session B's editor moves to its own origin").toMatch(originRe);
+    expect(a1.origin, "two sessions' editors must not share an origin").not.toBe(b1.origin);
+    expect(new URL(a1.frameUrl).pathname, "the editor owns its origin's root").toBe("/");
+
+    // The partition is real: B cannot see the value A wrote, because it is a
+    // different origin and the browser keeps their storage apart.
+    //
+    // Re-open A first. Selecting a session tears its predecessor's pane down, so
+    // after the openEditor(SB) above there is no A frame attached to write into —
+    // only ONE editor frame exists at a time, which is why every write/read below is
+    // bracketed by its own openEditor.
+    await openEditor(SA);
+    await inEditor(a1.origin, ([k, v]) => window.localStorage.setItem(k, v + "_ON_A"));
+    await openEditor(SB);
+    const isolated = await inEditor(b1.origin, ([k]) => window.localStorage.getItem(k));
+    expect(
+      isolated,
+      "session B's editor must NOT see session A's state once each session owns an origin",
+    ).toBeNull();
+
+    // ---- 3. STABILITY: the origin must survive a daemon restart --------------------
+    // The whole reason the editor cannot reuse the web-tab derivation: that label is
+    // keyed on an in-memory secret, so a restart would hand the editor a brand-new
+    // origin and therefore an empty IndexedDB — fixing a leak by destroying the same
+    // data. Re-resolving the origin must yield the SAME name.
+    const a2 = await openEditor(SA);
+    expect(a2.origin, "a session's editor origin must be stable, not per-render").toBe(a1.origin);
+    const kept = await inEditor(a2.origin, ([k]) => window.localStorage.getItem(k));
+    expect(kept, "and its state must still be there").toBe(PROBE_VALUE + "_ON_A");
+  } finally {
+    setPreview("");
+    // Kill rather than archive: these sessions exist only for this test, and killing
+    // prunes their worktrees and branches so nothing is left for later tests to trip
+    // over. Best-effort — a cleanup failure must not mask the assertion that ran.
+    for (const s of [SA, SB]) {
+      try {
+        af("sessions", "kill", s);
+      } catch {
+        // already gone, or the daemon is unhappy — either way, not this test's verdict
+      }
+    }
+    await page.reload();
+  }
+});
+
 test("vscode tab (#2077): the labelled New tab menu creates a VS Code tab and serves it through the proxy", REAL_FIXTURE, async () => {
   // End to end, with no seeded fixture: pick VS Code from the tab bar's kind menu,
   // and the daemon spawns a code-server (the FAKE one on PATH — no CI box has a

--- a/web/src/split.ts
+++ b/web/src/split.ts
@@ -1121,6 +1121,17 @@ export class SplitView {
     // #1817's pre-existing behavior, not something this change introduces or should
     // silently redesign mid-rebase. Reported as a follow-up.
     const webProxied = proxied && !isVSCode;
+    // Whether this pane may be moved onto the tab's OWN origin. Deliberately NOT
+    // webProxied: that flag scopes the dead-server probe and the cache buster, both of
+    // which are web-tab concerns, while the origin move covers BOTH kinds — and the
+    // editor is the kind that most needs it (#2743). A vscode tab's editor keeps its
+    // workbench state, including terminal history, in origin-scoped browser
+    // IndexedDB, so every session's editor sharing the SPA's origin means every
+    // session's editor shares that history.
+    //
+    // The archived fence still applies through `proxied`'s own caller: an archived
+    // session never reaches load() at all.
+    const mayUsePreviewOrigin = proxied && realId !== "";
     const probePath = webProxied ? webProxyPath(sessionId, realId, target, null) : "";
     let disposed = false;
     // Supersedes an in-flight probe: a slow answer from an earlier attempt must never
@@ -1214,7 +1225,7 @@ export class SplitView {
       }
       if (previewSrcOnce === null) {
         previewSrcOnce =
-          webProxied && !this.archived && canUsePreviewOrigin(window.location)
+          mayUsePreviewOrigin && !this.archived && canUsePreviewOrigin(window.location)
             ? fetchPreviewOrigin(sessionId, realId, this.token ?? "").then(async (origin) => {
                 if (origin === "") {
                   return "";

--- a/web/src/stable_tab_addressing.test.ts
+++ b/web/src/stable_tab_addressing.test.ts
@@ -567,3 +567,30 @@ test("webSandbox: a vscode frame keeps its own grant regardless of origin", () =
     assert.ok(s.includes("allow-downloads"), s);
   }
 });
+
+// --- a VS Code tab's origin (#2743) ------------------------------------------
+//
+// The editor keeps its workbench state — layout, opened editors, and the terminal
+// history this closes — in origin-scoped browser IndexedDB. On the shared SPA origin
+// every session's editor reads one database, so one session's "Run Recent Command"
+// offers another session's commands. A per-session origin is what partitions it, and
+// the editor must land on that origin's ROOT.
+
+test("previewOriginSrc: a vscode tab (no target) frames the origin root", () => {
+  assert.equal(previewOriginSrc("http://afedit.localhost:8444", ""), "http://afedit.localhost:8444/");
+});
+
+test("previewOriginSrc: a vscode tab's src carries no path or query to collide with the editor's own", () => {
+  const src = previewOriginSrc("http://afedit.localhost:8444", "");
+  assert.equal(new URL(src).pathname, "/");
+  assert.equal(new URL(src).search, "", "the editor reads its own query string (?folder=…)");
+});
+
+test("webSandbox: a vscode frame on its own origin still gets same-origin — now safely", () => {
+  // It always had allow-same-origin (VS Code cannot run under an opaque origin). What
+  // changes is that the frame is now CROSS-origin to the SPA, so the browser's own
+  // origin check — not the sandbox — is what keeps it away from the parent's token.
+  const s = webSandbox(true, true);
+  assert.ok(s.includes("allow-same-origin"), s);
+  assert.ok(s.includes("allow-downloads"), s);
+});

--- a/web/src/tabaddr.ts
+++ b/web/src/tabaddr.ts
@@ -297,7 +297,13 @@ export function canUsePreviewOrigin(loc: { protocol: string; hostname: string })
  *  prefix and 404ing (#1811).
  *
  *  The target's own query rides through verbatim, raw, for the same reason
- *  webProxyPath keeps it: for plenty of dev servers the query IS the address. */
+ *  webProxyPath keeps it: for plenty of dev servers the query IS the address.
+ *
+ *  A VSCODE tab passes target "" (it has none by design — its editor is a
+ *  daemon-managed code-server), which yields the bare origin root. That is exactly
+ *  right: the editor owns the whole origin, which is what stops one session's
+ *  workbench state — terminal history included — from being readable in another
+ *  session's editor (#2743). */
 export function previewOriginSrc(origin: string, target: string): string {
   const base = `${origin.replace(/\/$/, "")}/${targetPathOf(target)}`;
   const query = targetQueryOf(target);


### PR DESCRIPTION
Terminal history crosses between sessions' editors. The vector is the browser
**origin**, not the shared user-data directory this was originally filed against.

code-server is VS Code *Web*, which keeps workbench state in the browser's IndexedDB.
`vscode-web-state-db-global` holds `terminal.history.entries.commands` and `.dirs` and
is **not** workspace-scoped. Every session's editor was framed on the SPA's one origin,
so they all read one store: *Terminal: Run Recent Command* in one session offered
**another session's commands**, and *Go to Recent Directory* offered another session's
checkout. Those command lines carry branch names, paths and sometimes secrets — and the
entries look exactly like your own, so this would never have been reported as a bug.

## Why #2833 didn't close it

#2833 gave **web** tabs per-tab origins and deliberately left VS Code tabs on the app
origin (`split.ts`: `const webProxied = proxied && !isVSCode`). Those are precisely the
tabs this issue is about, so the leak survived it untouched.

## Why this is a different derivation, not a flag

- **Per SESSION, not per tab.** There is one code-server per session
  (`ensureVSCodeServer` keys on `daemonInstanceKey(repoID, title)`), so a per-tab origin
  would put one editor behind two IndexedDBs — the same process disagreeing with itself
  about its own state.
- **Stable across daemon restarts.** A web tab's label is `HMAC(previewSecret, …)`, and
  `previewSecret` is in-memory and rotates every restart. Right for a disposable dev
  server; applied to an editor it would blank the layout, the open editors and *the very
  history this fixes* on every restart — fixing a leak by causing a second, quieter data
  loss. The editor's label derives from a **persisted** secret (0600 in the af home, the
  posture the daemon bearer already has). The preview secret keeps its ephemeral lifetime,
  unchanged: two secrets because they protect two things with genuinely different
  lifetimes, and collapsing them would mean either weakening the preview posture or
  destroying editor state.

The **shared user-data directory is untouched**, so settings and extensions still carry
across sessions — the reason it is shared, and what the issue asked to preserve.

A welcome side effect: the editor frame is now **cross-origin** to the SPA, so the
`allow-same-origin` grant it already carried stops being "effectively no sandbox". The
browser's own origin check — not the sandbox — is now what keeps it from the parent's
token.

## Verified by driving it, not by reasoning

The selftest reproduces the bug and its absence **in one run**:

1. With `preview_listen_addr` unset, open session A's editor, write a value to its
   storage, open session B's editor — and **read that value back**. The leak, reproduced,
   with both editors asserted to be on the same origin.
2. Turn `preview_listen_addr` on, reload. Both editors move to `af….localhost:<port>`
   origins, the two origins are asserted **different**, and the editor owns its origin's
   root. The same read from B now returns **null**.
3. Re-resolve A's origin: it is the **same name**, and the value A wrote is still there —
   the stability property, which is what stops this fix from being a data loss.

`localStorage` stands in for IndexedDB because both are partitioned by the same origin
rule and the fixture's code-server is a stub with no real terminal. What is under test is
the partition, not VS Code.

Go tests cover the derivation directly: distinct per session, identical for two tabs of
one session, disjoint from the web-tab derivation even under an identical secret, stable
across simulated restarts, 0600 on disk, re-minted if truncated, and withheld entirely if
the secret cannot be persisted (the client then keeps today's mirror rather than being
promised a stable address the daemon cannot keep).

## Known limits, stated rather than discovered

- **Existing editor state does not migrate.** Turning the key on moves editors to new
  origins, so layout and history start empty once. That old state *is* the shared store
  being fixed, so leaving it behind is the point — but it is user-visible and is in the
  release notes.
- **Same-machine only.** `*.localhost` resolves to the browser's own loopback, so a
  remote viewer keeps the shared-origin editor and keeps this leak. Closing it there
  needs an origin scheme that survives a single forwarded port, which no `*.localhost`
  scheme does.
- **`preview_listen_addr` is off by default**, so the fix is opt-in. Whether the editor
  should force the listener on is a product call I have not made here.

Closes #2743

🤖 Generated with [Claude Code](https://claude.com/claude-code)
