### PR TITLE
feat(web): long-press to copy out of the terminal on touch (#2849)

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -24,6 +24,22 @@
   stream makes the endpoint a parse, and there is deliberately no opt-out: an
   escape hatch would restore exactly the ambiguity this removes.
 
+## Copying out of the web terminal on a phone
+
+- **Long-press the terminal to copy.** Touch had no copy gesture at all — not a
+  hard one, none: the rendered rows are `user-select: none` so the browser could
+  never build a selection to long-press on, xterm's own selection is driven from
+  mouse events a finger never sends, and every clipboard shortcut needs a Ctrl or
+  Cmd a phone does not have. Pressing and holding now selects the token under your
+  finger and copies it.
+- It takes the **whole whitespace-delimited token** — a path, a URL, a branch name,
+  a container id — rather than stopping at punctuation, because half of a URL is
+  not what anyone reached for. Pressing past the end of a line copies that line
+  instead, which is how you take a whole command or error message.
+- The selection stays highlighted, so you can see exactly what was copied. Scrolling
+  and tapping are unchanged: a drag still scrolls history and a tap still reaches a
+  mouse-aware TUI, since a press that moves is a scroll and never a copy.
+
 ## Absolute-path assets load in a web-tab preview
 
 - Setting `preview_listen_addr` (for example `127.0.0.1:8444`) now opens a second

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6999,6 +6999,57 @@ function touchScrollClaimsGesture(originY, y) {
 function touchHistoryScrollPlan(lastY, y, rows, rowHeight, remainder) {
   return historyWheelPlan({ deltaMode: 0, deltaY: lastY - y }, rows, rowHeight, remainder);
 }
+var TOUCH_LONG_PRESS_MS = 500;
+function touchPressStillHeld(originX, originY, x, y) {
+  return Math.abs(x - originX) < TOUCH_SCROLL_SLOP_PX && Math.abs(y - originY) < TOUCH_SCROLL_SLOP_PX;
+}
+function terminalCellAtPoint(x, y, rect, cols, rows) {
+  if (rect.width <= 0 || rect.height <= 0 || cols <= 0 || rows <= 0) {
+    return null;
+  }
+  const col = Math.floor((x - rect.left) / rect.width * cols);
+  const row = Math.floor((y - rect.top) / rect.height * rows);
+  if (col < 0 || col >= cols || row < 0 || row >= rows) {
+    return null;
+  }
+  return { col, row };
+}
+function wordRangeAtColumn(cells, col) {
+  const partOfWord = (index) => {
+    const cell = cells[index];
+    return cell !== void 0 && (cell === "" || cell.trim() !== "");
+  };
+  if (!partOfWord(col)) {
+    return null;
+  }
+  let start = col;
+  while (start > 0 && partOfWord(start - 1)) {
+    start -= 1;
+  }
+  let end = col;
+  while (end + 1 < cells.length && partOfWord(end + 1)) {
+    end += 1;
+  }
+  return { start, length: end - start + 1 };
+}
+function lineContentColumns(cells) {
+  let last = -1;
+  for (let col = cells.length - 1; col >= 0; col -= 1) {
+    const cell = cells[col];
+    if (cell !== void 0 && cell !== "" && cell.trim() !== "") {
+      last = col;
+      break;
+    }
+  }
+  if (last < 0) {
+    return 0;
+  }
+  let end = last;
+  while (end + 1 < cells.length && cells[end + 1] === "") {
+    end += 1;
+  }
+  return end + 1;
+}
 
 // src/theme.ts
 var THEME_CHOICES = ["auto", "light", "dark"];
@@ -7206,6 +7257,8 @@ var AttachTerminal = class {
     container.addEventListener("wheel", this.onWheel, { capture: true, passive: true });
     container.addEventListener("touchstart", this.onTouchStart, { capture: true, passive: true });
     container.addEventListener("touchmove", this.onTouchMove, { capture: true, passive: false });
+    container.addEventListener("touchend", this.onTouchEnd, { capture: true, passive: true });
+    container.addEventListener("touchcancel", this.onTouchEnd, { capture: true, passive: true });
     container.addEventListener("pointerdown", this.onPointerDown, true);
     container.addEventListener("mousedown", this.onMouseDownCapture, true);
     container.addEventListener("copy", this.onCopy);
@@ -7242,9 +7295,16 @@ var AttachTerminal = class {
   touchScrollY = null;
   touchScrollRemainder = 0;
   // Where the gesture started, and whether it has since travelled far enough to be a
-  // scroll rather than a tap. Until it has, the touch is left entirely alone.
-  touchScrollOriginY = 0;
+  // scroll rather than a tap. Until it has, the touch is left entirely alone. The
+  // origin serves the long press too (#2849): both gestures are decided against the
+  // point the finger went down on, by the same threshold.
+  touchOriginX = 0;
+  touchOriginY = 0;
   touchScrollClaimed = false;
+  // The pending long press, and whether it has already copied on this gesture — a
+  // copy has to swallow the compatibility click the same touch would otherwise fire.
+  touchLongPressTimer = null;
+  touchCopyFired = false;
   // Whether the gesture in flight came from a finger, read off the pointer event that
   // precedes the browser's compatibility mouse events (onPointerDown).
   lastPointerWasTouch = false;
@@ -7308,13 +7368,25 @@ var AttachTerminal = class {
   // touchstart that a tap's compatibility mouse events depend on.
   onTouchStart = (event) => {
     const onScrollbar = event.target === this.container.querySelector(".xterm-viewport");
-    this.touchScrollY = event.touches.length === 1 && !onScrollbar ? event.touches[0].clientY : null;
-    this.touchScrollOriginY = this.touchScrollY ?? 0;
+    const press = event.touches.length === 1 && !onScrollbar ? event.touches[0] : null;
+    this.touchScrollY = press?.clientY ?? null;
+    this.touchOriginX = press?.clientX ?? 0;
+    this.touchOriginY = press?.clientY ?? 0;
     this.touchScrollRemainder = 0;
     this.touchScrollClaimed = false;
+    this.touchCopyFired = false;
+    this.cancelTouchLongPress();
+    if (press) {
+      this.startTouchLongPress();
+    }
   };
+  onTouchEnd = () => this.cancelTouchLongPress();
   onTouchMove = (event) => {
     this.handleUserScroll("touch");
+    const moved = event.touches.length !== 1 || !touchPressStillHeld(this.touchOriginX, this.touchOriginY, event.touches[0].clientX, event.touches[0].clientY);
+    if (moved) {
+      this.cancelTouchLongPress();
+    }
     if (this.touchScrollY === null) {
       return;
     }
@@ -7329,7 +7401,7 @@ var AttachTerminal = class {
       return;
     }
     if (!this.touchScrollClaimed) {
-      if (!touchScrollClaimsGesture(this.touchScrollOriginY, y)) {
+      if (!touchScrollClaimsGesture(this.touchOriginY, y)) {
         return;
       }
       this.touchScrollClaimed = true;
@@ -7383,6 +7455,11 @@ var AttachTerminal = class {
   // gestures already separate without one, the drag scrolling history (#2682) and the
   // tap staying the click.
   onMouseDownCapture = (event) => {
+    if (this.lastPointerWasTouch && this.touchCopyFired) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
     if (!this.applicationOwnsMouse() || this.lastPointerWasTouch) {
       return;
     }
@@ -7417,6 +7494,7 @@ var AttachTerminal = class {
     }
     const plan = terminalUserScrollPlan(source, this.visibleFitFrame !== null);
     if (plan.cancelScheduledVisibleFit) {
+      this.cancelTouchLongPress();
       this.cancelVisibleFitFrame();
     }
     this.fitVisibleHost();
@@ -7450,6 +7528,8 @@ var AttachTerminal = class {
     this.container.removeEventListener("wheel", this.onWheel, true);
     this.container.removeEventListener("touchstart", this.onTouchStart, true);
     this.container.removeEventListener("touchmove", this.onTouchMove, true);
+    this.container.removeEventListener("touchend", this.onTouchEnd, true);
+    this.container.removeEventListener("touchcancel", this.onTouchEnd, true);
     this.container.removeEventListener("pointerdown", this.onPointerDown, true);
     this.container.removeEventListener("mousedown", this.onMouseDownCapture, true);
     this.container.removeEventListener("copy", this.onCopy);
@@ -7495,6 +7575,65 @@ var AttachTerminal = class {
       this.mouseCaptureHint.setAttribute("aria-hidden", "true");
       this.mouseCaptureHintTimer = null;
     }, 4e3);
+  }
+  /**
+   * The long press — the ONLY way to copy anything out of this terminal on a touch
+   * device (#2849), where all three of the usual routes are closed: xterm's rows are
+   * `user-select: none` so the browser can never build a DOM selection to long-press
+   * on, xterm's own selection is driven from mouse events a finger never sends, and
+   * every branch of clipboard.ts needs a Ctrl or Cmd that no phone has.
+   *
+   * So af makes the selection itself and copies it through the same never-silent
+   * ladder the keyboard path uses. The selection xterm then paints IS the feedback:
+   * it names exactly what landed on the clipboard, which is the one thing #2787's
+   * silent failure could not do.
+   */
+  startTouchLongPress() {
+    this.touchLongPressTimer = window.setTimeout(() => {
+      this.touchLongPressTimer = null;
+      this.copyTouchWord(this.touchOriginX, this.touchOriginY);
+    }, TOUCH_LONG_PRESS_MS);
+  }
+  cancelTouchLongPress() {
+    if (this.touchLongPressTimer !== null) {
+      window.clearTimeout(this.touchLongPressTimer);
+      this.touchLongPressTimer = null;
+    }
+  }
+  /** Selects the token under the finger — the whole line when that cell is blank —
+   *  and copies it. Silent only when there is genuinely nothing there to take. */
+  copyTouchWord(x, y) {
+    const rowsEl = this.container.querySelector(".xterm-rows");
+    if (!rowsEl) {
+      return;
+    }
+    const cell = terminalCellAtPoint(x, y, rowsEl.getBoundingClientRect(), this.term.cols, this.term.rows);
+    if (!cell) {
+      return;
+    }
+    const buffer = this.term.buffer.active;
+    const bufferRow = buffer.viewportY + cell.row;
+    const line = buffer.getLine(bufferRow);
+    if (!line) {
+      return;
+    }
+    const cells = [];
+    for (let col = 0; col < line.length; col += 1) {
+      const buffered = line.getCell(col);
+      cells.push(buffered === void 0 ? " " : buffered.getWidth() === 0 ? "" : buffered.getChars() || " ");
+    }
+    const range = wordRangeAtColumn(cells, cell.col) ?? { start: 0, length: lineContentColumns(cells) };
+    if (range.length === 0) {
+      return;
+    }
+    this.term.select(range.start, bufferRow, range.length);
+    const text = this.term.getSelection();
+    if (text.trim() === "") {
+      this.term.clearSelection();
+      return;
+    }
+    this.touchCopyFired = true;
+    this.copyToClipboard(text);
   }
   /** The painted height of one terminal row, which turns a pixel-denominated gesture
    *  into rows. Falls back to a font-size estimate before the first row exists. */

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "f75ced45391a";
+const VERSION = "a509e118aacd";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -584,6 +584,15 @@ async function touchDrag(cdp: CDPSession, x: number, fromY: number, toY: number,
  * compatibility mouse events, so a tap held slightly unsteady would silently stop
  * reaching the application while a perfectly still one kept working.
  */
+/** Holds one finger still at a point for long enough to be a long press, then lifts
+ *  it. No touchmove at all: a press that wobbles past the threshold is a scroll, and
+ *  that boundary is asserted separately. */
+async function touchLongPress(cdp: CDPSession, x: number, y: number, holdMs = 700): Promise<void> {
+  await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ x, y }] });
+  await new Promise((resolve) => setTimeout(resolve, holdMs));
+  await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+}
+
 async function touchTap(cdp: CDPSession, x: number, y: number): Promise<void> {
   await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ x, y }] });
   // Several small steps rather than one, because they are what a wobble really looks
@@ -2143,6 +2152,114 @@ test("#2682 mobile: one finger scrolls the terminal, and keeps doing so under ap
     // The shell holding mouse mode dies with its tab, so nothing has to unwind the
     // mode itself — and the mouse-report bytes the tap left on its command line go
     // with it rather than into a later `type()`.
+    try {
+      await resetToAgentTab(p);
+    } finally {
+      await ctx.close();
+    }
+  }
+});
+
+test("#2849 mobile: a long press copies the token under the finger", REAL_FIXTURE, async ({ browser }) => {
+  // The same phone-shaped, really-touch-emulated context as #2682 — and the same
+  // reason for it. Nothing here can be proved from a desktop window: what is being
+  // asserted is that a gesture with NO modifier key reaches the system clipboard.
+  const ctx = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    deviceScaleFactor: 3,
+    hasTouch: true,
+    isMobile: true,
+    permissions: ["clipboard-read", "clipboard-write"],
+  });
+  const p = await ctx.newPage();
+  const cdp = await ctx.newCDPSession(p);
+  const inputPayloads: number[][] = [];
+
+  p.on("websocket", (ws) => {
+    if (!ws.url().includes("/v1/sessions/") || !ws.url().includes("/stream")) {
+      return;
+    }
+    ws.on("framesent", ({ payload }) => {
+      const raw = typeof payload === "string" ? new TextEncoder().encode(payload) : new Uint8Array(payload);
+      const frame = decode(raw);
+      if (frame.op === Op.Input) {
+        inputPayloads.push(Array.from(frame.data));
+      }
+    });
+  });
+
+  try {
+    await openTokenless(p);
+    await p.locator(".af-nav-toggle").click();
+    await row(p, SESSION_B).click();
+    await resetToAgentTab(p);
+    await createTerminalTab(p);
+    await expect(p.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Terminal", { timeout: 30_000 });
+    const host = await typeableShellTab(p);
+    const selection = host.locator(".xterm-selection > div");
+
+    // A token carrying the punctuation that makes a terminal word worth copying
+    // whole — a path, a dash, a dot — printed FIRST on its line, with a second word
+    // after it. Starting at column 0 means the press needs no cell arithmetic (the
+    // row's own left edge is that cell), and the trailing word is what makes the
+    // word-vs-line assertions below actually discriminate.
+    const TOKEN = "/srv/af-2849.log";
+    const TRAILER = "ready";
+    await p.keyboard.type(`printf '%s %s\\n' ${TOKEN} ${TRAILER}`);
+    await p.keyboard.press("Enter");
+    await expect(host).toContainText(`${TOKEN} ${TRAILER}`, { timeout: 20_000 });
+
+    // The LAST row showing it is the printf output; the row above is the echoed
+    // command line, which would copy the same token from the wrong place.
+    const tokenRow = host.locator(".xterm-rows > div", { hasText: TOKEN }).last();
+    await expect(tokenRow).toBeVisible();
+    const rowBox = await tokenRow.boundingBox();
+    expect(rowBox, "the token's row must have geometry to press on").toBeTruthy();
+    const { x, y, width, height } = rowBox as ElementBox;
+    const pressY = y + height / 2;
+
+    await p.evaluate(() => navigator.clipboard.writeText("af-2849-clipboard-untouched").catch(() => {}));
+    inputPayloads.length = 0;
+    await touchLongPress(cdp, x + 2, pressY);
+
+    // THE assertion: a finger, no keyboard, and the token is on the system clipboard.
+    await expect
+      .poll(() => p.evaluate(() => navigator.clipboard.readText()), {
+        message: "a long press must put the token under the finger on the system clipboard",
+      })
+      .toContain(TOKEN);
+    // …the TOKEN, not its line. That is the difference between copying what the
+    // finger was on and copying everything near it.
+    expect(
+      await p.evaluate(() => navigator.clipboard.readText()),
+      "the press copies the token under the finger, not the whole line",
+    ).not.toContain(TRAILER);
+    // The selection xterm paints is the only feedback this gesture has, so it must
+    // survive the press rather than being cleared by the click that follows it.
+    await expect(selection, "the copied token must stay visibly selected").not.toHaveCount(0);
+    expect(inputPayloads, "a long press is not input — nothing may reach the PTY").toHaveLength(0);
+
+    // A press on blank space past the end of a line falls back to the line itself,
+    // which is how a whole command or error message gets copied.
+    await p.evaluate(() => navigator.clipboard.writeText("af-2849-clipboard-untouched").catch(() => {}));
+    await touchLongPress(cdp, x + width - 2, pressY);
+    await expect
+      .poll(() => p.evaluate(() => navigator.clipboard.readText()), {
+        message: "a press past the end of a line must copy the line",
+      })
+      .toContain(TRAILER);
+
+    // …and the gesture that is NOT a press still is not one. A drag from the same
+    // spot scrolls (#2682) and copies nothing, so the two cannot be confused.
+    await p.evaluate(() => navigator.clipboard.writeText("af-2849-clipboard-untouched").catch(() => {}));
+    const screenBox = await host.locator(".xterm-screen").boundingBox();
+    const box = screenBox as ElementBox;
+    await touchDrag(cdp, box.x + box.width / 2, box.y + box.height * 0.3, box.y + box.height * 0.8);
+    expect(
+      await p.evaluate(() => navigator.clipboard.readText()),
+      "a drag is a scroll, not a copy — it must leave the clipboard alone",
+    ).toContain("untouched");
+  } finally {
     try {
       await resetToAgentTab(p);
     } finally {

--- a/web/src/terminal-mouse.test.ts
+++ b/web/src/terminal-mouse.test.ts
@@ -7,9 +7,14 @@ import {
   terminalMouseOverride,
   terminalMouseOverrideFlag,
   terminalMouseOverrideHeld,
+  lineContentColumns,
+  terminalCellAtPoint,
+  TOUCH_LONG_PRESS_MS,
   TOUCH_SCROLL_SLOP_PX,
   touchHistoryScrollPlan,
+  touchPressStillHeld,
   touchScrollClaimsGesture,
+  wordRangeAtColumn,
 } from "./terminal-mouse.js";
 
 test("application-mouse escape matches xterm's platform selection modifier", () => {
@@ -100,4 +105,67 @@ test("a tap's wobble is not a scroll, in either direction (#2682)", () => {
 
   // Under one terminal row, or a real scroll would visibly lag the finger.
   assert.ok(TOUCH_SCROLL_SLOP_PX < 13 * 1.2);
+});
+
+test("a point resolves to the cell under it, and nothing outside the grid (#2849)", () => {
+  const rect = { left: 100, top: 50, width: 800, height: 400 }; // 80x20 grid → 10x20 cells
+  assert.deepEqual(terminalCellAtPoint(100, 50, rect, 80, 20), { col: 0, row: 0 });
+  assert.deepEqual(terminalCellAtPoint(105, 55, rect, 80, 20), { col: 0, row: 0 });
+  assert.deepEqual(terminalCellAtPoint(115, 71, rect, 80, 20), { col: 1, row: 1 });
+  // The last cell is inside; one pixel past the box is not — an off-by-one here
+  // would copy from a row the finger never touched.
+  assert.deepEqual(terminalCellAtPoint(899, 449, rect, 80, 20), { col: 79, row: 19 });
+  assert.equal(terminalCellAtPoint(900, 449, rect, 80, 20), null);
+  assert.equal(terminalCellAtPoint(899, 450, rect, 80, 20), null);
+  assert.equal(terminalCellAtPoint(99, 60, rect, 80, 20), null);
+
+  // A pane that has not been laid out yet must not resolve to cell 0,0.
+  assert.equal(terminalCellAtPoint(0, 0, { left: 0, top: 0, width: 0, height: 0 }, 80, 20), null);
+});
+
+test("long-press selects the whitespace-delimited token under the finger (#2849)", () => {
+  const cells = [..."cd /srv/app-2 && go test"];
+
+  // The token, not xterm's double-click word: a path keeps its slashes and a branch
+  // its dashes, because a fragment of either is not what anyone meant to copy.
+  assert.deepEqual(wordRangeAtColumn(cells, 5), { start: 3, length: 10 });
+  assert.deepEqual(wordRangeAtColumn(cells, 3), { start: 3, length: 10 });
+  assert.deepEqual(wordRangeAtColumn(cells, 12), { start: 3, length: 10 });
+  assert.deepEqual(wordRangeAtColumn(cells, 0), { start: 0, length: 2 });
+
+  // A blank cell has no word — the caller falls back to the whole line.
+  assert.equal(wordRangeAtColumn(cells, 2), null);
+  assert.equal(wordRangeAtColumn(cells, 999), null);
+  assert.equal(wordRangeAtColumn([], 0), null);
+
+  // A wide character spans two columns and reports "" in the second. It has to join
+  // the token it continues, or every CJK word would be cut at its first glyph.
+  const wide = ["ls", "", " ", "近", "", "藤", "", " "];
+  assert.deepEqual(wordRangeAtColumn(wide, 3), { start: 3, length: 4 });
+  assert.deepEqual(wordRangeAtColumn(wide, 4), { start: 3, length: 4 });
+  assert.deepEqual(wordRangeAtColumn(wide, 0), { start: 0, length: 2 });
+});
+
+test("the line fallback stops at the content, not the blank tail (#2849)", () => {
+  assert.equal(lineContentColumns([..."echo hi", " ", " ", " "]), 7);
+  assert.equal(lineContentColumns([..."x"]), 1);
+  assert.equal(lineContentColumns([" ", " "]), 0);
+  assert.equal(lineContentColumns([]), 0);
+  // A trailing wide-char continuation is content, not tail.
+  assert.equal(lineContentColumns(["近", "", " "]), 2);
+});
+
+test("a press and a scroll are decided by ONE threshold (#2849)", () => {
+  // Same number in both directions, so no gesture can be a press and a scroll at
+  // once, and none can be neither.
+  assert.equal(touchPressStillHeld(100, 200, 100, 200), true);
+  assert.equal(touchPressStillHeld(100, 200, 100 + TOUCH_SCROLL_SLOP_PX - 1, 200), true);
+  assert.equal(touchPressStillHeld(100, 200, 100, 200 - (TOUCH_SCROLL_SLOP_PX - 1)), true);
+  assert.equal(touchPressStillHeld(100, 200, 100 + TOUCH_SCROLL_SLOP_PX, 200), false);
+  assert.equal(touchPressStillHeld(100, 200, 100, 200 + TOUCH_SCROLL_SLOP_PX), false);
+  // The press gives up exactly where the scroll takes over.
+  assert.equal(touchPressStillHeld(0, 0, 0, TOUCH_SCROLL_SLOP_PX), !touchScrollClaimsGesture(0, TOUCH_SCROLL_SLOP_PX));
+
+  // Long enough to be deliberate, short enough that a thumb does not think it failed.
+  assert.ok(TOUCH_LONG_PRESS_MS >= 300 && TOUCH_LONG_PRESS_MS <= 800);
 });

--- a/web/src/terminal-mouse.ts
+++ b/web/src/terminal-mouse.ts
@@ -125,3 +125,118 @@ export function touchHistoryScrollPlan(
 ): HistoryWheelPlan {
   return historyWheelPlan({ deltaMode: 0, deltaY: lastY - y }, rows, rowHeight, remainder);
 }
+
+/**
+ * How long a finger must rest before its touch is a long press rather than a tap.
+ *
+ * 500ms is the platform convention on both Android and iOS, so it is what a thumb
+ * already expects. It sits far enough above a tap that neither gesture has to be
+ * described to the user, which matters because this is the only copy gesture a touch
+ * device has (#2849) and nothing on screen advertises it.
+ */
+export const TOUCH_LONG_PRESS_MS = 500;
+
+/**
+ * Whether a touch is still close enough to where it started to count as a press.
+ *
+ * Deliberately the SAME threshold that turns a drag into a scroll: one number decides
+ * both, so a gesture can never be a press and a scroll at once, and there is no band
+ * between them where a finger is doing neither.
+ */
+export function touchPressStillHeld(originX: number, originY: number, x: number, y: number): boolean {
+  return Math.abs(x - originX) < TOUCH_SCROLL_SLOP_PX && Math.abs(y - originY) < TOUCH_SCROLL_SLOP_PX;
+}
+
+export interface TerminalCellPoint {
+  col: number;
+  row: number;
+}
+
+/**
+ * Resolve a viewport point to the terminal cell under it, given the rendered rows'
+ * box. Returns null for a point outside the grid.
+ *
+ * The box is divided by the grid rather than by a measured character width: the rows
+ * element is sized to exactly cols × rows cells, so this needs no font metrics and
+ * cannot drift from them.
+ */
+export function terminalCellAtPoint(
+  x: number,
+  y: number,
+  rect: { left: number; top: number; width: number; height: number },
+  cols: number,
+  rows: number,
+): TerminalCellPoint | null {
+  if (rect.width <= 0 || rect.height <= 0 || cols <= 0 || rows <= 0) {
+    return null;
+  }
+  const col = Math.floor(((x - rect.left) / rect.width) * cols);
+  const row = Math.floor(((y - rect.top) / rect.height) * rows);
+  if (col < 0 || col >= cols || row < 0 || row >= rows) {
+    return null;
+  }
+  return { col, row };
+}
+
+export interface TerminalWordRange {
+  start: number;
+  length: number;
+}
+
+/**
+ * The run of non-blank cells containing `col`, or null when that cell is blank.
+ *
+ * `cells` carries ONE ENTRY PER COLUMN, so an index is a column. That is the whole
+ * reason it is not a string: a wide character occupies two columns but one code
+ * point, so a string index silently drifts from the column it is meant to name — and
+ * the drift only appears with CJK output, i.e. never in the tests and always in the
+ * field. A wide char's trailing column arrives as "" and belongs to the word it
+ * continues.
+ *
+ * A word is a run of non-whitespace, not xterm's double-click word (which stops at
+ * punctuation). What a terminal is worth copying from is exactly the whitespace-
+ * delimited token — a URL, a path, a branch name, a container id — and splitting
+ * those on `/` or `-` would hand back a fragment nobody wanted.
+ */
+export function wordRangeAtColumn(cells: readonly string[], col: number): TerminalWordRange | null {
+  const partOfWord = (index: number): boolean => {
+    const cell = cells[index];
+    return cell !== undefined && (cell === "" || cell.trim() !== "");
+  };
+  if (!partOfWord(col)) {
+    return null;
+  }
+  let start = col;
+  while (start > 0 && partOfWord(start - 1)) {
+    start -= 1;
+  }
+  let end = col;
+  while (end + 1 < cells.length && partOfWord(end + 1)) {
+    end += 1;
+  }
+  return { start, length: end - start + 1 };
+}
+
+/** How many columns the line's own content occupies, ignoring its blank tail — the
+ *  fallback selection for a press that lands past the end of a line. */
+export function lineContentColumns(cells: readonly string[]): number {
+  let last = -1;
+  for (let col = cells.length - 1; col >= 0; col -= 1) {
+    const cell = cells[col];
+    if (cell !== undefined && cell !== "" && cell.trim() !== "") {
+      last = col;
+      break;
+    }
+  }
+  if (last < 0) {
+    return 0;
+  }
+  // A wide character is the LAST thing on a line more often than one would guess (a
+  // CJK log line), and its trailing column is part of it: stopping at the glyph would
+  // hand back a length that cuts the character in half.
+  let end = last;
+  while (end + 1 < cells.length && cells[end + 1] === "") {
+    end += 1;
+  }
+  return end + 1;
+}

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -54,11 +54,16 @@ import {
 import {
   historyWheelPlan,
   invertTerminalMouseOverride,
+  lineContentColumns,
+  terminalCellAtPoint,
   terminalMouseOverride,
   terminalMouseOverrideHeld,
   type TerminalMouseOverride,
+  TOUCH_LONG_PRESS_MS,
   touchHistoryScrollPlan,
+  touchPressStillHeld,
   touchScrollClaimsGesture,
+  wordRangeAtColumn,
 } from "./terminal-mouse.js";
 import type { StreamEndpoint } from "./stream_endpoint.js";
 import { currentXtermTheme } from "./theme.js";
@@ -134,9 +139,16 @@ export class AttachTerminal {
   private touchScrollY: number | null = null;
   private touchScrollRemainder = 0;
   // Where the gesture started, and whether it has since travelled far enough to be a
-  // scroll rather than a tap. Until it has, the touch is left entirely alone.
-  private touchScrollOriginY = 0;
+  // scroll rather than a tap. Until it has, the touch is left entirely alone. The
+  // origin serves the long press too (#2849): both gestures are decided against the
+  // point the finger went down on, by the same threshold.
+  private touchOriginX = 0;
+  private touchOriginY = 0;
   private touchScrollClaimed = false;
+  // The pending long press, and whether it has already copied on this gesture — a
+  // copy has to swallow the compatibility click the same touch would otherwise fire.
+  private touchLongPressTimer: number | null = null;
+  private touchCopyFired = false;
   // Whether the gesture in flight came from a finger, read off the pointer event that
   // precedes the browser's compatibility mouse events (onPointerDown).
   private lastPointerWasTouch = false;
@@ -213,13 +225,28 @@ export class AttachTerminal {
     // same discriminator onPointerDown reads below, and taking it over would scroll
     // BACKWARDS, since a thumb follows the finger while the content opposes it.
     const onScrollbar = event.target === this.container.querySelector(".xterm-viewport");
-    this.touchScrollY = event.touches.length === 1 && !onScrollbar ? event.touches[0].clientY : null;
-    this.touchScrollOriginY = this.touchScrollY ?? 0;
+    const press = event.touches.length === 1 && !onScrollbar ? event.touches[0] : null;
+    this.touchScrollY = press?.clientY ?? null;
+    this.touchOriginX = press?.clientX ?? 0;
+    this.touchOriginY = press?.clientY ?? 0;
     this.touchScrollRemainder = 0;
     this.touchScrollClaimed = false;
+    this.touchCopyFired = false;
+    this.cancelTouchLongPress();
+    if (press) {
+      this.startTouchLongPress();
+    }
   };
+  private readonly onTouchEnd = (): void => this.cancelTouchLongPress();
   private readonly onTouchMove = (event: TouchEvent): void => {
     this.handleUserScroll("touch");
+    const moved = event.touches.length !== 1 ||
+      !touchPressStillHeld(this.touchOriginX, this.touchOriginY, event.touches[0].clientX, event.touches[0].clientY);
+    if (moved) {
+      // The finger left the spot it pressed on, so this gesture is a scroll (or a
+      // pinch) rather than a press. Both readings cannot be live at once.
+      this.cancelTouchLongPress();
+    }
     if (this.touchScrollY === null) {
       return;
     }
@@ -238,7 +265,7 @@ export class AttachTerminal {
       return;
     }
     if (!this.touchScrollClaimed) {
-      if (!touchScrollClaimsGesture(this.touchScrollOriginY, y)) {
+      if (!touchScrollClaimsGesture(this.touchOriginY, y)) {
         // Still within a tap's wobble. Leaving the event ALONE is the point: claiming
         // it would cancel the touch, and a cancelled touch fires no compatibility
         // mouse events — so an unsteady tap would stop reaching the application while
@@ -310,6 +337,15 @@ export class AttachTerminal {
   // gestures already separate without one, the drag scrolling history (#2682) and the
   // tap staying the click.
   private readonly onMouseDownCapture = (event: MouseEvent): void => {
+    if (this.lastPointerWasTouch && this.touchCopyFired) {
+      // A long press already consumed this touch (#2849). Its trailing click would
+      // reach a mouse-aware application as a press the user never aimed at it, and
+      // would clear the selection that says what was copied — so the gesture stops
+      // here, before xterm's own listeners on the descendant see it.
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
     if (!this.applicationOwnsMouse() || this.lastPointerWasTouch) {
       // Outside application mouse mode a plain drag already selects, and the
       // modifier keeps its xterm meaning (Shift extends an existing selection). A
@@ -351,7 +387,8 @@ export class AttachTerminal {
     }
     const plan = terminalUserScrollPlan(source, this.visibleFitFrame !== null);
     if (plan.cancelScheduledVisibleFit) {
-      this.cancelVisibleFitFrame();
+      this.cancelTouchLongPress();
+    this.cancelVisibleFitFrame();
     }
     this.fitVisibleHost();
     // fitVisibleHost schedules from the pre-input revision. xterm consumes the
@@ -485,6 +522,9 @@ export class AttachTerminal {
     // on a descendant) see it, and NON-passive, because claiming the pan means
     // calling preventDefault — a passive listener's is ignored outright.
     container.addEventListener("touchmove", this.onTouchMove, { capture: true, passive: false });
+    // A finger lifted or a gesture the system took over both end the press.
+    container.addEventListener("touchend", this.onTouchEnd, { capture: true, passive: true });
+    container.addEventListener("touchcancel", this.onTouchEnd, { capture: true, passive: true });
     container.addEventListener("pointerdown", this.onPointerDown, true);
     container.addEventListener("mousedown", this.onMouseDownCapture, true);
     // Bubbles from xterm's focused helper textarea, so this one listener catches
@@ -521,6 +561,8 @@ export class AttachTerminal {
     this.container.removeEventListener("wheel", this.onWheel, true);
     this.container.removeEventListener("touchstart", this.onTouchStart, true);
     this.container.removeEventListener("touchmove", this.onTouchMove, true);
+    this.container.removeEventListener("touchend", this.onTouchEnd, true);
+    this.container.removeEventListener("touchcancel", this.onTouchEnd, true);
     this.container.removeEventListener("pointerdown", this.onPointerDown, true);
     this.container.removeEventListener("mousedown", this.onMouseDownCapture, true);
     this.container.removeEventListener("copy", this.onCopy);
@@ -573,6 +615,76 @@ export class AttachTerminal {
       this.mouseCaptureHint.setAttribute("aria-hidden", "true");
       this.mouseCaptureHintTimer = null;
     }, 4_000);
+  }
+
+  /**
+   * The long press — the ONLY way to copy anything out of this terminal on a touch
+   * device (#2849), where all three of the usual routes are closed: xterm's rows are
+   * `user-select: none` so the browser can never build a DOM selection to long-press
+   * on, xterm's own selection is driven from mouse events a finger never sends, and
+   * every branch of clipboard.ts needs a Ctrl or Cmd that no phone has.
+   *
+   * So af makes the selection itself and copies it through the same never-silent
+   * ladder the keyboard path uses. The selection xterm then paints IS the feedback:
+   * it names exactly what landed on the clipboard, which is the one thing #2787's
+   * silent failure could not do.
+   */
+  private startTouchLongPress(): void {
+    this.touchLongPressTimer = window.setTimeout(() => {
+      this.touchLongPressTimer = null;
+      this.copyTouchWord(this.touchOriginX, this.touchOriginY);
+    }, TOUCH_LONG_PRESS_MS);
+  }
+
+  private cancelTouchLongPress(): void {
+    if (this.touchLongPressTimer !== null) {
+      window.clearTimeout(this.touchLongPressTimer);
+      this.touchLongPressTimer = null;
+    }
+  }
+
+  /** Selects the token under the finger — the whole line when that cell is blank —
+   *  and copies it. Silent only when there is genuinely nothing there to take. */
+  private copyTouchWord(x: number, y: number): void {
+    const rowsEl = this.container.querySelector<HTMLElement>(".xterm-rows");
+    if (!rowsEl) {
+      return;
+    }
+    const cell = terminalCellAtPoint(x, y, rowsEl.getBoundingClientRect(), this.term.cols, this.term.rows);
+    if (!cell) {
+      return;
+    }
+    // viewportY is the ABSOLUTE buffer row at the top of the view, and select() takes
+    // absolute rows (SelectionService stores what it is given straight into the
+    // model), so a press while scrolled up copies the line under the finger rather
+    // than the one that happens to be at that offset from the bottom.
+    const buffer = this.term.buffer.active;
+    const bufferRow = buffer.viewportY + cell.row;
+    const line = buffer.getLine(bufferRow);
+    if (!line) {
+      return;
+    }
+    // ONE ENTRY PER COLUMN, so an index is a column. translateToString would collapse
+    // a wide character into a single index and quietly shift every column after it.
+    const cells: string[] = [];
+    for (let col = 0; col < line.length; col += 1) {
+      const buffered = line.getCell(col);
+      cells.push(buffered === undefined ? " " : buffered.getWidth() === 0 ? "" : buffered.getChars() || " ");
+    }
+    const range = wordRangeAtColumn(cells, cell.col) ?? { start: 0, length: lineContentColumns(cells) };
+    if (range.length === 0) {
+      return; // a press on genuinely empty screen
+    }
+    this.term.select(range.start, bufferRow, range.length);
+    const text = this.term.getSelection();
+    if (text.trim() === "") {
+      this.term.clearSelection();
+      return;
+    }
+    // Marked BEFORE the copy: the compatibility click this touch still owes is what
+    // would otherwise reach the application and clear the selection just painted.
+    this.touchCopyFired = true;
+    this.copyToClipboard(text);
   }
 
   /** The painted height of one terminal row, which turns a pixel-denominated gesture


### PR DESCRIPTION
## Summary

Touch had **no way to copy anything out of the terminal** — not a hard gesture, none. #2849 verified three independent blocks, which is why nothing short of making the selection ourselves fixes it:

| Block | Evidence |
| --- | --- |
| The browser can't select the rows | `.xterm { user-select: none }` (`xterm.css:40-44`) — long-press has nothing to act on |
| xterm's own selection is mouse-only | `handleMouseDown` / `_handleMouseMove`, force-selection fork reads `altKey`/`shiftKey`; a tap's compatibility `mousedown` starts a zero-length range |
| Copy can't be invoked | `handleClipboardKeydown` is the sole caller of `copyToClipboard`, and every branch needs Ctrl or Cmd |

So af builds the selection itself. **Long press → select the token under the finger → copy through the existing never-silent ladder.** The selection xterm paints afterwards *is* the feedback: it names exactly what reached the clipboard, which is the one thing #2787's silent failure could not do.

## Decisions worth reviewing

- **A "word" is the whitespace-delimited token**, not xterm's double-click word. What a terminal is worth copying from is a path, a URL, a branch name, a container id — splitting those on `/` or `-` hands back a fragment nobody reached for. Pressing past the end of a line takes the **line**, which is how a whole command or error message gets copied.
- **Press and scroll share ONE threshold** — the 8px slop from #2839. A gesture can never be both, and there is no band where it is neither. The unit test asserts that equivalence directly rather than restating the number.
- **The press swallows the compatibility click it would otherwise owe.** Left alone, that click reaches a mouse-aware TUI as a press the user never aimed at it, and clears the selection that shows what was copied.
- **Column-indexed cells, not `translateToString`.** A wide character is two columns but one code point, so a string index silently drifts from the column it names — and only with CJK output, i.e. never in tests and always in the field. The helpers take one entry per column, so an index *is* a column.

## Verification

**Writing the unit tests first paid immediately:** `lineContentColumns` returned one column short for a line ending in a wide character, which would have selected half a glyph. That is fixed, and pinned.

- Unit tests (`terminal-mouse.test.ts`) cover point→cell (including the off-by-one at the grid edge and an unlaid-out pane), token bounds (punctuation kept, blanks rejected, wide-char continuations joined), the line fallback, and the shared press/scroll threshold. This is the layer that **gates on master** — web-selftest is a signal (#2762).
- A Playwright case in the existing `hasTouch`/`isMobile` context long-presses a real token and asserts `navigator.clipboard.readText()` — a finger, no keyboard, real system clipboard. It also asserts the press copies the **token and not its line** (a trailing word makes that discriminating), that the line fallback *does* take the trailer, that the selection survives, that nothing reaches the PTY, and that a **drag still scrolls and copies nothing**.
- Local: `gofmt -l .` clean · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `deadcode -test ./...` · `scripts/lint-file-length.sh` · `make web-test` (typecheck + unit suite) · `make web-build` reproduces the committed bundle. No containerized suites; CI runs the matrix.

## Deliberately not in scope

No "Copied" confirmation toast. Desktop copy has none either, and the highlight is a more precise signal than a toast — it shows *what* was taken, not just that something was. Easy to add if you want it; I did not want to invent user-facing copy inside a bug fix.

Draggable selection handles (extending a range by touch) remain the separate, larger piece of work #2849 flagged. This is the token case, which is the 80%.

Closes #2849
Refs #2831
