### PR TITLE
fix(upgrade): key the upgrade lock to the executable, not to one AF home

### DIFF
--- a/commands/upgrade_interlock.go
+++ b/commands/upgrade_interlock.go
@@ -274,7 +274,7 @@ func writeExecutableInPlace(resolvedPath string, binary []byte, override bool, f
 	// install exactly what the guard just declined.
 	swapRan := false
 	var swapErr error
-	lockErr := upgradetxn.WithInstallLock(home, func() error {
+	lockErr := upgradetxn.WithInstallLock(home, resolvedPath, func() error {
 		swapRan = true
 		swapErr = swap()
 		return swapErr

--- a/commands/upgrade_interlock_test.go
+++ b/commands/upgrade_interlock_test.go
@@ -375,7 +375,7 @@ func TestWriteExecutableInPlace_HoldsThePreparationLockAgainstPrepare(t *testing
 	release := make(chan struct{})
 	held := make(chan error, 1)
 	go func() {
-		held <- upgradetxn.WithInstallLock(home, func() error {
+		held <- upgradetxn.WithInstallLock(home, target, func() error {
 			close(holding)
 			<-release
 			return nil
@@ -557,4 +557,47 @@ func TestForeignUpgradeStagingOver_OnlyMatchesThisExecutable(t *testing.T) {
 	found := foreignUpgradeStagingOver(target)
 	require.NotNil(t, found)
 	require.Equal(t, "upgrade-real", found.ID)
+}
+
+// The in-place swap is serialised against a DIFFERENT AF home's transaction, not
+// just its own home's. One `af` binary serves many homes, so a per-home lock
+// excludes nothing over the binary they share; the interlock passes the resolved
+// executable so the lock is keyed to the thing actually contended.
+func TestWriteExecutableInPlace_SerialisesAgainstAnotherHomesLock(t *testing.T) {
+	upgradeHome(t) // this installer's home
+
+	target := filepath.Join(t.TempDir(), "af")
+	require.NoError(t, os.WriteFile(target, []byte("old binary"), 0o755))
+
+	// Another AF home entirely, holding the lock over the same executable.
+	otherHome := t.TempDir()
+	held := make(chan struct{})
+	release := make(chan struct{})
+	otherDone := make(chan error, 1)
+	go func() {
+		otherDone <- upgradetxn.WithInstallLock(otherHome, target, func() error {
+			close(held)
+			<-release
+			return nil
+		})
+	}()
+	<-held
+
+	done := make(chan error, 1)
+	go func() {
+		done <- writeExecutableInPlace(target, []byte("new binary"), false, "--"+ignoreActiveUpgradeFlag)
+	}()
+	select {
+	case <-done:
+		t.Fatal("the swap proceeded while another AF home held the executable lock")
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	on, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, "old binary", string(on))
+
+	close(release)
+	require.NoError(t, <-otherDone)
+	require.NoError(t, <-done)
 }

--- a/internal/upgradetxn/install_lock.go
+++ b/internal/upgradetxn/install_lock.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 // preparationLockName is the single lock that serialises publishing a
@@ -21,14 +22,11 @@ const preparationLockName = "prepare.lock"
 // for an active transaction and then writing the binary is a
 // time-of-check-to-time-of-use window on its own — a transaction published in
 // between is invisible to a check that already passed, and the swap lands
-// underneath it. Serialising both through one lock is what closes that window,
-// and it is why Prepare snapshots the running executable inside the lock rather
-// than before it.
+// underneath it.
 //
-// It is also why Prepare snapshots the running executable INSIDE this lock. An
-// in-place installer takes the same lock around its swap, so reading the
-// executable outside it would let a transaction preserve pre-swap bytes as its
-// "previous" binary while newer bytes sit on disk — and a later rollback would
+// It is also why Prepare snapshots the running executable INSIDE these locks:
+// reading it outside would let a transaction preserve pre-swap bytes as its
+// "previous" binary while newer bytes sit on disk, and a later rollback would
 // then silently undo that install.
 //
 // The lock blocks rather than failing: an installer that arrives mid-preparation
@@ -38,7 +36,7 @@ const preparationLockName = "prepare.lock"
 // Like Prepare, this materialises the upgrade root if it is absent — taking a
 // lock requires a file to take it on. That is a write, so this belongs on paths
 // that are already mutating (an install), never on a read-only probe.
-func WithInstallLock(homeDir string, fn func() error) (retErr error) {
+func WithInstallLock(homeDir, executablePath string, fn func() error) (retErr error) {
 	home, err := canonicalExistingDir(homeDir)
 	if err != nil {
 		return fmt.Errorf("validate upgrade home: %w", err)
@@ -54,7 +52,7 @@ func WithInstallLock(homeDir string, fn func() error) (retErr error) {
 	defer func() {
 		retErr = errors.Join(retErr, releaseFileLock(lock))
 	}()
-	return fn()
+	return withExecutableLock(executablePath, fn)
 }
 
 // ensureLockRoot makes the upgrade root usable as a lock location WITHOUT
@@ -85,4 +83,47 @@ func ensureLockRoot(path string) error {
 		return fmt.Errorf("secure new upgrade lock root %s: %w", path, chErr)
 	}
 	return validateDirectoryNoSymlink(path)
+}
+
+// executableLockPath returns the lock that serialises every writer of one
+// executable, whatever AF home they belong to.
+//
+// The home lock cannot do this job. One `af` binary can serve many AF homes
+// (AGENT_FACTORY_HOME), but a transaction is home-scoped while the executable is
+// not — so two homes take two different `prepare.lock`s and exclude nothing over
+// the binary they share. This lock is keyed to the executable instead, which is
+// the thing actually being contended.
+//
+// It lives beside the executable because that is the only location derivable
+// from the executable alone, and every writer already needs write access to that
+// directory: an in-place swap renames a temp file into it, and upgradetxn stages
+// its preserved and candidate binaries there. A world-writable location such as
+// /tmp would be derivable too, and is rejected — a local user could hold the lock
+// and stall every upgrade on the box, or pre-plant the path.
+//
+// The file is left behind on purpose. Removing a lock another process may be
+// holding is a race, and an empty 0600 dotfile beside the binary costs nothing.
+func executableLockPath(executable string) string {
+	return filepath.Join(
+		filepath.Dir(executable),
+		"."+filepath.Base(executable)+".af-upgrade.lock",
+	)
+}
+
+// withExecutableLock runs fn holding the executable-keyed lock. Callers take it
+// AFTER the per-home preparation lock, always in that order, so two homes racing
+// the same binary cannot deadlock against each other.
+func withExecutableLock(executablePath string, fn func() error) (retErr error) {
+	executable, err := canonicalExistingFile(executablePath)
+	if err != nil {
+		return fmt.Errorf("validate executable for the upgrade lock: %w", err)
+	}
+	lock, err := acquireFileLockFlags(executableLockPath(executable), syscall.O_NOFOLLOW, false)
+	if err != nil {
+		return fmt.Errorf("lock the executable for upgrade: %w", err)
+	}
+	defer func() {
+		retErr = errors.Join(retErr, releaseFileLock(lock))
+	}()
+	return fn()
 }

--- a/internal/upgradetxn/install_lock_test.go
+++ b/internal/upgradetxn/install_lock_test.go
@@ -1,0 +1,233 @@
+package upgradetxn
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func lockTestExecutable(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "af")
+	require.NoError(t, os.WriteFile(path, []byte("af binary"), 0o755))
+	return path
+}
+
+// The lock is keyed to the executable, beside the executable — the only location
+// derivable from the binary alone, which is what makes it work across AF homes.
+func TestExecutableLockPath(t *testing.T) {
+	require.Equal(t,
+		filepath.Join("/usr/local/bin", ".af.af-upgrade.lock"),
+		executableLockPath("/usr/local/bin/af"))
+
+	// It must not collide with the staged artifacts in the same directory: the
+	// installer's cross-home check scans for ".<base>.af-upgrade-<id>.previous",
+	// and a lock that matched that shape would look like a live transaction.
+	previous, candidate := binaryArtifactPaths("/usr/local/bin/af", "upgrade-abc")
+	lock := executableLockPath("/usr/local/bin/af")
+	require.NotEqual(t, previous, lock)
+	require.NotEqual(t, candidate, lock)
+	require.False(t, strings.HasPrefix(filepath.Base(lock), ".af.af-upgrade-"),
+		"the lock must not match the artifact prefix the interlock scans for")
+}
+
+// The whole point: two DIFFERENT AF homes writing the same binary exclude each
+// other. A per-home lock cannot do this, which is the gap this closes.
+func TestWithInstallLock_ExcludesAcrossDifferentHomes(t *testing.T) {
+	executable := lockTestExecutable(t)
+	homeA, homeB := t.TempDir(), t.TempDir()
+
+	inA := make(chan struct{})
+	releaseA := make(chan struct{})
+	doneA := make(chan error, 1)
+	go func() {
+		doneA <- WithInstallLock(homeA, executable, func() error {
+			close(inA)
+			<-releaseA
+			return nil
+		})
+	}()
+	<-inA
+
+	entered := make(chan struct{})
+	doneB := make(chan error, 1)
+	go func() {
+		doneB <- WithInstallLock(homeB, executable, func() error {
+			close(entered)
+			return nil
+		})
+	}()
+
+	select {
+	case <-entered:
+		t.Fatal("a second AF home entered the critical section while another held the executable lock")
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	close(releaseA)
+	require.NoError(t, <-doneA)
+	select {
+	case err := <-doneB:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("the second home never acquired the lock after the first released it")
+	}
+	<-entered
+}
+
+// Different executables must not block each other — the lock is per binary, not
+// a global mutex over all upgrades on the box.
+func TestWithInstallLock_DoesNotSerialiseUnrelatedExecutables(t *testing.T) {
+	first := lockTestExecutable(t)
+	second := lockTestExecutable(t)
+	home := t.TempDir()
+
+	held := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		_ = WithInstallLock(home, first, func() error {
+			close(held)
+			<-release
+			return nil
+		})
+	}()
+	<-held
+
+	done := make(chan error, 1)
+	go func() {
+		// A different home too, so only the executable identity can be what
+		// separates them.
+		done <- WithInstallLock(t.TempDir(), second, func() error { return nil })
+	}()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("an unrelated executable was blocked by another executable's lock")
+	}
+	close(release)
+}
+
+// Prepare takes the same executable lock, so a transaction cannot publish while
+// an in-place installer holds it — the cross-home half of the interlock.
+func TestPrepare_WaitsForTheExecutableLock(t *testing.T) {
+	executable := lockTestExecutable(t)
+	installerHome := t.TempDir()
+	daemonHome := t.TempDir()
+
+	held := make(chan struct{})
+	release := make(chan struct{})
+	installerDone := make(chan error, 1)
+	go func() {
+		installerDone <- WithInstallLock(installerHome, executable, func() error {
+			close(held)
+			<-release
+			return nil
+		})
+	}()
+	<-held
+
+	prepared := make(chan error, 1)
+	go func() {
+		_, err := Prepare(Plan{
+			ID:             "upgrade-" + strings.Repeat("b", 32),
+			HomeDir:        daemonHome,
+			ExecutablePath: executable,
+			FromVersion:    "1.0.100",
+			ToVersion:      "1.0.300",
+			Candidate:      []byte("candidate-af-binary"),
+			Daemon: DaemonSnapshot{
+				WasRunning: true,
+				BootID:     "boot",
+				Owner:      DaemonOwner{Kind: SupervisionAdHoc},
+			},
+			RecoveryJob: RecoveryJob{Kind: RecoveryJobDetached},
+		})
+		prepared <- err
+	}()
+
+	select {
+	case err := <-prepared:
+		t.Fatalf("Prepare published while an in-place install held the executable lock (err=%v)", err)
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	close(release)
+	require.NoError(t, <-installerDone)
+	select {
+	case err := <-prepared:
+		require.NoError(t, err, "Prepare must succeed once the executable lock is free")
+	case <-time.After(20 * time.Second):
+		t.Fatal("Prepare never completed after the executable lock was released")
+	}
+}
+
+// One acquisition order everywhere (home lock, then executable lock) is what
+// keeps two homes racing one binary from deadlocking. Drive both directions
+// concurrently and require both to finish.
+func TestWithInstallLock_OppositeHomesDoNotDeadlock(t *testing.T) {
+	executable := lockTestExecutable(t)
+	homeA, homeB := t.TempDir(), t.TempDir()
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 20)
+	for i := 0; i < 10; i++ {
+		home := homeA
+		if i%2 == 1 {
+			home = homeB
+		}
+		wg.Add(1)
+		go func(h string) {
+			defer wg.Done()
+			errs <- WithInstallLock(h, executable, func() error { return nil })
+		}(home)
+	}
+
+	finished := make(chan struct{})
+	go func() { wg.Wait(); close(finished) }()
+	select {
+	case <-finished:
+	case <-time.After(20 * time.Second):
+		t.Fatal("interleaved acquisitions from two homes deadlocked")
+	}
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
+// The lock lives outside the 0700 AF home, in whatever directory the binary is
+// installed to, and that can be group-writable. A symlink planted at the lock
+// path must not be followed into a file this never meant to touch.
+func TestWithExecutableLock_RefusesToFollowASymlink(t *testing.T) {
+	executable := lockTestExecutable(t)
+	elsewhere := filepath.Join(t.TempDir(), "victim")
+	require.NoError(t, os.Symlink(elsewhere, executableLockPath(executable)))
+
+	err := withExecutableLock(executable, func() error {
+		t.Fatal("the critical section must not run when the lock path is a symlink")
+		return nil
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, syscall.ELOOP)
+
+	_, statErr := os.Stat(elsewhere)
+	require.True(t, os.IsNotExist(statErr), "the symlink target must never be created")
+}
+
+// The lock file is deliberately left behind — removing one another process may
+// hold is a race — and it must be private.
+func TestWithExecutableLock_LeavesAPrivateLockFile(t *testing.T) {
+	executable := lockTestExecutable(t)
+	require.NoError(t, withExecutableLock(executable, func() error { return nil }))
+
+	info, err := os.Stat(executableLockPath(executable))
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(journalFileMode), info.Mode().Perm())
+}

--- a/internal/upgradetxn/lock.go
+++ b/internal/upgradetxn/lock.go
@@ -52,7 +52,17 @@ func fileIdentity(info os.FileInfo) (FileIdentity, error) {
 }
 
 func acquireFileLock(path string, nonblocking bool) (*os.File, error) {
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, journalFileMode)
+	return acquireFileLockFlags(path, 0, nonblocking)
+}
+
+// acquireFileLockFlags is acquireFileLock with extra open flags. The executable
+// lock passes O_NOFOLLOW: unlike every other lock here it lives outside the
+// 0700 AF home, in whatever directory the binary is installed to, and that
+// directory can be group-writable (a shared /usr/local/bin). Following a
+// symlink planted there would have this create a file somewhere it was never
+// asked to touch.
+func acquireFileLockFlags(path string, extraFlags int, nonblocking bool) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|extraFlags, journalFileMode)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/upgradetxn/prepare.go
+++ b/internal/upgradetxn/prepare.go
@@ -1,0 +1,205 @@
+package upgradetxn
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// Creating a transaction. Split from transaction.go, which keeps the journal
+// types and the Transaction lifecycle methods, when that file reached the
+// 1000-line limit (#1145).
+
+// Prepare snapshots every rollback input and publishes active.json last. A
+// process crash before publication therefore leaves no transaction that a
+// recovery actor could mistake for complete. Prepare does not quiesce a live
+// daemon; a production caller must first prove the metadata manifest is stable.
+func Prepare(stablePlan Plan) (_ *Transaction, retErr error) {
+	home, err := canonicalExistingDir(stablePlan.HomeDir)
+	if err != nil {
+		return nil, fmt.Errorf("validate upgrade home: %w", err)
+	}
+	if err := validateTransactionID(stablePlan.ID); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(stablePlan.FromVersion) == "" || strings.TrimSpace(stablePlan.ToVersion) == "" {
+		return nil, errors.New("upgrade versions cannot be blank")
+	}
+	if len(stablePlan.Candidate) == 0 {
+		return nil, errors.New("candidate binary cannot be empty")
+	}
+	nonceBytes := make([]byte, recoveryNonceBytes)
+	if _, err := rand.Read(nonceBytes); err != nil {
+		return nil, fmt.Errorf("generate upgrade recovery nonce: %w", err)
+	}
+	recoveryNonce := hex.EncodeToString(nonceBytes)
+
+	// Resolve the executable's canonical path before the locks so the
+	// executable-keyed lock location is known. This is path resolution only —
+	// the byte snapshot below stays inside both locks, which is the part that
+	// must not straddle an in-place swap.
+	executable, err := canonicalExistingFile(stablePlan.ExecutablePath)
+	if err != nil {
+		return nil, fmt.Errorf("validate running executable: %w", err)
+	}
+
+	root := upgradeRoot(home)
+	if err := ensureDurableDirectory(home, root, transactionDirMode); err != nil {
+		return nil, fmt.Errorf("prepare upgrade root: %w", err)
+	}
+
+	preparationLock, err := acquireFileLock(filepath.Join(root, preparationLockName), false)
+	if err != nil {
+		return nil, fmt.Errorf("lock upgrade preparation: %w", err)
+	}
+	defer func() {
+		retErr = errors.Join(retErr, releaseFileLock(preparationLock))
+	}()
+
+	// The per-home lock above excludes other writers in THIS home; it cannot
+	// exclude an `af upgrade` run against a different AGENT_FACTORY_HOME, which
+	// would still rename over the same binary. Take the executable-keyed lock
+	// too, always after the home lock so two homes racing one binary order their
+	// acquisitions identically and cannot deadlock (#2212).
+	executableLock, err := acquireFileLockFlags(executableLockPath(executable), syscall.O_NOFOLLOW, false)
+	if err != nil {
+		return nil, fmt.Errorf("lock the executable for upgrade: %w", err)
+	}
+	defer func() {
+		retErr = errors.Join(retErr, releaseFileLock(executableLock))
+	}()
+
+	// Snapshot the running executable under the preparation lock, never before
+	// it — see WithInstallLock for why that ordering is load-bearing (#2212).
+	executableInfo, err := os.Stat(executable)
+	if err != nil {
+		return nil, fmt.Errorf("stat running executable: %w", err)
+	}
+	if !executableInfo.Mode().IsRegular() {
+		return nil, fmt.Errorf("running executable %s is not a regular file", executable)
+	}
+	previousBinary, err := os.ReadFile(executable)
+	if err != nil {
+		return nil, fmt.Errorf("read running executable: %w", err)
+	}
+	if digest(previousBinary) == digest(stablePlan.Candidate) {
+		return nil, errors.New("candidate binary is byte-identical to the previous binary")
+	}
+
+	activePath := activeJournalPath(home)
+	if _, err := os.Lstat(activePath); err == nil {
+		return nil, fmt.Errorf("an upgrade transaction is already active at %s", activePath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("inspect active upgrade journal: %w", err)
+	}
+
+	txnDir := transactionDir(home, stablePlan.ID)
+	transactionsRoot := filepath.Dir(txnDir)
+	if err := ensureDurableDirectory(root, transactionsRoot, transactionDirMode); err != nil {
+		return nil, fmt.Errorf("prepare transactions root: %w", err)
+	}
+	if err := createDurableDirectory(transactionsRoot, txnDir, transactionDirMode); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return nil, fmt.Errorf("upgrade transaction artifacts already exist for %q", stablePlan.ID)
+		}
+		_ = os.Remove(txnDir)
+		return nil, fmt.Errorf("create transaction directory: %w", err)
+	}
+	published := false
+	previousPath, candidatePath := binaryArtifactPaths(executable, stablePlan.ID)
+	var createdArtifacts []string
+	defer func() {
+		if published {
+			return
+		}
+		for _, path := range createdArtifacts {
+			_ = os.Remove(path)
+		}
+		_ = os.RemoveAll(txnDir)
+	}()
+	metadataDir := filepath.Join(txnDir, "metadata")
+	if err := createDurableDirectory(txnDir, metadataDir, transactionDirMode); err != nil {
+		return nil, fmt.Errorf("create metadata snapshot directory: %w", err)
+	}
+	lockPath := recoveryLockPath(home, stablePlan.ID)
+	if _, err := os.Lstat(lockPath); err == nil {
+		return nil, fmt.Errorf("upgrade recovery lock already exists at %s", lockPath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("inspect upgrade recovery lock: %w", err)
+	}
+	createdArtifacts = append(createdArtifacts, lockPath)
+	if err := durableAtomicWriteFile(
+		lockPath, []byte(recoveryNonce+"\n"), journalFileMode,
+	); err != nil {
+		return nil, fmt.Errorf("create durable upgrade recovery lock: %w", err)
+	}
+	recoveryLockInfo, err := os.Lstat(lockPath)
+	if err != nil {
+		return nil, fmt.Errorf("inspect durable upgrade recovery lock: %w", err)
+	}
+	recoveryLockIdentity, err := fileIdentity(recoveryLockInfo)
+	if err != nil {
+		return nil, fmt.Errorf("identify durable upgrade recovery lock: %w", err)
+	}
+
+	for _, path := range []string{previousPath, candidatePath} {
+		if _, err := os.Lstat(path); err == nil {
+			return nil, fmt.Errorf("upgrade binary artifact already exists at %s", path)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("inspect upgrade binary artifact %s: %w", path, err)
+		}
+	}
+
+	mode := executableInfo.Mode().Perm()
+	createdArtifacts = append(createdArtifacts, previousPath)
+	if err := durableAtomicWriteFile(previousPath, previousBinary, mode); err != nil {
+		return nil, fmt.Errorf("snapshot previous binary: %w", err)
+	}
+	createdArtifacts = append(createdArtifacts, candidatePath)
+	if err := durableAtomicWriteFile(candidatePath, stablePlan.Candidate, mode); err != nil {
+		return nil, fmt.Errorf("stage candidate binary: %w", err)
+	}
+
+	metadata, err := snapshotMetadata(home, txnDir, stablePlan.MetadataPaths)
+	if err != nil {
+		return nil, err
+	}
+
+	journal := Journal{
+		SchemaVersion:        journalSchemaVersion,
+		ID:                   stablePlan.ID,
+		HomeDir:              home,
+		ExecutablePath:       executable,
+		FromVersion:          stablePlan.FromVersion,
+		ToVersion:            stablePlan.ToVersion,
+		Phase:                PhasePrepared,
+		RecoveryNonce:        recoveryNonce,
+		RecoveryLockIdentity: recoveryLockIdentity,
+		PreviousBinaryPath:   previousPath,
+		PreviousBinarySHA256: digest(previousBinary),
+		CandidatePath:        candidatePath,
+		CandidateSHA256:      digest(stablePlan.Candidate),
+		ExecutableMode:       uint32(mode),
+		Daemon:               stablePlan.Daemon,
+		RecoveryJob:          stablePlan.RecoveryJob,
+		Metadata:             metadata,
+		UpdatedAt:            time.Now().UTC(),
+	}
+	if err := validateJournal(home, journal); err != nil {
+		return nil, fmt.Errorf("validate prepared journal: %w", err)
+	}
+	if err := persistJournal(activePath, journal); err != nil {
+		if _, statErr := os.Lstat(activePath); statErr == nil {
+			published = true
+		}
+		return nil, fmt.Errorf("publish upgrade journal: %w", err)
+	}
+	published = true
+	return &Transaction{journal: journal}, nil
+}

--- a/internal/upgradetxn/transaction.go
+++ b/internal/upgradetxn/transaction.go
@@ -4,15 +4,12 @@
 package upgradetxn
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"sync"
 	"time"
 
@@ -275,176 +272,6 @@ type RecoveryStatus struct {
 	Phase         Phase     `json:"phase"`
 	HeartbeatAt   time.Time `json:"heartbeat_at"`
 	Deadline      time.Time `json:"deadline"`
-}
-
-// Prepare snapshots every rollback input and publishes active.json last. A
-// process crash before publication therefore leaves no transaction that a
-// recovery actor could mistake for complete. Prepare does not quiesce a live
-// daemon; a production caller must first prove the metadata manifest is stable.
-func Prepare(stablePlan Plan) (_ *Transaction, retErr error) {
-	home, err := canonicalExistingDir(stablePlan.HomeDir)
-	if err != nil {
-		return nil, fmt.Errorf("validate upgrade home: %w", err)
-	}
-	if err := validateTransactionID(stablePlan.ID); err != nil {
-		return nil, err
-	}
-	if strings.TrimSpace(stablePlan.FromVersion) == "" || strings.TrimSpace(stablePlan.ToVersion) == "" {
-		return nil, errors.New("upgrade versions cannot be blank")
-	}
-	if len(stablePlan.Candidate) == 0 {
-		return nil, errors.New("candidate binary cannot be empty")
-	}
-	nonceBytes := make([]byte, recoveryNonceBytes)
-	if _, err := rand.Read(nonceBytes); err != nil {
-		return nil, fmt.Errorf("generate upgrade recovery nonce: %w", err)
-	}
-	recoveryNonce := hex.EncodeToString(nonceBytes)
-
-	root := upgradeRoot(home)
-	if err := ensureDurableDirectory(home, root, transactionDirMode); err != nil {
-		return nil, fmt.Errorf("prepare upgrade root: %w", err)
-	}
-
-	preparationLock, err := acquireFileLock(filepath.Join(root, preparationLockName), false)
-	if err != nil {
-		return nil, fmt.Errorf("lock upgrade preparation: %w", err)
-	}
-	defer func() {
-		retErr = errors.Join(retErr, releaseFileLock(preparationLock))
-	}()
-
-	// Snapshot the running executable under the preparation lock, never before
-	// it — see WithInstallLock for why that ordering is load-bearing (#2212).
-	executable, err := canonicalExistingFile(stablePlan.ExecutablePath)
-	if err != nil {
-		return nil, fmt.Errorf("validate running executable: %w", err)
-	}
-	executableInfo, err := os.Stat(executable)
-	if err != nil {
-		return nil, fmt.Errorf("stat running executable: %w", err)
-	}
-	if !executableInfo.Mode().IsRegular() {
-		return nil, fmt.Errorf("running executable %s is not a regular file", executable)
-	}
-	previousBinary, err := os.ReadFile(executable)
-	if err != nil {
-		return nil, fmt.Errorf("read running executable: %w", err)
-	}
-	if digest(previousBinary) == digest(stablePlan.Candidate) {
-		return nil, errors.New("candidate binary is byte-identical to the previous binary")
-	}
-
-	activePath := activeJournalPath(home)
-	if _, err := os.Lstat(activePath); err == nil {
-		return nil, fmt.Errorf("an upgrade transaction is already active at %s", activePath)
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return nil, fmt.Errorf("inspect active upgrade journal: %w", err)
-	}
-
-	txnDir := transactionDir(home, stablePlan.ID)
-	transactionsRoot := filepath.Dir(txnDir)
-	if err := ensureDurableDirectory(root, transactionsRoot, transactionDirMode); err != nil {
-		return nil, fmt.Errorf("prepare transactions root: %w", err)
-	}
-	if err := createDurableDirectory(transactionsRoot, txnDir, transactionDirMode); err != nil {
-		if errors.Is(err, os.ErrExist) {
-			return nil, fmt.Errorf("upgrade transaction artifacts already exist for %q", stablePlan.ID)
-		}
-		_ = os.Remove(txnDir)
-		return nil, fmt.Errorf("create transaction directory: %w", err)
-	}
-	published := false
-	previousPath, candidatePath := binaryArtifactPaths(executable, stablePlan.ID)
-	var createdArtifacts []string
-	defer func() {
-		if published {
-			return
-		}
-		for _, path := range createdArtifacts {
-			_ = os.Remove(path)
-		}
-		_ = os.RemoveAll(txnDir)
-	}()
-	metadataDir := filepath.Join(txnDir, "metadata")
-	if err := createDurableDirectory(txnDir, metadataDir, transactionDirMode); err != nil {
-		return nil, fmt.Errorf("create metadata snapshot directory: %w", err)
-	}
-	lockPath := recoveryLockPath(home, stablePlan.ID)
-	if _, err := os.Lstat(lockPath); err == nil {
-		return nil, fmt.Errorf("upgrade recovery lock already exists at %s", lockPath)
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return nil, fmt.Errorf("inspect upgrade recovery lock: %w", err)
-	}
-	createdArtifacts = append(createdArtifacts, lockPath)
-	if err := durableAtomicWriteFile(
-		lockPath, []byte(recoveryNonce+"\n"), journalFileMode,
-	); err != nil {
-		return nil, fmt.Errorf("create durable upgrade recovery lock: %w", err)
-	}
-	recoveryLockInfo, err := os.Lstat(lockPath)
-	if err != nil {
-		return nil, fmt.Errorf("inspect durable upgrade recovery lock: %w", err)
-	}
-	recoveryLockIdentity, err := fileIdentity(recoveryLockInfo)
-	if err != nil {
-		return nil, fmt.Errorf("identify durable upgrade recovery lock: %w", err)
-	}
-
-	for _, path := range []string{previousPath, candidatePath} {
-		if _, err := os.Lstat(path); err == nil {
-			return nil, fmt.Errorf("upgrade binary artifact already exists at %s", path)
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("inspect upgrade binary artifact %s: %w", path, err)
-		}
-	}
-
-	mode := executableInfo.Mode().Perm()
-	createdArtifacts = append(createdArtifacts, previousPath)
-	if err := durableAtomicWriteFile(previousPath, previousBinary, mode); err != nil {
-		return nil, fmt.Errorf("snapshot previous binary: %w", err)
-	}
-	createdArtifacts = append(createdArtifacts, candidatePath)
-	if err := durableAtomicWriteFile(candidatePath, stablePlan.Candidate, mode); err != nil {
-		return nil, fmt.Errorf("stage candidate binary: %w", err)
-	}
-
-	metadata, err := snapshotMetadata(home, txnDir, stablePlan.MetadataPaths)
-	if err != nil {
-		return nil, err
-	}
-
-	journal := Journal{
-		SchemaVersion:        journalSchemaVersion,
-		ID:                   stablePlan.ID,
-		HomeDir:              home,
-		ExecutablePath:       executable,
-		FromVersion:          stablePlan.FromVersion,
-		ToVersion:            stablePlan.ToVersion,
-		Phase:                PhasePrepared,
-		RecoveryNonce:        recoveryNonce,
-		RecoveryLockIdentity: recoveryLockIdentity,
-		PreviousBinaryPath:   previousPath,
-		PreviousBinarySHA256: digest(previousBinary),
-		CandidatePath:        candidatePath,
-		CandidateSHA256:      digest(stablePlan.Candidate),
-		ExecutableMode:       uint32(mode),
-		Daemon:               stablePlan.Daemon,
-		RecoveryJob:          stablePlan.RecoveryJob,
-		Metadata:             metadata,
-		UpdatedAt:            time.Now().UTC(),
-	}
-	if err := validateJournal(home, journal); err != nil {
-		return nil, fmt.Errorf("validate prepared journal: %w", err)
-	}
-	if err := persistJournal(activePath, journal); err != nil {
-		if _, statErr := os.Lstat(activePath); statErr == nil {
-			published = true
-		}
-		return nil, fmt.Errorf("publish upgrade journal: %w", err)
-	}
-	published = true
-	return &Transaction{journal: journal}, nil
 }
 
 // Load validates the active journal and every derived path before returning


### PR DESCRIPTION
## What

#2859 made the in-place installers (`af upgrade`, launch-time auto-update) serialise against a transaction publish by holding `upgradetxn`'s preparation lock across the check and the write. That lock is **per-home**; the thing being contended is not.

One `af` binary serves many `AGENT_FACTORY_HOME`s while a transaction is home-scoped, so two homes took two different locks and excluded nothing over the binary they shared:

- home A's daemon runs `Prepare`, snapshotting the executable and staging its preserved binary;
- `AGENT_FACTORY_HOME=/tmp/other af upgrade` takes `/tmp/other`'s lock — which home A never holds — and renames over the same path.

#2859 closed the **check** half (the installer scans for artifacts staged beside the executable, which is where every home's transaction is visible). This closes **serialisation**: both sides now also take a lock keyed to the executable, so every writer of one binary excludes every other regardless of home.

This is the prerequisite I recorded on #2212 when #2859 landed, and it is deliberately *not* the A/B/C reconciliation — that remains the product call.

## Where the lock lives, and why there

Beside the executable: `<dir>/.<base>.af-upgrade.lock`.

- **It is the only location derivable from the binary alone**, which is the whole requirement — a home-derived path cannot serialise two homes.
- **Every writer already needs write access to that directory.** An in-place swap renames a temp file into it; `binaryArtifactPaths` stages the preserved and candidate binaries there.
- **`/tmp` was rejected**, though it is equally derivable: a local user could hold the lock and stall every upgrade on the box, or pre-plant the path.
- **`O_NOFOLLOW`.** Unlike every other lock in this package it sits outside the 0700 AF home, in a directory that can be group-writable (a shared `/usr/local/bin`). Following a planted symlink would have it create a file somewhere it was never asked to touch.
- **The file is left behind on purpose** — removing a lock another process may hold is a race, and an empty 0600 dotfile beside the binary costs nothing.
- **The name cannot collide with the artifact shape the interlock scans for** (`.<base>.af-upgrade-<id>.previous`). A lock that matched it would read as a live transaction and block every upgrade — pinned by a test.

## Ordering

One acquisition order everywhere: **home lock, then executable lock**. Two homes racing one binary take different first locks and the same second one, so no cycle exists and they cannot deadlock. `Prepare`'s executable snapshot stays inside both, preserving the ordering #2859 established — reading outside them would let a transaction preserve pre-swap bytes and a later rollback silently undo that install.

## Verification

Every load-bearing behaviour was **mutation-tested** — implementation broken, test watched go red, then restored:

| Mutation | Test that caught it |
| --- | --- |
| installer does not take the executable lock | `WithInstallLock_ExcludesAcrossDifferentHomes` |
| `Prepare` locks a different path | `Prepare_WaitsForTheExecutableLock` |
| `O_NOFOLLOW` neutralised | `WithExecutableLock_RefusesToFollowASymlink` |
| lock named like a staged artifact | `TestExecutableLockPath` |
| installer stops passing the executable through | `WriteExecutableInPlace_SerialisesAgainstAnotherHomesLock` |

Plus `DoesNotSerialiseUnrelatedExecutables` (the lock is per binary, not a global mutex over all upgrades on the box) and `OppositeHomesDoNotDeadlock` (ten interleaved acquisitions from two homes, all must finish).

Two mutations initially failed to *build* rather than failing the test — dropping the only use of `syscall` — which proves nothing, so I redid both build-clean before believing them.

Local gate green: `gofmt -l .` (empty), `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh`, plus `internal/upgradetxn`, `parity`, and the `commands` interlock tests. No daemon-package tests and no containerized suites — CI runs the matrix.

Note: `go build ./...` does **not** compile test files, so a stale 2-arg `WithInstallLock` call in a `commands` test survived it. `deadcode -test ./...` is what caught it — worth remembering as the cheap gate that covers test compilation.

## Incidental

`Prepare` moves to `internal/upgradetxn/prepare.go`. `transaction.go` was at 998 lines and this pushed it to 1017; the honest split is that `transaction.go` keeps the journal types and the `Transaction` lifecycle while creating a transaction gets its own file — not a grandfather entry. Pure code move, verified by the package's own suite.

Also tidies a doc paragraph in `install_lock.go` that I duplicated across two edits in #2859.

Closes #2896

Still open on #2212, and unchanged by this PR: the **A/B/C reconciliation** (my recommendation remains A — the transactional path as sole writer whenever a daemon owns the home), and **R4**'s destructive forward-then-rollback integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
