### PR TITLE
test: wait on the condition, not the clock, in five flake-prone assertions

### DIFF
--- a/app/cli_daemon_integration_test.go
+++ b/app/cli_daemon_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
@@ -156,9 +157,35 @@ func buildIntegrationBinary(t *testing.T) string {
 	return bin
 }
 
+// runIntegrationAFOK runs af and fails the test if it errors — but RETRIES for as
+// long as the daemon answers that it is still restoring sessions.
+//
+// That answer is not a failure, it is an instruction: the documented, retryable
+// warm-up state, which the daemon publishes precisely so a client can come back.
+// The FIRST call in one of these tests is what auto-starts the daemon, so it
+// races the daemon's own restore, and turning that race into require.NoError
+// reddened a PR whose diff was TypeScript (#2863).
+//
+// The retry is keyed on the product's own classifier rather than a string this
+// test keeps in step by hand, and on the CONDITION rather than a nap chosen to
+// out-wait a restore. A refused call did nothing, so re-running it is safe.
 func runIntegrationAFOK(t *testing.T, bin, dir string, args ...string) string {
 	t.Helper()
-	out, err := runIntegrationAF(t, bin, dir, args...)
+	var (
+		out string
+		err error
+	)
+	deadline := time.Now().Add(60 * time.Second)
+	for {
+		out, err = runIntegrationAF(t, bin, dir, args...)
+		if !daemon.IsDaemonStartingErr(err) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("af %s: the daemon never finished restoring: %v", strings.Join(args, " "), err)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 	require.NoError(t, err)
 	return out
 }

--- a/app/detach_watchdog_test.go
+++ b/app/detach_watchdog_test.go
@@ -95,10 +95,21 @@ func TestWatchdog_NoSpuriousDumpAfterHeaderDetach(t *testing.T) {
 	// threshold. This guards against the regression assertion silently passing
 	// because the dump path was misconfigured.
 	beginDetachWatchdog("control-uncanceled")
-	time.Sleep(slowDetachThreshold + 300*time.Millisecond)
-	_, err = os.Stat(dumpPath)
-	require.NoError(t, err,
+	// Wait for the dump on the CONDITION, not on a fixed nap. Writing it means a
+	// goroutine has to be scheduled and a full goroutine dump has to reach disk,
+	// neither of which has an upper bound on a loaded box; a nap sized for an idle
+	// one turns a busy machine into a failed assertion (#2879). The ceiling is a
+	// failure deadline, not an expectation.
+	control := time.Now()
+	dumpExists := func() bool {
+		_, statErr := os.Stat(dumpPath)
+		return statErr == nil
+	}
+	require.Eventually(t, dumpExists, 30*time.Second, 10*time.Millisecond,
 		"control: an un-canceled watchdog must write detach-slow.log after the threshold")
+	// How long a REAL dump took on this machine, used below to size the window the
+	// regression case must stay silent for.
+	controlTook := time.Since(control)
 	endDetachWatchdog()
 	require.NoError(t, os.Remove(dumpPath))
 
@@ -115,8 +126,11 @@ func TestWatchdog_NoSpuriousDumpAfterHeaderDetach(t *testing.T) {
 	_, cmd := h.Update(repaintAfterDetachMsg{})
 	require.Nil(t, cmd)
 
-	time.Sleep(slowDetachThreshold + 300*time.Millisecond)
-	_, err = os.Stat(dumpPath)
-	require.True(t, os.IsNotExist(err),
+	// An ABSENCE, so the window is what gives it teeth: require nothing to appear
+	// for at least as long as a real dump just took on this same machine, so a
+	// merely-slow watchdog cannot be mistaken for a silent one. Sized from that
+	// measurement rather than from a constant, which is what keeps it honest under
+	// the load that made the constant wrong in the first place (#2879).
+	require.Never(t, dumpExists, controlTook+300*time.Millisecond, 10*time.Millisecond,
 		"watchdog wrote a spurious goroutine dump for a header-selection detach (#683)")
 }

--- a/session/backend_hook_reap_test.go
+++ b/session/backend_hook_reap_test.go
@@ -100,11 +100,13 @@ mkdir -p '%s'/sandboxes/"$name"
 echo "a VM that bills by the hour" > '%s'/sandboxes/"$name"/resource.txt
 %s
 `, dir, dir, launchBody))
+	// No mkdir before the log line: dir is t.TempDir(), which already exists, and
+	// on the wedged-reap paths that mkdir was a whole fork+exec standing between
+	// the spawn and the only evidence the script ever writes (#2821).
 	writeHookScript(t, h.delete, fmt.Sprintf(`
-mkdir -p '%s'
 echo "$name" >> '%s'/delete-ran.log
 %s
-`, dir, dir, deleteBody))
+`, dir, deleteBody))
 	return h
 }
 
@@ -382,23 +384,48 @@ func TestHookReapTimeoutIsUnknownState(t *testing.T) {
 // then deleted the record and the workspace leaked exactly one poll later, the same
 // leak as master, one tick delayed. A second reap while delete_cmd is still wedged
 // must (i) ACTUALLY re-run delete_cmd and (ii) keep returning the unknown sentinel.
+//
+// (i) is asserted on how long the reap BLOCKED, not on what the script logged,
+// and that is the whole point of #2821. The script's log line was the old proof,
+// and it is not kill-proof: delete_cmd is SIGKILLed at the bound, so on a loaded
+// box the spawn can miss the budget and be killed before its first instruction —
+// leaving no line, and no way for the count to tell "the product latched" from
+// "this box was busy". The two look identical, so the count could only ever
+// produce a false FAIL.
+//
+// Blocking time cannot be destroyed that way. A latch returns the CACHED error
+// with no spawn and no wait, in microseconds; a real re-invocation runs the
+// wedged script into the bound and blocks for it. Load pushes that duration UP,
+// never down, so the assertion is one-sided in the safe direction. It is also the
+// only thing that separates the two here: the error assertions cannot, because
+// the cached error a latch returns IS the unknown-state error.
 func TestHookReapTimeoutIsReRunnable(t *testing.T) {
-	shrinkHookTimeouts(t, 300*time.Millisecond, 300*time.Millisecond)
-	h := newHookState(t, "exit 0\n", "sleep 5\n") // logs one line, then wedges
+	const bound = 300 * time.Millisecond
+	shrinkHookTimeouts(t, bound, bound)
+	h := newHookState(t, "exit 0\n", "sleep 5\n") // wedges until the bound kills it
 	p := newHookProvisioner(h, "re-runnable wedged reap")
 	p.launchStarted = true
 
-	first := p.reap()
+	first, firstTook := timeReap(p)
 	require.True(t, errors.Is(first, ErrWorkspaceStateUnknown), "first timed-out reap must be unknown-state")
-	require.Equal(t, 1, h.deleteRunCount(t), "delete_cmd ran once")
+	require.GreaterOrEqual(t, firstTook, bound,
+		"the first reap must run the wedged delete_cmd into its bound")
 
-	second := p.reap()
+	second, secondTook := timeReap(p)
 	require.Error(t, second,
 		"a second reap while delete_cmd is still wedged must not return nil — a nil would let deleteSessionRecord delete the record and orphan the workspace one poll later")
 	require.True(t, errors.Is(second, ErrWorkspaceStateUnknown),
 		"a re-run timed-out reap must keep returning ErrWorkspaceStateUnknown")
-	require.Equal(t, 2, h.deleteRunCount(t),
-		"the second reap must ACTUALLY re-invoke delete_cmd (the log line count grows), not skip it via a latch")
+	require.GreaterOrEqual(t, secondTook, bound,
+		"the second reap must ACTUALLY re-invoke delete_cmd, not skip it via a latch: it has to block on the still-wedged script for the full bound, where a latch would return the cached error immediately")
+}
+
+// timeReap runs a reap and reports how long it blocked, which is what tells a
+// real invocation apart from a latch — see TestHookReapTimeoutIsReRunnable.
+func timeReap(p *hookProvisioner) (error, time.Duration) {
+	started := time.Now()
+	err := p.reap()
+	return err, time.Since(started)
 }
 
 // TestHookReapAnsweredErrorIsKnownStateAndLatches is the other half: a delete_cmd

--- a/session/backend_hook_reap_test.go
+++ b/session/backend_hook_reap_test.go
@@ -933,7 +933,7 @@ func TestHookLaunchDoesNotKillBackgroundedChildren(t *testing.T) {
 
 	h := hookState{dir: dir, launch: filepath.Join(dir, "launch.sh"), delete: filepath.Join(dir, "delete.sh")}
 	writeHookScript(t, h.launch, fmt.Sprintf(`
-( for i in $(seq 1 100); do echo "still here"; echo tick >> %s; sleep 0.05; done ) &
+( for i in $(seq 1 400); do echo "still here"; echo tick >> %s; sleep 0.05; done ) &
 echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
 exit 0
 `, shellsuggest.Arg(hb)))
@@ -956,16 +956,23 @@ exit 0
 	_, err := p.provisionOrReap()
 	require.NoError(t, err)
 
-	// Let the script itself exit so what follows measures only the BACKGROUNDED
-	// child, then require the heartbeat to keep advancing. Asserting SUSTAINED
-	// ticking — several distinct advances at this later checkpoint, not a single
-	// early write — is deliberate: a capture-path kill lands at or just after Run()
-	// returns and freezes the mtime, so a first-advance-wins probe could observe one
-	// stale write and miss the regression. A brief scheduling stall is tolerated by
-	// the generous deadline; a killed child can never reach the required count.
-	time.Sleep(250 * time.Millisecond)
-	_, err = os.Stat(hb)
-	require.NoError(t, err, "the backgrounded child never ran")
+	// provisionOrReap has returned, so launch_cmd itself is already gone and what
+	// follows measures only the BACKGROUNDED child. Wait for its first heartbeat
+	// on the CONDITION rather than on a fixed nap: that write is gated on a
+	// process spawn, which has no upper bound on a loaded box, and a nap long
+	// enough on an idle one turns a busy machine into a failed assertion (#2879).
+	// The ceiling here is a failure deadline, not an expectation.
+	require.Eventually(t, func() bool {
+		_, statErr := os.Stat(hb)
+		return statErr == nil
+	}, 30*time.Second, 10*time.Millisecond, "the backgrounded child never ran")
+
+	// Then require the heartbeat to keep advancing. Asserting SUSTAINED ticking —
+	// several distinct advances at this later checkpoint, not a single early write
+	// — is deliberate: a capture-path kill lands at or just after Run() returns and
+	// freezes the mtime, so a first-advance-wins probe could observe one stale
+	// write and miss the regression. A brief scheduling stall is tolerated by the
+	// generous deadline; a killed child can never reach the required count.
 
 	const wantAdvances = 3
 	var last time.Time

--- a/session/tmux/close_wait_test.go
+++ b/session/tmux/close_wait_test.go
@@ -96,11 +96,23 @@ func exitedProcess(t *testing.T) proctree.Process {
 	return process
 }
 
+// The "did not burn its budget" assertions below are a FRACTION of the budget
+// they are given, never an absolute wall-clock figure. The property is "returns
+// as soon as the process is gone rather than polling to its deadline", and a
+// fraction states exactly that while staying true on a loaded machine — where an
+// absolute ceiling like 250ms is a statement about the scheduler, not about the
+// code under test (#2879). A regression that really does burn the budget takes
+// the whole of it and still fails.
+const (
+	exitWaitBudget = 30 * time.Second
+	exitWaitPrompt = exitWaitBudget / 4
+)
+
 func TestWaitForProcessExit_ExitedProcess(t *testing.T) {
 	start := time.Now()
-	require.True(t, waitForProcessExit(exitedProcess(t), 2*time.Second),
+	require.True(t, waitForProcessExit(exitedProcess(t), exitWaitBudget),
 		"an already-exited PID must report exited")
-	require.Less(t, time.Since(start), time.Second,
+	require.Less(t, time.Since(start), exitWaitPrompt,
 		"a dead PID must be detected without burning the timeout")
 }
 
@@ -118,9 +130,9 @@ func TestWaitForProcessExit_ZombieCountsAsExited(t *testing.T) {
 	require.NoError(t, cmd.Process.Kill())
 
 	start := time.Now()
-	require.True(t, waitForProcessExit(process, 500*time.Millisecond),
+	require.True(t, waitForProcessExit(process, exitWaitBudget),
 		"a pane that exited but remains an unreaped zombie is no longer writing")
-	require.Less(t, time.Since(start), 250*time.Millisecond,
+	require.Less(t, time.Since(start), exitWaitPrompt,
 		"an exited pane must not burn the teardown wait budget")
 }
 


### PR DESCRIPTION
## Summary

Proactive audit of the four flakes from 2026-08-04. #2823/#2838 turned out to be one production defect; #2843, #2863 and #2821 before them are one **test** mechanism, and it is still live in five more places. Test-only change; no product code is touched.

The mechanism, from #2879:

> An assertion whose truth is bounded by elapsed time rather than by a condition. The test does something asynchronous, waits a fixed amount, and asserts the result is already visible. The wait is chosen from how long it takes on an idle machine, so on a loaded one the assertion fires before the work it describes has happened.

Every instance is a **false FAIL** — the product is fine, the machine was busy. That is the safe direction, which is exactly why they survive review, and also why they redden PRs whose diff is a markdown file (#2823) or TypeScript (#2863).

## What changed

| where | assumed | now |
| --- | --- | --- |
| `session/backend_hook_reap_test.go` | a backgrounded child spawns and writes its first heartbeat within **250ms** | polls for the heartbeat; ceiling is a failure deadline |
| `app/detach_watchdog_test.go` | the watchdog fires and gets a goroutine dump to disk within **300ms** of its threshold | polls for the dump |
| `session/tmux/close_wait_test.go` ×2 | detecting a dead PID / a zombie completes in **<1s** / **<250ms** | a **fraction of the budget** it was given |
| `app/cli_daemon_integration_test.go` | the daemon is never still restoring when the first CLI call lands (#2863) | retries on `daemon.IsDaemonStartingErr` |

Three details worth review attention:

**The wall-clock ceilings became proportional, not bigger.** The property is "returns as soon as the process is gone rather than polling to its deadline". An absolute `<250ms` states that as a fact about the scheduler; `< budget/4` states it about the code. Verified by mutation — making `waitForProcessExit` poll to its deadline fails both tests at **30.05s against a 7.5s bound**, so the guard is intact with 30× the headroom it had.

**The absence assertion keeps a fixed window, and that is deliberate.** For an absence a longer wait is stricter, not flakier, so polling would be wrong. But the window is now sized from how long a *real* dump took on that same machine moments earlier (`require.Never(dumpExists, controlTook+300ms)`), so a merely-slow watchdog can no longer be mistaken for a silent one — which is a strengthening, not just a robustness fix.

**The daemon retry is keyed on the product's own classifier.** `daemon.IsDaemonStartingErr` rather than a copy of the string this test would have to keep in step by hand. A refused call did nothing, so re-running it is safe, and the retry is bounded by a deadline that fails loudly rather than hanging.

## Deliberately left alone

Four sleeps that look like the pattern and are not — each asserts an ABSENCE, where a longer wait is stricter, or models a race rather than waiting for one: `app/e2e_test.go:558` (debounce suppresses a re-fetch), `session/tmux/reap_test.go:401` (a survivor is not reaped), `session/tmux/codex_safety_real_test.go:74` (models the #2673 render race), `daemon/vscode_teardown_test.go:277` (best-effort wait inside a mock that asserts nothing). Reasoning recorded in #2879 so the next audit does not re-litigate them.

## Validation

Cheap gates only, per policy — no container suite:

- `gofmt -l .` (empty), `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...` (empty), `scripts/lint-file-length.sh`
- `go test ./session` and `go test ./session/tmux` — the two non-daemon, non-app packages changed — both green, plus the mutation run above
- the `app` changes are **not** run here, per the standing rule. They are type-checked with `go vet ./app` (which compiles the test package without executing it); CI's `Test` lane is what exercises them.

Closes #2879
Closes #2863
