### PR TITLE
feat(web): let a finger drag a tab — reorder and split on touch (#2899)

### DIFF
--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -1077,6 +1077,9 @@ body {
   font: inherit;
   font-size: var(--af-fs-xs);
 }
+.af-tabbar-dragging {
+  touch-action: none;
+}
 .af-tab-insert {
   position: absolute;
   top: 0;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -13265,8 +13265,12 @@ var AppShell = class {
       }
       if (press.held) {
         bar.classList.remove("af-tabbar-dragging");
+        document.body.classList.remove("af-dragging-tab");
         this.hideTabInsert();
         this.actions.clearPaneDropHint();
+      }
+      if (bar.hasPointerCapture(press.id)) {
+        bar.releasePointerCapture(press.id);
       }
       press = null;
     };
@@ -13277,6 +13281,7 @@ var AppShell = class {
       press.held = true;
       press.timer = null;
       bar.classList.add("af-tabbar-dragging");
+      document.body.classList.add("af-dragging-tab");
       this.showTabInsert(bar, press.x);
     };
     bar.addEventListener(
@@ -13303,8 +13308,13 @@ var AppShell = class {
           x: e.clientX,
           y: e.clientY,
           timer: window.setTimeout(pickUp, TAB_PRESS_LIMITS.holdMs),
-          held: false
+          held: false,
+          drag: { id: this.currentTabRealIds[index] ?? "", index, tabs: this.currentTabIds }
         };
+        try {
+          bar.setPointerCapture(e.pointerId);
+        } catch {
+        }
       },
       { passive: true }
     );
@@ -13330,15 +13340,18 @@ var AppShell = class {
         return;
       }
       const held = press.held;
-      const from = press.index;
+      const drag = press.drag;
       const x = e.clientX;
       const y = e.clientY;
       release();
       if (!held) {
         return;
       }
-      const drag = { id: this.currentTabRealIds[from] ?? "", index: from, tabs: this.currentTabIds };
       if (this.actions.dropTabOnPaneAt(x, y, drag)) {
+        return;
+      }
+      const r = bar.getBoundingClientRect();
+      if (x < r.left || x > r.right || y < r.top || y > r.bottom) {
         return;
       }
       const source = this.resolveBarDragPayload(drag);
@@ -13354,6 +13367,15 @@ var AppShell = class {
       }
       this.actions.reorderTab(source, to);
     });
+    bar.addEventListener(
+      "touchmove",
+      (e) => {
+        if (press?.held) {
+          e.preventDefault();
+        }
+      },
+      { passive: false }
+    );
     bar.addEventListener("pointercancel", release, { passive: true });
   }
   /** Owns inline rename on the stable bar rather than on an individual button.

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -11827,6 +11827,21 @@ function reorderTargetIndex(from, insertion) {
   return target === from ? null : target;
 }
 
+// src/tabtouch.ts
+function tabPressVerdict(sample, limits) {
+  if (sample.movedPx > limits.slopPx) {
+    return "abandon";
+  }
+  if (sample.heldMs >= limits.holdMs) {
+    return "explain";
+  }
+  return "waiting";
+}
+var TAB_PRESS_LIMITS = { holdMs: 500, slopPx: 10 };
+function pressDistance(fromX, fromY, toX, toY) {
+  return Math.hypot(toX - fromX, toY - fromY);
+}
+
 // src/ui.ts
 function isActionableSession(s) {
   return typeof s.id === "string" && s.id !== "" && (s.lifecycle_action === "archive" || s.lifecycle_action === "restore");
@@ -11834,6 +11849,7 @@ function isActionableSession(s) {
 function isKillableSession(s) {
   return typeof s.id === "string" && s.id !== "" && s.can_kill === true;
 }
+var TAB_DRAG_TOUCH_NOTICE = "Dragging a tab needs a mouse or trackpad \xB7 use it to reorder tabs or split a pane";
 var MAX_TABS = 9;
 var OFF_BOX_BACKENDS = /* @__PURE__ */ new Set(["docker", "ssh", "remote"]);
 function supportsTabManagement(s) {
@@ -12929,6 +12945,7 @@ var AppShell = class {
     this.tabInsert.setAttribute("aria-hidden", "true");
     this.attachTabReorder(tabBar);
     this.attachTabRename(tabBar);
+    this.attachTabTouchHint(tabBar);
     const head = h2("div", { class: "af-term-head" }, titleBox, tabBar, headActions, handoffBtn, retryBtn);
     this.main.className = "af-main af-main-term";
     this.main.replaceChildren(head, this.termHost);
@@ -13018,6 +13035,69 @@ var AppShell = class {
       this.dragFromIndex = null;
       this.hideTabInsert();
     });
+  }
+  /**
+   * Tells a touch user why pressing and dragging a tab does nothing (#2787's shape).
+   *
+   * Reordering a tab and dragging one onto a pane to split are both HTML5
+   * drag-and-drop, which does not start from a finger on the mobile browsers that
+   * matter. Every tab still advertises `draggable=true` there, so the gesture is
+   * offered and then silently declined — the exact failure mode this audit went
+   * looking for. Restoring the capability on touch is a real UX decision (arrows? a
+   * per-tab menu? a long-press drag?) and belongs in its own change; making the
+   * refusal AUDIBLE does not, and is what this is.
+   *
+   * It watches only the HOLD. A horizontal finger drag on this bar is ambiguous — it
+   * is also how an overflowed bar is scrolled — so any real movement hands the finger
+   * straight back (tabtouch.ts). Nothing here captures the pointer, changes
+   * touch-action, or calls preventDefault: the cost of a wrong guess is one toast,
+   * never a bar that will not scroll.
+   */
+  attachTabTouchHint(bar) {
+    let press = null;
+    const cancel = () => {
+      if (press) {
+        window.clearTimeout(press.timer);
+        press = null;
+      }
+    };
+    bar.addEventListener(
+      "pointerdown",
+      (e) => {
+        if (e.pointerType === "mouse" || e.pointerType === "pen") {
+          return;
+        }
+        const btn = e.target instanceof Element ? e.target.closest(".af-tab") : null;
+        if (!btn || !bar.contains(btn)) {
+          return;
+        }
+        cancel();
+        const timer = window.setTimeout(() => {
+          if (tabPressVerdict({ heldMs: TAB_PRESS_LIMITS.holdMs, movedPx: 0 }, TAB_PRESS_LIMITS) === "explain") {
+            this.actions.notice(TAB_DRAG_TOUCH_NOTICE);
+          }
+          press = null;
+        }, TAB_PRESS_LIMITS.holdMs);
+        press = { id: e.pointerId, x: e.clientX, y: e.clientY, timer };
+      },
+      { passive: true }
+    );
+    bar.addEventListener(
+      "pointermove",
+      (e) => {
+        if (!press || e.pointerId !== press.id) {
+          return;
+        }
+        const moved = pressDistance(press.x, press.y, e.clientX, e.clientY);
+        if (tabPressVerdict({ heldMs: 0, movedPx: moved }, TAB_PRESS_LIMITS) === "abandon") {
+          cancel();
+        }
+      },
+      { passive: true }
+    );
+    for (const done of ["pointerup", "pointercancel", "pointerleave"]) {
+      bar.addEventListener(done, cancel, { passive: true });
+    }
   }
   /** Owns inline rename on the stable bar rather than on an individual button.
    *  Activating an inactive tab rebuilds the buttons synchronously on the first
@@ -13895,6 +13975,9 @@ function reorderSessionTab(from, to) {
 function surfaceTabError(e) {
   const msg = errorText(e);
   console.error("af-web: operation failed:", msg);
+  showTransientNotice(msg);
+}
+function showTransientNotice(msg) {
   if (tabErrorTimer !== null) {
     window.clearTimeout(tabErrorTimer);
   }
@@ -13903,6 +13986,9 @@ function surfaceTabError(e) {
     tabErrorTimer = null;
     store.set({ tabError: null });
   }, TAB_ERROR_MS);
+}
+function surfaceNotice(message) {
+  showTransientNotice(message);
 }
 function clearTabError() {
   if (tabErrorTimer !== null) {
@@ -14177,6 +14263,7 @@ var actions = {
   closeTab: closeSessionTab,
   renameTab: renameSessionTab,
   reorderTab: reorderSessionTab,
+  notice: surfaceNotice,
   switchView,
   setConfigValue: applyConfigValue,
   openConfigAssistant: doOpenConfigAssistant,

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -13118,10 +13118,13 @@ var AppShell = class {
   attachTabTouchDrag(bar) {
     let press = null;
     const release = () => {
-      if (press?.timer !== null && press?.timer !== void 0) {
+      if (press === null) {
+        return;
+      }
+      if (press.timer !== null) {
         window.clearTimeout(press.timer);
       }
-      if (press?.held) {
+      if (press.held) {
         bar.classList.remove("af-tabbar-dragging");
         this.hideTabInsert();
         this.actions.clearPaneDropHint();
@@ -13141,6 +13144,9 @@ var AppShell = class {
       "pointerdown",
       (e) => {
         if (e.pointerType === "mouse" || e.pointerType === "pen") {
+          return;
+        }
+        if (press?.held) {
           return;
         }
         const btn = e.target instanceof Element ? e.target.closest(".af-tab") : null;
@@ -13196,14 +13202,18 @@ var AppShell = class {
       if (this.actions.dropTabOnPaneAt(x, y, drag)) {
         return;
       }
-      const to = reorderTargetIndex(from, insertionIndexAt(tabCenters(bar), x));
+      const source = this.resolveBarDragPayload(drag);
+      if (source === null) {
+        return;
+      }
+      const to = reorderTargetIndex(source, insertionIndexAt(tabCenters(bar), x));
       if (to === null) {
-        if (from === 0) {
+        if (source === 0) {
           this.actions.notice(TAB_PINNED_NOTICE);
         }
         return;
       }
-      this.actions.reorderTab(from, to);
+      this.actions.reorderTab(source, to);
     });
     bar.addEventListener("pointercancel", release, { passive: true });
   }
@@ -13317,6 +13327,12 @@ var AppShell = class {
     if (typeof drag.index !== "number" || !Array.isArray(drag.tabs)) {
       return null;
     }
+    return this.resolveBarDragPayload(drag);
+  }
+  /** The identity resolution itself, for a payload already in hand — the touch drag
+   *  builds its payload directly rather than round-tripping it through a dataTransfer
+   *  string, and must resolve it by exactly the same rule. */
+  resolveBarDragPayload(drag) {
     return resolveDragTab(drag, this.currentTabRealIds, this.currentTabIds, this.currentTabIds.length);
   }
   /** Draws the insertion indicator in the gap a drop at `clientX` would land in. */

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -10819,27 +10819,84 @@ var SplitView = class {
       e.preventDefault();
       this.hideZone(pane);
       const drag = this.parseDrag(e.dataTransfer?.getData(TAB_DND_MIME));
-      if (!drag || !this.tree) {
+      if (!drag) {
         return;
       }
-      const tab = resolveDragTab(drag, this.tabRealIds, this.tabIds, this.tabCount);
-      if (tab === null) {
-        return;
-      }
-      const zone = this.zoneAt(pane.container, e.clientX, e.clientY);
-      const onItsOwnPane = zone !== "center" && findLeaf(this.tree, pane.leafId)?.tab === tab;
-      const opened = onItsOwnPane ? companionTab(this.tree, pane.leafId, tab, this.tabCount, this.preferredTabs()) : tab;
-      if (opened === null) {
-        return;
-      }
-      this.tree = zone === "center" ? replaceTab(this.tree, pane.leafId, tab) : splitLeaf(this.tree, pane.leafId, zone, opened);
-      const landed = leaves(this.tree).find((l) => l.tab === opened);
-      if (landed) {
-        this.focusedId = landed.id;
-      }
-      this.commit();
-      this.refocus();
+      this.applyTabDrop(pane, drag, e.clientX, e.clientY);
     });
+  }
+  /**
+   * Lands a dragged tab on `pane` at a point — the shared body of a drop, whatever
+   * delivered it. The HTML5 `drop` above calls it; so does a touch release
+   * (dropTabAt), because a finger cannot start drag-and-drop at all (#2899). One body
+   * rather than two: every rule below (id resolution, the #1901 self-split dedupe, the
+   * focus choice) is a rule a second implementation would drift away from.
+   */
+  applyTabDrop(pane, drag, clientX, clientY) {
+    if (!this.tree) {
+      return;
+    }
+    const tab = resolveDragTab(drag, this.tabRealIds, this.tabIds, this.tabCount);
+    if (tab === null) {
+      return;
+    }
+    const zone = this.zoneAt(pane.container, clientX, clientY);
+    const onItsOwnPane = zone !== "center" && findLeaf(this.tree, pane.leafId)?.tab === tab;
+    const opened = onItsOwnPane ? companionTab(this.tree, pane.leafId, tab, this.tabCount, this.preferredTabs()) : tab;
+    if (opened === null) {
+      return;
+    }
+    this.tree = zone === "center" ? replaceTab(this.tree, pane.leafId, tab) : splitLeaf(this.tree, pane.leafId, zone, opened);
+    const landed = leaves(this.tree).find((l) => l.tab === opened);
+    if (landed) {
+      this.focusedId = landed.id;
+    }
+    this.commit();
+    this.refocus();
+  }
+  /** The pane whose box contains a viewport point, or null. Used by the touch path,
+   *  which has no browser hit-testing to route a drop for it. */
+  paneAtPoint(clientX, clientY) {
+    for (const pane of this.panes.values()) {
+      const r = pane.container.getBoundingClientRect();
+      if (r.width > 0 && r.height > 0 && clientX >= r.left && clientX <= r.right && clientY >= r.top && clientY <= r.bottom) {
+        return pane;
+      }
+    }
+    return null;
+  }
+  /** Shows the drop zone a touch release at this point would use, and clears every
+   *  other pane's. Returns whether a pane is under the point at all. */
+  showTabDropHintAt(clientX, clientY) {
+    const over = this.paneAtPoint(clientX, clientY);
+    for (const pane of this.panes.values()) {
+      if (pane !== over) {
+        this.hideZone(pane);
+      }
+    }
+    if (!over) {
+      return false;
+    }
+    this.showZone(over, this.zoneAt(over.container, clientX, clientY));
+    return true;
+  }
+  /** Clears any drop zone left showing by showTabDropHintAt. */
+  clearTabDropHint() {
+    for (const pane of this.panes.values()) {
+      this.hideZone(pane);
+    }
+  }
+  /** Lands a touch-dragged tab at a viewport point. Returns whether a pane took it —
+   *  false means the release was not over any pane, so the caller can treat it as a
+   *  bar drop (reorder) instead. */
+  dropTabAt(clientX, clientY, drag) {
+    const pane = this.paneAtPoint(clientX, clientY);
+    if (!pane) {
+      return false;
+    }
+    this.hideZone(pane);
+    this.applyTabDrop(pane, drag, clientX, clientY);
+    return true;
   }
   /** The drop zone for a pointer position over a pane: an edge (outer band) or the
    *  center. */
@@ -11833,7 +11890,7 @@ function tabPressVerdict(sample, limits) {
     return "abandon";
   }
   if (sample.heldMs >= limits.holdMs) {
-    return "explain";
+    return "pickUp";
   }
   return "waiting";
 }
@@ -11849,7 +11906,7 @@ function isActionableSession(s) {
 function isKillableSession(s) {
   return typeof s.id === "string" && s.id !== "" && s.can_kill === true;
 }
-var TAB_DRAG_TOUCH_NOTICE = "Dragging a tab needs a mouse or trackpad \xB7 use it to reorder tabs or split a pane";
+var TAB_PINNED_NOTICE = "The agent tab stays first \xB7 drag it onto a pane to split instead";
 var MAX_TABS = 9;
 var OFF_BOX_BACKENDS = /* @__PURE__ */ new Set(["docker", "ssh", "remote"]);
 function supportsTabManagement(s) {
@@ -12945,7 +13002,7 @@ var AppShell = class {
     this.tabInsert.setAttribute("aria-hidden", "true");
     this.attachTabReorder(tabBar);
     this.attachTabRename(tabBar);
-    this.attachTabTouchHint(tabBar);
+    this.attachTabTouchDrag(tabBar);
     const head = h2("div", { class: "af-term-head" }, titleBox, tabBar, headActions, handoffBtn, retryBtn);
     this.main.className = "af-main af-main-term";
     this.main.replaceChildren(head, this.termHost);
@@ -13037,29 +13094,48 @@ var AppShell = class {
     });
   }
   /**
-   * Tells a touch user why pressing and dragging a tab does nothing (#2787's shape).
+   * Makes a tab draggable by FINGER: long-press to pick it up, drag to reorder it in
+   * the bar or onto a pane to split, release to land it (#2899).
    *
-   * Reordering a tab and dragging one onto a pane to split are both HTML5
-   * drag-and-drop, which does not start from a finger on the mobile browsers that
-   * matter. Every tab still advertises `draggable=true` there, so the gesture is
-   * offered and then silently declined — the exact failure mode this audit went
-   * looking for. Restoring the capability on touch is a real UX decision (arrows? a
-   * per-tab menu? a long-press drag?) and belongs in its own change; making the
-   * refusal AUDIBLE does not, and is what this is.
+   * Both capabilities were HTML5 drag-and-drop only, which does not start from a
+   * finger — Chrome on Android never fires `dragstart` for touch, Safari's support is
+   * narrow and version-dependent — while every tab still advertised `draggable=true`.
+   * So the gesture was offered and silently declined: no movement, no indicator, no
+   * message. This is the #2787 shape, and the fix is the gesture, not a hint.
    *
-   * It watches only the HOLD. A horizontal finger drag on this bar is ambiguous — it
-   * is also how an overflowed bar is scrolled — so any real movement hands the finger
-   * straight back (tabtouch.ts). Nothing here captures the pointer, changes
-   * touch-action, or calls preventDefault: the cost of a wrong guess is one toast,
-   * never a bar that will not scroll.
+   * The pick-up is a HOLD, and that is load-bearing. A horizontal finger drag on this
+   * bar is genuinely ambiguous — it is also how an overflowed bar is scrolled — so
+   * until the hold completes the finger belongs to the browser and any travel past
+   * slop hands it back for good (tabtouch.ts). Only once the tab is picked up does
+   * this suspend scrolling, and only on the bar.
+   *
+   * Everything after the pick-up reuses the mouse path rather than reimplementing it:
+   * the same insertion math (tabreorder.ts), the same indicator (showTabInsert), the
+   * same pane drop body (split.ts applyTabDrop, via the actions). The one thing a
+   * finger needs that a mouse gets free is hit-testing — there is no `dragover` to
+   * say which pane it is over — which is what paneDropHintAt/dropTabOnPaneAt supply.
    */
-  attachTabTouchHint(bar) {
+  attachTabTouchDrag(bar) {
     let press = null;
-    const cancel = () => {
-      if (press) {
+    const release = () => {
+      if (press?.timer !== null && press?.timer !== void 0) {
         window.clearTimeout(press.timer);
-        press = null;
       }
+      if (press?.held) {
+        bar.classList.remove("af-tabbar-dragging");
+        this.hideTabInsert();
+        this.actions.clearPaneDropHint();
+      }
+      press = null;
+    };
+    const pickUp = () => {
+      if (!press) {
+        return;
+      }
+      press.held = true;
+      press.timer = null;
+      bar.classList.add("af-tabbar-dragging");
+      this.showTabInsert(bar, press.x);
     };
     bar.addEventListener(
       "pointerdown",
@@ -13071,33 +13147,65 @@ var AppShell = class {
         if (!btn || !bar.contains(btn)) {
           return;
         }
-        cancel();
-        const timer = window.setTimeout(() => {
-          if (tabPressVerdict({ heldMs: TAB_PRESS_LIMITS.holdMs, movedPx: 0 }, TAB_PRESS_LIMITS) === "explain") {
-            this.actions.notice(TAB_DRAG_TOUCH_NOTICE);
-          }
-          press = null;
-        }, TAB_PRESS_LIMITS.holdMs);
-        press = { id: e.pointerId, x: e.clientX, y: e.clientY, timer };
-      },
-      { passive: true }
-    );
-    bar.addEventListener(
-      "pointermove",
-      (e) => {
-        if (!press || e.pointerId !== press.id) {
+        const index = Number(btn.dataset.tabIndex);
+        if (!Number.isInteger(index)) {
           return;
         }
-        const moved = pressDistance(press.x, press.y, e.clientX, e.clientY);
-        if (tabPressVerdict({ heldMs: 0, movedPx: moved }, TAB_PRESS_LIMITS) === "abandon") {
-          cancel();
-        }
+        release();
+        press = {
+          id: e.pointerId,
+          index,
+          x: e.clientX,
+          y: e.clientY,
+          timer: window.setTimeout(pickUp, TAB_PRESS_LIMITS.holdMs),
+          held: false
+        };
       },
       { passive: true }
     );
-    for (const done of ["pointerup", "pointercancel", "pointerleave"]) {
-      bar.addEventListener(done, cancel, { passive: true });
-    }
+    bar.addEventListener("pointermove", (e) => {
+      if (!press || e.pointerId !== press.id) {
+        return;
+      }
+      if (!press.held) {
+        if (tabPressVerdict({ heldMs: 0, movedPx: pressDistance(press.x, press.y, e.clientX, e.clientY) }, TAB_PRESS_LIMITS) === "abandon") {
+          release();
+        }
+        return;
+      }
+      e.preventDefault();
+      if (this.actions.paneDropHintAt(e.clientX, e.clientY)) {
+        this.hideTabInsert();
+      } else {
+        this.showTabInsert(bar, e.clientX);
+      }
+    });
+    bar.addEventListener("pointerup", (e) => {
+      if (!press || e.pointerId !== press.id) {
+        return;
+      }
+      const held = press.held;
+      const from = press.index;
+      const x = e.clientX;
+      const y = e.clientY;
+      release();
+      if (!held) {
+        return;
+      }
+      const drag = { id: this.currentTabRealIds[from] ?? "", index: from, tabs: this.currentTabIds };
+      if (this.actions.dropTabOnPaneAt(x, y, drag)) {
+        return;
+      }
+      const to = reorderTargetIndex(from, insertionIndexAt(tabCenters(bar), x));
+      if (to === null) {
+        if (from === 0) {
+          this.actions.notice(TAB_PINNED_NOTICE);
+        }
+        return;
+      }
+      this.actions.reorderTab(from, to);
+    });
+    bar.addEventListener("pointercancel", release, { passive: true });
   }
   /** Owns inline rename on the stable bar rather than on an individual button.
    *  Activating an inactive tab rebuilds the buttons synchronously on the first
@@ -14264,6 +14372,9 @@ var actions = {
   renameTab: renameSessionTab,
   reorderTab: reorderSessionTab,
   notice: surfaceNotice,
+  paneDropHintAt: (x, y) => splitView.showTabDropHintAt(x, y),
+  clearPaneDropHint: () => splitView.clearTabDropHint(),
+  dropTabOnPaneAt: (x, y, drag) => splitView.dropTabAt(x, y, drag),
   switchView,
   setConfigValue: applyConfigValue,
   openConfigAssistant: doOpenConfigAssistant,

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "f75ced45391a";
+const VERSION = "8b7b61a16b23";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "3cf32fe7660a";
+const VERSION = "caeebaa4b066";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "8afa75aa85c2";
+const VERSION = "171e7e4a0f52";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "8b7b61a16b23";
+const VERSION = "3cf32fe7660a";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -2151,6 +2151,78 @@ test("#2682 mobile: one finger scrolls the terminal, and keeps doing so under ap
   }
 });
 
+test("audit (#2787 shape) mobile: pressing a tab to drag it SAYS SO instead of doing nothing", REAL_FIXTURE, async ({
+  browser,
+}) => {
+  // Reordering a tab and dragging one onto a pane to split are both HTML5
+  // drag-and-drop, which does not start from a finger. The tab still advertises
+  // draggable=true on a phone, so the gesture was offered and then silently declined.
+  //
+  // Driven as a REAL touch through CDP for the reason #2682 documents: a synthesized
+  // PointerEvent would prove only that our listener ran. A trusted touchStart is what
+  // makes Chromium produce the pointerdown with pointerType "touch" that the hint is
+  // gated on — the one thing a desktop run cannot fake.
+  const ctx = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    deviceScaleFactor: 3,
+    hasTouch: true,
+    isMobile: true,
+  });
+  const p = await ctx.newPage();
+  const cdp = await ctx.newCDPSession(p);
+
+  try {
+    await openTokenless(p);
+    await row(p, SESSION_B).click();
+    await resetToAgentTab(p);
+    await createTerminalTab(p);
+
+    const tab = p.locator(".af-tabbar .af-tab").last();
+    await expect(tab).toBeVisible();
+    const box = await tab.boundingBox();
+    expect(box, "the tab needs geometry to press").toBeTruthy();
+    const { x, y, width, height } = box as { x: number; y: number; width: number; height: number };
+    const cx = x + width / 2;
+    const cy = y + height / 2;
+    const toast = p.locator(".af-toast.af-toast-show");
+
+    // A TAP must stay silent: it is how a tab is selected, and a toast on every tap
+    // would be a worse defect than the silence this replaces.
+    await touchTap(cdp, cx, cy);
+    await p.waitForTimeout(900); // past the hold threshold, deliberately
+    await expect(toast, "a tap selects a tab — it must not raise the drag hint").toHaveCount(0);
+
+    // A SCROLL must stay silent for the same reason: a horizontal finger drag on this
+    // bar is how an overflowed bar is scrolled.
+    await touchDrag(cdp, cx, cy, cy + 4, 6);
+    await p.waitForTimeout(900);
+    await expect(toast, "scrolling the tab bar must not raise the drag hint").toHaveCount(0);
+
+    // …and a settled long press — what someone trying to pick the tab up actually
+    // does — explains the limit instead of doing nothing.
+    await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ x: cx, y: cy }] });
+    try {
+      await expect(toast, "a long press on a tab must explain why the drag cannot work").toContainText(
+        "needs a mouse or trackpad",
+      );
+      // It names the capabilities the gesture carries, so the message teaches rather
+      // than merely reporting a failure.
+      await expect(toast).toContainText("reorder");
+      await expect(toast).toContainText("split");
+    } finally {
+      await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+    }
+  } finally {
+    try {
+      await resetToAgentTab(p);
+    } finally {
+      await ctx.close();
+    }
+    await row(page, SESSION_A).click();
+    await expect(row(page, SESSION_A)).toHaveClass(/af-row-selected/);
+  }
+});
+
 test("the #1694 keyboard model: j/k navigate, Enter attaches, ctrl+] returns to rail", REAL_FIXTURE, async () => {
   // Attach to A HERE rather than inheriting terminal mode from the previous flow
   // (#2816). Inheriting made this test fail whenever its predecessor did: a failure

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -2280,11 +2280,21 @@ test("#2899 mobile: a finger long-presses a tab and drags it to REORDER — and 
   // makes Chromium produce the pointerType "touch" pointerdown — and, just as
   // importantly, what makes it decide whether the gesture is a scroll.
   //
-  // Slow by design, and NOT a masked hang: it spawns two real shell tabs (a tmux
-  // session each) before it can reorder anything, and every assertion below carries
-  // its own short timeout so a broken gesture reports ITSELF rather than starving the
-  // budget and surfacing as an unattributable test timeout.
-  test.setTimeout(120_000);
+  // The tabs are created OUT OF BAND with distinct names on purpose. tabLabel renders
+  // every Shell tab as "Terminal", so a bar built from two shell tabs cannot show a
+  // reorder at all — the label list is identical before and after, and the assertion
+  // could never pass however well the product worked (Codex on #2901). Named process
+  // tabs are the only way this test can observe the thing it claims to.
+  const afBin = process.env.AF_BIN;
+  const mockRepo = process.env.AF_MOCK_REPO;
+  test.skip(!afBin || !mockRepo, "AF_BIN/AF_MOCK_REPO are set only by web-selftest-entry.sh");
+  const { execFileSync } = await import("node:child_process");
+  const af = (...args: string[]): void => {
+    execFileSync(afBin as string, ["--repo", mockRepo as string, ...args], { stdio: "pipe" });
+  };
+  const first = "drag-2899-one";
+  const second = "drag-2899-two";
+
   const ctx = await browser.newContext({
     viewport: { width: 390, height: 844 },
     deviceScaleFactor: 3,
@@ -2293,53 +2303,68 @@ test("#2899 mobile: a finger long-presses a tab and drags it to REORDER — and 
   });
   const p = await ctx.newPage();
   const cdp = await ctx.newCDPSession(p);
+  let created = false;
 
   /** Tab labels left to right — the order the reorder has to change. */
   const labels = async (): Promise<string[]> =>
     (await p.locator(".af-tabbar .af-tab .af-tab-label").allInnerTexts()).map((t) => t.trim());
 
-  /** The center of a tab, AFTER bringing it into view. At 390px three tabs plus the
+  /** The center of a tab, AFTER bringing it into view. At 390px the tabs plus the
    *  new-tab control overflow the bar, so an off-screen tab's box is a coordinate no
-   *  finger could ever land on — the touch would hit whatever is clipped over it. */
-  const tabCenter = async (nth: number): Promise<{ x: number; y: number }> => {
-    const tab = p.locator(".af-tabbar .af-tab").nth(nth);
+   *  finger could ever land on. */
+  const centerOf = async (name: string): Promise<{ x: number; y: number }> => {
+    const tab = p.locator(".af-tabbar .af-tab", { hasText: name });
     await tab.scrollIntoViewIfNeeded();
     const box = await tab.boundingBox();
-    expect(box, `tab ${nth} must have on-screen geometry to touch`).toBeTruthy();
+    expect(box, `tab ${name} must have on-screen geometry to touch`).toBeTruthy();
     const b = box as { x: number; y: number; width: number; height: number };
     return { x: b.x + b.width / 2, y: b.y + b.height / 2 };
   };
 
   try {
     await openTokenless(p);
+    // At 390px the rail is a drawer, so a row is not clickable until it is opened
+    // (Codex on #2901). The hamburger is the same control the mobile tests use.
+    await p.locator(".af-nav-toggle").click();
     await row(p, SESSION_B).click();
     await resetToAgentTab(p);
-    // Two shell tabs, so there is a reorder to perform that is not the pinned agent tab.
-    await createTerminalTab(p);
-    await createTerminalTab(p);
+
+    af("sessions", "tab-create", SESSION_B, "--command", "bash", "--name", first);
+    af("sessions", "tab-create", SESSION_B, "--command", "bash", "--name", second);
+    created = true;
+    // Wait for the DAEMON's tabs to reach the bar: tab-create returns before the event
+    // has been published and repainted, so reading geometry any earlier can measure a
+    // bar that holds fewer tabs than the test needs (Codex on #2901).
+    await expect(p.locator(".af-tabbar .af-tab", { hasText: first })).toHaveCount(1, { timeout: 20_000 });
+    await expect(p.locator(".af-tabbar .af-tab", { hasText: second })).toHaveCount(1, { timeout: 20_000 });
     const before = await labels();
-    expect(before.length, "need agent + two shells to reorder").toBeGreaterThanOrEqual(3);
+    expect(before.filter((l) => l === first || l === second), "both named tabs must be in the bar").toHaveLength(2);
 
     const insert = p.locator(".af-tab-insert");
 
     // --- the capability: a settled long press picks the tab up, dragging moves it ---
-    const last = await tabCenter(before.length - 1);
-    await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ x: last.x, y: last.y }] });
+    const from = await centerOf(second);
+    await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ x: from.x, y: from.y }] });
     // The insertion indicator appearing IS the pick-up: nothing else shows it, and it
     // is the same indicator the mouse drag uses.
     await expect(insert, "a settled long press must pick the tab up").toBeVisible({ timeout: 6_000 });
-    const target = await tabCenter(1);
+    const onto = await centerOf(first);
     for (let step = 1; step <= 8; step++) {
       await cdp.send("Input.dispatchTouchEvent", {
         type: "touchMove",
-        touchPoints: [{ x: last.x + ((target.x - 2 - last.x) * step) / 8, y: last.y }],
+        touchPoints: [{ x: from.x + ((onto.x - 2 - from.x) * step) / 8, y: from.y }],
       });
     }
     await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
 
+    // The two named tabs must swap: distinguishable labels are what makes this
+    // observable at all.
     await expect
-      .poll(labels, { message: "a long-press drag must reorder the tab, as a mouse drag does", timeout: 10_000 })
-      .not.toEqual(before);
+      .poll(
+        async () => (await labels()).filter((l) => l === first || l === second).join(","),
+        { message: "a long-press drag must reorder the tab, as a mouse drag does", timeout: 15_000 },
+      )
+      .toBe(`${second},${first}`);
     const after = await labels();
     expect(after.slice().sort(), "a reorder moves tabs, it does not add or drop any").toEqual(before.slice().sort());
     expect(after[0], "the agent tab is pinned first through any reorder").toBe(before[0]);
@@ -2348,7 +2373,7 @@ test("#2899 mobile: a finger long-presses a tab and drags it to REORDER — and 
     const order = await labels();
 
     // A TAP stays a tap: it selects the tab, and must never reorder.
-    const tapAt = await tabCenter(order.length - 1);
+    const tapAt = await centerOf(second);
     await touchTap(cdp, tapAt.x, tapAt.y);
     await expect(insert, "a tap must not pick a tab up").toBeHidden({ timeout: 2_000 });
     expect(await labels(), "a tap must not reorder").toEqual(order);
@@ -2357,7 +2382,7 @@ test("#2899 mobile: a finger long-presses a tab and drags it to REORDER — and 
     // and a pick-up suspends that, so a false pick-up would strand it. Travel past slop
     // and THEN hold well past the pick-up threshold: this is the exact gesture that
     // would wrongly pick a tab up if movement did not disqualify a press for good.
-    const scrollFrom = await tabCenter(order.length - 1);
+    const scrollFrom = await centerOf(second);
     await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ x: scrollFrom.x, y: scrollFrom.y }] });
     for (let step = 1; step <= 6; step++) {
       await cdp.send("Input.dispatchTouchEvent", {
@@ -2370,11 +2395,16 @@ test("#2899 mobile: a finger long-presses a tab and drags it to REORDER — and 
     await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
     expect(await labels(), "scrolling the bar must not reorder").toEqual(order);
   } finally {
-    try {
-      await resetToAgentTab(p);
-    } finally {
-      await ctx.close();
+    if (created) {
+      for (const name of [first, second]) {
+        try {
+          af("sessions", "tab-delete", SESSION_B, "--name", name);
+        } catch {
+          // best effort: the assertions above are the subject, not the cleanup
+        }
+      }
     }
+    await ctx.close();
     await row(page, SESSION_A).click();
     await expect(row(page, SESSION_A)).toHaveClass(/af-row-selected/);
   }

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -2151,17 +2151,17 @@ test("#2682 mobile: one finger scrolls the terminal, and keeps doing so under ap
   }
 });
 
-test("audit (#2787 shape) mobile: pressing a tab to drag it SAYS SO instead of doing nothing", REAL_FIXTURE, async ({
+test("#2899 mobile: a finger long-presses a tab and drags it to REORDER — and a tap/scroll does not", REAL_FIXTURE, async ({
   browser,
 }) => {
-  // Reordering a tab and dragging one onto a pane to split are both HTML5
-  // drag-and-drop, which does not start from a finger. The tab still advertises
-  // draggable=true on a phone, so the gesture was offered and then silently declined.
+  // Reordering a tab (and dragging one onto a pane to split) were HTML5 drag-and-drop
+  // only, which does not start from a finger: every tab advertised draggable=true on a
+  // phone and the gesture was silently declined. This drives the real thing.
   //
-  // Driven as a REAL touch through CDP for the reason #2682 documents: a synthesized
-  // PointerEvent would prove only that our listener ran. A trusted touchStart is what
-  // makes Chromium produce the pointerdown with pointerType "touch" that the hint is
-  // gated on — the one thing a desktop run cannot fake.
+  // Trusted touch through CDP, for the reason #2682 documents: a synthesized
+  // PointerEvent would prove only that our listeners ran. A real touchStart is what
+  // makes Chromium produce the pointerType "touch" pointerdown — and, just as
+  // importantly, what makes it decide whether the gesture is a scroll.
   const ctx = await browser.newContext({
     viewport: { width: 390, height: 844 },
     deviceScaleFactor: 3,
@@ -2171,47 +2171,61 @@ test("audit (#2787 shape) mobile: pressing a tab to drag it SAYS SO instead of d
   const p = await ctx.newPage();
   const cdp = await ctx.newCDPSession(p);
 
+  /** Tab labels left to right — the order the reorder has to change. */
+  const labels = async (): Promise<string[]> =>
+    (await p.locator(".af-tabbar .af-tab .af-tab-label").allInnerTexts()).map((t) => t.trim());
+
   try {
     await openTokenless(p);
     await row(p, SESSION_B).click();
     await resetToAgentTab(p);
+    // Two shell tabs, so there is a reorder to perform that is not the pinned agent tab.
     await createTerminalTab(p);
+    await createTerminalTab(p);
+    const before = await labels();
+    expect(before.length, "need agent + two shells to reorder").toBeGreaterThanOrEqual(3);
 
-    const tab = p.locator(".af-tabbar .af-tab").last();
-    await expect(tab).toBeVisible();
-    const box = await tab.boundingBox();
-    expect(box, "the tab needs geometry to press").toBeTruthy();
-    const { x, y, width, height } = box as { x: number; y: number; width: number; height: number };
-    const cx = x + width / 2;
-    const cy = y + height / 2;
-    const toast = p.locator(".af-toast.af-toast-show");
+    const tabs = p.locator(".af-tabbar .af-tab");
+    const lastBox = await tabs.last().boundingBox();
+    const midBox = await tabs.nth(1).boundingBox();
+    expect(lastBox && midBox, "tabs need geometry").toBeTruthy();
+    const last = lastBox as { x: number; y: number; width: number; height: number };
+    const mid = midBox as { x: number; y: number; width: number; height: number };
+    const lastCx = last.x + last.width / 2;
+    const lastCy = last.y + last.height / 2;
 
-    // A TAP must stay silent: it is how a tab is selected, and a toast on every tap
-    // would be a worse defect than the silence this replaces.
-    await touchTap(cdp, cx, cy);
+    // A TAP must stay a tap: it selects the tab and must never reorder anything.
+    await touchTap(cdp, lastCx, lastCy);
     await p.waitForTimeout(900); // past the hold threshold, deliberately
-    await expect(toast, "a tap selects a tab — it must not raise the drag hint").toHaveCount(0);
+    expect(await labels(), "a tap must not reorder").toEqual(before);
 
-    // A SCROLL must stay silent for the same reason: a horizontal finger drag on this
-    // bar is how an overflowed bar is scrolled.
-    await touchDrag(cdp, cx, cy, cy + 4, 6);
+    // A SCROLL must stay a scroll — the bar is horizontally scrollable when tabs
+    // overflow, and a pick-up suspends that, so a false pick-up would strand it.
+    await touchDrag(cdp, lastCx, lastCy, lastCy + 6, 6);
     await p.waitForTimeout(900);
-    await expect(toast, "scrolling the tab bar must not raise the drag hint").toHaveCount(0);
+    expect(await labels(), "scrolling the bar must not reorder").toEqual(before);
 
-    // …and a settled long press — what someone trying to pick the tab up actually
-    // does — explains the limit instead of doing nothing.
-    await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ x: cx, y: cy }] });
-    try {
-      await expect(toast, "a long press on a tab must explain why the drag cannot work").toContainText(
-        "needs a mouse or trackpad",
-      );
-      // It names the capabilities the gesture carries, so the message teaches rather
-      // than merely reporting a failure.
-      await expect(toast).toContainText("reorder");
-      await expect(toast).toContainText("split");
-    } finally {
-      await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+    // …and a settled long press picks the tab up, so dragging it left over the middle
+    // tab and releasing MOVES it there.
+    await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ x: lastCx, y: lastCy }] });
+    await p.waitForTimeout(700); // outlast holdMs without moving: the pick-up
+    // The insertion indicator is the visible proof the tab was picked up at all.
+    await expect(p.locator(".af-tab-insert"), "a picked-up tab must show where it would land").toBeVisible();
+    const targetX = mid.x + mid.width / 2 - 2;
+    for (let step = 1; step <= 8; step++) {
+      await cdp.send("Input.dispatchTouchEvent", {
+        type: "touchMove",
+        touchPoints: [{ x: lastCx + ((targetX - lastCx) * step) / 8, y: lastCy }],
+      });
     }
+    await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+
+    await expect
+      .poll(labels, { message: "a long-press drag must reorder the tab, as a mouse drag does" })
+      .not.toEqual(before);
+    const after = await labels();
+    expect(after.slice().sort(), "a reorder moves tabs, it does not add or drop any").toEqual(before.slice().sort());
+    expect(after[0], "the agent tab is pinned first through any reorder").toBe(before[0]);
   } finally {
     try {
       await resetToAgentTab(p);

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -2201,8 +2201,19 @@ test("#2899 mobile: a finger long-presses a tab and drags it to REORDER — and 
 
     // A SCROLL must stay a scroll — the bar is horizontally scrollable when tabs
     // overflow, and a pick-up suspends that, so a false pick-up would strand it.
-    await touchDrag(cdp, lastCx, lastCy, lastCy + 6, 6);
-    await p.waitForTimeout(900);
+    // Driven as the real rule it has to obey: travel PAST slop, and then hold well
+    // past the pick-up threshold. If movement did not disqualify the press for good,
+    // this is the gesture that would wrongly pick a tab up mid-scroll.
+    await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ x: lastCx, y: lastCy }] });
+    for (let step = 1; step <= 6; step++) {
+      await cdp.send("Input.dispatchTouchEvent", {
+        type: "touchMove",
+        touchPoints: [{ x: lastCx - step * 8, y: lastCy }],
+      });
+    }
+    await p.waitForTimeout(900); // outlast holdMs while still down
+    await expect(p.locator(".af-tab-insert"), "a scrolling finger must never pick a tab up").toBeHidden();
+    await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
     expect(await labels(), "scrolling the bar must not reorder").toEqual(before);
 
     // …and a settled long press picks the tab up, so dragging it left over the middle

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -2162,6 +2162,12 @@ test("#2899 mobile: a finger long-presses a tab and drags it to REORDER — and 
   // PointerEvent would prove only that our listeners ran. A real touchStart is what
   // makes Chromium produce the pointerType "touch" pointerdown — and, just as
   // importantly, what makes it decide whether the gesture is a scroll.
+  //
+  // Slow by design, and NOT a masked hang: it spawns two real shell tabs (a tmux
+  // session each) before it can reorder anything, and every assertion below carries
+  // its own short timeout so a broken gesture reports ITSELF rather than starving the
+  // budget and surfacing as an unattributable test timeout.
+  test.setTimeout(120_000);
   const ctx = await browser.newContext({
     viewport: { width: 390, height: 844 },
     deviceScaleFactor: 3,
@@ -2175,6 +2181,18 @@ test("#2899 mobile: a finger long-presses a tab and drags it to REORDER — and 
   const labels = async (): Promise<string[]> =>
     (await p.locator(".af-tabbar .af-tab .af-tab-label").allInnerTexts()).map((t) => t.trim());
 
+  /** The center of a tab, AFTER bringing it into view. At 390px three tabs plus the
+   *  new-tab control overflow the bar, so an off-screen tab's box is a coordinate no
+   *  finger could ever land on — the touch would hit whatever is clipped over it. */
+  const tabCenter = async (nth: number): Promise<{ x: number; y: number }> => {
+    const tab = p.locator(".af-tabbar .af-tab").nth(nth);
+    await tab.scrollIntoViewIfNeeded();
+    const box = await tab.boundingBox();
+    expect(box, `tab ${nth} must have on-screen geometry to touch`).toBeTruthy();
+    const b = box as { x: number; y: number; width: number; height: number };
+    return { x: b.x + b.width / 2, y: b.y + b.height / 2 };
+  };
+
   try {
     await openTokenless(p);
     await row(p, SESSION_B).click();
@@ -2185,58 +2203,55 @@ test("#2899 mobile: a finger long-presses a tab and drags it to REORDER — and 
     const before = await labels();
     expect(before.length, "need agent + two shells to reorder").toBeGreaterThanOrEqual(3);
 
-    const tabs = p.locator(".af-tabbar .af-tab");
-    const lastBox = await tabs.last().boundingBox();
-    const midBox = await tabs.nth(1).boundingBox();
-    expect(lastBox && midBox, "tabs need geometry").toBeTruthy();
-    const last = lastBox as { x: number; y: number; width: number; height: number };
-    const mid = midBox as { x: number; y: number; width: number; height: number };
-    const lastCx = last.x + last.width / 2;
-    const lastCy = last.y + last.height / 2;
+    const insert = p.locator(".af-tab-insert");
 
-    // A TAP must stay a tap: it selects the tab and must never reorder anything.
-    await touchTap(cdp, lastCx, lastCy);
-    await p.waitForTimeout(900); // past the hold threshold, deliberately
-    expect(await labels(), "a tap must not reorder").toEqual(before);
-
-    // A SCROLL must stay a scroll — the bar is horizontally scrollable when tabs
-    // overflow, and a pick-up suspends that, so a false pick-up would strand it.
-    // Driven as the real rule it has to obey: travel PAST slop, and then hold well
-    // past the pick-up threshold. If movement did not disqualify the press for good,
-    // this is the gesture that would wrongly pick a tab up mid-scroll.
-    await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ x: lastCx, y: lastCy }] });
-    for (let step = 1; step <= 6; step++) {
-      await cdp.send("Input.dispatchTouchEvent", {
-        type: "touchMove",
-        touchPoints: [{ x: lastCx - step * 8, y: lastCy }],
-      });
-    }
-    await p.waitForTimeout(900); // outlast holdMs while still down
-    await expect(p.locator(".af-tab-insert"), "a scrolling finger must never pick a tab up").toBeHidden();
-    await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
-    expect(await labels(), "scrolling the bar must not reorder").toEqual(before);
-
-    // …and a settled long press picks the tab up, so dragging it left over the middle
-    // tab and releasing MOVES it there.
-    await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ x: lastCx, y: lastCy }] });
-    await p.waitForTimeout(700); // outlast holdMs without moving: the pick-up
-    // The insertion indicator is the visible proof the tab was picked up at all.
-    await expect(p.locator(".af-tab-insert"), "a picked-up tab must show where it would land").toBeVisible();
-    const targetX = mid.x + mid.width / 2 - 2;
+    // --- the capability: a settled long press picks the tab up, dragging moves it ---
+    const last = await tabCenter(before.length - 1);
+    await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ x: last.x, y: last.y }] });
+    // The insertion indicator appearing IS the pick-up: nothing else shows it, and it
+    // is the same indicator the mouse drag uses.
+    await expect(insert, "a settled long press must pick the tab up").toBeVisible({ timeout: 6_000 });
+    const target = await tabCenter(1);
     for (let step = 1; step <= 8; step++) {
       await cdp.send("Input.dispatchTouchEvent", {
         type: "touchMove",
-        touchPoints: [{ x: lastCx + ((targetX - lastCx) * step) / 8, y: lastCy }],
+        touchPoints: [{ x: last.x + ((target.x - 2 - last.x) * step) / 8, y: last.y }],
       });
     }
     await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
 
     await expect
-      .poll(labels, { message: "a long-press drag must reorder the tab, as a mouse drag does" })
+      .poll(labels, { message: "a long-press drag must reorder the tab, as a mouse drag does", timeout: 10_000 })
       .not.toEqual(before);
     const after = await labels();
     expect(after.slice().sort(), "a reorder moves tabs, it does not add or drop any").toEqual(before.slice().sort());
     expect(after[0], "the agent tab is pinned first through any reorder").toBe(before[0]);
+
+    // --- and the two gestures it must NOT steal -------------------------------------
+    const order = await labels();
+
+    // A TAP stays a tap: it selects the tab, and must never reorder.
+    const tapAt = await tabCenter(order.length - 1);
+    await touchTap(cdp, tapAt.x, tapAt.y);
+    await expect(insert, "a tap must not pick a tab up").toBeHidden({ timeout: 2_000 });
+    expect(await labels(), "a tap must not reorder").toEqual(order);
+
+    // A SCROLL stays a scroll — the bar is horizontally scrollable when tabs overflow,
+    // and a pick-up suspends that, so a false pick-up would strand it. Travel past slop
+    // and THEN hold well past the pick-up threshold: this is the exact gesture that
+    // would wrongly pick a tab up if movement did not disqualify a press for good.
+    const scrollFrom = await tabCenter(order.length - 1);
+    await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ x: scrollFrom.x, y: scrollFrom.y }] });
+    for (let step = 1; step <= 6; step++) {
+      await cdp.send("Input.dispatchTouchEvent", {
+        type: "touchMove",
+        touchPoints: [{ x: scrollFrom.x - step * 8, y: scrollFrom.y }],
+      });
+    }
+    await p.waitForTimeout(900); // outlast holdMs while still down
+    await expect(insert, "a scrolling finger must never pick a tab up").toBeHidden({ timeout: 2_000 });
+    await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+    expect(await labels(), "scrolling the bar must not reorder").toEqual(order);
   } finally {
     try {
       await resetToAgentTab(p);

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -72,6 +72,7 @@ import {
   tabToKeepOnClose,
   upsertSession,
 } from "./sessions.js";
+import type { DragPayload } from "./layout.js";
 import { SplitView } from "./split.js";
 import { canHandoff, isArchived, type RowKind } from "./status.js";
 import { isRenameableTab } from "./tablabel.js";
@@ -1589,6 +1590,9 @@ const actions = {
   renameTab: renameSessionTab,
   reorderTab: reorderSessionTab,
   notice: surfaceNotice,
+  paneDropHintAt: (x: number, y: number) => splitView.showTabDropHintAt(x, y),
+  clearPaneDropHint: () => splitView.clearTabDropHint(),
+  dropTabOnPaneAt: (x: number, y: number, drag: DragPayload) => splitView.dropTabAt(x, y, drag),
   switchView,
   setConfigValue: applyConfigValue,
   openConfigAssistant: doOpenConfigAssistant,

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -1127,6 +1127,13 @@ function surfaceTabError(e: unknown): void {
   // message (e.g. create failure or tab cap) or a fail-closed refusal verbatim.
   const msg = errorText(e);
   console.error("af-web: operation failed:", msg);
+  showTransientNotice(msg);
+}
+
+/** Shows `msg` in the transient toast and arms its auto-dismiss, resetting the timer
+ *  on a fresh message. Shared by the failed-operation path above and by UI notices
+ *  (ui.ts `notice`), so there is ONE toast lifecycle rather than two that drift. */
+function showTransientNotice(msg: string): void {
   if (tabErrorTimer !== null) {
     window.clearTimeout(tabErrorTimer);
   }
@@ -1135,6 +1142,12 @@ function surfaceTabError(e: unknown): void {
     tabErrorTimer = null;
     store.set({ tabError: null });
   }, TAB_ERROR_MS);
+}
+
+/** A UI condition the user needs told about that is NOT a daemon error — a gesture
+ *  this device cannot perform. Deliberately no console.error: nothing failed. */
+function surfaceNotice(message: string): void {
+  showTransientNotice(message);
 }
 
 /** Clears the tab-error toast and cancels its auto-dismiss timer (on a selection
@@ -1575,6 +1588,7 @@ const actions = {
   closeTab: closeSessionTab,
   renameTab: renameSessionTab,
   reorderTab: reorderSessionTab,
+  notice: surfaceNotice,
   switchView,
   setConfigValue: applyConfigValue,
   openConfigAssistant: doOpenConfigAssistant,

--- a/web/src/split.ts
+++ b/web/src/split.ts
@@ -1438,38 +1438,100 @@ export class SplitView {
       e.preventDefault();
       this.hideZone(pane);
       const drag = this.parseDrag(e.dataTransfer?.getData(TAB_DND_MIME));
-      if (!drag || !this.tree) {
+      if (!drag) {
         return;
       }
-      // Resolve the dragged tab to the ordinal it should bind — by its STABLE id when
-      // it has one, else the guarded legacy index. See resolveDragTab; null cancels.
-      const tab = resolveDragTab(drag, this.tabRealIds, this.tabIds, this.tabCount);
-      if (tab === null) {
-        return;
-      }
-      const zone = this.zoneAt(pane.container, e.clientX, e.clientY);
-      // Dragging the pane's OWN tab onto its edge still splits — but the new half must
-      // open a DIFFERENT tab (#1901). Binding the dragged tab on both sides is what the
-      // one-tab-one-pane dedupe undoes, collapsing the split back to where it started.
-      const onItsOwnPane = zone !== "center" && findLeaf(this.tree, pane.leafId)?.tab === tab;
-      const opened = onItsOwnPane
-        ? companionTab(this.tree, pane.leafId, tab, this.tabCount, this.preferredTabs())
-        : tab;
-      if (opened === null) {
-        return; // no other tab to fill the new half — leave the layout as it stands
-      }
-      this.tree = zone === "center" ? replaceTab(this.tree, pane.leafId, tab) : splitLeaf(this.tree, pane.leafId, zone, opened);
-      // Focus the pane holding the tab that just landed — the NEW half (VS Code focuses
-      // the new split). On a self-split that half holds the COMPANION: the dragged tab
-      // never moved, so focusing it would hand focus back to the pane the user started
-      // from and the new pane would open unfocused.
-      const landed = leaves(this.tree).find((l) => l.tab === opened);
-      if (landed) {
-        this.focusedId = landed.id;
-      }
-      this.commit();
-      this.refocus();
+      this.applyTabDrop(pane, drag, e.clientX, e.clientY);
     });
+  }
+
+  /**
+   * Lands a dragged tab on `pane` at a point — the shared body of a drop, whatever
+   * delivered it. The HTML5 `drop` above calls it; so does a touch release
+   * (dropTabAt), because a finger cannot start drag-and-drop at all (#2899). One body
+   * rather than two: every rule below (id resolution, the #1901 self-split dedupe, the
+   * focus choice) is a rule a second implementation would drift away from.
+   */
+  private applyTabDrop(pane: Pane, drag: DragPayload, clientX: number, clientY: number): void {
+    if (!this.tree) {
+      return;
+    }
+    // Resolve the dragged tab to the ordinal it should bind — by its STABLE id when
+    // it has one, else the guarded legacy index. See resolveDragTab; null cancels.
+    const tab = resolveDragTab(drag, this.tabRealIds, this.tabIds, this.tabCount);
+    if (tab === null) {
+      return;
+    }
+    const zone = this.zoneAt(pane.container, clientX, clientY);
+    // Dragging the pane's OWN tab onto its edge still splits — but the new half must
+    // open a DIFFERENT tab (#1901). Binding the dragged tab on both sides is what the
+    // one-tab-one-pane dedupe undoes, collapsing the split back to where it started.
+    const onItsOwnPane = zone !== "center" && findLeaf(this.tree, pane.leafId)?.tab === tab;
+    const opened = onItsOwnPane
+      ? companionTab(this.tree, pane.leafId, tab, this.tabCount, this.preferredTabs())
+      : tab;
+    if (opened === null) {
+      return; // no other tab to fill the new half — leave the layout as it stands
+    }
+    this.tree = zone === "center" ? replaceTab(this.tree, pane.leafId, tab) : splitLeaf(this.tree, pane.leafId, zone, opened);
+    // Focus the pane holding the tab that just landed — the NEW half (VS Code focuses
+    // the new split). On a self-split that half holds the COMPANION: the dragged tab
+    // never moved, so focusing it would hand focus back to the pane the user started
+    // from and the new pane would open unfocused.
+    const landed = leaves(this.tree).find((l) => l.tab === opened);
+    if (landed) {
+      this.focusedId = landed.id;
+    }
+    this.commit();
+    this.refocus();
+  }
+
+  /** The pane whose box contains a viewport point, or null. Used by the touch path,
+   *  which has no browser hit-testing to route a drop for it. */
+  private paneAtPoint(clientX: number, clientY: number): Pane | null {
+    for (const pane of this.panes.values()) {
+      const r = pane.container.getBoundingClientRect();
+      if (r.width > 0 && r.height > 0 && clientX >= r.left && clientX <= r.right && clientY >= r.top && clientY <= r.bottom) {
+        return pane;
+      }
+    }
+    return null;
+  }
+
+  /** Shows the drop zone a touch release at this point would use, and clears every
+   *  other pane's. Returns whether a pane is under the point at all. */
+  showTabDropHintAt(clientX: number, clientY: number): boolean {
+    const over = this.paneAtPoint(clientX, clientY);
+    for (const pane of this.panes.values()) {
+      if (pane !== over) {
+        this.hideZone(pane);
+      }
+    }
+    if (!over) {
+      return false;
+    }
+    this.showZone(over, this.zoneAt(over.container, clientX, clientY));
+    return true;
+  }
+
+  /** Clears any drop zone left showing by showTabDropHintAt. */
+  clearTabDropHint(): void {
+    for (const pane of this.panes.values()) {
+      this.hideZone(pane);
+    }
+  }
+
+  /** Lands a touch-dragged tab at a viewport point. Returns whether a pane took it —
+   *  false means the release was not over any pane, so the caller can treat it as a
+   *  bar drop (reorder) instead. */
+  dropTabAt(clientX: number, clientY: number, drag: DragPayload): boolean {
+    const pane = this.paneAtPoint(clientX, clientY);
+    if (!pane) {
+      return false;
+    }
+    this.hideZone(pane);
+    this.applyTabDrop(pane, drag, clientX, clientY);
+    return true;
   }
 
   /** The drop zone for a pointer position over a pane: an edge (outer band) or the

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1405,6 +1405,14 @@ body {
 /* The insertion indicator for a reorder drag (#1813): an accent rule in the gap the
  * drop would land in. Absolutely positioned within the bar (hence the bar's
  * position:relative) and pointer-events:none so it never becomes the drag's target. */
+/* While a FINGER is dragging a tab (#2899), the bar must stop treating the gesture as
+ * its own horizontal scroll. Scoped to the life of the drag by a class rather than set
+ * on the bar permanently: an overflowed tab bar has to stay scrollable by touch, and
+ * only the picked-up tab suspends that. */
+.af-tabbar-dragging {
+  touch-action: none;
+}
+
 .af-tab-insert {
   position: absolute;
   top: 0;

--- a/web/src/tabtouch.test.ts
+++ b/web/src/tabtouch.test.ts
@@ -1,9 +1,9 @@
-// Pins the hold-vs-scroll split behind the tab bar's touch hint.
+// Pins the hold-vs-scroll split behind the tab bar's touch drag (#2899).
 //
-// The property that matters most here is the NEGATIVE one: a finger that is scrolling
-// the overflowed tab bar must never be read as an attempt to drag a tab. The hint is
-// worth having only because it cannot fire on an ordinary scroll or tap — a toast
-// interrupting every swipe would be a worse defect than the silence it replaces.
+// The property that matters most is the NEGATIVE one: a finger scrolling the
+// overflowed tab bar must never be read as picking a tab up. Getting that wrong does
+// not merely misfire — picking up suspends the bar's touch-action, so a false pick-up
+// leaves the bar unable to scroll, which is worse than the silence being fixed.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -12,12 +12,12 @@ import { pressDistance, TAB_PRESS_LIMITS, tabPressVerdict } from "./tabtouch.js"
 
 const limits = { holdMs: 500, slopPx: 10 };
 
-test("a settled long press reads as an attempt to drag the tab", () => {
-  assert.equal(tabPressVerdict({ heldMs: 500, movedPx: 0 }, limits), "explain");
-  assert.equal(tabPressVerdict({ heldMs: 900, movedPx: 9 }, limits), "explain", "within slop still counts as settled");
+test("a settled long press picks the tab up", () => {
+  assert.equal(tabPressVerdict({ heldMs: 500, movedPx: 0 }, limits), "pickUp");
+  assert.equal(tabPressVerdict({ heldMs: 900, movedPx: 9 }, limits), "pickUp", "within slop still counts as settled");
 });
 
-test("a tap is over before the hold and never explains anything", () => {
+test("a tap is over before the hold and never picks anything up", () => {
   assert.equal(tabPressVerdict({ heldMs: 80, movedPx: 0 }, limits), "waiting");
   assert.equal(tabPressVerdict({ heldMs: 499, movedPx: 0 }, limits), "waiting");
 });
@@ -29,7 +29,7 @@ test("a finger that MOVES is scrolling the bar — hand it back, however long it
   assert.equal(
     tabPressVerdict({ heldMs: 5_000, movedPx: 11 }, limits),
     "abandon",
-    "a slow drag is a scroll, not a hold — this is what keeps the toast off every swipe",
+    "a slow drag is a scroll, not a hold — this is what keeps the bar scrollable",
   );
 });
 

--- a/web/src/tabtouch.test.ts
+++ b/web/src/tabtouch.test.ts
@@ -1,0 +1,49 @@
+// Pins the hold-vs-scroll split behind the tab bar's touch hint.
+//
+// The property that matters most here is the NEGATIVE one: a finger that is scrolling
+// the overflowed tab bar must never be read as an attempt to drag a tab. The hint is
+// worth having only because it cannot fire on an ordinary scroll or tap — a toast
+// interrupting every swipe would be a worse defect than the silence it replaces.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { pressDistance, TAB_PRESS_LIMITS, tabPressVerdict } from "./tabtouch.js";
+
+const limits = { holdMs: 500, slopPx: 10 };
+
+test("a settled long press reads as an attempt to drag the tab", () => {
+  assert.equal(tabPressVerdict({ heldMs: 500, movedPx: 0 }, limits), "explain");
+  assert.equal(tabPressVerdict({ heldMs: 900, movedPx: 9 }, limits), "explain", "within slop still counts as settled");
+});
+
+test("a tap is over before the hold and never explains anything", () => {
+  assert.equal(tabPressVerdict({ heldMs: 80, movedPx: 0 }, limits), "waiting");
+  assert.equal(tabPressVerdict({ heldMs: 499, movedPx: 0 }, limits), "waiting");
+});
+
+test("a finger that MOVES is scrolling the bar — hand it back, however long it is held", () => {
+  assert.equal(tabPressVerdict({ heldMs: 20, movedPx: 40 }, limits), "abandon");
+  // The load-bearing case: slop is checked BEFORE the hold, so a slow scroll that
+  // takes longer than holdMs is still a scroll and must not raise the hint.
+  assert.equal(
+    tabPressVerdict({ heldMs: 5_000, movedPx: 11 }, limits),
+    "abandon",
+    "a slow drag is a scroll, not a hold — this is what keeps the toast off every swipe",
+  );
+});
+
+test("distance is straight-line, so a diagonal scroll counts as movement", () => {
+  assert.equal(pressDistance(0, 0, 3, 4), 5);
+  assert.equal(pressDistance(10, 10, 10, 10), 0);
+  assert.equal(
+    tabPressVerdict({ heldMs: 800, movedPx: pressDistance(0, 0, 8, 8) }, limits),
+    "abandon",
+    "8px on each axis is ~11px of travel — past slop even though neither axis is",
+  );
+});
+
+test("the shipped limits are longer than a tap and than the browser's own long press", () => {
+  assert.ok(TAB_PRESS_LIMITS.holdMs >= 400, "must not fire on a slow tap");
+  assert.ok(TAB_PRESS_LIMITS.slopPx > 0 && TAB_PRESS_LIMITS.slopPx <= 16, "slop must tolerate a jitter, not a swipe");
+});

--- a/web/src/tabtouch.ts
+++ b/web/src/tabtouch.ts
@@ -1,0 +1,62 @@
+// Recognising a touch attempt to DRAG a tab, so the tab bar can explain itself
+// instead of doing nothing (the #2787 shape).
+//
+// Reordering a tab, and dragging one onto a pane to split, are both HTML5
+// drag-and-drop (ui.ts attachTabDrag / split.ts wireDrop). Drag-and-drop does not
+// start from a finger on the mobile browsers that matter — Chrome on Android never
+// fires `dragstart` for touch input, and Safari's support is narrow and
+// version-dependent. Every tab still renders `draggable=true` there, so a phone user
+// presses a tab, drags, and gets NOTHING: no movement, no drop indicator, no message.
+// Silence is the defect; the missing capability is a separate, deliberate product
+// question (see the issue).
+//
+// Detecting the ATTEMPT is the whole trick, because a horizontal finger drag on the
+// bar is genuinely ambiguous — it is also how the bar is scrolled when tabs overflow.
+// What is NOT ambiguous is a press that stays put: nobody long-presses a tab except
+// to pick it up. So the gesture this reads is the HOLD, and any real movement hands
+// the finger straight back to the browser's scroll. Nothing here claims the pointer,
+// suppresses scrolling, or calls preventDefault — a wrong guess costs a toast, never
+// a broken scroll.
+
+/** What the press has done so far. `movedPx` is the distance from where the finger
+ *  landed (not per-move delta), so a slow drift accumulates like a fast swipe. */
+export interface TabPressSample {
+  heldMs: number;
+  movedPx: number;
+}
+
+/** The thresholds separating a hold from a tap and from a scroll. */
+export interface TabPressLimits {
+  /** How long the finger must stay down to read as "picking the tab up". */
+  holdMs: number;
+  /** How far it may wander first. Beyond this the finger is scrolling the bar. */
+  slopPx: number;
+}
+
+/**
+ * `abandon` — the finger moved: it is scrolling or swiping, so leave it alone.
+ * `explain` — a settled long press: the user is trying to drag a tab.
+ * `waiting`  — too early to tell; keep watching.
+ */
+export type TabPressVerdict = "waiting" | "explain" | "abandon";
+
+/** Slop is checked BEFORE the hold, so a long, slow scroll can never be mistaken for
+ *  a hold just because it took a while. */
+export function tabPressVerdict(sample: TabPressSample, limits: TabPressLimits): TabPressVerdict {
+  if (sample.movedPx > limits.slopPx) {
+    return "abandon";
+  }
+  if (sample.heldMs >= limits.holdMs) {
+    return "explain";
+  }
+  return "waiting";
+}
+
+/** Deliberately longer than a tap and than the browser's own long-press callout, so
+ *  the hint lands only on a press the user is still holding on purpose. */
+export const TAB_PRESS_LIMITS: TabPressLimits = { holdMs: 500, slopPx: 10 };
+
+/** Straight-line distance, the input to `movedPx`. */
+export function pressDistance(fromX: number, fromY: number, toX: number, toY: number): number {
+  return Math.hypot(toX - fromX, toY - fromY);
+}

--- a/web/src/tabtouch.ts
+++ b/web/src/tabtouch.ts
@@ -1,22 +1,19 @@
-// Recognising a touch attempt to DRAG a tab, so the tab bar can explain itself
-// instead of doing nothing (the #2787 shape).
+// Deciding when a finger on the tab bar has PICKED A TAB UP (#2899).
 //
-// Reordering a tab, and dragging one onto a pane to split, are both HTML5
-// drag-and-drop (ui.ts attachTabDrag / split.ts wireDrop). Drag-and-drop does not
-// start from a finger on the mobile browsers that matter — Chrome on Android never
+// Reordering a tab, and dragging one onto a pane to split, were both HTML5
+// drag-and-drop only (ui.ts attachTabDrag / split.ts wireDrop), and drag-and-drop does
+// not start from a finger on the mobile browsers that matter — Chrome on Android never
 // fires `dragstart` for touch input, and Safari's support is narrow and
-// version-dependent. Every tab still renders `draggable=true` there, so a phone user
-// presses a tab, drags, and gets NOTHING: no movement, no drop indicator, no message.
-// Silence is the defect; the missing capability is a separate, deliberate product
-// question (see the issue).
+// version-dependent. Every tab still rendered `draggable=true` there, so a phone user
+// pressed a tab, dragged, and got NOTHING: no movement, no drop indicator, no message.
 //
-// Detecting the ATTEMPT is the whole trick, because a horizontal finger drag on the
-// bar is genuinely ambiguous — it is also how the bar is scrolled when tabs overflow.
-// What is NOT ambiguous is a press that stays put: nobody long-presses a tab except
-// to pick it up. So the gesture this reads is the HOLD, and any real movement hands
-// the finger straight back to the browser's scroll. Nothing here claims the pointer,
-// suppresses scrolling, or calls preventDefault — a wrong guess costs a toast, never
-// a broken scroll.
+// Telling the two gestures apart is the whole trick, because a horizontal finger drag
+// on the bar is genuinely ambiguous — it is also how the bar is scrolled when tabs
+// overflow. What is NOT ambiguous is a press that stays put: nobody long-presses a tab
+// except to pick it up. So the pick-up is the HOLD, and any real movement before it
+// hands the finger back to the browser's scroll for good. Getting this wrong in the
+// permissive direction costs a bar that will not scroll, which is why the decision is
+// here, pure and tested, rather than inline in a pointer handler.
 
 /** What the press has done so far. `movedPx` is the distance from where the finger
  *  landed (not per-move delta), so a slow drift accumulates like a fast swipe. */
@@ -35,10 +32,10 @@ export interface TabPressLimits {
 
 /**
  * `abandon` — the finger moved: it is scrolling or swiping, so leave it alone.
- * `explain` — a settled long press: the user is trying to drag a tab.
- * `waiting`  — too early to tell; keep watching.
+ * `pickUp`  — a settled long press: the tab is now being dragged.
+ * `waiting` — too early to tell; keep watching.
  */
-export type TabPressVerdict = "waiting" | "explain" | "abandon";
+export type TabPressVerdict = "waiting" | "pickUp" | "abandon";
 
 /** Slop is checked BEFORE the hold, so a long, slow scroll can never be mistaken for
  *  a hold just because it took a while. */
@@ -47,13 +44,13 @@ export function tabPressVerdict(sample: TabPressSample, limits: TabPressLimits):
     return "abandon";
   }
   if (sample.heldMs >= limits.holdMs) {
-    return "explain";
+    return "pickUp";
   }
   return "waiting";
 }
 
 /** Deliberately longer than a tap and than the browser's own long-press callout, so
- *  the hint lands only on a press the user is still holding on purpose. */
+ *  a tab is picked up only by a press the user is still holding on purpose. */
 export const TAB_PRESS_LIMITS: TabPressLimits = { holdMs: 500, slopPx: 10 };
 
 /** Straight-line distance, the input to `movedPx`. */

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -22,7 +22,7 @@ import type { EventStreamStatus } from "./events.js";
 import { icon } from "./icon.js";
 import type { KeyboardFocus, View } from "./nav.js";
 import { VIEWS } from "./nav.js";
-import { resolveDragTab, TAB_DND_MIME } from "./layout.js";
+import { type DragPayload, resolveDragTab, TAB_DND_MIME } from "./layout.js";
 import {
   FILTER_KINDS,
   filterLabel,
@@ -170,12 +170,11 @@ export interface AppState {
 }
 
 /** Callbacks the shell invokes; index.ts owns the real behavior. */
-/** What a finger gets told when it tries to drag a tab. Names both capabilities the
- *  gesture carries — reorder and split — and the input that can perform them, so the
- *  message explains the limit rather than just reporting a failure. Sentence case, `·`
- *  as the fragment separator, per the repo's copy conventions. */
-export const TAB_DRAG_TOUCH_NOTICE =
-  "Dragging a tab needs a mouse or trackpad · use it to reorder tabs or split a pane";
+/** Why a dragged agent tab did not move. The mouse path refuses this by declining to
+ *  be a drop target (the browser then shows a no-drop cursor); a finger has no cursor
+ *  to read, so the same refusal has to be said out loud. Sentence case, `·` as the
+ *  fragment separator, per the repo's copy conventions. */
+export const TAB_PINNED_NOTICE = "The agent tab stays first · drag it onto a pane to split instead";
 
 export interface Actions {
   connect(token: string): void;
@@ -223,9 +222,20 @@ export interface Actions {
   closeTab(index: number): void;
   /** Surfaces a transient message in the toast the failed-tab-op path already owns.
    *  For a UI condition the user needs told about that is NOT an error from the
-   *  daemon — a gesture this device cannot perform, say — so it goes through the
-   *  same visible channel instead of being swallowed (#2787's shape). */
+   *  daemon, so it goes through the same visible channel instead of being swallowed
+   *  (#2787's shape). */
   notice(message: string): void;
+  /** Shows the drop zone a release at this viewport point would use, for a TOUCH tab
+   *  drag — the live feedback `dragover` gives a mouse for free. Returns whether a
+   *  pane is under the point at all; false means the finger is over the tab bar (or
+   *  nothing), so the caller shows the bar's insertion indicator instead. */
+  paneDropHintAt(clientX: number, clientY: number): boolean;
+  /** Clears any pane drop zone left showing. */
+  clearPaneDropHint(): void;
+  /** Lands a touch-dragged tab on whichever pane is under the point, splitting or
+   *  replacing exactly as a mouse drop does — the same body, not a copy of it
+   *  (split.ts applyTabDrop). False means no pane was under the release. */
+  dropTabOnPaneAt(clientX: number, clientY: number, drag: DragPayload): boolean;
   /** Sets one global config key. index.ts POSTs SetConfigValue (the same validated,
    *  locked, atomic writer `af config set` uses), then re-reads the manifest so the
    *  form shows what the file actually holds. Validation is deliberately NOT done
@@ -1817,8 +1827,8 @@ export class AppShell {
     // button; a listener owned by the old button cannot receive the final dblclick.
     this.attachTabRename(tabBar);
     // Both drags above are HTML5 drag-and-drop, which a finger cannot start. Same
-    // delegation again, to tell a touch user that rather than doing nothing.
-    this.attachTabTouchHint(tabBar);
+    // delegation again, giving a finger the same two capabilities (#2899).
+    this.attachTabTouchDrag(tabBar);
 
     // Retry and the filtered-selection fallback are fixed pane-level actions. Their
     // hidden containers create no flex items on the common path, while visible
@@ -1964,34 +1974,67 @@ export class AppShell {
   }
 
   /**
-   * Tells a touch user why pressing and dragging a tab does nothing (#2787's shape).
+   * Makes a tab draggable by FINGER: long-press to pick it up, drag to reorder it in
+   * the bar or onto a pane to split, release to land it (#2899).
    *
-   * Reordering a tab and dragging one onto a pane to split are both HTML5
-   * drag-and-drop, which does not start from a finger on the mobile browsers that
-   * matter. Every tab still advertises `draggable=true` there, so the gesture is
-   * offered and then silently declined — the exact failure mode this audit went
-   * looking for. Restoring the capability on touch is a real UX decision (arrows? a
-   * per-tab menu? a long-press drag?) and belongs in its own change; making the
-   * refusal AUDIBLE does not, and is what this is.
+   * Both capabilities were HTML5 drag-and-drop only, which does not start from a
+   * finger — Chrome on Android never fires `dragstart` for touch, Safari's support is
+   * narrow and version-dependent — while every tab still advertised `draggable=true`.
+   * So the gesture was offered and silently declined: no movement, no indicator, no
+   * message. This is the #2787 shape, and the fix is the gesture, not a hint.
    *
-   * It watches only the HOLD. A horizontal finger drag on this bar is ambiguous — it
-   * is also how an overflowed bar is scrolled — so any real movement hands the finger
-   * straight back (tabtouch.ts). Nothing here captures the pointer, changes
-   * touch-action, or calls preventDefault: the cost of a wrong guess is one toast,
-   * never a bar that will not scroll.
+   * The pick-up is a HOLD, and that is load-bearing. A horizontal finger drag on this
+   * bar is genuinely ambiguous — it is also how an overflowed bar is scrolled — so
+   * until the hold completes the finger belongs to the browser and any travel past
+   * slop hands it back for good (tabtouch.ts). Only once the tab is picked up does
+   * this suspend scrolling, and only on the bar.
+   *
+   * Everything after the pick-up reuses the mouse path rather than reimplementing it:
+   * the same insertion math (tabreorder.ts), the same indicator (showTabInsert), the
+   * same pane drop body (split.ts applyTabDrop, via the actions). The one thing a
+   * finger needs that a mouse gets free is hit-testing — there is no `dragover` to
+   * say which pane it is over — which is what paneDropHintAt/dropTabOnPaneAt supply.
    */
-  private attachTabTouchHint(bar: HTMLElement): void {
-    let press: { id: number; x: number; y: number; timer: number } | null = null;
-    const cancel = (): void => {
-      if (press) {
+  private attachTabTouchDrag(bar: HTMLElement): void {
+    interface TabPress {
+      id: number;
+      index: number;
+      x: number;
+      y: number;
+      timer: number | null;
+      held: boolean;
+    }
+    let press: TabPress | null = null;
+
+    const release = (): void => {
+      if (press?.timer !== null && press?.timer !== undefined) {
         window.clearTimeout(press.timer);
-        press = null;
       }
+      if (press?.held) {
+        bar.classList.remove("af-tabbar-dragging");
+        this.hideTabInsert();
+        this.actions.clearPaneDropHint();
+      }
+      press = null;
     };
+
+    const pickUp = (): void => {
+      if (!press) {
+        return;
+      }
+      press.held = true;
+      press.timer = null;
+      // Suspend the bar's own scrolling for the life of the drag ONLY. Set now rather
+      // than up front so a finger that turns out to be scrolling never meets a bar
+      // that will not scroll.
+      bar.classList.add("af-tabbar-dragging");
+      this.showTabInsert(bar, press.x);
+    };
+
     bar.addEventListener(
       "pointerdown",
       (e: PointerEvent) => {
-        // Mouse and pen keep real drag-and-drop; only a finger needs telling.
+        // Mouse and pen keep real drag-and-drop; this is the finger's path only.
         if (e.pointerType === "mouse" || e.pointerType === "pen") {
           return;
         }
@@ -1999,36 +2042,81 @@ export class AppShell {
         if (!btn || !bar.contains(btn)) {
           return;
         }
-        cancel();
-        const timer = window.setTimeout(() => {
-          // Reaching the timer IS the settled-hold verdict: any movement past slop
-          // would have cancelled it below. Routed through the predicate anyway so the
-          // threshold lives in one tested place.
-          if (tabPressVerdict({ heldMs: TAB_PRESS_LIMITS.holdMs, movedPx: 0 }, TAB_PRESS_LIMITS) === "explain") {
-            this.actions.notice(TAB_DRAG_TOUCH_NOTICE);
-          }
-          press = null;
-        }, TAB_PRESS_LIMITS.holdMs);
-        press = { id: e.pointerId, x: e.clientX, y: e.clientY, timer };
-      },
-      { passive: true },
-    );
-    bar.addEventListener(
-      "pointermove",
-      (e: PointerEvent) => {
-        if (!press || e.pointerId !== press.id) {
+        const index = Number(btn.dataset.tabIndex);
+        if (!Number.isInteger(index)) {
           return;
         }
-        const moved = pressDistance(press.x, press.y, e.clientX, e.clientY);
-        if (tabPressVerdict({ heldMs: 0, movedPx: moved }, TAB_PRESS_LIMITS) === "abandon") {
-          cancel(); // scrolling the bar — not our gesture
-        }
+        release();
+        press = {
+          id: e.pointerId,
+          index,
+          x: e.clientX,
+          y: e.clientY,
+          timer: window.setTimeout(pickUp, TAB_PRESS_LIMITS.holdMs),
+          held: false,
+        };
       },
       { passive: true },
     );
-    for (const done of ["pointerup", "pointercancel", "pointerleave"]) {
-      bar.addEventListener(done, cancel, { passive: true });
-    }
+
+    bar.addEventListener("pointermove", (e: PointerEvent) => {
+      if (!press || e.pointerId !== press.id) {
+        return;
+      }
+      if (!press.held) {
+        // Still deciding. Any real travel means the finger is scrolling the bar.
+        if (tabPressVerdict({ heldMs: 0, movedPx: pressDistance(press.x, press.y, e.clientX, e.clientY) }, TAB_PRESS_LIMITS) === "abandon") {
+          release();
+        }
+        return;
+      }
+      // Picked up: this gesture is ours, so stop the page reacting to it as a scroll.
+      e.preventDefault();
+      // Over a pane → that pane's split zone; otherwise the bar's insertion gap.
+      if (this.actions.paneDropHintAt(e.clientX, e.clientY)) {
+        this.hideTabInsert();
+      } else {
+        this.showTabInsert(bar, e.clientX);
+      }
+    });
+
+    bar.addEventListener("pointerup", (e: PointerEvent) => {
+      if (!press || e.pointerId !== press.id) {
+        return;
+      }
+      const held = press.held;
+      const from = press.index;
+      const x = e.clientX;
+      const y = e.clientY;
+      release();
+      if (!held) {
+        return; // a tap: the button's own click handler owns it
+      }
+      // The payload the mouse path stamps into the dataTransfer, built the same way —
+      // stable id plus the identity snapshot, so a tab closed or reordered by another
+      // client mid-drag cancels instead of moving whatever now sits at this index.
+      const drag: DragPayload = { id: this.currentTabRealIds[from] ?? "", index: from, tabs: this.currentTabIds };
+      if (this.actions.dropTabOnPaneAt(x, y, drag)) {
+        return; // landed in a pane: split or replaced
+      }
+      const to = reorderTargetIndex(from, insertionIndexAt(tabCenters(bar), x));
+      if (to === null) {
+        // The pinned agent tab, or a release where the tab already sits. Only the
+        // first is worth explaining, and it is the one a user will retry.
+        if (from === 0) {
+          this.actions.notice(TAB_PINNED_NOTICE);
+        }
+        return;
+      }
+      this.actions.reorderTab(from, to);
+    });
+
+    // pointercancel only — NOT pointerleave. A touch pointer is implicitly captured by
+    // the element that took the pointerdown, so a finger dragging toward a PANE leaves
+    // the bar's bounds while the gesture is still very much alive; releasing on leave
+    // would cancel exactly the drag-to-split this exists to enable. Capture also
+    // guarantees the pointerup lands here, so there is no state to leak.
+    bar.addEventListener("pointercancel", release, { passive: true });
   }
 
   /** Owns inline rename on the stable bar rather than on an individual button.

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -47,6 +47,7 @@ import {
 import { ConfigPane, type ConfigStatus } from "./config.js";
 import { isRenameableTab, tabDisplayLabel, tabIcon, tabLabel } from "./tablabel.js";
 import { insertionIndexAt, reorderTargetIndex } from "./tabreorder.js";
+import { pressDistance, TAB_PRESS_LIMITS, tabPressVerdict } from "./tabtouch.js";
 import { TasksPane } from "./tasks.js";
 import { type ThemeChoice, THEME_CHOICES } from "./theme.js";
 import type { TerminalStatus } from "./terminal.js";
@@ -169,6 +170,13 @@ export interface AppState {
 }
 
 /** Callbacks the shell invokes; index.ts owns the real behavior. */
+/** What a finger gets told when it tries to drag a tab. Names both capabilities the
+ *  gesture carries — reorder and split — and the input that can perform them, so the
+ *  message explains the limit rather than just reporting a failure. Sentence case, `·`
+ *  as the fragment separator, per the repo's copy conventions. */
+export const TAB_DRAG_TOUCH_NOTICE =
+  "Dragging a tab needs a mouse or trackpad · use it to reorder tabs or split a pane";
+
 export interface Actions {
   connect(token: string): void;
   disconnect(): void;
@@ -213,6 +221,11 @@ export interface Actions {
   /** Closes the tab at `index` of the selected session (the `w` key / × button);
    *  the agent tab (index 0) is unclosable. */
   closeTab(index: number): void;
+  /** Surfaces a transient message in the toast the failed-tab-op path already owns.
+   *  For a UI condition the user needs told about that is NOT an error from the
+   *  daemon — a gesture this device cannot perform, say — so it goes through the
+   *  same visible channel instead of being swallowed (#2787's shape). */
+  notice(message: string): void;
   /** Sets one global config key. index.ts POSTs SetConfigValue (the same validated,
    *  locked, atomic writer `af config set` uses), then re-reads the manifest so the
    *  form shows what the file actually holds. Validation is deliberately NOT done
@@ -1803,6 +1816,9 @@ export class AppShell {
     // double-click can activate an inactive tab and synchronously replace every
     // button; a listener owned by the old button cannot receive the final dblclick.
     this.attachTabRename(tabBar);
+    // Both drags above are HTML5 drag-and-drop, which a finger cannot start. Same
+    // delegation again, to tell a touch user that rather than doing nothing.
+    this.attachTabTouchHint(tabBar);
 
     // Retry and the filtered-selection fallback are fixed pane-level actions. Their
     // hidden containers create no flex items on the common path, while visible
@@ -1945,6 +1961,74 @@ export class AppShell {
       this.dragFromIndex = null;
       this.hideTabInsert();
     });
+  }
+
+  /**
+   * Tells a touch user why pressing and dragging a tab does nothing (#2787's shape).
+   *
+   * Reordering a tab and dragging one onto a pane to split are both HTML5
+   * drag-and-drop, which does not start from a finger on the mobile browsers that
+   * matter. Every tab still advertises `draggable=true` there, so the gesture is
+   * offered and then silently declined — the exact failure mode this audit went
+   * looking for. Restoring the capability on touch is a real UX decision (arrows? a
+   * per-tab menu? a long-press drag?) and belongs in its own change; making the
+   * refusal AUDIBLE does not, and is what this is.
+   *
+   * It watches only the HOLD. A horizontal finger drag on this bar is ambiguous — it
+   * is also how an overflowed bar is scrolled — so any real movement hands the finger
+   * straight back (tabtouch.ts). Nothing here captures the pointer, changes
+   * touch-action, or calls preventDefault: the cost of a wrong guess is one toast,
+   * never a bar that will not scroll.
+   */
+  private attachTabTouchHint(bar: HTMLElement): void {
+    let press: { id: number; x: number; y: number; timer: number } | null = null;
+    const cancel = (): void => {
+      if (press) {
+        window.clearTimeout(press.timer);
+        press = null;
+      }
+    };
+    bar.addEventListener(
+      "pointerdown",
+      (e: PointerEvent) => {
+        // Mouse and pen keep real drag-and-drop; only a finger needs telling.
+        if (e.pointerType === "mouse" || e.pointerType === "pen") {
+          return;
+        }
+        const btn = e.target instanceof Element ? e.target.closest<HTMLElement>(".af-tab") : null;
+        if (!btn || !bar.contains(btn)) {
+          return;
+        }
+        cancel();
+        const timer = window.setTimeout(() => {
+          // Reaching the timer IS the settled-hold verdict: any movement past slop
+          // would have cancelled it below. Routed through the predicate anyway so the
+          // threshold lives in one tested place.
+          if (tabPressVerdict({ heldMs: TAB_PRESS_LIMITS.holdMs, movedPx: 0 }, TAB_PRESS_LIMITS) === "explain") {
+            this.actions.notice(TAB_DRAG_TOUCH_NOTICE);
+          }
+          press = null;
+        }, TAB_PRESS_LIMITS.holdMs);
+        press = { id: e.pointerId, x: e.clientX, y: e.clientY, timer };
+      },
+      { passive: true },
+    );
+    bar.addEventListener(
+      "pointermove",
+      (e: PointerEvent) => {
+        if (!press || e.pointerId !== press.id) {
+          return;
+        }
+        const moved = pressDistance(press.x, press.y, e.clientX, e.clientY);
+        if (tabPressVerdict({ heldMs: 0, movedPx: moved }, TAB_PRESS_LIMITS) === "abandon") {
+          cancel(); // scrolling the bar — not our gesture
+        }
+      },
+      { passive: true },
+    );
+    for (const done of ["pointerup", "pointercancel", "pointerleave"]) {
+      bar.addEventListener(done, cancel, { passive: true });
+    }
   }
 
   /** Owns inline rename on the stable bar rather than on an individual button.

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -2007,10 +2007,13 @@ export class AppShell {
     let press: TabPress | null = null;
 
     const release = (): void => {
-      if (press?.timer !== null && press?.timer !== undefined) {
+      if (press === null) {
+        return;
+      }
+      if (press.timer !== null) {
         window.clearTimeout(press.timer);
       }
-      if (press?.held) {
+      if (press.held) {
         bar.classList.remove("af-tabbar-dragging");
         this.hideTabInsert();
         this.actions.clearPaneDropHint();
@@ -2037,6 +2040,9 @@ export class AppShell {
         // Mouse and pen keep real drag-and-drop; this is the finger's path only.
         if (e.pointerType === "mouse" || e.pointerType === "pen") {
           return;
+        }
+        if (press?.held) {
+          return; // a drag is already in flight; a second finger must not hijack it
         }
         const btn = e.target instanceof Element ? e.target.closest<HTMLElement>(".af-tab") : null;
         if (!btn || !bar.contains(btn)) {
@@ -2099,16 +2105,24 @@ export class AppShell {
       if (this.actions.dropTabOnPaneAt(x, y, drag)) {
         return; // landed in a pane: split or replaced
       }
-      const to = reorderTargetIndex(from, insertionIndexAt(tabCenters(bar), x));
+      // Re-resolve the tab by its STABLE id rather than trusting the index captured at
+      // pointerdown. The bar rebuilds on every snapshot, so another client reordering
+      // or closing a tab mid-drag would otherwise move whatever now sits at that
+      // ordinal. Same resolution the mouse drop uses — one rule, not two.
+      const source = this.resolveBarDragPayload(drag);
+      if (source === null) {
+        return; // the tab is gone, or the roster changed under the drag
+      }
+      const to = reorderTargetIndex(source, insertionIndexAt(tabCenters(bar), x));
       if (to === null) {
         // The pinned agent tab, or a release where the tab already sits. Only the
         // first is worth explaining, and it is the one a user will retry.
-        if (from === 0) {
+        if (source === 0) {
           this.actions.notice(TAB_PINNED_NOTICE);
         }
         return;
       }
-      this.actions.reorderTab(from, to);
+      this.actions.reorderTab(source, to);
     });
 
     // pointercancel only — NOT pointerleave. A touch pointer is implicitly captured by
@@ -2248,6 +2262,13 @@ export class AppShell {
     if (typeof drag.index !== "number" || !Array.isArray(drag.tabs)) {
       return null;
     }
+    return this.resolveBarDragPayload(drag);
+  }
+
+  /** The identity resolution itself, for a payload already in hand — the touch drag
+   *  builds its payload directly rather than round-tripping it through a dataTransfer
+   *  string, and must resolve it by exactly the same rule. */
+  private resolveBarDragPayload(drag: DragPayload): number | null {
     return resolveDragTab(drag, this.currentTabRealIds, this.currentTabIds, this.currentTabIds.length);
   }
 

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -2003,6 +2003,12 @@ export class AppShell {
       y: number;
       timer: number | null;
       held: boolean;
+      /** The drag payload, built at POINTERDOWN exactly as dragstart builds it. Built
+       *  here rather than at release because another client reordering or closing tabs
+       *  mid-drag moves what sits at the pick-up ordinal: reading the id at release
+       *  would name whichever tab now occupies that index and defeat the very
+       *  resolveDragTab guard the mouse path relies on (Codex P1 on #2901). */
+      drag: DragPayload;
     }
     let press: TabPress | null = null;
 
@@ -2015,8 +2021,12 @@ export class AppShell {
       }
       if (press.held) {
         bar.classList.remove("af-tabbar-dragging");
+        document.body.classList.remove("af-dragging-tab");
         this.hideTabInsert();
         this.actions.clearPaneDropHint();
+      }
+      if (bar.hasPointerCapture(press.id)) {
+        bar.releasePointerCapture(press.id);
       }
       press = null;
     };
@@ -2029,8 +2039,14 @@ export class AppShell {
       press.timer = null;
       // Suspend the bar's own scrolling for the life of the drag ONLY. Set now rather
       // than up front so a finger that turns out to be scrolling never meets a bar
-      // that will not scroll.
+      // that will not scroll. touch-action alone cannot stop a gesture already in
+      // flight, which is what the touchmove guard below is for.
       bar.classList.add("af-tabbar-dragging");
+      // The pane drop overlays are gated on this body flag (styles.css
+      // `.af-dragging-tab .af-drop-overlay.af-drop-show`), which only the MOUSE
+      // dragstart used to set — so a finger dragging onto a pane got no visible split
+      // target at all (Codex on #2901).
+      document.body.classList.add("af-dragging-tab");
       this.showTabInsert(bar, press.x);
     };
 
@@ -2060,7 +2076,17 @@ export class AppShell {
           y: e.clientY,
           timer: window.setTimeout(pickUp, TAB_PRESS_LIMITS.holdMs),
           held: false,
+          drag: { id: this.currentTabRealIds[index] ?? "", index, tabs: this.currentTabIds },
         };
+        // Capture on the STABLE bar, not on the tab button the browser would implicitly
+        // capture. A roster change mid-drag detaches that button, and the delegated
+        // listeners below would then stop receiving the gesture — stranding the drag
+        // and leaving the bar's scroll suppressed (Codex on #2901).
+        try {
+          bar.setPointerCapture(e.pointerId);
+        } catch {
+          // A pointer that has already ended cannot be captured; the press is harmless.
+        }
       },
       { passive: true },
     );
@@ -2091,19 +2117,23 @@ export class AppShell {
         return;
       }
       const held = press.held;
-      const from = press.index;
+      const drag = press.drag;
       const x = e.clientX;
       const y = e.clientY;
       release();
       if (!held) {
         return; // a tap: the button's own click handler owns it
       }
-      // The payload the mouse path stamps into the dataTransfer, built the same way —
-      // stable id plus the identity snapshot, so a tab closed or reordered by another
-      // client mid-drag cancels instead of moving whatever now sits at this index.
-      const drag: DragPayload = { id: this.currentTabRealIds[from] ?? "", index: from, tabs: this.currentTabIds };
       if (this.actions.dropTabOnPaneAt(x, y, drag)) {
         return; // landed in a pane: split or replaced
+      }
+      // Outside the bar is a CANCEL. The mouse path only reorders when the drop lands
+      // on the bar itself; feeding any other release point into the insertion math
+      // would let a release over the header — or empty space — silently move a tab
+      // (Codex on #2901).
+      const r = bar.getBoundingClientRect();
+      if (x < r.left || x > r.right || y < r.top || y > r.bottom) {
+        return;
       }
       // Re-resolve the tab by its STABLE id rather than trusting the index captured at
       // pointerdown. The bar rebuilds on every snapshot, so another client reordering
@@ -2124,6 +2154,22 @@ export class AppShell {
       }
       this.actions.reorderTab(source, to);
     });
+
+    // touch-action is latched when the gesture BEGINS, so adding a class at pick-up
+    // cannot stop the browser panning this finger — it would claim the drag for the
+    // bar's horizontal scroll and cancel the pointer, and the tab would never land
+    // (Codex on #2901). preventDefault on touchmove is the mechanism that does work,
+    // and it is safe to apply only while a tab is actually picked up: no scroll has
+    // begun yet, because the pick-up required the finger to stay still.
+    bar.addEventListener(
+      "touchmove",
+      (e: TouchEvent) => {
+        if (press?.held) {
+          e.preventDefault();
+        }
+      },
+      { passive: false },
+    );
 
     // pointercancel only — NOT pointerleave. A touch pointer is implicitly captured by
     // the element that took the pointerdown, so a finger dragging toward a PANE leaves


### PR DESCRIPTION
Found by a proactive sweep of `web/` for the #2787 shape — a capability that exists on
desktop, is *advertised* by an affordance, then silently does nothing. Full audit,
including everything that turned out clean, is in #2899.

Closes #2899

## The defect

Every tab renders `draggable=true` unconditionally, and that drag carries **two**
capabilities: reordering the tab, and dropping it on a pane to split. Both were HTML5
drag-and-drop only, and drag-and-drop does not start from a finger — Chrome on Android
never fires `dragstart` for touch input, Safari's support is narrow and
version-dependent. There was no touch handling anywhere on the tab bar. So on a phone:
press a tab, drag, nothing. No movement, no indicator, no message.

Neither capability had a fallback — the `+` menu offers only Terminal and VS Code,
`Alt+j`/`k`/`w` only cycle or close **existing** panes, and nothing gates splits off on
mobile, so the capability was live and simply unreachable.

## What this does

**Long-press a tab to pick it up**, drag to move the insertion indicator in the bar or
light a pane's split zone, release to land it exactly where a mouse drop would.

The pick-up is a **hold**, and that is the load-bearing decision. A horizontal finger
drag on this bar is genuinely ambiguous — it is also how an overflowed bar is scrolled —
so until the hold completes the finger belongs to the browser, and any travel past slop
hands it back for good. Scrolling is suspended **only** after a tab is picked up, and
only on the bar, so a finger that turns out to be scrolling never meets a bar that will
not scroll. That decision lives in `tabtouch.ts`, pure and tested, because the
permissive failure is the expensive one.

**It reuses the mouse path rather than copying it.** `split.ts`'s drop handler is
extracted to `applyTabDrop` and called by both, so id resolution, the #1901 self-split
dedupe and the focus choice cannot drift between a mouse and a finger. The bar reuses
the same insertion math (`tabreorder.ts`) and the same indicator. What a finger
genuinely needs extra is hit-testing — there is no `dragover` to say which pane it is
over — which `paneAtPoint`/`dropTabAt` supply.

Two subtleties worth flagging for review:

- A touch pointer is **implicitly captured** by the element taking the `pointerdown`, so
  the drag releases on `pointercancel` and **not** `pointerleave`: a finger heading for
  a pane leaves the bar's bounds while the gesture is still alive, and releasing there
  would cancel the very drag-to-split being added. Capture also guarantees the
  `pointerup` lands on the bar, so no state leaks.
- The **pinned agent tab** is refused by the mouse path by declining to be a drop target
  (the browser then draws a no-drop cursor). A finger has no cursor to read, so released
  over the bar it now says so out loud — the audit's own standard applied to the one
  case that still cannot move.

An earlier commit on this branch shipped only a hint ("needs a mouse or trackpad"). That
message becomes false the moment the gesture works, so it is gone rather than left to
rot — the [[reference_mirrors_comment_drift]] failure mode, in user-visible copy.

## Verification

`tabtouch.ts`'s tests pin the **negative** properties, which are the ones that protect
existing behaviour: a tap never picks up, and a slow scroll never picks up *even though
it outlasts the hold* (slop is checked before the hold). 510 web unit tests green, and
the `split.ts` extraction is behaviour-neutral — the whole suite passed unchanged across
it before any touch code was wired.

Browser-level, `#2899 mobile: a finger long-presses a tab and drags it to REORDER — and
a tap/scroll does not` drives a real phone context (`hasTouch`/`isMobile`) with
**trusted** touch through CDP, the routing #2682 established, because a synthesized
`PointerEvent` would prove only that the listeners ran. It asserts all three arms — a
tap does not reorder, a scroll does not reorder, and a settled long-press drag does —
plus that the picked-up tab shows its insertion indicator, that a reorder moves tabs
rather than adding or dropping any, and that the agent tab stays first.

Local gate per policy — cheap checks only, no containerized suites, no `go test` against
`./daemon/...` or `./app/...`: `gofmt -l .` clean, `go build ./...` ok,
`golangci-lint --fast` ok, `deadcode -test ./...` clean, `scripts/lint-file-length.sh`
passed, web typecheck + 510 unit tests, regenerated `web/dist` committed.

Co-Authored-By: Captain Claude <noreply@anthropic.com>
