### PR TITLE
fix(log): scrub every credential shape at the log boundary, not just access_token

### DIFF
--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -12,6 +12,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/sachiniyer/agent-factory/internal/credscrub"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/task"
 )
@@ -21,52 +22,10 @@ import (
 // `secretMarker` replaces a substring a best-effort pattern flagged as a
 // credential inside otherwise-kept text (log lines, config values).
 const (
-	redactedMarker = "[redacted]"
-	secretMarker   = "[redacted-secret]"
+	redactedMarker = credscrub.RedactedMarker
+	secretMarker   = credscrub.SecretMarker
 	userMarker     = "[user]"
 )
-
-// secretPatterns are targeted, high-confidence credential shapes scrubbed
-// wherever they appear (log tail, config, instance/task text). They are
-// deliberately specific — a broad "any long hex string" rule would also nuke
-// the git SHAs and IDs a triager needs, so those are left intact. Best-effort
-// by construction; the bundle always warns the user to review before sharing.
-var secretPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`sk-[A-Za-z0-9_-]{16,}`),                                     // OpenAI / Anthropic-style keys (incl. sk-ant-…)
-	regexp.MustCompile(`gh[pousr]_[A-Za-z0-9]{20,}`),                                // GitHub PAT / OAuth / server / refresh tokens
-	regexp.MustCompile(`github_pat_[A-Za-z0-9_]{20,}`),                              // GitHub fine-grained PAT
-	regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`),                              // Slack tokens
-	regexp.MustCompile(`AKIA[0-9A-Z]{16}`),                                          // AWS access key id
-	regexp.MustCompile(`AIza[0-9A-Za-z_-]{35}`),                                     // Google API key
-	regexp.MustCompile(`eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+`), // JWT (header.payload.signature)
-}
-
-// keyValueSecret matches a `<credential-key> = <value>` / `<key>: <value>`
-// assignment and redacts only the value, preserving the key so triage can see
-// *that* a credential is configured without leaking it. The key half tolerates
-// a prefix (github_token, x-api-key, client_secret) and optional quotes. The
-// value half recognizes TOML/JSON-style double-quoted strings, TOML literal
-// single-quoted strings, and bare token-like values.
-//
-// THE BARE CLASS MUST NOT EXCLUDE `]`. It used to, which meant a bare value
-// stopped BEFORE a `]` instead of at a real terminator — so the captured text
-// was not the value, only a prefix of it. Everything downstream inherited that
-// lie: `api_key=[redacted-secret]actualcredential` captured just
-// `[redacted-secret`, which looks exactly like a marker this redactor wrote, and
-// the credential rode out untouched behind it. The bug was never in the
-// comparison, so no guard on top of the capture could fix it.
-//
-// The value now ends only at a genuine terminator — whitespace, a quote, `,`,
-// `}`, or end of text — so what the regex hands back IS the whole bare value,
-// and comparing it to a marker is a real comparison. Values carrying structural
-// characters are covered by the quoted alternatives, which consume their own
-// delimiters. Dropping `]` also errs toward MORE redaction (a `]` adjacent to a
-// bare value is absorbed rather than left behind), which is the safe direction.
-var keyValueSecret = regexp.MustCompile(
-	`(?i)(["']?[a-z0-9_-]*(?:api[_-]?key|secret|token|password|passwd|pwd|auth|access[_-]?token|refresh[_-]?token|client[_-]?secret|bearer|credential|private[_-]?key)s?["']?\s*[:=]\s*)(?:"(?:\\.|[^"\\\r\n])*"|'[^'\r\n]*'|[^\s"',}]{6,})`)
-
-// privateKeyBlock matches a PEM private-key block in its entirety.
-var privateKeyBlock = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----`)
 
 // afTmuxSessionName matches a repo-scoped af tmux session name
 // (af_<8 hex>_<title>, incl. any __tab / _paste suffix). The <title> segment is
@@ -163,11 +122,7 @@ func addUserVariant(users []string, name string) []string {
 // field-redacted content, so it is defense-in-depth, not the only line of
 // defense.
 func (r *redactor) scrub(s string) string {
-	s = privateKeyBlock.ReplaceAllString(s, secretMarker)
-	s = keyValueSecret.ReplaceAllStringFunc(s, redactKeyValueSecret)
-	for _, re := range secretPatterns {
-		s = re.ReplaceAllString(s, secretMarker)
-	}
+	s = credscrub.Scrub(s)
 	if r.home != "" && r.home != "/" {
 		s = strings.ReplaceAll(s, r.home, "~")
 	}
@@ -467,75 +422,6 @@ func (r *redactor) noteUnknownJSON(v any) {
 			r.noteUnknownJSON(e)
 		}
 	}
-}
-
-func redactKeyValueSecret(match string) string {
-	idx := keyValueSecret.FindStringSubmatchIndex(match)
-	if len(idx) < 4 || idx[2] < 0 {
-		return secretMarker
-	}
-	prefix := match[idx[2]:idx[3]]
-	value := match[idx[3]:]
-	// A value an earlier pass already redacted must survive untouched. scrub is
-	// applied more than once to the same text by design — per section, again over
-	// the assembled text/JSON, and again on each component the issue draft inlines
-	// — so it has to be idempotent. It was not: re-scrubbing a marker re-wrapped
-	// it and grew a bracket per pass, and a real bundle shipped 28
-	// `[redacted-secret]]`.
-	//
-	// This skip is only safe because `value` is the COMPLETE value; see
-	// redactionMarkerValues for why, and keyValueSecret for the boundary that
-	// makes it true.
-	if isRedactionMarker(value) {
-		return match
-	}
-	if len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"' {
-		return prefix + `"` + secretMarker + `"`
-	}
-	if len(value) >= 2 && value[0] == '\'' && value[len(value)-1] == '\'' {
-		return prefix + `'` + secretMarker + `'`
-	}
-	return prefix + secretMarker
-}
-
-// redactionMarkerValues are the EXACT, COMPLETE value forms this redactor emits,
-// and nothing else. isRedactionMarker is a fast-path AROUND the scrub, and a
-// fast-path around a redactor is sound only if it recognizes precisely what that
-// redactor produces — anything looser is a way for a real credential to reach a
-// public bundle unscrubbed.
-//
-// Every entry is a whole value, which is what makes the comparison sound. That
-// is a property of keyValueSecret, not of this map: each alternative in its value
-// half now ends at a genuine terminator (see the regex comment), so the captured
-// text is the entire value —
-//
-//	bare      `[redacted-secret]`   ends at whitespace/quote/`,`/`}`/EOS
-//	bare      `[redacted]`          ditto
-//	quoted    `"[redacted-secret]"` the alternative consumes both quotes
-//	quoted    `'[redacted-secret]'` ditto
-//	quoted    `"[redacted]"`        ditto
-//	quoted    `'[redacted]'`        ditto
-//
-// — so a value that merely BEGINS with a marker (`[redacted-secret]hunter2`,
-// `"[redacted-secret]hunter2"`) is captured in full, matches no entry here, and
-// takes the normal redacting path. It cannot reach the unchanged path.
-//
-// Derived from the marker constants so they cannot drift if a marker is reworded.
-var redactionMarkerValues = map[string]bool{
-	secretMarker:               true,
-	redactedMarker:             true,
-	`"` + secretMarker + `"`:   true,
-	`'` + secretMarker + `'`:   true,
-	`"` + redactedMarker + `"`: true,
-	`'` + redactedMarker + `'`: true,
-}
-
-// isRedactionMarker reports whether value is EXACTLY a marker an earlier scrub
-// pass wrote, so re-scrubbing it would only re-wrap it. Exact match against a
-// COMPLETE value — never a prefix, never a substring, and never a truncated
-// capture: a value this redactor did not write must take the normal path.
-func isRedactionMarker(value string) bool {
-	return redactionMarkerValues[value]
 }
 
 // unparsedInstancesNote is emitted (as a JSON string) when instances.json is

--- a/internal/credscrub/credscrub.go
+++ b/internal/credscrub/credscrub.go
@@ -1,0 +1,153 @@
+// Package credscrub holds the credential-shape patterns Agent Factory scrubs
+// out of text, and the single Scrub that applies them.
+//
+// It exists because two sinks need the identical policy and used to have
+// different ones (#2884): the bug-report bundle, which is built to be shared,
+// and agent-factory.log, whose writer previously redacted only `access_token`.
+// The same GitHub PAT was therefore removed from a bundle and written in
+// cleartext to disk. Anything that learns a new credential shape must teach it
+// here, so a sink cannot fall behind again.
+//
+// The patterns are deliberately narrow. A broad "any long opaque string" rule
+// would also destroy the git SHAs, session ids and tmux names a triager needs,
+// so this is best-effort on high-confidence shapes rather than a guarantee; the
+// bug-report bundle still tells the user to review before sharing.
+package credscrub
+
+import "regexp"
+
+// Markers replacing redacted content. SecretMarker replaces a substring a
+// pattern flagged as a credential inside otherwise-kept text; RedactedMarker is
+// the whole-field marker its callers write, named here only so the
+// already-redacted check below can recognize both.
+const (
+	SecretMarker   = "[redacted-secret]"
+	RedactedMarker = "[redacted]"
+)
+
+// shapePatterns are targeted, high-confidence credential shapes scrubbed
+// wherever they appear.
+var shapePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`sk-[A-Za-z0-9_-]{16,}`),                                     // OpenAI / Anthropic-style keys (incl. sk-ant-…)
+	regexp.MustCompile(`gh[pousr]_[A-Za-z0-9]{20,}`),                                // GitHub PAT / OAuth / server / refresh tokens
+	regexp.MustCompile(`github_pat_[A-Za-z0-9_]{20,}`),                              // GitHub fine-grained PAT
+	regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`),                              // Slack tokens
+	regexp.MustCompile(`AKIA[0-9A-Z]{16}`),                                          // AWS access key id
+	regexp.MustCompile(`AIza[0-9A-Za-z_-]{35}`),                                     // Google API key
+	regexp.MustCompile(`eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+`), // JWT (header.payload.signature)
+	// An echoed Authorization header. keyValueSecret cannot reach this: its key
+	// half requires the key to END at `auth`, so "Authorization" never matches,
+	// and even where a key does match, its bare-value class stops at the space
+	// after the scheme — capturing "Bearer" and leaving the credential behind it
+	// standing. Match the scheme AND its value as one unit instead. Only the two
+	// real HTTP schemes, not a bare "token", which would eat ordinary log prose.
+	regexp.MustCompile(`(?i)\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]{8,}`), // Authorization header value
+}
+
+// keyValueSecret matches a `<credential-key> = <value>` / `<key>: <value>`
+// assignment and redacts only the value, preserving the key so triage can see
+// *that* a credential is configured without leaking it. The key half tolerates
+// a prefix (github_token, x-api-key, client_secret) and optional quotes. The
+// value half recognizes TOML/JSON-style double-quoted strings, TOML literal
+// single-quoted strings, and bare token-like values.
+//
+// THE BARE CLASS MUST NOT EXCLUDE `]`. It used to, which meant a bare value
+// stopped BEFORE a `]` instead of at a real terminator — so the captured text
+// was not the value, only a prefix of it. Everything downstream inherited that
+// lie: `api_key=[redacted-secret]actualcredential` captured just
+// `[redacted-secret`, which looks exactly like a marker this code wrote, and the
+// credential rode out untouched behind it. The bug was never in the comparison,
+// so no guard on top of the capture could fix it.
+//
+// The value now ends only at a genuine terminator — whitespace, a quote, `,`,
+// `}`, or end of text — so what the regex hands back IS the whole bare value,
+// and comparing it to a marker is a real comparison. Values carrying structural
+// characters are covered by the quoted alternatives, which consume their own
+// delimiters. Dropping `]` also errs toward MORE redaction (a `]` adjacent to a
+// bare value is absorbed rather than left behind), which is the safe direction.
+var keyValueSecret = regexp.MustCompile(
+	`(?i)(["']?[a-z0-9_-]*(?:api[_-]?key|secret|token|password|passwd|pwd|auth|access[_-]?token|refresh[_-]?token|client[_-]?secret|bearer|credential|private[_-]?key)s?["']?\s*[:=]\s*)(?:"(?:\\.|[^"\\\r\n])*"|'[^'\r\n]*'|[^\s"',}]{6,})`)
+
+// privateKeyBlock matches a PEM private-key block in its entirety.
+var privateKeyBlock = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----`)
+
+// Scrub replaces every credential shape recognized here with a marker. It is
+// idempotent: re-scrubbing text this package already scrubbed returns it
+// unchanged, which matters because the bug report scrubs the same text more than
+// once by design, and now also scrubs a log that was scrubbed on the way to disk.
+func Scrub(s string) string {
+	s = privateKeyBlock.ReplaceAllString(s, SecretMarker)
+	s = keyValueSecret.ReplaceAllStringFunc(s, redactKeyValueSecret)
+	for _, re := range shapePatterns {
+		s = re.ReplaceAllString(s, SecretMarker)
+	}
+	return s
+}
+
+func redactKeyValueSecret(match string) string {
+	idx := keyValueSecret.FindStringSubmatchIndex(match)
+	if len(idx) < 4 || idx[2] < 0 {
+		return SecretMarker
+	}
+	prefix := match[idx[2]:idx[3]]
+	value := match[idx[3]:]
+	// A value an earlier pass already redacted must survive untouched. Scrub is
+	// applied more than once to the same text by design — per section, again over
+	// the assembled text/JSON, and again on each component the issue draft inlines
+	// — so it has to be idempotent. It was not: re-scrubbing a marker re-wrapped
+	// it and grew a bracket per pass, and a real bundle shipped 28
+	// `[redacted-secret]]`.
+	//
+	// This skip is only safe because `value` is the COMPLETE value; see
+	// markerValues for why, and keyValueSecret for the boundary that makes it true.
+	if isMarker(value) {
+		return match
+	}
+	if len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"' {
+		return prefix + `"` + SecretMarker + `"`
+	}
+	if len(value) >= 2 && value[0] == '\'' && value[len(value)-1] == '\'' {
+		return prefix + `'` + SecretMarker + `'`
+	}
+	return prefix + SecretMarker
+}
+
+// markerValues are the EXACT, COMPLETE value forms this package and its callers
+// emit, and nothing else. isMarker is a fast-path AROUND the scrub, and a
+// fast-path around a redactor is sound only if it recognizes precisely what that
+// redactor produces — anything looser is a way for a real credential to reach a
+// public bundle unscrubbed.
+//
+// Every entry is a whole value, which is what makes the comparison sound. That
+// is a property of keyValueSecret, not of this map: each alternative in its value
+// half ends at a genuine terminator (see the regex comment), so the captured text
+// is the entire value —
+//
+//	bare      `[redacted-secret]`   ends at whitespace/quote/`,`/`}`/EOS
+//	bare      `[redacted]`          ditto
+//	quoted    `"[redacted-secret]"` the alternative consumes both quotes
+//	quoted    `'[redacted-secret]'` ditto
+//	quoted    `"[redacted]"`        ditto
+//	quoted    `'[redacted]'`        ditto
+//
+// — so a value that merely BEGINS with a marker (`[redacted-secret]hunter2`,
+// `"[redacted-secret]hunter2"`) is captured in full, matches no entry here, and
+// takes the normal redacting path. It cannot reach the unchanged path.
+//
+// Derived from the marker constants so they cannot drift if a marker is reworded.
+var markerValues = map[string]bool{
+	SecretMarker:               true,
+	RedactedMarker:             true,
+	`"` + SecretMarker + `"`:   true,
+	`'` + SecretMarker + `'`:   true,
+	`"` + RedactedMarker + `"`: true,
+	`'` + RedactedMarker + `'`: true,
+}
+
+// isMarker reports whether value is EXACTLY a marker an earlier scrub pass
+// wrote, so re-scrubbing it would only re-wrap it. Exact match against a
+// COMPLETE value — never a prefix, never a substring, and never a truncated
+// capture: a value this package did not write must take the normal path.
+func isMarker(value string) bool {
+	return markerValues[value]
+}

--- a/internal/credscrub/credscrub_test.go
+++ b/internal/credscrub/credscrub_test.go
@@ -1,0 +1,86 @@
+package credscrub
+
+import (
+	"strings"
+	"testing"
+)
+
+const sentinel = "S3NT1NELVALUEDONOTLOG"
+
+func TestScrubRemovesCredentialShapes(t *testing.T) {
+	cases := []struct{ name, in string }{
+		{"openai/anthropic key", "key sk-ant-" + sentinel + "abcdefghij here"},
+		{"github PAT", "token ghp_" + sentinel + "abcdefghij here"},
+		{"github fine-grained PAT", "token github_pat_" + sentinel + "abcdefghij"},
+		{"slack token", "xoxb-" + sentinel + "-abcdef"},
+		{"aws access key id", "AKIA" + strings.ToUpper(sentinel[:16])},
+		{"google api key", "AIza" + sentinel + "abcdefghijklmnop1234"},
+		{"jwt", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIx" + sentinel + "In0.abcdefghij"},
+		{"bare key=value", "SOME_API_KEY=" + sentinel},
+		{"quoted key=value", `api_key = "` + sentinel + `"`},
+		{"single quoted key=value", `token: '` + sentinel + `'`},
+		{"authorization bearer", "Authorization: Bearer " + sentinel + "abcdef"},
+		{"authorization basic", "Authorization: Basic " + sentinel + "abcdef"},
+		{"git url userinfo", "https://x-access-token:ghp_" + sentinel + "abcdefghij@github.com/o/r"},
+		{"pem private key", "-----BEGIN RSA PRIVATE KEY-----\n" + sentinel + "\n-----END RSA PRIVATE KEY-----"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Scrub(tc.in)
+			if strings.Contains(got, sentinel) {
+				t.Fatalf("credential survived Scrub: %q", got)
+			}
+		})
+	}
+}
+
+// TestScrubIsIdempotent is the #1260 lesson as a property: the bug report scrubs
+// the same text repeatedly by design, and the log is now scrubbed on the way to
+// disk and again when a bundle reads it back. A pass that re-wraps its own marker
+// shipped 28 `[redacted-secret]]` in a real bundle.
+func TestScrubIsIdempotent(t *testing.T) {
+	inputs := []string{
+		"SOME_API_KEY=" + sentinel,
+		`api_key = "` + sentinel + `"`,
+		"token ghp_" + sentinel + "abcdefghij",
+		"Authorization: Bearer " + sentinel + "abcdef",
+		"nothing sensitive here, commit 4f2a9c1 on af_0f8fc14c_fix-login",
+	}
+	for _, in := range inputs {
+		once := Scrub(in)
+		twice := Scrub(once)
+		if once != twice {
+			t.Fatalf("Scrub not idempotent for %q:\n once: %q\ntwice: %q", in, once, twice)
+		}
+	}
+}
+
+// TestScrubRedactsValueThatMerelyBeginsWithAMarker pins the boundary that makes
+// the already-redacted fast path sound. A value starting with a marker is NOT a
+// marker, and treating it as one let a credential ride out behind it.
+func TestScrubRedactsValueThatMerelyBeginsWithAMarker(t *testing.T) {
+	got := Scrub("api_key=" + SecretMarker + sentinel)
+	if strings.Contains(got, sentinel) {
+		t.Fatalf("credential hiding behind a marker survived: %q", got)
+	}
+}
+
+// TestScrubKeepsTriageContext guards the other direction. These patterns are
+// deliberately narrow because a broad rule would destroy what a triager reads.
+func TestScrubKeepsTriageContext(t *testing.T) {
+	in := "worktree af_0f8fc14c_fix-login at 4f2a9c1e8b7d6c5a4f3e2d1c0b9a8f7e6d5c4b3a removed; session id 01J8Z9"
+	if got := Scrub(in); got != in {
+		t.Fatalf("Scrub destroyed benign triage context:\n in: %q\nout: %q", in, got)
+	}
+}
+
+// BenchmarkScrubTypicalLogLine measures the cost added to every log write. The
+// patterns run on the write path, so a regression here is paid by the daemon on
+// every line it emits.
+func BenchmarkScrubTypicalLogLine(b *testing.B) {
+	line := "ERROR:2026/08/05 11:15:52 worktree_ops.go:529: failed to remove worktree /home/u/.agent-factory/worktrees/af_0f8fc14c_fix-login: exit status 128"
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = Scrub(line)
+	}
+}

--- a/log/redact.go
+++ b/log/redact.go
@@ -4,15 +4,33 @@ import (
 	"io"
 
 	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/internal/credscrub"
 )
 
-// accessTokenRedactingWriter is a last-line defense for agent-factory.log and
-// its stderr fallback. URL-producing call sites still redact structurally so
+// credentialRedactingWriter is a last-line defense for agent-factory.log and its
+// stderr fallback. URL-producing call sites still redact structurally so
 // returned errors and non-log surfaces are safe too.
-type accessTokenRedactingWriter struct{ writer io.Writer }
+//
+// Two passes, because they cover different things and neither subsumes the
+// other. RedactAccessTokenText is key-aware: it knows `access_token` is a
+// credential whatever the value looks like. credscrub.Scrub is shape-aware: it
+// recognizes a GitHub PAT or a PEM block with no key in sight, which is how a
+// credential arrives here in practice — folded into a git stderr, an operator's
+// docker run_args, or an echoed Authorization header.
+//
+// Shape pass FIRST, so the key-aware pass has the last word on its own key.
+// The other order rewrote `access_token=REDACTED` into
+// `access_token=[redacted-secret]`, because the shape pass sees a credential
+// key with a value and cannot know REDACTED is another redactor's marker.
+// Either order removes the secret; only this one keeps the documented output.
+//
+// Until #2884 only the first pass ran, so the bug-report bundle scrubbed eight
+// credential shapes this file wrote to disk in cleartext. Sharing the patterns
+// with bugreport is what keeps the two from drifting again.
+type credentialRedactingWriter struct{ writer io.Writer }
 
-func (w accessTokenRedactingWriter) Write(p []byte) (int, error) {
-	redacted := []byte(agentproto.RedactAccessTokenText(string(p)))
+func (w credentialRedactingWriter) Write(p []byte) (int, error) {
+	redacted := []byte(agentproto.RedactAccessTokenText(credscrub.Scrub(string(p))))
 	n, err := w.writer.Write(redacted)
 	if err != nil {
 		return 0, err
@@ -24,5 +42,5 @@ func (w accessTokenRedactingWriter) Write(p []byte) (int, error) {
 }
 
 func redactedLogSink(writer io.Writer) io.Writer {
-	return accessTokenRedactingWriter{writer: writer}
+	return credentialRedactingWriter{writer: writer}
 }

--- a/log/redact_test.go
+++ b/log/redact_test.go
@@ -7,6 +7,89 @@ import (
 	"testing"
 )
 
+// TestInitializedLoggerRedactsCredentialShapes covers the half of the boundary
+// that is shape-aware rather than key-aware (#2884). Every line here is one an
+// af log line can plausibly carry — git folds its stderr into the errors this
+// package logs, docker run_args are operator text, and an echoed Authorization
+// header is a normal way a client error reads — and none of them contain the
+// word `access_token`, so the key-aware pass alone wrote all of them to disk.
+//
+// Driven through the real logger and read back off the real file, because the
+// property is "what lands in agent-factory.log", not "what a helper returns".
+func TestInitializedLoggerRedactsCredentialShapes(t *testing.T) {
+	// Synthetic values shaped like the real thing. The suffix is a sentinel: it
+	// must never appear in the file, whichever pattern was supposed to catch it.
+	const sentinel = "S3NT1NELVALUEDONOTLOG"
+	cases := []struct {
+		name    string
+		format  string
+		secret  string
+		context string
+	}{
+		{
+			name:    "git URL userinfo",
+			format:  "failed to push branch: fatal: could not read from %s",
+			secret:  "https://x-access-token:ghp_" + sentinel + "@github.com/o/r",
+			context: "failed to push branch",
+		},
+		{
+			name:    "bare github PAT",
+			format:  "gh auth rejected the token %s",
+			secret:  "ghp_" + sentinel + "abcdefghij",
+			context: "gh auth rejected",
+		},
+		{
+			name:    "anthropic style key",
+			format:  "agent start failed, key %s",
+			secret:  "sk-ant-" + sentinel + "abcdefghij",
+			context: "agent start failed",
+		},
+		{
+			name:    "authorization header echo",
+			format:  "request failed: %s",
+			secret:  "Authorization: Bearer " + sentinel + "abcdef",
+			context: "request failed",
+		},
+		{
+			name:    "operator run_args env value",
+			format:  "docker run failed: %s",
+			secret:  "-e SOME_API_KEY=" + sentinel,
+			context: "docker run failed",
+		},
+		{
+			name:    "af daemon token assignment",
+			format:  "control socket rejected: %s",
+			secret:  "AF_DAEMON_TOKEN=" + sentinel,
+			context: "control socket rejected",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logPathOverride = filepath.Join(t.TempDir(), "agent-factory.log")
+			t.Cleanup(func() {
+				CloseQuiet()
+				logPathOverride = ""
+			})
+
+			Initialize(false)
+			ErrorLog.Printf(tc.format, tc.secret)
+			CloseQuiet()
+
+			contents, err := os.ReadFile(logPathOverride)
+			if err != nil {
+				t.Fatalf("read log: %v", err)
+			}
+			got := string(contents)
+			if strings.Contains(got, sentinel) {
+				t.Fatalf("logging boundary persisted a credential: %s", got)
+			}
+			if !strings.Contains(got, tc.context) {
+				t.Fatalf("logging boundary destroyed the diagnostic context %q: %s", tc.context, got)
+			}
+		})
+	}
+}
+
 func TestInitializedLoggerRedactsAccessTokenQuery(t *testing.T) {
 	const token = "af-sentinel-logger-boundary"
 	logPathOverride = filepath.Join(t.TempDir(), "agent-factory.log")


### PR DESCRIPTION
## What

`log/redact.go` wraps `agent-factory.log` and its stderr fallback in a
last-line-of-defense writer — the right design. But it called only
`agentproto.RedactAccessTokenText`, which by construction recognises **one key**.
Every other credential shape was written to disk in cleartext, while
`bugreport/redact.go` **in this same repo** already scrubbed eight of them on the
way out of a bundle.

So the same GitHub PAT was removed from a bundle you'd share and persisted to the
log you actually read.

I probed the boundary with synthetic values before changing anything:

| shape | before | after |
|---|---|---|
| `?access_token=…` | redacted | redacted |
| git URL userinfo (`https://x-access-token:<pat>@…`) | **cleartext** | redacted |
| bare `ghp_…` / `github_pat_…` | **cleartext** | redacted |
| `sk-…` / `sk-ant-…` | **cleartext** | redacted |
| `Authorization: Bearer …` | **cleartext** | redacted |
| `-e SOME_API_KEY=…` from operator run_args | **cleartext** | redacted |
| JWT | **cleartext** | redacted |
| af's own `AF_DAEMON_TOKEN=…` | **cleartext** | redacted |

## Factoring

The patterns move to `internal/credscrub`, used by both sinks, so they cannot
drift apart again — that drift *is* the bug, not a side effect of it. The move
carries over the marker-collision handling learned in #1260/#1680/#1839,
including the value boundary that makes the already-redacted fast path sound.

Behaviour-preserving for bugreport: its suite passes untouched.

## Two things the tests found that I did not predict

**`Authorization: Bearer <token>` was matched by nothing.** `keyValueSecret`
requires the key to *end* at `auth`, so "Authorization" never matched it — and
even where a key does match, the bare-value class stops at the space after the
scheme, capturing `Bearer` and leaving the credential behind it standing. Now
matched as one unit, scheme and value together. Only `bearer`/`basic`, not a bare
`token`, which would eat ordinary log prose.

**Pass ordering is load-bearing.** Running the shape pass *second* rewrote
`access_token=REDACTED` into `access_token=[redacted-secret]` and broke the
existing boundary test — the shape pass sees a credential key with a value and
cannot know `REDACTED` is another redactor's marker. Shape pass first, so the
key-aware pass has the last word on its own key. Either order removes the secret;
only this one keeps the documented output.

## Cost, measured rather than assumed

`BenchmarkScrubTypicalLogLine`: **64µs, 30 allocs** per scrubbed line.

Against the real log on this box: **155 lines in 7 days** — about one an hour.

So no pre-filter. A fast path *around* a redactor is precisely the shape that has
leaked here before (the `]`-boundary bug in `keyValueSecret`), and at this volume
it would buy nothing while adding a way to skip the scrub. If the log ever
becomes high-volume the gate can come then, with its own proof that it is a
superset of what the patterns match.

## Verification

- `TestInitializedLoggerRedactsCredentialShapes` drives the **real logger** and
  reads the **real file** back, because the property is "what lands in
  agent-factory.log", not "what a helper returns".
- **Watched failing first:** reverting the writer to the pre-fix single pass
  fails all six subtests; restoring it passes all six.
- `credscrub` tests cover each shape, idempotency (the #1260 lesson — a real
  bundle once shipped 28 `[redacted-secret]]`), a value that merely *begins* with
  a marker, and a guard in the other direction that benign triage context (git
  SHAs, `af_<hash>_<title>` names) survives untouched.
- Cheap gate green: `gofmt -l .`, `go build ./...`, `golangci-lint --fast`,
  `deadcode -test ./...`, `scripts/lint-file-length.sh`, plus
  `go test ./internal/credscrub/ ./log/ ./bugreport/ ./agentproto/`. No
  containerized suites; nothing under `daemon/` or `app/` run locally.

## The rest of the audit

Recorded on #2884 so the next sweep doesn't redo it. Four surfaces were already
handled deliberately and are untouched here:

- **argv / `/proc`** — `sessionenv.WrapCommand` puts only the binary, agent name,
  variable *names* and the pane command in argv ("environment values never enter
  argv", and the code matches); `backend_docker.go` passes `-e NAME`, name-only.
- **session environment** — default-deny allowlist via `FilterForCommand`.
- **tmux pane content in bug reports** — goes through the redactor's pattern set.
- **request-wrapping errors** — the token-in-URL paths already use
  `RedactAccessTokenURL` / `RedactAccessTokenError`.

Closes #2884

🤖 Generated with [Claude Code](https://claude.com/claude-code)
