### PR TITLE
fix(git): let the cross-device copy handle a read-only source directory

### DIFF
--- a/session/git/worktree_archive_test.go
+++ b/session/git/worktree_archive_test.go
@@ -1318,14 +1318,30 @@ func TestMoveWorktree_ArchiveRestoreRoundTripPreservesModes(t *testing.T) {
 	require.NoError(t, os.WriteFile(hook, []byte("#!/bin/sh\ntrue\n"), 0600))
 	require.NoError(t, os.Chmod(hook, 0755))
 	require.NoError(t, os.Chmod(filepath.Join(srcPath, "dirty.txt"), 0664))
+	// A group-readable directory and a read-only one, so this covers both the
+	// mode the umask would have eaten (#2869) and the mode the copier could not
+	// write into (#2872) through the same round trip.
+	shared := filepath.Join(srcPath, "shared")
+	require.NoError(t, os.Mkdir(shared, 0700))
+	require.NoError(t, os.Chmod(shared, 0750))
+	vendored := filepath.Join(srcPath, "vendored")
+	require.NoError(t, os.Mkdir(vendored, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(vendored, "pinned.txt"), []byte("pinned"), 0444))
+	t.Cleanup(func() { chmodTreeWritable(t, filepath.Dir(srcPath)) })
+	require.NoError(t, os.Chmod(vendored, 0555))
 	beforeArchive := collectTreeDescription(t, srcPath)
 
+	// Each CanonicalTempDir call makes its own t.TempDir, and a faithfully
+	// preserved 0555 directory defeats that TempDir's RemoveAll. Registering
+	// after each one puts these ahead of it in the LIFO cleanup order.
 	archived := filepath.Join(testguard.CanonicalTempDir(t), "archived", "repoid", "arch")
+	t.Cleanup(func() { chmodTreeWritable(t, archived) })
 	require.NoError(t, gw.MoveWorktree(archived))
 	assert.Equal(t, beforeArchive, collectTreeDescription(t, archived),
 		"the archived copy must be mode-identical to the worktree it took")
 
 	restored := filepath.Join(testguard.CanonicalTempDir(t), "restored", "arch")
+	t.Cleanup(func() { chmodTreeWritable(t, restored) })
 	require.NoError(t, gw.RestoreWorktreeTo(restored))
 	assert.Equal(t, beforeArchive, collectTreeDescription(t, restored),
 		"a restored session must come back with the modes it had, executable hooks included")

--- a/session/git/worktree_archive_test.go
+++ b/session/git/worktree_archive_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io/fs"
 	stdlog "log"
 	"os"
 	"path/filepath"
@@ -1328,4 +1329,99 @@ func TestMoveWorktree_ArchiveRestoreRoundTripPreservesModes(t *testing.T) {
 	require.NoError(t, gw.RestoreWorktreeTo(restored))
 	assert.Equal(t, beforeArchive, collectTreeDescription(t, restored),
 		"a restored session must come back with the modes it had, executable hooks included")
+}
+
+// TestMoveDirCrossDevice_CopiesIntoAReadOnlySourceDirectory is the #2872
+// regression. A worktree may legitimately contain a directory the owner cannot
+// write — a vendored or generated tree checked in read-only. The same-device
+// rename(2) moves it without ever looking inside, but the cross-device copy
+// created each destination directory at its final mode and then tried to
+// populate it, so a 0555 directory could not be filled and the whole archive
+// failed. Which filesystem $AF_HOME sits on decided whether the session could
+// be archived at all.
+func TestMoveDirCrossDevice_CopiesIntoAReadOnlySourceDirectory(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses the directory write check, so this scenario needs a non-root uid")
+	}
+	withUmask(t, 0022)
+	src := filepath.Join(t.TempDir(), "src")
+	readOnly := filepath.Join(src, "vendored")
+	require.NoError(t, os.MkdirAll(readOnly, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(readOnly, "pinned.txt"), []byte("pinned"), 0444))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "tracked.txt"), []byte("tracked"), 0644))
+	destinationParent := t.TempDir()
+	dest := filepath.Join(destinationParent, "dest")
+	// Registered after both TempDirs, so it runs before their RemoveAll: a
+	// leftover read-only directory would otherwise fail the harness cleanup
+	// rather than the assertion under test.
+	t.Cleanup(func() {
+		chmodTreeWritable(t, filepath.Dir(src))
+		chmodTreeWritable(t, destinationParent)
+	})
+	require.NoError(t, os.Chmod(readOnly, 0555))
+
+	originalRename := renamePath
+	renamePath = func(_, _ string) error { return syscall.EXDEV }
+	t.Cleanup(func() { renamePath = originalRename })
+
+	require.NoError(t, moveDirCrossDevice(src, dest),
+		"a read-only source directory must not fail the cross-device move")
+	assert.NoDirExists(t, src, "the source must be gone after a successful move")
+
+	contents, err := os.ReadFile(filepath.Join(dest, "vendored", "pinned.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "pinned", string(contents))
+	info, err := os.Stat(filepath.Join(dest, "vendored"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0555), info.Mode().Perm(),
+		"the read-only directory must arrive read-only, not left writable by the copy")
+}
+
+// TestMoveDirCrossDevice_CleansStagingContainingAReadOnlyDirectory covers the
+// other half of the #2872 removal problem. The copy now reproduces a read-only
+// directory faithfully, which means the private staging tree contains one too —
+// and unlinking anything out of it needs write permission the mode does not
+// grant. A failure between the copy and the commit must still leave the archive
+// root empty rather than stranding a staging tree nothing can delete.
+func TestMoveDirCrossDevice_CleansStagingContainingAReadOnlyDirectory(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses the directory write check, so this scenario needs a non-root uid")
+	}
+	src := filepath.Join(t.TempDir(), "src")
+	readOnly := filepath.Join(src, "vendored")
+	require.NoError(t, os.MkdirAll(readOnly, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(readOnly, "pinned.txt"), []byte("pinned"), 0444))
+	destinationParent := t.TempDir()
+	dest := filepath.Join(destinationParent, "dest")
+	t.Cleanup(func() { chmodTreeWritable(t, src) })
+	require.NoError(t, os.Chmod(readOnly, 0555))
+
+	originalRename := renamePath
+	renamePath = func(_, _ string) error { return syscall.EXDEV }
+	t.Cleanup(func() { renamePath = originalRename })
+	originalHook := moveDirBeforeSourceCommit
+	moveDirBeforeSourceCommit = func(string) error { return errors.New("forced failure after the copy") }
+	t.Cleanup(func() { moveDirBeforeSourceCommit = originalHook })
+
+	err := moveDirCrossDevice(src, dest)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "failed to clean private staging tree",
+		"a read-only directory in the copy must not defeat staging cleanup")
+
+	entries, readErr := os.ReadDir(destinationParent)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries, "the private staging tree must be gone, read-only directories and all")
+	assert.FileExists(t, filepath.Join(readOnly, "pinned.txt"), "the untouched source must survive")
+}
+
+// chmodTreeWritable restores owner write on every directory under root so the
+// harness can delete a fixture that deliberately contains read-only directories.
+func chmodTreeWritable(t *testing.T, root string) {
+	t.Helper()
+	_ = filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err == nil && entry.IsDir() {
+			_ = os.Chmod(path, 0755)
+		}
+		return nil
+	})
 }

--- a/session/git/worktree_copy_cleanup.go
+++ b/session/git/worktree_copy_cleanup.go
@@ -356,6 +356,10 @@ func removeCopiedTree(root *os.File, path string, manifest copiedDirectory, prot
 			return changedCleanupError(protectUnexpected, "failed to reopen copied source tree: %v", err)
 		}
 		directoryPath := directoryRoutePath(path, components)
+		if err := ensureOwnerWritableDirectory(directory, directoryPath); err != nil {
+			_ = directory.Close()
+			return changedCleanupError(protectUnexpected, "%v", err)
+		}
 		for _, entry := range route.directory.entries {
 			if entry.directory != nil {
 				continue
@@ -385,11 +389,54 @@ func removeCopiedTree(root *os.File, path string, manifest copiedDirectory, prot
 		if err != nil {
 			return changedCleanupError(protectUnexpected, "failed to reopen copied source parent: %v", err)
 		}
-		err = removeCopiedEntry(parent, directoryRoutePath(path, parentComponents), route.entry, protectUnexpected)
+		parentPath := directoryRoutePath(path, parentComponents)
+		// The parent needs the same treatment, and it needs it here rather than
+		// at its own route: this walk is deepest-first, so a child is unlinked
+		// from its parent long before that parent's own turn comes around.
+		if err := ensureOwnerWritableDirectory(parent, parentPath); err != nil {
+			_ = parent.Close()
+			return changedCleanupError(protectUnexpected, "%v", err)
+		}
+		err = removeCopiedEntry(parent, parentPath, route.entry, protectUnexpected)
 		_ = parent.Close()
 		if err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// ensureOwnerWritableDirectory grants the owner write and search on a directory
+// this process is about to empty.
+//
+// Removing an entry means renaming and unlinking it, and both need write
+// permission on the directory that holds it — so a read-only directory that the
+// copier can now reproduce (see workingDirectoryMode) still could not be cleaned
+// up or deleted afterwards. That is the second half of #2872, and it is not
+// confined to failure paths: a completed cross-device move deletes the original
+// worktree through this same walk, so one read-only directory anywhere in the
+// tree left the source behind and reported the archive as half-done.
+//
+// Only owner bits are added, and only to a tree being deleted — no other user
+// gains access at any point. The descriptor was identity-checked by the route
+// walk that opened it, so this widens a node the manifest already accounts for,
+// never one that merely holds the same name. A directory that already has the
+// bits is left untouched, so an ordinary tree is never chmodded at all.
+//
+// A tree that then fails to be removed is left with those owner bits added.
+// That is deliberate: the alternative is refusing to delete it at all, and the
+// caller reports the leftover either way.
+func ensureOwnerWritableDirectory(directory *os.File, path string) error {
+	var stat unix.Stat_t
+	if err := unix.Fstat(int(directory.Fd()), &stat); err != nil {
+		return fmt.Errorf("failed to inspect directory %s before removing its entries: %w", path, err)
+	}
+	mode := uint32(stat.Mode) & 0o7777
+	if mode&0o700 == 0o700 {
+		return nil
+	}
+	if err := unix.Fchmod(int(directory.Fd()), mode|0o700); err != nil {
+		return fmt.Errorf("failed to make directory %s writable so its entries can be removed: %w", path, err)
 	}
 	return nil
 }

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -17,9 +17,11 @@ import (
 
 // copyTree recursively copies the directory rooted at src to dest, preserving
 // regular files (contents + permission bits), subdirectories, and symlinks
-// (copied as links, never followed). Permission bits are restored explicitly
-// after each node is created rather than left to the mode passed at creation,
-// because that mode is subtracted by the process umask — see preserveSourceMode.
+// (copied as links, never followed). Permission bits are applied explicitly
+// rather than left to the mode passed at creation, because that mode is
+// subtracted by the process umask and because a directory has to stay writable
+// until its own contents are in place — see preserveSourceMode and
+// workingDirectoryMode.
 // Traversal stays anchored to open directory descriptors: a worktree process can
 // replace any pathname after it is inspected, so every source open is
 // nonblocking and no-follow, and every destination node is created exclusively.
@@ -176,7 +178,7 @@ func copyTreeWithIdentities(src, dest string) (*copiedTreeIdentities, error) {
 		return nil, err
 	}
 	destName := filepath.Base(dest)
-	if err := unix.Mkdirat(int(destParent.Fd()), destName, uint32(sourceInfo.Mode().Perm())); err != nil {
+	if err := unix.Mkdirat(int(destParent.Fd()), destName, workingDirectoryMode(sourceInfo.Mode())); err != nil {
 		_ = destParent.Close()
 		_ = source.Close()
 		return nil, fmt.Errorf("cannot move worktree across filesystems: failed to create destination directory %s exclusively: %w", dest, err)
@@ -200,12 +202,6 @@ func copyTreeWithIdentities(src, dest string) (*copiedTreeIdentities, error) {
 		return nil, errors.Join(err, cleanupErr)
 	}
 	destinationIdentity, err := identityFromFile(destination)
-	if err == nil {
-		// The whole copy is anchored to this descriptor, so it is also where the
-		// root's mode belongs. Every child mode is restored the same way, at the
-		// point its own descriptor is confirmed.
-		err = preserveSourceMode(int(destination.Fd()), sourceInfo.Mode(), dest, "directory")
-	}
 	if err != nil {
 		cleanupErr := removeCreatedDirectory(destParent, destParentPath, destName, createdIdentity)
 		_ = destination.Close()
@@ -257,6 +253,17 @@ func copyDirectoryContents(source, destination *os.File, sourcePath, destination
 			directoryRoutePath(destinationPath, components),
 			job.directory,
 		)
+		if err == nil {
+			// The level is complete, and nothing is ever written directly into
+			// this directory again — descendants are filled through their own
+			// descriptors, which need only the search bit here. So this is the
+			// first moment the real mode can be applied, and the last moment it
+			// is free: a read-only source directory takes its mode now rather
+			// than blocking its own contents (#2872).
+			err = applyCopiedDirectoryMode(
+				sourceDirectory, destinationDirectory, directoryRoutePath(destinationPath, components),
+			)
+		}
 		_ = destinationDirectory.Close()
 		_ = sourceDirectory.Close()
 		if err != nil {
@@ -347,7 +354,7 @@ func copyDirectoryEntry(
 	if !inspected.same(sourceIdentity) {
 		return copiedEntry{}, fmt.Errorf("cannot move worktree across filesystems: source directory %s changed before it was opened", sourcePath)
 	}
-	if err := unix.Mkdirat(int(destination.Fd()), name, uint32(sourceInfo.Mode().Perm())); err != nil {
+	if err := unix.Mkdirat(int(destination.Fd()), name, workingDirectoryMode(sourceInfo.Mode())); err != nil {
 		return copiedEntry{}, fmt.Errorf("cannot move worktree across filesystems: failed to create destination directory %s exclusively: %w", destinationPath, err)
 	}
 	// Identify the node right after creating it: every later step can fail, and
@@ -376,11 +383,6 @@ func copyDirectoryEntry(
 	}
 	if !destinationIdentity.same(openedIdentity) {
 		return created, fmt.Errorf("cannot move worktree across filesystems: destination directory %s changed after it was created", destinationPath)
-	}
-	// Only now: the descriptor has just been confirmed to be the node this
-	// process created, which is what makes chmodding it safe.
-	if err := preserveSourceMode(int(destinationChild.Fd()), sourceInfo.Mode(), destinationPath, "directory"); err != nil {
-		return created, err
 	}
 	return created, nil
 }
@@ -422,6 +424,38 @@ func copySymlinkEntry(
 	return created, nil
 }
 
+// workingDirectoryMode is the mode a destination directory is created with while
+// the copy is still filling it.
+//
+// A worktree may legitimately contain a directory its owner cannot write — a
+// vendored or generated tree checked in read-only. rename(2) relocates one
+// without ever looking inside, but a copy has to put the contents back, and
+// creating the directory at its final 0555 makes it impossible to fill: the
+// archive failed outright on a worktree the same-device path moves without
+// complaint (#2872). So the copy runs in a mode that guarantees it can write,
+// and applyCopiedDirectoryMode installs the real one the moment the directory's
+// own level is complete.
+//
+// Only owner bits are added. No other user gains access to the staging tree at
+// any point, whatever the source's mode says.
+func workingDirectoryMode(sourceMode os.FileMode) uint32 {
+	return uint32(sourceMode.Perm()) | 0o700
+}
+
+// applyCopiedDirectoryMode gives a finished destination directory the mode its
+// source carries, reading that mode from the source descriptor the route walk
+// just validated rather than from anything cached earlier.
+func applyCopiedDirectoryMode(source, destination *os.File, destinationPath string) error {
+	info, err := source.Stat()
+	if err != nil {
+		return fmt.Errorf(
+			"cannot move worktree across filesystems: failed to read the source mode for destination directory %s: %w",
+			destinationPath, err,
+		)
+	}
+	return preserveSourceMode(int(destination.Fd()), info.Mode(), destinationPath, "directory")
+}
+
 // preserveSourceMode restores a source node's permission bits on the descriptor
 // that owns its copy.
 //
@@ -437,7 +471,8 @@ func copySymlinkEntry(
 // It chmods a descriptor rather than a name because this copier's entire premise
 // is that a worktree process can replace any pathname mid-copy: fchmodat() would
 // apply the source's mode to whatever node holds the name by the time it runs.
-// Callers pass a descriptor only after confirming it is the node they created.
+// Callers pass a descriptor only after the route walk or the creation check has
+// confirmed which node it is.
 //
 // Setuid, setgid and sticky bits sit outside Perm() and are not carried over,
 // which is the behavior this copier has always had. Symlinks are skipped


### PR DESCRIPTION
Sibling of #2871 in the same fallback path. That one fixed permissions being *changed*; this one fixes the archive failing outright.

## The bug

A worktree may legitimately contain a directory its owner cannot write — a vendored or generated tree checked in read-only. `rename(2)` relocates one without ever looking inside, so the same-device move never noticed. The cross-device fallback created each destination directory at its **final** mode and then tried to fill it, so a `0555` directory could not be populated and the whole archive failed. Which filesystem `$AF_HOME` sits on decided whether the session could be archived at all.

## It has two halves

Fixing only the copy moves the failure rather than removing it. Both measured, in order:

```
failed to create destination file .../vendored/pinned.txt exclusively: permission denied   <- the copy
```
then, with only the copy fixed:
```
copied worktree to ... but failed to remove original .../af-source-…:
  failed to secure entry .../vendored/pinned.txt for removal: permission denied            <- the removal
```

Unlinking an entry requires write permission on the directory holding it, and a **completed** cross-device move deletes the original worktree through that same walk. So one read-only directory anywhere in the tree also stranded the original and reported the archive as half-done — not just a failure-path concern.

## The fix

**Copy side.** Create each destination directory in a mode that guarantees it can be written (`workingDirectoryMode`), and apply the real mode the moment its own level is complete (`applyCopiedDirectoryMode`). That moment is exact rather than approximate: once `copyDirectoryLevel` returns, nothing is ever written *directly* into that directory again — descendants are filled through their own descriptors and need only the search bit here. So it is both the first moment the real mode can be applied and the last moment it is free.

**Removal side.** Grant the owner write+search before emptying a directory, on both the staging-cleanup and source-removal paths. It has to happen at the point of use, not at each directory's own route: the walk is deepest-first, so a child is unlinked from its parent long before that parent's turn arrives.

Both only ever add **owner** bits, so no other user gains access to a staging tree or to a tree being deleted, and a directory that already has them is skipped — an ordinary worktree is never chmodded at all. The removal-side descriptor was already identity-checked by the route walk that opened it, so this widens a node the manifest accounts for, never one that merely holds the same name.

One deliberate trade-off, documented at the call site: a tree that then *fails* to be removed is left with those owner bits added. The alternative is refusing to delete it at all, and the caller reports the leftover either way.

## Tests

- `TestMoveDirCrossDevice_CopiesIntoAReadOnlySourceDirectory` — the headline case: a `0555` directory must move, and arrive still `0555`.
- `TestMoveDirCrossDevice_CleansStagingContainingAReadOnlyDirectory` — the staging-cleanup path, which is distinct code from source removal: a failure between copy and commit must leave the archive root empty rather than stranding a tree nothing can delete.
- `TestMoveWorktree_ArchiveRestoreRoundTripPreservesModes` — extended (it landed in #2871) to carry both a `0750` and a `0555` directory, so one end-to-end round trip now covers this issue and #2869 together.

**Mutation-tested — each lever independently pinned:**

| mutation | result |
|---|---|
| `workingDirectoryMode` drops `\|0700` | copy-side tests fail |
| `ensureOwnerWritableDirectory` → no-op | read-only + staging-cleanup tests fail |
| `applyCopiedDirectoryMode` → no-op | all directory-mode tests fail |

The round-trip test catches all three. Worth noting: before I extended its fixture it passed under the third mutation, because git had created every directory in it at `0700` under the test umask — no directory mode the change could affect. That gap is why the `0750`/`0555` directories are there now.

## Verification

`gofmt -l .` clean · `go build ./...` · `golangci-lint run --fast` · `deadcode -test ./...` · `scripts/lint-file-length.sh` · `go test ./session/git/` (full package, green). No daemon/app tests and no container suites run locally.

Closes #2872