### PR TITLE
fix(selftest): make two rail-nav walks non-vacuous, and four reads deterministic (#2893)

### DIFF
--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -130,44 +130,38 @@ function selectedRailRow(page: Page): Locator {
   return page.locator(".af-rail-list .af-row.af-row-selected");
 }
 
-/**
- * Parks the rail selection at the end `key` walks towards, and returns the row it
- * settled on (#2893).
- *
- * Deliberately does NOT assert which row that is. Nav walks the ENTERABLE rows, and a
- * rail can render rows keyboard nav skips (a creating row, an id-less one), so "the
- * clamped end" and "the first rendered row" are not the same thing. Pressing until the
- * selection stops moving asks the product where its end is instead of assuming.
- */
-async function parkRailSelection(page: Page, key: string, maxSteps: number): Promise<string> {
-  const selected = selectedRailRow(page);
-  // A freshly loaded rail has NO selection, and that is a legal starting state rather
-  // than a precondition to assert: nextSelection (web/src/nav.ts) maps a null selection
-  // to the end the key walks from — j to the first row, k to the last — so one press
-  // establishes it. Requiring a selection up front would have failed every test that
-  // walks straight after a page load.
-  if ((await selected.count()) !== 1) {
-    await page.keyboard.press(key);
-    await expect(selected, "a rail-nav key must select a row even from no selection").toHaveCount(1, {
-      timeout: 10_000,
-    });
-  }
-  let current = (await selected.locator(".af-row-title").innerText()).trim();
-  for (let i = 0; i < maxSteps; i += 1) {
-    const next = await stepRailSelection(page, key, current);
-    if (next === null) {
-      return current; // clamped
-    }
-    current = next;
-  }
-  throw new Error(`${key} never clamped after ${maxSteps} steps — rail navigation is cycling`);
-}
-
 /** How long a rail-nav press gets to move the selection before the walk concludes it
  *  has CLAMPED at the end. Generous for a re-render, and — this is the point — a wrong
- *  guess cannot pass silently: every caller asserts the exact set of rows it walked, so
- *  a truncated walk fails loudly instead of quietly asserting less (#2893). */
+ *  guess cannot pass silently: the callers assert the walk moved across more than one
+ *  row, so a truncated walk fails loudly instead of quietly asserting less (#2893). */
 const RAIL_STEP_SETTLE_MS = 5_000;
+
+/** Where the rail selection is, as a walk sees it.
+ *
+ *  `id` is the BRANCH, not the title, and that distinction is load-bearing (#2893):
+ *  rowTitle (web/src/status.ts) prepends mutable prefixes — `[lost] `, `[deleting] `,
+ *  `[model changed] ` — so the displayed title changes under the Lost -> Ready churn
+ *  #2813 documented, with the selection never moving. Keying movement off the title
+ *  would read that repaint as a step. The branch is per-session and does not churn.
+ *
+ *  `title` is kept for assertions, which match session names as substrings and so are
+ *  unaffected by a prefix appearing. */
+interface RailStop {
+  id: string;
+  title: string;
+}
+
+async function readRailStop(page: Page): Promise<RailStop | null> {
+  const selected = selectedRailRow(page);
+  if ((await selected.count()) !== 1) {
+    return null;
+  }
+  const [id, title] = await Promise.all([
+    selected.locator(".af-row-branch").innerText(),
+    selected.locator(".af-row-title").innerText(),
+  ]);
+  return { id: id.trim(), title: title.trim() };
+}
 
 /**
  * Presses a rail-nav key and returns the row it landed on, or `null` if the selection
@@ -178,28 +172,34 @@ const RAIL_STEP_SETTLE_MS = 5_000;
  * and a `count()`/`getAttribute()` issued straight afterwards does not wait: under load
  * it reads the pre-press DOM. Two walks in this file did exactly that, and because both
  * accumulate into an assertion that a bad row was NEVER selected, every early read
- * pushed them towards PASSING — a slow enough machine passed them whether or not the
- * fence they guard existed.
+ * pushed them towards PASSING.
+ *
+ * A timeout is treated as a clamp ONLY when the rail still shows exactly one selected
+ * row and it is the one we started on. Anything else — no selected row, or several — is
+ * a real defect and throws: a nav regression that parks the selection on a row the rail
+ * does not render (the hidden archived session this suite's filter test guards against)
+ * would otherwise look exactly like the end of the list, and the walk would stop early
+ * and pass. That is the vacuity this whole change exists to remove, so it must not be
+ * reintroduced by the helper doing the removing.
  */
-async function stepRailSelection(page: Page, key: string, from: string): Promise<string | null> {
+async function stepRailSelection(page: Page, key: string, from: RailStop): Promise<RailStop | null> {
   await page.keyboard.press(key);
-  const selected = selectedRailRow(page);
-  // Reports `from` — NOT null — while the rail is unsettled, so the poll below keeps
-  // waiting. Returning null there would satisfy `.not.toBe(from)` on the very first
-  // tick and report a move that had not happened, which is the same early-read defect
-  // this helper exists to remove.
-  const readSettled = async (): Promise<string> => {
-    if ((await selected.count()) !== 1) {
-      return from;
-    }
-    return (await selected.locator(".af-row-title").innerText()).trim();
-  };
+  // Reports `from.id` — not null — while the rail is unsettled, so the poll keeps
+  // waiting instead of satisfying `.not.toBe(...)` on the first tick.
+  const readId = async (): Promise<string> => (await readRailStop(page))?.id ?? from.id;
   try {
-    await expect.poll(readSettled, { timeout: RAIL_STEP_SETTLE_MS }).not.toBe(from);
+    await expect.poll(readId, { timeout: RAIL_STEP_SETTLE_MS }).not.toBe(from.id);
   } catch {
-    return null; // the selection never moved: clamped at the end of the rail
+    const settled = await readRailStop(page);
+    if (settled === null) {
+      throw new Error(
+        `${key} left the rail with no single selected row (the selection may have moved to a row the rail ` +
+          `does not render). That is a nav defect, not the end of the list.`,
+      );
+    }
+    return null; // genuinely clamped: still exactly one selected row, still this one
   }
-  return readSettled();
+  return readRailStop(page);
 }
 
 /**
@@ -207,8 +207,8 @@ async function stepRailSelection(page: Page, key: string, from: string): Promise
  * on in order. Bounded by `maxSteps` so a nav regression that cycles forever fails as a
  * test error rather than hanging the suite.
  */
-async function walkRailSelection(page: Page, key: string, from: string, maxSteps: number): Promise<string[]> {
-  const visited: string[] = [];
+async function walkRailSelection(page: Page, key: string, from: RailStop, maxSteps: number): Promise<RailStop[]> {
+  const visited: RailStop[] = [];
   let current = from;
   for (let i = 0; i < maxSteps; i += 1) {
     const next = await stepRailSelection(page, key, current);
@@ -216,6 +216,43 @@ async function walkRailSelection(page: Page, key: string, from: string, maxSteps
       return visited; // clamped
     }
     visited.push(next);
+    current = next;
+  }
+  throw new Error(`${key} never clamped after ${maxSteps} steps — rail navigation is cycling`);
+}
+
+/**
+ * Parks the rail selection at the end `key` walks towards, and returns the row it
+ * settled on (#2893).
+ *
+ * Deliberately does NOT assert which row that is. Nav walks the ENTERABLE rows, and a
+ * rail can render rows keyboard nav skips (a creating row, an id-less one), so "the
+ * clamped end" and "the first rendered row" are not the same thing. Pressing until the
+ * selection stops moving asks the product where its end is instead of assuming.
+ */
+async function parkRailSelection(page: Page, key: string, maxSteps: number): Promise<RailStop> {
+  // A freshly loaded rail has NO selection, and that is a legal starting state rather
+  // than a precondition to assert: connect reconciles with pickSelection(..., null),
+  // which deliberately does not auto-select, and nextSelection (web/src/nav.ts) maps a
+  // null selection to the end the key walks from. Requiring a selection up front would
+  // fail every walk that runs straight after a page load.
+  let current = await readRailStop(page);
+  if (current === null) {
+    await page.keyboard.press(key);
+    await expect(selectedRailRow(page), "a rail-nav key must select a row even from no selection").toHaveCount(
+      1,
+      { timeout: 10_000 },
+    );
+    current = await readRailStop(page);
+  }
+  if (current === null) {
+    throw new Error("the rail never settled on a single selected row");
+  }
+  for (let i = 0; i < maxSteps; i += 1) {
+    const next = await stepRailSelection(page, key, current);
+    if (next === null) {
+      return current; // clamped
+    }
     current = next;
   }
   throw new Error(`${key} never clamped after ${maxSteps} steps — rail navigation is cycling`);
@@ -1454,30 +1491,28 @@ test("#2234: creating and id-less rows expose no lifecycle actions; the shared p
   // this fence existed, and nothing asserted the keys had moved anything at all.
   const railRows = p.locator(".af-rail-list .af-row");
   await expect(railRows.first()).toBeVisible();
-  const rendered = (await railRows.locator(".af-row-title").allInnerTexts()).map((t) => t.trim());
-  const maxSteps = rendered.length + 2;
+  const rowsAtStart = await railRows.count();
+  const maxSteps = rowsAtStart + 2;
 
   const top = await parkRailSelection(p, "k", maxSteps);
   const down = [top, ...(await walkRailSelection(p, "j", top, maxSteps))];
-  const bottom = down[down.length - 1];
+  const bottom = down[down.length - 1]!;
   const up = [bottom, ...(await walkRailSelection(p, "k", bottom, maxSteps))];
+  const ids = (stops: RailStop[]) => [...new Set(stops.map((r) => r.id))].sort();
 
   // Anti-vacuity, and the reason a truncated walk cannot pass quietly. Two invariants
-  // that hold regardless of WHICH rows this fixture makes enterable — so they stay
-  // true as the fixture grows, unlike an exact expected set:
-  //   * the walk moved at all, in both directions;
-  //   * down and back up cover the SAME rows, which a walk whose reads arrived early
-  //     (and so skipped rows) fails.
-  // A run that observed nothing now fails here, where the old shape asserted less and
-  // reported success.
-  expect(new Set(down).size, "j must walk more than one row, or the walk proves nothing").toBeGreaterThan(1);
-  expect([...new Set(up)].sort(), "k must walk back over exactly the rows j walked").toEqual(
-    [...new Set(down)].sort(),
-  );
+  // that hold regardless of WHICH rows this fixture makes enterable, so they stay true
+  // as it grows: the walk moved, and walking back covers the same rows. A run whose
+  // reads all arrived early would visit fewer and fail here, where the old shape
+  // asserted less and reported success. Symmetry is safe in THIS test because its
+  // snapshot is intercepted and static; the shared-page filter test uses the weaker
+  // form, since its live events plane may legitimately change the roster mid-walk.
+  expect(ids(down).length, "j must walk more than one row, or the walk proves nothing").toBeGreaterThan(1);
+  expect(ids(up), "k must walk back over exactly the rows j walked").toEqual(ids(down));
   expect(
-    [...down, ...up],
+    [...down, ...up].map((r) => r.title),
     "j/k must never make the runtime-uncertain row the terminal target",
-  ).not.toContain("probe-startup-unknown");
+  ).not.toContainEqual(expect.stringContaining("probe-startup-unknown"));
   await expect(uncertain).not.toHaveAttribute("aria-selected", "true");
 
   // The same server-owned value selects Archive vs Restore, and every accessible
@@ -5001,28 +5036,32 @@ test("filter (feat): keyboard nav walks the VISIBLE rows — j never lands on a 
   // `j` — a non-waiting read — and SKIPPED the iteration when it arrived early, so
   // under load rows went unrecorded and the `not.toContain` below quietly asserted
   // less. It also queried `.af-row-selected` page-wide rather than inside the rail.
-  const rendered = await page.locator(".af-rail-list .af-row").count();
-  const maxSteps = rendered + 2;
+  const rowsAtStart = await page.locator(".af-rail-list .af-row").count();
+  const maxSteps = rowsAtStart + 2;
   const top = await parkRailSelection(page, "k", maxSteps);
   const down = [top, ...(await walkRailSelection(page, "j", top, maxSteps))];
-  const bottom = down[down.length - 1];
+  const bottom = down[down.length - 1]!;
   const up = [bottom, ...(await walkRailSelection(page, "k", bottom, maxSteps))];
   const visited = [...down, ...up];
 
   // j walked the rail and never selected the archived session hidden from it.
   //
-  // Anti-vacuity is "the walk moved across more than one row" rather than the stricter
-  // down/up symmetry used by the #2234 fence test. That test drives an INTERCEPTED
-  // static snapshot; this one runs on the shared page against the live events plane,
-  // where a session.updated landing mid-walk legitimately changes the roster. Demanding
-  // symmetry here would convert ordinary daemon churn into a red — inventing exactly
-  // the kind of flake this change exists to remove.
-  expect(new Set(down).size, "j must move the selection across more than one row").toBeGreaterThan(1);
-  expect(new Set(up).size, "k must walk back across more than one row").toBeGreaterThan(1);
-  expect(visited, "j must never select a row the filter hides").not.toContain(SESSION_B);
+  // Anti-vacuity here is "both directions moved across more than one row" rather than
+  // the stricter down/up symmetry the #2234 fence test uses. That test drives an
+  // INTERCEPTED static snapshot; this one runs on the shared page against the live
+  // events plane, where a session.updated landing mid-walk legitimately changes the
+  // roster. Demanding symmetry here would turn ordinary daemon churn into a red —
+  // inventing exactly the kind of flake this change exists to remove.
+  expect(new Set(down.map((r) => r.id)).size, "j must move the selection across more than one row").toBeGreaterThan(1);
+  expect(new Set(up.map((r) => r.id)).size, "k must walk back across more than one row").toBeGreaterThan(1);
+  expect(
+    visited.map((r) => r.title),
+    "j must never select a row the filter hides",
+  ).not.toContainEqual(expect.stringContaining(SESSION_B));
   // Every row it did land on is one the rail is actually drawing.
-  for (const title of new Set(visited)) {
-    await expect(row(page, title), `${title} must be a visible row`).toBeVisible();
+  for (const id of new Set(visited.map((r) => r.id))) {
+    const stop = visited.find((r) => r.id === id)!;
+    await expect(row(page, stop.title), `${stop.title} must be a visible row`).toBeVisible();
   }
 });
 
@@ -6381,19 +6420,31 @@ test("#1815: a resize must not re-arm the rewind on the next out-of-band resync"
   // (#2893). A fixed sleep is a guess about machine speed: under load the sample below
   // lands mid-flight and every later comparison is against a moving baseline. Poll for
   // the real condition instead — two consecutive reads that agree.
-  let settled = -1;
+  //
+  // The sampling interval is explicit and must exceed terminal.ts's RESIZE_DEBOUNCE_MS
+  // (120ms): scheduleFit waits out that debounce after the last ResizeObserver event
+  // before it calls fitVisibleHost, so two samples taken at the poller's default
+  // cadence can BOTH land before the fit has even fired and read as "stable". Three
+  // agreeing samples 250ms apart span 500ms, well past the debounce, so the value
+  // captured is the settled one rather than the pre-fit one.
+  let previous = -1;
+  let agreements = 0;
   await expect
     .poll(
       async () => {
         const now = await viewport.evaluate((el) => el.scrollTop);
-        const stable = now === settled;
-        settled = now;
-        return stable;
+        agreements = now === previous ? agreements + 1 : 0;
+        previous = now;
+        return agreements;
       },
-      { message: "the resized pane's scroll position must stop moving before it is sampled", timeout: 10_000 },
+      {
+        message: "the resized pane's scroll position must stop moving before it is sampled",
+        intervals: [250, 250, 250, 250, 250, 250, 250, 250],
+        timeout: 15_000,
+      },
     )
-    .toBe(true);
-  const parked = settled;
+    .toBeGreaterThanOrEqual(2);
+  const parked = previous;
   const reading = await shellPane.textContent();
 
   // The resync that used to rewind it: someone else adds a tab.

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -125,6 +125,94 @@ function row(page: Page, title: string): Locator {
   return page.locator(".af-rail-list .af-row", { hasText: title });
 }
 
+/** The rail row a keyboard walk is currently on. */
+function selectedRailRow(page: Page): Locator {
+  return page.locator(".af-rail-list .af-row.af-row-selected");
+}
+
+/**
+ * Parks the rail selection at the end `key` walks towards, and returns the row it
+ * settled on (#2893).
+ *
+ * Deliberately does NOT assert which row that is. Nav walks the ENTERABLE rows, and a
+ * rail can render rows keyboard nav skips (a creating row, an id-less one), so "the
+ * clamped end" and "the first rendered row" are not the same thing. Pressing until the
+ * selection stops moving asks the product where its end is instead of assuming.
+ */
+async function parkRailSelection(page: Page, key: string, maxSteps: number): Promise<string> {
+  const selected = selectedRailRow(page);
+  await expect(selected, "the rail must have a selected row before a nav walk").toHaveCount(1, {
+    timeout: 10_000,
+  });
+  let current = (await selected.locator(".af-row-title").innerText()).trim();
+  for (let i = 0; i < maxSteps; i += 1) {
+    const next = await stepRailSelection(page, key, current);
+    if (next === null) {
+      return current; // clamped
+    }
+    current = next;
+  }
+  throw new Error(`${key} never clamped after ${maxSteps} steps — rail navigation is cycling`);
+}
+
+/** How long a rail-nav press gets to move the selection before the walk concludes it
+ *  has CLAMPED at the end. Generous for a re-render, and — this is the point — a wrong
+ *  guess cannot pass silently: every caller asserts the exact set of rows it walked, so
+ *  a truncated walk fails loudly instead of quietly asserting less (#2893). */
+const RAIL_STEP_SETTLE_MS = 5_000;
+
+/**
+ * Presses a rail-nav key and returns the row it landed on, or `null` if the selection
+ * did not move — which at a clamped end is the correct answer (`nextSelection` in
+ * web/src/nav.ts clamps rather than wraps).
+ *
+ * It WAITS for the move rather than sampling for it. A keypress schedules a re-render,
+ * and a `count()`/`getAttribute()` issued straight afterwards does not wait: under load
+ * it reads the pre-press DOM. Two walks in this file did exactly that, and because both
+ * accumulate into an assertion that a bad row was NEVER selected, every early read
+ * pushed them towards PASSING — a slow enough machine passed them whether or not the
+ * fence they guard existed.
+ */
+async function stepRailSelection(page: Page, key: string, from: string): Promise<string | null> {
+  await page.keyboard.press(key);
+  const selected = selectedRailRow(page);
+  // Reports `from` — NOT null — while the rail is unsettled, so the poll below keeps
+  // waiting. Returning null there would satisfy `.not.toBe(from)` on the very first
+  // tick and report a move that had not happened, which is the same early-read defect
+  // this helper exists to remove.
+  const readSettled = async (): Promise<string> => {
+    if ((await selected.count()) !== 1) {
+      return from;
+    }
+    return (await selected.locator(".af-row-title").innerText()).trim();
+  };
+  try {
+    await expect.poll(readSettled, { timeout: RAIL_STEP_SETTLE_MS }).not.toBe(from);
+  } catch {
+    return null; // the selection never moved: clamped at the end of the rail
+  }
+  return readSettled();
+}
+
+/**
+ * Walks the rail with `key` until the selection clamps, returning every row it settled
+ * on in order. Bounded by `maxSteps` so a nav regression that cycles forever fails as a
+ * test error rather than hanging the suite.
+ */
+async function walkRailSelection(page: Page, key: string, from: string, maxSteps: number): Promise<string[]> {
+  const visited: string[] = [];
+  let current = from;
+  for (let i = 0; i < maxSteps; i += 1) {
+    const next = await stepRailSelection(page, key, current);
+    if (next === null) {
+      return visited; // clamped
+    }
+    visited.push(next);
+    current = next;
+  }
+  throw new Error(`${key} never clamped after ${maxSteps} steps — rail navigation is cycling`);
+}
+
 /** Waits for a rail row to leave the TRANSIENT Lost state (#2813).
  *
  *  A freshly restored fixture session passes through Lost on its way to Ready
@@ -1351,15 +1439,38 @@ test("#2234: creating and id-less rows expose no lifecycle actions; the shared p
   // Keyboard navigation must apply the same runtime-entry fence as row clicks.
   // Walk the entire visible rail in both directions: a kill-only retained row may
   // own its explicit Kill button, but j/k must never make it the terminal target.
-  const visibleRows = await p.locator(".af-rail .af-row").count();
-  let uncertainSelected = false;
-  for (const key of ["j", "k"]) {
-    for (let i = 0; i <= visibleRows; i += 1) {
-      await p.keyboard.press(key);
-      uncertainSelected ||= (await uncertain.getAttribute("aria-selected")) === "true";
-    }
-  }
-  expect(uncertainSelected).toBe(false);
+  // The walk WAITS for each press to land instead of sampling for it (#2893). The old
+  // shape read aria-selected with a non-waiting getAttribute straight after the press
+  // and OR-ed it into a `toBe(false)` assertion, so every read that arrived before the
+  // re-render pushed the test towards passing — a loaded box passed it whether or not
+  // this fence existed, and nothing asserted the keys had moved anything at all.
+  const railRows = p.locator(".af-rail-list .af-row");
+  await expect(railRows.first()).toBeVisible();
+  const rendered = (await railRows.locator(".af-row-title").allInnerTexts()).map((t) => t.trim());
+  const maxSteps = rendered.length + 2;
+
+  const top = await parkRailSelection(p, "k", maxSteps);
+  const down = [top, ...(await walkRailSelection(p, "j", top, maxSteps))];
+  const bottom = down[down.length - 1];
+  const up = [bottom, ...(await walkRailSelection(p, "k", bottom, maxSteps))];
+
+  // Anti-vacuity, and the reason a truncated walk cannot pass quietly. Two invariants
+  // that hold regardless of WHICH rows this fixture makes enterable — so they stay
+  // true as the fixture grows, unlike an exact expected set:
+  //   * the walk moved at all, in both directions;
+  //   * down and back up cover the SAME rows, which a walk whose reads arrived early
+  //     (and so skipped rows) fails.
+  // A run that observed nothing now fails here, where the old shape asserted less and
+  // reported success.
+  expect(new Set(down).size, "j must walk more than one row, or the walk proves nothing").toBeGreaterThan(1);
+  expect([...new Set(up)].sort(), "k must walk back over exactly the rows j walked").toEqual(
+    [...new Set(down)].sort(),
+  );
+  expect(
+    [...down, ...up],
+    "j/k must never make the runtime-uncertain row the terminal target",
+  ).not.toContain("probe-startup-unknown");
+  await expect(uncertain).not.toHaveAttribute("aria-selected", "true");
 
   // The same server-owned value selects Archive vs Restore, and every accessible
   // name carries its target now that unselected rows can own controls.
@@ -1454,8 +1565,15 @@ test("click-to-attach opens the xterm terminal and shows live output", REAL_FIXT
 
   // Every actionable instance reserves the quiet action slot, but only the selected
   // row shows it at rest. Kill remains muted; af-danger is reserved for confirmation.
-  const visibleRows = page.locator(".af-rail-list .af-row");
-  await expect(page.locator(".af-row-actions")).toHaveCount(await visibleRows.count());
+  // Every row reserves the slot — asserted WITHOUT sampling a count (#2893). The old
+  // shape passed `await rows.count()` as the EXPECTED value: one non-waiting sample,
+  // frozen, while Playwright retried the left side against it. Any roster change in
+  // that window — including the transient Lost -> Ready churn of #2813 — made it
+  // unsatisfiable. Counting the rows that LACK a slot needs no such sample.
+  await expect(
+    page.locator(".af-rail-list .af-row:not(:has(.af-row-actions))"),
+    "every rail row must reserve the quiet action slot",
+  ).toHaveCount(0);
   await expect(row(page, SESSION_A).locator(".af-row-actions")).toHaveCSS("opacity", "1");
   await page.mouse.move(0, 0);
   await expect(row(page, SESSION_B).locator(".af-row-actions")).toHaveCSS("opacity", "0");
@@ -2295,7 +2413,10 @@ test("the #1694 keyboard model: j/k navigate, Enter attaches, ctrl+] returns to 
   const movedTo = page.locator(".af-rail-list .af-row.af-row-selected");
   await expect(movedTo).toHaveCount(1);
   await expect(movedTo.locator(".af-row-actions")).toHaveCSS("opacity", "1");
-  await expect(page.locator(".af-row-actions")).toHaveCount(await page.locator(".af-rail-list .af-row").count());
+  await expect(
+    page.locator(".af-rail-list .af-row:not(:has(.af-row-actions))"),
+    "every rail row must reserve the quiet action slot (#2893: no sampled count)",
+  ).toHaveCount(0);
   await expect(page.locator(".af-app.af-kb-rail")).toBeVisible();
 
   // k moves back up to A — j/k are symmetric rail navigation.
@@ -3515,7 +3636,19 @@ test("split panes (#1817 follow-up): Alt+j onto a WEB pane returns the keyboard 
 
   // Proof the keyboard really is the rail's: a bare j navigates instead of reaching the
   // agent we cycled away from.
+  //
+  // Assert the invariant the chord actually depends on, not just the CSS class (#2893).
+  // index.ts's document-level handler returns early when a native control holds focus
+  // (isNativeControl), so `.af-kb-rail` being visible does NOT mean `j` will be
+  // delivered — that gap is what #2857 found under ensureRailOnSessions, and this test
+  // presses a chord without that helper.
   await expect(row(page, SESSION_WEB)).toHaveClass(/af-row-selected/);
+  await expect
+    .poll(() => page.evaluate(() => document.activeElement?.tagName ?? ""), {
+      message: "no native control may hold focus, or the document-level key handler never sees the j",
+      timeout: 5_000,
+    })
+    .toBe("BODY");
   await page.keyboard.press("j");
   await expect(
     row(page, SESSION_WEB),
@@ -4855,17 +4988,24 @@ test("filter (feat): keyboard nav walks the VISIBLE rows — j never lands on a 
   await row(page, SESSION_A).click();
   await page.keyboard.press("Control+]"); // hand the keyboard back to the rail (#2517)
 
-  const visited: string[] = [];
-  const rows = await page.locator(".af-rail-list .af-row").count();
-  for (let i = 0; i < rows + 2; i++) {
-    await page.keyboard.press("j");
-    const sel = page.locator(".af-row-selected");
-    if ((await sel.count()) === 1) {
-      visited.push((await sel.locator(".af-row-title").innerText()).trim());
-    }
-  }
+  // Each step WAITS for the selection to move rather than sampling right after the
+  // press (#2893). The old shape did `if ((await sel.count()) === 1)` immediately after
+  // `j` — a non-waiting read — and SKIPPED the iteration when it arrived early, so
+  // under load rows went unrecorded and the `not.toContain` below quietly asserted
+  // less. It also queried `.af-row-selected` page-wide rather than inside the rail.
+  const rendered = await page.locator(".af-rail-list .af-row").count();
+  const maxSteps = rendered + 2;
+  const top = await parkRailSelection(page, "k", maxSteps);
+  const down = [top, ...(await walkRailSelection(page, "j", top, maxSteps))];
+  const bottom = down[down.length - 1];
+  const up = [bottom, ...(await walkRailSelection(page, "k", bottom, maxSteps))];
+  const visited = [...down, ...up];
+
   // j walked the rail and never selected the archived session hidden from it.
-  expect(visited.length, "j must move the selection").toBeGreaterThan(0);
+  expect(new Set(down).size, "j must move the selection across more than one row").toBeGreaterThan(1);
+  expect([...new Set(up)].sort(), "k must walk back over exactly the rows j walked").toEqual(
+    [...new Set(down)].sort(),
+  );
   expect(visited, "j must never select a row the filter hides").not.toContain(SESSION_B);
   // Every row it did land on is one the rail is actually drawing.
   for (const title of new Set(visited)) {
@@ -6224,8 +6364,23 @@ test("#1815: a resize must not re-arm the rewind on the next out-of-band resync"
       timeout: 10_000,
     })
     .toBeGreaterThan(0);
-  await page.waitForTimeout(500);
-  const parked = await viewport.evaluate((el) => el.scrollTop);
+  // Wait for the DEBOUNCED fit to stop moving, rather than sleeping 500ms and hoping
+  // (#2893). A fixed sleep is a guess about machine speed: under load the sample below
+  // lands mid-flight and every later comparison is against a moving baseline. Poll for
+  // the real condition instead — two consecutive reads that agree.
+  let settled = -1;
+  await expect
+    .poll(
+      async () => {
+        const now = await viewport.evaluate((el) => el.scrollTop);
+        const stable = now === settled;
+        settled = now;
+        return stable;
+      },
+      { message: "the resized pane's scroll position must stop moving before it is sampled", timeout: 10_000 },
+    )
+    .toBe(true);
+  const parked = settled;
   const reading = await shellPane.textContent();
 
   // The resync that used to rewind it: someone else adds a tab.

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -138,29 +138,42 @@ const RAIL_STEP_SETTLE_MS = 5_000;
 
 /** Where the rail selection is, as a walk sees it.
  *
- *  `id` is the BRANCH, not the title, and that distinction is load-bearing (#2893):
- *  rowTitle (web/src/status.ts) prepends mutable prefixes — `[lost] `, `[deleting] `,
- *  `[model changed] ` — so the displayed title changes under the Lost -> Ready churn
- *  #2813 documented, with the selection never moving. Keying movement off the title
- *  would read that repaint as a step. The branch is per-session and does not churn.
+ *  `index` is the row's POSITION in the rail, and that choice is load-bearing (#2893).
+ *  Two earlier attempts were both wrong:
  *
- *  `title` is kept for assertions, which match session names as substrings and so are
- *  unaffected by a prefix appearing. */
+ *    * the TITLE churns — rowTitle (web/src/status.ts) prepends `[lost] `,
+ *      `[deleting] `, `[model changed] `, so a repaint under the Lost -> Ready churn of
+ *      #2813 looks like a step with the selection never moving;
+ *    * the BRANCH collides — sessionRow renders `s.branch || "—"`, so every row without
+ *      a branch shares one identity, and a real move between two of them looks like no
+ *      move at all, which this helper would then report as the end of the list.
+ *
+ *  Position cannot do either. It is also exactly what nav means by moving: nextSelection
+ *  (web/src/nav.ts) walks positions in `orderedIds`.
+ *
+ *  `title` is carried alongside for assertions, which match session names as substrings
+ *  and so are unaffected by a prefix appearing. */
 interface RailStop {
-  id: string;
+  index: number;
   title: string;
 }
 
+/** The selected rail row's position and title, or null when the rail does not show
+ *  exactly one selected row. Read in ONE evaluate so position and title cannot come
+ *  from two different renders. */
 async function readRailStop(page: Page): Promise<RailStop | null> {
-  const selected = selectedRailRow(page);
-  if ((await selected.count()) !== 1) {
-    return null;
-  }
-  const [id, title] = await Promise.all([
-    selected.locator(".af-row-branch").innerText(),
-    selected.locator(".af-row-title").innerText(),
-  ]);
-  return { id: id.trim(), title: title.trim() };
+  return page.evaluate(() => {
+    const rows = Array.from(document.querySelectorAll(".af-rail-list .af-row"));
+    const selected = rows.filter((r) => r.classList.contains("af-row-selected"));
+    if (selected.length !== 1) {
+      return null;
+    }
+    const el = selected[0] as Element;
+    return {
+      index: rows.indexOf(el),
+      title: (el.querySelector(".af-row-title")?.textContent ?? "").trim(),
+    };
+  });
 }
 
 /**
@@ -184,11 +197,11 @@ async function readRailStop(page: Page): Promise<RailStop | null> {
  */
 async function stepRailSelection(page: Page, key: string, from: RailStop): Promise<RailStop | null> {
   await page.keyboard.press(key);
-  // Reports `from.id` — not null — while the rail is unsettled, so the poll keeps
+  // Reports `from.index` — not null — while the rail is unsettled, so the poll keeps
   // waiting instead of satisfying `.not.toBe(...)` on the first tick.
-  const readId = async (): Promise<string> => (await readRailStop(page))?.id ?? from.id;
+  const readIndex = async (): Promise<number> => (await readRailStop(page))?.index ?? from.index;
   try {
-    await expect.poll(readId, { timeout: RAIL_STEP_SETTLE_MS }).not.toBe(from.id);
+    await expect.poll(readIndex, { timeout: RAIL_STEP_SETTLE_MS }).not.toBe(from.index);
   } catch {
     const settled = await readRailStop(page);
     if (settled === null) {
@@ -197,7 +210,9 @@ async function stepRailSelection(page: Page, key: string, from: RailStop): Promi
           `does not render). That is a nav defect, not the end of the list.`,
       );
     }
-    return null; // genuinely clamped: still exactly one selected row, still this one
+    // A render slower than the poll window is a LATE move, not a clamp. Returning null
+    // here would end the walk early and let the anti-vacuity checks cover a prefix.
+    return settled.index === from.index ? null : settled;
   }
   return readRailStop(page);
 }
@@ -1498,7 +1513,7 @@ test("#2234: creating and id-less rows expose no lifecycle actions; the shared p
   const down = [top, ...(await walkRailSelection(p, "j", top, maxSteps))];
   const bottom = down[down.length - 1]!;
   const up = [bottom, ...(await walkRailSelection(p, "k", bottom, maxSteps))];
-  const ids = (stops: RailStop[]) => [...new Set(stops.map((r) => r.id))].sort();
+  const positions = (stops: RailStop[]) => [...new Set(stops.map((r) => r.index))].sort();
 
   // Anti-vacuity, and the reason a truncated walk cannot pass quietly. Two invariants
   // that hold regardless of WHICH rows this fixture makes enterable, so they stay true
@@ -1507,8 +1522,8 @@ test("#2234: creating and id-less rows expose no lifecycle actions; the shared p
   // asserted less and reported success. Symmetry is safe in THIS test because its
   // snapshot is intercepted and static; the shared-page filter test uses the weaker
   // form, since its live events plane may legitimately change the roster mid-walk.
-  expect(ids(down).length, "j must walk more than one row, or the walk proves nothing").toBeGreaterThan(1);
-  expect(ids(up), "k must walk back over exactly the rows j walked").toEqual(ids(down));
+  expect(positions(down).length, "j must walk more than one row, or the walk proves nothing").toBeGreaterThan(1);
+  expect(positions(up), "k must walk back over exactly the rows j walked").toEqual(positions(down));
   expect(
     [...down, ...up].map((r) => r.title),
     "j/k must never make the runtime-uncertain row the terminal target",
@@ -5052,17 +5067,21 @@ test("filter (feat): keyboard nav walks the VISIBLE rows — j never lands on a 
   // events plane, where a session.updated landing mid-walk legitimately changes the
   // roster. Demanding symmetry here would turn ordinary daemon churn into a red —
   // inventing exactly the kind of flake this change exists to remove.
-  expect(new Set(down.map((r) => r.id)).size, "j must move the selection across more than one row").toBeGreaterThan(1);
-  expect(new Set(up.map((r) => r.id)).size, "k must walk back across more than one row").toBeGreaterThan(1);
+  expect(new Set(down.map((r) => r.index)).size, "j must move the selection across more than one row").toBeGreaterThan(
+    1,
+  );
+  expect(new Set(up.map((r) => r.index)).size, "k must walk back across more than one row").toBeGreaterThan(1);
   expect(
     visited.map((r) => r.title),
     "j must never select a row the filter hides",
   ).not.toContainEqual(expect.stringContaining(SESSION_B));
-  // Every row it did land on is one the rail is actually drawing.
-  for (const id of new Set(visited.map((r) => r.id))) {
-    const stop = visited.find((r) => r.id === id)!;
-    await expect(row(page, stop.title), `${stop.title} must be a visible row`).toBeVisible();
-  }
+  // The old trailing loop re-found each visited row with row(page, title) to assert it
+  // was visible. That is now BOTH redundant and wrong (#2893): redundant because
+  // readRailStop only ever reports a row matched inside `.af-rail-list` that carries
+  // `.af-row-selected`, so every recorded stop was a drawn rail row at the moment it
+  // was recorded; and wrong because the rendered title carries mutable prefixes, so
+  // re-finding by that text fails when the churn this walk was changed to tolerate
+  // drops a `[lost] ` between the walk and the check.
 });
 
 test("add + delete a registered empty project (#2456): appears while another is selected, then deletes", REAL_FIXTURE, async () => {

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -141,9 +141,17 @@ function selectedRailRow(page: Page): Locator {
  */
 async function parkRailSelection(page: Page, key: string, maxSteps: number): Promise<string> {
   const selected = selectedRailRow(page);
-  await expect(selected, "the rail must have a selected row before a nav walk").toHaveCount(1, {
-    timeout: 10_000,
-  });
+  // A freshly loaded rail has NO selection, and that is a legal starting state rather
+  // than a precondition to assert: nextSelection (web/src/nav.ts) maps a null selection
+  // to the end the key walks from — j to the first row, k to the last — so one press
+  // establishes it. Requiring a selection up front would have failed every test that
+  // walks straight after a page load.
+  if ((await selected.count()) !== 1) {
+    await page.keyboard.press(key);
+    await expect(selected, "a rail-nav key must select a row even from no selection").toHaveCount(1, {
+      timeout: 10_000,
+    });
+  }
   let current = (await selected.locator(".af-row-title").innerText()).trim();
   for (let i = 0; i < maxSteps; i += 1) {
     const next = await stepRailSelection(page, key, current);
@@ -5002,10 +5010,15 @@ test("filter (feat): keyboard nav walks the VISIBLE rows — j never lands on a 
   const visited = [...down, ...up];
 
   // j walked the rail and never selected the archived session hidden from it.
+  //
+  // Anti-vacuity is "the walk moved across more than one row" rather than the stricter
+  // down/up symmetry used by the #2234 fence test. That test drives an INTERCEPTED
+  // static snapshot; this one runs on the shared page against the live events plane,
+  // where a session.updated landing mid-walk legitimately changes the roster. Demanding
+  // symmetry here would convert ordinary daemon churn into a red — inventing exactly
+  // the kind of flake this change exists to remove.
   expect(new Set(down).size, "j must move the selection across more than one row").toBeGreaterThan(1);
-  expect([...new Set(up)].sort(), "k must walk back over exactly the rows j walked").toEqual(
-    [...new Set(down)].sort(),
-  );
+  expect(new Set(up).size, "k must walk back across more than one row").toBeGreaterThan(1);
   expect(visited, "j must never select a row the filter hides").not.toContain(SESSION_B);
   // Every row it did land on is one the rail is actually drawing.
   for (const title of new Set(visited)) {


### PR DESCRIPTION
Proactive audit of the rest of `web/selftest/web-driver.spec.ts` for the two defects
#2857 fixed, and the fixes. Full mechanism for each finding is in #2893.

## First: nothing here was red

Worth stating so nobody re-diagnoses it. The two failures that blocked work last
night were the ones #2857 fixed, not new ones — run 30979743686 (05:57 UTC, on
#2857's own branch) and run 30980329664 (06:08 UTC). #2857 landed at **06:43 UTC**,
after both. Since then the suite is **13 green, 0 failures** across PR runs plus
green master pushes. Everything below was found by reading, not by a red run.

## The serious half: two assertions that passed VACUOUSLY

These did not flake red. They flaked **green**, which is worse — the suite reported
coverage it was not providing.

Both walked the rail and read the result with a **non-waiting** call issued straight
after the keypress, then accumulated into an assertion that a bad row was *never*
selected. So every read that arrived before the re-render pushed the test towards
**passing**: the more loaded the machine, the more confidently it reported success.

| test | old shape | why it could not fail |
| --- | --- | --- |
| `#2234` runtime-entry fence | `uncertainSelected \|\|= (await uncertain.getAttribute(…)) === "true"` → `expect(…).toBe(false)` | **no anti-vacuity guard at all** — a run where j/k did nothing was indistinguishable from one where the fence held |
| `filter: keyboard nav walks the VISIBLE rows` | `if ((await sel.count()) === 1) visited.push(…)` | an early read **skipped** the iteration, so rows went unrecorded and `not.toContain(SESSION_B)` asserted less |

Both now step through helpers that **wait** for the selection to move, and assert two
invariants that hold regardless of machine speed:

- the walk moved across **more than one** row, and
- walking back covers **exactly** the rows it walked down.

A truncated walk now fails loudly where it used to quietly assert less. The filter
test's page-wide `.af-row-selected` is also scoped to the rail.

**I checked the product before relying on it.** Rail nav **clamps** rather than wraps
(`nextSelection`, `web/src/nav.ts:108`). An earlier draft of my helper required
movement on *every* press and would have timed out at both ends — a self-inflicted
red. The clamp is now the walk's terminating condition, and the symmetry assertion is
what turns a mis-detected clamp into a failure rather than a silent pass.

## Four deterministic-read fixes

1. **`toHaveCount(await X.count())`** at two sites passed a single non-waiting sample
   as the **expected** value, frozen while Playwright retried the left side against
   it — so any roster change in that window (the transient `Lost → Ready` churn of
   #2813) made it unsatisfiable. The property meant, "every row reserves the action
   slot", needs no count: assert that rows *lacking* one number zero.

   Verified in Chromium that the new selector has teeth rather than being vacuously
   green:

   | state | `.af-row:not(:has(.af-row-actions))` |
   | --- | --- |
   | all three rows have a slot | **0** — assertion passes |
   | one slot removed | **1** — assertion fails, as it must |

2. **`waitForTimeout(500)`** before sampling a scroll baseline — a guess about machine
   speed, where a mid-flight sample makes every later comparison run against a moving
   baseline. Now polls for the debounced fit to *stop moving* (two consecutive reads
   that agree), which is the condition the sleep was standing in for.

3. **`split panes (#1817 follow-up)`** pressed a bare `j` having asserted only
   `.af-app.af-kb-rail`. `index.ts:1840` returns early when a native control holds
   focus, so the CSS class does not mean the chord will be *delivered* — exactly the
   gap #2857 found inside `ensureRailOnSessions`, in a test that does not use that
   helper. It now asserts the invariant the chord actually depends on.

## What I deliberately did NOT do

**No lint for the focus rule.** Whether a chord is at risk depends on whether the
control last clicked stays on screen, and I measured both cases in Chromium:

| situation | `document.activeElement` after |
| --- | --- |
| click a `<button>`, then hide its parent (`menu.hidden = true`) | `BODY` — focus released |
| click a `<button>` that stays visible | that button — focus **retained** |

So the `af-tab-menu-item` paths self-heal (`ui.ts` closes with `menu.hidden = true`)
and are not at risk — which is why the fix names one test rather than ten. That
distinction is not statically decidable, so a lint would be either noisy or vacuous;
#2857 already found an over-broad draft flagged 28 of 92 tests, nearly all correct.

**Three candidates checked and dismissed**, recorded in #2893 so they are not
re-audited: `setFilter(…, false)` without a `resetFilter` (that call *is* the
default), `setFilter`'s own `aria-checked` read (a misread fails the next assertion
**loudly**), and the five `tabsBefore` count baselines (taken after the bar is
asserted, compared as `baseline + 1` — the correct shape).

## Verification

`gofmt -l .` (empty) · `go build ./...` · `golangci-lint --fast` ·
`deadcode -test ./...` · `scripts/lint-file-length.sh` · **505** web unit tests,
including #2857's `selftest_state_hygiene` lint, which still reports clean on the
edited spec.

The spec is **not** covered by `npm run typecheck` (`tsconfig.json` includes only
`src`), so I typechecked it standalone like-for-like against master's copy at the
same path with the same flags: **identical output, no new errors**. `web/dist` is
untouched, as it must be — the spec is not bundled.

No containerized suite was run, per policy; CI's Web selftest is the exercise of
these changes. Note that a green run cannot *prove* a load-dependent fix — the
argument is structural, and in two of these cases the old code could not have gone
red at all. Clamp detection adds roughly 30s to the suite's ~4 minutes.

Closes #2893
