### PR TITLE
fix(doctor): refuse an unreadable tmux listing instead of reading it as empty

### DIFF
--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -69,10 +69,18 @@ const (
 // being true in #2870, which made the reset-side listing distinguish tmux's
 // definitive no-server diagnostics from an unreadable one and fail closed;
 // session/tmux has the classifier this needs.
-func listTmuxSessions(ctx *scanContext) []string {
+func listTmuxSessions(ctx *scanContext) ([]string, error) {
 	out, err := ctx.opts.Exec.Output(exec.Command("tmux", "ls", "-F", "#{session_name}"))
 	if err != nil {
-		return nil
+		if tmux.ListingFoundNoServer(err) {
+			// tmux's definitive "there is no server": genuinely zero sessions.
+			return nil, nil
+		}
+		// Anything else — a permission refusal, a wedged server, a timeout, a
+		// missing binary — leaves the session set UNKNOWN. Returning it empty
+		// would tell checkOrphanedProcesses that nothing is alive, which is the
+		// input that arms --fix to kill every live session's processes (#2874).
+		return nil, err
 	}
 	var names []string
 	for _, line := range strings.Split(string(out), "\n") {
@@ -80,7 +88,7 @@ func listTmuxSessions(ctx *scanContext) []string {
 			names = append(names, line)
 		}
 	}
-	return names
+	return names, nil
 }
 
 // describeProc renders "pid 123 (yes, 99% CPU over 15d2h): yes" for findings.
@@ -317,8 +325,21 @@ func checkOrphanedProcesses(ctx *scanContext, report *Report) {
 	if ctx.snap == nil {
 		return
 	}
+	// `live` is a PROTECTIVE set: a session named here is running, so its
+	// processes are not orphans. An unreadable listing must therefore not be
+	// treated as an empty one — that would mark every marked process orphaned
+	// and arm --fix to kill them (#2874). Report the blindness and classify
+	// nothing, the same shape as the ctx.snap == nil branch above.
+	names, err := listTmuxSessions(ctx)
+	if err != nil {
+		report.Fail(sectionProcesses, "orphaned-processes",
+			fmt.Sprintf("could not list tmux sessions, so af cannot tell a live session's processes from an "+
+				"orphan and has classified none: %v", err),
+			"resolve the tmux listing failure, then re-run `af doctor`")
+		return
+	}
 	live := map[string]bool{}
-	for _, name := range listTmuxSessions(ctx) {
+	for _, name := range names {
 		live[name] = true
 	}
 
@@ -526,8 +547,17 @@ func checkRunawayChildren(ctx *scanContext, report *Report) {
 	if ctx.snap == nil {
 		return
 	}
+	names, err := listTmuxSessions(ctx)
+	if err != nil {
+		// Under-reporting here is safe, but reporting it as CLEAN is not: a
+		// silent pass reads as evidence no session is pegging a core (#2874).
+		report.Fail(sectionProcesses, "runaway-children",
+			fmt.Sprintf("could not list tmux sessions, so no session was measured for runaway CPU: %v", err),
+			"this check is UNKNOWN, not clean — resolve the tmux listing failure and re-run `af doctor`")
+		return
+	}
 	unmeasurable := 0
-	for _, name := range listTmuxSessions(ctx) {
+	for _, name := range names {
 		if !strings.HasPrefix(name, tmux.TmuxPrefix) {
 			continue
 		}
@@ -572,8 +602,15 @@ func checkRunawayChildren(ctx *scanContext, report *Report) {
 // server, and killing someone else's live session is worse than a leak.
 func checkLeakedTmuxSessions(ctx *scanContext, report *Report) {
 	recorded := recordedTmuxNames(ctx.opts.ConfigDir)
+	names, err := listTmuxSessions(ctx)
+	if err != nil {
+		report.Fail(sectionProcesses, "leaked-tmux-sessions",
+			fmt.Sprintf("could not list tmux sessions, so none was checked for a backing record: %v", err),
+			"this check is UNKNOWN, not clean — resolve the tmux listing failure and re-run `af doctor`")
+		return
+	}
 	var leaked []string
-	for _, name := range listTmuxSessions(ctx) {
+	for _, name := range names {
 		if strings.HasPrefix(name, tmux.TmuxPrefix) && !recorded[name] {
 			leaked = append(leaked, name)
 		}
@@ -653,101 +690,6 @@ func recordedTmuxNames(configDir string) map[string]bool {
 	return names
 }
 
-// afHomeMarkers are the files/dirs whose presence identifies a directory as
-// an agent-factory home. Two or more must match before doctor will even
-// report a directory, let alone remove it.
-var afHomeMarkers = []string{
-	config.TomlConfigFileName, config.ConfigFileName, "state.json", "instances", "daemon.sock", "daemon.pid", "agent-factory.log",
-}
-
-// checkStaleTempHomes finds abandoned agent-factory homes under the temp
-// dir (leaked by tests/debug runs — the #1093 immortal-daemon fuel). A home
-// is stale only when nothing references it: no live process has it as
-// AGENT_FACTORY_HOME, no live tmux session marks it as AF_HOME, its
-// daemon.pid (if any) is verified absent/dead/stale rather than merely
-// unreadable, and it has not been touched for MinTempHomeAge.
-func checkStaleTempHomes(ctx *scanContext, report *Report) {
-	tempDir := filepath.Clean(ctx.opts.TempDir)
-	activeHome := filepath.Clean(ctx.opts.ConfigDir)
-	processHomes := processReferencedHomes(ctx.snap)
-	tmuxHomes := liveTmuxHomes(ctx)
-
-	for _, dir := range candidateTempHomes(tempDir) {
-		dir = filepath.Clean(dir)
-		if dir == activeHome || !isAFHome(dir) {
-			continue
-		}
-		// POSITIVE proofs of use come first. Each can only ADD a reason to keep
-		// the home; none authorises a delete, so an unread or unavailable surface
-		// here costs at worst an unreported keep — never a wrong removal.
-		if processHomes[dir] {
-			report.Pass(sectionProcesses, "temp home", fmt.Sprintf("%s is in use (a live process references it)", dir))
-			continue
-		}
-		if tmuxHomes[dir] {
-			report.Pass(sectionProcesses, "temp home", fmt.Sprintf("%s is in use (a live tmux session references it)", dir))
-			continue
-		}
-		// The AUTHORITATIVE signal: does a live daemon hold the home's lock? This
-		// replaces the old "did I see a process referencing this home?" — a
-		// negative four consecutive P1 reviews each found a fresh way to falsify,
-		// every one ending at an rm -rf. The lock cannot be falsified that way:
-		// the kernel releases it on the daemon's death, so a takeable lock is
-		// PROOF (not inference) that no live daemon owns the home (#1989).
-		lock := tempHomeLockProbe(dir)
-		var daemonHoldsLock, provablyFree bool
-		var lockCause error
-		lock.Match(
-			func() { daemonHoldsLock = true }, // Yes: a live daemon owns it
-			func() { provablyFree = true },    // No: we took the lock; no daemon owns it
-			func() {},                         // NotFound: ProbeHomeLock never returns this; treat as unknown
-			func(cause error) { lockCause = cause },
-		)
-		if daemonHoldsLock {
-			report.Pass(sectionProcesses, "temp home", fmt.Sprintf("%s is in use (an af daemon holds its lock)", dir))
-			continue
-		}
-
-		age := timeSince(newestMtime(dir))
-		if age < ctx.opts.MinTempHomeAge {
-			continue
-		}
-		if !pathInside(tempDir, dir) {
-			continue
-		}
-
-		if provablyFree {
-			// The teeth, restored on a FACT. The lock is takeable (no live daemon)
-			// and no live tmux session names it, so the home is provably unused.
-			// The fix re-verifies every precondition at fix time (TOCTOU): a
-			// daemon may have started, or a tmux session appeared, since detection.
-			report.addActionableFinding(Finding{
-				Check: "stale-temp-home",
-				Detail: fmt.Sprintf("agent-factory home %s is abandoned (untouched for %s) and no live daemon "+
-					"holds its lock, so it is safe to remove", dir, formatAge(age.Seconds())),
-				FixAction:   "remove " + dir,
-				fix:         staleTempHomeRemoveFix(ctx, dir, tempDir, activeHome),
-				Severity:    StatusWarn,
-				Remediation: "run `af doctor --fix` to remove it, or `rm -rf " + dir + "`",
-			})
-			continue
-		}
-
-		// UNKNOWN: no lock file at all (absence of a lock is not proof of
-		// non-use), a filesystem whose flock cannot be trusted (NFS), or an I/O
-		// error. Report it — reporting is safe — but never authorise the delete
-		// on a proof we do not have. The operator decides.
-		report.addAdvisoryFinding(Finding{
-			Check: "stale-temp-home",
-			Detail: fmt.Sprintf("agent-factory home %s looks abandoned (untouched for %s), but nothing here can "+
-				"PROVE it is unused (%s) — inspect it and remove it yourself if it is dead",
-				dir, formatAge(age.Seconds()), lockUnknownReason(lockCause)),
-			Severity:    StatusWarn,
-			Remediation: "verify nothing is using it, then `rm -rf " + dir + "`",
-		})
-	}
-}
-
 // lockUnknownReason renders the cause of an undetermined lock probe for the
 // report, defaulting to a plain phrase when the probe carried none.
 func lockUnknownReason(cause error) string {
@@ -757,82 +699,6 @@ func lockUnknownReason(cause error) string {
 	return cause.Error()
 }
 
-// timeSince is time.Since, indirected so tests can pin the clock if needed.
-var timeSince = time.Since
-
-// candidateTempHomes lists directories one and two levels below tempDir —
-// Go tests produce /tmp/TestName123/001-style homes, manual runs
-// /tmp/tmp.XXXX ones.
-func candidateTempHomes(tempDir string) []string {
-	var out []string
-	level1, err := os.ReadDir(tempDir)
-	if err != nil {
-		return nil
-	}
-	for _, e := range level1 {
-		if !e.IsDir() {
-			continue
-		}
-		dir := filepath.Join(tempDir, e.Name())
-		out = append(out, dir)
-		level2, err := os.ReadDir(dir)
-		if err != nil {
-			continue
-		}
-		for _, e2 := range level2 {
-			if e2.IsDir() {
-				out = append(out, filepath.Join(dir, e2.Name()))
-			}
-		}
-	}
-	return out
-}
-
-func isAFHome(dir string) bool {
-	found := 0
-	for _, marker := range afHomeMarkers {
-		if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
-			found++
-		}
-	}
-	return found >= 2
-}
-
-// processReferencedHomes returns the AF homes live processes name in their
-// AGENT_FACTORY_HOME environment. It is a POSITIVE signal only: finding a
-// process that names a home proves the home is in use, which spares it. The
-// converse — "no process names it" — is NOT proof of non-use and is deliberately
-// not derived here: that inference was the unsound predicate behind the
-// temp-home rm -rf, and the delete now rests on the daemon lock instead (#1989,
-// staleTempHomeRemoveFix). So an unreadable environment simply contributes no
-// home, which can only under-spare — never authorise a removal.
-//
-// Only EnvFound attributes a home. A redacted or denied read (EnvUnknown) must
-// add nothing to the set in either direction — "I could not read its home" is
-// not "its home is X", and it is not "it names no home" either.
-func processReferencedHomes(snap map[int]proctree.Process) map[string]bool {
-	homes := map[string]bool{}
-	for pid := range snap {
-		if home, status := proctree.LookupEnv(pid, "AGENT_FACTORY_HOME"); status == proctree.EnvFound && home != "" {
-			homes[filepath.Clean(home)] = true
-		}
-	}
-	return homes
-}
-
-func liveTmuxHomes(ctx *scanContext) map[string]bool {
-	homes := map[string]bool{}
-	for _, name := range listTmuxSessions(ctx) {
-		if !strings.HasPrefix(name, tmux.TmuxPrefix) {
-			continue
-		}
-		if home, ok := tmuxSessionHomeMarker(ctx, name); ok && home != "" {
-			homes[filepath.Clean(home)] = true
-		}
-	}
-	return homes
-}
-
 func tmuxSessionHomeMarker(ctx *scanContext, name string) (string, bool) {
 	out, err := ctx.opts.Exec.Output(exec.Command("tmux", "show-environment", "-t",
 		fmt.Sprintf("=%s:", name), tmux.EnvMarkerHome))
@@ -840,82 +706,6 @@ func tmuxSessionHomeMarker(ctx *scanContext, name string) (string, bool) {
 		return "", false
 	}
 	return strings.CutPrefix(strings.TrimSpace(string(out)), tmux.EnvMarkerHome+"=")
-}
-
-// staleTempHomeRemoveFix rm -rf's an abandoned temp home — the teeth #1969 took
-// out, restored on a predicate the kernel guarantees rather than an inference we
-// assemble (#1989).
-//
-// The old closure was careful — containment, active-home and isAFHome checks, a
-// fresh snapshot at fix time — and none of that was the problem. Its PREDICATE
-// was: "did I see any process referencing this home? no → delete." Four
-// consecutive P1 reviews each found a fresh way for that "no" to be false, every
-// one ending here in an rm -rf. You cannot make an unsound question safe by
-// validating its inputs harder.
-//
-// So the gate is now a FACT: re-probe the home's daemon lock, and delete only on
-// AnswerNo — the lock existed on a trusted filesystem and we took it, proving no
-// live daemon owns the home. Everything is re-checked at fix time because the
-// findings are applied after detection, leaving a window in which a daemon could
-// start (its lock would then be held → refuse) or a tmux session could claim the
-// home (refuse). Undetermined (no lock file, untrusted filesystem) never reaches
-// here: only a provably-free home carries this closure.
-func staleTempHomeRemoveFix(ctx *scanContext, dir, tempDir, activeHome string) func() error {
-	return func() error {
-		dir = filepath.Clean(dir)
-		// Re-assert containment and identity at fix time — cheap, and the home
-		// may have changed under us since detection.
-		if dir == activeHome {
-			return fmt.Errorf("refusing to remove the active home %s", dir)
-		}
-		if !pathInside(tempDir, dir) {
-			return fmt.Errorf("refusing to remove %s: it is not inside the temp dir %s", dir, tempDir)
-		}
-		if !isAFHome(dir) {
-			return fmt.Errorf("refusing to remove %s: it no longer looks like an agent-factory home", dir)
-		}
-		// A live tmux session naming the home is the second, sound signal the
-		// lock cannot see (a home with live tmux sessions but a dead daemon holds
-		// no lock). Re-check it fresh.
-		if liveTmuxHomes(ctx)[dir] {
-			return fmt.Errorf("refusing to remove %s: a live tmux session now references it", dir)
-		}
-		// The authoritative gate: delete ONLY on a proven "no live daemon owns
-		// this" (AnswerNo). A daemon that appeared since detection now holds the
-		// lock (Yes → refuse); an unprovable answer (Undetermined → refuse) is not
-		// a licence to os.RemoveAll.
-		answer := tempHomeLockProbe(dir)
-		proven := false
-		answer.Match(func() {}, func() { proven = true }, func() {}, func(error) {})
-		if !proven {
-			return fmt.Errorf("refusing to remove %s: cannot prove no daemon owns it (lock answer: %s)", dir, answer.String())
-		}
-		return os.RemoveAll(dir)
-	}
-}
-
-func pathInside(base, path string) bool {
-	rel, err := filepath.Rel(base, path)
-	if err != nil || rel == "." || rel == ".." {
-		return false
-	}
-	return !strings.HasPrefix(rel, ".."+string(filepath.Separator))
-}
-
-// newestMtime returns the most recent mtime among the dir itself and its
-// marker files — a fair "last touched" signal without a full tree walk.
-func newestMtime(dir string) time.Time {
-	newest := time.Time{}
-	consider := func(path string) {
-		if info, err := os.Stat(path); err == nil && info.ModTime().After(newest) {
-			newest = info.ModTime()
-		}
-	}
-	consider(dir)
-	for _, marker := range afHomeMarkers {
-		consider(filepath.Join(dir, marker))
-	}
-	return newest
 }
 
 // checkForeignDaemons finds agent-factory daemon processes serving a home

--- a/doctor/checks_temp_homes.go
+++ b/doctor/checks_temp_homes.go
@@ -1,0 +1,294 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/proctree"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// Temp-home liveness: which abandoned agent-factory homes under the temp dir are
+// safe to remove, and the --fix that removes them. Split out of checks.go to keep
+// both files under the length limit (#1145); the rules live together because
+// every one of them is a KEEP-reason guarding the same rm -rf.
+
+// afHomeMarkers are the files/dirs whose presence identifies a directory as
+// an agent-factory home. Two or more must match before doctor will even
+// report a directory, let alone remove it.
+var afHomeMarkers = []string{
+	config.TomlConfigFileName, config.ConfigFileName, "state.json", "instances", "daemon.sock", "daemon.pid", "agent-factory.log",
+}
+
+// checkStaleTempHomes finds abandoned agent-factory homes under the temp
+// dir (leaked by tests/debug runs — the #1093 immortal-daemon fuel). A home
+// is stale only when nothing references it: no live process has it as
+// AGENT_FACTORY_HOME, no live tmux session marks it as AF_HOME, its
+// daemon.pid (if any) is verified absent/dead/stale rather than merely
+// unreadable, and it has not been touched for MinTempHomeAge.
+func checkStaleTempHomes(ctx *scanContext, report *Report) {
+	tempDir := filepath.Clean(ctx.opts.TempDir)
+	activeHome := filepath.Clean(ctx.opts.ConfigDir)
+	processHomes := processReferencedHomes(ctx.snap)
+	tmuxHomes, err := liveTmuxHomes(ctx)
+	if err != nil {
+		// Without the tmux signal a home whose daemon is dead but whose sessions
+		// are live has NO keep-reason left, and the lock probe cannot see them.
+		// Classify nothing rather than arm a removal on a surface we could not read.
+		report.Fail(sectionProcesses, "stale-temp-home",
+			fmt.Sprintf("could not list tmux sessions, so no temp home was checked for a live session "+
+				"referencing it: %v", err),
+			"this check is UNKNOWN, not clean — resolve the tmux listing failure and re-run `af doctor`")
+		return
+	}
+
+	for _, dir := range candidateTempHomes(tempDir) {
+		dir = filepath.Clean(dir)
+		if dir == activeHome || !isAFHome(dir) {
+			continue
+		}
+		// POSITIVE proofs of use come first. Each can only ADD a reason to keep
+		// the home; none authorises a delete, so an unread surface here costs at
+		// worst an unreported keep — never a wrong removal.
+		//
+		// That holds only because a FAILED tmux listing is refused above rather
+		// than read as "no session references this home". Collapsing it would
+		// withdraw the one keep-reason a home with live sessions and a dead
+		// daemon has, and the removal below would proceed on the lock alone.
+		if processHomes[dir] {
+			report.Pass(sectionProcesses, "temp home", fmt.Sprintf("%s is in use (a live process references it)", dir))
+			continue
+		}
+		if tmuxHomes[dir] {
+			report.Pass(sectionProcesses, "temp home", fmt.Sprintf("%s is in use (a live tmux session references it)", dir))
+			continue
+		}
+		// The AUTHORITATIVE signal: does a live daemon hold the home's lock? This
+		// replaces the old "did I see a process referencing this home?" — a
+		// negative four consecutive P1 reviews each found a fresh way to falsify,
+		// every one ending at an rm -rf. The lock cannot be falsified that way:
+		// the kernel releases it on the daemon's death, so a takeable lock is
+		// PROOF (not inference) that no live daemon owns the home (#1989).
+		lock := tempHomeLockProbe(dir)
+		var daemonHoldsLock, provablyFree bool
+		var lockCause error
+		lock.Match(
+			func() { daemonHoldsLock = true }, // Yes: a live daemon owns it
+			func() { provablyFree = true },    // No: we took the lock; no daemon owns it
+			func() {},                         // NotFound: ProbeHomeLock never returns this; treat as unknown
+			func(cause error) { lockCause = cause },
+		)
+		if daemonHoldsLock {
+			report.Pass(sectionProcesses, "temp home", fmt.Sprintf("%s is in use (an af daemon holds its lock)", dir))
+			continue
+		}
+
+		age := timeSince(newestMtime(dir))
+		if age < ctx.opts.MinTempHomeAge {
+			continue
+		}
+		if !pathInside(tempDir, dir) {
+			continue
+		}
+
+		if provablyFree {
+			// The teeth, restored on a FACT. The lock is takeable (no live daemon)
+			// and no live tmux session names it, so the home is provably unused.
+			// The fix re-verifies every precondition at fix time (TOCTOU): a
+			// daemon may have started, or a tmux session appeared, since detection.
+			report.addActionableFinding(Finding{
+				Check: "stale-temp-home",
+				Detail: fmt.Sprintf("agent-factory home %s is abandoned (untouched for %s) and no live daemon "+
+					"holds its lock, so it is safe to remove", dir, formatAge(age.Seconds())),
+				FixAction:   "remove " + dir,
+				fix:         staleTempHomeRemoveFix(ctx, dir, tempDir, activeHome),
+				Severity:    StatusWarn,
+				Remediation: "run `af doctor --fix` to remove it, or `rm -rf " + dir + "`",
+			})
+			continue
+		}
+
+		// UNKNOWN: no lock file at all (absence of a lock is not proof of
+		// non-use), a filesystem whose flock cannot be trusted (NFS), or an I/O
+		// error. Report it — reporting is safe — but never authorise the delete
+		// on a proof we do not have. The operator decides.
+		report.addAdvisoryFinding(Finding{
+			Check: "stale-temp-home",
+			Detail: fmt.Sprintf("agent-factory home %s looks abandoned (untouched for %s), but nothing here can "+
+				"PROVE it is unused (%s) — inspect it and remove it yourself if it is dead",
+				dir, formatAge(age.Seconds()), lockUnknownReason(lockCause)),
+			Severity:    StatusWarn,
+			Remediation: "verify nothing is using it, then `rm -rf " + dir + "`",
+		})
+	}
+}
+
+// candidateTempHomes lists directories one and two levels below tempDir —
+// Go tests produce /tmp/TestName123/001-style homes, manual runs
+// /tmp/tmp.XXXX ones.
+func candidateTempHomes(tempDir string) []string {
+	var out []string
+	level1, err := os.ReadDir(tempDir)
+	if err != nil {
+		return nil
+	}
+	for _, e := range level1 {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(tempDir, e.Name())
+		out = append(out, dir)
+		level2, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e2 := range level2 {
+			if e2.IsDir() {
+				out = append(out, filepath.Join(dir, e2.Name()))
+			}
+		}
+	}
+	return out
+}
+
+func isAFHome(dir string) bool {
+	found := 0
+	for _, marker := range afHomeMarkers {
+		if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
+			found++
+		}
+	}
+	return found >= 2
+}
+
+// processReferencedHomes returns the AF homes live processes name in their
+// AGENT_FACTORY_HOME environment. It is a POSITIVE signal only: finding a
+// process that names a home proves the home is in use, which spares it. The
+// converse — "no process names it" — is NOT proof of non-use and is deliberately
+// not derived here: that inference was the unsound predicate behind the
+// temp-home rm -rf, and the delete now rests on the daemon lock instead (#1989,
+// staleTempHomeRemoveFix). So an unreadable environment simply contributes no
+// home, which can only under-spare — never authorise a removal.
+//
+// Only EnvFound attributes a home. A redacted or denied read (EnvUnknown) must
+// add nothing to the set in either direction — "I could not read its home" is
+// not "its home is X", and it is not "it names no home" either.
+func processReferencedHomes(snap map[int]proctree.Process) map[string]bool {
+	homes := map[string]bool{}
+	for pid := range snap {
+		if home, status := proctree.LookupEnv(pid, "AGENT_FACTORY_HOME"); status == proctree.EnvFound && home != "" {
+			homes[filepath.Clean(home)] = true
+		}
+	}
+	return homes
+}
+
+// liveTmuxHomes is a PROTECTIVE set: a home named by a live tmux session must
+// not be removed. An unreadable listing therefore cannot be reported as an empty
+// one — that silently withdraws the keep-reason and lets the rm -rf proceed
+// (#2874's class). The error is returned so both the detection and the fix
+// refuse rather than guess.
+func liveTmuxHomes(ctx *scanContext) (map[string]bool, error) {
+	names, err := listTmuxSessions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	homes := map[string]bool{}
+	for _, name := range names {
+		if !strings.HasPrefix(name, tmux.TmuxPrefix) {
+			continue
+		}
+		if home, ok := tmuxSessionHomeMarker(ctx, name); ok && home != "" {
+			homes[filepath.Clean(home)] = true
+		}
+	}
+	return homes, nil
+}
+
+// staleTempHomeRemoveFix rm -rf's an abandoned temp home — the teeth #1969 took
+// out, restored on a predicate the kernel guarantees rather than an inference we
+// assemble (#1989).
+//
+// The old closure was careful — containment, active-home and isAFHome checks, a
+// fresh snapshot at fix time — and none of that was the problem. Its PREDICATE
+// was: "did I see any process referencing this home? no → delete." Four
+// consecutive P1 reviews each found a fresh way for that "no" to be false, every
+// one ending here in an rm -rf. You cannot make an unsound question safe by
+// validating its inputs harder.
+//
+// So the gate is now a FACT: re-probe the home's daemon lock, and delete only on
+// AnswerNo — the lock existed on a trusted filesystem and we took it, proving no
+// live daemon owns the home. Everything is re-checked at fix time because the
+// findings are applied after detection, leaving a window in which a daemon could
+// start (its lock would then be held → refuse) or a tmux session could claim the
+// home (refuse). Undetermined (no lock file, untrusted filesystem) never reaches
+// here: only a provably-free home carries this closure.
+func staleTempHomeRemoveFix(ctx *scanContext, dir, tempDir, activeHome string) func() error {
+	return func() error {
+		dir = filepath.Clean(dir)
+		// Re-assert containment and identity at fix time — cheap, and the home
+		// may have changed under us since detection.
+		if dir == activeHome {
+			return fmt.Errorf("refusing to remove the active home %s", dir)
+		}
+		if !pathInside(tempDir, dir) {
+			return fmt.Errorf("refusing to remove %s: it is not inside the temp dir %s", dir, tempDir)
+		}
+		if !isAFHome(dir) {
+			return fmt.Errorf("refusing to remove %s: it no longer looks like an agent-factory home", dir)
+		}
+		// A live tmux session naming the home is the second, sound signal the
+		// lock cannot see (a home with live tmux sessions but a dead daemon holds
+		// no lock). Re-check it fresh.
+		tmuxHomes, err := liveTmuxHomes(ctx)
+		if err != nil {
+			return fmt.Errorf("refusing to remove %s: could not list tmux sessions, so af cannot tell "+
+				"whether a live session references it: %w", dir, err)
+		}
+		if tmuxHomes[dir] {
+			return fmt.Errorf("refusing to remove %s: a live tmux session now references it", dir)
+		}
+		// The authoritative gate: delete ONLY on a proven "no live daemon owns
+		// this" (AnswerNo). A daemon that appeared since detection now holds the
+		// lock (Yes → refuse); an unprovable answer (Undetermined → refuse) is not
+		// a licence to os.RemoveAll.
+		answer := tempHomeLockProbe(dir)
+		proven := false
+		answer.Match(func() {}, func() { proven = true }, func() {}, func(error) {})
+		if !proven {
+			return fmt.Errorf("refusing to remove %s: cannot prove no daemon owns it (lock answer: %s)", dir, answer.String())
+		}
+		return os.RemoveAll(dir)
+	}
+}
+
+// newestMtime returns the most recent mtime among the dir itself and its
+// marker files — a fair "last touched" signal without a full tree walk.
+func newestMtime(dir string) time.Time {
+	newest := time.Time{}
+	consider := func(path string) {
+		if info, err := os.Stat(path); err == nil && info.ModTime().After(newest) {
+			newest = info.ModTime()
+		}
+	}
+	consider(dir)
+	for _, marker := range afHomeMarkers {
+		consider(filepath.Join(dir, marker))
+	}
+	return newest
+}
+
+func pathInside(base, path string) bool {
+	rel, err := filepath.Rel(base, path)
+	if err != nil || rel == "." || rel == ".." {
+		return false
+	}
+	return !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// timeSince is time.Since, indirected so tests can pin the clock if needed.
+var timeSince = time.Since

--- a/doctor/temp_home_liveness_test.go
+++ b/doctor/temp_home_liveness_test.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -56,10 +57,35 @@ func macLikeTempHomeOptions(t *testing.T, tempRoot string, fix bool) Options {
 	opts.Exec = cmd_test.MockCmdExec{
 		RunFunc: func(cmd *exec.Cmd) error { return nil },
 		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
-			return nil, fmt.Errorf("no tmux")
+			// tmux's DEFINITIVE "there is no server" answer, which is what a box
+			// with no tmux running actually returns. A bare error here would be an
+			// UNREADABLE listing, which the temp-home checks must refuse rather
+			// than treat as "no session references this home" (#2874's class) —
+			// see TestUnreadableTmuxListingSparesTempHome.
+			return nil, noTmuxServerExitError(t)
 		},
 	}
 	return opts
+}
+
+// noTmuxServerExitError builds tmux's real exit-1-with-diagnostic answer for
+// "no server on this socket". Constructed from a genuine failed command so the
+// *exec.ExitError carries a real exit status, with tmux's stderr attached.
+func noTmuxServerExitError(t *testing.T) error {
+	t.Helper()
+	return tmuxExitError(t, "error connecting to /tmp/tmux-1000/default (No such file or directory)")
+}
+
+// tmuxExitError builds an exit-1 *exec.ExitError carrying diagnostic on stderr.
+func tmuxExitError(t *testing.T, diagnostic string) error {
+	t.Helper()
+	err := exec.Command("sh", "-c", "exit 1").Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected an *exec.ExitError from a failing command, got %v", err)
+	}
+	exitErr.Stderr = []byte(diagnostic)
+	return exitErr
 }
 
 // holdDaemonLock creates dir's daemon.lock and holds an exclusive flock on it
@@ -234,4 +260,61 @@ func TestStaleTempHomeFixRefusesWhenDaemonAppearsAfterDetection(t *testing.T) {
 	require.Contains(t, findings[0].FixErr.Error(), "cannot prove no daemon owns it")
 	require.DirExists(t, dir, "the newly-claimed home must survive the --fix run")
 	require.GreaterOrEqual(t, probes, 2, "the fix must re-probe the lock rather than trust detection")
+}
+
+// TestUnreadableTmuxListingSparesTempHome pins the #2874 class on the temp-home
+// path.
+//
+// "A live tmux session references this home" is a KEEP-reason. Reading an
+// unreadable listing as an empty one withdraws it silently, and the scan then
+// renders as clean — the operator sees no finding at all for a surface af could
+// not read.
+//
+// Scope, measured rather than assumed: on master the removal is still blocked by
+// the lock probe, so this collapse alone was not shown to reach the rm -rf. What
+// it does reach is the report, which is the fabricated negative in its reporting
+// form. The keep-reason is restored here so the removal never depends on the
+// lock probe being the only surviving guard.
+func TestUnreadableTmuxListingSparesTempHome(t *testing.T) {
+	unreadable := []struct{ name, diagnostic string }{
+		{"permission denied", "error connecting to /tmp/tmux-1000/default (Permission denied)"},
+		{"unsafe permissions", "directory /tmp/tmux-1000 has unsafe permissions"},
+		{"empty diagnostic", ""},
+		{"wrapper refusal", "af: refusing to run tmux"},
+	}
+	for _, test := range unreadable {
+		t.Run(test.name, func(t *testing.T) {
+			tempRoot := t.TempDir()
+			dir := makeOldTempAFHome(t, tempRoot, "tmp.unreadable-tmux")
+			stubTempHomeLockProbe(t, func(string) daemon.ProbeAnswer { return daemon.AnswerNo() })
+
+			opts := macLikeTempHomeOptions(t, tempRoot, true) // Fix: true
+			opts.Exec = cmd_test.MockCmdExec{
+				RunFunc:    func(cmd *exec.Cmd) error { return nil },
+				OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return nil, tmuxExitError(t, test.diagnostic) },
+			}
+
+			report, err := Run(opts)
+			require.NoError(t, err)
+			require.DirExists(t, dir,
+				"an unreadable tmux listing must not authorise removing a temp home that may be in use")
+			rows := findCheckRows(report, "stale-temp-home")
+			require.NotEmpty(t, rows, "and the blindness must be reported, not rendered as a clean scan")
+			require.Equal(t, StatusFail, rows[0].Status,
+				"an unreadable surface is a FAIL, not a pass — the scan is UNKNOWN, not clean")
+		})
+	}
+}
+
+// The definitive "no server" answer is still an empty session set, so a genuinely
+// unreferenced home is still removed — the guard must not become a blanket stop.
+func TestDefinitiveNoTmuxServerStillAllowsRemoval(t *testing.T) {
+	tempRoot := t.TempDir()
+	dir := makeOldTempAFHome(t, tempRoot, "tmp.definitely-stale")
+	stubTempHomeLockProbe(t, func(string) daemon.ProbeAnswer { return daemon.AnswerNo() })
+
+	_, err := Run(macLikeTempHomeOptions(t, tempRoot, true)) // Fix: true
+	require.NoError(t, err)
+	require.NoDirExists(t, dir,
+		"tmux's definitive no-server answer is an empty session set, not an unreadable one")
 }

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -194,6 +194,31 @@ func noTmuxServerDiagnostic(diagnostic string) bool {
 	return absent && strings.TrimSpace(socket) != ""
 }
 
+// ListingFoundNoServer reports whether a failed `tmux ls` is tmux's DEFINITIVE
+// "there is no server" answer — an empty session set — rather than a failure to
+// find out what the session set is.
+//
+// Exported because that difference is load-bearing OUTSIDE this package and was
+// got wrong twice by copying: #2870 (`af reset` wiping worktrees on an
+// unreadable listing) and #2874 (`af doctor --fix` arming a kill of every live
+// session's processes). Both had a comment claiming to mirror the other. The
+// classifier lives here, beside the diagnostics it matches, so there is one
+// place to be right rather than a shape to re-derive per caller.
+//
+// Anything that is not one of tmux's two definitive diagnostics — a timeout, a
+// permission refusal, a wrapper's exit 1, a missing binary, an empty stderr —
+// is UNKNOWN, and a caller that cannot tell must not treat it as empty.
+func ListingFoundNoServer(err error) bool {
+	if err == nil {
+		return false
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+		return false
+	}
+	return noTmuxServerDiagnostic(strings.TrimSpace(string(exitErr.Stderr)))
+}
+
 // tmuxDiagnosticSuffix renders tmux's stderr as a parenthesized clause for an
 // error message, or "" when there is nothing to render.
 //


### PR DESCRIPTION
## What

`af doctor` collapsed **every** `tmux ls` failure into an empty session list — permission refusal, wedged server, timeout, missing binary all became "there are no sessions".

That list is a **protective** set. An empty one says nothing is alive:

- `checkOrphanedProcesses` builds `live` from it, so every marked process looks orphaned and **`--fix` is armed to kill every live session's processes** (#2874);
- `liveTmuxHomes` builds the "a live tmux session references this home" keep-reason, guarding an `rm -rf`;
- `checkRunawayChildren` and `checkLeakedTmuxSessions` rendered as **clean** for a surface af could not read — the same fabricated negative in its reporting form.

## The fix is one classifier, not four judgement calls

The classifier already existed in `session/tmux`, unexported — and doctor's own comment said that is where it lived. `tmux.ListingFoundNoServer` exports it, beside the diagnostics it matches:

- `no server running on <socket>` and `error connecting to <socket> (No such file or directory)` → genuinely **zero sessions**;
- everything else → **UNKNOWN**, and a caller that cannot tell must not treat it as empty.

#2870 and #2874 each got this wrong by copying, each citing the other as the model. A comment is not a mechanism; there is now one place to be right.

Every consumer fails closed and **reports the blindness** rather than a clean check.

## Scope, corrected mid-audit

I first rated the `liveTmuxHomes` path HIGH — a home with live tmux sessions but a dead daemon holds no lock, so the tmux keep-reason looked like all that stood between it and `rm -rf`. **Measured on master, that does not reproduce**: the lock probe still blocks the removal, and I could not construct a case where the collapsed signal alone reached the delete.

Rated MEDIUM in #2905 and fixed anyway, so the removal never depends on the lock probe being the only surviving guard. The verified consequence is the report: a check that says clean about something af never read.

## Test-stub correction

The temp-home tests stubbed `tmux ls` as `fmt.Errorf("no tmux")` — a bare error, which is an *unreadable* listing, not the definitive answer a box without tmux actually gives. Under the new guard those tests failed, and the honest fix was the stub, not the guard: it now emulates tmux's real exit-1 diagnostic, so the existing tests exercise "no sessions" while a new case covers "could not tell".

## Regressions

- `TestUnreadableTmuxListingSparesTempHome` — permission denied / unsafe permissions / empty diagnostic / wrapper refusal: the home survives **and** the check reports `StatusFail`. Red against master.
- `TestDefinitiveNoTmuxServerStillAllowsRemoval` — the guard must not become a blanket stop; a genuinely unreferenced home is still removed.

## File split

`doctor/checks.go` crossed the 1000-line limit, so the temp-home liveness rules moved to `doctor/checks_temp_homes.go`. They belong together: every one of them is a keep-reason guarding the same `rm -rf`. No entry added to the allowlist.

## Validation

- `gofmt -l .` (no output) · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `deadcode -test ./...` (no output) · `scripts/lint-file-length.sh` (0 grandfathered)
- `go test ./doctor/ ./session/tmux/` — the packages changed, both non-daemon and non-app

No containerized suite; nothing run against `./daemon/...` or `./app/...`.

Closes #2874
Refs #2905, #2870
