### PR TITLE
fix(doctor): the fix-time tmux recheck must re-list, and an uninvokable client is blindness

### DIFF
--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -722,10 +722,11 @@ func staleTempHomeRemoveFix(ctx *scanContext, dir, tempDir, activeHome string) f
 		// no lock). Re-check it fresh — and refuse if the recheck cannot be
 		// PERFORMED, because a guard that cannot run has not passed.
 		//
-		// Fresh: ctx.tmuxSessions memoizes the listing for the run, so a listing
-		// that succeeded at detection is reused here rather than re-shelled. The
-		// marker lookups behind it are not memoized and do re-run.
-		claimed, err := liveTmuxHomes(ctx)
+		// liveTmuxHomesNow, not liveTmuxHomes: the run's memoized listing was
+		// taken before this window opened, so a session started since detection
+		// is absent from it and would be missed by exactly the guard meant to
+		// catch it.
+		claimed, err := liveTmuxHomesNow(ctx)
 		if err != nil {
 			return fmt.Errorf("refusing to remove %s: cannot check whether a live tmux session references it: %w", dir, err)
 		}

--- a/doctor/temp_home_liveness_test.go
+++ b/doctor/temp_home_liveness_test.go
@@ -55,15 +55,15 @@ func macLikeTempHomeOptions(t *testing.T, tempRoot string, fix bool) Options {
 	}
 	opts.Exec = cmd_test.MockCmdExec{
 		RunFunc: func(cmd *exec.Cmd) error { return nil },
-		// "no tmux" means the BINARY is absent, and the shape matters now that
-		// doctor classifies tmux failures (#2874): exec.ErrNotFound is a
-		// determinate empty — af drives tmux through PATH, so a tmux it cannot
-		// execute holds none of its sessions — whereas an unclassifiable failure
-		// means the session set is UNKNOWN and blocks every removal below.
-		// TestUnreadableTmuxSessionListRefusesTempHomeRemoval covers that half;
-		// these tests are about the lock gate, so they state the case they mean.
+		// tmux ANSWERED and has no sessions. The shape matters now that doctor
+		// classifies tmux failures (#2874): only a determinate empty lets the
+		// removal below be reached at all, and every failure — including a tmux
+		// the process cannot execute — leaves the session set UNKNOWN and blocks
+		// it. These tests are about the LOCK gate, so they state the tmux case
+		// they mean rather than leaning on an error whose classification is the
+		// subject of other tests (TestUnreadableTmuxSessionList*).
 		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
-			return nil, &exec.Error{Name: "tmux", Err: exec.ErrNotFound}
+			return []byte(""), nil
 		},
 	}
 	return opts

--- a/doctor/tmux_inspection_test.go
+++ b/doctor/tmux_inspection_test.go
@@ -190,17 +190,6 @@ func TestListedTmuxSessionsPass(t *testing.T) {
 			},
 			wantDetail: "0",
 		},
-		{
-			// tmux is not installed, so no tmux session can exist.
-			name: "tmux not installed",
-			exec: func(t *testing.T) cmd.Executor {
-				return cmd_test.MockCmdExec{
-					RunFunc:    func(*exec.Cmd) error { return nil },
-					OutputFunc: func(*exec.Cmd) ([]byte, error) { return nil, &exec.Error{Name: "tmux", Err: exec.ErrNotFound} },
-				}
-			},
-			wantDetail: "0",
-		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := testOptionsWithHome(t, home, false)
@@ -215,6 +204,80 @@ func TestListedTmuxSessionsPass(t *testing.T) {
 			require.Contains(t, rows[0].Detail, tc.wantDetail)
 		})
 	}
+}
+
+// TestUninvokableTmuxClientIsBlindness pins the case that reads most like a
+// determinate empty and is not one. `exec.ErrNotFound` proves doctor could not
+// invoke the tmux CLIENT — not that no server holds sessions. doctor's PATH is
+// not the sessions' PATH: a scan from a cron job or systemd unit with a minimal
+// PATH, or one straddling a package upgrade, finds no tmux while the server is
+// up. Reading that as "no sessions are live" is the #2874 defect wearing the
+// costume of an optimisation.
+func TestUninvokableTmuxClientIsBlindness(t *testing.T) {
+	home := testguard.SocketTempDir(t)
+	opts := testOptionsWithHome(t, home, true) // Fix: true
+	opts.Exec = cmd_test.MockCmdExec{
+		RunFunc:    func(*exec.Cmd) error { return nil },
+		OutputFunc: func(*exec.Cmd) ([]byte, error) { return nil, &exec.Error{Name: "tmux", Err: exec.ErrNotFound} },
+	}
+
+	report, err := Run(opts)
+	require.NoError(t, err)
+
+	rows := findCheckRows(report, "tmux-inspection")
+	require.Len(t, rows, 1)
+	require.Equal(t, StatusFail, rows[0].Status,
+		"a tmux client doctor could not execute is a session set it could not read, not an empty one")
+	require.Contains(t, rows[0].Detail, "executable file not found",
+		"the row must name why doctor could not look")
+	for _, f := range report.Findings {
+		require.Empty(t, f.FixAction,
+			"no fix may be armed when the tmux client could not be invoked: %s / %s", f.Check, f.Detail)
+	}
+}
+
+// TestStaleTempHomeFixRelistsTmux is the TOCTOU half of the recheck, and the
+// regression lock for a freshness bug the memo introduced: findings are applied
+// AFTER detection, so the session that must veto an rm -rf is exactly the one
+// that STARTED in that window — and it cannot appear in a listing taken before
+// the window opened. Detection here sees no sessions; by fix time one claims the
+// home.
+func TestStaleTempHomeFixRelistsTmux(t *testing.T) {
+	tempRoot := t.TempDir()
+	dir := makeOldTempAFHome(t, tempRoot, "tmp.claimed-after-detection")
+	stubTempHomeLockProbe(t, func(string) daemon.ProbeAnswer { return daemon.AnswerNo() })
+
+	const late = tmux.TmuxPrefix + "started-after-detection"
+	detected := false
+	opts := macLikeTempHomeOptions(t, tempRoot, true) // Fix: true
+	opts.Exec = cmd_test.MockCmdExec{
+		RunFunc: func(*exec.Cmd) error { return nil },
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			if len(c.Args) > 1 && c.Args[1] == "ls" {
+				if !detected {
+					detected = true
+					return []byte(""), nil // detection: nothing claims the home
+				}
+				return []byte(late + "\n"), nil // fix time: a session has appeared
+			}
+			if len(c.Args) > 1 && c.Args[1] == "show-environment" {
+				return []byte(tmux.EnvMarkerHome + "=" + dir + "\n"), nil
+			}
+			return []byte(""), nil
+		},
+	}
+
+	report, err := Run(opts)
+	require.NoError(t, err)
+
+	require.DirExists(t, dir,
+		"the fix-time recheck reused the run's memoized session list, so a session that started after "+
+			"detection was invisible and `--fix` removed a home a live session claims")
+	findings := findByCheck(report, "stale-temp-home")
+	require.Len(t, findings, 1)
+	require.False(t, findings[0].Fixed)
+	require.Error(t, findings[0].FixErr, "the refusal must surface as a fix error, not a silent skip")
+	require.Contains(t, findings[0].FixErr.Error(), "live tmux session")
 }
 
 // TestUnreadableTmuxSessionListRefusesTempHomeRemoval covers the second
@@ -241,6 +304,38 @@ func TestUnreadableTmuxSessionListRefusesTempHomeRemoval(t *testing.T) {
 			"a home whose tmux claim could not be checked must not be offered for removal: %s", f.Detail)
 		require.False(t, f.Fixed)
 	}
+}
+
+// TestDefinitiveNoTmuxServerStillAllowsTempHomeRemoval is the anti-regression
+// direction for the removal path, and it is not redundant with the fixtures that
+// model an empty SUCCESSFUL listing: this drives tmux's exit-1 no-server
+// DIAGNOSTIC, the shape a real box with no tmux server returns. Refusing here
+// would leave abandoned temp homes uncollectable forever on exactly the machines
+// where they accumulate.
+//
+// Idea taken from #2906, a sibling attempt at this fix that is otherwise
+// superseded by #2877.
+func TestDefinitiveNoTmuxServerStillAllowsTempHomeRemoval(t *testing.T) {
+	tempRoot := t.TempDir()
+	dir := makeOldTempAFHome(t, tempRoot, "tmp.no-server-at-all")
+	stubTempHomeLockProbe(t, func(string) daemon.ProbeAnswer { return daemon.AnswerNo() })
+
+	opts := macLikeTempHomeOptions(t, tempRoot, true) // Fix: true
+	opts.Exec = blindTmuxLsExec(t, "no server running on /tmp/tmux-1000/default", 1)
+
+	report, err := Run(opts)
+	require.NoError(t, err)
+
+	rows := findCheckRows(report, "tmux-inspection")
+	require.Len(t, rows, 1)
+	require.Equal(t, StatusPass, rows[0].Status,
+		"tmux answered — there is no server, so this is a real empty session set, not blindness")
+	findings := findByCheck(report, "stale-temp-home")
+	require.Len(t, findings, 1)
+	require.True(t, findings[0].Fixed, "fix outcome: %v", findings[0].FixErr)
+	require.NoDirExists(t, dir,
+		"a provably-unused home must still be removable on a box with no tmux server, or the guard "+
+			"has traded one bug for an uncollectable temp dir")
 }
 
 // TestUnreadableSessionRecordsDoNotMakeSessionsLookLeaked is the third read in
@@ -277,9 +372,16 @@ func TestUnreadableSessionRecordsDoNotMakeSessionsLookLeaked(t *testing.T) {
 	require.Equal(t, StatusFail, rows[0].Status)
 }
 
-// TestDoctorRunTimeIsBounded is a guard on the memo rather than on behaviour:
-// the session list feeds four checks, and re-shelling out per check would both
-// cost four tmux round trips and let one run see two different worlds.
+// TestDoctorSharesOneSessionListing guards the memo: the session list feeds four
+// checks, and re-shelling out per check would both cost four tmux round trips and
+// let one DETECTION pass see two different worlds.
+//
+// Scoped to a report-only run on purpose, and read the scope before "fixing" a
+// count that exceeds one. A `--fix` run lists again, deliberately:
+// staleTempHomeRemoveFix must see sessions that started AFTER detection, so
+// tightening this assertion to cover the fix path would mean deleting exactly
+// the re-list that keeps an rm -rf off a live home
+// (TestStaleTempHomeFixRelistsTmux is the one that would catch it).
 func TestDoctorSharesOneSessionListing(t *testing.T) {
 	home := testguard.SocketTempDir(t)
 	calls := 0

--- a/doctor/tmux_sessions.go
+++ b/doctor/tmux_sessions.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -29,42 +28,26 @@ import (
 // error when tmux could not tell us.
 //
 // THE INVARIANT, stated rather than borrowed: A FAILED READ IS NOT AN EMPTY
-// RESULT. `tmux ls` exits 1 both for "there is no server" and for "I could not
-// reach the server", so the exit status alone cannot separate them and only the
-// diagnostic can — tmux.NoServerRunning is the one place that judgement lives.
+// RESULT. Every consumer below treats a name's ABSENCE as evidence the session
+// is dead, and two of them spend that evidence on a kill or an rm -rf.
 //
-// The version this replaces returned nil for every failure and explained itself
-// by claiming parity with CleanupSessions, which had the same defect: an
-// unreachable socket read as "no sessions are live", and checkOrphanedProcesses
-// turned that into an armed `kill pid N` for every live session's processes
-// (#2874). Do not restore a "mirrors X" comment in either direction. State the
-// property, so a copy of this code cannot inherit a bug by inheriting a claim.
+// It DELEGATES rather than shelling out — the second read in this file to do so,
+// after tmuxSessionHomeMarker, and for the same reason. The copy that lived here
+// fell outside both invariants session/tmux maintains:
 //
-// A tmux binary missing from THIS process's PATH is blindness too, not a
-// determinate empty. It proves only that doctor could not invoke the client —
-// and doctor's PATH is not the sessions' PATH: a scan run from a cron job or a
-// systemd unit with a minimal PATH, or run across a package upgrade, can fail to
-// find a tmux whose server is up with live sessions. "I could not ask" is the
-// very thing this function exists to keep separate from "there is nothing there".
+//   - the classification of tmux's ambiguous exit 1, which it got wrong: every
+//     failure became an empty list, an unreachable socket read as "no sessions
+//     are live", and checkOrphanedProcesses turned that into an armed
+//     `kill pid N` for every live session's processes (#2874);
+//   - the tmuxCommandTimeout BOUND, which it lacked entirely. `af doctor --fix`
+//     re-lists before removing a stale home, so against a server that wedged
+//     mid-run an unbounded listing hangs the cleanup instead of refusing the
+//     removal it can no longer justify (#2910).
+//
+// Do not restore a "mirrors X" comment in either direction, and do not
+// re-inline the shell-out. State the property; keep the mechanism in one place.
 func listTmuxSessions(ctx *scanContext) ([]string, error) {
-	out, err := ctx.opts.Exec.Output(exec.Command("tmux", "ls", "-F", "#{session_name}"))
-	if err != nil {
-		if tmux.NoServerRunning(err) {
-			return nil, nil
-		}
-		diagnostic := tmux.CommandDiagnostic(err)
-		if diagnostic != "" {
-			diagnostic = " (" + diagnostic + ")"
-		}
-		return nil, fmt.Errorf("could not list tmux sessions%s: %w", diagnostic, err)
-	}
-	var names []string
-	for _, line := range strings.Split(string(out), "\n") {
-		if line = strings.TrimSpace(line); line != "" {
-			names = append(names, line)
-		}
-	}
-	return names, nil
+	return tmux.ListSessionNames(ctx.opts.Exec)
 }
 
 // tmuxSessions returns the run's memoized session listing, or the error that

--- a/doctor/tmux_sessions.go
+++ b/doctor/tmux_sessions.go
@@ -40,13 +40,16 @@ import (
 // (#2874). Do not restore a "mirrors X" comment in either direction. State the
 // property, so a copy of this code cannot inherit a bug by inheriting a claim.
 //
-// A missing tmux binary is a determinate empty, not blindness: af drives tmux
-// through PATH, so a tmux it cannot execute is a tmux that holds none of its
-// sessions.
+// A tmux binary missing from THIS process's PATH is blindness too, not a
+// determinate empty. It proves only that doctor could not invoke the client —
+// and doctor's PATH is not the sessions' PATH: a scan run from a cron job or a
+// systemd unit with a minimal PATH, or run across a package upgrade, can fail to
+// find a tmux whose server is up with live sessions. "I could not ask" is the
+// very thing this function exists to keep separate from "there is nothing there".
 func listTmuxSessions(ctx *scanContext) ([]string, error) {
 	out, err := ctx.opts.Exec.Output(exec.Command("tmux", "ls", "-F", "#{session_name}"))
 	if err != nil {
-		if tmux.NoServerRunning(err) || errors.Is(err, exec.ErrNotFound) {
+		if tmux.NoServerRunning(err) {
 			return nil, nil
 		}
 		diagnostic := tmux.CommandDiagnostic(err)
@@ -296,6 +299,26 @@ func liveTmuxHomes(ctx *scanContext) (map[string]bool, error) {
 	if err != nil {
 		return nil, err
 	}
+	return tmuxHomesFor(ctx, names)
+}
+
+// liveTmuxHomesNow is liveTmuxHomes against a FRESH listing rather than the
+// run's memo, for the fix-time recheck.
+//
+// The memo is right for detection — one run, one view. It is wrong for the
+// recheck, and the difference is the whole point of rechecking: findings are
+// applied after detection, so the session that must veto an rm -rf is precisely
+// the one that STARTED in that window, and it cannot appear in a listing taken
+// before the window opened. Re-reading markers for the old list would miss it.
+func liveTmuxHomesNow(ctx *scanContext) (map[string]bool, error) {
+	names, err := listTmuxSessions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return tmuxHomesFor(ctx, names)
+}
+
+func tmuxHomesFor(ctx *scanContext, names []string) (map[string]bool, error) {
 	homes := map[string]bool{}
 	var unreadable []string
 	for _, name := range names {

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -162,6 +162,48 @@ func NoServerRunning(err error) bool {
 	return exitOne && noTmuxServerDiagnostic(diagnostic)
 }
 
+// ListSessionNames returns the name of every session on the tmux server, or an
+// error when tmux could not tell us — the same three-valued contract
+// CleanupSessions applies to its own listing, and for the same reason: a caller
+// that reads a missing name as proof the session is DEAD will act on it.
+//
+// Exported for `af doctor` (#2874/#2910). Doctor shelled out to `tmux ls`
+// itself, which put its listing outside two invariants this package maintains
+// and states as obligations:
+//
+//   - the classification of tmux's ambiguous exit 1 (see NoServerRunning), and
+//   - the BOUND. Every tmux command here runs under tmuxCommandTimeout through
+//     boundedTmuxCommand, because a wedged server parks the client forever and a
+//     bare context is not a bound — it has to carry the process-group kill and
+//     WaitDelay too (#1787/#2099). Doctor's copy had neither, so `af doctor
+//     --fix` could hang in the cleanup phase against a server that wedged
+//     mid-run, instead of refusing the removal it could no longer justify.
+//
+// A tripped deadline is an error, never an empty list: a server that did not
+// answer has told us nothing about what is running on it.
+func ListSessionNames(cmdExec cmd.Executor) ([]string, error) {
+	ctx, cancel := tmuxTimeoutContext()
+	out, err := outputTmuxBoundedWith(ctx, cmdExec, "ls", "-F", "#{session_name}")
+	timedOut := ctx.Err() != nil
+	cancel()
+	if err != nil {
+		if timedOut {
+			return nil, fmt.Errorf("%w: tmux ls after %s", ErrTmuxTimeout, tmuxCommandTimeout)
+		}
+		if NoServerRunning(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("could not list tmux sessions%s: %w", tmuxDiagnosticSuffix(err), err)
+	}
+	var names []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			names = append(names, line)
+		}
+	}
+	return names, nil
+}
+
 // CommandDiagnostic returns what tmux wrote to stderr for a failed command,
 // whitespace-collapsed onto one line, or "" when there is nothing to report.
 //

--- a/session/tmux/cleanup_list_test.go
+++ b/session/tmux/cleanup_list_test.go
@@ -1,12 +1,14 @@
 package tmux
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/cmd"
 )
@@ -253,5 +255,45 @@ func TestCleanupSessionsAgainstRealTmuxSocket(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "could not list tmux sessions") {
 		t.Errorf("error = %q, want it to name the read that failed", err)
+	}
+}
+
+// TestListSessionNamesIsBounded is the #2910 regression. `af doctor --fix`
+// re-lists tmux sessions before it removes a stale AF home, so an unbounded
+// listing against a server that wedged mid-run hangs the cleanup phase instead
+// of refusing a removal it can no longer justify — a hang with no way out but
+// ^C, at the moment the user is already cleaning up.
+//
+// The stalling tmux sleeps in a CHILD, so passing requires the process-group
+// kill and WaitDelay, not just a context: a deadline alone leaves Output()
+// blocked on the inherited pipe.
+func TestListSessionNamesIsBounded(t *testing.T) {
+	stallingTmuxOnPath(t)
+	shortTmuxTimeout(t, 200*time.Millisecond)
+
+	done := make(chan struct{})
+	var names []string
+	var err error
+	go func() {
+		defer close(done)
+		names, err = ListSessionNames(cmd.MakeExecutor())
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("ListSessionNames never returned against a wedged tmux — an unbounded listing hangs " +
+			"`af doctor --fix` in its cleanup phase (#2910)")
+	}
+
+	if err == nil {
+		t.Fatalf("ListSessionNames returned (%v, nil) on a tripped deadline — a server that did not "+
+			"answer has told us nothing about what is running, and must never read as an empty list", names)
+	}
+	if !errors.Is(err, ErrTmuxTimeout) {
+		t.Errorf("error = %v, want ErrTmuxTimeout so callers can tell a wedge from a refusal", err)
+	}
+	if names != nil {
+		t.Errorf("names = %v, want nil alongside the error", names)
 	}
 }


### PR DESCRIPTION
Follow-up to #2877. That PR auto-merged on green CI a few minutes before the
Codex review landed, so both P1s it raised are still on master. Both were real,
and one of them is a regression #2877 introduced itself.

## 1. The fix-time recheck was reading the run's memo

`staleTempHomeRemoveFix` re-checks "does a live tmux session claim this home?"
before it `rm -rf`s, because a home with live sessions but a dead daemon holds no
lock for the authoritative probe to find. #2877 memoized the session listing on
`scanContext` — correct for detection, one run one view — and the recheck
silently inherited it.

That defeats the recheck. Findings are applied **after** detection, so the
session that must veto the removal is exactly the one that STARTED in that
window, and it cannot appear in a listing taken before the window opened.
Re-reading markers for the stale list misses it entirely. The pre-#2877 code
re-shelled `tmux ls` on every call, so this was a freshness regression, not a
pre-existing gap.

`liveTmuxHomesNow` re-lists; `liveTmuxHomes` keeps the memo for detection.

## 2. `exec.ErrNotFound` was treated as a determinate empty

#2877 justified it as: *af drives tmux through PATH, so a tmux it cannot execute
holds none of its sessions.* That is an inference about the environment, not a
fact about the server — and doctor's PATH is not the sessions' PATH. A scan from
a cron job or a systemd unit with a minimal PATH, or one straddling a package
upgrade, finds no tmux client while the server is up with live sessions. Every
`AF_SESSION` process then reads as a dead session's orphan, and `--fix` kills
them: this PR's own defect wearing the costume of an optimisation.

It now fails closed like every other unreadable listing, which also aligns doctor
with the reset side — `session/tmux.CleanupSessions` never accepted it.

## Tests

Both lock the behaviour with a fixture that **fails against master**:

- `TestStaleTempHomeFixRelistsTmux` — detection sees no sessions; by fix time one
  claims the home. The home must survive, with the refusal surfacing as a
  `FixErr` rather than a silent skip.
- `TestUninvokableTmuxClientIsBlindness` — a FAIL row naming the cause, and **no
  fix armed anywhere on the run**.

`macLikeTempHomeOptions` now models "tmux answered, no sessions" with an empty
successful listing instead of leaning on an error whose classification is the
subject of the tests above. That removed the last fixture driving tmux's exit-1
no-server *diagnostic* into the removal path, so
`TestDefinitiveNoTmuxServerStillAllowsTempHomeRemoval` covers it — refusing there
would leave abandoned temp homes uncollectable on exactly the machines where they
accumulate. That test idea is salvaged from #2906.

## On #2906

A sibling session independently produced the same fix on
`agent/audit-failed-read-empty` (its `ListingFoundNoServer` is functionally
identical to the `NoServerRunning` merged in #2877, and its comment reaches the
same conclusion about a missing binary being UNKNOWN). It was opened after #2877
merged, conflicts with master, and is closed. Rebasing it would land a **second**
classifier for the same judgement beside the first — the exact duplication that
caused #2870 and #2874 in the first place. Its one non-redundant test idea is
carried here instead.

## Verification

Local gate clean (`gofmt`, `go build`, `golangci-lint --fast`, `deadcode -test`,
`scripts/lint-file-length.sh`); `go test ./doctor/` green. Exercised with the
real binary against a throwaway home:

| scenario | row | exit |
| --- | --- | --- |
| unreachable socket | `FAIL tmux-inspection` | 1 |
| uninvokable client (`PATH=/nonexistent`) | `FAIL tmux-inspection` | 1 |
| definitive no-server | `PASS tmux-inspection: listed … (0)` | 0 |
| `--fix` on an indeterminate read | 0 lines claiming any action | 1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
