### PR TITLE
fix(attach): join the stdin pump before closing its descriptor

### DIFF
--- a/apiclient/attach.go
+++ b/apiclient/attach.go
@@ -243,9 +243,18 @@ func driveAttachStream(conn *websocket.Conn, handback *terminalHandback, in canc
 	// a PANIC did not, so it closed the fd straight out from under a blocked
 	// reader. That is the path #2784 added, so it is the path this has to cover.
 	//
-	// closeConn is in here for the same reason it is on the drained path: a pump
-	// parked in a WS write to a dead peer unblocks when the socket goes, so the
-	// join cannot outlast the write timeout.
+	// The socket is torn down here for the same reason it is on the drained path:
+	// a pump parked in a WS write to a dead peer unblocks when the socket goes, so
+	// the join cannot outlast the write timeout.
+	//
+	// CloseNow, NOT the graceful closeConn. A graceful close performs the close
+	// HANDSHAKE — 5s to write the frame plus 5s waiting for the peer's — and this
+	// runs BEFORE the terminal hand-back. On a panic, with the reader still parked
+	// in ReadMessage, that is up to ten seconds of the user staring at a raw
+	// terminal before the panic even surfaces: the exact cost #2784 exists to
+	// prevent, reintroduced by the fix for it. The unwind has no protocol left to
+	// be polite about; the detach path below still closes gracefully, because
+	// there the handshake is the point.
 	//
 	// pumpRunning gates the join on the goroutine below actually having been
 	// started — a panic before that leaves nothing to wait for, and waiting anyway
@@ -253,7 +262,7 @@ func driveAttachStream(conn *websocket.Conn, handback *terminalHandback, in canc
 	pumpRunning := false
 	defer func() {
 		_ = in.Cancel()
-		closeConn()
+		_ = conn.CloseNow()
 		if pumpRunning {
 			<-stdinDone
 		}

--- a/apiclient/attach.go
+++ b/apiclient/attach.go
@@ -137,7 +137,6 @@ var attachWriteTimeout = 10 * time.Second
 // locals up front so no goroutine re-reads package-level vars a test swaps back
 // in Cleanup.
 func driveAttachStream(conn *websocket.Conn, handback *terminalHandback, in cancelreader.CancelReader) {
-	defer in.Close()
 	// Give the terminal back on every exit from here — the drained detach at the
 	// bottom, a server disconnect, a signal, and the ones nobody wrote a handler
 	// for. A tail-called restore covers only the anticipated exits; #2784 is what
@@ -145,11 +144,11 @@ func driveAttachStream(conn *websocket.Conn, handback *terminalHandback, in canc
 	// the terminal back — and still crashes the process with its stack trace,
 	// because a recovered panic is a bug nobody ever sees. See terminalHandback.
 	//
-	// On the normal path the terminal still goes back exactly where it used to.
-	// Defers unwind last-registered-first, so this runs after the body has waited
-	// out copyDone (every byte the pane program wrote is on the terminal) and
-	// stdinDone (the input pump has proven it is gone, #2671), and still ahead of
-	// the in.Close registered above it.
+	// Registered FIRST so it unwinds LAST: the stdin pump has to be gone before
+	// the terminal goes back, or the stale reader eats the first post-attach
+	// keystroke (#2671). The reader teardown below is registered after this one
+	// and therefore runs before it, which is what keeps that ordering true on
+	// every exit rather than only on the drained one at the bottom.
 	defer handback.release()
 	// Snapshot EVERY package-level seam/tunable once, here, before any goroutine
 	// spawns. The goroutines then read only these locals — never the package vars
@@ -233,6 +232,33 @@ func driveAttachStream(conn *websocket.Conn, handback *terminalHandback, in canc
 	// terminal report ctrl+<key> as an escape sequence, and matching 0x17 alone
 	// left the user unable to detach at all (#1832). See detachkey.go.
 	stdinDone := make(chan struct{})
+	// The pump owns `in` for as long as it is running, so the descriptor must not
+	// be closed until the pump is STOPPED and JOINED. Closing a file out from
+	// under an in-flight Read is a data race — the reader is inside the fd while
+	// Close tears it down — and cancelreader exposes Cancel precisely so a caller
+	// never has to make Close do that job.
+	//
+	// Deferred, and in ONE place, because the ordering has to hold on the exits
+	// nobody writes by hand: the drained detach below reached it explicitly, and
+	// a PANIC did not, so it closed the fd straight out from under a blocked
+	// reader. That is the path #2784 added, so it is the path this has to cover.
+	//
+	// closeConn is in here for the same reason it is on the drained path: a pump
+	// parked in a WS write to a dead peer unblocks when the socket goes, so the
+	// join cannot outlast the write timeout.
+	//
+	// pumpRunning gates the join on the goroutine below actually having been
+	// started — a panic before that leaves nothing to wait for, and waiting anyway
+	// would hang the unwind forever.
+	pumpRunning := false
+	defer func() {
+		_ = in.Cancel()
+		closeConn()
+		if pumpRunning {
+			<-stdinDone
+		}
+		_ = in.Close()
+	}()
 	go func() {
 		defer close(stdinDone)
 		buf := make([]byte, 32)
@@ -255,6 +281,7 @@ func driveAttachStream(conn *websocket.Conn, handback *terminalHandback, in canc
 			}
 		}
 	}()
+	pumpRunning = true
 
 	// SIGWINCH → RESIZE, plus an initial RESIZE on connect so the pane matches the
 	// terminal immediately (the job the retired monitorWindowSize's forced initial
@@ -282,13 +309,9 @@ func driveAttachStream(conn *websocket.Conn, handback *terminalHandback, in canc
 	}()
 
 	<-copyDone
-	// A server close/MsgExit can end copyDone while stdin is still blocked. Cancel
-	// that read and wait for the pump to prove it has exited before restoring the
-	// terminal; requesting cancellation alone is not proof the reader is gone.
-	_ = in.Cancel()
-	closeConn()
-	<-stdinDone
-	// The terminal goes back from here via the deferred handback.release() above:
-	// the stream is fully drained (copyDone) and the stdin pump is gone, so the
-	// hand-back still lands strictly after any modes the pane program set.
+	// Everything after this is the deferred teardown above: a server close/MsgExit
+	// can end copyDone while stdin is still blocked, so the reader is cancelled and
+	// JOINED (requesting cancellation alone is not proof it is gone, #2671) before
+	// the descriptor closes, and the terminal goes back after that — still strictly
+	// after any modes the pane program set, because the stream is fully drained.
 }

--- a/apiclient/attach_pty_test.go
+++ b/apiclient/attach_pty_test.go
@@ -59,6 +59,11 @@ const (
 	// as the rest arrives, and it cannot be confused with a local terminal echo of
 	// those same bytes.
 	attachHelperSawPrefix = "AF-ATTACH-STREAM-SAW:"
+	// attachHelperEndedOnItsOwn is the helper giving up because the attach ended
+	// before anything exercised the exit under test. The parent checks for it: a
+	// child that never reached its case can still leave the parent's assertions
+	// satisfied, which is a vacuous pass rather than a failure.
+	attachHelperEndedOnItsOwn = "the attach ended on its own; nothing exercised the exit under test"
 )
 
 // TestAttachStream_PanicHandsTheTerminalBack is #2784. The attach driver panics
@@ -291,7 +296,16 @@ func TestAttachTerminalHandbackHelper(t *testing.T) {
 	}
 	fmt.Println(attachHelperReady)
 	<-done
-	t.Fatalf("helper: the attach ended on its own; nothing exercised the exit under test")
+	if mode == "panic" {
+		// done closes as the driver goroutine UNWINDS, so in this mode it fires
+		// while the runtime is already on its way out from the injected panic.
+		// Reporting "the attach ended on its own" here would be a lie about a case
+		// that did run, and it races the process exit — which is exactly how it
+		// showed up: intermittently, in the child, invisible to the parent. Let the
+		// panic be the only way out.
+		select {}
+	}
+	t.Fatalf("helper: %s", attachHelperEndedOnItsOwn)
 }
 
 // reportInputToStdout prints everything typed so far, each time an INPUT frame
@@ -424,8 +438,41 @@ func startAttachInPTY(t *testing.T, mode string) *ptyAttach {
 	t.Cleanup(func() {
 		_ = cmd.Process.Kill() // ErrProcessDone once it has been reaped
 		<-h.exited
+		h.requireCleanChildRun(t)
 	})
 	return h
+}
+
+// requireCleanChildRun fails the test for problems the CHILD reported, which the
+// parent would otherwise never see: its output goes to the pty, so a child that
+// died of a data race or gave up without reaching its case can still leave every
+// parent assertion satisfied. That is how the #2810 attach teardown race reached
+// master — the race was in the child, the parent was green, and it surfaced only
+// once it started failing unrelated PRs.
+func (h *ptyAttach) requireCleanChildRun(t *testing.T) {
+	t.Helper()
+	out := h.settledOutput()
+	require.NotContains(t, out, "DATA RACE",
+		"the helper process reported a data race; the pty output is the only place it appears")
+	require.NotContains(t, out, attachHelperEndedOnItsOwn,
+		"the helper never reached the exit it was started for, so whatever the parent asserted was vacuous")
+}
+
+// settledOutput waits for the drain to stop growing before reading it, so a
+// check for something the child printed just before exiting is not racing the
+// copy out of the pty. Bounded, and quiet-based rather than a fixed nap.
+func (h *ptyAttach) settledOutput() string {
+	deadline := time.Now().Add(5 * time.Second)
+	last := -1
+	for time.Now().Before(deadline) {
+		got := len(h.output())
+		if got == last {
+			break
+		}
+		last = got
+		time.Sleep(100 * time.Millisecond)
+	}
+	return h.output()
 }
 
 // shellTrapFor returns the shell trap that gives a mode its inherited-ignored


### PR DESCRIPTION
## Summary

The attach teardown I added in #2810 closes the stdin cancelreader while its pump goroutine is still blocked reading that descriptor. `-race` runs on every lane, so it is reddening unrelated PRs (found in #2903, a git/archive change).

**The race is on the PANIC path — the path #2784 added the deferred hand-back for.** The fix for #2784 raced on the exit it was written to cover. `defer in.Close()` was the first defer; the drained exit at the bottom cancels and joins the pump before returning, so that path closes a descriptor nothing is inside, but a panic skips all of it and closes the fd straight out from under a blocked reader.

## Fix

One ordered teardown, deferred so it covers the exits nobody writes by hand:

```go
defer func() {
    _ = in.Cancel()   // stop the reader …
    closeConn()       // … and unblock a pump parked in a WS write
    if pumpRunning {
        <-stdinDone   // … JOIN it …
    }
    _ = in.Close()    // … only then close the descriptor
}()
```

`Cancel` exists precisely so `Close` never has to be the thing that stops a reader. It is registered *after* the terminal hand-back so it still unwinds *before* it, which keeps #2671 — the pump is gone before the terminal goes back — true on every path rather than only on the drained one. `pumpRunning` gates the join, because a panic before the goroutine starts leaves nothing to wait for and waiting anyway would hang the unwind.

## Why this reached master, and the two test fixes for it

The pty tests run the attach in a **child** process, and the child's output goes to the pty — which the parent prints only on failure. So a child that died of a data race left the parent green. That blind spot is the actual reason a `-race` defect got through a `-race` gate.

- **The parent now fails on it.** Every pty test checks the child's output for `DATA RACE` and for the helper giving up. Verified: with the racy teardown restored, the guard catches it on the runs where the race manifests (**2/8**, against **0/8** visible before). It cannot make a race deterministic — nothing can — but a race that IS detected can no longer be swallowed.
- **The helper stopped lying.** It reported *"the attach ended on its own; nothing exercised the exit under test"* in panic mode, where `done` closes as the driver goroutine unwinds — so the guard fired while the process was already exiting, about a case that had in fact run. That is a vacuous pass waiting to happen, and the parent now treats it as a failure too.

## Validation

Fail-first, then fixed, both measured rather than argued:

| | racy teardown | fixed |
| --- | --- | --- |
| child race caught by the new guard | 2/8 (0/8 visible before the guard) | — |
| panic test under `-race` | — | **15/15 clean** |
| whole `apiclient` suite under `-race`, 3-way parallel | — | **6/6 clean** |

Cheap gates only, per policy — no container suite, nothing run against `daemon/` or `app/`:

- `gofmt -l .` (empty), `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...` (empty), `scripts/lint-file-length.sh`
- `go test ./apiclient -race` — the only package touched

Closes #2914
