### PR TITLE
ci: make the pinned integration test prove it resolved before trusting it

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -214,7 +214,26 @@ jobs:
       - name: Test abrupt daemon failure ownership
         env:
           AF_SYSTEMD_LIFECYCLE_TEST: "1"
-        run: go test -v -count=1 ./integration -run '^TestAbruptDaemonFailureReapsOwnedChildrenAndPreservesTmux$'
+        run: |
+          set -euo pipefail
+          pin='^TestAbruptDaemonFailureReapsOwnedChildrenAndPreservesTmux$'
+          # `go test -run` EXITS 0 when the pattern matches nothing — it prints
+          # "ok … [no tests to run]" and the job goes green having tested nothing.
+          # So a rename of this test silently retires the gate, on the merge path,
+          # and nobody reads the log of a green job (#2916).
+          #
+          # `-list` does not discriminate either: it also exits 0 with no match.
+          # The printed NAME COUNT is the only signal, so resolve the pin first and
+          # require exactly one match before running it.
+          matched="$(go test ./integration -list "$pin" | grep -c '^Test' || true)"
+          if [ "$matched" != "1" ]; then
+            echo "::error::the pinned test does not resolve — $matched matches for $pin"
+            echo "This gate would have run NOTHING and gone green. The test was renamed,"
+            echo "moved out of ./integration, or deleted; update the pin to match."
+            go test ./integration -list '.*' | grep '^TestAbrupt' || echo "(no TestAbrupt* in ./integration)"
+            exit 1
+          fi
+          go test -v -count=1 ./integration -run "$pin"
 
   # The web client's deterministic gates (#2069). Until this landed, NOTHING in
   # GitHub Actions ran them: the schedule/frame/icons parity tests, the typecheck,


### PR DESCRIPTION
## The mechanism

`go test -run '<pattern>'` **exits 0 when the pattern matches nothing**:

```
$ go test ./session/ -run '^TestThisNameDoesNotExistAnywhere$' -count=1
ok  	github.com/sachiniyer/agent-factory/session	0.039s [no tests to run]
$ echo $?
0
```

So a gate pinned to an exact test name stops testing the moment that test is renamed — and reports **success** while doing it. The miss is indistinguishable from the pass, the same disease as #2878 and #2822.

## Where it gated a merge

`pr.yml:217`, in `test-systemd` — which is in the required `Build` proxy's `needs`, so it is on the merge path.

**Failure scenario:** someone renames the test to `TestAbruptDaemonFailureReapsChildren` during a daemon-teardown refactor. Grepping a YAML file for a Go test name is not part of anyone's rename workflow. The step matches nothing, prints `ok … [no tests to run]`, exits 0; `test-systemd` goes green, `Build` goes green, the PR merges. The abrupt-daemon-failure reaping invariant — that a crashed daemon does not orphan its children or destroy tmux state — is now tested nowhere, and every later PR is green about it.

## The fix

`-list` also exits 0 either way, so the exit status is not the discriminator — the **printed name count** is. The step resolves the pin first, requires exactly one match, and on failure lists the near-misses so the fixer sees what to update it to.

Watched both directions with the guard body verbatim:

```
current pin             1 match   -> proceeds to run it
simulated rename        0 matches -> ::error:: + exit 1, listing
                                     TestAbruptDaemonFailureReapsOwnedChildrenAndPreservesTmux
old line, same rename   ok … [no tests to run], exit 0
```

## Scope

Six more instances live in Makefile targets and one scenario script (catalogued in #2916 with this recipe). **All nine pinned names resolve today** — latent, not a live outage. Those six are developer-facing rather than merge-gating: a human who typed the target sees "no tests to run" scroll past. This fixes the one that gates a merge.

## Test plan

- [x] YAML parses (`yaml.safe_load`)
- [x] Guard verified in both directions, verbatim
- [x] `gofmt -l .`, `go build ./...`, `golangci-lint`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — clean
- [x] The three node suites the Lint job runs: 25/17/24, 0 failures
- [x] No Go changed, so no `go test`; no container run

Closes #2916