### PR TITLE
fix(session): declare off-box-ness instead of re-deriving it per call site

### DIFF
--- a/session/backend_parity_test.go
+++ b/session/backend_parity_test.go
@@ -1,0 +1,54 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEveryRegisteredRuntimeDeclaresOffBox is the mechanism behind the
+// declaration, not a restatement of it.
+//
+// #2778 was a guard that enumerated the backends it knew about and missed a
+// path. Any hand-written `kind == A || kind == B || kind == C` is that hazard
+// waiting for the next backend: the new kind gets a Runtime from the registry
+// and is silently absent from the condition. Here, a kind registered without a
+// declaration fails this test instead.
+func TestEveryRegisteredRuntimeDeclaresOffBox(t *testing.T) {
+	for kind := range runtimeRegistry {
+		_, declared := backendProvisionsOffBox[kind]
+		assert.True(t, declared,
+			"backend %q is registered as a runtime but does not declare whether it provisions off-box; "+
+				"add it to backendProvisionsOffBox so create knows whether to resolve the repo's origin URL", kind)
+	}
+	for kind := range backendProvisionsOffBox {
+		_, registered := runtimeRegistry[kind]
+		assert.True(t, registered,
+			"backend %q declares off-box-ness but has no registered runtime; the declaration is dead", kind)
+	}
+}
+
+// The declaration must also cover every backend the config layer accepts, or a
+// user could select one that create then treats as local.
+func TestEverySupportedBackendDeclaresOffBox(t *testing.T) {
+	for _, name := range config.SupportedBackends {
+		kind, err := ParseBackendKind(name)
+		require.NoError(t, err, "config lists %q as supported but it does not parse as a backend kind", name)
+		_, declared := backendProvisionsOffBox[kind]
+		assert.True(t, declared, "supported backend %q does not declare whether it provisions off-box", name)
+	}
+}
+
+// The property itself: local uses the worktree in place, every off-box runtime
+// clones from the durable store and therefore needs the origin URL.
+func TestProvisionsOffBoxMatchesRuntimeShape(t *testing.T) {
+	assert.False(t, BackendLocal.ProvisionsOffBox(), "a local session runs in the worktree it already has")
+	for _, kind := range []BackendKind{BackendDocker, BackendSSH, BackendHook} {
+		assert.True(t, kind.ProvisionsOffBox(),
+			"%s provisions a workspace off the local filesystem and clones from origin", kind)
+	}
+	assert.False(t, BackendKind("not-a-backend").ProvisionsOffBox(),
+		"an unregistered kind must not be treated as off-box")
+}

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -137,7 +137,7 @@ func defaultBackendFactory(opts InstanceOptions, absPath string) (ProvisionResul
 	// with no origin yields "", and each runtime surfaces the actionable
 	// "no origin remote" error at create (the hook runtime hands the URL to
 	// launch_cmd, which does the clone on the user's infra).
-	if kind == BackendDocker || kind == BackendSSH || kind == BackendHook {
+	if kind.ProvisionsOffBox() {
 		spec.CloneURL = originRemoteURL(absPath)
 	}
 	return rt.Provision(spec)

--- a/session/runtime.go
+++ b/session/runtime.go
@@ -134,6 +134,34 @@ var runtimeRegistry = map[BackendKind]func() Runtime{
 	BackendSSH:    func() Runtime { return sshRuntime{} },
 }
 
+// backendProvisionsOffBox declares, per registered kind, whether the runtime
+// establishes the workspace somewhere other than the local filesystem.
+//
+// It is a DECLARATION beside the registry rather than a condition rewritten at
+// each call site. #2778 was exactly that hazard in another form — a guard that
+// enumerated the paths it knew about and silently missed one — and a hand-written
+// `kind == BackendDocker || kind == BackendSSH || kind == BackendHook` is the
+// same enumeration waiting for the next backend to be added.
+//
+// TestEveryRegisteredRuntimeDeclaresOffBox fails if a kind is registered without
+// an entry here, so the next backend cannot be added without answering this. That
+// test is the mechanism; this comment is not.
+var backendProvisionsOffBox = map[BackendKind]bool{
+	BackendLocal:  false,
+	BackendDocker: true,
+	BackendSSH:    true,
+	BackendHook:   true,
+}
+
+// ProvisionsOffBox reports whether kind runs the session's workspace off the
+// local filesystem. It is what decides whether a create resolves the repo's
+// origin URL for the runtime to clone from: an off-box runtime clones from the
+// durable store, a local one uses the worktree in place.
+//
+// An unregistered kind reports false, which is the conservative answer —
+// ParseBackendKind rejects those before they reach a runtime.
+func (k BackendKind) ProvisionsOffBox() bool { return backendProvisionsOffBox[k] }
+
 // SetRuntimeForTest replaces the Runtime registered for kind with ctor and
 // returns a restore function. It is the exported form of the registry swap the
 // in-package sandbox tests already do by hand, so tests OUTSIDE this package (the


### PR DESCRIPTION
## What

`create` decided whether to resolve the repo's origin URL behind a hand-maintained list:

```go
if kind == BackendDocker || kind == BackendSSH || kind == BackendHook {
    spec.CloneURL = originRemoteURL(absPath)
}
```

`runtimeRegistry` is documented as "the single source of truth for which runtimes exist", but it does not encode off-box-ness — and `BackendKind` had **no methods at all**, so this site re-derived the property by listing the three kinds it knew.

## Why it matters even though the list is correct today

The enumeration is the defect, not its contents. Register a fifth off-box backend — runtime, config key, `Provision` — and everything wires up **except this condition**. Its `Provision` then receives `spec.CloneURL == ""` and fails to clone.

The comment three lines above promises each runtime "surfaces the actionable *no origin remote* error at create". That becomes false for the new backend: an empty URL produced by a missing case is indistinguishable from a repo that genuinely has no origin, so the operator is sent to check their git remote for a bug in af's dispatch.

This is #2778's shape — a guard that enumerated the paths it knew about and missed one.

## Fix

`BackendKind.ProvisionsOffBox()`, declared once beside the registry, plus a test that fails when a kind is registered without declaring it. Verified by registering an undeclared backend:

```
backend "modal" is registered as a runtime but does not declare whether it
provisions off-box; add it to backendProvisionsOffBox so create knows whether
to resolve the repo's origin URL
```

The test is the mechanism. A comment asking the next author to remember is precisely what failed in #2778.

Also covered: every backend the *config layer* accepts must declare it too, so a user cannot select a supported backend that create then treats as local.

## The rest of the sweep was clean

Recorded in #2924 with reasons, so it is not re-checked:

- **Preview** — one implementation serves all three off-box backends; symmetric by construction.
- **Archive / restore** — derived from `backendKindForType`, not from a kind list.
- **Kill cleanup handles** and **capabilities** — already enforced by existing parity tests, which is why the surface was this clean.
- `BackendConfigError` (no Local case) and `runtimeNamespaceForKind` (default branch) — asymmetric with the reason stated.
- `BackendUnusableReason` checking `lookPath("docker")` but no ssh equivalent — **justified**: ssh uses `golang.org/x/crypto/ssh`, so there is no binary to look up. Verified in source rather than assumed; the only gap is that the reason is not written at that switch.

## Validation

- `gofmt -l .` (no output) · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `deadcode -test ./...` (no output) · `scripts/lint-file-length.sh`
- `go test ./session/` — the only package changed, non-daemon and non-app

No containerized suite; nothing run against `./daemon/...` or `./app/...`.

Closes #2924
