### PR TITLE
fix(daemon): stop the preview origin's capability label leaking upstream (#2921)

### DIFF
--- a/daemon/preview_origin.go
+++ b/daemon/preview_origin.go
@@ -66,7 +66,11 @@ import (
 // box, and a browser page that did reach the port still cannot read the response
 // (no ACAO). A local process could, but a local process can already reach the
 // control plane, which is tokenless on loopback by default. The dev server itself
-// never sees the label: the proxy sets the upstream Host to the target's own.
+// never sees the label: the proxy rewrites EVERY header that carries the
+// browser-facing origin — Host, X-Forwarded-Host, Origin and Referer — to the
+// target's own address (rewriteOriginHeader). That set is the invariant: any future
+// header quoting the request's origin has to join it, or the credential ends up in
+// an ordinary dev-server request log.
 //
 // REMOTE VIEWERS ARE UNCHANGED. A browser off this machine resolves *.localhost to
 // ITS OWN loopback, so per-tab origins are localhost-only by nature. The web client

--- a/daemon/preview_origin_test.go
+++ b/daemon/preview_origin_test.go
@@ -340,6 +340,60 @@ func upstreamHost(t *testing.T, raw string) string {
 	return u.Host
 }
 
+// TestPreviewOrigin_NoHeaderCarriesTheLabelUpstream pins the CLASS, not the one
+// header that was found first. The tab's hostname IS its credential, and
+// ReverseProxy clones inbound headers — so every header quoting the browser-facing
+// origin hands that credential to the untrusted dev server, which writes it straight
+// into an ordinary request log (Vite, Django and Rails all log by default).
+//
+// Host and X-Forwarded-Host were the two already covered. Origin (sent on any
+// non-GET fetch the app makes) and Referer (sent on essentially every sub-resource)
+// were not, and were reaching the upstream verbatim. This asserts on the WHOLE
+// header set rather than naming the ones known today, so a future header that quotes
+// the request origin trips it instead of quietly joining the leak.
+func TestPreviewOrigin_NoHeaderCarriesTheLabelUpstream(t *testing.T) {
+	seen := make(chan http.Header, 4)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := r.Header.Clone()
+		h.Set("Host-Pseudo-Header", r.Host)
+		seen <- h
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	m, previewAddr, sessionID, tabIDs := newPreviewOriginFixture(t, upstream.URL)
+	host := previewHostOf(t, m, previewAddr, sessionID, tabIDs[0])
+	label, ok := previewHostLabel(host)
+	require.True(t, ok)
+
+	// A browser framing this origin sends both of these on an app's own fetch.
+	req, err := http.NewRequest(http.MethodPost, "http://"+previewAddr+"/api/save", strings.NewReader("{}"))
+	require.NoError(t, err)
+	req.Host = host
+	req.Header.Set("Origin", "http://"+host)
+	req.Header.Set("Referer", "http://"+host+"/app/page?doc=1")
+	resp, err := previewHTTPClient().Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	got := <-seen
+	for name, values := range got {
+		for _, v := range values {
+			require.NotContains(t, v, label,
+				"header %s carried the tab's capability label to the dev server", name)
+		}
+	}
+
+	// Rewritten to the target's own address, not dropped: an Origin-checking CSRF
+	// guard must see a value that agrees with its own Host, and Referer's path is
+	// ordinary app data worth keeping.
+	targetURL, err := url.Parse(upstream.URL)
+	require.NoError(t, err)
+	require.Equal(t, "http://"+targetURL.Host, got.Get("Origin"))
+	require.Equal(t, "http://"+targetURL.Host+"/app/page?doc=1", got.Get("Referer"),
+		"only the ORIGIN part of Referer is secret — its path and query survive")
+}
+
 // TestPreviewOrigin_RewritesSetCookieToItsOwnHost pins the cookie half of the
 // isolation. rewriteSetCookiePaths drops Domain, so a dev server that tries to set
 // Domain=localhost — which every per-tab origin would then send, defeating the

--- a/daemon/webtab_proxy.go
+++ b/daemon/webtab_proxy.go
@@ -534,6 +534,37 @@ func rewriteRefreshURL(h http.Header, prefix string, target *url.URL) {
 	h.Set("Refresh", strings.TrimSpace(delay)+"; url="+quote+dest+quote)
 }
 
+// rewriteOriginHeader replaces the browser-facing origin in the request headers that
+// carry one — Origin and Referer — with the upstream target's own.
+//
+// It exists because the per-tab preview origin's HOSTNAME is that tab's credential
+// (#1856), and a header quoting it hands that credential to the untrusted dev server,
+// which will write it into an ordinary request log. Host and X-Forwarded-Host are
+// handled at the call site; these two are the rest of the class.
+//
+// Rewritten, not deleted: an app that checks Origin for CSRF should see the same
+// value it would have seen served directly, and Referer's path/query are ordinary
+// app data — only its origin part is secret, so only that part changes. A Referer
+// that does not parse is dropped rather than forwarded, since it cannot be edited
+// safely and no correct app depends on a malformed one.
+func rewriteOriginHeader(h http.Header, target *url.URL) {
+	targetOrigin := target.Scheme + "://" + target.Host
+	if h.Get("Origin") != "" {
+		h.Set("Origin", targetOrigin)
+	}
+	ref := h.Get("Referer")
+	if ref == "" {
+		return
+	}
+	parsed, err := url.Parse(ref)
+	if err != nil {
+		h.Del("Referer")
+		return
+	}
+	parsed.Scheme, parsed.Host, parsed.User = target.Scheme, target.Host, nil
+	h.Set("Referer", parsed.String())
+}
+
 // corsGrantHeaders are the response headers by which a server hands a DIFFERENT
 // origin permission to read it (or to time it). Every one is stripped from an
 // upstream response on a per-tab preview origin: cross-tab isolation there is the

--- a/daemon/webtab_serve.go
+++ b/daemon/webtab_serve.go
@@ -406,8 +406,33 @@ func (cs *controlServer) serveWebTabRoute(w http.ResponseWriter, r *http.Request
 			// dev server the origin exists to contain, where any request log keeps it.
 			// pr.Out.Host is already the target's; this makes the header agree with it,
 			// which is also the honest answer (it is the host the app serves itself on).
-			if route.previewOrigin {
+			// Skipped for a SOCKET-backed target, whose "host" is the dummy
+			// vscode.invalid: rewriting to a name that never reaches a wire would tell
+			// code-server its browser-facing host does not exist, and it validates its
+			// WebSocket upgrade against X-Forwarded-Host — the editor would load and
+			// then fail to connect. The exemption is principled: these rewrites keep a
+			// tab's capability label away from UNTRUSTED repo/agent-controlled content,
+			// and a socket target is a code-server the daemon itself spawned, which
+			// would learn only a label authorizing its own tab. Found on #2743's review;
+			// applied here too, since this PR extends the same rewrite to two more
+			// headers and would otherwise reintroduce it through them.
+			if route.previewOrigin && !target.isUnixSocket() {
 				pr.Out.Header.Set("X-Forwarded-Host", targetURL.Host)
+				// X-Forwarded-Host was one INSTANCE of a class, not the whole of it.
+				// ReverseProxy clones the inbound headers, so every header that carries
+				// the BROWSER-facing origin reaches the dev server verbatim — and on this
+				// route that origin is the tab's unguessable capability label. Origin (on
+				// any non-GET fetch the app makes) and Referer (on essentially every
+				// sub-resource) both carry it, so a dev server that logs requests — Vite,
+				// Django, Rails, all of them by default — writes the credential into its
+				// log file.
+				//
+				// Both are rewritten to the target's own address rather than deleted:
+				// that is what the app would have seen served directly, so an
+				// Origin-checking CSRF guard now agrees with its own Host instead of
+				// seeing a name it does not recognize. Referer keeps its path and query,
+				// since only the origin part is the secret.
+				rewriteOriginHeader(pr.Out.Header, targetURL)
 			}
 		},
 		ModifyResponse: func(resp *http.Response) error {


### PR DESCRIPTION
From a proactive sweep of the web-tab proxy invariants as a set (#2921). This PR
fixes the one finding that is a security-shaped invariant violation; the other
finding and the verified-clean results are recorded on the issue.

## The class

On a per-tab preview origin the request's **hostname is that tab's credential**.
`httputil.ReverseProxy` clones the inbound headers, and this proxy's `Rewrite` only
ever touched `Authorization`, cookies and `X-Forwarded-*` — so every *other* header
quoting the browser-facing origin reached the dev server verbatim.

A Codex review on #2833 caught `X-Forwarded-Host`. That was **one instance of a
class**, and the class had two more members:

- **`Origin`** — sent on any non-GET fetch the framed app makes;
- **`Referer`** — sent on essentially every sub-resource request.

## Failure scenario

A previewed Vite app POSTs to its own `/api`. The browser attaches
`Origin: http://af<label>.localhost:8444`. The proxy forwards it. Vite logs the
request — as do Django, Rails and every other dev server, by default — so the tab's
credential is written in plaintext to a log file on disk, where any local process or
backup can read it, and where a `--log` upload or a pasted traceback carries it
further.

It also made af's own comment false. `preview_origin.go` claimed *"the dev server
itself never sees the label: the proxy sets the upstream Host to the target's own."*
True of `Host`. False of three other headers.

## Bounded, and the PR should say so

The leaked label is the tab's **own**, so the dev server learns a credential for the
origin it is already serving — no cross-tab reach. And `af….localhost` resolves to the
*reader's* loopback, so a remote reader cannot use it. The defect is that a credential
is written into an untrusted party's log while the code asserts that it is not.

## The fix

`rewriteOriginHeader` rewrites both headers to the target's own address on
preview-origin routes only; the mirrored route is untouched.

**Rewritten, not deleted**, and that is the better behavior independently: an
Origin-checking CSRF guard now sees a value that agrees with its own `Host`, where
today it sees `af<label>.localhost` — a name it does not recognize and may refuse.
Referer keeps its path and query, since only the origin part is secret. A Referer that
does not parse is dropped rather than forwarded, because it cannot be edited safely
and no correct app depends on a malformed one.

## Test

`TestPreviewOrigin_NoHeaderCarriesTheLabelUpstream` captures the **entire** header set
the upstream receives and asserts the label appears in none of it — rather than naming
the three headers known today. A future header that quotes the request origin trips
this test instead of quietly joining the leak. It also pins the rewrite *values*, so
"fixing" it by deleting the headers (and breaking CSRF guards) would not pass.

## Also on the issue, not fixed here

Framed routes still answer several failures with the JSON envelope — including the
common tab-gone/archived 404 — against the invariant stated in `webtab_serve.go`
itself. Filed rather than fixed because the obvious repair changes the status code on
a route the mirror shares, and I can't run `go test ./daemon/...` on this host to see
what moves. It deserves its own PR with CI watching.

Closes #2921

🤖 Generated with [Claude Code](https://claude.com/claude-code)
