### PR TITLE
fix(tui): stop the footer advertising two key pairs that cannot fire

### DIFF
--- a/app/home_model.go
+++ b/app/home_model.go
@@ -888,6 +888,23 @@ func (m *home) syncFocus() {
 	m.menu.SetFocusRegion(active)
 	m.syncSplitPaneHint()
 	m.syncScrollHint()
+	// ←/→ move focus between VISIBLE panes, and focusAdjacentPane returns early
+	// below two of them, so the pair is inert with one pane open. Advertising it
+	// there is the same dead-affordance class as #2830/#2864.
+	m.menu.SetPaneCycleAvailable(len(m.visiblePanes) > 1)
+	m.syncProjectsHint()
+}
+
+// syncProjectsHint keeps the Projects footer's row-scoped verbs (Enter switch,
+// D delete) in step with whether the section HAS a row. Both act on the cursor,
+// and handleProjectsFocus consumes each as a no-op when SelectedProject reports
+// false, so an empty section must advertise neither.
+//
+// Called from syncFocus AND from both project refreshes: rows change on a
+// background poll, which is not guaranteed to reach a relayout, and a stale
+// gate here would re-advertise a verb that had just gone inert.
+func (m *home) syncProjectsHint() {
+	m.menu.SetProjectRowsAvailable(m.projects.HasProjects())
 }
 
 // focusRegion moves focus directly to the given region and re-solves the

--- a/app/switch_project.go
+++ b/app/switch_project.go
@@ -155,6 +155,7 @@ func (m *home) projectRows(projects []overlay.Project) []ui.SidebarProject {
 // launch and on project switch (paths that fetch synchronously).
 func (m *home) refreshSidebarProjects() {
 	m.projects.SetProjects(m.projectRows(m.buildProjectList()))
+	m.syncProjectsHint()
 }
 
 // refreshSidebarProjectsFromSnapshot rebuilds the Projects rows from the all-repos
@@ -167,7 +168,9 @@ func (m *home) refreshSidebarProjectsFromSnapshot(data []session.InstanceData, f
 		log.WarningLog.Printf("failed to refresh projects section: %v", fetchErr)
 		return false
 	}
-	return m.projects.SetProjects(m.projectRows(m.buildProjectListFrom(data)))
+	changed := m.projects.SetProjects(m.projectRows(m.buildProjectListFrom(data)))
+	m.syncProjectsHint()
+	return changed
 }
 
 // switchToProjectRoot resolves a Projects-section row's repo root and switches

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"math"
+	"slices"
 	"strings"
 
 	"github.com/sachiniyer/agent-factory/keys"
@@ -82,6 +83,15 @@ type Menu struct {
 	// `S` can commit as another pane. Without that preview the key no-ops, so
 	// the footer must not advertise it (#1419).
 	splitPaneAvailable bool
+	// paneCycleAvailable is true only while a SECOND visible pane exists for
+	// ←/→ to move focus to. focusAdjacentPane returns early below two visible
+	// panes, so with one open the pair is inert and advertising it is a lie.
+	paneCycleAvailable bool
+	// projectRowsAvailable is true only while the Projects section has a row
+	// under its cursor. Enter and `D` there are row-scoped — SelectedProject
+	// reports false with none, and handleProjectsFocus consumes both as no-ops
+	// — so an empty section must advertise neither.
+	projectRowsAvailable bool
 	// statusText temporarily replaces key hints with a plain status row. Used
 	// for pointer gestures that need feedback but should not advertise
 	// clickable key zones while the gesture is in flight.
@@ -136,6 +146,27 @@ var automationsMenuOptions = []keys.KeyName{
 // do nothing.
 var projectsMenuOptions = []keys.KeyName{
 	keys.KeySwitchProjectRow, keys.KeyDeleteProject, keys.KeySearch, keys.KeyTab, keys.KeyHelp, keys.KeyQuit,
+}
+
+// projectsRowVerbs are the entries of projectsMenuOptions that act on the
+// CURSOR'S ROW, so an empty section can offer neither.
+var projectsRowVerbs = []keys.KeyName{keys.KeySwitchProjectRow, keys.KeyDeleteProject}
+
+// projectsOptions drops the row-scoped verbs when the section has no rows. The
+// comment above claims this set "advertises exactly the keys that DO something
+// there" — that was only true with a row under the cursor.
+func (m *Menu) projectsOptions() []keys.KeyName {
+	if m.projectRowsAvailable {
+		return projectsMenuOptions
+	}
+	opts := make([]keys.KeyName, 0, len(projectsMenuOptions))
+	for _, k := range projectsMenuOptions {
+		if slices.Contains(projectsRowVerbs, k) {
+			continue
+		}
+		opts = append(opts, k)
+	}
+	return opts
 }
 
 // interactiveMenuOptions is the whole bar while interactive (#1089, RFC
@@ -218,6 +249,29 @@ func (m *Menu) SetSplitPaneAvailable(available bool) {
 	m.updateOptions()
 }
 
+// SetPaneCycleAvailable controls whether the focused-pane hints advertise the
+// ←/→ pane-focus pair. Like the split-pane hint, the keys stay globally bound;
+// this only keeps the footer honest when there is nowhere for them to move
+// focus to.
+func (m *Menu) SetPaneCycleAvailable(available bool) {
+	if m.paneCycleAvailable == available {
+		return
+	}
+	m.paneCycleAvailable = available
+	m.updateOptions()
+}
+
+// SetProjectRowsAvailable controls whether the Projects hints advertise the
+// row-scoped verbs (Enter switch, D delete). Both act on the cursor's row, so
+// with no rows they are consumed as no-ops and must not be offered.
+func (m *Menu) SetProjectRowsAvailable(available bool) {
+	if m.projectRowsAvailable == available {
+		return
+	}
+	m.projectRowsAvailable = available
+	m.updateOptions()
+}
+
 // SetStatusText temporarily replaces the hint row with a centered status
 // message. Empty restores the normal context-sensitive key hints.
 func (m *Menu) SetStatusText(text string) {
@@ -251,10 +305,14 @@ func (m *Menu) updateOptions() {
 	// the automations branch: Enter switch / `/` search are its actions, the rest
 	// is cross-region chrome. Naming's submit/change-program hints still win.
 	if m.focusRegion == layout.RegionProjects && m.state != StateNewInstance {
-		m.options = projectsMenuOptions
+		m.options = m.projectsOptions()
+		actionEnd := 0
+		if m.projectRowsAvailable {
+			actionEnd = 2
+		}
 		m.groups = []menuGroup{
-			{start: 0, end: 2, isAction: true},
-			{start: 2, end: len(projectsMenuOptions), isAction: false},
+			{start: 0, end: actionEnd, isAction: true},
+			{start: actionEnd, end: len(m.options), isAction: false},
 		}
 		return
 	}
@@ -454,7 +512,10 @@ func (m *Menu) setPaneFocusOptions() {
 	if m.scrollAvailable {
 		actionGroup = append(actionGroup, keys.KeyShiftUp, keys.KeyShiftDown)
 	}
-	focusGroup := []keys.KeyName{keys.KeyPanePrev, keys.KeyPaneNext}
+	var focusGroup []keys.KeyName
+	if m.paneCycleAvailable {
+		focusGroup = []keys.KeyName{keys.KeyPanePrev, keys.KeyPaneNext}
+	}
 	paneGroup := []keys.KeyName{keys.KeyOpenPane}
 	if m.splitPaneAvailable {
 		paneGroup = append(paneGroup, keys.KeySplitPane)

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -510,6 +510,9 @@ func TestMenuPaneHintsFollowFocus(t *testing.T) {
 	m.SetSplitPaneAvailable(false)
 
 	m.SetFocusRegion(layout.PaneRegion(7))
+	// A SECOND visible pane, which is what makes ←/→ meaningful: with one pane
+	// focusAdjacentPane has nowhere to move focus and the pair is gated off.
+	m.SetPaneCycleAvailable(true)
 	if !has(keys.KeyOpenPane) || has(keys.KeySplitPane) || !has(keys.KeyHidePane) ||
 		!has(keys.KeyPanePrev) || !has(keys.KeyPaneNext) || !has(keys.KeyEnter) {
 		t.Errorf("a focused pane must advertise pane focus/open/hide + attach, not split without a preview; options=%v", m.options)
@@ -533,6 +536,10 @@ func TestMenuProjectsFocusFooterIsHonest(t *testing.T) {
 	m := NewMenu()
 	m.SetInstance(readyUIInstance())
 	m.SetFocusRegion(layout.RegionProjects)
+	// A row under the cursor, which is what makes Enter and `D` live at all.
+	// The empty section is the same honesty question one state further out and
+	// has its own test: handleProjectsFocus consumes both as no-ops with no rows.
+	m.SetProjectRowsAvailable(true)
 
 	has := func(want keys.KeyName) bool {
 		for _, k := range m.options {
@@ -645,6 +652,79 @@ func TestMenuScrollChipKeepsBothClickZones(t *testing.T) {
 		}
 		if got := cellSlice(line, r.X, r.X+r.W); got != want {
 			t.Fatalf("the %q zone covers %q, want the key's own glyph", want, got)
+		}
+	}
+}
+
+// The footer must not offer a key that cannot fire from the state it is shown
+// in. menu.go already gates several — `S split pane` on a live preview (#1419),
+// the scroll pair on a truthful history owner, tab verbs on TabManagement,
+// retry/handoff on a limit wall — and the whole tree row on StateEmpty. These
+// two were the ungated ones, and each is a documented no-op in the state it was
+// still advertised in.
+
+// ←/→ move focus between VISIBLE panes; focusAdjacentPane returns early below
+// two of them, so with one pane open the pair does nothing at all.
+func TestMenuHidesPaneCycleWithNothingToCycleTo(t *testing.T) {
+	m := NewMenu()
+	m.SetInstance(readyUIInstance())
+	m.SetFocusRegion(layout.PaneRegion(1))
+	m.SetSize(200, 1)
+
+	out := xansi.Strip(m.String())
+	if strings.Contains(out, "prev pane") || strings.Contains(out, "next pane") {
+		t.Fatalf("one visible pane has nowhere to move focus to:\n%s", out)
+	}
+
+	m.SetPaneCycleAvailable(true)
+	out = xansi.Strip(m.String())
+	if !strings.Contains(out, "prev pane") || !strings.Contains(out, "next pane") {
+		t.Fatalf("a second visible pane makes the pair live and it must be offered:\n%s", out)
+	}
+}
+
+// Enter and `D` in the Projects section act on the CURSOR'S ROW.
+// handleProjectsFocus consumes both as no-ops when SelectedProject reports
+// false, which is every time the section is empty.
+func TestMenuHidesProjectRowVerbsWithNoRows(t *testing.T) {
+	m := NewMenu()
+	m.SetFocusRegion(layout.RegionProjects)
+	m.SetSize(200, 1)
+
+	out := xansi.Strip(m.String())
+	if strings.Contains(out, "switch") || strings.Contains(out, "delete project") {
+		t.Fatalf("an empty Projects section has no row for these to act on:\n%s", out)
+	}
+	// The section is still escapable and searchable — gating the row verbs must
+	// not strand the user in it.
+	for _, want := range []string{"search", "focus", "help", "quit"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("the way out of the section must survive; missing %q:\n%s", want, out)
+		}
+	}
+
+	m.SetProjectRowsAvailable(true)
+	out = xansi.Strip(m.String())
+	if !strings.Contains(out, "switch") || !strings.Contains(out, "delete project") {
+		t.Fatalf("with a row under the cursor both verbs are live and must be offered:\n%s", out)
+	}
+}
+
+// The gate must not disturb the row's group styling/separators, which are
+// computed from indices into the option slice.
+func TestMenuProjectsRowStaysWellFormedWhenGated(t *testing.T) {
+	for _, rows := range []bool{false, true} {
+		m := NewMenu()
+		m.SetFocusRegion(layout.RegionProjects)
+		m.SetProjectRowsAvailable(rows)
+		m.SetSize(200, 1)
+
+		out := xansi.Strip(m.String())
+		if strings.Contains(out, "  │") || strings.Contains(out, "│  ·") {
+			t.Fatalf("rows=%v: dangling separator in the hint row:\n%s", rows, out)
+		}
+		if strings.HasPrefix(strings.TrimSpace(out), "·") || strings.HasPrefix(strings.TrimSpace(out), "│") {
+			t.Fatalf("rows=%v: the row must not open with a separator:\n%s", rows, out)
 		}
 	}
 }


### PR DESCRIPTION
Proactive audit for the class behind #2830 / #2848 / #2864 — **an affordance that
lies**: a key the footer advertises which cannot fire from the state it is shown
in. Full findings, method and clean results in #2926.

## The mechanism

`ui/menu.go` already gates most hints on whether the action can fire:

| hint | gated on |
| --- | --- |
| `S split pane` | a live preview to commit (#1419) |
| `ctrl+u/ctrl+d` | a truthful host-history owner |
| `t` / `w` | the backend's TabManagement capability (#988) |
| `c` / `F` | the session actually at a limit wall (#2085) |
| `a` vs `r` | the row's lifecycle action (#1605) |
| the whole instance row | `StateEmpty` vs `StateDefault` |

That is a real discipline. **Two sets escaped it**, and each is a *documented*
no-op in the state it was still advertised in.

### Projects row verbs with no rows

`enter switch` and `D delete project` both act on the cursor's row, and
`handleProjectsFocus` consumes each as a no-op when `SelectedProject` reports
false — every time the section is empty. Its own comment claimed the bar
"advertises exactly the keys that DO something there"; that held only with a row.

Fresh install, nothing registered, tab into Projects: two dead keys side by side,
on the one section the user is trying to understand.

### ←/→ with one pane

`focusAdjacentPane` opens with `if delta == 0 || len(m.visiblePanes) < 2 { … }`,
but the pair was added unconditionally. Distinct from the edge clamp, which is
fine — with two panes the pair stays meaningful and only one direction is spent.
With one pane it is inert outright, and one pane is the common case at 80 columns.

## The fix

The treatment the file already gives `S`: availability setters
(`SetPaneCycleAvailable`, `SetProjectRowsAvailable`) fed from `syncFocus`.

The Projects gate is additionally refreshed where the rows change
(`refreshSidebarProjects` / `…FromSnapshot`): a background poll can empty the
section without reaching a relayout, and a stale gate would re-offer a verb that
had just gone inert. That is the same "the poll contradicts the other path" shape
as #2864, so it is guarded rather than assumed.

## Tests, and the two I changed

New coverage in `ui` (runnable without a container): each pair hidden when
unavailable, shown when available, the way out of the section surviving the gate,
and the hint row staying well-formed with no dangling separator.

**Both gates were mutation-verified** — I wrote the fix first here, so I un-gated
each in turn and confirmed its test fails. Neither passes vacuously.

Two existing tests pinned the ungated behavior and are updated, not weakened:
`TestMenuProjectsFocusFooterIsHonest` and `TestMenuPaneHintsFollowFocus` are both
named for this exact principle and simply predate the states in question, so each
now sets the availability it always meant — a second pane, a row under the cursor
— and the empty cases get their own tests.

## Found but deliberately not fixed

`esc` returns focus to the tree from both captive sections, is routed in both
handlers, and appears in **neither** footer nor the `?` help overlay. Severity is
low (`tab` also cycles out, so nobody is trapped), but it is a real capability
with zero discoverability. Putting it on a row that already sheds by width — and
adding a canonical binding-table entry for it — is a product call rather than a
defect fix, so it is recorded in #2926 rather than decided here.

## On method

I did **not** drive a live TUI: the container harnesses are off under the
no-containers policy, and running `af` bare here would start a second daemon
beside the maintainer's live one. This is derived from the routing code and
covered by unit tests, not observed on a screen. #2926 says the same, and lists
what came back clean so the next person does not re-check it.

## Gate

`gofmt -l .` (empty), `go build ./...`, `golangci-lint run --timeout=3m --fast`,
`deadcode -test ./...` (empty), `scripts/lint-file-length.sh`, `go test ./ui/...`
(7 packages ok). The `app` tests are left to CI.

Closes #2926

-- Captain Claude
