### PR TITLE
fix(daemon): show a task that was refused arming instead of leaving it looking healthy

### DIFF
--- a/daemon/task_arming.go
+++ b/daemon/task_arming.go
@@ -3,9 +3,11 @@ package daemon
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/task"
 )
 
@@ -38,8 +40,10 @@ func (m *Manager) persistedTasksForArming() (taskArmingSnapshot, error) {
 		validation := m.prepareTaskTargetValidation(candidate.RepoID, target, true)
 		if err := m.validateEnabledTaskTarget(candidate, validation); err != nil {
 			snapshot.refused = append(snapshot.refused, fmt.Errorf("persisted task %q was not armed because its target relationship is unsafe: %w", candidate.ID, err))
+			m.recordArmingStatus(candidate, notArmedStatus(err))
 			continue
 		}
+		m.clearStaleNotArmedStatus(candidate)
 		snapshot.safe = append(snapshot.safe, candidate)
 	}
 	return snapshot, nil
@@ -95,4 +99,58 @@ func taskRepoIDForValidation(projectPath string) string {
 		return ""
 	}
 	return repo.ID
+}
+
+// notArmedPrefix marks a LastRunStatus written by arming rather than by a run.
+// It carries the "errored:" prefix the TUI already keys on to render a task as
+// failed (ui/task_pane.go), so a refusal shows up where people look without a
+// new surface to build or discover.
+const notArmedPrefix = "errored: not armed — "
+
+func notArmedStatus(cause error) string {
+	return notArmedPrefix + cause.Error()
+}
+
+// recordArmingStatus writes a refusal onto the task's own status.
+//
+// Without this a refused task is INDISTINGUISHABLE FROM A HEALTHY ONE: it stays
+// enabled on disk, keeps whatever LastRunStatus its last successful run wrote,
+// and is absent from both cron and watch. The only trace is one joined warning
+// at daemon startup, and armed-ness is exposed on no surface —
+// scheduledTaskIDs/watchingTaskIDs have no production callers. On a box nobody
+// opens the TUI on, which is the case this daemon exists to serve, a nightly
+// task can stop running forever while every surface says it ran fine (#2929).
+//
+// LastRunAt is deliberately left alone (UpdateTaskStatus's nil mode): arming is
+// a supervision decision, not a run, so the timestamp of the last real delivery
+// must survive it.
+//
+// Written only when the status actually changes. Arming runs on every task CRUD
+// as well as at startup, and a persistently refused task must not rewrite
+// tasks.json each time.
+func (m *Manager) recordArmingStatus(t task.Task, status string) {
+	if t.LastRunStatus == status {
+		return
+	}
+	if err := task.UpdateTaskStatus(t.ID, nil, status); err != nil {
+		log.WarningLog.Printf("could not record the arming status for task %q: %v", t.ID, err)
+		return
+	}
+	t.LastRunStatus = status
+	m.publishEvent(agentproto.EventTaskUpdated, t)
+}
+
+// clearStaleNotArmedStatus removes a not-armed status from a task that is armed
+// again, so the refusal does not outlive the condition that caused it. A task
+// whose target came back would otherwise keep claiming it is unarmed until its
+// next run writes a real status — up to a full day for a nightly schedule, and
+// indefinitely for a watch task that has not fired.
+//
+// Only statuses this file wrote are cleared; a genuine "errored:" from a failed
+// run is left exactly as the run recorded it.
+func (m *Manager) clearStaleNotArmedStatus(t task.Task) {
+	if !strings.HasPrefix(t.LastRunStatus, notArmedPrefix) {
+		return
+	}
+	m.recordArmingStatus(t, "")
 }

--- a/daemon/task_arming.go
+++ b/daemon/task_arming.go
@@ -33,16 +33,18 @@ func (m *Manager) persistedTasksForArming() (taskArmingSnapshot, error) {
 	}
 	for _, candidate := range tasks {
 		target := task.CanonicalTargetSession(candidate.TargetSession)
-		if !candidate.Enabled || target == "" {
-			snapshot.safe = append(snapshot.safe, candidate)
-			continue
+		if candidate.Enabled && target != "" {
+			validation := m.prepareTaskTargetValidation(candidate.RepoID, target, true)
+			if err := m.validateEnabledTaskTarget(candidate, validation); err != nil {
+				snapshot.refused = append(snapshot.refused, fmt.Errorf("persisted task %q was not armed because its target relationship is unsafe: %w", candidate.ID, err))
+				m.recordArmingStatus(candidate, notArmedStatus(err))
+				continue
+			}
 		}
-		validation := m.prepareTaskTargetValidation(candidate.RepoID, target, true)
-		if err := m.validateEnabledTaskTarget(candidate, validation); err != nil {
-			snapshot.refused = append(snapshot.refused, fmt.Errorf("persisted task %q was not armed because its target relationship is unsafe: %w", candidate.ID, err))
-			m.recordArmingStatus(candidate, notArmedStatus(err))
-			continue
-		}
+		// Everything reaching here is armed, or deliberately not enabled. Either
+		// way a previous not-armed refusal no longer describes it — including the
+		// repair of DROPPING the target, which turns the task into an ordinary
+		// cron/watch task and never reaches the validation above.
 		m.clearStaleNotArmedStatus(candidate)
 		snapshot.safe = append(snapshot.safe, candidate)
 	}

--- a/daemon/task_arming_status_test.go
+++ b/daemon/task_arming_status_test.go
@@ -139,3 +139,22 @@ func reloadArmingTask(t *testing.T, id string) task.Task {
 	require.NoError(t, err)
 	return *loaded
 }
+
+// The repair of DROPPING target_session turns a refused task into an ordinary
+// cron/watch task, and that path never reaches the target validation — so the
+// clear has to happen for everything that lands in the safe set, not only for
+// tasks that passed validation. Otherwise the fix leaves behind exactly the
+// stale status it exists to eliminate.
+func TestClearStaleNotArmedStatus_ClearsWhenTheTargetIsDropped(t *testing.T) {
+	withArmingTaskFile(t)
+	seeded := seedArmingTask(t, "repaired-task", notArmedStatus(errors.New("target was archived")))
+	require.Empty(t, seeded.TargetSession, "seeded without a target: the dropped-target repair shape")
+
+	m := &Manager{}
+	snapshot, err := m.persistedTasksForArming()
+	require.NoError(t, err)
+	require.Empty(t, snapshot.refused)
+
+	require.Empty(t, reloadArmingTask(t, "repaired-task").LastRunStatus,
+		"a task armed as an ordinary cron task must not keep claiming it is unarmed")
+}

--- a/daemon/task_arming_status_test.go
+++ b/daemon/task_arming_status_test.go
@@ -1,0 +1,141 @@
+package daemon
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/task"
+	"github.com/stretchr/testify/require"
+)
+
+// A refused task must not be indistinguishable from a healthy one. Before this,
+// a task excluded from arming kept the LastRunStatus its last successful run
+// wrote, stayed enabled on disk, and was absent from both cron and watch — with
+// armed-ness exposed on no surface at all (#2929).
+func TestRecordArmingStatus_WritesTheRefusalWhereUsersLook(t *testing.T) {
+	withArmingTaskFile(t)
+	seeded := seedArmingTask(t, "refused-task", "started")
+
+	m := &Manager{}
+	m.recordArmingStatus(seeded, notArmedStatus(errors.New("target session is archived")))
+
+	after := reloadArmingTask(t, "refused-task")
+	require.True(t, strings.HasPrefix(after.LastRunStatus, "errored:"),
+		"the refusal must carry the prefix the TUI renders as failed, got %q", after.LastRunStatus)
+	require.Contains(t, after.LastRunStatus, "target session is archived",
+		"the status must say why, not just that something is wrong")
+}
+
+// Arming is a supervision decision, not a run, so the timestamp of the last real
+// delivery must survive it.
+func TestRecordArmingStatus_PreservesLastRunAt(t *testing.T) {
+	withArmingTaskFile(t)
+	seeded := seedArmingTask(t, "refused-task", "started")
+	require.NotNil(t, seeded.LastRunAt)
+	before := *seeded.LastRunAt
+
+	m := &Manager{}
+	m.recordArmingStatus(seeded, notArmedStatus(errors.New("unsafe")))
+
+	after := reloadArmingTask(t, "refused-task")
+	require.NotNil(t, after.LastRunAt)
+	require.True(t, after.LastRunAt.Equal(before),
+		"a supervision-status change must not move LastRunAt")
+}
+
+// Arming runs on every task CRUD as well as at startup. A persistently refused
+// task must not rewrite tasks.json each time.
+func TestRecordArmingStatus_IsIdempotent(t *testing.T) {
+	withArmingTaskFile(t)
+	seeded := seedArmingTask(t, "refused-task", "started")
+	status := notArmedStatus(errors.New("unsafe"))
+
+	m := &Manager{}
+	m.recordArmingStatus(seeded, status)
+	first := reloadArmingTask(t, "refused-task")
+
+	// Feed the already-updated record back in, as the next reload would.
+	writes := armingTaskFileWrites(t)
+	m.recordArmingStatus(first, status)
+	require.Equal(t, writes, armingTaskFileWrites(t),
+		"an unchanged arming status must not rewrite the task file")
+}
+
+// A refusal must not outlive the condition that caused it: a task whose target
+// came back would otherwise keep claiming it is unarmed until its next run — up
+// to a day for a nightly schedule, indefinitely for a watch task.
+func TestClearStaleNotArmedStatus_ClearsOnlyItsOwnStatus(t *testing.T) {
+	withArmingTaskFile(t)
+	m := &Manager{}
+
+	t.Run("clears a not-armed status", func(t *testing.T) {
+		seeded := seedArmingTask(t, "recovered-task", notArmedStatus(errors.New("was unsafe")))
+		m.clearStaleNotArmedStatus(seeded)
+		require.Empty(t, reloadArmingTask(t, "recovered-task").LastRunStatus)
+	})
+
+	t.Run("leaves a real run failure alone", func(t *testing.T) {
+		seeded := seedArmingTask(t, "failed-task", "errored: project path is not a git repository")
+		m.clearStaleNotArmedStatus(seeded)
+		require.Equal(t, "errored: project path is not a git repository",
+			reloadArmingTask(t, "failed-task").LastRunStatus,
+			"a genuine run failure must survive arming")
+	})
+
+	t.Run("leaves a successful run alone", func(t *testing.T) {
+		seeded := seedArmingTask(t, "ok-task", "started")
+		m.clearStaleNotArmedStatus(seeded)
+		require.Equal(t, "started", reloadArmingTask(t, "ok-task").LastRunStatus)
+	})
+}
+
+// withArmingTaskFile points the task store at a private home for this test.
+func withArmingTaskFile(t *testing.T) {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+}
+
+// seedArmingTask persists an enabled cron task carrying an existing run status
+// and LastRunAt, the shape a task has after a successful run.
+func seedArmingTask(t *testing.T, id, status string) task.Task {
+	t.Helper()
+	tsk := task.Task{
+		ID:        id,
+		Name:      id,
+		Prompt:    "do the thing",
+		CronExpr:  "0 3 * * *",
+		Program:   "claude",
+		Enabled:   true,
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, task.AddTask(tsk))
+	ran := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+	require.NoError(t, task.UpdateTaskStatus(id, &ran, status))
+	return reloadArmingTask(t, id)
+}
+
+// armingTaskFileWrites fingerprints the task file so a test can prove a
+// no-op arming pass did not rewrite it.
+func armingTaskFileWrites(t *testing.T) string {
+	t.Helper()
+	path, err := task.MigrateOnLoadPath()
+	require.NoError(t, err)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return fmt.Sprintf("%d:%d:%x", info.Size(), info.ModTime().UnixNano(), sha256.Sum256(data))
+}
+
+func reloadArmingTask(t *testing.T, id string) task.Task {
+	t.Helper()
+	loaded, err := task.GetTask(id)
+	require.NoError(t, err)
+	return *loaded
+}

--- a/ui/automations.go
+++ b/ui/automations.go
@@ -221,7 +221,11 @@ func (a *AutomationsPane) nextRunSummary(tsk task.Task) string {
 	// has never run, so gating this on a timestamp would hide the one thing it
 	// has to report — and an unarmed task is exactly the one that looks healthy
 	// otherwise (#2929).
-	if strings.HasPrefix(tsk.LastRunStatus, "errored:") {
+	//
+	// Not for a watch task: the watch branch above already reported it through
+	// watchTaskStatus, which reads the same "errored:" prefix, and appending here
+	// too renders "watch: … · errored · errored".
+	if !tsk.IsWatch() && strings.HasPrefix(tsk.LastRunStatus, "errored:") {
 		parts = append(parts, "errored")
 	}
 	return strings.Join(parts, " · ")

--- a/ui/automations.go
+++ b/ui/automations.go
@@ -217,6 +217,13 @@ func (a *AutomationsPane) nextRunSummary(tsk task.Task) string {
 	if tsk.LastRunAt != nil {
 		parts = append(parts, "last "+tsk.LastRunAt.Format("Jan 02 15:04"))
 	}
+	// An errored task says so even with no LastRunAt. A task refused at arming
+	// has never run, so gating this on a timestamp would hide the one thing it
+	// has to report — and an unarmed task is exactly the one that looks healthy
+	// otherwise (#2929).
+	if strings.HasPrefix(tsk.LastRunStatus, "errored:") {
+		parts = append(parts, "errored")
+	}
 	return strings.Join(parts, " · ")
 }
 

--- a/ui/automations_errored_test.go
+++ b/ui/automations_errored_test.go
@@ -1,0 +1,43 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/task"
+	"github.com/stretchr/testify/require"
+)
+
+// A task refused at arming has never run, so it has no LastRunAt — and gating
+// the summary on a timestamp would hide the one thing it has to report (#2929).
+// But a watch task already reports the same prefix through watchTaskStatus, so
+// saying it again renders "watch: … · errored · errored" (#2948).
+func TestNextRunSummary_ErroredAppearsOnceAndWithoutATimestamp(t *testing.T) {
+	pane := &AutomationsPane{now: func() time.Time { return time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC) }}
+
+	t.Run("cron task with no prior run still reports errored", func(t *testing.T) {
+		summary := pane.nextRunSummary(task.Task{
+			ID: "t", Enabled: true, CronExpr: "0 3 * * *",
+			LastRunStatus: "errored: not armed — target session is archived",
+		})
+		require.Contains(t, summary, "errored",
+			"a task that never ran is exactly the one whose refusal must show")
+	})
+
+	t.Run("watch task reports errored exactly once", func(t *testing.T) {
+		summary := pane.nextRunSummary(task.Task{
+			ID: "t", Enabled: true, WatchCmd: "tail -f log",
+			LastRunStatus: "errored: watch command failed",
+		})
+		require.Equal(t, 1, strings.Count(summary, "errored"),
+			"watchTaskStatus already reported it; a second copy renders as \"errored · errored\": %q", summary)
+	})
+
+	t.Run("a healthy cron task says nothing about errors", func(t *testing.T) {
+		summary := pane.nextRunSummary(task.Task{
+			ID: "t", Enabled: true, CronExpr: "0 3 * * *", LastRunStatus: "started",
+		})
+		require.NotContains(t, summary, "errored")
+	})
+}

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -578,9 +578,13 @@ func (s *TaskPane) renderListMode() string {
 		}
 		b.WriteString("\n")
 
-		// A crash-looped watcher gets its full #797 failure summary on a
-		// detail line — the only always-on detail, and only when errored.
-		if tsk.IsWatch() && strings.HasPrefix(tsk.LastRunStatus, "errored:") {
+		// An errored task gets its full failure summary on a detail line — the
+		// only always-on detail, and only when errored. Originally watch-only for
+		// a crash-looped watcher's #797 summary; a cron task's failure is just as
+		// actionable, and an arming refusal (#2929) may be the ONLY thing a task
+		// ever reports, since a task that never armed never runs to write a
+		// status of its own.
+		if strings.HasPrefix(tsk.LastRunStatus, "errored:") {
 			b.WriteString(erroredStyle.Render(fitLine("      "+tsk.LastRunStatus, s.width)))
 			b.WriteString("\n")
 		}


### PR DESCRIPTION
## What

A proactive audit of the task scheduler — cron parsing, watch triggers, task-spawned session lifecycle — found three classes. Full write-up with mechanisms, failure scenarios, and the clean-sweep list is in #2929. This PR fixes the dangerous one.

## The bug

**An enabled-but-unarmed task is indistinguishable from a healthy one.**

`persistedTasksForArming` excludes a task whose target relationship fails validation from `snapshot.safe`, so it is armed in **neither** cron nor watch. But it stays `enabled: true` on disk with whatever `LastRunStatus` its last successful run wrote. The refusal becomes an error string, `errors.Join`ed with every other refusal, and logged **once** at daemon startup.

Nothing else surfaces it. `scheduledTaskIDs()` and `watchingTaskIDs()` exist and their comments claim "for tests and status reporting" — grep confirms **neither has a production call site**. The TUI and CLI render `Enabled` and `LastRunStatus`, and both still say the task is fine.

**Concrete scenario.** A nightly task ran successfully yesterday (`LastRunStatus: "started"`). Its target session is archived overnight, so tonight's arming refuses it. One warning is logged at startup. `af tasks list` shows the task enabled with a successful last run. It never fires again — not tonight, not any night — and every surface a user would check says it is healthy. On a box nobody opens the TUI on, which is exactly the case #2212 exists to serve, the loss is total, permanent and silent.

## The fix

Write the refusal onto the task's own `LastRunStatus`, prefixed `errored:` — the prefix `ui/task_pane.go` already keys on to render a task as failed. The refusal therefore appears where people already look, with no new surface to build, document, or discover.

Three details that keep it honest:

- **`LastRunAt` is preserved.** `UpdateTaskStatus`'s documented nil mode. Arming is a supervision decision, not a run; the timestamp of the last real delivery must survive it.
- **Written only when the status changes.** Arming runs on every task CRUD as well as at startup — a persistently refused task must not rewrite `tasks.json` on every reload.
- **Cleared once the task arms again.** Otherwise the refusal outlives its cause: a task whose target came back would keep claiming it is unarmed until its next run, up to a day for a nightly schedule and indefinitely for a watch task that has not fired. Only statuses this path wrote are cleared — a genuine `errored:` from a failed run is left exactly as the run recorded it.

## Filed, not fixed

Two further classes are in #2929 with their mechanisms. Both need a product decision or a format change, so filing beat guessing:

- **A cron occurrence during daemon downtime is dropped silently.** `cron.New()` has no persistence and nothing reads `LastRunAt` to detect a miss. Whether to catch up is a policy call (systemd makes it opt-in via `Persistent=`; a catch-up storm after a long outage is its own hazard) and needs durable last-fire state.
- **Watch replay is at-least-once.** `drainLoop` advances the queue cursor only *after* a successful delivery, so a SIGKILL in that window redelivers one event and creates a duplicate session. Making it effectively-once needs a delivery identity in the queue format.

## Verification

Four tests: the refusal reaches `LastRunStatus` with the prefix the TUI renders and says *why*; `LastRunAt` survives; a repeated refusal does not rewrite the task file (fingerprinted by size, mtime and content hash); and clearing touches only statuses this path wrote — a real run failure and a successful run both survive.

Local gate green: `gofmt -l .` (empty), `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh`.

**The daemon tests here have not been executed locally** — the daemon package spawns real daemons and tmux on the maintainer's machine, so per the standing rule I verified compilation with `go vet ./daemon/` and reasoned through each case. CI runs them. Saying so because on the last PR that same gap let an ordering bug through that Codex caught.

Closes #2929

🤖 Generated with [Claude Code](https://claude.com/claude-code)
