### PR TITLE
fix(daemon): stop holding the manager lock across unbounded git in reserveCreate

### DIFF
--- a/daemon/create_lock_scope_test.go
+++ b/daemon/create_lock_scope_test.go
@@ -1,0 +1,80 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// TestReserveCreate_DoesNotHoldTheManagerLockAcrossBackendResolution is the
+// #2931 regression guard.
+//
+// reserveCreate resolves the backend through config.RepoFromPath, which shells
+// out to `git rev-parse` with no context, no timeout and no WaitDelay. While that
+// ran under m.mu, one unreachable repo — a stalled NFS/FUSE mount, a spun-down
+// disk — was a daemon-wide outage: the exec never returns, the deferred unlock
+// never runs, and everything needing m.mu blocks behind it in every project.
+//
+// The property is invisible to an ordinary create test: the resolution succeeds
+// whether or not the lock is held, and only its LOCK CONTEXT is the defect. So
+// this blocks inside the resolver and asks, from another goroutine, whether the
+// manager lock is still obtainable.
+//
+// It is written to FAIL rather than hang on a regression, following
+// deadlock_2006_test.go: the observer reports through a channel with a deadline,
+// so a re-introduced hold is a red test and not a wedged CI job.
+func TestReserveCreate_DoesNotHoldTheManagerLockAcrossBackendResolution(t *testing.T) {
+	manager, _, repoPath := newStatusTestManager(t)
+
+	inResolver := make(chan struct{})
+	releaseResolver := make(chan struct{})
+	prev := backendKindForCreate
+	backendKindForCreate = func(opts session.InstanceOptions, root string) (session.BackendKind, error) {
+		close(inResolver)
+		<-releaseResolver
+		return prev(opts, root)
+	}
+	t.Cleanup(func() { backendKindForCreate = prev })
+
+	created := make(chan struct{})
+	go func() {
+		defer close(created)
+		_, _, release, _, err := manager.reserveCreate(CreateSessionRequest{
+			RepoPath: repoPath, TitleBase: "lockscope", Program: "claude",
+		})
+		if err == nil && release != nil {
+			release()
+		}
+	}()
+
+	select {
+	case <-inResolver:
+	case <-time.After(20 * time.Second):
+		t.Fatal("the create never reached backend resolution")
+	}
+
+	// THE CLAIM: with a create parked mid-resolution, the manager lock is free.
+	// Snapshot is the reader that matters — it is what every TUI and web client
+	// polls, so a held lock here is a frozen UI for every project.
+	lockFree := make(chan struct{})
+	go func() {
+		manager.Snapshot("")
+		close(lockFree)
+	}()
+
+	select {
+	case <-lockFree:
+	case <-time.After(10 * time.Second):
+		close(releaseResolver)
+		t.Fatal("m.mu was held across backend resolution: Snapshot could not run while a create " +
+			"was resolving its runtime, so one stalled repo would wedge every session (#2931)")
+	}
+
+	close(releaseResolver)
+	select {
+	case <-created:
+	case <-time.After(20 * time.Second):
+		t.Fatal("the create never finished after the resolver was released")
+	}
+}

--- a/daemon/create_lock_scope_test.go
+++ b/daemon/create_lock_scope_test.go
@@ -149,3 +149,104 @@ func TestReserveCreate_RefusesWhenAProjectDeleteCompletedDuringResolution(t *tes
 	require.ErrorContains(t, got.err, "while this session create resolved its backend")
 	require.Nil(t, got.release, "a refused create must not hand back a reservation to release")
 }
+
+// TestReserveCreate_RefusesWhenAProjectDeleteWasAlreadyRunningAtTheSample is the
+// INVERSE ordering, and the delete generation alone does not catch it.
+//
+// The generation answers "did a delete BEGIN after my sample". A delete that was
+// ALREADY running when the create sampled bumped the counter before that sample
+// and removes its fence before the re-check — so both readings match, the fence
+// reads clear, and the create is admitted even though the delete ran to
+// completion across the entire unlocked region. Reported on the #2937 review with
+// a working repro; this is that repro.
+//
+// The delete is parked inside deregisterRootAgents, which runs after the fence is
+// installed, so a create that starts while it is parked necessarily samples with
+// the fence up — which is the state the test needs and cannot otherwise pin down.
+func TestReserveCreate_RefusesWhenAProjectDeleteWasAlreadyRunningAtTheSample(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	inDelete := make(chan struct{})
+	releaseDelete := make(chan struct{})
+	prevDeregister := deregisterRootAgents
+	deregisterRootAgents = func(id string) ([]string, error) {
+		close(inDelete)
+		<-releaseDelete
+		return prevDeregister(id)
+	}
+	t.Cleanup(func() { deregisterRootAgents = prevDeregister })
+
+	deleted := make(chan error, 1)
+	go func() {
+		_, err := manager.DeleteProject(DeleteProjectRequest{RepoID: repoID, RepoPath: repoPath})
+		deleted <- err
+	}()
+	select {
+	case <-inDelete:
+	case <-time.After(20 * time.Second):
+		t.Fatal("the delete never reached its root-agent deregistration")
+	}
+	// The fence is up and the generation is already bumped. Anything the create
+	// samples from here carries the delete's post-bump value.
+	manager.mu.Lock()
+	_, fenceUp := manager.projectDeletes[repoID]
+	manager.mu.Unlock()
+	require.True(t, fenceUp, "precondition: the delete must hold its fence while parked")
+
+	inResolver := make(chan struct{})
+	releaseResolver := make(chan struct{})
+	prevResolver := backendKindForCreate
+	backendKindForCreate = func(opts session.InstanceOptions, root string) (session.BackendKind, error) {
+		close(inResolver)
+		<-releaseResolver
+		return prevResolver(opts, root)
+	}
+	t.Cleanup(func() { backendKindForCreate = prevResolver })
+
+	type createResult struct {
+		release func()
+		err     error
+	}
+	results := make(chan createResult, 1)
+	go func() {
+		_, _, release, _, err := manager.reserveCreate(CreateSessionRequest{
+			RepoPath: repoPath, TitleBase: "sampled-mid-delete", Program: "claude",
+		})
+		results <- createResult{release: release, err: err}
+	}()
+	// Reaching the resolver is what proves the sample already happened, and it
+	// happened while the fence above was up.
+	select {
+	case <-inResolver:
+	case <-time.After(20 * time.Second):
+		t.Fatal("the create never reached backend resolution")
+	}
+
+	// Now let the delete finish and drop its fence, so the create's re-check sees
+	// a clear field and an unchanged generation.
+	close(releaseDelete)
+	select {
+	case err := <-deleted:
+		require.NoError(t, err)
+	case <-time.After(20 * time.Second):
+		t.Fatal("the delete never completed")
+	}
+	manager.mu.Lock()
+	_, fenceStillUp := manager.projectDeletes[repoID]
+	manager.mu.Unlock()
+	require.False(t, fenceStillUp, "precondition: the fence must be down before the create resumes")
+
+	close(releaseResolver)
+	var got createResult
+	select {
+	case got = <-results:
+	case <-time.After(20 * time.Second):
+		t.Fatal("the create never finished after the resolver was released")
+	}
+	if got.release != nil {
+		got.release()
+	}
+	require.Error(t, got.err, "a create that sampled DURING an active delete must be refused, not admitted once that delete finishes")
+	require.ErrorContains(t, got.err, "while this session create resolved its backend")
+	require.Nil(t, got.release, "a refused create must not hand back a reservation to release")
+}

--- a/daemon/create_lock_scope_test.go
+++ b/daemon/create_lock_scope_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -151,18 +152,21 @@ func TestReserveCreate_RefusesWhenAProjectDeleteCompletedDuringResolution(t *tes
 }
 
 // TestReserveCreate_RefusesWhenAProjectDeleteWasAlreadyRunningAtTheSample is the
-// INVERSE ordering, and the delete generation alone does not catch it.
+// INVERSE ordering, which the delete generation alone does not catch.
 //
-// The generation answers "did a delete BEGIN after my sample". A delete that was
-// ALREADY running when the create sampled bumped the counter before that sample
-// and removes its fence before the re-check — so both readings match, the fence
-// reads clear, and the create is admitted even though the delete ran to
-// completion across the entire unlocked region. Reported on the #2937 review with
-// a working repro; this is that repro.
+// The generation answers "did a delete BEGIN after my sample". A delete already
+// running at the sample bumped the counter before it and drops its fence before
+// the re-check, so both readings match and the create would be admitted despite
+// that delete running across the entire unlocked region.
+//
+// It asserts two things, and the second is why the refusal sits where it does:
+// the create is refused, and it is refused WITHOUT resolving its backend. A
+// create that is already known to be impossible must not first wait on the
+// unbounded `git rev-parse` this change exists to keep off blocking paths.
 //
 // The delete is parked inside deregisterRootAgents, which runs after the fence is
 // installed, so a create that starts while it is parked necessarily samples with
-// the fence up — which is the state the test needs and cannot otherwise pin down.
+// the fence up — the state the test needs and cannot otherwise pin down.
 func TestReserveCreate_RefusesWhenAProjectDeleteWasAlreadyRunningAtTheSample(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 
@@ -193,12 +197,17 @@ func TestReserveCreate_RefusesWhenAProjectDeleteWasAlreadyRunningAtTheSample(t *
 	manager.mu.Unlock()
 	require.True(t, fenceUp, "precondition: the delete must hold its fence while parked")
 
-	inResolver := make(chan struct{})
-	releaseResolver := make(chan struct{})
+	// The resolver must never run. A create refused for an active delete is
+	// already known to be impossible, and backend resolution is the unbounded
+	// `git rev-parse` this whole change exists to keep off the blocking paths —
+	// so making that create wait on a stalled mount before telling it no is the
+	// defect, not merely an inefficiency. Before the resolution was hoisted, the
+	// fence check ran ahead of it and such a create returned promptly (#2937
+	// review); this asserts that property survived the hoist.
+	var resolverRuns atomic.Int64
 	prevResolver := backendKindForCreate
 	backendKindForCreate = func(opts session.InstanceOptions, root string) (session.BackendKind, error) {
-		close(inResolver)
-		<-releaseResolver
+		resolverRuns.Add(1)
 		return prevResolver(opts, root)
 	}
 	t.Cleanup(func() { backendKindForCreate = prevResolver })
@@ -214,16 +223,27 @@ func TestReserveCreate_RefusesWhenAProjectDeleteWasAlreadyRunningAtTheSample(t *
 		})
 		results <- createResult{release: release, err: err}
 	}()
-	// Reaching the resolver is what proves the sample already happened, and it
-	// happened while the fence above was up.
-	select {
-	case <-inResolver:
-	case <-time.After(20 * time.Second):
-		t.Fatal("the create never reached backend resolution")
-	}
 
-	// Now let the delete finish and drop its fence, so the create's re-check sees
-	// a clear field and an unchanged generation.
+	// It must refuse while the delete is STILL PARKED. Waiting on the result here,
+	// before releasing the delete, is the assertion: a create that only refused
+	// after the delete finished would time out instead.
+	var got createResult
+	select {
+	case got = <-results:
+	case <-time.After(20 * time.Second):
+		close(releaseDelete)
+		<-deleted
+		t.Fatal("the create did not refuse while a delete held the fence: it is waiting on something, which is what refusing before backend resolution is meant to prevent")
+	}
+	if got.release != nil {
+		got.release()
+	}
+	require.Error(t, got.err, "a create sampled during an active delete must be refused")
+	require.ErrorContains(t, got.err, "is being deleted")
+	require.Nil(t, got.release, "a refused create must not hand back a reservation to release")
+	require.Zero(t, resolverRuns.Load(),
+		"the refusal must come BEFORE backend resolution: resolving first makes an impossible create wait on unbounded git")
+
 	close(releaseDelete)
 	select {
 	case err := <-deleted:
@@ -231,22 +251,4 @@ func TestReserveCreate_RefusesWhenAProjectDeleteWasAlreadyRunningAtTheSample(t *
 	case <-time.After(20 * time.Second):
 		t.Fatal("the delete never completed")
 	}
-	manager.mu.Lock()
-	_, fenceStillUp := manager.projectDeletes[repoID]
-	manager.mu.Unlock()
-	require.False(t, fenceStillUp, "precondition: the fence must be down before the create resumes")
-
-	close(releaseResolver)
-	var got createResult
-	select {
-	case got = <-results:
-	case <-time.After(20 * time.Second):
-		t.Fatal("the create never finished after the resolver was released")
-	}
-	if got.release != nil {
-		got.release()
-	}
-	require.Error(t, got.err, "a create that sampled DURING an active delete must be refused, not admitted once that delete finishes")
-	require.ErrorContains(t, got.err, "while this session create resolved its backend")
-	require.Nil(t, got.release, "a refused create must not hand back a reservation to release")
 }

--- a/daemon/create_lock_scope_test.go
+++ b/daemon/create_lock_scope_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/sachiniyer/agent-factory/session"
 )
 
@@ -77,4 +79,73 @@ func TestReserveCreate_DoesNotHoldTheManagerLockAcrossBackendResolution(t *testi
 	case <-time.After(20 * time.Second):
 		t.Fatal("the create never finished after the resolver was released")
 	}
+}
+
+// TestReserveCreate_RefusesWhenAProjectDeleteCompletedDuringResolution is the
+// other half of moving backend resolution out from under m.mu.
+//
+// m.projectDeletes answers "is a delete running RIGHT NOW". That was a complete
+// answer only while the slow resolution happened under m.mu, because a delete
+// then could not reach its own fence-install until the create had already
+// reserved or refused. With the resolution hoisted, a delete has room to install
+// the fence, run to completion, and REMOVE the fence entirely inside the window
+// — after which the fence check reads a clear field and would admit a create
+// into a project the user just deleted, re-creating its state behind them.
+//
+// The delete below is the real DeleteProject, not a hand-installed fence, so the
+// test fails if the generation stops being bumped on the production path.
+func TestReserveCreate_RefusesWhenAProjectDeleteCompletedDuringResolution(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	inResolver := make(chan struct{})
+	releaseResolver := make(chan struct{})
+	prev := backendKindForCreate
+	backendKindForCreate = func(opts session.InstanceOptions, root string) (session.BackendKind, error) {
+		close(inResolver)
+		<-releaseResolver
+		return prev(opts, root)
+	}
+	t.Cleanup(func() { backendKindForCreate = prev })
+
+	type createResult struct {
+		release func()
+		err     error
+	}
+	results := make(chan createResult, 1)
+	go func() {
+		_, _, release, _, err := manager.reserveCreate(CreateSessionRequest{
+			RepoPath: repoPath, TitleBase: "deleted-under-me", Program: "claude",
+		})
+		results <- createResult{release: release, err: err}
+	}()
+
+	select {
+	case <-inResolver:
+	case <-time.After(20 * time.Second):
+		t.Fatal("the create never reached backend resolution")
+	}
+
+	// The whole delete — fence install, durable removals, fence removal — runs
+	// and FINISHES while the create is parked. By the time the create takes m.mu
+	// there is nothing left in m.projectDeletes for it to see.
+	_, err := manager.DeleteProject(DeleteProjectRequest{RepoID: repoID, RepoPath: repoPath})
+	require.NoError(t, err, "the delete must complete: the create has reserved nothing to block it")
+	manager.mu.Lock()
+	_, fenceStillUp := manager.projectDeletes[repoID]
+	manager.mu.Unlock()
+	require.False(t, fenceStillUp, "precondition: the delete must have removed its own fence before the create resumes")
+
+	close(releaseResolver)
+	var got createResult
+	select {
+	case got = <-results:
+	case <-time.After(20 * time.Second):
+		t.Fatal("the create never finished after the resolver was released")
+	}
+	if got.release != nil {
+		got.release()
+	}
+	require.Error(t, got.err, "a create must not be admitted into a project whose delete completed while it resolved")
+	require.ErrorContains(t, got.err, "while this session create resolved its backend")
+	require.Nil(t, got.release, "a refused create must not hand back a reservation to release")
 }

--- a/daemon/create_lock_scope_test.go
+++ b/daemon/create_lock_scope_test.go
@@ -151,6 +151,47 @@ func TestReserveCreate_RefusesWhenAProjectDeleteCompletedDuringResolution(t *tes
 	require.Nil(t, got.release, "a refused create must not hand back a reservation to release")
 }
 
+// A task create that is already at its concurrency cap must be refused BEFORE
+// backend resolution, for the same reason an already-deleted project's create
+// is: the answer is already known, and the resolver is unbounded git.
+//
+// The cap's contract is that a refusal is cheap and the watch-delivery path
+// parks the event to retry when a slot frees. Hanging in the resolver instead
+// converts that park into a stall on exactly the repo this change is about.
+func TestReserveCreate_RefusesACappedTaskRunBeforeResolvingTheBackend(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	// Fill the single slot with a reservation — an admitted create that has not
+	// registered its instance yet, which is what the cap counts.
+	manager.mu.Lock()
+	manager.reserveTaskRunLocked(repoID, "task-1", 1)
+	manager.mu.Unlock()
+
+	var resolverRuns atomic.Int64
+	prev := backendKindForCreate
+	backendKindForCreate = func(opts session.InstanceOptions, root string) (session.BackendKind, error) {
+		resolverRuns.Add(1)
+		return prev(opts, root)
+	}
+	t.Cleanup(func() { backendKindForCreate = prev })
+
+	_, _, release, _, err := manager.reserveCreate(CreateSessionRequest{
+		RepoPath:          repoPath,
+		TitleBase:         "capped",
+		Program:           "claude",
+		TaskID:            "task-1",
+		MaxConcurrentRuns: 1,
+	})
+	if release != nil {
+		release()
+	}
+	require.ErrorIs(t, err, errAtConcurrencyLimit,
+		"a create over its task cap must be refused with the sentinel the delivery path parks on")
+	require.Nil(t, release, "a refused create must not hand back a reservation to release")
+	require.Zero(t, resolverRuns.Load(),
+		"the cap refusal must come BEFORE backend resolution: resolving first makes a capped delivery wait on unbounded git instead of parking")
+}
+
 // TestReserveCreate_RefusesWhenAProjectDeleteWasAlreadyRunningAtTheSample is the
 // INVERSE ordering, which the delete generation alone does not catch.
 //

--- a/daemon/deleteproject.go
+++ b/daemon/deleteproject.go
@@ -224,6 +224,15 @@ func (m *Manager) deleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 			m.projectDeletes = make(map[string]struct{})
 		}
 		m.projectDeletes[repoID] = struct{}{}
+		// Bump on INSTALL, not on removal, and under the same lock that installs
+		// the fence. A create that sampled the generation before this line and
+		// reads it again after taking m.mu sees the change whether or not the
+		// delete has finished by then, so the two checks together cover the whole
+		// interval rather than only its trailing edge.
+		if m.projectDeleteGen == nil {
+			m.projectDeleteGen = make(map[string]uint64)
+		}
+		m.projectDeleteGen[repoID]++
 	}
 	m.mu.Unlock()
 	if len(starting) > 0 {

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -108,6 +108,18 @@ type Manager struct {
 	// reuse or reservation mutation. This closes the preflight-to-first-mutation
 	// gap without holding m.mu across config, task, or archive I/O.
 	projectDeletes map[string]struct{}
+	// projectDeleteGen counts completed delete ATTEMPTS per repo so a create can
+	// detect a delete that both started and finished while the create was outside
+	// m.mu. The fence above only answers "is a delete running right now", which is
+	// not the same question: reserveCreate resolves the repo and the backend kind
+	// before it can take m.mu at all (those resolvers shell out to git, and holding
+	// m.mu across them wedges the whole daemon — #2931), so a delete has room to
+	// install the fence, run, and remove it inside that gap. Sampled per repo
+	// rather than globally: a delete of some OTHER project must not refuse this
+	// create. Entries are never removed — one uint64 per repo ever deleted in this
+	// daemon's lifetime — because a reset would read equal to an old sample and
+	// silently stop fencing.
+	projectDeleteGen map[string]uint64
 	// reservedTmuxNames closes the second namespace a local create claims. Titles
 	// such as "a/b" and "a_b" can derive distinct git branches but the same
 	// positive-policy tmux name; reserving only the raw title leaves that collision
@@ -401,6 +413,7 @@ func newManagerShellForDaemon(cfg *config.Config, transactionID string) (*Manage
 		pendingCreates:         make(map[string]session.InstanceData),
 		reservedTitles:         make(map[string]struct{}),
 		projectDeletes:         make(map[string]struct{}),
+		projectDeleteGen:       make(map[string]uint64),
 		reservedTmuxNames:      make(map[string]string),
 		reservedRemoteNames:    make(map[string]struct{}),
 		reservedTaskRuns:       make(map[string]int),

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -265,13 +265,19 @@ func (m *Manager) projectDeleteGenLocked(repoID string) uint64 {
 	return m.projectDeleteGen[repoID]
 }
 
-// projectDeleteGenFor is the same read for a caller that does NOT hold m.mu; it
-// takes the lock itself. Both spellings exist because reserveCreate needs the
-// value on each side of a region it deliberately runs unlocked.
-func (m *Manager) projectDeleteGenFor(repoID string) uint64 {
+// projectDeleteStateFor samples BOTH halves of the repo's delete state for a
+// caller that does not hold m.mu; it takes the lock itself.
+//
+// The two must be read together, in one acquisition. The generation alone
+// answers "did a delete BEGIN after this point" — it cannot answer "was a delete
+// already running AT this point", because such a delete bumped the counter
+// before the sample and removes its fence before the re-check, leaving both
+// readings identical while the delete ran to completion across the entire gap.
+func (m *Manager) projectDeleteStateFor(repoID string) (active bool, generation uint64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.projectDeleteGenLocked(repoID)
+	_, active = m.projectDeletes[repoID]
+	return active, m.projectDeleteGenLocked(repoID)
 }
 
 func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, string, func(), *session.InstanceData, error) {
@@ -302,13 +308,28 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 	// damage to the one create that asked. The sibling git call this function makes
 	// under the lock (branch holds) is already bounded with its own deadline (#856);
 	// this was the path that was not.
-	// Sample the repo's delete generation first. The resolvers below run outside
-	// m.mu, which leaves room for a DeleteProject to install its fence, complete,
-	// and remove the fence entirely within this gap — so the post-lock fence check
-	// alone would see a clear field and admit a create into a project the user just
-	// deleted. Comparing the generation across the gap turns that invisible
-	// completed delete back into the same refusal the fence gives.
-	deleteGen := m.projectDeleteGenFor(repo.ID)
+	// Sample the repo's delete state first. The resolvers below run outside m.mu,
+	// which leaves room for a DeleteProject to install its fence, complete, and
+	// remove the fence entirely within this gap — so the post-lock fence check
+	// alone would see a clear field and admit a create into a project the user
+	// just deleted.
+	//
+	// Sampled state plus the post-lock check cover EVERY delete that overlaps the
+	// unlocked region, and it takes both halves to do it. Writing the delete's
+	// fence interval as [install, remove] and this region as [sample, check]:
+	//
+	//   - install before sample, remove after sample -> deleteActive here
+	//   - install within the region                  -> the generation moved
+	//   - remove after check                         -> the fence is still up
+	//   - install after check                        -> the create has reserved by
+	//     then, so DeleteProject's own fail-closed preflight refuses instead
+	//
+	// The first case is why the fence is sampled and not just the counter: such a
+	// delete bumped the generation BEFORE the sample and drops its fence BEFORE
+	// the check, so both readings match while it ran across the whole gap (#2937
+	// review). A delete that finished entirely before the sample is not an overlap
+	// at all — that is an ordinary create after a completed delete.
+	deleteActive, deleteGen := m.projectDeleteStateFor(repo.ID)
 
 	runtimeKind := session.BackendLocal
 	if req.ForceRemote {
@@ -335,10 +356,11 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	_, deleting := m.projectDeletes[repo.ID]
-	// Either arm is the same refusal: a delete owns this project's state and this
-	// create has reserved nothing. The generation arm catches the delete that
-	// already finished, which the fence by construction cannot report.
-	if deleting || m.projectDeleteGenLocked(repo.ID) != deleteGen {
+	// Every arm is the same refusal: a delete owns this project's state and this
+	// create has reserved nothing. The two sampled arms catch the deletes the
+	// fence cannot report here — one that finished during the gap, and one that
+	// was already running when the gap opened.
+	if deleting || deleteActive || m.projectDeleteGenLocked(repo.ID) != deleteGen {
 		err := fmt.Errorf("project %s is being deleted; retry the session create after deletion finishes", repo.ID)
 		if !deleting {
 			err = fmt.Errorf("project %s was being deleted while this session create resolved its backend; nothing was created — retry if the project still exists", repo.ID)

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -258,6 +258,22 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 // Production never reassigns it.
 var backendKindForCreate = session.BackendKindFor
 
+// projectDeleteGenLocked reads the repo's completed-delete-attempt counter. The
+// caller MUST already hold m.mu; a missing entry means no delete has ever been
+// attempted for this repo and reads as 0, which is also what a first sample sees.
+func (m *Manager) projectDeleteGenLocked(repoID string) uint64 {
+	return m.projectDeleteGen[repoID]
+}
+
+// projectDeleteGenFor is the same read for a caller that does NOT hold m.mu; it
+// takes the lock itself. Both spellings exist because reserveCreate needs the
+// value on each side of a region it deliberately runs unlocked.
+func (m *Manager) projectDeleteGenFor(repoID string) uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.projectDeleteGenLocked(repoID)
+}
+
 func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, string, func(), *session.InstanceData, error) {
 	if req.RepoPath == "" {
 		return nil, "", nil, nil, fmt.Errorf("repo path is required")
@@ -286,6 +302,14 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 	// damage to the one create that asked. The sibling git call this function makes
 	// under the lock (branch holds) is already bounded with its own deadline (#856);
 	// this was the path that was not.
+	// Sample the repo's delete generation first. The resolvers below run outside
+	// m.mu, which leaves room for a DeleteProject to install its fence, complete,
+	// and remove the fence entirely within this gap — so the post-lock fence check
+	// alone would see a clear field and admit a create into a project the user just
+	// deleted. Comparing the generation across the gap turns that invisible
+	// completed delete back into the same refusal the fence gives.
+	deleteGen := m.projectDeleteGenFor(repo.ID)
+
 	runtimeKind := session.BackendLocal
 	if req.ForceRemote {
 		runtimeKind = session.BackendHook
@@ -310,8 +334,15 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if _, deleting := m.projectDeletes[repo.ID]; deleting {
+	_, deleting := m.projectDeletes[repo.ID]
+	// Either arm is the same refusal: a delete owns this project's state and this
+	// create has reserved nothing. The generation arm catches the delete that
+	// already finished, which the fence by construction cannot report.
+	if deleting || m.projectDeleteGenLocked(repo.ID) != deleteGen {
 		err := fmt.Errorf("project %s is being deleted; retry the session create after deletion finishes", repo.ID)
+		if !deleting {
+			err = fmt.Errorf("project %s was being deleted while this session create resolved its backend; nothing was created — retry if the project still exists", repo.ID)
+		}
 		// TaskOrigin is daemon-only provenance independent of retained identity or
 		// concurrency ownership. Legacy targeted rows can have neither TaskID nor
 		// TaskRepoID, but admission still knows this create came from automation.

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -265,6 +265,33 @@ func (m *Manager) projectDeleteGenLocked(repoID string) uint64 {
 	return m.projectDeleteGen[repoID]
 }
 
+// projectDeleteRefusal builds the refusal every delete-fence arm returns, so the
+// three of them cannot drift in wording or in what they promise the caller.
+//
+// inProgress distinguishes a delete still running from one that finished while
+// this create was outside m.mu; the guidance differs, and a create told to
+// "retry after deletion finishes" about a delete that already finished would be
+// telling the user to wait for nothing.
+//
+// TaskOrigin is daemon-only provenance independent of retained identity or
+// concurrency ownership. Legacy targeted rows can have neither TaskID nor
+// TaskRepoID, but admission still knows this create came from automation.
+// Nothing has reserved a name, created a runtime, or sent a prompt on any of
+// these paths, so the refusal is provably not attempted and carries the
+// wire-visible marker. Keep the older identity shapes as compatibility evidence
+// for in-process callers constructed before TaskOrigin was added; ordinary
+// client creates carry none of these fields and retain their plain error.
+func projectDeleteRefusal(req CreateSessionRequest, repoID string, inProgress bool) error {
+	err := fmt.Errorf("project %s is being deleted; retry the session create after deletion finishes", repoID)
+	if !inProgress {
+		err = fmt.Errorf("project %s was being deleted while this session create resolved its backend; nothing was created — retry if the project still exists", repoID)
+	}
+	if req.TaskOrigin || req.TaskID != "" || req.TaskRepoID != "" {
+		err = notAttempted(fmt.Errorf("%w; %s", err, notDeliveredMarker))
+	}
+	return err
+}
+
 // projectDeleteStateFor samples BOTH halves of the repo's delete state for a
 // caller that does not hold m.mu; it takes the lock itself.
 //
@@ -308,28 +335,36 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 	// damage to the one create that asked. The sibling git call this function makes
 	// under the lock (branch holds) is already bounded with its own deadline (#856);
 	// this was the path that was not.
-	// Sample the repo's delete state first. The resolvers below run outside m.mu,
-	// which leaves room for a DeleteProject to install its fence, complete, and
-	// remove the fence entirely within this gap — so the post-lock fence check
-	// alone would see a clear field and admit a create into a project the user
-	// just deleted.
+	// Sample the repo's delete state first, and refuse an ALREADY-RUNNING delete
+	// right here — ahead of the resolvers, not after them.
 	//
-	// Sampled state plus the post-lock check cover EVERY delete that overlaps the
-	// unlocked region, and it takes both halves to do it. Writing the delete's
-	// fence interval as [install, remove] and this region as [sample, check]:
+	// Deferring this refusal until after the resolution would make a create that
+	// is already known to be impossible wait on the unbounded git below, which is
+	// exactly the stall this hoist exists to bound. Before the hoist the fence
+	// check ran ahead of backend resolution and such a create returned promptly;
+	// keeping the refusal early preserves that. It is still behind everything a
+	// refusal needs — repo identity and the task-binding check — and still ahead
+	// of every mutation, so admission order is unchanged.
 	//
-	//   - install before sample, remove after sample -> deleteActive here
+	// The sampled state plus the post-lock check cover EVERY delete overlapping
+	// the unlocked region. Writing the delete's fence interval as
+	// [install, remove] and this region as [sample, check]:
+	//
+	//   - install before sample, remove after sample -> refused immediately below
 	//   - install within the region                  -> the generation moved
 	//   - remove after check                         -> the fence is still up
 	//   - install after check                        -> the create has reserved by
 	//     then, so DeleteProject's own fail-closed preflight refuses instead
 	//
-	// The first case is why the fence is sampled and not just the counter: such a
+	// The first arm is why the fence is sampled and not just the counter: such a
 	// delete bumped the generation BEFORE the sample and drops its fence BEFORE
 	// the check, so both readings match while it ran across the whole gap (#2937
 	// review). A delete that finished entirely before the sample is not an overlap
 	// at all — that is an ordinary create after a completed delete.
 	deleteActive, deleteGen := m.projectDeleteStateFor(repo.ID)
+	if deleteActive {
+		return nil, "", nil, nil, projectDeleteRefusal(req, repo.ID, true)
+	}
 
 	runtimeKind := session.BackendLocal
 	if req.ForceRemote {
@@ -355,28 +390,12 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	// The remaining two arms: a delete still holding its fence, and one that both
+	// started and finished while this create resolved. The already-running case
+	// returned above, before the resolvers.
 	_, deleting := m.projectDeletes[repo.ID]
-	// Every arm is the same refusal: a delete owns this project's state and this
-	// create has reserved nothing. The two sampled arms catch the deletes the
-	// fence cannot report here — one that finished during the gap, and one that
-	// was already running when the gap opened.
-	if deleting || deleteActive || m.projectDeleteGenLocked(repo.ID) != deleteGen {
-		err := fmt.Errorf("project %s is being deleted; retry the session create after deletion finishes", repo.ID)
-		if !deleting {
-			err = fmt.Errorf("project %s was being deleted while this session create resolved its backend; nothing was created — retry if the project still exists", repo.ID)
-		}
-		// TaskOrigin is daemon-only provenance independent of retained identity or
-		// concurrency ownership. Legacy targeted rows can have neither TaskID nor
-		// TaskRepoID, but admission still knows this create came from automation.
-		// Nothing has reserved a name, created a runtime, or sent a prompt, so the
-		// refusal is provably not attempted and carries the wire-visible marker.
-		// Keep the older identity shapes as compatibility evidence for in-process
-		// callers constructed before TaskOrigin was added; ordinary client creates
-		// carry none of these fields and retain their plain error.
-		if req.TaskOrigin || req.TaskID != "" || req.TaskRepoID != "" {
-			err = notAttempted(fmt.Errorf("%w; %s", err, notDeliveredMarker))
-		}
-		return nil, "", nil, nil, err
+	if deleting || m.projectDeleteGenLocked(repo.ID) != deleteGen {
+		return nil, "", nil, nil, projectDeleteRefusal(req, repo.ID, deleting)
 	}
 	if err := m.refreshLocked(); err != nil {
 		return nil, "", nil, nil, err

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -251,6 +251,13 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 	return data, nil
 }
 
+// backendKindForCreate is the runtime resolution reserveCreate performs before
+// taking the manager lock. A package var so a test can block inside it and prove
+// m.mu is genuinely not held across it — the property is invisible otherwise,
+// since the call succeeds either way and only its LOCK CONTEXT is the bug (#2931).
+// Production never reassigns it.
+var backendKindForCreate = session.BackendKindFor
+
 func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, string, func(), *session.InstanceData, error) {
 	if req.RepoPath == "" {
 		return nil, "", nil, nil, fmt.Errorf("repo path is required")
@@ -262,6 +269,44 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 	if req.TaskRepoID != "" && req.TaskRepoID != repo.ID {
 		return nil, "", nil, nil, fmt.Errorf("task is bound to repo %s, but project path %q now resolves to repo %s; session was not created and prompt not delivered — rebind the task to use this project", req.TaskRepoID, req.RepoPath, repo.ID)
 	}
+
+	// Resolve the runtime BEFORE taking the manager lock (#2931).
+	//
+	// Both resolvers below reach session.resolveBackendKind -> resolveRepoConfig ->
+	// config.RepoFromPath, which shells out to `git rev-parse` with no context, no
+	// timeout, and no WaitDelay. Under m.mu that turned one unreachable repo — a
+	// stalled NFS/FUSE mount, a spun-down disk — into a daemon-wide outage: the
+	// exec never returns, the deferred unlock never runs, and every operation that
+	// needs m.mu blocks behind it. Snapshot (so every TUI and web client), the
+	// liveness poll, kill, archive, delete-project, task delivery: all of them, in
+	// every project, not just the broken one.
+	//
+	// Neither resolver reads any manager state — they are pure functions of the
+	// request and the repo root — so hoisting them costs nothing and bounds the
+	// damage to the one create that asked. The sibling git call this function makes
+	// under the lock (branch holds) is already bounded with its own deadline (#856);
+	// this was the path that was not.
+	runtimeKind := session.BackendLocal
+	if req.ForceRemote {
+		runtimeKind = session.BackendHook
+	}
+	backendOpts := session.InstanceOptions{
+		Backend:     session.BackendKind(req.Backend),
+		ForceRemote: req.ForceRemote,
+		InPlace:     req.InPlace,
+	}
+	if kind, kerr := backendKindForCreate(backendOpts, repo.Root); kerr == nil {
+		runtimeKind = kind
+	}
+	// A kerr means an invalid backend value. Leave the conservative default above
+	// and let NewInstance surface the canonical error rather than duplicating it.
+	//
+	// The in-place/off-box contradiction is resolved here too but REPORTED below,
+	// inside the lock, at the point it was refused before. Hoisting the resolution
+	// must not hoist the refusal: reserveCreate's admission order is load-bearing
+	// (#2778/#2415), and this check has to stay ahead of the archived-name-reuse
+	// rename and behind the project-delete fence, exactly where it was.
+	inPlaceConflict := session.InPlaceBackendConflict(backendOpts, repo.Root)
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -303,22 +348,6 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 		return nil, "", nil, nil, err
 	}
 
-	// Resolve the runtime once for every namespace decision below. Hook creates
-	// claim a global external slug; local creates claim a repo-scoped tmux name;
-	// docker/ssh claim neither on this host. ForceRemote is only one way to select
-	// hook, so ask the same resolver NewInstance uses.
-	runtimeKind := session.BackendLocal
-	if req.ForceRemote {
-		runtimeKind = session.BackendHook
-	}
-	if kind, kerr := session.BackendKindFor(session.InstanceOptions{
-		Backend:     session.BackendKind(req.Backend),
-		ForceRemote: req.ForceRemote,
-	}, repo.Root); kerr == nil {
-		runtimeKind = kind
-	}
-	// A kerr means an invalid backend value. Leave the conservative default above
-	// and let NewInstance surface the canonical error rather than duplicating it.
 	nameNamespace := runtimeNamespaceForKind(runtimeKind)
 
 	// An in-place session and an off-box runtime are contradictory, and
@@ -338,12 +367,8 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 	// against runtimeKind, so the daemon's answer and NewInstance's cannot drift
 	// — including on the deliberate non-firing for a backend value that will not
 	// resolve, which belongs to the factory's canonical error.
-	if err := session.InPlaceBackendConflict(session.InstanceOptions{
-		Backend:     session.BackendKind(req.Backend),
-		ForceRemote: req.ForceRemote,
-		InPlace:     req.InPlace,
-	}, repo.Root); err != nil {
-		return nil, "", nil, nil, err
+	if inPlaceConflict != nil {
+		return nil, "", nil, nil, inPlaceConflict
 	}
 
 	var renamedArchived *session.InstanceData

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -292,6 +292,16 @@ func projectDeleteRefusal(req CreateSessionRequest, repoID string, inProgress bo
 	return err
 }
 
+// admitTaskRunFast is the pre-resolver half of the task-run cap, for a caller
+// that does not hold m.mu. It returns the SAME errAtConcurrencyLimit sentinel as
+// the authoritative check, so the watch-delivery path cannot tell the two apart
+// and parks the event either way.
+func (m *Manager) admitTaskRunFast(repoID, taskID string, limit int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.admitTaskRunLocked(repoID, taskID, limit)
+}
+
 // projectDeleteStateFor samples BOTH halves of the repo's delete state for a
 // caller that does not hold m.mu; it takes the lock itself.
 //
@@ -364,6 +374,23 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 	deleteActive, deleteGen := m.projectDeleteStateFor(repo.ID)
 	if deleteActive {
 		return nil, "", nil, nil, projectDeleteRefusal(req, repo.ID, true)
+	}
+
+	// Same reasoning for the task-run cap, which the hoist also moved behind the
+	// resolvers. A capped watch delivery for a stalled repo would otherwise hang
+	// in unbounded git instead of returning errAtConcurrencyLimit promptly and
+	// parking the event on the durable queue — the cap's whole contract is that a
+	// refusal is cheap and the event retries when a slot frees.
+	//
+	// ADVISORY, and one-way on purpose. It reads the counts without the
+	// refreshLocked below, so it may only REFUSE early, never admit: the
+	// authoritative check still runs post-refresh, under the same lock hold as the
+	// reservation. refreshLocked replaces m.instances wholesale, so a stale count
+	// can be high as well as low, and a spurious refusal here costs one park and
+	// retry — the same tradeoff releaseTaskRunLocked already documents for its
+	// momentary over-count, and the opposite of admitting one too many.
+	if err := m.admitTaskRunFast(repo.ID, req.TaskID, req.MaxConcurrentRuns); err != nil {
+		return nil, "", nil, nil, err
 	}
 
 	runtimeKind := session.BackendLocal


### PR DESCRIPTION
Proactive concurrency/lock-order audit of `daemon/`. One real defect, fixed here;
the rest of the sweep came back clean and is recorded in #2931 so it is not
re-run.

## The defect

`reserveCreate` took `m.mu` with a `defer` and then resolved the backend twice
while still holding it. Both resolvers reach `config.RepoFromPath` →
`resolveMainRepoRoot`:

```go
// config/repo.go:56 — no context, no timeout, no WaitDelay
topCmd := exec.Command("git", append(pathArgs, "rev-parse", "--show-toplevel")...)
```

So every session create held the **manager-wide** lock across 2–6 unbounded `git`
execs.

### Failure scenario

A project on a stalled NFS/FUSE mount, or a spun-down external disk:

1. a create in that project reaches the resolver; `git rev-parse` blocks and
   never returns;
2. `m.mu` is held by `defer`, so nothing releases it;
3. everything needing `m.mu` blocks forever — `Snapshot` (**every** TUI and web
   client, in every project), the liveness poll, kill, archive, delete-project,
   task delivery.

One unreachable repo takes down every session in every project; recovery is
killing the daemon. The blast radius is daemon-wide because the lock is, while
the fault is one repo.

### Why this one was the odd one out

The repo has bounded its git systematically — teardown paths (#1917), network
(#896), and the branch-hold `worktree list` **this same function already calls
under `m.mu`** (#856). `worktree_git.go` argues the general case outright: the
"local git cannot stall" assumption *"is false"*. `resolveMainRepoRoot` still
relies on it, and it was the only such call reached while holding a lock.

## The fix

Resolve **before** taking the lock rather than bounding the exec. Neither
resolver reads manager state — both are pure functions of the request and the
repo root — so hoisting costs nothing and reduces a daemon-wide wedge to one hung
create, the blast radius every other unbounded metadata read already has.

Hoisting the resolution deliberately does **not** hoist the refusal: the
in-place/off-box conflict is still *reported* where it was — after the
project-delete fence and admission, ahead of the archived-name-reuse rename —
because `reserveCreate`'s admission order is load-bearing (#2778, #2415).

Bounding `resolveMainRepoRoot` itself is a reasonable follow-up across its 17
callers, but is not needed to fix the wedge and is a much wider change.

## The test

The property is invisible to an ordinary create test — the resolution succeeds
whether or not the lock is held, and only its *lock context* is the defect. So
the test blocks inside the resolver and asks, from another goroutine, whether
`Snapshot` can still run. **It fails on the pre-fix code** and passes after.

It reports through a deadline rather than blocking, so a re-introduced hold is a
red test and not a wedged CI job — the same shape as `deadcode_2006_test.go`'s
10s guard.

## What the audit checked and found clean

Recorded in #2931 in full. Summary:

- **Lock order (#2006, target-before-op): clean.** All 5 `lockTarget` sites take
  target before op; all 15 `opLockFor` sites checked for the inverse, including
  transitively — no op-holder reaches a target acquisition. The five
  target-takers are entry points (3 RPC handlers, 2 background loops) reached
  with no locks held; both loops release `m.mu` before their per-session work.
- **`Locked`-suffix re-entrancy (#2106): no live defect.** Of 47 `*Locked`
  functions none takes `m.mu` directly. Two reach an `m.mu` taker one hop out and
  both are safe — `resumeFromLimitLocked`'s `Locked` names the target+op pair
  (its doc says so), and `startConversationCaptureLocked` dispatches its takers
  on a **new goroutine**.
- **Latent, not filed as a bug:** 15 of 28 `Manager` `*Locked` methods do not say
  *which* lock the caller must hold.

Per the standing rules `./daemon/...` was not run on the dev box; the cheap gate
is clean and CI exercises the rest.

## Second commit: the fence the hoist invalidated (Codex P2)

Moving the resolver out of `m.mu` left `m.projectDeletes` answering the wrong
question. That fence reports "a delete is running **right now**", which was a
complete answer only while the slow work sat under the lock — a delete could not
reach its own fence-install until the create had already reserved or refused.
Unlocked, the delete's entire lifetime (install → durable removals → remove) fits
inside the resolution window, and the post-lock check then reads a clear field and
admits a create into a project the user just deleted.

Re-reading the fence around the resolution does not fix it: there is no instant at
which a *finished* delete is visible in that map. So `reserveCreate` samples a
per-repo **delete generation** before resolving and compares it after taking `m.mu`.
Bumped on fence **install**, under the same critical section that installs it, so
the pair covers the whole interval and not just its trailing edge. Per repo, so an
unrelated project's delete does not refuse this create. Entries are never removed —
a reset would read equal to an old sample and silently stop fencing.

`TestReserveCreate_RefusesWhenAProjectDeleteCompletedDuringResolution` parks a create
in the resolver, runs the **real** `DeleteProject` to completion, asserts the fence is
already down, then asserts the create is refused — so it fails if the bump ever leaves
the production path.

Not in scope: `config.RepoFromPath` at the top of `reserveCreate` is the same
unbounded `git rev-parse` outside `m.mu` **on master**, so this window pre-existed the
hoist. It sits upstream of the point where `repo.ID` exists to sample; filed separately
as #2947.

Closes #2931

🤖 Generated with [Claude Code](https://claude.com/claude-code)