### PR TITLE
test(config): pin a manifest Enum against the validator that enforces it

### DIFF
--- a/config/manifest_enum_enforcement_test.go
+++ b/config/manifest_enum_enforcement_test.go
@@ -1,0 +1,148 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The manifest's anti-drift net covers Settable, Default, Type, source coverage,
+// and well-formedness (manifest_test.go). These two tests close the gaps it left
+// on the other half of the contract — that a key's advertised CONSTRAINTS are the
+// ones actually enforced, and at the right time.
+
+// manifestEnumBogusValue is a value no enum will ever contain. Deliberately not
+// a near-miss: this asserts that validation happens at all, and a near-miss
+// would make a failure ambiguous between "no validator" and "a lenient one".
+const manifestEnumBogusValue = "definitely-not-a-valid-enum-value-9f3a"
+
+// TestManifestEnumIsEnforcedAtSetTime pins every enumerated, settable manifest
+// key against the validator `af config set` really runs — in both directions.
+//
+// Without this, a key can advertise an Enum that nothing enforces: add the entry,
+// add `{kind: cfgString}` to settableKeySpecs with no `validate`, and every
+// existing manifest test still passes. `af config set <key> nonsense` then WRITES
+// the invalid value, and the failure surfaces at the next daemon start or first
+// read — pointing at a config file the user last touched days ago rather than at
+// the command that accepted it. The config agent, briefed from this manifest,
+// believes the key is constrained when it is not (#2930).
+//
+// The accept direction matters just as much and fails the opposite way: a
+// manifest Enum listing a value the validator refuses tells the agent to type a
+// command the CLI rejects.
+func TestManifestEnumIsEnforcedAtSetTime(t *testing.T) {
+	checked := 0
+	for _, entry := range AllManifest() {
+		if len(entry.Enum) == 0 || !entry.Settable {
+			continue
+		}
+		spec, ok := settableKeySpecs[entry.Key]
+		if !ok {
+			// TestManifestAgreesWithSettableKeys owns this direction; skip rather
+			// than duplicate its (better-worded) failure.
+			continue
+		}
+		if spec.validate == nil {
+			t.Errorf("manifest key %q advertises Enum %v but settableKeySpecs[%q] has no validate: "+
+				"`af config set %s %s` would be accepted and written, and the value would only fail "+
+				"later, at a read far from the command that took it. Add a validate to the spec in "+
+				"config/configset.go.", entry.Key, entry.Enum, entry.Key, entry.Key, manifestEnumBogusValue)
+			continue
+		}
+		checked++
+
+		// For a DYNAMIC family the Enum constrains the LEAF, not the value:
+		// `af config set program_overrides.claude "<command>"` enumerates the agent
+		// names, and the command itself is free-form. So the enum is exercised
+		// through whichever position it actually governs.
+		constrained := func(enumValue string) error { return spec.validate(entry.Key, enumValue) }
+		bogus := func() error { return spec.validate(entry.Key, manifestEnumBogusValue) }
+		position := "value"
+		if spec.dynamic {
+			constrained = func(enumValue string) error { return spec.validate(enumValue, "a-command") }
+			bogus = func() error { return spec.validate(manifestEnumBogusValue, "a-command") }
+			position = "leaf"
+		}
+
+		if err := bogus(); err == nil {
+			t.Errorf("settableKeySpecs[%q].validate ACCEPTED %q as its %s, which is outside the manifest's "+
+				"Enum %v: the advertised constraint is not enforced at set time.",
+				entry.Key, manifestEnumBogusValue, position, entry.Enum)
+		}
+		for _, allowed := range entry.Enum {
+			if err := constrained(allowed); err != nil {
+				t.Errorf("settableKeySpecs[%q].validate REJECTED %q as its %s, which the manifest advertises "+
+					"as allowed: %v. A config agent briefed from the manifest would type a command the CLI "+
+					"refuses — one of the two is wrong.", entry.Key, allowed, position, err)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no enumerated settable key was checked — this test has stopped covering anything " +
+			"(did Manifest/AllManifest, Settable, or the Enum field change shape?)")
+	}
+}
+
+// TestNonRepoSharedKeysAreRejectedFromAnInRepoFile drives the real loader over a
+// real file for every key the manifest does NOT admit at SourceRepoShared.
+//
+// It pins the OUTCOME — a checked-in `.agent-factory/config.toml` cannot set
+// these keys — and deliberately not one mechanism, because two independent
+// manifest-derived gates defend it: `inRepoAllowedKeys`
+// (`manifestKeysForSource(SourceRepoShared)`, the unknown-key rejection) and
+// `inRepoGlobalOnlyKeys` (`manifestGlobalOnlyKeySet()`, which produces the more
+// actionable "is a global setting and cannot be set per-repo" error). Measured:
+// widening either one alone leaves this green, because the other still refuses.
+// What it does catch is the regression that reaches a user — BOTH gates gone, or
+// the manifest itself starting to admit the key (the cross-check below).
+//
+// That matters because a checked-in repo file is written by whoever opens a PR
+// against the repo, so a key that leaks into it is a cloned repo choosing an
+// operator's setting. `root_agent`/`root_agents` are the sharp end (the #2216
+// singleton), which is why the tables are covered here and not just the scalars.
+func TestNonRepoSharedKeysAreRejectedFromAnInRepoFile(t *testing.T) {
+	// A shaped TOML body per key. Tables need a literal, so they are spelled out
+	// rather than generated — and they are exactly the ones worth pinning.
+	bodies := map[string]string{
+		"theme":                   "[theme]\nselected_fg = \"#ffffff\"\n",
+		"keys":                    "[keys]\nquit = \"Q\"\n",
+		"root_agent":              "[root_agent]\nenabled = true\n",
+		"root_agents":             "[root_agents]\n\"/audit/probe\" = { program = \"claude\" }\n",
+		"limit_patterns":          "[limit_patterns]\nclaude = \"probe\"\n",
+		"session_env_passthrough": "session_env_passthrough = [\"AUDIT_PROBE\"]\n",
+		"cors_allowed_origins":    "cors_allowed_origins = [\"http://audit.probe\"]\n",
+	}
+
+	admitted := map[string]bool{}
+	for _, entry := range AllManifest() {
+		if entry.Sources.Has(SourceRepoShared) {
+			admitted[entry.Key] = true
+		}
+	}
+
+	checked := 0
+	for key, body := range bodies {
+		if admitted[key] {
+			t.Errorf("this test asserts %q is NOT admitted in-repo, but the manifest now says it is. "+
+				"If that admission is intended, drop the key here; if not, the manifest entry is wrong.", key)
+			continue
+		}
+		checked++
+		root := t.TempDir()
+		dir := filepath.Join(root, InRepoConfigDirName)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("preparing %s: %v", dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, TomlConfigFileName), []byte(body), 0o644); err != nil {
+			t.Fatalf("writing the in-repo config: %v", err)
+		}
+		if _, _, err := LoadInRepoConfig(root); err == nil {
+			t.Errorf("an in-repo .agent-factory/config.toml setting %q was ACCEPTED: the manifest does not "+
+				"admit that key at SourceRepoShared, so a cloned repo just chose a setting only the operator "+
+				"should own.", key)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no key was checked — every key in this test became repo-shared, which is itself worth review")
+	}
+}


### PR DESCRIPTION
Result of a proactive audit of config validation and precedence. **Nothing is broken today** — this closes the one gap the audit found, which is a missing *guard*, not a missing fix. The rest of the sweep came back verified clean and is recorded below so nobody re-checks it.

## The gap

`config/manifest.go` is kept honest by a deliberate net of anti-drift tests: `TestManifestCoversEveryConfigKey`, `TestManifestAgreesWithSettableKeys` (both directions), `TestManifestDefaultsMatchDefaultConfig`, `TestManifestTypeMatchesTheRealField`, `TestManifestEntriesAreWellFormed`.

`ManifestEntry.Enum` had no lock at all.

**Failure scenario.** Someone adds an enumerated key and writes `{kind: cfgString}` in `settableKeySpecs` without a `validate`. Every existing test passes — the key is covered, `Settable` agrees with the allowlist, the type and default match. Then `af config set the_new_key nonsense` is **accepted and written**, and the failure surfaces at the next daemon start or first read, pointing at a config file the user last touched days ago rather than at the command that took the value. `af config list` prints `nonsense` beside the `Enum` the briefing advertises, so the config agent believes the key is constrained when it is not.

The reverse drift is equally silent: a manifest `Enum` listing a value the validator refuses tells the agent to type a command the CLI rejects. Both directions are pinned.

One subtlety the test handles: for a **dynamic** family the `Enum` constrains the **leaf** (`program_overrides.<agent>`), not the value, so the enum is exercised through the position it actually governs. My first draft got this wrong and the test caught it.

## Proven by mutation, since it passes on master

A guard for a defect that does not exist yet cannot be watched failing naturally, so I broke the code three ways and confirmed each is caught with the message that names the cause:

| Mutation | Result |
|---|---|
| Remove `ssh_host_key_verification`'s validator | FAIL — *"advertises Enum [strict accept-new insecure] but … has no validate"* |
| Make that validator lenient (`return nil`) | FAIL — *"ACCEPTED … which is outside the manifest's Enum"* |
| Give `root_agent` `sourceGlobalRepoPersonal` | FAIL — *"the manifest now says it is [admitted in-repo]"* |

A fourth mutation is why the second test's comment says what it does: widening `inRepoAllowedKeys` to every key left it **green**, because a second manifest-derived gate (`inRepoGlobalOnlyKeys`) still refuses with the more actionable *"is a global setting and cannot be set per-repo"*. So that test pins the **outcome**, defended by two independent gates, and its comment now says exactly that rather than claiming to guard one mechanism it does not.

## The rest of the audit: verified clean

Recorded so the next person does not re-derive it. Checked against `AllManifest()` (33 entries) — note `Manifest()` is **global-only**, and an earlier pass that used it silently skipped every repo key.

- **Every key documents its scope** — 0 of 33 entries have a zero `Sources`. Stronger than documentation: `inRepoAllowedKeys` and `projectPersonalAllowedKeys` are *derived from* the manifest via `manifestKeysForSource`, so the declared scope **is** the enforcement.
- **Scope is enforced end to end** — a real `LoadInRepoConfig` round-trip over a written `.agent-factory/config.toml` rejects all 27 keys the manifest does not admit in-repo, including every table (`root_agent`, `root_agents`, `keys`, `theme`, `limit_patterns`, `cors_allowed_origins`, `session_env_passthrough`). 0 violations.
- **Invalid enum values are rejected at set time** — all 6 enumerated settable keys already reject. That is what this PR now pins.
- **9 settable keys have no validator, all justified** — 6 are bools (the parse is the validation); `on_archive_command` is a free-form shell command; `vscode_server_binary` is a path that may legitimately not exist yet; `branch_prefix` cannot produce an invalid ref because `BranchForTitle` runs `SanitizeBranchName` over the combined name.
- **#2607's scope-default class is fixed for the whole per-project key set**, not just `root_agent`. Verified by round-trip against a built binary in an isolated `AGENT_FACTORY_HOME`: with global `default_program = claude` and a personal project override of `codex`, a bare `af config get default_program` inside the project returns **codex**, outside any repo returns **claude**, and `--explain` names the project and marks the shadowed sources. `configReadProjectSelector` falls back to `CurrentRepo()`, so the global-only path is reached only outside a git repo — where global is the right answer.

## One candidate investigated and dismissed

`af config get`/`list` take `--repo` (canonical, `--project` a deprecated alias) while `set`/`unset` take only `--project`, so `af config set … --repo P` errors with `unknown flag`. That looked like drift from the #2607 rename, but it is deliberate and documented: `--repo` is a pure path selector needing no registration, while `--project` targets a **registered** project and also accepts a `prj_` id. `warnDeprecatedConfigProjectAlias` is wired only to `get`/`list`, so no command tells a user to use a flag its sibling rejects. No issue filed.

## Validation

- `gofmt -l .` (no output) · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `deadcode -test ./...` · `scripts/lint-file-length.sh`
- `go test ./config/` — the only package touched — green.

Test-only change; no production code touched.

Closes #2930