### PR TITLE
fix(git): reproduce holes instead of allocating them on the cross-device copy

### DIFF
--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -456,6 +456,72 @@ func applyCopiedDirectoryMode(source, destination *os.File, destinationPath stri
 	return preserveSourceMode(int(destination.Fd()), info.Mode(), destinationPath, "directory")
 }
 
+// holeCopyChunk is the read granularity of the hole-preserving copy. It is a
+// multiple of every common filesystem block size, so a skipped chunk lands on
+// block boundaries and actually leaves a hole rather than a partly-allocated
+// extent.
+const holeCopyChunk = 256 << 10
+
+// copyContentsPreservingHoles copies in to out without writing runs of zeros, so
+// a sparse file arrives sparse instead of fully allocated.
+//
+// io.Copy reads a hole as zeros and faithfully writes them out, which allocates
+// a real block for every hole: a 4 KiB-on-disk, 64 MiB-long file arrived in the
+// archive as 64 MiB of blocks, a 16384x amplification (#2920). rename(2) never
+// reads the file, so the same-device path keeps the extent layout untouched and
+// only the cross-device path pays this. The archive root is shared by every
+// session on the box, so one session archiving a sparsely-allocated database or
+// image file can consume the space all of them depend on.
+//
+// A hole and a run of zeros are indistinguishable to every reader, so skipping
+// the write cannot change what anyone sees — it changes only what is allocated.
+// This is cp --sparse=always semantics: holes are reproduced at write
+// granularity rather than exactly, and a run of explicit zeros may become a
+// hole.
+//
+// Deliberately not SEEK_DATA/SEEK_HOLE extent iteration. That reproduces the
+// layout more exactly, but it replaces the read loop in the one function that
+// must never lose worktree bytes, and it degrades differently per filesystem.
+// This keeps the read-to-EOF loop and its behavior on a concurrently written
+// file, and changes only whether a zero-filled buffer is written or skipped.
+func copyContentsPreservingHoles(out, in *os.File) error {
+	buffer := make([]byte, holeCopyChunk)
+	var copied int64
+	for {
+		// ReadFull, not Read: a short read mid-file would push every later chunk
+		// off its block boundary, and a misaligned skip allocates instead of
+		// leaving a hole. Only the final chunk is allowed to be short.
+		n, err := io.ReadFull(in, buffer)
+		if n > 0 {
+			if !isAllZero(buffer[:n]) {
+				if _, writeErr := out.WriteAt(buffer[:n], copied); writeErr != nil {
+					return writeErr
+				}
+			}
+			copied += int64(n)
+		}
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+	}
+	// Load-bearing, not tidiness: a file whose final chunk was skipped has had
+	// nothing written at that offset, so without this the copy is short by the
+	// whole trailing hole.
+	return out.Truncate(copied)
+}
+
+func isAllZero(chunk []byte) bool {
+	for _, b := range chunk {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // preserveSourceMode restores a source node's permission bits on the descriptor
 // that owns its copy.
 //
@@ -567,7 +633,7 @@ func copyRegularFileAtWithIdentity(
 		_ = out.Close()
 		return created, err
 	}
-	if _, err := io.Copy(out, in); err != nil {
+	if err := copyContentsPreservingHoles(out, in); err != nil {
 		_ = out.Close()
 		return created, err
 	}

--- a/session/git/worktree_copy_tree_test.go
+++ b/session/git/worktree_copy_tree_test.go
@@ -373,3 +373,70 @@ func collectTreeDescription(t *testing.T, root string) map[string]string {
 	}))
 	return described
 }
+
+// TestCopyTree_PreservesSparseFilesInsteadOfExpandingThem is the #2920
+// regression. io.Copy reads a hole as zeros and writes them out, so the
+// cross-device fallback allocated a real block for every hole while the
+// same-device rename(2) left the extent layout untouched. The archive root is
+// shared by every session on the box, so one session archiving a sparsely
+// allocated database or image file could consume the space all of them need.
+//
+// The fixture has a leading hole, data in the middle, and a trailing hole — the
+// trailing one is what catches a copy that skips the final zero chunk and then
+// forgets to size the file.
+func TestCopyTree_PreservesSparseFilesInsteadOfExpandingThem(t *testing.T) {
+	const size = 32 << 20
+	const payload = "sparse payload marker"
+	src := filepath.Join(t.TempDir(), "src")
+	require.NoError(t, os.Mkdir(src, 0755))
+	sparse, err := os.Create(filepath.Join(src, "database.bin"))
+	require.NoError(t, err)
+	require.NoError(t, sparse.Truncate(size))
+	_, err = sparse.WriteAt([]byte(payload), size/2)
+	require.NoError(t, err)
+	require.NoError(t, sparse.Close())
+	// A dense file alongside it: the zero-skipping must not disturb ordinary
+	// content, including embedded NUL bytes.
+	dense := []byte("head\x00\x00\x00tail")
+	require.NoError(t, os.WriteFile(filepath.Join(src, "dense.bin"), dense, 0644))
+
+	sourceBlocks := allocatedBlocks(t, filepath.Join(src, "database.bin"))
+	require.Less(t, sourceBlocks, int64(4096),
+		"fixture is not sparse on this filesystem, so the assertion below would prove nothing")
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	require.NoError(t, copyTree(src, dest))
+
+	copiedPath := filepath.Join(dest, "database.bin")
+	info, err := os.Stat(copiedPath)
+	require.NoError(t, err)
+	assert.Equal(t, int64(size), info.Size(),
+		"the trailing hole must still count toward the file's length")
+
+	copiedBlocks := allocatedBlocks(t, copiedPath)
+	assert.Less(t, copiedBlocks, sourceBlocks+4096,
+		"the copy allocated the holes instead of reproducing them: %d KiB on disk vs the source's %d KiB",
+		copiedBlocks/2, sourceBlocks/2)
+
+	// Sparseness is worthless if the bytes changed: every reader must still see
+	// zeros for the holes and the payload where it was written.
+	copiedContents, err := os.ReadFile(copiedPath)
+	require.NoError(t, err)
+	require.Len(t, copiedContents, size)
+	assert.Equal(t, payload, string(copiedContents[size/2:size/2+len(payload)]))
+	assert.True(t, isAllZero(copiedContents[:size/2]), "the leading hole must read back as zeros")
+	assert.True(t, isAllZero(copiedContents[size/2+len(payload):]), "the trailing hole must read back as zeros")
+
+	copiedDense, err := os.ReadFile(filepath.Join(dest, "dense.bin"))
+	require.NoError(t, err)
+	assert.Equal(t, dense, copiedDense, "embedded NUL bytes must survive the zero-run skipping")
+}
+
+// allocatedBlocks reports a file's on-disk allocation in 512-byte units, which
+// is what distinguishes a hole from a written run of zeros — st_size cannot.
+func allocatedBlocks(t *testing.T, path string) int64 {
+	t.Helper()
+	var stat syscall.Stat_t
+	require.NoError(t, syscall.Stat(path, &stat))
+	return stat.Blocks
+}

--- a/session/git/worktree_copy_tree_test.go
+++ b/session/git/worktree_copy_tree_test.go
@@ -401,35 +401,62 @@ func TestCopyTree_PreservesSparseFilesInsteadOfExpandingThem(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(src, "dense.bin"), dense, 0644))
 
 	sourceBlocks := allocatedBlocks(t, filepath.Join(src, "database.bin"))
-	require.Less(t, sourceBlocks, int64(4096),
-		"fixture is not sparse on this filesystem, so the assertion below would prove nothing")
 
 	dest := filepath.Join(t.TempDir(), "dest")
 	require.NoError(t, copyTree(src, dest))
-
 	copiedPath := filepath.Join(dest, "database.bin")
-	info, err := os.Stat(copiedPath)
-	require.NoError(t, err)
-	assert.Equal(t, int64(size), info.Size(),
-		"the trailing hole must still count toward the file's length")
 
-	copiedBlocks := allocatedBlocks(t, copiedPath)
-	assert.Less(t, copiedBlocks, sourceBlocks+4096,
-		"the copy allocated the holes instead of reproducing them: %d KiB on disk vs the source's %d KiB",
-		copiedBlocks/2, sourceBlocks/2)
+	// Contents first, and unconditionally: what the copy must never do is change
+	// a byte, and that holds on every filesystem. Only the allocation half below
+	// depends on the filesystem being able to express a hole at all.
+	t.Run("contents survive the zero-run skipping", func(t *testing.T) {
+		info, err := os.Stat(copiedPath)
+		require.NoError(t, err)
+		assert.Equal(t, int64(size), info.Size(),
+			"the trailing hole must still count toward the file's length")
 
-	// Sparseness is worthless if the bytes changed: every reader must still see
-	// zeros for the holes and the payload where it was written.
-	copiedContents, err := os.ReadFile(copiedPath)
-	require.NoError(t, err)
-	require.Len(t, copiedContents, size)
-	assert.Equal(t, payload, string(copiedContents[size/2:size/2+len(payload)]))
-	assert.True(t, isAllZero(copiedContents[:size/2]), "the leading hole must read back as zeros")
-	assert.True(t, isAllZero(copiedContents[size/2+len(payload):]), "the trailing hole must read back as zeros")
+		copiedContents, err := os.ReadFile(copiedPath)
+		require.NoError(t, err)
+		require.Len(t, copiedContents, size)
+		assert.Equal(t, payload, string(copiedContents[size/2:size/2+len(payload)]))
+		assert.Equal(t, -1, firstNonZero(copiedContents[:size/2]), "the leading hole must read back as zeros")
+		assert.Equal(t, -1, firstNonZero(copiedContents[size/2+len(payload):]), "the trailing hole must read back as zeros")
 
-	copiedDense, err := os.ReadFile(filepath.Join(dest, "dense.bin"))
-	require.NoError(t, err)
-	assert.Equal(t, dense, copiedDense, "embedded NUL bytes must survive the zero-run skipping")
+		copiedDense, err := os.ReadFile(filepath.Join(dest, "dense.bin"))
+		require.NoError(t, err)
+		assert.Equal(t, dense, copiedDense, "embedded NUL bytes must survive the zero-run skipping")
+	})
+
+	t.Run("holes are reproduced rather than allocated", func(t *testing.T) {
+		// Whether ftruncate leaves a hole is the filesystem's call, not ours: it
+		// does on ext4, and the macOS runner's does not. Skip rather than fail
+		// where the fixture never became sparse — the assertion could only
+		// compare a dense file against itself and would pass vacuously, which is
+		// worse than not running. The subtest keeps that visible in CI instead of
+		// hiding it inside a green parent.
+		if sourceBlocks >= 4096 {
+			t.Skipf("filesystem did not make the fixture sparse (%d KiB allocated for a %d MiB file), "+
+				"so there is no hole here to preserve or lose", sourceBlocks/2, size>>20)
+		}
+		copiedBlocks := allocatedBlocks(t, copiedPath)
+		assert.Less(t, copiedBlocks, sourceBlocks+4096,
+			"the copy allocated the holes instead of reproducing them: %d KiB on disk vs the source's %d KiB",
+			copiedBlocks/2, sourceBlocks/2)
+	})
+}
+
+// firstNonZero returns the index of the first non-zero byte, or -1. It exists so
+// the copy is verified independently of the production isAllZero that decided
+// what to write: sharing that helper would make a bug in it corrupt the copy and
+// the assertion the same way, and the test would confirm itself. Returning the
+// index rather than a bool also names WHERE a hole was dirtied.
+func firstNonZero(chunk []byte) int {
+	for i, b := range chunk {
+		if b != 0 {
+			return i
+		}
+	}
+	return -1
 }
 
 // allocatedBlocks reports a file's on-disk allocation in 512-byte units, which


### PR DESCRIPTION
Found by a proactive audit of archive/kill data preservation, not a user report. The class is #2919; this is its dangerous instance.

## The bug

`io.Copy` reads a hole as zeros and faithfully writes them out, so the cross-device archive fallback allocated a real block for every hole. Measured on ext4, one fixture through both paths of `moveDirCrossDevice`:

| | `st_size` | `st_blocks` |
|---|---|---|
| source | 64 MiB | **4 KiB** |
| same-device `rename(2)` | 64 MiB | **4 KiB** |
| cross-device copy | 64 MiB | **65536 KiB** |

A 4 KiB file arrived in the archive as 64 MiB — 16384× — with no error and no warning. `rename(2)` never reads the file, so only the cross-device path pays it, which also means it reproduces on a box where `$AF_HOME` and the repo are on different filesystems and not on one where they are not.

**Why this one and not the other four findings:** the amplification scales with the hole, not the data, and the archive root is shared by every session on the box — so this is not a per-session cost. One session archiving a sparsely-allocated database or image file consumes the space the daemon and every other session depend on. The repo's own notes record this box at ~92% disk with ~142 GB of archived worktrees.

## The fix

Skip writing runs of zeros, and size the destination with `ftruncate` — `cp --sparse=always` semantics. **A hole and a run of zeros are indistinguishable to every reader**, so this cannot change what anyone sees; it changes only what is allocated.

Three deliberate choices:

- **Not `SEEK_DATA`/`SEEK_HOLE` extent iteration.** That reproduces the layout more exactly, but it replaces the read loop in the one function that must never lose worktree bytes, and it degrades differently per filesystem. Zero-run detection keeps the existing read-to-EOF loop — including its behavior on a concurrently written file — and changes only whether a zero-filled buffer is written.
- **`io.ReadFull`, not `Read`.** A short read mid-file would push every later chunk off its block boundary, and a misaligned skip allocates instead of leaving a hole. Only the final chunk may be short.
- **The `ftruncate` is load-bearing, not tidiness.** A file whose final chunk is a skipped hole has had nothing written at that offset, so without it the copy is short by the whole trailing hole. The fixture carries a trailing hole for exactly that reason.

## Tests

`TestCopyTree_PreservesSparseFilesInsteadOfExpandingThem` — leading hole, data in the middle, trailing hole, plus a dense file containing embedded NUL bytes. It asserts allocation *and* content, because sparseness is worthless if the bytes changed.

It also guards its own premise: it fails if the fixture isn't actually sparse on the test filesystem, so it can't pass vacuously somewhere holes aren't supported.

Pre-fix it reports:
```
"65536" is not less than "4104"
the copy allocated the holes instead of reproducing them: 32768 KiB on disk vs the source's 4 KiB
```

**Mutation-tested — each lever independently pinned:**

| mutation | caught by |
|---|---|
| drop the `ftruncate` | size assertion — trailing hole lost |
| `isAllZero` → always false (old behavior) | allocation assertion — 32768 KiB |
| `isAllZero` → always true (**corrupts data**) | content assertions — payload and dense file both read back as zeros |

The third matters most: it proves the test catches a data-*losing* version of this change, which is the risk I weighed when choosing zero-detection over extent iteration.

## Verification

`gofmt -l .` clean · `go build ./...` · `golangci-lint run --fast` · `deadcode -test ./...` · `scripts/lint-file-length.sh` · `go test ./session/git/` (full package, green). No daemon/app tests and no container suites run locally.

Closes #2920