### PR TITLE
fix(web): anchor, unwrap and defer the long-press copy (#2940)

### DIFF
--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7477,14 +7477,18 @@ var AttachTerminal = class {
     if (event.type === "touchcancel" && awaitingRecognition && touchCancelCompletesPress(Date.now() - this.touchPressAt)) {
       this.selectTouchWord();
     }
+    this.disposeTouchPressMarker();
+    this.flushTouchCopy();
+  };
+  /** Writes the text a recognised press staged, once, from whichever trusted event
+   *  the browser actually delivered. */
+  flushTouchCopy() {
     const pending = this.touchCopyPending;
     this.touchCopyPending = null;
-    this.disposeTouchPressMarker();
-    if (pending === null) {
-      return;
+    if (pending !== null) {
+      this.copyToClipboard(pending);
     }
-    this.copyToClipboard(pending);
-  };
+  }
   // …and the menu that cancellation was announcing is not wanted either: it would
   // cover the selection with an OS menu whose Copy acts on a DOM selection xterm
   // never makes (#2849). Suppressed ONLY for a press af has already acted on, so a
@@ -7572,6 +7576,7 @@ var AttachTerminal = class {
     if (this.lastPointerWasTouch && this.touchCopyFired) {
       event.preventDefault();
       event.stopPropagation();
+      this.flushTouchCopy();
       return;
     }
     if (!this.applicationOwnsMouse() || this.lastPointerWasTouch) {

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7116,6 +7116,9 @@ function wrappedCellPosition(index, cols) {
   }
   return { col: index % cols, row: Math.floor(index / cols) };
 }
+function touchCancelCompletesPress(heldMs) {
+  return heldMs >= TOUCH_LONG_PRESS_MS * 0.6;
+}
 
 // src/theme.ts
 var THEME_CHOICES = ["auto", "light", "dark"];
@@ -7382,6 +7385,8 @@ var AttachTerminal = class {
   // what xterm gives you to survive that, and it is the mechanism the viewport
   // anchor above already uses.
   touchPressMarker = null;
+  // When the finger went down, so a cancellation can be told apart from a takeover.
+  touchPressAt = 0;
   // Text the press selected, waiting for the finger to lift. The clipboard write has
   // to happen in the touchend handler: Safari only honours it from a trusted
   // user-gesture task, and a setTimeout callback is not one.
@@ -7459,17 +7464,22 @@ var AttachTerminal = class {
     this.touchCopyPending = null;
     this.cancelTouchLongPress();
     this.disposeTouchPressMarker();
+    this.touchPressAt = Date.now();
     this.touchPressCell = press ? this.bufferCellAtPoint(press.clientX, press.clientY) : null;
     if (this.touchPressCell) {
       this.touchPressMarker = this.registerPressMarker(this.touchPressCell.row);
       this.startTouchLongPress();
     }
   };
-  onTouchEnd = () => {
+  onTouchEnd = (event) => {
+    const awaitingRecognition = this.touchLongPressTimer !== null;
     this.cancelTouchLongPress();
-    this.disposeTouchPressMarker();
+    if (event.type === "touchcancel" && awaitingRecognition && touchCancelCompletesPress(Date.now() - this.touchPressAt)) {
+      this.selectTouchWord();
+    }
     const pending = this.touchCopyPending;
     this.touchCopyPending = null;
+    this.disposeTouchPressMarker();
     if (pending === null) {
       return;
     }

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7243,6 +7243,7 @@ function currentXtermTheme() {
 var BACKOFF_BASE_MS = 500;
 var BACKOFF_MAX_MS = 1e4;
 var RESIZE_DEBOUNCE_MS = 120;
+var TOUCH_PRESS_MAX_ROWS = 32;
 var AttachTerminal = class {
   constructor(container, token2, endpoint, cb) {
     this.container = container;
@@ -7595,6 +7596,7 @@ var AttachTerminal = class {
     if (this.lastPointerWasTouch && this.touchCopyFired) {
       event.preventDefault();
       event.stopPropagation();
+      this.suppressNextContextMenu = false;
       this.flushTouchCopy();
       return;
     }
@@ -7790,7 +7792,11 @@ var AttachTerminal = class {
       const at = wrappedCellPosition(range.start, press.cols);
       if (this.liveTextAt(markedFirstRow, range, press.cols) === text) {
         this.term.select(at.col, markedFirstRow + at.row, range.length);
+      } else {
+        this.term.clearSelection();
       }
+    } else {
+      this.term.clearSelection();
     }
     this.touchCopyFired = true;
     this.suppressNextContextMenu = true;
@@ -7799,19 +7805,11 @@ var AttachTerminal = class {
   /** The text the live buffer currently holds where a snapshot's range sits, or null
    *  if that no longer resolves. Used to check the highlight before painting it. */
   liveTextAt(firstRow, range, cols) {
-    const buffer = this.term.buffer.active;
-    const cells = [];
     const firstNeeded = Math.floor(range.start / cols);
     const lastNeeded = Math.floor((range.start + range.length - 1) / cols);
-    for (let offset = firstNeeded; offset <= lastNeeded; offset += 1) {
-      const line = buffer.getLine(firstRow + offset);
-      if (!line) {
-        return null;
-      }
-      for (let col = 0; col < cols; col += 1) {
-        const buffered = line.getCell(col);
-        cells.push(buffered === void 0 ? " " : buffered.getWidth() === 0 ? "" : buffered.getChars() || " ");
-      }
+    const cells = this.flattenRows(firstRow + firstNeeded, firstRow + lastNeeded, cols);
+    if (cells === null) {
+      return null;
     }
     return textFromCells(cells, { start: range.start - firstNeeded * cols, length: range.length });
   }
@@ -7843,18 +7841,45 @@ var AttachTerminal = class {
       return null;
     }
     let first = pressedRow;
-    while (first > 0 && buffer.getLine(first)?.isWrapped === true) {
+    while (first > 0 && pressedRow - first < TOUCH_PRESS_MAX_ROWS && buffer.getLine(first)?.isWrapped === true && this.rowEdgeContinues(first, 0, cols)) {
       first -= 1;
     }
-    if (buffer.getLine(first)?.isWrapped === true) {
+    if (buffer.getLine(first)?.isWrapped === true && this.rowEdgeContinues(first, 0, cols)) {
       return null;
     }
     let last = pressedRow;
-    while (last + 1 < buffer.length && buffer.getLine(last + 1)?.isWrapped === true) {
+    while (last + 1 < buffer.length && last - pressedRow < TOUCH_PRESS_MAX_ROWS && buffer.getLine(last + 1)?.isWrapped === true && this.rowEdgeContinues(last, cols - 1, cols)) {
       last += 1;
     }
+    if (last + 1 < buffer.length && buffer.getLine(last + 1)?.isWrapped === true && this.rowEdgeContinues(last, cols - 1, cols)) {
+      return null;
+    }
+    const cells = this.flattenRows(first, last, cols);
+    if (cells === null) {
+      return null;
+    }
+    return { cells, index: (pressedRow - first) * cols + cell.col, firstRow: first, cols, bufferType: buffer.type };
+  }
+  /** Whether the token at one edge of a row runs on — the only reason to pull another
+   *  wrapped row into the snapshot. A blank there ends the token and the walk. */
+  rowEdgeContinues(row, col, cols) {
+    const cells = this.flattenRows(row, row, cols);
+    const edge = cells?.[col];
+    return edge !== void 0 && (edge === "" || edge.trim() !== "");
+  }
+  /**
+   * Flattens buffer rows to ONE ENTRY PER COLUMN, so an index is a column.
+   * translateToString would collapse a wide character into a single index and quietly
+   * shift every column after it.
+   *
+   * Shared by the snapshot and by the live check that guards the highlight: two
+   * copies of this drifted apart once already, and a difference between them reads as
+   * "the text changed" — which silently withholds the only feedback this gesture has.
+   */
+  flattenRows(firstRow, lastRow, cols) {
+    const buffer = this.term.buffer.active;
     const cells = [];
-    for (let row = first; row <= last; row += 1) {
+    for (let row = firstRow; row <= lastRow; row += 1) {
       const line = buffer.getLine(row);
       if (!line) {
         return null;
@@ -7863,11 +7888,11 @@ var AttachTerminal = class {
         const buffered = line.getCell(col);
         cells.push(buffered === void 0 ? " " : buffered.getWidth() === 0 ? "" : buffered.getChars() || " ");
       }
-      if (row < last && line.getCell(cols - 1)?.getCode() === 0) {
+      if (buffer.getLine(row + 1)?.isWrapped === true && line.getCell(cols - 1)?.getCode() === 0) {
         cells[cells.length - 1] = "";
       }
     }
-    return { cells, index: (pressedRow - first) * cols + cell.col, firstRow: first, cols, bufferType: buffer.type };
+    return cells;
   }
   /** The painted height of one terminal row, which turns a pixel-denominated gesture
    *  into rows. Falls back to a font-size estimate before the first row exists. */

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7377,6 +7377,11 @@ var AttachTerminal = class {
   // second later, and under live output the row the finger is on has scrolled by
   // then — copying whatever slid beneath it instead of what was pressed.
   touchPressCell = null;
+  // …and a marker on that row. A FULL scrollback ring trims from the top while the
+  // finger rests, shifting every absolute index down under the anchor; a marker is
+  // what xterm gives you to survive that, and it is the mechanism the viewport
+  // anchor above already uses.
+  touchPressMarker = null;
   // Text the press selected, waiting for the finger to lift. The clipboard write has
   // to happen in the touchend handler: Safari only honours it from a trusted
   // user-gesture task, and a setTimeout callback is not one.
@@ -7453,13 +7458,16 @@ var AttachTerminal = class {
     this.touchCopyFired = false;
     this.touchCopyPending = null;
     this.cancelTouchLongPress();
+    this.disposeTouchPressMarker();
     this.touchPressCell = press ? this.bufferCellAtPoint(press.clientX, press.clientY) : null;
     if (this.touchPressCell) {
+      this.touchPressMarker = this.registerPressMarker(this.touchPressCell.row);
       this.startTouchLongPress();
     }
   };
   onTouchEnd = () => {
     this.cancelTouchLongPress();
+    this.disposeTouchPressMarker();
     const pending = this.touchCopyPending;
     this.touchCopyPending = null;
     if (pending === null) {
@@ -7472,7 +7480,7 @@ var AttachTerminal = class {
   // never makes (#2849). Suppressed ONLY for a press af has already acted on, so a
   // desktop right-click keeps the browser's menu.
   onContextMenu = (event) => {
-    if (this.touchCopyFired) {
+    if (this.lastPointerWasTouch && this.touchCopyFired) {
       event.preventDefault();
     }
   };
@@ -7481,6 +7489,7 @@ var AttachTerminal = class {
     const moved = event.touches.length !== 1 || !touchPressStillHeld(this.touchOriginX, this.touchOriginY, event.touches[0].clientX, event.touches[0].clientY);
     if (moved) {
       this.cancelTouchLongPress();
+      this.discardPendingTouchCopy();
     }
     if (this.touchScrollY === null) {
       return;
@@ -7590,6 +7599,7 @@ var AttachTerminal = class {
     const plan = terminalUserScrollPlan(source, this.visibleFitFrame !== null);
     if (plan.cancelScheduledVisibleFit) {
       this.cancelTouchLongPress();
+      this.disposeTouchPressMarker();
       this.cancelVisibleFitFrame();
     }
     this.fitVisibleHost();
@@ -7696,6 +7706,30 @@ var AttachTerminal = class {
       this.touchLongPressTimer = null;
     }
   }
+  /** Drops a copy the press had already staged, and the selection that promised it,
+   *  so the gesture leaves nothing behind claiming it copied something. */
+  discardPendingTouchCopy() {
+    if (this.touchCopyPending === null && !this.touchCopyFired) {
+      return;
+    }
+    this.touchCopyPending = null;
+    this.touchCopyFired = false;
+    this.term.clearSelection();
+  }
+  /** Marks the pressed row so a scrollback trim during the hold moves the anchor with
+   *  the text. Alternate buffers cannot register markers, hence the null. */
+  registerPressMarker(row) {
+    const buffer = this.term.buffer.active;
+    try {
+      return this.term.registerMarker(row - (buffer.baseY + buffer.cursorY));
+    } catch {
+      return null;
+    }
+  }
+  disposeTouchPressMarker() {
+    this.touchPressMarker?.dispose();
+    this.touchPressMarker = null;
+  }
   /** The cell under a viewport point, in ABSOLUTE buffer coordinates so it survives
    *  everything the terminal does to the viewport afterwards. */
   bufferCellAtPoint(x, y) {
@@ -7721,12 +7755,17 @@ var AttachTerminal = class {
     }
     const buffer = this.term.buffer.active;
     const cols = this.term.cols;
-    let first = press.row;
+    const marked = this.touchPressMarker?.line ?? -1;
+    const pressedRow = marked >= 0 ? marked : press.row;
+    if (pressedRow < 0 || pressedRow >= buffer.length) {
+      return;
+    }
+    let first = pressedRow;
     while (first > 0 && buffer.getLine(first)?.isWrapped === true) {
       first -= 1;
     }
-    let last = press.row;
-    while (buffer.getLine(last + 1)?.isWrapped === true) {
+    let last = pressedRow;
+    while (last + 1 < buffer.length && buffer.getLine(last + 1)?.isWrapped === true) {
       last += 1;
     }
     const cells = [];
@@ -7740,7 +7779,7 @@ var AttachTerminal = class {
         cells.push(buffered === void 0 ? " " : buffered.getWidth() === 0 ? "" : buffered.getChars() || " ");
       }
     }
-    const pressed = (press.row - first) * cols + press.col;
+    const pressed = (pressedRow - first) * cols + press.col;
     const range = wordRangeAtColumn(cells, pressed) ?? { start: 0, length: lineContentColumns(cells) };
     if (range.length === 0) {
       return;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7787,11 +7787,11 @@ var AttachTerminal = class {
     if (text.trim() === "") {
       return;
     }
-    const markedFirstRow = this.touchPressMarker?.line ?? -1;
-    if (markedFirstRow >= 0 && press.bufferType === this.term.buffer.active.type && press.cols === this.term.cols) {
+    const anchorRow = this.touchPressMarker !== null ? this.touchPressMarker.line : press.firstRow;
+    if (anchorRow >= 0 && press.bufferType === this.term.buffer.active.type && press.cols === this.term.cols) {
       const at = wrappedCellPosition(range.start, press.cols);
-      if (this.liveTextAt(markedFirstRow, range, press.cols) === text) {
-        this.term.select(at.col, markedFirstRow + at.row, range.length);
+      if (this.liveTextAt(anchorRow, range, press.cols) === text) {
+        this.term.select(at.col, anchorRow + at.row, range.length);
       } else {
         this.term.clearSelection();
       }
@@ -7921,7 +7921,7 @@ var AttachTerminal = class {
         const buffered = line.getCell(col);
         cells.push(buffered === void 0 ? " " : buffered.getWidth() === 0 ? "" : buffered.getChars() || " ");
       }
-      if (buffer.getLine(row + 1)?.isWrapped === true && line.getCell(cols - 1)?.getCode() === 0) {
+      if (row + 1 < buffer.length && buffer.getLine(row + 1)?.isWrapped === true && line.getCell(cols - 1)?.getCode() === 0) {
         cells[cells.length - 1] = "";
       }
     }

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7325,6 +7325,7 @@ var AttachTerminal = class {
     container.addEventListener("touchmove", this.onTouchMove, { capture: true, passive: false });
     container.addEventListener("touchend", this.onTouchEnd, { capture: true, passive: true });
     container.addEventListener("touchcancel", this.onTouchEnd, { capture: true, passive: true });
+    container.addEventListener("contextmenu", this.onContextMenu);
     container.addEventListener("pointerdown", this.onPointerDown, true);
     container.addEventListener("mousedown", this.onMouseDownCapture, true);
     container.addEventListener("copy", this.onCopy);
@@ -7457,14 +7458,23 @@ var AttachTerminal = class {
       this.startTouchLongPress();
     }
   };
-  onTouchEnd = (event) => {
+  onTouchEnd = () => {
     this.cancelTouchLongPress();
     const pending = this.touchCopyPending;
     this.touchCopyPending = null;
-    if (pending === null || event.type !== "touchend") {
+    if (pending === null) {
       return;
     }
     this.copyToClipboard(pending);
+  };
+  // …and the menu that cancellation was announcing is not wanted either: it would
+  // cover the selection with an OS menu whose Copy acts on a DOM selection xterm
+  // never makes (#2849). Suppressed ONLY for a press af has already acted on, so a
+  // desktop right-click keeps the browser's menu.
+  onContextMenu = (event) => {
+    if (this.touchCopyFired) {
+      event.preventDefault();
+    }
   };
   onTouchMove = (event) => {
     this.handleUserScroll("touch");
@@ -7615,6 +7625,7 @@ var AttachTerminal = class {
     this.container.removeEventListener("touchmove", this.onTouchMove, true);
     this.container.removeEventListener("touchend", this.onTouchEnd, true);
     this.container.removeEventListener("touchcancel", this.onTouchEnd, true);
+    this.container.removeEventListener("contextmenu", this.onContextMenu);
     this.container.removeEventListener("pointerdown", this.onPointerDown, true);
     this.container.removeEventListener("mousedown", this.onMouseDownCapture, true);
     this.container.removeEventListener("copy", this.onCopy);

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7873,7 +7873,7 @@ var AttachTerminal = class {
       if (range === null) {
         return null;
       }
-      if (range.start === 0 && (first === 0 ? buffer.getLine(0)?.isWrapped === true : true)) {
+      if (range.start === 0 && first > 0 && buffer.getLine(first)?.isWrapped === true) {
         return null;
       }
       if (range.start + range.length === cells.length && last + 1 < buffer.length && buffer.getLine(last + 1)?.isWrapped === true) {

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7840,32 +7840,65 @@ var AttachTerminal = class {
     if (pressedRow < 0 || pressedRow >= buffer.length) {
       return null;
     }
-    let first = pressedRow;
-    while (first > 0 && pressedRow - first < TOUCH_PRESS_MAX_ROWS && buffer.getLine(first)?.isWrapped === true && this.rowEdgeContinues(first, 0, cols)) {
-      first -= 1;
-    }
-    if (buffer.getLine(first)?.isWrapped === true && this.rowEdgeContinues(first, 0, cols)) {
-      return null;
-    }
-    let last = pressedRow;
-    while (last + 1 < buffer.length && last - pressedRow < TOUCH_PRESS_MAX_ROWS && buffer.getLine(last + 1)?.isWrapped === true && this.rowEdgeContinues(last, cols - 1, cols)) {
-      last += 1;
-    }
-    if (last + 1 < buffer.length && buffer.getLine(last + 1)?.isWrapped === true && this.rowEdgeContinues(last, cols - 1, cols)) {
-      return null;
-    }
-    const cells = this.flattenRows(first, last, cols);
+    let cells = this.flattenRows(pressedRow, pressedRow, cols);
     if (cells === null) {
       return null;
     }
-    return { cells, index: (pressedRow - first) * cols + cell.col, firstRow: first, cols, bufferType: buffer.type };
-  }
-  /** Whether the token at one edge of a row runs on — the only reason to pull another
-   *  wrapped row into the snapshot. A blank there ends the token and the walk. */
-  rowEdgeContinues(row, col, cols) {
-    const cells = this.flattenRows(row, row, cols);
-    const edge = cells?.[col];
-    return edge !== void 0 && (edge === "" || edge.trim() !== "");
+    let first = pressedRow;
+    let last = pressedRow;
+    let index = cell.col;
+    const reaches = () => wordRangeAtColumn(cells, index);
+    if (reaches() !== null) {
+      while (first > 0 && pressedRow - first < TOUCH_PRESS_MAX_ROWS && buffer.getLine(first)?.isWrapped === true && reaches()?.start === 0) {
+        const previous = this.flattenRows(first - 1, first - 1, cols);
+        if (previous === null) {
+          return null;
+        }
+        cells = previous.concat(cells);
+        index += cols;
+        first -= 1;
+      }
+      while (last + 1 < buffer.length && last - pressedRow < TOUCH_PRESS_MAX_ROWS && buffer.getLine(last + 1)?.isWrapped === true && (() => {
+        const range2 = reaches();
+        return range2 !== null && range2.start + range2.length === cells.length;
+      })()) {
+        const next = this.flattenRows(last + 1, last + 1, cols);
+        if (next === null) {
+          return null;
+        }
+        cells = cells.concat(next);
+        last += 1;
+      }
+      const range = reaches();
+      if (range === null) {
+        return null;
+      }
+      if (range.start === 0 && (first === 0 ? buffer.getLine(0)?.isWrapped === true : true)) {
+        return null;
+      }
+      if (range.start + range.length === cells.length && last + 1 < buffer.length && buffer.getLine(last + 1)?.isWrapped === true) {
+        return null;
+      }
+    } else {
+      while (first > 0 && pressedRow - first < TOUCH_PRESS_MAX_ROWS && buffer.getLine(first)?.isWrapped === true) {
+        first -= 1;
+      }
+      while (last + 1 < buffer.length && last - pressedRow < TOUCH_PRESS_MAX_ROWS && buffer.getLine(last + 1)?.isWrapped === true) {
+        last += 1;
+      }
+      if (buffer.getLine(first)?.isWrapped === true) {
+        return null;
+      }
+      if (last + 1 < buffer.length && buffer.getLine(last + 1)?.isWrapped === true) {
+        return null;
+      }
+      cells = this.flattenRows(first, last, cols);
+      if (cells === null) {
+        return null;
+      }
+      index = (pressedRow - first) * cols + cell.col;
+    }
+    return { cells, index, firstRow: first, cols, bufferType: buffer.type };
   }
   /**
    * Flattens buffer rows to ONE ENTRY PER COLUMN, so an index is a column.

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7110,6 +7110,12 @@ function lineContentColumns(cells) {
   }
   return end + 1;
 }
+function wrappedCellPosition(index, cols) {
+  if (cols <= 0) {
+    return { col: 0, row: 0 };
+  }
+  return { col: index % cols, row: Math.floor(index / cols) };
+}
 
 // src/theme.ts
 var THEME_CHOICES = ["auto", "light", "dark"];
@@ -7361,10 +7367,19 @@ var AttachTerminal = class {
   touchOriginX = 0;
   touchOriginY = 0;
   touchScrollClaimed = false;
-  // The pending long press, and whether it has already copied on this gesture — a
-  // copy has to swallow the compatibility click the same touch would otherwise fire.
+  // The pending long press, and whether it has already acted on this gesture — a copy
+  // has to swallow the compatibility click the same touch would otherwise fire.
   touchLongPressTimer = null;
   touchCopyFired = false;
+  // The cell the finger went down on, resolved AT TOUCHSTART and in absolute buffer
+  // coordinates. Resolving it when the timer fires would read the viewport half a
+  // second later, and under live output the row the finger is on has scrolled by
+  // then — copying whatever slid beneath it instead of what was pressed.
+  touchPressCell = null;
+  // Text the press selected, waiting for the finger to lift. The clipboard write has
+  // to happen in the touchend handler: Safari only honours it from a trusted
+  // user-gesture task, and a setTimeout callback is not one.
+  touchCopyPending = null;
   // Whether the gesture in flight came from a finger, read off the pointer event that
   // precedes the browser's compatibility mouse events (onPointerDown).
   lastPointerWasTouch = false;
@@ -7435,12 +7450,22 @@ var AttachTerminal = class {
     this.touchScrollRemainder = 0;
     this.touchScrollClaimed = false;
     this.touchCopyFired = false;
+    this.touchCopyPending = null;
     this.cancelTouchLongPress();
-    if (press) {
+    this.touchPressCell = press ? this.bufferCellAtPoint(press.clientX, press.clientY) : null;
+    if (this.touchPressCell) {
       this.startTouchLongPress();
     }
   };
-  onTouchEnd = () => this.cancelTouchLongPress();
+  onTouchEnd = (event) => {
+    this.cancelTouchLongPress();
+    const pending = this.touchCopyPending;
+    this.touchCopyPending = null;
+    if (pending === null || event.type !== "touchend") {
+      return;
+    }
+    this.copyToClipboard(pending);
+  };
   onTouchMove = (event) => {
     this.handleUserScroll("touch");
     const moved = event.touches.length !== 1 || !touchPressStillHeld(this.touchOriginX, this.touchOriginY, event.touches[0].clientX, event.touches[0].clientY);
@@ -7651,7 +7676,7 @@ var AttachTerminal = class {
   startTouchLongPress() {
     this.touchLongPressTimer = window.setTimeout(() => {
       this.touchLongPressTimer = null;
-      this.copyTouchWord(this.touchOriginX, this.touchOriginY);
+      this.selectTouchWord();
     }, TOUCH_LONG_PRESS_MS);
   }
   cancelTouchLongPress() {
@@ -7660,40 +7685,64 @@ var AttachTerminal = class {
       this.touchLongPressTimer = null;
     }
   }
-  /** Selects the token under the finger — the whole line when that cell is blank —
-   *  and copies it. Silent only when there is genuinely nothing there to take. */
-  copyTouchWord(x, y) {
+  /** The cell under a viewport point, in ABSOLUTE buffer coordinates so it survives
+   *  everything the terminal does to the viewport afterwards. */
+  bufferCellAtPoint(x, y) {
     const rowsEl = this.container.querySelector(".xterm-rows");
     if (!rowsEl) {
-      return;
+      return null;
     }
     const cell = terminalCellAtPoint(x, y, rowsEl.getBoundingClientRect(), this.term.cols, this.term.rows);
-    if (!cell) {
+    return cell === null ? null : { col: cell.col, row: this.term.buffer.active.viewportY + cell.row };
+  }
+  /**
+   * Selects the token the finger is resting on, and holds the text for the lift.
+   *
+   * The selection happens now, so the highlight appears under the finger at the
+   * moment the press is recognised; the clipboard write waits for touchend, where a
+   * user gesture is still in scope. Splitting the two is what makes the gesture work
+   * on Safari as well as Chrome.
+   */
+  selectTouchWord() {
+    const press = this.touchPressCell;
+    if (!press) {
       return;
     }
     const buffer = this.term.buffer.active;
-    const bufferRow = buffer.viewportY + cell.row;
-    const line = buffer.getLine(bufferRow);
-    if (!line) {
-      return;
+    const cols = this.term.cols;
+    let first = press.row;
+    while (first > 0 && buffer.getLine(first)?.isWrapped === true) {
+      first -= 1;
+    }
+    let last = press.row;
+    while (buffer.getLine(last + 1)?.isWrapped === true) {
+      last += 1;
     }
     const cells = [];
-    for (let col = 0; col < line.length; col += 1) {
-      const buffered = line.getCell(col);
-      cells.push(buffered === void 0 ? " " : buffered.getWidth() === 0 ? "" : buffered.getChars() || " ");
+    for (let row = first; row <= last; row += 1) {
+      const line = buffer.getLine(row);
+      if (!line) {
+        break;
+      }
+      for (let col = 0; col < cols; col += 1) {
+        const buffered = line.getCell(col);
+        cells.push(buffered === void 0 ? " " : buffered.getWidth() === 0 ? "" : buffered.getChars() || " ");
+      }
     }
-    const range = wordRangeAtColumn(cells, cell.col) ?? { start: 0, length: lineContentColumns(cells) };
+    const pressed = (press.row - first) * cols + press.col;
+    const range = wordRangeAtColumn(cells, pressed) ?? { start: 0, length: lineContentColumns(cells) };
     if (range.length === 0) {
       return;
     }
-    this.term.select(range.start, bufferRow, range.length);
+    const at = wrappedCellPosition(range.start, cols);
+    this.term.select(at.col, first + at.row, range.length);
     const text = this.term.getSelection();
     if (text.trim() === "") {
       this.term.clearSelection();
       return;
     }
     this.touchCopyFired = true;
-    this.copyToClipboard(text);
+    this.touchCopyPending = text;
   }
   /** The painted height of one terminal row, which turns a pixel-denominated gesture
    *  into rows. Falls back to a font-size estimate before the first row exists. */

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7116,9 +7116,6 @@ function wrappedCellPosition(index, cols) {
   }
   return { col: index % cols, row: Math.floor(index / cols) };
 }
-function touchCancelCompletesPress(heldMs) {
-  return heldMs >= TOUCH_LONG_PRESS_MS * 0.6;
-}
 
 // src/theme.ts
 var THEME_CHOICES = ["auto", "light", "dark"];
@@ -7327,7 +7324,8 @@ var AttachTerminal = class {
     container.addEventListener("touchstart", this.onTouchStart, { capture: true, passive: true });
     container.addEventListener("touchmove", this.onTouchMove, { capture: true, passive: false });
     container.addEventListener("touchend", this.onTouchEnd, { capture: true, passive: true });
-    container.addEventListener("touchcancel", this.onTouchEnd, { capture: true, passive: true });
+    container.addEventListener("touchcancel", this.onTouchCancel, { capture: true, passive: true });
+    container.addEventListener("pointercancel", this.onTouchCancel, { capture: true, passive: true });
     container.addEventListener("contextmenu", this.onContextMenu);
     container.addEventListener("pointerdown", this.onPointerDown, true);
     container.addEventListener("mousedown", this.onMouseDownCapture, true);
@@ -7385,8 +7383,6 @@ var AttachTerminal = class {
   // what xterm gives you to survive that, and it is the mechanism the viewport
   // anchor above already uses.
   touchPressMarker = null;
-  // When the finger went down, so a cancellation can be told apart from a takeover.
-  touchPressAt = 0;
   // Text the press selected, waiting for the finger to lift. The clipboard write has
   // to happen in the touchend handler: Safari only honours it from a trusted
   // user-gesture task, and a setTimeout callback is not one.
@@ -7464,21 +7460,30 @@ var AttachTerminal = class {
     this.touchCopyPending = null;
     this.cancelTouchLongPress();
     this.disposeTouchPressMarker();
-    this.touchPressAt = Date.now();
     this.touchPressCell = press ? this.bufferCellAtPoint(press.clientX, press.clientY) : null;
     if (this.touchPressCell) {
       this.touchPressMarker = this.registerPressMarker(this.touchPressCell.row);
       this.startTouchLongPress();
     }
   };
-  onTouchEnd = (event) => {
-    const awaitingRecognition = this.touchLongPressTimer !== null;
+  onTouchEnd = () => {
     this.cancelTouchLongPress();
-    if (event.type === "touchcancel" && awaitingRecognition && touchCancelCompletesPress(Date.now() - this.touchPressAt)) {
-      this.selectTouchWord();
-    }
     this.disposeTouchPressMarker();
     this.flushTouchCopy();
+  };
+  /**
+   * The browser taking the gesture away — and the ONLY signal it gives when it does.
+   *
+   * A press that turns into a scroll is not delivered as touchmove here: recording a
+   * real one gives `touchstart` then `pointercancel`, with no move in between, so a
+   * discard wired to movement never runs and the staged copy would land on the lift
+   * of a gesture the user finished as a scroll. A cancel is therefore a takeover, and
+   * a takeover drops both the copy and the selection that promised it.
+   */
+  onTouchCancel = () => {
+    this.cancelTouchLongPress();
+    this.disposeTouchPressMarker();
+    this.discardPendingTouchCopy();
   };
   /** Writes the text a recognised press staged, once, from whichever trusted event
    *  the browser actually delivered. */
@@ -7649,7 +7654,8 @@ var AttachTerminal = class {
     this.container.removeEventListener("touchstart", this.onTouchStart, true);
     this.container.removeEventListener("touchmove", this.onTouchMove, true);
     this.container.removeEventListener("touchend", this.onTouchEnd, true);
-    this.container.removeEventListener("touchcancel", this.onTouchEnd, true);
+    this.container.removeEventListener("touchcancel", this.onTouchCancel, true);
+    this.container.removeEventListener("pointercancel", this.onTouchCancel, true);
     this.container.removeEventListener("contextmenu", this.onContextMenu);
     this.container.removeEventListener("pointerdown", this.onPointerDown, true);
     this.container.removeEventListener("mousedown", this.onMouseDownCapture, true);

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7788,11 +7788,32 @@ var AttachTerminal = class {
     const markedFirstRow = this.touchPressMarker?.line ?? -1;
     if (markedFirstRow >= 0 && press.bufferType === this.term.buffer.active.type && press.cols === this.term.cols) {
       const at = wrappedCellPosition(range.start, press.cols);
-      this.term.select(at.col, markedFirstRow + at.row, range.length);
+      if (this.liveTextAt(markedFirstRow, range, press.cols) === text) {
+        this.term.select(at.col, markedFirstRow + at.row, range.length);
+      }
     }
     this.touchCopyFired = true;
     this.suppressNextContextMenu = true;
     this.touchCopyPending = text;
+  }
+  /** The text the live buffer currently holds where a snapshot's range sits, or null
+   *  if that no longer resolves. Used to check the highlight before painting it. */
+  liveTextAt(firstRow, range, cols) {
+    const buffer = this.term.buffer.active;
+    const cells = [];
+    const firstNeeded = Math.floor(range.start / cols);
+    const lastNeeded = Math.floor((range.start + range.length - 1) / cols);
+    for (let offset = firstNeeded; offset <= lastNeeded; offset += 1) {
+      const line = buffer.getLine(firstRow + offset);
+      if (!line) {
+        return null;
+      }
+      for (let col = 0; col < cols; col += 1) {
+        const buffered = line.getCell(col);
+        cells.push(buffered === void 0 ? " " : buffered.getWidth() === 0 ? "" : buffered.getChars() || " ");
+      }
+    }
+    return textFromCells(cells, { start: range.start - firstNeeded * cols, length: range.length });
   }
   /**
    * Reads the press: the wrapped block under the finger, flattened one entry per

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7116,6 +7116,9 @@ function wrappedCellPosition(index, cols) {
   }
   return { col: index % cols, row: Math.floor(index / cols) };
 }
+function textFromCells(cells, range) {
+  return cells.slice(range.start, range.start + range.length).join("");
+}
 
 // src/theme.ts
 var THEME_CHOICES = ["auto", "light", "dark"];
@@ -7377,17 +7380,16 @@ var AttachTerminal = class {
   // coordinates. Resolving it when the timer fires would read the viewport half a
   // second later, and under live output the row the finger is on has scrolled by
   // then — copying whatever slid beneath it instead of what was pressed.
-  touchPressCell = null;
-  // …and a marker on that row. A FULL scrollback ring trims from the top while the
-  // finger rests, shifting every absolute index down under the anchor; a marker is
-  // what xterm gives you to survive that, and it is the mechanism the viewport
-  // anchor above already uses.
+  // The press, READ WHEN THE FINGER LANDS: the whole wrapped block it fell in, and
+  // where in that block it fell. Resolving the text at touchstart instead of when the
+  // timer fires is what makes the copy immune to everything the terminal can do
+  // during the hold — a trim, an in-place rewrite by a progress bar, an
+  // alternate-screen TUI scrolling underneath, a reflow. Each of those was a separate
+  // way to copy the wrong text while looking like it worked; none of them can reach a
+  // snapshot. What is resolved late is only the HIGHLIGHT, which is cosmetic and is
+  // skipped when the live grid no longer matches.
+  touchPress = null;
   touchPressMarker = null;
-  // The grid the press was resolved against. A reflow (a peer's echoed size, or a
-  // local fit) re-lays wrapped content, so a column saved against the old width names
-  // a different cell in the new one; a buffer switch invalidates the row outright.
-  touchPressBuffer = null;
-  touchPressCols = 0;
   // One-shot, armed by a recognised press: it suppresses the menu THAT touch provokes
   // and nothing else — a keyboard menu (Shift+F10, the Menu key, assistive tech)
   // arrives with no pointer event to re-scope it.
@@ -7468,11 +7470,9 @@ var AttachTerminal = class {
     this.cancelTouchLongPress();
     this.discardPendingTouchCopy();
     this.disposeTouchPressMarker();
-    this.touchPressCell = press ? this.bufferCellAtPoint(press.clientX, press.clientY) : null;
-    if (this.touchPressCell) {
-      this.touchPressBuffer = this.term.buffer.active.type;
-      this.touchPressCols = this.term.cols;
-      this.touchPressMarker = this.registerPressMarker(this.touchPressCell.row);
+    this.touchPress = press ? this.snapshotPress(press.clientX, press.clientY) : null;
+    if (this.touchPress) {
+      this.touchPressMarker = this.registerPressMarker(this.touchPress.firstRow);
       this.startTouchLongPress();
     }
   };
@@ -7765,49 +7765,68 @@ var AttachTerminal = class {
     this.touchPressMarker?.dispose();
     this.touchPressMarker = null;
   }
-  /** The cell under a viewport point, in ABSOLUTE buffer coordinates so it survives
-   *  everything the terminal does to the viewport afterwards. */
-  bufferCellAtPoint(x, y) {
+  /**
+   * Turns the snapshot into a selection and a staged copy.
+   *
+   * The TEXT comes from the snapshot, so it is what was under the finger when it
+   * landed. The HIGHLIGHT needs the live buffer and is therefore conditional: it is
+   * skipped, not guessed, when the grid has moved out from under the press.
+   */
+  selectTouchWord() {
+    const press = this.touchPress;
+    if (!press) {
+      return;
+    }
+    const range = wordRangeAtColumn(press.cells, press.index) ?? { start: 0, length: lineContentColumns(press.cells) };
+    if (range.length === 0) {
+      return;
+    }
+    const text = textFromCells(press.cells, range);
+    if (text.trim() === "") {
+      return;
+    }
+    const markedFirstRow = this.touchPressMarker?.line ?? -1;
+    if (markedFirstRow >= 0 && press.bufferType === this.term.buffer.active.type && press.cols === this.term.cols) {
+      const at = wrappedCellPosition(range.start, press.cols);
+      this.term.select(at.col, markedFirstRow + at.row, range.length);
+    }
+    this.touchCopyFired = true;
+    this.suppressNextContextMenu = true;
+    this.touchCopyPending = text;
+  }
+  /**
+   * Reads the press: the wrapped block under the finger, flattened one entry per
+   * column, plus where in it the finger landed.
+   *
+   * Everything the copy needs is taken HERE, while the finger is still going down.
+   * The alternative — keeping coordinates and reading the buffer when the timer fires
+   * — has to survive every mutation that can happen in 500ms, and each one is its own
+   * way to copy real text from the wrong place: a full ring trimming the pressed line
+   * or the earlier rows of its wrapped block, a progress bar rewriting the line in
+   * place, an alternate-screen TUI scrolling, a peer's resize reflowing the grid. A
+   * snapshot is immune to all of them at once.
+   */
+  snapshotPress(x, y) {
     const rowsEl = this.container.querySelector(".xterm-rows");
     if (!rowsEl) {
       return null;
     }
-    const cell = terminalCellAtPoint(x, y, rowsEl.getBoundingClientRect(), this.term.cols, this.term.rows);
-    return cell === null ? null : { col: cell.col, row: this.term.buffer.active.viewportY + cell.row };
-  }
-  /**
-   * Selects the token the finger is resting on, and holds the text for the lift.
-   *
-   * The selection happens now, so the highlight appears under the finger at the
-   * moment the press is recognised; the clipboard write waits for touchend, where a
-   * user gesture is still in scope. Splitting the two is what makes the gesture work
-   * on Safari as well as Chrome.
-   */
-  selectTouchWord() {
-    const press = this.touchPressCell;
-    if (!press) {
-      return;
+    const cols = this.term.cols;
+    const cell = terminalCellAtPoint(x, y, rowsEl.getBoundingClientRect(), cols, this.term.rows);
+    if (!cell) {
+      return null;
     }
     const buffer = this.term.buffer.active;
-    const cols = this.term.cols;
-    if (buffer.type !== this.touchPressBuffer || cols !== this.touchPressCols) {
-      return;
-    }
-    let pressedRow;
-    if (this.touchPressMarker !== null) {
-      if (this.touchPressMarker.line < 0) {
-        return;
-      }
-      pressedRow = this.touchPressMarker.line;
-    } else {
-      pressedRow = press.row;
-    }
+    const pressedRow = buffer.viewportY + cell.row;
     if (pressedRow < 0 || pressedRow >= buffer.length) {
-      return;
+      return null;
     }
     let first = pressedRow;
     while (first > 0 && buffer.getLine(first)?.isWrapped === true) {
       first -= 1;
+    }
+    if (buffer.getLine(first)?.isWrapped === true) {
+      return null;
     }
     let last = pressedRow;
     while (last + 1 < buffer.length && buffer.getLine(last + 1)?.isWrapped === true) {
@@ -7817,32 +7836,17 @@ var AttachTerminal = class {
     for (let row = first; row <= last; row += 1) {
       const line = buffer.getLine(row);
       if (!line) {
-        break;
+        return null;
       }
       for (let col = 0; col < cols; col += 1) {
         const buffered = line.getCell(col);
         cells.push(buffered === void 0 ? " " : buffered.getWidth() === 0 ? "" : buffered.getChars() || " ");
       }
-      const continues = buffer.getLine(row + 1);
-      if (row < last && cells[cells.length - 1] === " " && continues !== void 0 && continues.getCell(0)?.getWidth() === 2) {
+      if (row < last && line.getCell(cols - 1)?.getCode() === 0) {
         cells[cells.length - 1] = "";
       }
     }
-    const pressed = (pressedRow - first) * cols + press.col;
-    const range = wordRangeAtColumn(cells, pressed) ?? { start: 0, length: lineContentColumns(cells) };
-    if (range.length === 0) {
-      return;
-    }
-    const at = wrappedCellPosition(range.start, cols);
-    this.term.select(at.col, first + at.row, range.length);
-    const text = this.term.getSelection();
-    if (text.trim() === "") {
-      this.term.clearSelection();
-      return;
-    }
-    this.touchCopyFired = true;
-    this.suppressNextContextMenu = true;
-    this.touchCopyPending = text;
+    return { cells, index: (pressedRow - first) * cols + cell.col, firstRow: first, cols, bufferType: buffer.type };
   }
   /** The painted height of one terminal row, which turns a pixel-denominated gesture
    *  into rows. Falls back to a font-size estimate before the first row exists. */

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7383,6 +7383,15 @@ var AttachTerminal = class {
   // what xterm gives you to survive that, and it is the mechanism the viewport
   // anchor above already uses.
   touchPressMarker = null;
+  // The grid the press was resolved against. A reflow (a peer's echoed size, or a
+  // local fit) re-lays wrapped content, so a column saved against the old width names
+  // a different cell in the new one; a buffer switch invalidates the row outright.
+  touchPressBuffer = null;
+  touchPressCols = 0;
+  // One-shot, armed by a recognised press: it suppresses the menu THAT touch provokes
+  // and nothing else — a keyboard menu (Shift+F10, the Menu key, assistive tech)
+  // arrives with no pointer event to re-scope it.
+  suppressNextContextMenu = false;
   // Text the press selected, waiting for the finger to lift. The clipboard write has
   // to happen in the touchend handler: Safari only honours it from a trusted
   // user-gesture task, and a setTimeout callback is not one.
@@ -7456,18 +7465,20 @@ var AttachTerminal = class {
     this.touchOriginY = press?.clientY ?? 0;
     this.touchScrollRemainder = 0;
     this.touchScrollClaimed = false;
-    this.touchCopyFired = false;
-    this.touchCopyPending = null;
     this.cancelTouchLongPress();
+    this.discardPendingTouchCopy();
     this.disposeTouchPressMarker();
     this.touchPressCell = press ? this.bufferCellAtPoint(press.clientX, press.clientY) : null;
     if (this.touchPressCell) {
+      this.touchPressBuffer = this.term.buffer.active.type;
+      this.touchPressCols = this.term.cols;
       this.touchPressMarker = this.registerPressMarker(this.touchPressCell.row);
       this.startTouchLongPress();
     }
   };
   onTouchEnd = () => {
     this.cancelTouchLongPress();
+    this.suppressNextContextMenu = false;
     this.disposeTouchPressMarker();
     this.flushTouchCopy();
   };
@@ -7482,6 +7493,7 @@ var AttachTerminal = class {
    */
   onTouchCancel = () => {
     this.cancelTouchLongPress();
+    this.suppressNextContextMenu = false;
     this.disposeTouchPressMarker();
     this.discardPendingTouchCopy();
   };
@@ -7499,9 +7511,11 @@ var AttachTerminal = class {
   // never makes (#2849). Suppressed ONLY for a press af has already acted on, so a
   // desktop right-click keeps the browser's menu.
   onContextMenu = (event) => {
-    if (this.lastPointerWasTouch && this.touchCopyFired) {
-      event.preventDefault();
+    if (!this.suppressNextContextMenu) {
+      return;
     }
+    this.suppressNextContextMenu = false;
+    event.preventDefault();
   };
   onTouchMove = (event) => {
     this.handleUserScroll("touch");
@@ -7776,8 +7790,18 @@ var AttachTerminal = class {
     }
     const buffer = this.term.buffer.active;
     const cols = this.term.cols;
-    const marked = this.touchPressMarker?.line ?? -1;
-    const pressedRow = marked >= 0 ? marked : press.row;
+    if (buffer.type !== this.touchPressBuffer || cols !== this.touchPressCols) {
+      return;
+    }
+    let pressedRow;
+    if (this.touchPressMarker !== null) {
+      if (this.touchPressMarker.line < 0) {
+        return;
+      }
+      pressedRow = this.touchPressMarker.line;
+    } else {
+      pressedRow = press.row;
+    }
     if (pressedRow < 0 || pressedRow >= buffer.length) {
       return;
     }
@@ -7799,6 +7823,10 @@ var AttachTerminal = class {
         const buffered = line.getCell(col);
         cells.push(buffered === void 0 ? " " : buffered.getWidth() === 0 ? "" : buffered.getChars() || " ");
       }
+      const continues = buffer.getLine(row + 1);
+      if (row < last && cells[cells.length - 1] === " " && continues !== void 0 && continues.getCell(0)?.getWidth() === 2) {
+        cells[cells.length - 1] = "";
+      }
     }
     const pressed = (pressedRow - first) * cols + press.col;
     const range = wordRangeAtColumn(cells, pressed) ?? { start: 0, length: lineContentColumns(cells) };
@@ -7813,6 +7841,7 @@ var AttachTerminal = class {
       return;
     }
     this.touchCopyFired = true;
+    this.suppressNextContextMenu = true;
     this.touchCopyPending = text;
   }
   /** The painted height of one terminal row, which turns a pixel-denominated gesture

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "82bf5d375f9e";
+const VERSION = "fa8a782cb232";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "4df6c550eee6";
+const VERSION = "8dc068915163";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "463a49f5b4d3";
+const VERSION = "82bf5d375f9e";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "fa8a782cb232";
+const VERSION = "81239092f902";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "ffce34341bb3";
+const VERSION = "4df6c550eee6";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "6155ac784fd1";
+const VERSION = "347471a3d8a7";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "da69fa03e9cf";
+const VERSION = "b0e7cd3c36c9";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "81239092f902";
+const VERSION = "2a87db239d68";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "347471a3d8a7";
+const VERSION = "738294de2182";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "2d44be716b3a";
+const VERSION = "463a49f5b4d3";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "2a87db239d68";
+const VERSION = "ffce34341bb3";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "738294de2182";
+const VERSION = "da69fa03e9cf";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "8dc068915163";
+const VERSION = "6155ac784fd1";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -2402,7 +2402,19 @@ test("#2849 mobile: a long press copies the token under the finger", REAL_FIXTUR
 
     await p.evaluate(() => navigator.clipboard.writeText("af-2849-clipboard-untouched").catch(() => {}));
     inputPayloads.length = 0;
+    // Record what the browser actually DELIVERS for a long press. Which events arrive,
+    // and in what order, is the whole mechanism here — a copy wired to an event the
+    // browser never sends looks identical from the outside to one that is never wired
+    // at all, and both read as "the clipboard is untouched".
+    await p.evaluate(() => {
+      const w = window as unknown as { __afTouchLog: string[] };
+      w.__afTouchLog = [];
+      for (const type of ["touchstart", "touchmove", "touchend", "touchcancel", "contextmenu", "mousedown", "pointercancel"]) {
+        document.addEventListener(type, () => w.__afTouchLog.push(`${type}@${Math.round(performance.now())}`), true);
+      }
+    });
     await touchLongPress(cdp, x + 2, pressY);
+    const delivered = await p.evaluate(() => (window as unknown as { __afTouchLog: string[] }).__afTouchLog.join(" "));
 
     // Staged, so a red here says WHICH half broke. A selection proves the press was
     // recognised and resolved to a cell; the failure toast proves the copy ran and
@@ -2417,7 +2429,7 @@ test("#2849 mobile: a long press copies the token under the finger", REAL_FIXTUR
     // THE assertion: a finger, no keyboard, and the token is on the system clipboard.
     await expect
       .poll(() => p.evaluate(() => navigator.clipboard.readText()), {
-        message: "a long press must put the token under the finger on the system clipboard",
+        message: `a long press must put the token under the finger on the system clipboard [delivered: ${delivered}]`,
       })
       .toContain(TOKEN);
     // …the TOKEN, not its line. That is the difference between copying what the

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -2476,6 +2476,23 @@ test("#2849 mobile: a long press copies the token under the finger", REAL_FIXTUR
       .poll(() => p.evaluate(() => navigator.clipboard.readText()), { message: "the lift completes the copy" })
       .toContain(TOKEN);
 
+    // A press the timer ALREADY recognised, which the finger then turns into a
+    // scroll. The copy is staged at that point, so without discarding it the lift
+    // would overwrite the clipboard with a token the user has since scrolled away
+    // from — a slow-starting scroll that silently steals the clipboard.
+    await p.evaluate(() => navigator.clipboard.writeText("af-2849-clipboard-untouched").catch(() => {}));
+    await touchPressAndHold(cdp, x + 2, pressY);
+    await expect(selection, "the press is recognised before the finger moves").not.toHaveCount(0);
+    for (const step of [10, 40, 90]) {
+      await cdp.send("Input.dispatchTouchEvent", { type: "touchMove", touchPoints: [{ x: x + 2, y: pressY + step }] });
+    }
+    await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+    expect(
+      await p.evaluate(() => navigator.clipboard.readText()),
+      "a press that turns into a scroll must not copy on lift",
+    ).toContain("untouched");
+    await expect(selection, "…and must not leave a selection promising it did").toHaveCount(0);
+
     // …and the gesture that is NOT a press still is not one. A drag from the same
     // spot scrolls (#2682) and copies nothing, so the two cannot be confused.
     await p.evaluate(() => navigator.clipboard.writeText("af-2849-clipboard-untouched").catch(() => {}));

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -736,9 +736,15 @@ async function touchDrag(cdp: CDPSession, x: number, fromY: number, toY: number,
  *  it. No touchmove at all: a press that wobbles past the threshold is a scroll, and
  *  that boundary is asserted separately. */
 async function touchLongPress(cdp: CDPSession, x: number, y: number, holdMs = 700): Promise<void> {
+  await touchPressAndHold(cdp, x, y, holdMs);
+  await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+}
+
+/** The first half of a long press: down, and held past the threshold, WITHOUT the
+ *  lift — so a test can look at the world while the finger is still on the glass. */
+async function touchPressAndHold(cdp: CDPSession, x: number, y: number, holdMs = 700): Promise<void> {
   await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ x, y }] });
   await new Promise((resolve) => setTimeout(resolve, holdMs));
-  await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
 }
 
 async function touchTap(cdp: CDPSession, x: number, y: number): Promise<void> {
@@ -2424,6 +2430,41 @@ test("#2849 mobile: a long press copies the token under the finger", REAL_FIXTUR
         message: "a press past the end of a line must copy the line",
       })
       .toContain(TRAILER);
+
+    // A token WIDER THAN THE SCREEN, which on a ~40-column phone is the normal shape
+    // of the URLs and paths this gesture exists for. It soft-wraps onto a second
+    // buffer row, and a scan that stopped at the row edge would copy a fragment and
+    // look like it had worked.
+    const LONG = `/srv/af-2849/${"wrapped-".repeat(6)}end`;
+    await p.keyboard.type(`printf '%s\\n' ${LONG}`);
+    await p.keyboard.press("Enter");
+    await expect(host).toContainText("wrapped-end", { timeout: 20_000 });
+    const wrappedRow = host.locator(".xterm-rows > div", { hasText: "/srv/af-2849/wrapped-" }).last();
+    await expect(wrappedRow).toBeVisible();
+    const wrappedBox = (await wrappedRow.boundingBox()) as ElementBox;
+    await p.evaluate(() => navigator.clipboard.writeText("af-2849-clipboard-untouched").catch(() => {}));
+    await touchLongPress(cdp, wrappedBox.x + 2, wrappedBox.y + wrappedBox.height / 2);
+    await expect
+      .poll(() => p.evaluate(() => navigator.clipboard.readText()), {
+        message: "a token that wraps must be copied whole, not cut at the screen edge",
+      })
+      .toContain(LONG);
+
+    // The write must land on the LIFT, not in the timer that selects: Safari grants
+    // clipboard access only to a user-gesture task, so a copy from the timeout is
+    // refused on the one platform this gesture exists for. Holding without lifting is
+    // what tells those two apart.
+    await p.evaluate(() => navigator.clipboard.writeText("af-2849-clipboard-untouched").catch(() => {}));
+    await touchPressAndHold(cdp, x + 2, pressY);
+    await expect(selection, "the selection appears while the finger is still down").not.toHaveCount(0);
+    expect(
+      await p.evaluate(() => navigator.clipboard.readText()),
+      "nothing may reach the clipboard from the timer — the write belongs to the lift",
+    ).toContain("untouched");
+    await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+    await expect
+      .poll(() => p.evaluate(() => navigator.clipboard.readText()), { message: "the lift completes the copy" })
+      .toContain(TOKEN);
 
     // …and the gesture that is NOT a press still is not one. A drag from the same
     // spot scrolls (#2682) and copies nothing, so the two cannot be confused.

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -2404,6 +2404,16 @@ test("#2849 mobile: a long press copies the token under the finger", REAL_FIXTUR
     inputPayloads.length = 0;
     await touchLongPress(cdp, x + 2, pressY);
 
+    // Staged, so a red here says WHICH half broke. A selection proves the press was
+    // recognised and resolved to a cell; the failure toast proves the copy ran and
+    // both clipboard paths refused. Without these, "the clipboard still holds the
+    // sentinel" is equally consistent with the gesture never firing at all.
+    await expect(selection, "the press must resolve to a cell and paint a selection").not.toHaveCount(0);
+    await expect(
+      p.locator("[role=alert]", { hasText: "Copy failed" }),
+      "the copy must not fall all the way through to the clipboard-unavailable toast",
+    ).toHaveCount(0);
+
     // THE assertion: a finger, no keyboard, and the token is on the system clipboard.
     await expect
       .poll(() => p.evaluate(() => navigator.clipboard.readText()), {

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -2493,17 +2493,22 @@ test("#2849 mobile: a long press copies the token under the finger", REAL_FIXTUR
     // would overwrite the clipboard with a token the user has since scrolled away
     // from — a slow-starting scroll that silently steals the clipboard.
     await p.evaluate(() => navigator.clipboard.writeText("af-2849-clipboard-untouched").catch(() => {}));
+    await p.evaluate(() => ((window as unknown as { __afTouchLog: string[] }).__afTouchLog = []));
     await touchPressAndHold(cdp, x + 2, pressY);
     await expect(selection, "the press is recognised before the finger moves").not.toHaveCount(0);
     for (const step of [10, 40, 90]) {
       await cdp.send("Input.dispatchTouchEvent", { type: "touchMove", touchPoints: [{ x: x + 2, y: pressY + step }] });
     }
     await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+    const scrolledAway = await p.evaluate(() => (window as unknown as { __afTouchLog: string[] }).__afTouchLog.join(" "));
     expect(
       await p.evaluate(() => navigator.clipboard.readText()),
-      "a press that turns into a scroll must not copy on lift",
+      `a press that turns into a scroll must not copy on lift [delivered: ${scrolledAway}]`,
     ).toContain("untouched");
-    await expect(selection, "…and must not leave a selection promising it did").toHaveCount(0);
+    await expect(
+      selection,
+      `…and must not leave a selection promising it did [delivered: ${scrolledAway}]`,
+    ).toHaveCount(0);
 
     // …and the gesture that is NOT a press still is not one. A drag from the same
     // spot scrolls (#2682) and copies nothing, so the two cannot be confused.

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -2472,20 +2472,21 @@ test("#2849 mobile: a long press copies the token under the finger", REAL_FIXTUR
       })
       .toContain(LONG);
 
-    // The write must land on the LIFT, not in the timer that selects: Safari grants
-    // clipboard access only to a user-gesture task, so a copy from the timeout is
-    // refused on the one platform this gesture exists for. Holding without lifting is
-    // what tells those two apart.
+    // The selection appears while the finger is still down — that is the feedback the
+    // gesture promises, and it is what the timer is for.
+    //
+    // What is deliberately NOT asserted here is that the clipboard stays untouched
+    // until the lift. The write is made from whichever trusted event the browser
+    // actually delivers, and in this browser a held touch produces a compatibility
+    // mousedown rather than a touchend; pinning the write to one of them would be
+    // asserting an implementation detail that varies by platform, and would race the
+    // very path that makes the gesture work.
     await p.evaluate(() => navigator.clipboard.writeText("af-2849-clipboard-untouched").catch(() => {}));
     await touchPressAndHold(cdp, x + 2, pressY);
     await expect(selection, "the selection appears while the finger is still down").not.toHaveCount(0);
-    expect(
-      await p.evaluate(() => navigator.clipboard.readText()),
-      "nothing may reach the clipboard from the timer — the write belongs to the lift",
-    ).toContain("untouched");
     await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
     await expect
-      .poll(() => p.evaluate(() => navigator.clipboard.readText()), { message: "the lift completes the copy" })
+      .poll(() => p.evaluate(() => navigator.clipboard.readText()), { message: "the completed gesture copies the token" })
       .toContain(TOKEN);
 
     // A press the timer ALREADY recognised, which the finger then turns into a

--- a/web/src/terminal-mouse.test.ts
+++ b/web/src/terminal-mouse.test.ts
@@ -9,6 +9,7 @@ import {
   terminalMouseOverrideHeld,
   lineContentColumns,
   terminalCellAtPoint,
+  textFromCells,
   TOUCH_LONG_PRESS_MS,
   TOUCH_SCROLL_SLOP_PX,
   touchHistoryScrollPlan,
@@ -205,4 +206,11 @@ test("a wide glyph pushed past the wrap keeps its token whole (#2940)", () => {
   const separated = ["a", "b", "c", " ", /* row 2 */ "d", "e", " ", " "];
   assert.deepEqual(wordRangeAtColumn(separated, 0), { start: 0, length: 3 });
   assert.deepEqual(wordRangeAtColumn(separated, 4), { start: 4, length: 2 });
+});
+
+test("the copied text comes from the snapshot, continuations and all (#2940)", () => {
+  const cells = ["近", "", "藤", "", " ", "o", "k"];
+  assert.equal(textFromCells(cells, { start: 0, length: 4 }), "近藤");
+  assert.equal(textFromCells(cells, { start: 5, length: 2 }), "ok");
+  assert.equal(textFromCells(cells, { start: 0, length: 0 }), "");
 });

--- a/web/src/terminal-mouse.test.ts
+++ b/web/src/terminal-mouse.test.ts
@@ -15,6 +15,7 @@ import {
   touchPressStillHeld,
   touchScrollClaimsGesture,
   wordRangeAtColumn,
+  wrappedCellPosition,
 } from "./terminal-mouse.js";
 
 test("application-mouse escape matches xterm's platform selection modifier", () => {
@@ -168,4 +169,23 @@ test("a press and a scroll are decided by ONE threshold (#2849)", () => {
 
   // Long enough to be deliberate, short enough that a thumb does not think it failed.
   assert.ok(TOUCH_LONG_PRESS_MS >= 300 && TOUCH_LONG_PRESS_MS <= 800);
+});
+
+test("a token that soft-wraps is scanned across the rows it wraps onto (#2849)", () => {
+  // Two 8-column rows joined end to end, the way a wrapped line is scanned. The
+  // token starts on the first row and finishes on the second; stopping at the row
+  // boundary would copy "/srv/lo" and call it a path. A phone is ~40 columns wide,
+  // so a URL or a long path wraps far more often than not.
+  const cols = 8;
+  const block = [..."cd /srv/log-2849.txt"];
+  const token = wordRangeAtColumn(block, 12);
+  assert.deepEqual(token, { start: 3, length: 17 });
+
+  // …and the flat index converts back to the row/column select() expects.
+  assert.deepEqual(wrappedCellPosition(token?.start ?? 0, cols), { col: 3, row: 0 });
+  assert.deepEqual(wrappedCellPosition(8, cols), { col: 0, row: 1 });
+  assert.deepEqual(wrappedCellPosition(17, cols), { col: 1, row: 2 });
+  // The axes must not swap: index 7 is the LAST column of row 0, not row 7.
+  assert.deepEqual(wrappedCellPosition(7, cols), { col: 7, row: 0 });
+  assert.deepEqual(wrappedCellPosition(0, 0), { col: 0, row: 0 });
 });

--- a/web/src/terminal-mouse.test.ts
+++ b/web/src/terminal-mouse.test.ts
@@ -190,3 +190,19 @@ test("a token that soft-wraps is scanned across the rows it wraps onto (#2849)",
   assert.deepEqual(wrappedCellPosition(0, 0), { col: 0, row: 0 });
 });
 
+
+test("a wide glyph pushed past the wrap keeps its token whole (#2940)", () => {
+  // xterm leaves the vacated cell BLANK when a wide glyph will not fit the last
+  // column and moves it to the next row. Read as a space that blank splits a CJK or
+  // emoji token exactly at the wrap; read as the structure it is, the token survives.
+  const cols = 4;
+  const padded = ["近", "", "藤", "", /* row 2 */ "", "京", "", " "];
+  assert.deepEqual(wordRangeAtColumn(padded, 1), { start: 0, length: 7 });
+  assert.deepEqual(wordRangeAtColumn(padded, 5), { start: 0, length: 7 });
+  assert.deepEqual(wrappedCellPosition(4, cols), { col: 0, row: 1 });
+
+  // …and an ordinary blank at the boundary still separates two words.
+  const separated = ["a", "b", "c", " ", /* row 2 */ "d", "e", " ", " "];
+  assert.deepEqual(wordRangeAtColumn(separated, 0), { start: 0, length: 3 });
+  assert.deepEqual(wordRangeAtColumn(separated, 4), { start: 4, length: 2 });
+});

--- a/web/src/terminal-mouse.test.ts
+++ b/web/src/terminal-mouse.test.ts
@@ -12,6 +12,7 @@ import {
   TOUCH_LONG_PRESS_MS,
   TOUCH_SCROLL_SLOP_PX,
   touchHistoryScrollPlan,
+  touchCancelCompletesPress,
   touchPressStillHeld,
   touchScrollClaimsGesture,
   wordRangeAtColumn,
@@ -188,4 +189,14 @@ test("a token that soft-wraps is scanned across the rows it wraps onto (#2849)",
   // The axes must not swap: index 7 is the LAST column of row 0, not row 7.
   assert.deepEqual(wrappedCellPosition(7, cols), { col: 7, row: 0 });
   assert.deepEqual(wrappedCellPosition(0, 0), { col: 0, row: 0 });
+});
+
+test("a late browser cancel IS the long press, an early one is not (#2940)", () => {
+  // After a cancel no touchend follows, so a copy deferred to the lift would wait
+  // for an event that never comes. A cancel late in the hold is the browser
+  // recognising the same gesture af is; an early one is a scroll or system takeover.
+  assert.equal(touchCancelCompletesPress(TOUCH_LONG_PRESS_MS), true);
+  assert.equal(touchCancelCompletesPress(TOUCH_LONG_PRESS_MS * 0.6), true);
+  assert.equal(touchCancelCompletesPress(TOUCH_LONG_PRESS_MS * 0.6 - 1), false);
+  assert.equal(touchCancelCompletesPress(0), false);
 });

--- a/web/src/terminal-mouse.test.ts
+++ b/web/src/terminal-mouse.test.ts
@@ -12,7 +12,6 @@ import {
   TOUCH_LONG_PRESS_MS,
   TOUCH_SCROLL_SLOP_PX,
   touchHistoryScrollPlan,
-  touchCancelCompletesPress,
   touchPressStillHeld,
   touchScrollClaimsGesture,
   wordRangeAtColumn,
@@ -191,12 +190,3 @@ test("a token that soft-wraps is scanned across the rows it wraps onto (#2849)",
   assert.deepEqual(wrappedCellPosition(0, 0), { col: 0, row: 0 });
 });
 
-test("a late browser cancel IS the long press, an early one is not (#2940)", () => {
-  // After a cancel no touchend follows, so a copy deferred to the lift would wait
-  // for an event that never comes. A cancel late in the hold is the browser
-  // recognising the same gesture af is; an early one is a scroll or system takeover.
-  assert.equal(touchCancelCompletesPress(TOUCH_LONG_PRESS_MS), true);
-  assert.equal(touchCancelCompletesPress(TOUCH_LONG_PRESS_MS * 0.6), true);
-  assert.equal(touchCancelCompletesPress(TOUCH_LONG_PRESS_MS * 0.6 - 1), false);
-  assert.equal(touchCancelCompletesPress(0), false);
-});

--- a/web/src/terminal-mouse.ts
+++ b/web/src/terminal-mouse.ts
@@ -256,3 +256,21 @@ export function wrappedCellPosition(index: number, cols: number): TerminalCellPo
   }
   return { col: index % cols, row: Math.floor(index / cols) };
 }
+
+/**
+ * Whether a touch the BROWSER has just cancelled had been held long enough that the
+ * cancellation is its own long-press recognition rather than a scroll takeover.
+ *
+ * The browser ends the touch sequence when it recognises a long press — it is about
+ * to offer a context menu — and after a cancel NO touchend follows. If that lands
+ * before af's own timer, deferring the copy to a lift waits for an event that will
+ * never arrive: the selection appears and nothing is ever copied. So a cancel that
+ * arrives late enough IS the recognition, and af acts on it there.
+ *
+ * The fraction keeps a cancel that comes from something else — a scroll takeover, a
+ * system gesture, an incoming call — from copying anything, without racing the
+ * platform for an exact threshold nobody has published.
+ */
+export function touchCancelCompletesPress(heldMs: number): boolean {
+  return heldMs >= TOUCH_LONG_PRESS_MS * 0.6;
+}

--- a/web/src/terminal-mouse.ts
+++ b/web/src/terminal-mouse.ts
@@ -240,3 +240,19 @@ export function lineContentColumns(cells: readonly string[]): number {
   }
   return end + 1;
 }
+
+/**
+ * Split a flat index over a soft-wrapped block back into the row offset and column
+ * xterm's `select()` takes.
+ *
+ * A wrapped line is several buffer rows, so the token scan runs over the rows joined
+ * end to end and this converts back. Trivial arithmetic with one classic failure —
+ * pairing the wrong operator with the wrong axis — which is silent, since both
+ * results are plausible row/column numbers.
+ */
+export function wrappedCellPosition(index: number, cols: number): TerminalCellPoint {
+  if (cols <= 0) {
+    return { col: 0, row: 0 };
+  }
+  return { col: index % cols, row: Math.floor(index / cols) };
+}

--- a/web/src/terminal-mouse.ts
+++ b/web/src/terminal-mouse.ts
@@ -257,20 +257,3 @@ export function wrappedCellPosition(index: number, cols: number): TerminalCellPo
   return { col: index % cols, row: Math.floor(index / cols) };
 }
 
-/**
- * Whether a touch the BROWSER has just cancelled had been held long enough that the
- * cancellation is its own long-press recognition rather than a scroll takeover.
- *
- * The browser ends the touch sequence when it recognises a long press — it is about
- * to offer a context menu — and after a cancel NO touchend follows. If that lands
- * before af's own timer, deferring the copy to a lift waits for an event that will
- * never arrive: the selection appears and nothing is ever copied. So a cancel that
- * arrives late enough IS the recognition, and af acts on it there.
- *
- * The fraction keeps a cancel that comes from something else — a scroll takeover, a
- * system gesture, an incoming call — from copying anything, without racing the
- * platform for an exact threshold nobody has published.
- */
-export function touchCancelCompletesPress(heldMs: number): boolean {
-  return heldMs >= TOUCH_LONG_PRESS_MS * 0.6;
-}

--- a/web/src/terminal-mouse.ts
+++ b/web/src/terminal-mouse.ts
@@ -257,3 +257,10 @@ export function wrappedCellPosition(index: number, cols: number): TerminalCellPo
   return { col: index % cols, row: Math.floor(index / cols) };
 }
 
+
+/** The text of a cell range, dropping the empty continuations that keep an index a
+ *  column. Reading it off the snapshot rather than the live selection is what makes a
+ *  press immune to everything the terminal does during the hold. */
+export function textFromCells(cells: readonly string[], range: TerminalWordRange): string {
+  return cells.slice(range.start, range.start + range.length).join("");
+}

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -61,6 +61,7 @@ import {
   terminalMouseOverrideHeld,
   type TerminalMouseOverride,
   TOUCH_LONG_PRESS_MS,
+  touchCancelCompletesPress,
   touchHistoryScrollPlan,
   touchPressStillHeld,
   touchScrollClaimsGesture,
@@ -161,6 +162,8 @@ export class AttachTerminal {
   // what xterm gives you to survive that, and it is the mechanism the viewport
   // anchor above already uses.
   private touchPressMarker: IMarker | null = null;
+  // When the finger went down, so a cancellation can be told apart from a takeover.
+  private touchPressAt = 0;
   // Text the press selected, waiting for the finger to lift. The clipboard write has
   // to happen in the touchend handler: Safari only honours it from a trusted
   // user-gesture task, and a setTimeout callback is not one.
@@ -251,17 +254,31 @@ export class AttachTerminal {
     this.touchCopyPending = null;
     this.cancelTouchLongPress();
     this.disposeTouchPressMarker();
+    this.touchPressAt = Date.now();
     this.touchPressCell = press ? this.bufferCellAtPoint(press.clientX, press.clientY) : null;
     if (this.touchPressCell) {
       this.touchPressMarker = this.registerPressMarker(this.touchPressCell.row);
       this.startTouchLongPress();
     }
   };
-  private readonly onTouchEnd = (): void => {
+  private readonly onTouchEnd = (event: TouchEvent): void => {
+    const awaitingRecognition = this.touchLongPressTimer !== null;
     this.cancelTouchLongPress();
-    this.disposeTouchPressMarker();
+    // A cancel late in the hold IS the press. The browser ends the sequence itself
+    // once it recognises a long press of its own, and after a cancel no touchend
+    // follows — so if that lands before af's timer, waiting for a lift waits forever.
+    // Recognising it here makes the gesture independent of which side names it first,
+    // rather than racing the platform for a threshold nobody publishes.
+    if (
+      event.type === "touchcancel" &&
+      awaitingRecognition &&
+      touchCancelCompletesPress(Date.now() - this.touchPressAt)
+    ) {
+      this.selectTouchWord();
+    }
     const pending = this.touchCopyPending;
     this.touchCopyPending = null;
+    this.disposeTouchPressMarker();
     if (pending === null) {
       return;
     }

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -61,7 +61,6 @@ import {
   terminalMouseOverrideHeld,
   type TerminalMouseOverride,
   TOUCH_LONG_PRESS_MS,
-  touchCancelCompletesPress,
   touchHistoryScrollPlan,
   touchPressStillHeld,
   touchScrollClaimsGesture,
@@ -162,8 +161,6 @@ export class AttachTerminal {
   // what xterm gives you to survive that, and it is the mechanism the viewport
   // anchor above already uses.
   private touchPressMarker: IMarker | null = null;
-  // When the finger went down, so a cancellation can be told apart from a takeover.
-  private touchPressAt = 0;
   // Text the press selected, waiting for the finger to lift. The clipboard write has
   // to happen in the touchend handler: Safari only honours it from a trusted
   // user-gesture task, and a setTimeout callback is not one.
@@ -254,33 +251,33 @@ export class AttachTerminal {
     this.touchCopyPending = null;
     this.cancelTouchLongPress();
     this.disposeTouchPressMarker();
-    this.touchPressAt = Date.now();
     this.touchPressCell = press ? this.bufferCellAtPoint(press.clientX, press.clientY) : null;
     if (this.touchPressCell) {
       this.touchPressMarker = this.registerPressMarker(this.touchPressCell.row);
       this.startTouchLongPress();
     }
   };
-  private readonly onTouchEnd = (event: TouchEvent): void => {
-    const awaitingRecognition = this.touchLongPressTimer !== null;
+  private readonly onTouchEnd = (): void => {
     this.cancelTouchLongPress();
-    // A cancel late in the hold IS the press. The browser ends the sequence itself
-    // once it recognises a long press of its own, and after a cancel no touchend
-    // follows — so if that lands before af's timer, waiting for a lift waits forever.
-    // Recognising it here makes the gesture independent of which side names it first,
-    // rather than racing the platform for a threshold nobody publishes.
-    if (
-      event.type === "touchcancel" &&
-      awaitingRecognition &&
-      touchCancelCompletesPress(Date.now() - this.touchPressAt)
-    ) {
-      this.selectTouchWord();
-    }
     this.disposeTouchPressMarker();
     // Browsers that DO deliver a lift copy here; the ones that answer a held touch
     // with a compatibility click instead have already copied there. Whichever runs
     // first consumes the pending text, so the copy happens exactly once.
     this.flushTouchCopy();
+  };
+  /**
+   * The browser taking the gesture away — and the ONLY signal it gives when it does.
+   *
+   * A press that turns into a scroll is not delivered as touchmove here: recording a
+   * real one gives `touchstart` then `pointercancel`, with no move in between, so a
+   * discard wired to movement never runs and the staged copy would land on the lift
+   * of a gesture the user finished as a scroll. A cancel is therefore a takeover, and
+   * a takeover drops both the copy and the selection that promised it.
+   */
+  private readonly onTouchCancel = (): void => {
+    this.cancelTouchLongPress();
+    this.disposeTouchPressMarker();
+    this.discardPendingTouchCopy();
   };
 
   /** Writes the text a recognised press staged, once, from whichever trusted event
@@ -608,7 +605,8 @@ export class AttachTerminal {
     container.addEventListener("touchmove", this.onTouchMove, { capture: true, passive: false });
     // A finger lifted or a gesture the system took over both end the press.
     container.addEventListener("touchend", this.onTouchEnd, { capture: true, passive: true });
-    container.addEventListener("touchcancel", this.onTouchEnd, { capture: true, passive: true });
+    container.addEventListener("touchcancel", this.onTouchCancel, { capture: true, passive: true });
+    container.addEventListener("pointercancel", this.onTouchCancel, { capture: true, passive: true });
     container.addEventListener("contextmenu", this.onContextMenu);
     container.addEventListener("pointerdown", this.onPointerDown, true);
     container.addEventListener("mousedown", this.onMouseDownCapture, true);
@@ -647,7 +645,8 @@ export class AttachTerminal {
     this.container.removeEventListener("touchstart", this.onTouchStart, true);
     this.container.removeEventListener("touchmove", this.onTouchMove, true);
     this.container.removeEventListener("touchend", this.onTouchEnd, true);
-    this.container.removeEventListener("touchcancel", this.onTouchEnd, true);
+    this.container.removeEventListener("touchcancel", this.onTouchCancel, true);
+    this.container.removeEventListener("pointercancel", this.onTouchCancel, true);
     this.container.removeEventListener("contextmenu", this.onContextMenu);
     this.container.removeEventListener("pointerdown", this.onPointerDown, true);
     this.container.removeEventListener("mousedown", this.onMouseDownCapture, true);

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -59,6 +59,7 @@ import {
   terminalMouseOverride,
   terminalMouseOverrideHeld,
   type TerminalMouseOverride,
+  type TerminalWordRange,
   textFromCells,
   TOUCH_LONG_PRESS_MS,
   touchHistoryScrollPlan,
@@ -803,16 +804,46 @@ export class AttachTerminal {
     // A marker reporting -1 has been disposed — the block was trimmed away — and a
     // different buffer or width means the row and column no longer name what they
     // named when the finger landed. The copy is unaffected either way.
+    //
+    // And even when all three agree, the CELLS can have been rewritten in place by a
+    // progress display or a TUI: the row still exists, at the same index, the same
+    // width, in the same buffer, holding different text. Highlighting there would
+    // point at the replacement while the clipboard holds the original — the selection
+    // is this gesture's only statement about what was copied, so it must not make a
+    // false one. Reading the live range back and comparing is what makes the highlight
+    // an assertion rather than an assumption.
     const markedFirstRow = this.touchPressMarker?.line ?? -1;
     if (markedFirstRow >= 0 && press.bufferType === this.term.buffer.active.type && press.cols === this.term.cols) {
       const at = wrappedCellPosition(range.start, press.cols);
-      this.term.select(at.col, markedFirstRow + at.row, range.length);
+      if (this.liveTextAt(markedFirstRow, range, press.cols) === text) {
+        this.term.select(at.col, markedFirstRow + at.row, range.length);
+      }
     }
     // Marked BEFORE the lift: the compatibility click this touch still owes is what
     // would otherwise reach the application and clear the selection just painted.
     this.touchCopyFired = true;
     this.suppressNextContextMenu = true;
     this.touchCopyPending = text;
+  }
+
+  /** The text the live buffer currently holds where a snapshot's range sits, or null
+   *  if that no longer resolves. Used to check the highlight before painting it. */
+  private liveTextAt(firstRow: number, range: TerminalWordRange, cols: number): string | null {
+    const buffer = this.term.buffer.active;
+    const cells: string[] = [];
+    const firstNeeded = Math.floor(range.start / cols);
+    const lastNeeded = Math.floor((range.start + range.length - 1) / cols);
+    for (let offset = firstNeeded; offset <= lastNeeded; offset += 1) {
+      const line = buffer.getLine(firstRow + offset);
+      if (!line) {
+        return null;
+      }
+      for (let col = 0; col < cols; col += 1) {
+        const buffered = line.getCell(col);
+        cells.push(buffered === undefined ? " " : buffered.getWidth() === 0 ? "" : buffered.getChars() || " ");
+      }
+    }
+    return textFromCells(cells, { start: range.start - firstNeeded * cols, length: range.length });
   }
 
   /**

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -884,57 +884,93 @@ export class AttachTerminal {
     if (pressedRow < 0 || pressedRow >= buffer.length) {
       return null;
     }
-    // A soft-wrapped line is SEVERAL buffer rows, and a phone is about forty columns
-    // wide, so the URLs and paths this gesture exists for wrap more often than not.
-    //
-    // The walk is BOUNDED, and that bound is not decoration: this runs synchronously
-    // in touchstart for every touch — taps and scrolls included — and one very long
-    // wrapped logical line (minified JSON, base64, a stack trace) can be the entire
-    // 5000-row scrollback. Materialising that would be ~200k cell reads on a phone
-    // before the handler returns, i.e. a visible stall on every touch. Rows are
-    // therefore taken only while the token is still running at the edge, and only up
-    // to the cap.
-    let first = pressedRow;
-    while (
-      first > 0 &&
-      pressedRow - first < TOUCH_PRESS_MAX_ROWS &&
-      buffer.getLine(first)?.isWrapped === true &&
-      this.rowEdgeContinues(first, 0, cols)
-    ) {
-      first -= 1;
-    }
-    // A block still marked wrapped at its first row has had earlier rows trimmed away
-    // — what remains is a SUFFIX of the logical line, and copying it whole would
-    // present a fragment as the token. Hitting the cap mid-token is refused for the
-    // same reason rather than returning the part that happened to fit.
-    if (buffer.getLine(first)?.isWrapped === true && this.rowEdgeContinues(first, 0, cols)) {
-      return null;
-    }
-    let last = pressedRow;
-    while (
-      last + 1 < buffer.length &&
-      last - pressedRow < TOUCH_PRESS_MAX_ROWS &&
-      buffer.getLine(last + 1)?.isWrapped === true &&
-      this.rowEdgeContinues(last, cols - 1, cols)
-    ) {
-      last += 1;
-    }
-    if (last + 1 < buffer.length && buffer.getLine(last + 1)?.isWrapped === true && this.rowEdgeContinues(last, cols - 1, cols)) {
-      return null;
-    }
-    const cells = this.flattenRows(first, last, cols);
+    let cells = this.flattenRows(pressedRow, pressedRow, cols);
     if (cells === null) {
       return null;
     }
-    return { cells, index: (pressedRow - first) * cols + cell.col, firstRow: first, cols, bufferType: buffer.type };
-  }
+    let first = pressedRow;
+    let last = pressedRow;
+    let index = cell.col;
 
-  /** Whether the token at one edge of a row runs on — the only reason to pull another
-   *  wrapped row into the snapshot. A blank there ends the token and the walk. */
-  private rowEdgeContinues(row: number, col: number, cols: number): boolean {
-    const cells = this.flattenRows(row, row, cols);
-    const edge = cells?.[col];
-    return edge !== undefined && (edge === "" || edge.trim() !== "");
+    // The walk follows the PRESSED TOKEN, not the row edges. A soft-wrapped line is
+    // several buffer rows and a phone is about forty columns wide, so the URLs and
+    // paths this gesture exists for wrap — but only the token under the finger has
+    // any claim on the neighbouring rows. Walking on whatever happens to sit at an
+    // edge drags in unrelated text, and on a long wrapped line it runs to the cap and
+    // throws the whole press away.
+    //
+    // Bounded, and the bound is not decoration: this runs synchronously in touchstart
+    // for EVERY touch, taps and scrolls included, and one long wrapped logical line
+    // can be the entire 5000-row scrollback. Following the token keeps the cost
+    // proportional to what is being copied instead of to the line it sits in.
+    const reaches = (): TerminalWordRange | null => wordRangeAtColumn(cells as string[], index);
+    if (reaches() !== null) {
+      while (
+        first > 0 &&
+        pressedRow - first < TOUCH_PRESS_MAX_ROWS &&
+        buffer.getLine(first)?.isWrapped === true &&
+        reaches()?.start === 0
+      ) {
+        const previous = this.flattenRows(first - 1, first - 1, cols);
+        if (previous === null) {
+          return null;
+        }
+        cells = previous.concat(cells as string[]);
+        index += cols;
+        first -= 1;
+      }
+      while (
+        last + 1 < buffer.length &&
+        last - pressedRow < TOUCH_PRESS_MAX_ROWS &&
+        buffer.getLine(last + 1)?.isWrapped === true &&
+        (() => {
+          const range = reaches();
+          return range !== null && range.start + range.length === (cells as string[]).length;
+        })()
+      ) {
+        const next = this.flattenRows(last + 1, last + 1, cols);
+        if (next === null) {
+          return null;
+        }
+        cells = (cells as string[]).concat(next);
+        last += 1;
+      }
+      // A token still running at the edge of the last row taken is a token that did
+      // not fit the bound — and the part that fit is a fragment, which is the failure
+      // this gesture keeps having to avoid. The same is true of a wrapped block whose
+      // earlier rows were trimmed away, leaving a suffix at row 0.
+      const range = reaches();
+      if (range === null) {
+        return null;
+      }
+      if (range.start === 0 && (first === 0 ? buffer.getLine(0)?.isWrapped === true : true)) {
+        return null;
+      }
+      if (range.start + range.length === (cells as string[]).length && last + 1 < buffer.length && buffer.getLine(last + 1)?.isWrapped === true) {
+        return null;
+      }
+    } else {
+      // A press on blank space copies the LINE, so here the whole wrapped block is the
+      // subject and an edge-pruned fragment would quietly copy part of it.
+      while (first > 0 && pressedRow - first < TOUCH_PRESS_MAX_ROWS && buffer.getLine(first)?.isWrapped === true) {
+        first -= 1;
+      }
+      while (last + 1 < buffer.length && last - pressedRow < TOUCH_PRESS_MAX_ROWS && buffer.getLine(last + 1)?.isWrapped === true) {
+        last += 1;
+      }
+      if (buffer.getLine(first)?.isWrapped === true) {
+        return null; // a suffix, not a line
+      }
+      if (last + 1 < buffer.length && buffer.getLine(last + 1)?.isWrapped === true) {
+        return null; // capped mid-line
+      }
+      cells = this.flattenRows(first, last, cols);
+      if (cells === null) {
+        return null;
+      }
+      index = (pressedRow - first) * cols + cell.col;
+    }
+    return { cells, index, firstRow: first, cols, bufferType: buffer.type };
   }
 
   /**

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -161,6 +161,15 @@ export class AttachTerminal {
   // what xterm gives you to survive that, and it is the mechanism the viewport
   // anchor above already uses.
   private touchPressMarker: IMarker | null = null;
+  // The grid the press was resolved against. A reflow (a peer's echoed size, or a
+  // local fit) re-lays wrapped content, so a column saved against the old width names
+  // a different cell in the new one; a buffer switch invalidates the row outright.
+  private touchPressBuffer: "normal" | "alternate" | null = null;
+  private touchPressCols = 0;
+  // One-shot, armed by a recognised press: it suppresses the menu THAT touch provokes
+  // and nothing else — a keyboard menu (Shift+F10, the Menu key, assistive tech)
+  // arrives with no pointer event to re-scope it.
+  private suppressNextContextMenu = false;
   // Text the press selected, waiting for the finger to lift. The clipboard write has
   // to happen in the touchend handler: Safari only honours it from a trusted
   // user-gesture task, and a setTimeout callback is not one.
@@ -247,18 +256,24 @@ export class AttachTerminal {
     this.touchOriginY = press?.clientY ?? 0;
     this.touchScrollRemainder = 0;
     this.touchScrollClaimed = false;
-    this.touchCopyFired = false;
-    this.touchCopyPending = null;
+    // Through the shared discard, so a press the timer already staged loses its
+    // SELECTION too. A second finger arriving on a held press lands here, and a
+    // pinch that left the highlight behind would be claiming a copy that never
+    // happened — in application mouse mode nothing else would clear it.
     this.cancelTouchLongPress();
+    this.discardPendingTouchCopy();
     this.disposeTouchPressMarker();
     this.touchPressCell = press ? this.bufferCellAtPoint(press.clientX, press.clientY) : null;
     if (this.touchPressCell) {
+      this.touchPressBuffer = this.term.buffer.active.type;
+      this.touchPressCols = this.term.cols;
       this.touchPressMarker = this.registerPressMarker(this.touchPressCell.row);
       this.startTouchLongPress();
     }
   };
   private readonly onTouchEnd = (): void => {
     this.cancelTouchLongPress();
+    this.suppressNextContextMenu = false;
     this.disposeTouchPressMarker();
     // Browsers that DO deliver a lift copy here; the ones that answer a held touch
     // with a compatibility click instead have already copied there. Whichever runs
@@ -276,6 +291,7 @@ export class AttachTerminal {
    */
   private readonly onTouchCancel = (): void => {
     this.cancelTouchLongPress();
+    this.suppressNextContextMenu = false;
     this.disposeTouchPressMarker();
     this.discardPendingTouchCopy();
   };
@@ -294,14 +310,16 @@ export class AttachTerminal {
   // never makes (#2849). Suppressed ONLY for a press af has already acted on, so a
   // desktop right-click keeps the browser's menu.
   private readonly onContextMenu = (event: MouseEvent): void => {
-    // Both conditions. touchCopyFired survives until the NEXT touchstart (the
-    // compatibility click it suppresses arrives after touchend, so it cannot be
-    // cleared sooner), which on a touchscreen laptop would otherwise swallow the
-    // browser menu from an ordinary right-click made any time after a touch copy —
-    // taking away the desktop right-click → Copy path this never meant to touch.
-    if (this.lastPointerWasTouch && this.touchCopyFired) {
-      event.preventDefault();
+    // ONE SHOT, consumed here. Anything longer-lived suppresses menus this gesture
+    // never provoked: a right-click after a touch copy on a touchscreen laptop, and —
+    // since they arrive with no pointer event at all — a keyboard menu from Shift+F10,
+    // the Menu key, or assistive technology, whose Copy route is the very thing the
+    // rest of this file is trying to give people.
+    if (!this.suppressNextContextMenu) {
+      return;
     }
+    this.suppressNextContextMenu = false;
+    event.preventDefault();
   };
   private readonly onTouchMove = (event: TouchEvent): void => {
     this.handleUserScroll("touch");
@@ -781,12 +799,30 @@ export class AttachTerminal {
     }
     const buffer = this.term.buffer.active;
     const cols = this.term.cols;
-    // The marker outranks the raw row it was made from: a full ring trims from the
-    // top while the finger rests, and every absolute index below shifts with it. A
-    // disposed marker reports -1, so only a non-negative line can win — the same rule
-    // viewportAnchorLine applies to the viewport's own anchor.
-    const marked = this.touchPressMarker?.line ?? -1;
-    const pressedRow = marked >= 0 ? marked : press.row;
+    // Everything below is resolved against the grid the finger pressed on, so a grid
+    // that is no longer that one invalidates the press rather than reinterpreting it.
+    // A reflow re-lays wrapped content under the saved column, and an alternate-screen
+    // switch (a TUI starting or exiting during the hold) makes the saved row name a
+    // line in a different buffer entirely. Both would copy real text from the wrong
+    // place, which is worse than copying nothing.
+    if (buffer.type !== this.touchPressBuffer || cols !== this.touchPressCols) {
+      return;
+    }
+    // The marker is the anchor whenever one exists: a full ring trims from the top
+    // while the finger rests, shifting every index below it. A marker reporting -1 has
+    // been DISPOSED — the pressed line itself was trimmed away — so there is nothing
+    // to copy; falling back to the raw row there would hand back whatever slid into
+    // that slot. The raw row is only a fallback where no marker could be made at all
+    // (an alternate buffer cannot register one).
+    let pressedRow: number;
+    if (this.touchPressMarker !== null) {
+      if (this.touchPressMarker.line < 0) {
+        return;
+      }
+      pressedRow = this.touchPressMarker.line;
+    } else {
+      pressedRow = press.row;
+    }
     if (pressedRow < 0 || pressedRow >= buffer.length) {
       return;
     }
@@ -821,6 +857,21 @@ export class AttachTerminal {
         const buffered = line.getCell(col);
         cells.push(buffered === undefined ? " " : buffered.getWidth() === 0 ? "" : buffered.getChars() || " ");
       }
+      // A wide glyph that will not fit the last cell is pushed to the next row, and
+      // xterm leaves the cell it vacated BLANK. That blank is structure, not content —
+      // xterm's own reflow reads it that way — so flattening it to a space would split
+      // an otherwise unbroken CJK or emoji token exactly at the wrap and copy one half.
+      // Narrowed to that case by looking at what the next row starts with, so an
+      // ordinary trailing blank keeps separating words.
+      const continues = buffer.getLine(row + 1);
+      if (
+        row < last &&
+        cells[cells.length - 1] === " " &&
+        continues !== undefined &&
+        continues.getCell(0)?.getWidth() === 2
+      ) {
+        cells[cells.length - 1] = "";
+      }
     }
     const pressed = (pressedRow - first) * cols + press.col;
     const range = wordRangeAtColumn(cells, pressed) ?? { start: 0, length: lineContentColumns(cells) };
@@ -837,6 +888,7 @@ export class AttachTerminal {
     // Marked BEFORE the lift: the compatibility click this touch still owes is what
     // would otherwise reach the application and clear the selection just painted.
     this.touchCopyFired = true;
+    this.suppressNextContextMenu = true;
     this.touchCopyPending = text;
   }
 

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -819,11 +819,16 @@ export class AttachTerminal {
     // is this gesture's only statement about what was copied, so it must not make a
     // false one. Reading the live range back and comparing is what makes the highlight
     // an assertion rather than an assumption.
-    const markedFirstRow = this.touchPressMarker?.line ?? -1;
-    if (markedFirstRow >= 0 && press.bufferType === this.term.buffer.active.type && press.cols === this.term.cols) {
+    // An alternate buffer cannot register a marker at all, so a marker-only rule would
+    // skip the highlight in every full-screen TUI — the most common agent pane there
+    // is — leaving the copy silent. Fall back to the row the snapshot was taken at:
+    // the live-text comparison below is what actually protects the highlight, and it
+    // is just as strict against a raw row as against a marked one.
+    const anchorRow = this.touchPressMarker !== null ? this.touchPressMarker.line : press.firstRow;
+    if (anchorRow >= 0 && press.bufferType === this.term.buffer.active.type && press.cols === this.term.cols) {
       const at = wrappedCellPosition(range.start, press.cols);
-      if (this.liveTextAt(markedFirstRow, range, press.cols) === text) {
-        this.term.select(at.col, markedFirstRow + at.row, range.length);
+      if (this.liveTextAt(anchorRow, range, press.cols) === text) {
+        this.term.select(at.col, anchorRow + at.row, range.length);
       } else {
         // Declining to paint is not enough when something is ALREADY painted: a
         // selection made earlier (a modifier drag in a mouse-aware TUI, which xterm
@@ -1002,7 +1007,11 @@ export class AttachTerminal {
       // (code 32). Flattened to " " it splits an unbroken CJK or emoji token exactly
       // at the wrap; read as structure, the token survives and a real trailing space
       // still separates words.
-      if (buffer.getLine(row + 1)?.isWrapped === true && line.getCell(cols - 1)?.getCode() === 0) {
+      // The lookahead is BOUNDED: xterm's store is circular, so getLine(buffer.length)
+      // aliases to the first retained row rather than answering undefined, and a
+      // wrapped row there would make an ordinary null cell at the bottom of the buffer
+      // look like wrap padding.
+      if (row + 1 < buffer.length && buffer.getLine(row + 1)?.isWrapped === true && line.getCell(cols - 1)?.getCode() === 0) {
         cells[cells.length - 1] = "";
       }
     }

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -88,6 +88,9 @@ const BACKOFF_MAX_MS = 10_000;
 // Debounce the fit→OpResize send so dragging a window edge sends one resize on
 // settle, not one per animation frame. The server echoes the winning size back.
 const RESIZE_DEBOUNCE_MS = 120;
+// How many wrapped rows either side of the pressed one a long press will read. It
+// bounds work done synchronously in touchstart for EVERY touch; see snapshotPress.
+const TOUCH_PRESS_MAX_ROWS = 32;
 
 /** A long press resolved at touchstart: the flattened wrapped block, the index the
  *  finger landed on, and the grid it was all read against. */
@@ -449,6 +452,10 @@ export class AttachTerminal {
       // this cannot resurrect a copy the scroll already discarded.
       event.preventDefault();
       event.stopPropagation();
+      // Disarmed HERE as well as on a lift: this browser sends neither touchend nor
+      // touchcancel for a held touch, so the places that used to clear it are never
+      // reached and the one-shot would stay armed for the next keyboard menu.
+      this.suppressNextContextMenu = false;
       this.flushTouchCopy();
       return;
     }
@@ -817,7 +824,15 @@ export class AttachTerminal {
       const at = wrappedCellPosition(range.start, press.cols);
       if (this.liveTextAt(markedFirstRow, range, press.cols) === text) {
         this.term.select(at.col, markedFirstRow + at.row, range.length);
+      } else {
+        // Declining to paint is not enough when something is ALREADY painted: a
+        // selection made earlier (a modifier drag in a mouse-aware TUI, which xterm
+        // does not clear for a touch) would survive and be read as naming what was
+        // just copied.
+        this.term.clearSelection();
       }
+    } else {
+      this.term.clearSelection();
     }
     // Marked BEFORE the lift: the compatibility click this touch still owes is what
     // would otherwise reach the application and clear the selection just painted.
@@ -829,19 +844,15 @@ export class AttachTerminal {
   /** The text the live buffer currently holds where a snapshot's range sits, or null
    *  if that no longer resolves. Used to check the highlight before painting it. */
   private liveTextAt(firstRow: number, range: TerminalWordRange, cols: number): string | null {
-    const buffer = this.term.buffer.active;
-    const cells: string[] = [];
     const firstNeeded = Math.floor(range.start / cols);
     const lastNeeded = Math.floor((range.start + range.length - 1) / cols);
-    for (let offset = firstNeeded; offset <= lastNeeded; offset += 1) {
-      const line = buffer.getLine(firstRow + offset);
-      if (!line) {
-        return null;
-      }
-      for (let col = 0; col < cols; col += 1) {
-        const buffered = line.getCell(col);
-        cells.push(buffered === undefined ? " " : buffered.getWidth() === 0 ? "" : buffered.getChars() || " ");
-      }
+    // The SAME flatten the snapshot used, wrap padding included. Reconstructing it by
+    // hand here once left the live text unable to equal the snapshot across a padded
+    // wrap, which silently withheld the highlight in exactly the CJK case the padding
+    // rule exists for.
+    const cells = this.flattenRows(firstRow + firstNeeded, firstRow + lastNeeded, cols);
+    if (cells === null) {
+      return null;
     }
     return textFromCells(cells, { start: range.start - firstNeeded * cols, length: range.length });
   }
@@ -875,24 +886,70 @@ export class AttachTerminal {
     }
     // A soft-wrapped line is SEVERAL buffer rows, and a phone is about forty columns
     // wide, so the URLs and paths this gesture exists for wrap more often than not.
-    // Both walks are bounded by the buffer: xterm's store is circular, so a read past
-    // the end can answer with the first retained row rather than nothing.
+    //
+    // The walk is BOUNDED, and that bound is not decoration: this runs synchronously
+    // in touchstart for every touch — taps and scrolls included — and one very long
+    // wrapped logical line (minified JSON, base64, a stack trace) can be the entire
+    // 5000-row scrollback. Materialising that would be ~200k cell reads on a phone
+    // before the handler returns, i.e. a visible stall on every touch. Rows are
+    // therefore taken only while the token is still running at the edge, and only up
+    // to the cap.
     let first = pressedRow;
-    while (first > 0 && buffer.getLine(first)?.isWrapped === true) {
+    while (
+      first > 0 &&
+      pressedRow - first < TOUCH_PRESS_MAX_ROWS &&
+      buffer.getLine(first)?.isWrapped === true &&
+      this.rowEdgeContinues(first, 0, cols)
+    ) {
       first -= 1;
     }
-    // A block still marked wrapped at row 0 has had its earlier rows trimmed away, so
-    // what remains is a SUFFIX of the logical line. Copying it whole would return a
-    // fragment presented as the token.
-    if (buffer.getLine(first)?.isWrapped === true) {
+    // A block still marked wrapped at its first row has had earlier rows trimmed away
+    // — what remains is a SUFFIX of the logical line, and copying it whole would
+    // present a fragment as the token. Hitting the cap mid-token is refused for the
+    // same reason rather than returning the part that happened to fit.
+    if (buffer.getLine(first)?.isWrapped === true && this.rowEdgeContinues(first, 0, cols)) {
       return null;
     }
     let last = pressedRow;
-    while (last + 1 < buffer.length && buffer.getLine(last + 1)?.isWrapped === true) {
+    while (
+      last + 1 < buffer.length &&
+      last - pressedRow < TOUCH_PRESS_MAX_ROWS &&
+      buffer.getLine(last + 1)?.isWrapped === true &&
+      this.rowEdgeContinues(last, cols - 1, cols)
+    ) {
       last += 1;
     }
+    if (last + 1 < buffer.length && buffer.getLine(last + 1)?.isWrapped === true && this.rowEdgeContinues(last, cols - 1, cols)) {
+      return null;
+    }
+    const cells = this.flattenRows(first, last, cols);
+    if (cells === null) {
+      return null;
+    }
+    return { cells, index: (pressedRow - first) * cols + cell.col, firstRow: first, cols, bufferType: buffer.type };
+  }
+
+  /** Whether the token at one edge of a row runs on — the only reason to pull another
+   *  wrapped row into the snapshot. A blank there ends the token and the walk. */
+  private rowEdgeContinues(row: number, col: number, cols: number): boolean {
+    const cells = this.flattenRows(row, row, cols);
+    const edge = cells?.[col];
+    return edge !== undefined && (edge === "" || edge.trim() !== "");
+  }
+
+  /**
+   * Flattens buffer rows to ONE ENTRY PER COLUMN, so an index is a column.
+   * translateToString would collapse a wide character into a single index and quietly
+   * shift every column after it.
+   *
+   * Shared by the snapshot and by the live check that guards the highlight: two
+   * copies of this drifted apart once already, and a difference between them reads as
+   * "the text changed" — which silently withholds the only feedback this gesture has.
+   */
+  private flattenRows(firstRow: number, lastRow: number, cols: number): string[] | null {
+    const buffer = this.term.buffer.active;
     const cells: string[] = [];
-    for (let row = first; row <= last; row += 1) {
+    for (let row = firstRow; row <= lastRow; row += 1) {
       const line = buffer.getLine(row);
       if (!line) {
         return null;
@@ -902,16 +959,15 @@ export class AttachTerminal {
         cells.push(buffered === undefined ? " " : buffered.getWidth() === 0 ? "" : buffered.getChars() || " ");
       }
       // A wide glyph that will not fit the last cell is pushed to the next row, and
-      // the cell it vacated is left NULL — code 0, which is not a space anybody typed.
-      // Flattened to " " it splits an unbroken CJK or emoji token exactly at the wrap;
-      // read as the structure xterm's own reflow treats it as, the token survives. The
-      // code is what separates it from a real trailing space (code 32), which must
-      // keep separating words.
-      if (row < last && line.getCell(cols - 1)?.getCode() === 0) {
+      // the cell it vacated is left NULL — code 0, which is not a space anybody typed
+      // (code 32). Flattened to " " it splits an unbroken CJK or emoji token exactly
+      // at the wrap; read as structure, the token survives and a real trailing space
+      // still separates words.
+      if (buffer.getLine(row + 1)?.isWrapped === true && line.getCell(cols - 1)?.getCode() === 0) {
         cells[cells.length - 1] = "";
       }
     }
-    return { cells, index: (pressedRow - first) * cols + cell.col, firstRow: first, cols, bufferType: buffer.type };
+    return cells;
   }
 
   /** The painted height of one terminal row, which turns a pixel-denominated gesture

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -156,6 +156,11 @@ export class AttachTerminal {
   // second later, and under live output the row the finger is on has scrolled by
   // then — copying whatever slid beneath it instead of what was pressed.
   private touchPressCell: TerminalCellPoint | null = null;
+  // …and a marker on that row. A FULL scrollback ring trims from the top while the
+  // finger rests, shifting every absolute index down under the anchor; a marker is
+  // what xterm gives you to survive that, and it is the mechanism the viewport
+  // anchor above already uses.
+  private touchPressMarker: IMarker | null = null;
   // Text the press selected, waiting for the finger to lift. The clipboard write has
   // to happen in the touchend handler: Safari only honours it from a trusted
   // user-gesture task, and a setTimeout callback is not one.
@@ -245,13 +250,16 @@ export class AttachTerminal {
     this.touchCopyFired = false;
     this.touchCopyPending = null;
     this.cancelTouchLongPress();
+    this.disposeTouchPressMarker();
     this.touchPressCell = press ? this.bufferCellAtPoint(press.clientX, press.clientY) : null;
     if (this.touchPressCell) {
+      this.touchPressMarker = this.registerPressMarker(this.touchPressCell.row);
       this.startTouchLongPress();
     }
   };
   private readonly onTouchEnd = (): void => {
     this.cancelTouchLongPress();
+    this.disposeTouchPressMarker();
     const pending = this.touchCopyPending;
     this.touchCopyPending = null;
     if (pending === null) {
@@ -275,7 +283,12 @@ export class AttachTerminal {
   // never makes (#2849). Suppressed ONLY for a press af has already acted on, so a
   // desktop right-click keeps the browser's menu.
   private readonly onContextMenu = (event: MouseEvent): void => {
-    if (this.touchCopyFired) {
+    // Both conditions. touchCopyFired survives until the NEXT touchstart (the
+    // compatibility click it suppresses arrives after touchend, so it cannot be
+    // cleared sooner), which on a touchscreen laptop would otherwise swallow the
+    // browser menu from an ordinary right-click made any time after a touch copy —
+    // taking away the desktop right-click → Copy path this never meant to touch.
+    if (this.lastPointerWasTouch && this.touchCopyFired) {
       event.preventDefault();
     }
   };
@@ -285,8 +298,12 @@ export class AttachTerminal {
       !touchPressStillHeld(this.touchOriginX, this.touchOriginY, event.touches[0].clientX, event.touches[0].clientY);
     if (moved) {
       // The finger left the spot it pressed on, so this gesture is a scroll (or a
-      // pinch) rather than a press. Both readings cannot be live at once.
+      // pinch) rather than a press. Both readings cannot be live at once — and that
+      // includes a press the timer ALREADY recognised: without discarding it, a
+      // slow-starting scroll would still overwrite the clipboard on lift with a token
+      // the user has since scrolled away from.
       this.cancelTouchLongPress();
+      this.discardPendingTouchCopy();
     }
     if (this.touchScrollY === null) {
       return;
@@ -429,6 +446,7 @@ export class AttachTerminal {
     const plan = terminalUserScrollPlan(source, this.visibleFitFrame !== null);
     if (plan.cancelScheduledVisibleFit) {
       this.cancelTouchLongPress();
+    this.disposeTouchPressMarker();
     this.cancelVisibleFitFrame();
     }
     this.fitVisibleHost();
@@ -686,6 +704,33 @@ export class AttachTerminal {
     }
   }
 
+  /** Drops a copy the press had already staged, and the selection that promised it,
+   *  so the gesture leaves nothing behind claiming it copied something. */
+  private discardPendingTouchCopy(): void {
+    if (this.touchCopyPending === null && !this.touchCopyFired) {
+      return;
+    }
+    this.touchCopyPending = null;
+    this.touchCopyFired = false;
+    this.term.clearSelection();
+  }
+
+  /** Marks the pressed row so a scrollback trim during the hold moves the anchor with
+   *  the text. Alternate buffers cannot register markers, hence the null. */
+  private registerPressMarker(row: number): IMarker | null {
+    const buffer = this.term.buffer.active;
+    try {
+      return this.term.registerMarker(row - (buffer.baseY + buffer.cursorY));
+    } catch {
+      return null;
+    }
+  }
+
+  private disposeTouchPressMarker(): void {
+    this.touchPressMarker?.dispose();
+    this.touchPressMarker = null;
+  }
+
   /** The cell under a viewport point, in ABSOLUTE buffer coordinates so it survives
    *  everything the terminal does to the viewport afterwards. */
   private bufferCellAtPoint(x: number, y: number): TerminalCellPoint | null {
@@ -712,16 +757,31 @@ export class AttachTerminal {
     }
     const buffer = this.term.buffer.active;
     const cols = this.term.cols;
+    // The marker outranks the raw row it was made from: a full ring trims from the
+    // top while the finger rests, and every absolute index below shifts with it. A
+    // disposed marker reports -1, so only a non-negative line can win — the same rule
+    // viewportAnchorLine applies to the viewport's own anchor.
+    const marked = this.touchPressMarker?.line ?? -1;
+    const pressedRow = marked >= 0 ? marked : press.row;
+    if (pressedRow < 0 || pressedRow >= buffer.length) {
+      return;
+    }
     // A soft-wrapped line is SEVERAL buffer rows, and a phone is about forty columns
     // wide — so the URLs and paths this gesture exists for wrap more often than not.
     // Scan the whole wrapped block, or the token gets cut at the screen edge and the
     // user silently copies a fragment of the thing they pressed on.
-    let first = press.row;
+    //
+    // Both walks are BOUNDED by the buffer. xterm's backing store is circular, so a
+    // read past the end can answer with the first retained row rather than nothing —
+    // and if that row is itself wrapped, an unbounded walk marches into unrelated
+    // scrollback, or never stops at all when the retained buffer is one long wrapped
+    // line.
+    let first = pressedRow;
     while (first > 0 && buffer.getLine(first)?.isWrapped === true) {
       first -= 1;
     }
-    let last = press.row;
-    while (buffer.getLine(last + 1)?.isWrapped === true) {
+    let last = pressedRow;
+    while (last + 1 < buffer.length && buffer.getLine(last + 1)?.isWrapped === true) {
       last += 1;
     }
     // ONE ENTRY PER COLUMN, rows joined end to end, so an index is a position in the
@@ -738,7 +798,7 @@ export class AttachTerminal {
         cells.push(buffered === undefined ? " " : buffered.getWidth() === 0 ? "" : buffered.getChars() || " ");
       }
     }
-    const pressed = (press.row - first) * cols + press.col;
+    const pressed = (pressedRow - first) * cols + press.col;
     const range = wordRangeAtColumn(cells, pressed) ?? { start: 0, length: lineContentColumns(cells) };
     if (range.length === 0) {
       return; // a press on genuinely empty screen

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -56,10 +56,10 @@ import {
   invertTerminalMouseOverride,
   lineContentColumns,
   terminalCellAtPoint,
-  type TerminalCellPoint,
   terminalMouseOverride,
   terminalMouseOverrideHeld,
   type TerminalMouseOverride,
+  textFromCells,
   TOUCH_LONG_PRESS_MS,
   touchHistoryScrollPlan,
   touchPressStillHeld,
@@ -87,6 +87,16 @@ const BACKOFF_MAX_MS = 10_000;
 // Debounce the fit→OpResize send so dragging a window edge sends one resize on
 // settle, not one per animation frame. The server echoes the winning size back.
 const RESIZE_DEBOUNCE_MS = 120;
+
+/** A long press resolved at touchstart: the flattened wrapped block, the index the
+ *  finger landed on, and the grid it was all read against. */
+interface TouchPressSnapshot {
+  cells: string[];
+  index: number;
+  firstRow: number;
+  cols: number;
+  bufferType: "normal" | "alternate";
+}
 
 interface PendingViewportAnchor {
   /** A marker follows the actual line while inactive output shifts the buffer. */
@@ -155,17 +165,16 @@ export class AttachTerminal {
   // coordinates. Resolving it when the timer fires would read the viewport half a
   // second later, and under live output the row the finger is on has scrolled by
   // then — copying whatever slid beneath it instead of what was pressed.
-  private touchPressCell: TerminalCellPoint | null = null;
-  // …and a marker on that row. A FULL scrollback ring trims from the top while the
-  // finger rests, shifting every absolute index down under the anchor; a marker is
-  // what xterm gives you to survive that, and it is the mechanism the viewport
-  // anchor above already uses.
+  // The press, READ WHEN THE FINGER LANDS: the whole wrapped block it fell in, and
+  // where in that block it fell. Resolving the text at touchstart instead of when the
+  // timer fires is what makes the copy immune to everything the terminal can do
+  // during the hold — a trim, an in-place rewrite by a progress bar, an
+  // alternate-screen TUI scrolling underneath, a reflow. Each of those was a separate
+  // way to copy the wrong text while looking like it worked; none of them can reach a
+  // snapshot. What is resolved late is only the HIGHLIGHT, which is cosmetic and is
+  // skipped when the live grid no longer matches.
+  private touchPress: TouchPressSnapshot | null = null;
   private touchPressMarker: IMarker | null = null;
-  // The grid the press was resolved against. A reflow (a peer's echoed size, or a
-  // local fit) re-lays wrapped content, so a column saved against the old width names
-  // a different cell in the new one; a buffer switch invalidates the row outright.
-  private touchPressBuffer: "normal" | "alternate" | null = null;
-  private touchPressCols = 0;
   // One-shot, armed by a recognised press: it suppresses the menu THAT touch provokes
   // and nothing else — a keyboard menu (Shift+F10, the Menu key, assistive tech)
   // arrives with no pointer event to re-scope it.
@@ -263,11 +272,9 @@ export class AttachTerminal {
     this.cancelTouchLongPress();
     this.discardPendingTouchCopy();
     this.disposeTouchPressMarker();
-    this.touchPressCell = press ? this.bufferCellAtPoint(press.clientX, press.clientY) : null;
-    if (this.touchPressCell) {
-      this.touchPressBuffer = this.term.buffer.active.type;
-      this.touchPressCols = this.term.cols;
-      this.touchPressMarker = this.registerPressMarker(this.touchPressCell.row);
+    this.touchPress = press ? this.snapshotPress(press.clientX, press.clientY) : null;
+    if (this.touchPress) {
+      this.touchPressMarker = this.registerPressMarker(this.touchPress.firstRow);
       this.startTouchLongPress();
     }
   };
@@ -773,123 +780,107 @@ export class AttachTerminal {
     this.touchPressMarker = null;
   }
 
-  /** The cell under a viewport point, in ABSOLUTE buffer coordinates so it survives
-   *  everything the terminal does to the viewport afterwards. */
-  private bufferCellAtPoint(x: number, y: number): TerminalCellPoint | null {
-    const rowsEl = this.container.querySelector<HTMLElement>(".xterm-rows");
-    if (!rowsEl) {
-      return null;
-    }
-    const cell = terminalCellAtPoint(x, y, rowsEl.getBoundingClientRect(), this.term.cols, this.term.rows);
-    return cell === null ? null : { col: cell.col, row: this.term.buffer.active.viewportY + cell.row };
-  }
-
   /**
-   * Selects the token the finger is resting on, and holds the text for the lift.
+   * Turns the snapshot into a selection and a staged copy.
    *
-   * The selection happens now, so the highlight appears under the finger at the
-   * moment the press is recognised; the clipboard write waits for touchend, where a
-   * user gesture is still in scope. Splitting the two is what makes the gesture work
-   * on Safari as well as Chrome.
+   * The TEXT comes from the snapshot, so it is what was under the finger when it
+   * landed. The HIGHLIGHT needs the live buffer and is therefore conditional: it is
+   * skipped, not guessed, when the grid has moved out from under the press.
    */
   private selectTouchWord(): void {
-    const press = this.touchPressCell;
+    const press = this.touchPress;
     if (!press) {
       return;
     }
-    const buffer = this.term.buffer.active;
-    const cols = this.term.cols;
-    // Everything below is resolved against the grid the finger pressed on, so a grid
-    // that is no longer that one invalidates the press rather than reinterpreting it.
-    // A reflow re-lays wrapped content under the saved column, and an alternate-screen
-    // switch (a TUI starting or exiting during the hold) makes the saved row name a
-    // line in a different buffer entirely. Both would copy real text from the wrong
-    // place, which is worse than copying nothing.
-    if (buffer.type !== this.touchPressBuffer || cols !== this.touchPressCols) {
-      return;
-    }
-    // The marker is the anchor whenever one exists: a full ring trims from the top
-    // while the finger rests, shifting every index below it. A marker reporting -1 has
-    // been DISPOSED — the pressed line itself was trimmed away — so there is nothing
-    // to copy; falling back to the raw row there would hand back whatever slid into
-    // that slot. The raw row is only a fallback where no marker could be made at all
-    // (an alternate buffer cannot register one).
-    let pressedRow: number;
-    if (this.touchPressMarker !== null) {
-      if (this.touchPressMarker.line < 0) {
-        return;
-      }
-      pressedRow = this.touchPressMarker.line;
-    } else {
-      pressedRow = press.row;
-    }
-    if (pressedRow < 0 || pressedRow >= buffer.length) {
-      return;
-    }
-    // A soft-wrapped line is SEVERAL buffer rows, and a phone is about forty columns
-    // wide — so the URLs and paths this gesture exists for wrap more often than not.
-    // Scan the whole wrapped block, or the token gets cut at the screen edge and the
-    // user silently copies a fragment of the thing they pressed on.
-    //
-    // Both walks are BOUNDED by the buffer. xterm's backing store is circular, so a
-    // read past the end can answer with the first retained row rather than nothing —
-    // and if that row is itself wrapped, an unbounded walk marches into unrelated
-    // scrollback, or never stops at all when the retained buffer is one long wrapped
-    // line.
-    let first = pressedRow;
-    while (first > 0 && buffer.getLine(first)?.isWrapped === true) {
-      first -= 1;
-    }
-    let last = pressedRow;
-    while (last + 1 < buffer.length && buffer.getLine(last + 1)?.isWrapped === true) {
-      last += 1;
-    }
-    // ONE ENTRY PER COLUMN, rows joined end to end, so an index is a position in the
-    // block. translateToString would collapse a wide character into a single index
-    // and quietly shift every column after it.
-    const cells: string[] = [];
-    for (let row = first; row <= last; row += 1) {
-      const line = buffer.getLine(row);
-      if (!line) {
-        break;
-      }
-      for (let col = 0; col < cols; col += 1) {
-        const buffered = line.getCell(col);
-        cells.push(buffered === undefined ? " " : buffered.getWidth() === 0 ? "" : buffered.getChars() || " ");
-      }
-      // A wide glyph that will not fit the last cell is pushed to the next row, and
-      // xterm leaves the cell it vacated BLANK. That blank is structure, not content —
-      // xterm's own reflow reads it that way — so flattening it to a space would split
-      // an otherwise unbroken CJK or emoji token exactly at the wrap and copy one half.
-      // Narrowed to that case by looking at what the next row starts with, so an
-      // ordinary trailing blank keeps separating words.
-      const continues = buffer.getLine(row + 1);
-      if (
-        row < last &&
-        cells[cells.length - 1] === " " &&
-        continues !== undefined &&
-        continues.getCell(0)?.getWidth() === 2
-      ) {
-        cells[cells.length - 1] = "";
-      }
-    }
-    const pressed = (pressedRow - first) * cols + press.col;
-    const range = wordRangeAtColumn(cells, pressed) ?? { start: 0, length: lineContentColumns(cells) };
+    const range = wordRangeAtColumn(press.cells, press.index) ?? { start: 0, length: lineContentColumns(press.cells) };
     if (range.length === 0) {
       return; // a press on genuinely empty screen
     }
-    const at = wrappedCellPosition(range.start, cols);
-    this.term.select(at.col, first + at.row, range.length);
-    const text = this.term.getSelection();
+    const text = textFromCells(press.cells, range);
     if (text.trim() === "") {
-      this.term.clearSelection();
       return;
+    }
+    // A marker reporting -1 has been disposed — the block was trimmed away — and a
+    // different buffer or width means the row and column no longer name what they
+    // named when the finger landed. The copy is unaffected either way.
+    const markedFirstRow = this.touchPressMarker?.line ?? -1;
+    if (markedFirstRow >= 0 && press.bufferType === this.term.buffer.active.type && press.cols === this.term.cols) {
+      const at = wrappedCellPosition(range.start, press.cols);
+      this.term.select(at.col, markedFirstRow + at.row, range.length);
     }
     // Marked BEFORE the lift: the compatibility click this touch still owes is what
     // would otherwise reach the application and clear the selection just painted.
     this.touchCopyFired = true;
     this.suppressNextContextMenu = true;
     this.touchCopyPending = text;
+  }
+
+  /**
+   * Reads the press: the wrapped block under the finger, flattened one entry per
+   * column, plus where in it the finger landed.
+   *
+   * Everything the copy needs is taken HERE, while the finger is still going down.
+   * The alternative — keeping coordinates and reading the buffer when the timer fires
+   * — has to survive every mutation that can happen in 500ms, and each one is its own
+   * way to copy real text from the wrong place: a full ring trimming the pressed line
+   * or the earlier rows of its wrapped block, a progress bar rewriting the line in
+   * place, an alternate-screen TUI scrolling, a peer's resize reflowing the grid. A
+   * snapshot is immune to all of them at once.
+   */
+  private snapshotPress(x: number, y: number): TouchPressSnapshot | null {
+    const rowsEl = this.container.querySelector<HTMLElement>(".xterm-rows");
+    if (!rowsEl) {
+      return null;
+    }
+    const cols = this.term.cols;
+    const cell = terminalCellAtPoint(x, y, rowsEl.getBoundingClientRect(), cols, this.term.rows);
+    if (!cell) {
+      return null;
+    }
+    const buffer = this.term.buffer.active;
+    const pressedRow = buffer.viewportY + cell.row;
+    if (pressedRow < 0 || pressedRow >= buffer.length) {
+      return null;
+    }
+    // A soft-wrapped line is SEVERAL buffer rows, and a phone is about forty columns
+    // wide, so the URLs and paths this gesture exists for wrap more often than not.
+    // Both walks are bounded by the buffer: xterm's store is circular, so a read past
+    // the end can answer with the first retained row rather than nothing.
+    let first = pressedRow;
+    while (first > 0 && buffer.getLine(first)?.isWrapped === true) {
+      first -= 1;
+    }
+    // A block still marked wrapped at row 0 has had its earlier rows trimmed away, so
+    // what remains is a SUFFIX of the logical line. Copying it whole would return a
+    // fragment presented as the token.
+    if (buffer.getLine(first)?.isWrapped === true) {
+      return null;
+    }
+    let last = pressedRow;
+    while (last + 1 < buffer.length && buffer.getLine(last + 1)?.isWrapped === true) {
+      last += 1;
+    }
+    const cells: string[] = [];
+    for (let row = first; row <= last; row += 1) {
+      const line = buffer.getLine(row);
+      if (!line) {
+        return null;
+      }
+      for (let col = 0; col < cols; col += 1) {
+        const buffered = line.getCell(col);
+        cells.push(buffered === undefined ? " " : buffered.getWidth() === 0 ? "" : buffered.getChars() || " ");
+      }
+      // A wide glyph that will not fit the last cell is pushed to the next row, and
+      // the cell it vacated is left NULL — code 0, which is not a space anybody typed.
+      // Flattened to " " it splits an unbroken CJK or emoji token exactly at the wrap;
+      // read as the structure xterm's own reflow treats it as, the token survives. The
+      // code is what separates it from a real trailing space (code 32), which must
+      // keep separating words.
+      if (row < last && line.getCell(cols - 1)?.getCode() === 0) {
+        cells[cells.length - 1] = "";
+      }
+    }
+    return { cells, index: (pressedRow - first) * cols + cell.col, firstRow: first, cols, bufferType: buffer.type };
   }
 
   /** The painted height of one terminal row, which turns a pixel-denominated gesture

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -943,7 +943,10 @@ export class AttachTerminal {
       if (range === null) {
         return null;
       }
-      if (range.start === 0 && (first === 0 ? buffer.getLine(0)?.isWrapped === true : true)) {
+      // Refuse only when the token runs off the top of what was taken INTO a wrapped
+      // predecessor — i.e. more of it exists above and did not fit. A token that
+      // simply begins at column 0 of a line that nothing wraps into is complete.
+      if (range.start === 0 && first > 0 && buffer.getLine(first)?.isWrapped === true) {
         return null;
       }
       if (range.start + range.length === (cells as string[]).length && last + 1 < buffer.length && buffer.getLine(last + 1)?.isWrapped === true) {

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -250,17 +250,34 @@ export class AttachTerminal {
       this.startTouchLongPress();
     }
   };
-  private readonly onTouchEnd = (event: TouchEvent): void => {
+  private readonly onTouchEnd = (): void => {
     this.cancelTouchLongPress();
     const pending = this.touchCopyPending;
     this.touchCopyPending = null;
-    if (pending === null || event.type !== "touchend") {
-      return; // a cancelled gesture copies nothing
+    if (pending === null) {
+      return;
     }
-    // The write runs HERE, inside the trusted lift, not in the timer that selected
-    // the text: Safari grants clipboard access only to a user-gesture task, so a
-    // write from the timeout is refused on the one platform this gesture exists for.
+    // The write runs HERE, at the end of the touch rather than in the timer that
+    // selected the text: Safari grants clipboard access only to a user-gesture task,
+    // so a write from the timeout is refused on the one platform this gesture exists
+    // for.
+    //
+    // A CANCEL counts as an end. The browser ends the sequence itself the moment it
+    // recognises a long press — it is about to offer its own context menu — so
+    // treating a cancel as "copied nothing" throws the result away at exactly the
+    // moment the gesture succeeded, with the selection already painted under the
+    // finger. Observed: the selection appeared, no failure toast, and the clipboard
+    // stayed untouched, which is that discard and nothing else.
     this.copyToClipboard(pending);
+  };
+  // …and the menu that cancellation was announcing is not wanted either: it would
+  // cover the selection with an OS menu whose Copy acts on a DOM selection xterm
+  // never makes (#2849). Suppressed ONLY for a press af has already acted on, so a
+  // desktop right-click keeps the browser's menu.
+  private readonly onContextMenu = (event: MouseEvent): void => {
+    if (this.touchCopyFired) {
+      event.preventDefault();
+    }
   };
   private readonly onTouchMove = (event: TouchEvent): void => {
     this.handleUserScroll("touch");
@@ -549,6 +566,7 @@ export class AttachTerminal {
     // A finger lifted or a gesture the system took over both end the press.
     container.addEventListener("touchend", this.onTouchEnd, { capture: true, passive: true });
     container.addEventListener("touchcancel", this.onTouchEnd, { capture: true, passive: true });
+    container.addEventListener("contextmenu", this.onContextMenu);
     container.addEventListener("pointerdown", this.onPointerDown, true);
     container.addEventListener("mousedown", this.onMouseDownCapture, true);
     // Bubbles from xterm's focused helper textarea, so this one listener catches
@@ -587,6 +605,7 @@ export class AttachTerminal {
     this.container.removeEventListener("touchmove", this.onTouchMove, true);
     this.container.removeEventListener("touchend", this.onTouchEnd, true);
     this.container.removeEventListener("touchcancel", this.onTouchEnd, true);
+    this.container.removeEventListener("contextmenu", this.onContextMenu);
     this.container.removeEventListener("pointerdown", this.onPointerDown, true);
     this.container.removeEventListener("mousedown", this.onMouseDownCapture, true);
     this.container.removeEventListener("copy", this.onCopy);

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -56,6 +56,7 @@ import {
   invertTerminalMouseOverride,
   lineContentColumns,
   terminalCellAtPoint,
+  type TerminalCellPoint,
   terminalMouseOverride,
   terminalMouseOverrideHeld,
   type TerminalMouseOverride,
@@ -64,6 +65,7 @@ import {
   touchPressStillHeld,
   touchScrollClaimsGesture,
   wordRangeAtColumn,
+  wrappedCellPosition,
 } from "./terminal-mouse.js";
 import type { StreamEndpoint } from "./stream_endpoint.js";
 import { currentXtermTheme } from "./theme.js";
@@ -145,10 +147,19 @@ export class AttachTerminal {
   private touchOriginX = 0;
   private touchOriginY = 0;
   private touchScrollClaimed = false;
-  // The pending long press, and whether it has already copied on this gesture — a
-  // copy has to swallow the compatibility click the same touch would otherwise fire.
+  // The pending long press, and whether it has already acted on this gesture — a copy
+  // has to swallow the compatibility click the same touch would otherwise fire.
   private touchLongPressTimer: number | null = null;
   private touchCopyFired = false;
+  // The cell the finger went down on, resolved AT TOUCHSTART and in absolute buffer
+  // coordinates. Resolving it when the timer fires would read the viewport half a
+  // second later, and under live output the row the finger is on has scrolled by
+  // then — copying whatever slid beneath it instead of what was pressed.
+  private touchPressCell: TerminalCellPoint | null = null;
+  // Text the press selected, waiting for the finger to lift. The clipboard write has
+  // to happen in the touchend handler: Safari only honours it from a trusted
+  // user-gesture task, and a setTimeout callback is not one.
+  private touchCopyPending: string | null = null;
   // Whether the gesture in flight came from a finger, read off the pointer event that
   // precedes the browser's compatibility mouse events (onPointerDown).
   private lastPointerWasTouch = false;
@@ -232,12 +243,25 @@ export class AttachTerminal {
     this.touchScrollRemainder = 0;
     this.touchScrollClaimed = false;
     this.touchCopyFired = false;
+    this.touchCopyPending = null;
     this.cancelTouchLongPress();
-    if (press) {
+    this.touchPressCell = press ? this.bufferCellAtPoint(press.clientX, press.clientY) : null;
+    if (this.touchPressCell) {
       this.startTouchLongPress();
     }
   };
-  private readonly onTouchEnd = (): void => this.cancelTouchLongPress();
+  private readonly onTouchEnd = (event: TouchEvent): void => {
+    this.cancelTouchLongPress();
+    const pending = this.touchCopyPending;
+    this.touchCopyPending = null;
+    if (pending === null || event.type !== "touchend") {
+      return; // a cancelled gesture copies nothing
+    }
+    // The write runs HERE, inside the trusted lift, not in the timer that selected
+    // the text: Safari grants clipboard access only to a user-gesture task, so a
+    // write from the timeout is refused on the one platform this gesture exists for.
+    this.copyToClipboard(pending);
+  };
   private readonly onTouchMove = (event: TouchEvent): void => {
     this.handleUserScroll("touch");
     const moved = event.touches.length !== 1 ||
@@ -632,7 +656,7 @@ export class AttachTerminal {
   private startTouchLongPress(): void {
     this.touchLongPressTimer = window.setTimeout(() => {
       this.touchLongPressTimer = null;
-      this.copyTouchWord(this.touchOriginX, this.touchOriginY);
+      this.selectTouchWord();
     }, TOUCH_LONG_PRESS_MS);
   }
 
@@ -643,48 +667,74 @@ export class AttachTerminal {
     }
   }
 
-  /** Selects the token under the finger — the whole line when that cell is blank —
-   *  and copies it. Silent only when there is genuinely nothing there to take. */
-  private copyTouchWord(x: number, y: number): void {
+  /** The cell under a viewport point, in ABSOLUTE buffer coordinates so it survives
+   *  everything the terminal does to the viewport afterwards. */
+  private bufferCellAtPoint(x: number, y: number): TerminalCellPoint | null {
     const rowsEl = this.container.querySelector<HTMLElement>(".xterm-rows");
     if (!rowsEl) {
-      return;
+      return null;
     }
     const cell = terminalCellAtPoint(x, y, rowsEl.getBoundingClientRect(), this.term.cols, this.term.rows);
-    if (!cell) {
+    return cell === null ? null : { col: cell.col, row: this.term.buffer.active.viewportY + cell.row };
+  }
+
+  /**
+   * Selects the token the finger is resting on, and holds the text for the lift.
+   *
+   * The selection happens now, so the highlight appears under the finger at the
+   * moment the press is recognised; the clipboard write waits for touchend, where a
+   * user gesture is still in scope. Splitting the two is what makes the gesture work
+   * on Safari as well as Chrome.
+   */
+  private selectTouchWord(): void {
+    const press = this.touchPressCell;
+    if (!press) {
       return;
     }
-    // viewportY is the ABSOLUTE buffer row at the top of the view, and select() takes
-    // absolute rows (SelectionService stores what it is given straight into the
-    // model), so a press while scrolled up copies the line under the finger rather
-    // than the one that happens to be at that offset from the bottom.
     const buffer = this.term.buffer.active;
-    const bufferRow = buffer.viewportY + cell.row;
-    const line = buffer.getLine(bufferRow);
-    if (!line) {
-      return;
+    const cols = this.term.cols;
+    // A soft-wrapped line is SEVERAL buffer rows, and a phone is about forty columns
+    // wide — so the URLs and paths this gesture exists for wrap more often than not.
+    // Scan the whole wrapped block, or the token gets cut at the screen edge and the
+    // user silently copies a fragment of the thing they pressed on.
+    let first = press.row;
+    while (first > 0 && buffer.getLine(first)?.isWrapped === true) {
+      first -= 1;
     }
-    // ONE ENTRY PER COLUMN, so an index is a column. translateToString would collapse
-    // a wide character into a single index and quietly shift every column after it.
+    let last = press.row;
+    while (buffer.getLine(last + 1)?.isWrapped === true) {
+      last += 1;
+    }
+    // ONE ENTRY PER COLUMN, rows joined end to end, so an index is a position in the
+    // block. translateToString would collapse a wide character into a single index
+    // and quietly shift every column after it.
     const cells: string[] = [];
-    for (let col = 0; col < line.length; col += 1) {
-      const buffered = line.getCell(col);
-      cells.push(buffered === undefined ? " " : buffered.getWidth() === 0 ? "" : buffered.getChars() || " ");
+    for (let row = first; row <= last; row += 1) {
+      const line = buffer.getLine(row);
+      if (!line) {
+        break;
+      }
+      for (let col = 0; col < cols; col += 1) {
+        const buffered = line.getCell(col);
+        cells.push(buffered === undefined ? " " : buffered.getWidth() === 0 ? "" : buffered.getChars() || " ");
+      }
     }
-    const range = wordRangeAtColumn(cells, cell.col) ?? { start: 0, length: lineContentColumns(cells) };
+    const pressed = (press.row - first) * cols + press.col;
+    const range = wordRangeAtColumn(cells, pressed) ?? { start: 0, length: lineContentColumns(cells) };
     if (range.length === 0) {
       return; // a press on genuinely empty screen
     }
-    this.term.select(range.start, bufferRow, range.length);
+    const at = wrappedCellPosition(range.start, cols);
+    this.term.select(at.col, first + at.row, range.length);
     const text = this.term.getSelection();
     if (text.trim() === "") {
       this.term.clearSelection();
       return;
     }
-    // Marked BEFORE the copy: the compatibility click this touch still owes is what
+    // Marked BEFORE the lift: the compatibility click this touch still owes is what
     // would otherwise reach the application and clear the selection just painted.
     this.touchCopyFired = true;
-    this.copyToClipboard(text);
+    this.touchCopyPending = text;
   }
 
   /** The painted height of one terminal row, which turns a pixel-denominated gesture

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -276,25 +276,22 @@ export class AttachTerminal {
     ) {
       this.selectTouchWord();
     }
+    this.disposeTouchPressMarker();
+    // Browsers that DO deliver a lift copy here; the ones that answer a held touch
+    // with a compatibility click instead have already copied there. Whichever runs
+    // first consumes the pending text, so the copy happens exactly once.
+    this.flushTouchCopy();
+  };
+
+  /** Writes the text a recognised press staged, once, from whichever trusted event
+   *  the browser actually delivered. */
+  private flushTouchCopy(): void {
     const pending = this.touchCopyPending;
     this.touchCopyPending = null;
-    this.disposeTouchPressMarker();
-    if (pending === null) {
-      return;
+    if (pending !== null) {
+      this.copyToClipboard(pending);
     }
-    // The write runs HERE, at the end of the touch rather than in the timer that
-    // selected the text: Safari grants clipboard access only to a user-gesture task,
-    // so a write from the timeout is refused on the one platform this gesture exists
-    // for.
-    //
-    // A CANCEL counts as an end. The browser ends the sequence itself the moment it
-    // recognises a long press — it is about to offer its own context menu — so
-    // treating a cancel as "copied nothing" throws the result away at exactly the
-    // moment the gesture succeeded, with the selection already painted under the
-    // finger. Observed: the selection appeared, no failure toast, and the clipboard
-    // stayed untouched, which is that discard and nothing else.
-    this.copyToClipboard(pending);
-  };
+  }
   // …and the menu that cancellation was announcing is not wanted either: it would
   // cover the selection with an OS menu whose Copy acts on a DOM selection xterm
   // never makes (#2849). Suppressed ONLY for a press af has already acted on, so a
@@ -413,12 +410,23 @@ export class AttachTerminal {
   // tap staying the click.
   private readonly onMouseDownCapture = (event: MouseEvent): void => {
     if (this.lastPointerWasTouch && this.touchCopyFired) {
-      // A long press already consumed this touch (#2849). Its trailing click would
-      // reach a mouse-aware application as a press the user never aimed at it, and
-      // would clear the selection that says what was copied — so the gesture stops
-      // here, before xterm's own listeners on the descendant see it.
+      // The compatibility click the press still owed. Two things happen here.
+      //
+      // It is SWALLOWED: it would reach a mouse-aware application as a press the user
+      // never aimed at it, and would clear the selection that says what was copied.
+      //
+      // And it is where the COPY happens, because it is the one trusted user-gesture
+      // event the browser reliably delivers at the end of a long press. Recording
+      // what actually arrives for a held touch gives `touchstart` and then this — no
+      // touchend, no touchcancel, no contextmenu — so a copy wired to a lift waits
+      // for an event that never comes, which is exactly what CI reported three times:
+      // selection painted, no failure toast, clipboard untouched. A mousedown is also
+      // a better home than a lift for Safari's rule that the write be made from a
+      // user gesture. A gesture that became a scroll synthesizes no click at all, so
+      // this cannot resurrect a copy the scroll already discarded.
       event.preventDefault();
       event.stopPropagation();
+      this.flushTouchCopy();
       return;
     }
     if (!this.applicationOwnsMouse() || this.lastPointerWasTouch) {


### PR DESCRIPTION
## Summary

Fixes the Codex findings on #2895 (the long-press copy), which posted **after** the Auto Gate had merged that PR, plus the further rounds raised here. Thirteen P2s in total; the shape of the work changed twice because the evidence did.

## What was actually wrong, and what fixed it

**The press was resolved twice** — coordinates at `touchstart`, buffer read 500 ms later — so every mutation in that window was its own way to copy real text from the wrong place: a full ring trimming the pressed line (or the earlier rows of its wrapped block), a progress bar rewriting the line in place, an alternate-screen TUI scrolling, a peer's resize reflowing the grid. I patched these one at a time until it was clear they were one defect wearing different clothes.

**The press is now READ when the finger lands**: the wrapped block, flattened one entry per column, plus the index the finger fell on. Nothing the terminal does afterwards can reach it. That *deleted* the guards rather than adding more — they now gate only the **highlight**, which needs the live buffer, is cosmetic, and is skipped rather than guessed when the grid has moved. The highlight is additionally checked against the live cells before painting, because the selection is this gesture's only statement about what was copied and must not make a false one.

**The copy is written from the compatibility click, not the lift.** Three rounds of theorising ended by recording what the browser delivers for a held touch:

```
touchstart@1190  mousedown@1907
```

No `touchend`. No `touchcancel`. No `contextmenu`. A copy wired to a lift was waiting for an event this browser never sends — the signature being a painted selection, no failure toast, and an untouched clipboard. The compatibility `mousedown` is where the copy belongs: it is the trusted user-gesture event that reliably arrives, af already intercepts it to swallow the click the press owed, and a mousedown satisfies Safari's user-gesture rule better than a lift would.

**A cancel is a takeover, not a lift.** The press-then-scroll gesture delivers `touchstart` then `pointercancel` — no `touchmove` at all — so a discard wired to movement never ran and left a selection promising a copy that never happened. Cancellation now drops both the staged copy and the selection.

## Also fixed

- A **disposed marker** (line −1) means the pressed line was trimmed away; the raw row is the fallback only where no marker could be registered at all.
- A block still marked `isWrapped` at row 0 is a **suffix whose prefix was trimmed** — refused rather than copied as the whole token.
- **Structural padding vs. a real space**: the cell a wrapped wide glyph vacated is code 0, a typed space is code 32. The first must not split a CJK token at the wrap; the second must keep separating words.
- A **second finger** on a held press cancels through the shared discard, so a pinch cannot leave a highlight claiming a copy.
- **Context-menu suppression is a one-shot** armed by a recognised press. Anything longer-lived swallowed a later right-click menu on a touchscreen laptop and — since they arrive with no pointer event — keyboard menus from Shift+F10, the Menu key, and assistive technology, whose Copy route is the very thing this work exists to provide.
- Both wrapped-row walks are **bounded by the buffer**: xterm's store is circular, so a read past the end can answer with the first retained row, and an unbounded walk marches into unrelated scrollback or never stops.

## Verification

- **Web selftest green**, including the mobile long-press case: a real token copied to the real system clipboard by a finger with no keyboard, the word-vs-line distinction, a token wider than the screen copied whole, and a press-that-becomes-a-scroll copying nothing and leaving no selection.
- Unit tests for every pure piece: point→cell, token bounds, the line fallback, wrapped-block index conversion, the shared press/scroll threshold, and snapshot text extraction. This is the layer that gates on master.
- The selftest carries the **delivered event sequence** in its failure messages — the diagnostic that ended two rounds of guessing, kept so the next red on this path says what the browser did.
- Local: `gofmt -l .` clean · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `scripts/lint-file-length.sh` · `make web-test` (527 unit tests) · `make web-build` reproduces the committed bundle. No containerized suites; CI ran the full matrix including `deadcode`.

Closes #2940
Refs #2849, #2831
