### PR TITLE
test: land the four #2898 review fixes that missed the merge

### DIFF
--- a/app/detach_watchdog_test.go
+++ b/app/detach_watchdog_test.go
@@ -94,13 +94,18 @@ func TestWatchdog_NoSpuriousDumpAfterHeaderDetach(t *testing.T) {
 	// --- Control: an un-canceled watchdog DOES write a dump after the
 	// threshold. This guards against the regression assertion silently passing
 	// because the dump path was misconfigured.
+	// Timed from BEFORE the watchdog is armed. Taking it after would start the
+	// clock partway through the threshold whenever this goroutine is descheduled
+	// in between, under-measuring controlTook and shrinking the absence window
+	// below — which is the window that has to outlast a real dump for the
+	// regression check to mean anything.
+	control := time.Now()
 	beginDetachWatchdog("control-uncanceled")
 	// Wait for the dump on the CONDITION, not on a fixed nap. Writing it means a
 	// goroutine has to be scheduled and a full goroutine dump has to reach disk,
 	// neither of which has an upper bound on a loaded box; a nap sized for an idle
 	// one turns a busy machine into a failed assertion (#2879). The ceiling is a
 	// failure deadline, not an expectation.
-	control := time.Now()
 	dumpExists := func() bool {
 		_, statErr := os.Stat(dumpPath)
 		return statErr == nil
@@ -131,6 +136,12 @@ func TestWatchdog_NoSpuriousDumpAfterHeaderDetach(t *testing.T) {
 	// merely-slow watchdog cannot be mistaken for a silent one. Sized from that
 	// measurement rather than from a constant, which is what keeps it honest under
 	// the load that made the constant wrong in the first place (#2879).
-	require.Never(t, dumpExists, controlTook+300*time.Millisecond, 10*time.Millisecond,
+	// Floored at the threshold: the window must cover the point a spurious dump
+	// would land even if controlTook came back implausibly small.
+	silence := controlTook + 300*time.Millisecond
+	if floor := slowDetachThreshold + 300*time.Millisecond; silence < floor {
+		silence = floor
+	}
+	require.Never(t, dumpExists, silence, 10*time.Millisecond,
 		"watchdog wrote a spurious goroutine dump for a header-selection detach (#683)")
 }

--- a/session/backend_hook_reap_test.go
+++ b/session/backend_hook_reap_test.go
@@ -385,8 +385,20 @@ func TestHookReapTimeoutIsUnknownState(t *testing.T) {
 // leak as master, one tick delayed. A second reap while delete_cmd is still wedged
 // must (i) ACTUALLY re-run delete_cmd and (ii) keep returning the unknown sentinel.
 //
-// (i) is asserted on how long the reap BLOCKED, not on what the script logged,
-// and that is the whole point of #2821. The script's log line was the old proof,
+// (i) is asserted two ways, neither of which is what the script logged, and that
+// is the point of #2821 and of the #2879 review that followed it.
+//
+// The DETERMINISTIC half is p.reaped: the latch flag is what the next poll
+// consults, so a timed-out reap leaving it false IS the property, observable
+// with no clock and no script in the way. #2529 was precisely that flag being
+// set on the timeout path, so this catches the regression outright.
+//
+// The duration is the behavioural half — it says delete_cmd was actually
+// spawned and waited on, which the flag alone does not. It cannot be the only
+// proof: a latch returns in nanoseconds, but a runner that deschedules this
+// goroutine for longer than the bound between the call and the measurement
+// would let that latch through. So the two are asserted together, and the
+// deterministic one carries the guard. The script's log line was the old proof,
 // and it is not kill-proof: delete_cmd is SIGKILLed at the bound, so on a loaded
 // box the spawn can miss the budget and be killed before its first instruction —
 // leaving no line, and no way for the count to tell "the product latched" from
@@ -408,6 +420,8 @@ func TestHookReapTimeoutIsReRunnable(t *testing.T) {
 
 	first, firstTook := timeReap(p)
 	require.True(t, errors.Is(first, ErrWorkspaceStateUnknown), "first timed-out reap must be unknown-state")
+	require.False(t, p.reaped,
+		"a timed-out reap must not memoize: reaped is what the next poll consults, and a latch here is #2529 exactly")
 	require.GreaterOrEqual(t, firstTook, bound,
 		"the first reap must run the wedged delete_cmd into its bound")
 
@@ -416,6 +430,8 @@ func TestHookReapTimeoutIsReRunnable(t *testing.T) {
 		"a second reap while delete_cmd is still wedged must not return nil — a nil would let deleteSessionRecord delete the record and orphan the workspace one poll later")
 	require.True(t, errors.Is(second, ErrWorkspaceStateUnknown),
 		"a re-run timed-out reap must keep returning ErrWorkspaceStateUnknown")
+	require.False(t, p.reaped,
+		"a re-run timed-out reap must still not memoize, or the poll after this one gets a cached error and no delete_cmd at all")
 	require.GreaterOrEqual(t, secondTook, bound,
 		"the second reap must ACTUALLY re-invoke delete_cmd, not skip it via a latch: it has to block on the still-wedged script for the full bound, where a latch would return the cached error immediately")
 }
@@ -966,7 +982,7 @@ func TestHookLaunchDoesNotKillBackgroundedChildren(t *testing.T) {
 
 	h := hookState{dir: dir, launch: filepath.Join(dir, "launch.sh"), delete: filepath.Join(dir, "delete.sh")}
 	writeHookScript(t, h.launch, fmt.Sprintf(`
-( for i in $(seq 1 400); do echo "still here"; echo tick >> %s; sleep 0.05; done ) &
+( for i in $(seq 1 1000); do echo "still here"; echo tick >> %s; sleep 0.05; done ) &
 echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
 exit 0
 `, shellsuggest.Arg(hb)))
@@ -995,10 +1011,15 @@ exit 0
 	// process spawn, which has no upper bound on a loaded box, and a nap long
 	// enough on an idle one turns a busy machine into a failed assertion (#2879).
 	// The ceiling here is a failure deadline, not an expectation.
+	// The ceiling is deliberately well inside the writer's own lifetime: it ticks
+	// for ~50s, and this wait plus the advance loop below can consume at most ~23s,
+	// so observing the first heartbeat late still leaves ticks to measure. A
+	// ceiling past the writer's lifetime would turn a slow start into a failure of
+	// the NEXT assertion, which is the same bug wearing a different hat.
 	require.Eventually(t, func() bool {
 		_, statErr := os.Stat(hb)
 		return statErr == nil
-	}, 30*time.Second, 10*time.Millisecond, "the backgrounded child never ran")
+	}, 20*time.Second, 10*time.Millisecond, "the backgrounded child never ran")
 
 	// Then require the heartbeat to keep advancing. Asserting SUSTAINED ticking —
 	// several distinct advances at this later checkpoint, not a single early write

--- a/session/tmux/close_wait_test.go
+++ b/session/tmux/close_wait_test.go
@@ -103,9 +103,16 @@ func exitedProcess(t *testing.T) proctree.Process {
 // absolute ceiling like 250ms is a statement about the scheduler, not about the
 // code under test (#2879). A regression that really does burn the budget takes
 // the whole of it and still fails.
-const (
+var (
+	// The budget these calls are GIVEN. Large, so an implementation that polls to
+	// its deadline is unmistakable and no honest run can reach it under load.
 	exitWaitBudget = 30 * time.Second
-	exitWaitPrompt = exitWaitBudget / 4
+	// The bound that "did not burn its budget" is measured against. It has to sit
+	// BELOW the production wait: an implementation that always waited paneExitWait
+	// before answering is exactly the slow teardown this guards, so any bound above
+	// that would wave it through. Derived from it so the relationship survives a
+	// change to either, and still ~1000x the detection this measures in practice.
+	exitWaitPrompt = paneExitWait * 2 / 3
 )
 
 func TestWaitForProcessExit_ExitedProcess(t *testing.T) {


### PR DESCRIPTION
## Summary

#2898 merged at its **pre-fixup head**, so the four Codex findings raised on it were fixed on the branch and never reached master. This carries them over unchanged — the same commit, cherry-picked onto current master and re-gated. No new work.

Two of the four are **false PASSes**, which is why this matters more than a tidy-up: they are guards that currently do not guard.

| finding | on master now | this PR |
| --- | --- | --- |
| control timer started AFTER arming the watchdog | a deschedule under-measures it, shrinking the `require.Never` window below the threshold, so a spurious dump at 2s is never observed — the #683 regression passes | timed from before arming, and floored at `slowDetachThreshold+300ms` |
| promptness bound `7.5s`, above the production `paneExitWait` (3s) | an implementation that always burned the real teardown budget passes | derived as `paneExitWait * 2 / 3`, so it stays below the production wait |
| re-invocation proven only by elapsed time | a latch returns in nanoseconds; a runner descheduled past the bound lets #2529 through | `p.reaped` — the flag the next poll consults — as the deterministic half, duration kept as the behavioural half |
| heartbeat wait ceiling (30s) outlived the writer (~20s) | a late first observation fails the NEXT assertion — a false FAIL I introduced in #2898 | writer ticks ~50s against a ~23s worst-case wait |

## Verification

Both directions were measured on the branch and re-confirmed here on top of master:

- reintroducing the #2529 latch-on-timeout is caught **5/5**, deterministically, failing on `p.reaped` (`Should be false`) rather than on a duration a busy scheduler could satisfy;
- an implementation that sleeps `paneExitWait` before answering is caught **5/5** at `"3.019525545s" is not less than "2s"` — the same mutant passed under the 7.5s bound now on master.

## Validation

Cheap gates only, on top of current master — no container suite, nothing run against `daemon/`:

- `gofmt -l .` (empty), `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...` (empty), `scripts/lint-file-length.sh`
- `go test ./session` and `go test ./session/tmux` — the packages changed
- the `app/` change is type-checked with `go vet ./app` and left to CI's lane, per the standing rule

Closes #2945
