### PR TITLE
fix(projects): an unresolvable project root is absent, not ambiguous

### DIFF
--- a/config/project_registry.go
+++ b/config/project_registry.go
@@ -613,7 +613,12 @@ func storedProjectMarkerPath(root string) (string, bool, error) {
 		return binding.checkoutMarkerPath, true, nil
 	}
 	info, statErr := os.Stat(root)
-	if errors.Is(statErr, os.ErrNotExist) {
+	// determinatelyAbsent, not ErrNotExist alone: a root replaced by a symlink
+	// cycle or a regular-file ancestor resolves to nothing, so it holds no marker
+	// — and erroring there would leave the record neither usable nor repairable
+	// while ListProjects already reports it absent (#2949 review). An ambiguous
+	// failure (EACCES, EIO) still errors: we cannot tell, so we do not guess.
+	if determinatelyAbsent(statErr) {
 		return "", false, nil
 	}
 	if statErr != nil {
@@ -632,7 +637,10 @@ func storedProjectMarkerPath(root string) (string, bool, error) {
 
 func projectRootHasCheckoutID(root, checkoutID string) (bool, error) {
 	info, statErr := os.Stat(root)
-	if errors.Is(statErr, os.ErrNotExist) {
+	// Same rule as storedProjectMarkerPath above: a root that resolves to nothing
+	// carries no marker, and saying so is what lets a moved checkout re-register
+	// against a dead old path (#2949 review). Ambiguous failures still error.
+	if determinatelyAbsent(statErr) {
 		return false, nil
 	}
 	if statErr != nil {

--- a/config/project_registry.go
+++ b/config/project_registry.go
@@ -758,11 +758,10 @@ func projectFromRecord(record projectRecord) Project {
 // of which take ErrNotExist as determinate and turn every other stat failure
 // into an error rather than a verdict.
 //
-// ENOTDIR is determinate too, and belongs with ErrNotExist rather than in the
-// fail-closed arm: an ancestor that is a regular file means nothing can exist
-// below it. Go does not map ENOTDIR to ErrNotExist, so special-casing only
-// ErrNotExist would report that path as PRESENT — a fabricated positive, the
-// exact mirror of the bug this function was fixed for (#2889 review).
+// Which failures count as absence is decided by determinatelyAbsent below, not
+// by ErrNotExist alone: Go maps neither ENOTDIR nor ELOOP to ErrNotExist, so
+// special-casing ErrNotExist would report an unresolvable path as PRESENT — a
+// fabricated positive, the exact mirror of the bug this function was fixed for.
 //
 // It also moves the two registration guards that consult this in the safe
 // direction: an ambiguous re-registration is REFUSED rather than allowed to
@@ -770,10 +769,37 @@ func projectFromRecord(record projectRecord) Project {
 func projectPathExists(path string) bool {
 	info, err := os.Stat(path)
 	if err != nil {
-		determinatelyAbsent := errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOTDIR)
-		return !determinatelyAbsent
+		return !determinatelyAbsent(err)
 	}
 	return info.IsDir()
+}
+
+// determinatelyAbsent reports whether a stat failure PROVES that nothing is
+// resolvable at that path (#2948).
+//
+// The question to ask of an errno is whose fact it is. These four are properties
+// of the PATH — no process, holding any credentials, resolves an object there:
+//
+//	ENOENT        a component does not exist
+//	ENOTDIR       a component is not a directory, so nothing can lie below it
+//	ELOOP         resolution never terminates: a symlink cycle, or a chain past
+//	              the kernel's limit
+//	ENAMETOOLONG  the path cannot name anything on this filesystem
+//
+// Everything else is a property of US or of the storage, and is evidence of
+// NOTHING about whether the checkout is there: EACCES/EPERM say only that this
+// process cannot look, and EIO/ESTALE say the storage misbehaved, often
+// transiently. Those must fail closed to "present", which is the #2889 fix.
+//
+// Enumerated with the rule written down rather than extended one errno at a
+// time: the first version of this handled only ENOENT and was corrected twice —
+// ENOTDIR, then ELOOP — because each was argued case by case. The rule decides
+// the next one.
+func determinatelyAbsent(err error) bool {
+	return errors.Is(err, os.ErrNotExist) ||
+		errors.Is(err, syscall.ENOTDIR) ||
+		errors.Is(err, syscall.ELOOP) ||
+		errors.Is(err, syscall.ENAMETOOLONG)
 }
 
 // sameProjectPath reports whether two paths name the same directory.

--- a/config/project_registry_path_exists_test.go
+++ b/config/project_registry_path_exists_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,6 +42,40 @@ func TestProjectPathExists_DeterminateAnswers(t *testing.T) {
 	ancestorIsAFile := filepath.Join(root, "notes.txt", "checkout")
 	assert.False(t, projectPathExists(ancestorIsAFile),
 		"a path under a regular-file ancestor cannot exist, and ENOTDIR proves it")
+}
+
+// The sibling errnos of ENOTDIR (#2948, from the #2889 review): each PROVES the
+// path resolves to nothing, for any process with any credentials, so each is a
+// determinate absence rather than the ambiguity that fails closed.
+func TestProjectPathExists_UnresolvablePathsAreAbsent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX path resolution errnos")
+	}
+	root := t.TempDir()
+
+	// A symlink cycle: a -> b -> a. Resolution never terminates, so ELOOP.
+	a, b := filepath.Join(root, "a"), filepath.Join(root, "b")
+	require.NoError(t, os.Symlink(b, a))
+	require.NoError(t, os.Symlink(a, b))
+	require.ErrorIs(t, statErrOf(a), syscall.ELOOP, "the fixture must actually produce ELOOP")
+	assert.False(t, projectPathExists(a),
+		"a symlink cycle resolves to nothing: no checkout is present there")
+	assert.False(t, projectPathExists(filepath.Join(a, "checkout")),
+		"and nothing below it is present either")
+
+	// A component longer than NAME_MAX cannot name anything on this filesystem.
+	tooLong := filepath.Join(root, strings.Repeat("x", 5000))
+	require.ErrorIs(t, statErrOf(tooLong), syscall.ENAMETOOLONG, "the fixture must actually produce ENAMETOOLONG")
+	assert.False(t, projectPathExists(tooLong),
+		"a path that cannot name anything is absent, not ambiguous")
+}
+
+// statErrOf is the raw stat error, so a fixture can assert it really produced the
+// errno the case is about — a test for ELOOP that silently got ENOENT would be
+// asserting nothing.
+func statErrOf(path string) error {
+	_, err := os.Stat(path)
+	return err
 }
 
 // The regression this pins: an unreadable root must not be reported as gone.

--- a/config/project_registry_path_exists_test.go
+++ b/config/project_registry_path_exists_test.go
@@ -102,3 +102,41 @@ func TestProjectPathExists_UnreadableRootIsPresentNotGone(t *testing.T) {
 	assert.True(t, projectPathExists(target),
 		"an unreadable root is PRESENT: a failed stat is evidence of nothing, and answering 'gone' invents a disappearance")
 }
+
+// The #2949 review's scenario: a registered checkout MOVES, and its old path is
+// then replaced by a symlink cycle. ListProjects already reports that old root
+// absent (determinatelyAbsent), so the registry must be able to act on that
+// absence too — re-registering the same checkout at its new path has to rebind
+// rather than fail with "too many levels of symbolic links".
+//
+// Before the fix the two are incoherent: the read says the root is gone while
+// every write path that consults it errors out, so the record can be neither
+// used nor repaired.
+func TestRegisterProject_RebindsWhenTheOldRootBecameASymlinkCycle(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX symlink cycles")
+	}
+	base := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(base, "af-home"))
+
+	oldRoot := initProjectRegistryRepo(t, filepath.Join(base, "checkout"))
+	registered, err := RegisterProject(oldRoot)
+	require.NoError(t, err)
+
+	// Move the checkout, then make the OLD path an unresolvable cycle.
+	newRoot := filepath.Join(base, "moved")
+	require.NoError(t, os.Rename(oldRoot, newRoot))
+	loop := filepath.Join(base, "loop-target")
+	require.NoError(t, os.Symlink(loop, oldRoot))
+	require.NoError(t, os.Symlink(oldRoot, loop))
+	require.ErrorIs(t, statErrOf(oldRoot), syscall.ELOOP, "the fixture must actually produce ELOOP")
+
+	// The read already calls it absent…
+	assert.False(t, projectPathExists(oldRoot), "an unresolvable old root reads as absent")
+
+	// …so the write must be able to act on that, not fail on the same stat.
+	rebound, err := RegisterProject(newRoot)
+	require.NoError(t, err, "re-registering the moved checkout must rebind, not fail on the dead old root")
+	assert.Equal(t, registered.ID, rebound.ID, "the durable identity survives the rebind")
+	assert.Equal(t, canonicalExistingPath(t, newRoot), rebound.Root, "the record now names the new root")
+}


### PR DESCRIPTION
Refs #2948
Refs #2889

Clears the unresolved Codex finding on the already-merged #2889.

## The finding

A registered root replaced by a **symlink cycle** fails `os.Stat` with `ELOOP`, which is neither `ErrNotExist` nor `ENOTDIR` — so it landed in the fail-closed arm and reported `PathExists=true` for a path that resolves to nothing. `af projects list` showed a determinately unavailable checkout as still present.

**Still live on master** before fixing: `bcd345aa` (#2889) is the newest change to this file, and its two-errno check is what master carries.

## Verified empirically, not from the errno tables

```
cycle a->b->a    ErrNotExist=false  ENOTDIR=false  ELOOP=true
5000-char name   ErrNotExist=false  ENOTDIR=false  ENAMETOOLONG=true
```

That second line is why this does not simply add `ELOOP`. **`ENAMETOOLONG` has the identical shape and the finding did not name it** — patching only what was reported would have left the same bug one errno over. This function has now been corrected exactly that way twice: `ENOTDIR`, then `ELOOP`, each argued case by case.

## So the rule is written down instead

Ask **whose fact the errno is**:

- **Property of the PATH** — no process, with any credentials, resolves an object there: `ENOENT`, `ENOTDIR`, `ELOOP`, `ENAMETOOLONG`. Determinate absence.
- **Property of US or the storage** — `EACCES`/`EPERM` say only that this process cannot look; `EIO`/`ESTALE` say the storage misbehaved, often transiently. Evidence of nothing, so they keep failing closed to "present" — which is exactly what #2889 fixed.

The rule decides the next errno without another review round trip.

## Verification

Watched all three new cases fail first, then pass. The fixtures `require.ErrorIs` the raw stat error against the errno under test — a case for `ELOOP` that silently got `ENOENT` would be asserting nothing. The original unreadable-root case still skips honestly, with a stated reason, under a root runner.

`gofmt -l .` empty, `go build ./...`, `golangci-lint --fast`, `deadcode -test ./...`, file-length, and the full `./config` package — a non-daemon, non-app package, the only one run per policy. Cross-compiles for linux and darwin. No containerized suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
