### PR TITLE
fix(daemon): clear four post-merge findings on the per-tab preview origin (#2948)

### DIFF
--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -405,6 +405,22 @@ func authoritativeStreamTarget(idOrTitle, repoID string) streamTarget {
 // trackedStreamSessionLocked resolves only facts already materialized in
 // m.instances. The caller holds m.mu. The streamTarget, rather than this helper,
 // decides the namespace so the hot path and post-refresh path cannot drift.
+// trackedStreamSession resolves idOrTitle against the ALREADY-RESTORED instance map
+// and nothing else — no disk read, no refresh, no fallback. It is for callers that
+// must not let a lookup miss turn into I/O, because the lookup is reachable by an
+// untrusted peer: /v1/preview-auth's mint guard is a GET that a cross-origin page can
+// drive under the tokenless-loopback default, so a refreshing miss path there is an
+// amplifier rather than a convenience (#2833 review).
+//
+// Callers that legitimately need a session the daemon has not tracked yet keep using
+// resolveStreamSession; this is deliberately the weaker, cheaper question.
+func (m *Manager) trackedStreamSession(idOrTitle string) *session.Instance {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	instance, _, _ := m.trackedStreamSessionLocked(authoritativeStreamTarget(idOrTitle, ""))
+	return instance
+}
+
 func (m *Manager) trackedStreamSessionLocked(target streamTarget) (*session.Instance, string, string) {
 	if target.repoID != "" {
 		if instance := m.instances[daemonInstanceKey(target.repoID, target.title)]; instance != nil {

--- a/daemon/preview_origin.go
+++ b/daemon/preview_origin.go
@@ -265,8 +265,20 @@ func (m *Manager) hasIframeTab(sessionID, tabID string) bool {
 	if !m.Ready() {
 		return false
 	}
-	instance, _, _, err := m.resolveStreamSession(sessionID, "")
-	if err != nil || instance == nil {
+	// The ALREADY-RESTORED map, never resolveStreamSession. That resolver's miss path
+	// runs findSessionByStableID + refreshLocked, i.e. it reads session state off disk
+	// — and this validation sits on a GET that, under the default tokenless posture,
+	// any cross-origin page can drive without being able to read the reply. Resolving
+	// through the refreshing path would let a page force repeated disk work simply by
+	// embedding preview-auth URLs with random session ids: the guard added to stop the
+	// registry being filled would have handed over a cheaper amplifier instead.
+	//
+	// A miss here means "not in the restored map", which is exactly the right answer
+	// for minting: an origin is only ever vended for a session the daemon already
+	// holds. Nothing legitimate depends on the refresh — the web client asks about a
+	// tab it is currently rendering.
+	instance := m.trackedStreamSession(sessionID)
+	if instance == nil {
 		return false
 	}
 	kind, _, ok := instance.TabTargetByID(tabID)

--- a/daemon/preview_origin_test.go
+++ b/daemon/preview_origin_test.go
@@ -394,6 +394,70 @@ func TestPreviewOrigin_NoHeaderCarriesTheLabelUpstream(t *testing.T) {
 		"only the ORIGIN part of Referer is secret — its path and query survive")
 }
 
+// TestPreviewOrigin_DoesNotLaunderHostileOrigins is the other half of the rewrite,
+// and the half that makes it safe rather than merely tidy.
+//
+// Rewriting EVERY non-empty Origin would convert a hostile one into a trusted one: a
+// form POST from another site (or an `Origin: null` from a sandboxed frame) to a
+// known — or leaked — preview URL would arrive at the dev server looking same-origin,
+// defeating the only signal an upstream CSRF guard has. And since this rewrite exists
+// precisely because labels can escape into request logs, "the attacker knows the
+// label" is the case it has to survive, not one it may assume away.
+//
+// A foreign Origin carries no secret of ours — it is the sender's own — so it is
+// passed through untouched for the upstream to refuse.
+func TestPreviewOrigin_DoesNotLaunderHostileOrigins(t *testing.T) {
+	seen := make(chan http.Header, 4)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen <- r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	m, previewAddr, sessionID, tabIDs := newPreviewOriginFixture(t, upstream.URL)
+	host := previewHostOf(t, m, previewAddr, sessionID, tabIDs[0])
+	targetURL, err := url.Parse(upstream.URL)
+	require.NoError(t, err)
+
+	// A forged X-Forwarded-Proto must not change what counts as "our own origin".
+	// If it did, the tab's real http:// Origin would stop matching and be forwarded
+	// verbatim — leaking the label this rewrite exists to contain — and the matching
+	// https spelling would be laundered instead.
+	forged, err := http.NewRequest(http.MethodPost, "http://"+previewAddr+"/api/save", strings.NewReader("{}"))
+	require.NoError(t, err)
+	forged.Host = host
+	forged.Header.Set("X-Forwarded-Proto", "https")
+	forged.Header.Set("Origin", "http://"+host)
+	fResp, err := previewHTTPClient().Do(forged)
+	require.NoError(t, err)
+	require.NoError(t, fResp.Body.Close())
+	fGot := <-seen
+	require.Equal(t, "http://"+targetURL.Host, fGot.Get("Origin"),
+		"a forged X-Forwarded-Proto must not make the tab's OWN origin look foreign — that would leak the label")
+	label2, ok2 := previewHostLabel(host)
+	require.True(t, ok2)
+	require.NotContains(t, fGot.Get("Origin"), label2)
+
+	for _, hostile := range []string{"http://evil.example", "null", "https://" + host} {
+		req, rerr := http.NewRequest(http.MethodPost, "http://"+previewAddr+"/api/save", strings.NewReader("{}"))
+		require.NoError(t, rerr)
+		req.Host = host
+		req.Header.Set("Origin", hostile)
+		req.Header.Set("Referer", hostile+"/attack")
+		resp, derr := previewHTTPClient().Do(req)
+		require.NoError(t, derr)
+		require.NoError(t, resp.Body.Close())
+
+		got := <-seen
+		require.Equal(t, hostile, got.Get("Origin"),
+			"a foreign Origin must reach the dev server AS IS, so its CSRF guard can refuse it")
+		require.NotEqual(t, "http://"+targetURL.Host, got.Get("Origin"),
+			"it must never be laundered into one the upstream trusts")
+		require.Equal(t, hostile+"/attack", got.Get("Referer"),
+			"the same holds for Referer — it is the sender's own, not this tab's secret")
+	}
+}
+
 // TestPreviewOrigin_RewritesSetCookieToItsOwnHost pins the cookie half of the
 // isolation. rewriteSetCookiePaths drops Domain, so a dev server that tries to set
 // Domain=localhost — which every per-tab origin would then send, defeating the
@@ -417,6 +481,47 @@ func TestPreviewOrigin_RewritesSetCookieToItsOwnHost(t *testing.T) {
 	require.Equal(t, "/api", c.Path, "at prefix \"\" the app's own cookie path is already correct")
 	require.Empty(t, c.Domain,
 		"Domain must be dropped: a Domain=localhost cookie would be sent to EVERY per-tab origin")
+
+	// A preview frame is CROSS-SITE with the SPA, so a Lax or Strict cookie — which is
+	// what an app gets by default — is withheld on every request from it, including
+	// same-origin ones. Left alone, a cookie-backed app looks permanently logged out
+	// the moment preview_listen_addr is enabled, having worked on the mirror.
+	require.Equal(t, http.SameSiteNoneMode, c.SameSite,
+		"Lax/Strict mean NEVER SENT in a cross-site frame, so the cookie is inert unless rewritten")
+	require.Contains(t, resp.Header.Get("Set-Cookie"), "SameSite=None",
+		"and it must reach the browser spelled that way, not merely parse as it")
+	require.True(t, c.Secure, "SameSite=None requires Secure; *.localhost is trustworthy so the browser takes it")
+	require.True(t, c.Partitioned,
+		"partitioned keeps this in a jar keyed to the top-level site rather than creating an ambient third-party cookie")
+}
+
+// TestMirrorRoute_LeavesAppCookieSemanticsAlone is the other half of the previous
+// test, and the reason it exists is that the fix must not reach the route that
+// already works. The mirrored preview is same-origin with the SPA, so the app's own
+// SameSite choice is honored there and must survive untouched.
+func TestMirrorRoute_LeavesAppCookieSemanticsAlone(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Add("Set-Cookie", "sid=1; Path=/api; HttpOnly")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	m, _, sessionID, tabIDs := newPreviewOriginFixture(t, upstream.URL)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, webtabPathPrefix+sessionID+"/"+tabIDs[0]+"/api/login", nil)
+	newHTTPMux(&controlServer{manager: m}).ServeHTTP(rec, req)
+
+	// Asserted on the SERIALIZED header, which is what the browser actually reads.
+	// The parsed enum is a trap here: http.SameSiteDefaultMode is 1, while a cookie
+	// carrying no SameSite attribute parses to the zero value 0 — so comparing against
+	// the named constant tests something other than "the app's attribute is untouched".
+	setCookie := rec.Header().Get("Set-Cookie")
+	require.NotEmpty(t, setCookie)
+	require.NotContains(t, setCookie, "SameSite",
+		"the mirror is same-origin with the SPA: the app's cookie semantics are already correct there")
+	require.NotContains(t, setCookie, "Partitioned")
+	require.NotContains(t, setCookie, "Secure", "and must not be forced Secure on a plain-HTTP mirror")
+	require.Contains(t, setCookie, "Path=/v1/webtab/", "it is still re-scoped under the tab's prefix")
 }
 
 // TestPreviewOrigin_RootIsTheAppsOwnRoot pins that "/" on a per-tab origin reaches
@@ -699,4 +804,27 @@ func TestPreviewOrigin_ProbeHostAnswersUnauthenticated(t *testing.T) {
 	// label, so no tab could ever be addressed at it.
 	require.False(t, isPreviewLabel(previewProbeLabel),
 		"the probe label must be unable to name a tab")
+}
+
+// TestPreviewAuth_DoesNotRefreshOnUnknownSession pins that the mint guard reads only
+// the ALREADY-RESTORED map. /v1/preview-auth is a GET, and under the default
+// tokenless-loopback posture any cross-origin page can drive it without being able to
+// read the reply — so a miss path that runs findSessionByStableID + refreshLocked
+// would let that page force repeated disk work with random session ids. The guard
+// that stopped the registry being filled must not hand over a cheaper amplifier.
+func TestPreviewAuth_DoesNotRefreshOnUnknownSession(t *testing.T) {
+	upstream := echoUpstream(t, "app")
+	m, _, sessionID, tabIDs := newPreviewOriginFixture(t, upstream.URL)
+
+	// A live tab still validates through the tracked map.
+	require.True(t, m.hasIframeTab(sessionID, tabIDs[0]))
+
+	// Unknown ids answer false, and do so from memory. resolveStreamSession is the
+	// refreshing path; trackedStreamSession is the one this must use.
+	for _, id := range []string{"no-such-session", "", "af-" + sessionID, sessionID + "x"} {
+		require.False(t, m.hasIframeTab(id, tabIDs[0]), "unknown session %q must not validate", id)
+		require.Nil(t, m.trackedStreamSession(id), "and must not be resolvable from the tracked map")
+	}
+	// A known session with an unknown tab is equally a miss, with no refresh either.
+	require.False(t, m.hasIframeTab(sessionID, "no-such-tab"))
 }

--- a/daemon/webtab_proxy.go
+++ b/daemon/webtab_proxy.go
@@ -440,7 +440,36 @@ func forwardAppCookies(r *http.Request) {
 // /v1/webtab/ token cookie. Domain is dropped so the cookie defaults to the proxy
 // (daemon) host rather than the dev server's own host. Unparseable Set-Cookie
 // lines are passed through untouched.
-func rewriteSetCookiePaths(h http.Header, prefix string) {
+// repartitionPreviewCookie makes an upstream app cookie usable inside a per-tab
+// preview frame, which is a CROSS-SITE context.
+//
+// This is the dev app's cookies, not af's, and it is a regression the origin split
+// causes rather than one it inherits. On the mirrored route the frame is same-origin
+// with the SPA, so an ordinary session cookie — no SameSite attribute, therefore Lax
+// by default — is sent and login flows work. On a per-tab origin the frame's site
+// differs from the top-level's ("localhost" is an effective TLD), so its
+// site-for-cookies is null and EVERY Lax or Strict cookie is withheld, including
+// same-origin ones. A cookie-backed app (Django, Rails, Laravel, anything with
+// sessions) would look permanently logged out the moment an operator enabled
+// preview_listen_addr.
+//
+// SameSite=None is therefore not a relaxation here: in this context Lax and Strict
+// mean "never sent at all", so the cookie is inert either way and rewriting it is the
+// only spelling under which it functions. Secure rides along because None requires
+// it, and *.localhost is a potentially-trustworthy origin so the browser accepts it
+// over plain HTTP. Partitioned (CHIPS) keeps the cookie in a jar keyed to this
+// top-level site, so the rewrite does not quietly create an ambient third-party
+// cookie and it survives third-party-cookie blocking.
+//
+// Applied ONLY on a preview origin: the mirror keeps the app's own semantics
+// untouched, so nothing changes for the deployment that has them working today.
+func repartitionPreviewCookie(c *http.Cookie) {
+	c.SameSite = http.SameSiteNoneMode
+	c.Secure = true
+	c.Partitioned = true
+}
+
+func rewriteSetCookiePaths(h http.Header, prefix string, previewOrigin bool) {
 	values := h.Values("Set-Cookie")
 	if len(values) == 0 {
 		return
@@ -464,6 +493,9 @@ func rewriteSetCookiePaths(h http.Header, prefix string) {
 		orig = "/" + strings.TrimLeft(orig, "/")
 		c.Path = joinURLPath(prefix, orig)
 		c.Domain = "" // default to the proxy host
+		if previewOrigin {
+			repartitionPreviewCookie(c)
+		}
 		if s := c.String(); s != "" {
 			rewritten = append(rewritten, s)
 		}
@@ -544,12 +576,24 @@ func rewriteRefreshURL(h http.Header, prefix string, target *url.URL) {
 //
 // Rewritten, not deleted: an app that checks Origin for CSRF should see the same
 // value it would have seen served directly, and Referer's path/query are ordinary
-// app data — only its origin part is secret, so only that part changes. A Referer
-// that does not parse is dropped rather than forwarded, since it cannot be edited
-// safely and no correct app depends on a malformed one.
-func rewriteOriginHeader(h http.Header, target *url.URL) {
+// app data — only its origin part is secret, so only that part changes.
+//
+// ONLY the tab's OWN origin is rewritten, and that restriction is the whole safety of
+// this function rather than a refinement of it. Rewriting every non-empty Origin
+// LAUNDERS a hostile one: a form POST from http://evil.example (or an `Origin: null`
+// from a sandboxed frame) to a known — or leaked — af<label>.localhost URL would be
+// delivered to the dev server looking same-origin, defeating the one signal an
+// upstream CSRF guard has. Since this rewrite exists precisely because labels can
+// escape into logs, "the attacker knows the label" is the case it must survive, not
+// the case it can assume away.
+//
+// A foreign or opaque Origin is therefore passed through UNTOUCHED, so the upstream
+// sees it for what it is and can refuse. It carries no secret of ours: it is the
+// attacker's own origin, not the tab's label.
+func rewriteOriginHeader(h http.Header, target *url.URL, ownOrigin string) {
 	targetOrigin := target.Scheme + "://" + target.Host
-	if h.Get("Origin") != "" {
+	// Only OUR origin is laundered into the target's; anything else stays as it is.
+	if h.Get("Origin") == ownOrigin {
 		h.Set("Origin", targetOrigin)
 	}
 	ref := h.Get("Referer")
@@ -558,8 +602,13 @@ func rewriteOriginHeader(h http.Header, target *url.URL) {
 	}
 	parsed, err := url.Parse(ref)
 	if err != nil {
+		// Unparseable: it cannot be edited safely, and no correct app depends on a
+		// malformed Referer. Dropping leaks nothing and asserts nothing.
 		h.Del("Referer")
 		return
+	}
+	if parsed.Scheme+"://"+parsed.Host != ownOrigin {
+		return // a Referer from somewhere else is the sender's own, and the upstream's business
 	}
 	parsed.Scheme, parsed.Host, parsed.User = target.Scheme, target.Host, nil
 	h.Set("Referer", parsed.String())

--- a/daemon/webtab_serve.go
+++ b/daemon/webtab_serve.go
@@ -143,6 +143,33 @@ func (cs *controlServer) webTabProxyHandler(w http.ResponseWriter, r *http.Reque
 	})
 }
 
+// requestOwnOrigin is the origin THIS request was addressed to, as the browser would
+// spell it in an Origin header: the scheme it actually reached af on, plus its Host.
+// It is what rewriteOriginHeader compares against, so only a header naming this very
+// tab's origin is rewritten and a foreign one is left for the upstream to judge.
+//
+// It deliberately does NOT use requestIsHTTPS, and the difference is the point.
+// That helper honors X-Forwarded-Proto because for its purpose — telling the upstream
+// what scheme the user's page is on — a forged value buys a peer nothing but broken
+// links for itself. Here the value decides IDENTITY, and a client-settable input
+// deciding identity is a bypass in both directions: send `X-Forwarded-Proto: https`
+// and the browser's real `Origin: http://…` stops matching, so the tab's own header
+// is misread as foreign and forwarded verbatim — leaking the capability label this
+// rewrite exists to contain; send the matching https spelling too and a foreign
+// origin gets laundered instead.
+//
+// So the scheme comes from the connection alone. The preview origin is plain HTTP by
+// construction: af terminates no TLS, and per-tab origins are *.localhost, which is
+// same-machine only — there is no legitimate TLS-terminating front on this route for
+// r.TLS to be missing behind.
+func requestOwnOrigin(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	return scheme + "://" + r.Host
+}
+
 // serveWebTabRoute is the proxy itself, for a tab already resolved to a route. It
 // is reached from BOTH origins (webTabProxyHandler, previewOriginHandler) and holds
 // every invariant of the route in one place.
@@ -432,7 +459,7 @@ func (cs *controlServer) serveWebTabRoute(w http.ResponseWriter, r *http.Request
 				// Origin-checking CSRF guard now agrees with its own Host instead of
 				// seeing a name it does not recognize. Referer keeps its path and query,
 				// since only the origin part is the secret.
-				rewriteOriginHeader(pr.Out.Header, targetURL)
+				rewriteOriginHeader(pr.Out.Header, targetURL, requestOwnOrigin(pr.In))
 			}
 		},
 		ModifyResponse: func(resp *http.Response) error {
@@ -476,7 +503,7 @@ func (cs *controlServer) serveWebTabRoute(w http.ResponseWriter, r *http.Request
 			// this tab's proxy path (and Domain dropped so it defaults to the proxy
 			// host) so the cookie lands on the right path and coexists with the
 			// daemon's token cookie.
-			rewriteSetCookiePaths(resp.Header, tabPathPrefix)
+			rewriteSetCookiePaths(resp.Header, tabPathPrefix, route.previewOrigin)
 			// Send the app's own redirects back through the prefix rather than out
 			// to the daemon's origin, which is where a bare "/login" would otherwise
 			// land (#1843).

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -10187,6 +10187,9 @@ function previewOriginReachable(origin) {
       window.clearTimeout(timer);
       window.removeEventListener("message", onMessage);
       frame.remove();
+      if (!ok) {
+        previewReachable.delete(port);
+      }
       resolve(ok);
     };
     const onMessage = (e) => {

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "171e7e4a0f52";
+const VERSION = "a3b34a81d44a";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/split.ts
+++ b/web/src/split.ts
@@ -184,6 +184,14 @@ function previewOriginReachable(origin: string): Promise<boolean> {
   if (cached !== undefined) {
     return cached;
   }
+  // Only a SUCCESS is cached; a failure is evicted below so the next ↻ re-probes.
+  // A cached false is sticky in the worst way: the everyday causes are transient —
+  // the operator has not forwarded the port yet, the listener is mid-rebind, the
+  // hidden frame timed out once under load — and every one of them resolves without
+  // the page reloading. Retry already clears the per-pane origin and re-fetches
+  // /v1/preview-auth, so a remembered "unreachable" would silently pin the pane to
+  // the mirror until a full SPA reload, which is the one thing the user has no reason
+  // to think of doing.
   // Keyed on the PORT, so a listener that moved is a different key and gets its own
   // probe; only a listener that came back on the SAME port reuses this answer, which
   // is the case where the answer is still true.
@@ -202,6 +210,9 @@ function previewOriginReachable(origin: string): Promise<boolean> {
       window.clearTimeout(timer);
       window.removeEventListener("message", onMessage);
       frame.remove();
+      if (!ok) {
+        previewReachable.delete(port);
+      }
       resolve(ok);
     };
     const onMessage = (e: MessageEvent): void => {


### PR DESCRIPTION
Cleanup for #2948. Codex posted a **third** review round on #2833 at `00:30:36Z` — two
minutes after that PR merged at `00:28:18Z` — so four findings landed on shipped code.
All four were checked against current master; three are still true and fixed here, the
fourth is already fixed in an open PR.

## 1 · A failed reachability probe was cached forever

`previewOriginReachable` memoizes per port and cached a `false` as readily as a `true`.
Every everyday cause of a failed probe is **transient** — the operator has not
forwarded the port yet, the listener is mid-rebind, the hidden frame times out once
under load — and each resolves without the page reloading. ↻/Retry already clears the
per-pane origin and re-fetches `/v1/preview-auth`, so a remembered "unreachable"
silently pinned the pane to the mirror until a full SPA reload, which is the one
recovery a user has no reason to think of. Only successes are cached now.

## 2 · The mint guard resolved through the refreshing path

`/v1/preview-auth` is a GET, and under the default tokenless-loopback posture a
cross-origin page can drive it without being able to read the reply.
`resolveStreamSession`'s miss path runs `findSessionByStableID` + `refreshLocked`, so
random session ids forced repeated disk work — **the guard I added to stop the registry
being filled had handed over a cheaper amplifier instead.**

It now reads the already-restored map via a new `Manager.trackedStreamSession`, which
is the right question for minting anyway: an origin is only ever vended for a session
the daemon already holds, and the web client is asking about a tab it is currently
rendering.

## 3 · Cookie-backed apps broke on a per-tab origin

The one I most should have caught: I reasoned at length about SameSite for **af's own**
credential — it is why the credential moved into the hostname — and never applied the
same reasoning to **the dev app's** cookies.

A preview frame is cross-site with the SPA (`localhost` is an effective TLD), so its
site-for-cookies is null and every `Lax` or `Strict` cookie is withheld, **including
same-origin ones**. An ordinary session cookie carries no SameSite attribute and is
therefore Lax by default — so a Django/Rails/Laravel app that works on the mirror would
look permanently logged out the moment an operator enabled `preview_listen_addr`.

Upstream cookies are now repartitioned, **on that route only**:

- `SameSite=None` — not a relaxation here. In this context Lax and Strict mean *never
  sent at all*, so the cookie is inert either way; None is the only spelling under
  which it functions.
- `Secure` — required by None, and `*.localhost` is a potentially-trustworthy origin,
  so the browser accepts it over plain HTTP.
- `Partitioned` (CHIPS) — keeps it in a jar keyed to this top-level site, so the
  rewrite does not quietly create an ambient third-party cookie, and it survives
  third-party-cookie blocking.

A companion test pins that the **mirrored** route keeps the app's own semantics
untouched, so nothing changes for the deployment that has them working today.

## 4 · A P1 on #2932 that I merged past without reading

#2932 (the `Origin`/`Referer` leak fix) went green and I merged it on **CI status
alone** — the exact mistake #2948 exists to clean up, repeated while cleaning it up.
It carried an unread P1, so this fix is on shipped code.

`rewriteOriginHeader` rewrote **every** non-empty `Origin` to the target's, which
**launders a hostile one**. A form POST from another site — or an `Origin: null` from a
sandboxed frame — to a known or leaked `af<label>.localhost` URL reached the dev server
looking same-origin, defeating the only signal an upstream CSRF guard has.

The inversion is the sharp part: I justified "rewrite rather than delete" partly
because it *helps* a CSRF guard. For the tab's own origin it does. For a hostile one it
does the opposite. And the premise cannot be waved away because it is mine — that
rewrite exists *because* labels escape into request logs, so "the attacker knows the
label" is the case it must survive.

Only the request's **own** origin is rewritten now (`requestOwnOrigin`); anything
foreign, opaque, or same-host-different-scheme passes through untouched for the
upstream to refuse. It carries no secret of ours — it is the sender's own value.
`TestPreviewOrigin_DoesNotLaunderHostileOrigins` drives all three shapes.

Refs #2948, #2833

🤖 Generated with [Claude Code](https://claude.com/claude-code)