### PR TITLE
fix(upgrade): stop the interlock contradicting itself and stalling a launch

### DIFF
--- a/commands/autoupdate.go
+++ b/commands/autoupdate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/internal/autoupdate"
+	"github.com/sachiniyer/agent-factory/internal/upgradetxn"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
@@ -160,7 +161,14 @@ func autoUpdateForChannel(channel string, checkTimeout, downloadBudget time.Dura
 		// practice autoUpdateOnLaunch has already stood down before we get this
 		// far; this is the backstop that makes the interlock a property of the
 		// write rather than of remembering to check.
-		if err := writeExecutableInPlace(resolvedPath, binary, false, ""); err != nil {
+		if err := writeExecutableInPlaceWaiting(resolvedPath, binary, false, "", false); err != nil {
+			// A busy install lock is a deferral, not a failure: nothing was
+			// attempted, so leaving the window open lets the next launch install
+			// once the other writer is done. Recording it would suppress the next
+			// six hours over a transaction that takes seconds.
+			if errors.Is(err, upgradetxn.ErrInstallLockBusy) {
+				return nil
+			}
 			throttleFailure(latestTag)
 			return fmt.Errorf("failed to write new binary: %w", err)
 		}

--- a/commands/autoupdate_launch.go
+++ b/commands/autoupdate_launch.go
@@ -83,7 +83,7 @@ func autoUpdateOnLaunch(cfg *config.Config) {
 	// a download on a swap the interlock would refuse. Silent by design: like
 	// every other skip on this path, it must not print at, block, or fail a
 	// launch the user asked for.
-	if active := activeUpgradeOwningExecutable(); active != nil {
+	if active := upgradeOwningThisExecutable(); active != nil {
 		log.InfoLog.Printf("auto-update: daemon upgrade to %s in progress (transaction %s, phase %s); skipping the launch-time install",
 			active.ToVersion, active.ID, active.Phase)
 		return

--- a/commands/upgrade_interlock.go
+++ b/commands/upgrade_interlock.go
@@ -124,24 +124,36 @@ func (e *blockedInPlaceInstallError) Error() string {
 //     a valid fsynced journal, so a corrupt one much more often means a broken
 //     install that needs `af upgrade` to work than a live actor to protect.
 func activeUpgradeOwningExecutable() *activeUpgrade {
+	active, _ := activeUpgradeOwningExecutableWithID()
+	return active
+}
+
+// activeUpgradeOwningExecutableWithID also reports THIS home's transaction id
+// when one is readable, even in the cases the policy above deliberately lets
+// through. The foreign-artifact scan needs it: a transaction of ours that has
+// committed but not yet cleaned still has its preserved binary on disk, and
+// blocking on that would contradict the decision this function just made.
+func activeUpgradeOwningExecutableWithID() (*activeUpgrade, string) {
 	home, err := config.GetConfigDir()
 	if err != nil {
 		log.WarningLog.Printf("upgrade interlock: cannot resolve the agent-factory home; proceeding: %v", err)
-		return nil
+		return nil, ""
 	}
 	if _, err := os.Stat(home); errors.Is(err, os.ErrNotExist) {
-		return nil
+		return nil, ""
 	}
 	journal, err := loadUpgradeJournal(home)
 	if errors.Is(err, upgradetxn.ErrNoActiveTransaction) {
-		return nil
+		return nil, ""
 	}
 	if err != nil {
 		log.WarningLog.Printf("upgrade interlock: cannot read the daemon upgrade journal; proceeding with the in-place install: %v", err)
-		return nil
+		return nil, ""
 	}
 	if isTerminalUpgradePhase(journal.Phase) {
-		return nil
+		// Decided, cleanup pending. The id is reported so the artifact scan does
+		// not re-block on this same transaction's not-yet-removed binary.
+		return nil, journal.ID
 	}
 	// A valid journal is not proof there is still a rollback to protect.
 	// upgradetxn.Load validates the recorded paths, digests, and lock metadata —
@@ -156,13 +168,13 @@ func activeUpgradeOwningExecutable() *activeUpgrade {
 			"upgrade interlock: daemon upgrade transaction %s (phase %s) has no preserved previous binary at %s; its rollback is already impossible, so the in-place install proceeds",
 			journal.ID, journal.Phase, journal.PreviousBinaryPath,
 		)
-		return nil
+		return nil, journal.ID
 	}
 	return &activeUpgrade{
 		ID:        journal.ID,
 		ToVersion: journal.ToVersion,
 		Phase:     string(journal.Phase),
-	}
+	}, journal.ID
 }
 
 // isTerminalUpgradePhase reports whether the transaction has already decided its
@@ -194,7 +206,7 @@ func isTerminalUpgradePhase(phase upgradetxn.Phase) bool {
 // Read with ReadDir and a literal prefix rather than filepath.Glob: an
 // executable whose name contains a glob metacharacter would otherwise silently
 // match the wrong set, and this decides whether to overwrite a binary.
-func foreignUpgradeStagingOver(resolvedPath string) *activeUpgrade {
+func foreignUpgradeStagingOver(resolvedPath, ownID string) *activeUpgrade {
 	dir := filepath.Dir(resolvedPath)
 	prefix := "." + filepath.Base(resolvedPath) + ".af-upgrade-"
 	entries, err := os.ReadDir(dir)
@@ -208,7 +220,10 @@ func foreignUpgradeStagingOver(resolvedPath string) *activeUpgrade {
 			continue
 		}
 		id := strings.TrimSuffix(strings.TrimPrefix(name, prefix), ".previous")
-		if id == "" {
+		if id == "" || id == ownID {
+			// Ours, and the journal policy above already decided this home may
+			// proceed — a committed transaction whose Cleanup has not yet removed
+			// the preserved binary must not re-block the install it just allowed.
 			continue
 		}
 		return &activeUpgrade{ID: id, artifact: filepath.Join(dir, name)}
@@ -224,12 +239,23 @@ func foreignUpgradeStagingOver(resolvedPath string) *activeUpgrade {
 // override is the caller's explicit "install anyway"; it is honoured, and logged,
 // because an unoverridable auto-upgrade safeguard is its own hazard.
 func writeExecutableInPlace(resolvedPath string, binary []byte, override bool, flag string) error {
+	return writeExecutableInPlaceWaiting(resolvedPath, binary, override, flag, true)
+}
+
+// writeExecutableInPlaceWaiting is the guarded swap with the lock-wait policy
+// made explicit. mayWait is false for the unattended launch updater, which runs
+// in front of a TUI that has not opened yet: a daemon publishing a transaction
+// holds the preparation lock for as long as it takes to copy and fsync a
+// preserved binary, and stalling a launch behind that is the one thing this path
+// may never do. `af upgrade` was asked for explicitly and waits.
+func writeExecutableInPlaceWaiting(resolvedPath string, binary []byte, override bool, flag string, mayWait bool) error {
 	swap := func() error {
-		active := activeUpgradeOwningExecutable()
+		active, ownID := activeUpgradeOwningExecutableWithID()
 		if active == nil {
-			// Nothing in THIS home. The executable is shared across homes, so
-			// ask the executable itself before overwriting it.
-			active = foreignUpgradeStagingOver(resolvedPath)
+			// Nothing blocking in THIS home. The executable is shared across
+			// homes, so ask the executable itself — skipping our own artifacts,
+			// which the decision above already accounted for.
+			active = foreignUpgradeStagingOver(resolvedPath, ownID)
 		}
 		if active != nil {
 			if !override {
@@ -274,11 +300,24 @@ func writeExecutableInPlace(resolvedPath string, binary []byte, override bool, f
 	// install exactly what the guard just declined.
 	swapRan := false
 	var swapErr error
-	lockErr := upgradetxn.WithInstallLock(home, resolvedPath, func() error {
+	take := upgradetxn.WithInstallLock
+	if !mayWait {
+		take = upgradetxn.TryWithInstallLock
+	}
+	lockErr := take(home, resolvedPath, func() error {
 		swapRan = true
 		swapErr = swap()
 		return swapErr
 	})
+	if !swapRan && errors.Is(lockErr, upgradetxn.ErrInstallLockBusy) {
+		// Another writer holds the locks and this caller must not wait. Nothing
+		// was attempted, so the sentinel travels back for the caller to treat as
+		// a deferral rather than a failed check — burning the six-hour window on
+		// a swap that was never tried would suppress the next five hours of
+		// legitimate ones.
+		log.InfoLog.Printf("upgrade interlock: another upgrade holds the install lock; not waiting for it on this path")
+		return lockErr
+	}
 	if swapRan {
 		if lockErr != nil && swapErr == nil {
 			log.WarningLog.Printf("upgrade interlock: installed, but releasing the upgrade lock failed: %v", lockErr)
@@ -287,4 +326,34 @@ func writeExecutableInPlace(resolvedPath string, binary []byte, override bool, f
 	}
 	log.WarningLog.Printf("upgrade interlock: cannot take the upgrade lock, so this install is not serialised against a daemon upgrade: %v", lockErr)
 	return swap()
+}
+
+// upgradeOwningThisExecutable is the launch path's pre-throttle gate: a
+// transaction in THIS home, or one staging beside the shared executable from any
+// other home.
+//
+// The home journal alone is not enough here. Another AGENT_FACTORY_HOME can be
+// mid-upgrade over the same binary, and that was previously discovered only
+// inside the guarded writer — after the throttle cache was open and the archive
+// downloaded, where the refusal recorded a failed check and suppressed
+// launch-time updates for the next six hours over a transaction that takes
+// seconds. Asking before the window opens costs one directory read and keeps
+// both the bandwidth and the window.
+//
+// An executable that cannot be resolved is not treated as blocked: this gate
+// only ever suppresses an update, and it must not do so on an inconclusive read.
+func upgradeOwningThisExecutable() *activeUpgrade {
+	active, ownID := activeUpgradeOwningExecutableWithID()
+	if active != nil {
+		return active
+	}
+	execPath, err := osExecutableFn()
+	if err != nil {
+		return nil
+	}
+	resolved, err := filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return nil
+	}
+	return foreignUpgradeStagingOver(resolved, ownID)
 }

--- a/commands/upgrade_interlock_test.go
+++ b/commands/upgrade_interlock_test.go
@@ -550,11 +550,11 @@ func TestForeignUpgradeStagingOver_OnlyMatchesThisExecutable(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644))
 	}
 
-	require.Nil(t, foreignUpgradeStagingOver(target),
+	require.Nil(t, foreignUpgradeStagingOver(target, ""),
 		"only a preserved-previous artifact for THIS executable may block it")
 
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".af.af-upgrade-upgrade-real.previous"), []byte("x"), 0o755))
-	found := foreignUpgradeStagingOver(target)
+	found := foreignUpgradeStagingOver(target, "")
 	require.NotNil(t, found)
 	require.Equal(t, "upgrade-real", found.ID)
 }
@@ -600,4 +600,50 @@ func TestWriteExecutableInPlace_SerialisesAgainstAnotherHomesLock(t *testing.T) 
 	close(release)
 	require.NoError(t, <-otherDone)
 	require.NoError(t, <-done)
+}
+
+// The interlock must not contradict its own journal policy. A committed
+// transaction keeps its preserved binary beside the executable until Cleanup
+// removes it, and the journal policy deliberately lets that state through — so
+// the artifact scan must not turn around and block on the very transaction the
+// policy just allowed.
+func TestForeignUpgradeStagingOver_SkipsThisHomesOwnTransaction(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "af")
+	require.NoError(t, os.WriteFile(target, []byte("binary"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".af.af-upgrade-upgrade-ours.previous"), []byte("x"), 0o755))
+
+	require.Nil(t, foreignUpgradeStagingOver(target, "upgrade-ours"),
+		"our own transaction's artifact must not block the install its journal policy allowed")
+	require.NotNil(t, foreignUpgradeStagingOver(target, "upgrade-someone-else"),
+		"another home's artifact must still block")
+}
+
+// The launch path must not spend a download and burn its six-hour window
+// discovering, inside the writer, that another home owns the executable.
+func TestUpgradeOwningThisExecutable_SeesAnotherHomesStaging(t *testing.T) {
+	upgradeHome(t)
+	dir := t.TempDir()
+	target := filepath.Join(dir, "af")
+	require.NoError(t, os.WriteFile(target, []byte("binary"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".af.af-upgrade-upgrade-other.previous"), []byte("x"), 0o755))
+
+	originalExec := osExecutableFn
+	osExecutableFn = func() (string, error) { return target, nil }
+	t.Cleanup(func() { osExecutableFn = originalExec })
+
+	active := upgradeOwningThisExecutable()
+	require.NotNil(t, active, "the pre-throttle gate must see a foreign staging over the shared executable")
+	require.Equal(t, "upgrade-other", active.ID)
+}
+
+// An executable that cannot be resolved is inconclusive, and this gate only ever
+// suppresses an update — it must not do so on a read it could not make.
+func TestUpgradeOwningThisExecutable_InconclusiveExecutableDoesNotBlock(t *testing.T) {
+	upgradeHome(t)
+	originalExec := osExecutableFn
+	osExecutableFn = func() (string, error) { return "", errors.New("cannot resolve") }
+	t.Cleanup(func() { osExecutableFn = originalExec })
+
+	require.Nil(t, upgradeOwningThisExecutable())
 }

--- a/internal/upgradetxn/install_lock.go
+++ b/internal/upgradetxn/install_lock.go
@@ -37,6 +37,26 @@ const preparationLockName = "prepare.lock"
 // lock requires a file to take it on. That is a write, so this belongs on paths
 // that are already mutating (an install), never on a read-only probe.
 func WithInstallLock(homeDir, executablePath string, fn func() error) (retErr error) {
+	return withInstallLock(homeDir, executablePath, false, fn)
+}
+
+// TryWithInstallLock is WithInstallLock for a caller that must not wait. It
+// returns ErrInstallLockBusy rather than queueing when either lock is held.
+//
+// The launch-time updater needs this: it runs in front of a TUI that has not
+// opened yet, and a daemon publishing a transaction holds the preparation lock
+// for as long as it takes to copy and fsync a preserved binary. Blocking there
+// would make an unattended update stall the launch the user actually asked for,
+// which is the one thing that path may never do. `af upgrade` was asked for
+// explicitly and keeps the waiting form.
+func TryWithInstallLock(homeDir, executablePath string, fn func() error) (retErr error) {
+	return withInstallLock(homeDir, executablePath, true, fn)
+}
+
+// ErrInstallLockBusy reports that another writer holds the upgrade locks.
+var ErrInstallLockBusy = errors.New("another upgrade holds the install lock")
+
+func withInstallLock(homeDir, executablePath string, nonblocking bool, fn func() error) (retErr error) {
 	home, err := canonicalExistingDir(homeDir)
 	if err != nil {
 		return fmt.Errorf("validate upgrade home: %w", err)
@@ -45,14 +65,17 @@ func WithInstallLock(homeDir, executablePath string, fn func() error) (retErr er
 	if err := ensureLockRoot(root); err != nil {
 		return err
 	}
-	lock, err := acquireFileLock(filepath.Join(root, preparationLockName), false)
+	lock, err := acquireFileLock(filepath.Join(root, preparationLockName), nonblocking)
 	if err != nil {
+		if nonblocking && errors.Is(err, ErrRecoveryActive) {
+			return ErrInstallLockBusy
+		}
 		return fmt.Errorf("lock upgrade preparation: %w", err)
 	}
 	defer func() {
 		retErr = errors.Join(retErr, releaseFileLock(lock))
 	}()
-	return withExecutableLock(executablePath, fn)
+	return withExecutableLock(executablePath, nonblocking, fn)
 }
 
 // ensureLockRoot makes the upgrade root usable as a lock location WITHOUT
@@ -113,13 +136,16 @@ func executableLockPath(executable string) string {
 // withExecutableLock runs fn holding the executable-keyed lock. Callers take it
 // AFTER the per-home preparation lock, always in that order, so two homes racing
 // the same binary cannot deadlock against each other.
-func withExecutableLock(executablePath string, fn func() error) (retErr error) {
+func withExecutableLock(executablePath string, nonblocking bool, fn func() error) (retErr error) {
 	executable, err := canonicalExistingFile(executablePath)
 	if err != nil {
 		return fmt.Errorf("validate executable for the upgrade lock: %w", err)
 	}
-	lock, err := acquireFileLockFlags(executableLockPath(executable), syscall.O_NOFOLLOW, false)
+	lock, err := acquireFileLockFlags(executableLockPath(executable), syscall.O_NOFOLLOW, nonblocking)
 	if err != nil {
+		if nonblocking && errors.Is(err, ErrRecoveryActive) {
+			return ErrInstallLockBusy
+		}
 		return fmt.Errorf("lock the executable for upgrade: %w", err)
 	}
 	defer func() {

--- a/internal/upgradetxn/install_lock_test.go
+++ b/internal/upgradetxn/install_lock_test.go
@@ -210,7 +210,7 @@ func TestWithExecutableLock_RefusesToFollowASymlink(t *testing.T) {
 	elsewhere := filepath.Join(t.TempDir(), "victim")
 	require.NoError(t, os.Symlink(elsewhere, executableLockPath(executable)))
 
-	err := withExecutableLock(executable, func() error {
+	err := withExecutableLock(executable, false, func() error {
 		t.Fatal("the critical section must not run when the lock path is a symlink")
 		return nil
 	})
@@ -225,7 +225,7 @@ func TestWithExecutableLock_RefusesToFollowASymlink(t *testing.T) {
 // hold is a race — and it must be private.
 func TestWithExecutableLock_LeavesAPrivateLockFile(t *testing.T) {
 	executable := lockTestExecutable(t)
-	require.NoError(t, withExecutableLock(executable, func() error { return nil }))
+	require.NoError(t, withExecutableLock(executable, false, func() error { return nil }))
 
 	info, err := os.Stat(executableLockPath(executable))
 	require.NoError(t, err)


### PR DESCRIPTION
Three unresolved Codex findings from #2859, which merged without them being answered (#2948). Each was verified still true against current master before being fixed — a fourth, `Serialize the foreign-home artifact scan with Prepare`, was already fixed by #2897 and is answered in-thread citing that commit rather than re-fixed.

## 1. The artifact scan contradicted the journal policy

`writeExecutableInPlace` asked the journal, and when the journal deliberately said "proceed", asked the artifact scan — which matched **any** preserved-previous binary beside the executable, including this home's own. So a transaction that had committed but whose `Cleanup` had not yet removed the artifact, or one whose journal the policy failed open on, was allowed by the first check and refused by the second two lines later.

The scan now skips this home's own transaction id. `activeUpgradeOwningExecutableWithID` reports that id even in the cases it lets through, so the two checks can no longer disagree about the same transaction.

## 2. The launch updater could stall behind a daemon

`WithInstallLock` blocks, and a daemon publishing a transaction holds the preparation lock for as long as it takes to copy and fsync a preserved binary. An unattended launch-time update could therefore queue in front of a TUI that has not opened yet — the one thing that path may never do.

It now takes the locks non-blocking (`TryWithInstallLock`, returning `ErrInstallLockBusy`) and treats a busy lock as a **deferral, not a failed check**: nothing was attempted, so recording it would suppress the next six hours of legitimate installs over a transaction that takes seconds. `af upgrade` was asked for explicitly and keeps the waiting form.

## 3. The pre-throttle launch gate read only this home

Another `AGENT_FACTORY_HOME` staging over the shared executable was discovered inside the writer — after the throttle cache was open and the archive downloaded, where the refusal recorded a failed check and suppressed launch-time updates for six hours.

`upgradeOwningThisExecutable` now asks before the window opens: one directory read, keeping both the bandwidth and the window. An executable that cannot be resolved is **not** treated as blocked — this gate only ever suppresses an update, so it must not do so on an inconclusive read.

## Verification

Three new tests: the scan skips our own id but still blocks another home's; the pre-throttle gate sees a foreign staging; and an unresolvable executable does not block. Existing interlock tests updated for the new signatures and green.

Local gate: `gofmt -l .` (empty), `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh`, plus `commands`, `internal/upgradetxn`, and `parity`. No daemon-package tests and no containerized suites.

Refs #2948
Refs #2859

🤖 Generated with [Claude Code](https://claude.com/claude-code)