### PR TITLE
fix(upgrade): make the executable lock usable by every authorized writer

### DIFF
--- a/internal/upgradetxn/executable_lock_sharing_test.go
+++ b/internal/upgradetxn/executable_lock_sharing_test.go
@@ -325,6 +325,36 @@ func TestExecutableLock_NonblockingReportsBusyInsteadOfDeniedWhenShared(t *testi
 		"it must not also present as a permission error, or a caller matching on that first would still take the unlocked path")
 }
 
+// A PERMANENT denial in a SHARED directory must stay a permission error too.
+//
+// This is the topology this PR accepts as unfixable: a 0770 directory whose
+// owner is not in its group, with the lock already widened to that group. The
+// directory owner can still replace the binary through the owner bits, but can
+// never open the lock — and the directory is genuinely shared, so a busy answer
+// keyed on sharedness alone would tell the launch updater to defer, report
+// success, and silently never install again.
+//
+// The lock is left group-usable but owner-inaccessible, which is what an
+// already-completed widening looks like to someone outside its group.
+func TestExecutableLock_NonblockingStaysDeniedWhenTheLockIsAlreadyWidened(t *testing.T) {
+	requireUnprivileged(t)
+	executable := sharedInstallDir(t, 0o770)
+	lockPath := executableLockPath(executable)
+	require.NoError(t, os.WriteFile(lockPath, nil, 0o600))
+	// Group rw, owner nothing: Linux checks the owner class first, so this is the
+	// EACCES a non-group caller sees against a lock whose widening already landed.
+	require.NoError(t, os.Chmod(lockPath, 0o060))
+
+	err := withExecutableLock(executable, true, func() error {
+		t.Fatal("the critical section must not run when the lock cannot be opened")
+		return nil
+	})
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrInstallLockBusy,
+		"the widening already completed, so this denial is permanent: reporting busy would defer the launch updater forever and silently retire auto-update for this user")
+	require.ErrorIs(t, err, os.ErrPermission)
+}
+
 // The same nonblocking call in a PRIVATE directory must stay a permission error.
 // There the denial is permanent and means a genuinely unauthorized caller;
 // reporting BUSY would tell the launch updater to defer forever and silently

--- a/internal/upgradetxn/executable_lock_sharing_test.go
+++ b/internal/upgradetxn/executable_lock_sharing_test.go
@@ -27,9 +27,29 @@ func sharedInstallDir(t *testing.T, perm os.FileMode) string {
 	require.NoError(t, err)
 	require.Equal(t, perm, info.Mode().Perm(), "the test fixture must actually have the mode it is testing")
 
+	// Same umask trap as the directory above, and it bites harder here because it
+	// is silent: under umask 077 the write lands on 0700, and the hard-link test
+	// then asserts a 0755 that was never there. chmod explicitly, then prove it.
 	executable := filepath.Join(dir, "af")
 	require.NoError(t, os.WriteFile(executable, []byte("af binary"), 0o755))
+	require.NoError(t, os.Chmod(executable, 0o755))
+	execInfo, err := os.Stat(executable)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o755), execInfo.Mode().Perm(),
+		"the fixture binary must actually be 0755 whatever the umask, or a test asserting its mode survived proves nothing")
 	return executable
+}
+
+// requireUnprivileged skips a test whose mechanism is a permission DENIAL. Root
+// bypasses the mode bits entirely: it opens a 0000 file happily, so the EACCES
+// these tests are built on never occurs. That does not merely make them fail —
+// the retry test would PASS vacuously, reporting that a retry works when no
+// retry ever ran — so skipping honestly beats either outcome.
+func requireUnprivileged(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: a 0000 lock is still openable, so the permission denial this test is built on cannot be produced")
+	}
 }
 
 func lockFileStat(t *testing.T, executable string) (os.FileMode, uint32) {
@@ -140,6 +160,38 @@ func TestExecutableLock_NotWidenedInAWorldWritableDirectory(t *testing.T) {
 		"a world-writable directory must not get a world-usable lock: any local user could then hold it and stall every upgrade")
 }
 
+// On a DIRECTORY, the write bit alone confers nothing — creating, removing or
+// renaming an entry needs search permission too. So the classification has to
+// test write AND execute per class, and getting it wrong breaks BOTH ways.
+//
+// 0772: group rwx, plus a stray other-write bit that grants no traversal. Those
+// group members really can replace the binary, so reading the mode as
+// world-writable and declining leaves them with EACCES and an unlocked install —
+// the original bug, reintroduced through the predicate.
+func TestExecutableLock_SharedWhenAStrayOtherWriteBitGrantsNoTraversal(t *testing.T) {
+	executable := sharedInstallDir(t, 0o772)
+
+	require.NoError(t, withExecutableLock(executable, false, func() error { return nil }))
+
+	perm, _ := lockFileStat(t, executable)
+	require.Equal(t, os.FileMode(0o660), perm,
+		"other-write without other-execute cannot traverse the directory, so this is a group-shared install and its group writers still need the lock")
+}
+
+// The inverse. 0720: group write, no group execute. Those members cannot
+// traverse the directory and so cannot replace the binary — widening the lock to
+// them would hand a blocking handle to principals who are not writers at all,
+// which is the same over-admission the world-writable case declines.
+func TestExecutableLock_NotWidenedWhenTheGroupCannotTraverse(t *testing.T) {
+	executable := sharedInstallDir(t, 0o720)
+
+	require.NoError(t, withExecutableLock(executable, false, func() error { return nil }))
+
+	perm, _ := lockFileStat(t, executable)
+	require.Equal(t, os.FileMode(journalFileMode), perm,
+		"group write without group execute is not write access to a directory, so there is no second writer to admit")
+}
+
 // A HARD LINK at the lock path aims the mode change at somebody else's inode.
 // O_NOFOLLOW rejects a symlink; it says nothing about a hard link, which is not
 // a separate object at all but a second name for an existing one. Anyone who can
@@ -195,6 +247,7 @@ func TestExecutableLock_NarrowsAgainWhenTheDirectoryIsTightened(t *testing.T) {
 // the same EACCES the racing writer sees. Widening it from another goroutine
 // stands in for the first writer finishing its chmod.
 func TestExecutableLock_RetriesWhileAnotherWriterIsStillWideningIt(t *testing.T) {
+	requireUnprivileged(t)
 	executable := sharedInstallDir(t, 0o770)
 	lockPath := executableLockPath(executable)
 	require.NoError(t, os.WriteFile(lockPath, nil, 0o600))
@@ -221,6 +274,7 @@ func TestExecutableLock_RetriesWhileAnotherWriterIsStillWideningIt(t *testing.T)
 // genuinely unauthorized caller, waiting cannot change the answer, and a retry
 // budget would only delay every such attempt.
 func TestExecutableLock_DoesNotRetryInAPrivateDirectory(t *testing.T) {
+	requireUnprivileged(t)
 	executable := sharedInstallDir(t, 0o700)
 	lockPath := executableLockPath(executable)
 	require.NoError(t, os.WriteFile(lockPath, nil, 0o600))

--- a/internal/upgradetxn/executable_lock_sharing_test.go
+++ b/internal/upgradetxn/executable_lock_sharing_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -137,6 +138,119 @@ func TestExecutableLock_NotWidenedInAWorldWritableDirectory(t *testing.T) {
 	perm, _ := lockFileStat(t, executable)
 	require.Equal(t, os.FileMode(journalFileMode), perm,
 		"a world-writable directory must not get a world-usable lock: any local user could then hold it and stall every upgrade")
+}
+
+// A HARD LINK at the lock path aims the mode change at somebody else's inode.
+// O_NOFOLLOW rejects a symlink; it says nothing about a hard link, which is not
+// a separate object at all but a second name for an existing one. Anyone who can
+// write a shared install directory can leave `.af.af-upgrade.lock` pointing at
+// `af` itself — and an fchmod through that name strips the executable bit off
+// the binary before the swap even starts, bricking the install from a routine
+// upgrade.
+//
+// This hazard is created by adjusting the mode at all, so it ships with the fix
+// that introduced it.
+func TestExecutableLock_DoesNotRestyleAHardLinkedTarget(t *testing.T) {
+	executable := sharedInstallDir(t, 0o770)
+	require.NoError(t, os.Link(executable, executableLockPath(executable)),
+		"the hazard is a second NAME for the binary's inode, planted at the lock path")
+
+	require.NoError(t, withExecutableLock(executable, false, func() error { return nil }),
+		"a suspicious lock path must not block the upgrade, only decline to restyle")
+
+	info, err := os.Stat(executable)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o755), info.Mode().Perm(),
+		"the executable bit must survive: an fchmod through a hard-linked lock path would leave af non-executable")
+}
+
+// The narrowing direction. A directory later tightened from group-writable to
+// private leaves a previously widened lock at 0660: the old group can no longer
+// replace the binary, but can still OPEN the known lock path and hold it — and
+// because this lock blocks, that hangs every future upgrade by the owner. So the
+// audience has to track the directory in BOTH directions, not ratchet open.
+func TestExecutableLock_NarrowsAgainWhenTheDirectoryIsTightened(t *testing.T) {
+	executable := sharedInstallDir(t, 0o770)
+	dir := filepath.Dir(executable)
+
+	require.NoError(t, withExecutableLock(executable, false, func() error { return nil }))
+	perm, _ := lockFileStat(t, executable)
+	require.Equal(t, os.FileMode(0o660), perm, "precondition: the shared directory widened the lock")
+
+	require.NoError(t, os.Chmod(dir, 0o750))
+	require.NoError(t, withExecutableLock(executable, false, func() error { return nil }))
+
+	perm, _ = lockFileStat(t, executable)
+	require.Equal(t, os.FileMode(journalFileMode), perm,
+		"a tightened directory must narrow the lock back, or its former group keeps a blocking handle on every future upgrade")
+}
+
+// The creation window. The file must exist before its mode can be adjusted, so
+// it is briefly 0600 even in a shared directory, and a second authorized writer
+// arriving in that gap gets EACCES — which the in-place installer turns into an
+// UNLOCKED swap, the exact outcome being closed.
+//
+// A real two-user race is not reproducible in a unit test, so this drives the
+// mechanism directly: a lock at 0000 is unopenable even by its owner, which is
+// the same EACCES the racing writer sees. Widening it from another goroutine
+// stands in for the first writer finishing its chmod.
+func TestExecutableLock_RetriesWhileAnotherWriterIsStillWideningIt(t *testing.T) {
+	executable := sharedInstallDir(t, 0o770)
+	lockPath := executableLockPath(executable)
+	require.NoError(t, os.WriteFile(lockPath, nil, 0o600))
+	require.NoError(t, os.Chmod(lockPath, 0o000))
+
+	// A budget long enough that a loaded machine cannot lose the race for real
+	// reasons; the acquisition returns as soon as the open succeeds, so a passing
+	// run does not actually wait this long.
+	defer restoreRetryBudget(setRetryBudget(200, 5*time.Millisecond))
+
+	widened := make(chan struct{})
+	go func() {
+		defer close(widened)
+		time.Sleep(20 * time.Millisecond)
+		_ = os.Chmod(lockPath, 0o660)
+	}()
+
+	require.NoError(t, withExecutableLock(executable, false, func() error { return nil }),
+		"the acquisition must wait out the brief private window instead of falling back to an unlocked install")
+	<-widened
+}
+
+// The retry must NOT apply to an ordinary private install. There EACCES means a
+// genuinely unauthorized caller, waiting cannot change the answer, and a retry
+// budget would only delay every such attempt.
+func TestExecutableLock_DoesNotRetryInAPrivateDirectory(t *testing.T) {
+	executable := sharedInstallDir(t, 0o700)
+	lockPath := executableLockPath(executable)
+	require.NoError(t, os.WriteFile(lockPath, nil, 0o600))
+	require.NoError(t, os.Chmod(lockPath, 0o000))
+
+	// Budget long enough that spending it would be unmistakable in the elapsed
+	// time below.
+	defer restoreRetryBudget(setRetryBudget(50, 100*time.Millisecond))
+
+	started := time.Now()
+	err := withExecutableLock(executable, false, func() error {
+		t.Fatal("the critical section must not run when the lock cannot be opened")
+		return nil
+	})
+	elapsed := time.Since(started)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, os.ErrPermission)
+	require.Less(t, elapsed, time.Second,
+		"a private directory must fail fast: the full 5s budget here would mean the shared-directory retry is running where it cannot help")
+}
+
+func setRetryBudget(retries int, delay time.Duration) (int, time.Duration) {
+	prevRetries, prevDelay := executableLockOpenRetries, executableLockOpenRetryDelay
+	executableLockOpenRetries, executableLockOpenRetryDelay = retries, delay
+	return prevRetries, prevDelay
+}
+
+func restoreRetryBudget(retries int, delay time.Duration) {
+	executableLockOpenRetries, executableLockOpenRetryDelay = retries, delay
 }
 
 // Prepare takes the executable lock through its own acquisition rather than

--- a/internal/upgradetxn/executable_lock_sharing_test.go
+++ b/internal/upgradetxn/executable_lock_sharing_test.go
@@ -258,6 +258,43 @@ func TestExecutableLock_NotWidenedWhenAnACLMakesTheModeBitsAmbiguous(t *testing.
 		"an ACL makes the group bits a mask, so they no longer describe who may replace the binary and must not decide who gets the lock")
 }
 
+// A DEFAULT ACL is the inheritance case, and it is invisible to a probe that
+// looks only at the directory's own access ACL.
+//
+// A directory can carry a `system.posix_acl_default` named-user entry and no
+// access ACL at all: the mode bits then look plainly group-writable. The lock
+// created inside it INHERITS that entry, with the mask intersected down by the
+// 0600 create mode, so the entry is present but inert — and a later Chmod(0660)
+// does not touch the entry, it widens the MASK, which switches the entry on. A
+// named user who can traverse but not write the directory can then open a lock
+// that BLOCKS, without ever being able to replace the binary.
+func TestExecutableLock_NotWidenedWhenTheLockInheritsADefaultACL(t *testing.T) {
+	executable := sharedInstallDir(t, 0o770)
+	dir := filepath.Dir(executable)
+
+	if _, err := exec.LookPath("setfacl"); err != nil {
+		t.Skip("setfacl is unavailable, so a real default ACL cannot be created here")
+	}
+	// -d is the point: a DEFAULT entry only, leaving the directory with no access
+	// ACL of its own.
+	if out, err := exec.Command("setfacl", "-d", "-m", "u:root:rwx", dir).CombinedOutput(); err != nil {
+		t.Skipf("this filesystem does not support POSIX ACLs: %v (%s)", err, strings.TrimSpace(string(out)))
+	}
+	if _, err := unix.Getxattr(dir, "system.posix_acl_default", nil); err != nil {
+		t.Skipf("no default ACL landed on the fixture: %v", err)
+	}
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o770), info.Mode().Perm(),
+		"precondition: the mode bits must still look group-writable, or the test proves nothing about the inherited case")
+
+	require.NoError(t, withExecutableLock(executable, false, func() error { return nil }))
+
+	perm, _ := lockFileStat(t, executable)
+	require.Equal(t, os.FileMode(journalFileMode), perm,
+		"widening the mode widens the inherited ACL's mask, turning on entries for principals who cannot replace the binary but can hold the blocking lock")
+}
+
 // A NONBLOCKING caller that hits the transient 0600-to-0660 window must be told
 // BUSY, not denied.
 //

--- a/internal/upgradetxn/executable_lock_sharing_test.go
+++ b/internal/upgradetxn/executable_lock_sharing_test.go
@@ -2,6 +2,7 @@ package upgradetxn
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 // sharedInstallDir builds an install directory that is GROUP-writable, the shape
@@ -190,6 +192,121 @@ func TestExecutableLock_NotWidenedWhenTheGroupCannotTraverse(t *testing.T) {
 	perm, _ := lockFileStat(t, executable)
 	require.Equal(t, os.FileMode(journalFileMode), perm,
 		"group write without group execute is not write access to a directory, so there is no second writer to admit")
+}
+
+// A STICKY group-writable directory (1770) is not shared for this purpose.
+// Group write and search let a member CREATE entries, but the sticky bit
+// restricts renaming and removing to the entry's owner, the directory's owner,
+// or a privileged process — so a group member generally cannot replace a binary
+// owned by someone else. Widening there would hand a blocking lock to exactly
+// the principals who cannot install, which is a denial of service the private
+// lock never had.
+//
+// os.FileMode.Perm() drops the sticky bit, so a classifier reading Perm() alone
+// cannot see this at all.
+func TestExecutableLock_NotWidenedInAStickyDirectory(t *testing.T) {
+	executable := sharedInstallDir(t, 0o770)
+	dir := filepath.Dir(executable)
+	require.NoError(t, os.Chmod(dir, 0o770|os.ModeSticky))
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	require.NotZero(t, info.Mode()&os.ModeSticky, "fixture must actually be sticky")
+
+	require.NoError(t, withExecutableLock(executable, false, func() error { return nil }))
+
+	perm, _ := lockFileStat(t, executable)
+	require.Equal(t, os.FileMode(journalFileMode), perm,
+		"a sticky directory does not let the group replace another user's binary, so the group must not get the lock either")
+}
+
+// With a POSIX ACL present, the group-class bits stat returns are the ACL MASK,
+// not the owning group's effective rights. A directory can grant a named user
+// rwx while the owning group has only r-x and the mask reads rwx: the mode says
+// "group-writable", the truth is that the group cannot write and a user the mode
+// cannot express can. Widening on that gets both halves wrong at once — it hands
+// a blocking lock to non-writers and still excludes the real writer.
+//
+// So the classifier declines whenever an ACL makes the bits ambiguous. This
+// drives setfacl rather than hand-encoding an ACL blob, and skips honestly where
+// the tool or the filesystem cannot provide one.
+func TestExecutableLock_NotWidenedWhenAnACLMakesTheModeBitsAmbiguous(t *testing.T) {
+	executable := sharedInstallDir(t, 0o770)
+	dir := filepath.Dir(executable)
+
+	if _, err := exec.LookPath("setfacl"); err != nil {
+		t.Skip("setfacl is unavailable, so a real POSIX ACL cannot be created here")
+	}
+	// A named-user entry is what makes the group bits a mask rather than a
+	// statement about the group.
+	if out, err := exec.Command("setfacl", "-m", "u:root:rwx", dir).CombinedOutput(); err != nil {
+		t.Skipf("this filesystem does not support POSIX ACLs: %v (%s)", err, strings.TrimSpace(string(out)))
+	}
+	// Read the xattr directly rather than through the helper under test, so this
+	// test compiles — and fails — against the code that lacks the helper.
+	if _, err := unix.Getxattr(dir, "system.posix_acl_access", nil); err != nil {
+		t.Skipf("no access ACL landed on the fixture: %v", err)
+	}
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o770), info.Mode().Perm(),
+		"precondition: the mode bits must still LOOK group-writable, or the test proves nothing about ambiguity")
+
+	require.NoError(t, withExecutableLock(executable, false, func() error { return nil }))
+
+	perm, _ := lockFileStat(t, executable)
+	require.Equal(t, os.FileMode(journalFileMode), perm,
+		"an ACL makes the group bits a mask, so they no longer describe who may replace the binary and must not decide who gets the lock")
+}
+
+// A NONBLOCKING caller that hits the transient 0600-to-0660 window must be told
+// BUSY, not denied.
+//
+// The distinction decides what happens next, and the outcomes are not close:
+// writeExecutableInPlaceWaiting defers only on ErrInstallLockBusy, and on any
+// other error it swaps the binary with NEITHER lock held — the interleave with a
+// live transaction this lock exists to prevent. Deferring an unattended
+// launch-time update costs a retry next launch; swapping unlocked can corrupt
+// someone's rollback.
+//
+// A 0000 lock stands in for the window: unopenable even by its owner, which is
+// the same EACCES the racing writer sees.
+func TestExecutableLock_NonblockingReportsBusyInsteadOfDeniedWhenShared(t *testing.T) {
+	requireUnprivileged(t)
+	executable := sharedInstallDir(t, 0o770)
+	lockPath := executableLockPath(executable)
+	require.NoError(t, os.WriteFile(lockPath, nil, 0o600))
+	require.NoError(t, os.Chmod(lockPath, 0o000))
+
+	err := withExecutableLock(executable, true, func() error {
+		t.Fatal("the critical section must not run when the lock cannot be opened")
+		return nil
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrInstallLockBusy,
+		"a shared-directory denial must reach the caller as BUSY: any other error makes the launch updater swap the binary with no lock held")
+	require.NotErrorIs(t, err, os.ErrPermission,
+		"it must not also present as a permission error, or a caller matching on that first would still take the unlocked path")
+}
+
+// The same nonblocking call in a PRIVATE directory must stay a permission error.
+// There the denial is permanent and means a genuinely unauthorized caller;
+// reporting BUSY would tell the launch updater to defer forever and silently
+// stop auto-updating rather than fall back.
+func TestExecutableLock_NonblockingStaysDeniedInAPrivateDirectory(t *testing.T) {
+	requireUnprivileged(t)
+	executable := sharedInstallDir(t, 0o700)
+	lockPath := executableLockPath(executable)
+	require.NoError(t, os.WriteFile(lockPath, nil, 0o600))
+	require.NoError(t, os.Chmod(lockPath, 0o000))
+
+	err := withExecutableLock(executable, true, func() error {
+		t.Fatal("the critical section must not run when the lock cannot be opened")
+		return nil
+	})
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrInstallLockBusy,
+		"a permanent denial must not masquerade as transient contention, or the updater defers forever instead of falling back")
+	require.ErrorIs(t, err, os.ErrPermission)
 }
 
 // A HARD LINK at the lock path aims the mode change at somebody else's inode.

--- a/internal/upgradetxn/executable_lock_sharing_test.go
+++ b/internal/upgradetxn/executable_lock_sharing_test.go
@@ -355,6 +355,44 @@ func TestExecutableLock_NonblockingStaysDeniedWhenTheLockIsAlreadyWidened(t *tes
 	require.ErrorIs(t, err, os.ErrPermission)
 }
 
+// The STALE denial. The nonblocking open can fail while the lock is still 0600
+// and the creator can finish its chmod before the follow-up stat runs — so the
+// lock reads as widened while the error in hand describes a moment that has
+// already passed. Inferring "permanent" from the current state there returns a
+// stale EACCES, and the caller swaps with no lock held, which is the interleave
+// this branch exists to prevent.
+//
+// The window is between two adjacent syscalls, so it is pinned through the seam
+// rather than raced: the probe reports "not transient" (as a completed widening
+// would) and, at that instant, makes the lock openable — exactly the ordering
+// where the first denial is already out of date. The acquisition must re-ask and
+// succeed, not report the error it was holding.
+func TestExecutableLock_NonblockingRetriesAStaleDenialAgainstAWidenedLock(t *testing.T) {
+	requireUnprivileged(t)
+	executable := sharedInstallDir(t, 0o770)
+	lockPath := executableLockPath(executable)
+	require.NoError(t, os.WriteFile(lockPath, nil, 0o600))
+	require.NoError(t, os.Chmod(lockPath, 0o000))
+
+	var probes int
+	prev := lockDenialIsTransient
+	lockDenialIsTransient = func(path string, dirGid int) bool {
+		probes++
+		// The creator's chmod lands here — after our open failed, before we decide.
+		require.NoError(t, os.Chmod(path, 0o660))
+		return false
+	}
+	t.Cleanup(func() { lockDenialIsTransient = prev })
+
+	ran := false
+	require.NoError(t, withExecutableLock(executable, true, func() error {
+		ran = true
+		return nil
+	}), "a denial that was already stale must be re-asked, not reported")
+	require.True(t, ran, "the critical section must run once the re-attempt succeeds")
+	require.Equal(t, 1, probes, "the discriminator must be consulted exactly once")
+}
+
 // The same nonblocking call in a PRIVATE directory must stay a permission error.
 // There the denial is permanent and means a genuinely unauthorized caller;
 // reporting BUSY would tell the launch updater to defer forever and silently

--- a/internal/upgradetxn/executable_lock_sharing_test.go
+++ b/internal/upgradetxn/executable_lock_sharing_test.go
@@ -419,6 +419,42 @@ func TestExecutableLock_NonblockingRetriesAStaleDenialAgainstAWidenedLock(t *tes
 	require.Equal(t, 1, probes, "the discriminator must be consulted exactly once")
 }
 
+// A LEGACY private lock is not a creation race, however much it looks like one.
+//
+// A 0600 lock left in a shared directory by a pre-change version, owned by
+// another user, denies an authorized group writer permanently — nobody but its
+// owner can ever widen it. Its missing group bits are indistinguishable from the
+// create-then-chmod window by mode alone, so classifying on mode would return
+// busy on every launch: `commands/autoupdate.go` treats that as a successful
+// deferral, and auto-update goes silently dead for that writer with no error
+// anywhere to say so.
+//
+// Age separates them. The real window is a create followed immediately by an
+// fchmod; anything older is a leftover, and falls through to the permission
+// error and the documented unlocked-swap fallback — which is what such a lock
+// already does today.
+func TestExecutableLock_NonblockingStaysDeniedForALegacyPrivateLock(t *testing.T) {
+	requireACLAwarePlatform(t)
+	requireUnprivileged(t)
+	executable := sharedInstallDir(t, 0o770)
+	lockPath := executableLockPath(executable)
+	require.NoError(t, os.WriteFile(lockPath, nil, 0o600))
+	require.NoError(t, os.Chmod(lockPath, 0o000))
+	// Older than any create-then-chmod window, which is what "left by a previous
+	// version" means in the only terms the filesystem records.
+	old := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(lockPath, old, old))
+
+	err := withExecutableLock(executable, true, func() error {
+		t.Fatal("the critical section must not run when the lock cannot be opened")
+		return nil
+	})
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrInstallLockBusy,
+		"a leftover private lock never clears, so reporting busy defers the updater on every launch and silently retires auto-update")
+	require.ErrorIs(t, err, os.ErrPermission)
+}
+
 // The same nonblocking call in a PRIVATE directory must stay a permission error.
 // There the denial is permanent and means a genuinely unauthorized caller;
 // reporting BUSY would tell the launch updater to defer forever and silently

--- a/internal/upgradetxn/executable_lock_sharing_test.go
+++ b/internal/upgradetxn/executable_lock_sharing_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -54,6 +55,21 @@ func requireUnprivileged(t *testing.T) {
 	}
 }
 
+// requireACLAwarePlatform skips a test that depends on the lock actually being
+// WIDENED. The widening is Linux-only by design: on other platforms ACL state
+// cannot be determined without the platform ACL API, and "cannot determine"
+// reads as ambiguous, so the classifier declines and the lock stays private.
+//
+// These tests would therefore fail everywhere else for the right reason, which
+// is worse than not running: a red macOS job that is reporting correct
+// behaviour teaches the next reader to ignore it.
+func requireACLAwarePlatform(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		t.Skip("the lock widening is Linux-only: elsewhere ACL state cannot be determined, so the classifier declines and the lock stays private")
+	}
+}
+
 func lockFileStat(t *testing.T, executable string) (os.FileMode, uint32) {
 	t.Helper()
 	info, err := os.Stat(executableLockPath(executable))
@@ -77,6 +93,7 @@ func lockFileStat(t *testing.T, executable string) (os.FileMode, uint32) {
 // So: where the directory says other principals may replace the binary, the lock
 // must say they may take it.
 func TestExecutableLock_SharedWithTheDirectorysWriters(t *testing.T) {
+	requireACLAwarePlatform(t)
 	executable := sharedInstallDir(t, 0o770)
 
 	require.NoError(t, withExecutableLock(executable, false, func() error { return nil }))
@@ -96,6 +113,7 @@ func TestExecutableLock_SharedWithTheDirectorysWriters(t *testing.T) {
 // against completely unfixed code. Retarget the directory to a SECONDARY group
 // first, which makes the two differ and gives the assertion teeth.
 func TestExecutableLock_TakesTheDirectorysGroup(t *testing.T) {
+	requireACLAwarePlatform(t)
 	executable := sharedInstallDir(t, 0o770)
 	dir := filepath.Dir(executable)
 
@@ -134,6 +152,7 @@ func secondaryGroup(t *testing.T) (int, bool) {
 // acquisition by its owner, or the very first upgrade on a shared box would
 // poison the lock for every other user permanently.
 func TestExecutableLock_WidensAnExistingPrivateLock(t *testing.T) {
+	requireACLAwarePlatform(t)
 	executable := sharedInstallDir(t, 0o770)
 	lockPath := executableLockPath(executable)
 	require.NoError(t, os.WriteFile(lockPath, nil, 0o600))
@@ -171,6 +190,7 @@ func TestExecutableLock_NotWidenedInAWorldWritableDirectory(t *testing.T) {
 // world-writable and declining leaves them with EACCES and an unlocked install —
 // the original bug, reintroduced through the predicate.
 func TestExecutableLock_SharedWhenAStrayOtherWriteBitGrantsNoTraversal(t *testing.T) {
+	requireACLAwarePlatform(t)
 	executable := sharedInstallDir(t, 0o772)
 
 	require.NoError(t, withExecutableLock(executable, false, func() error { return nil }))
@@ -205,6 +225,7 @@ func TestExecutableLock_NotWidenedWhenTheGroupCannotTraverse(t *testing.T) {
 // os.FileMode.Perm() drops the sticky bit, so a classifier reading Perm() alone
 // cannot see this at all.
 func TestExecutableLock_NotWidenedInAStickyDirectory(t *testing.T) {
+	requireACLAwarePlatform(t)
 	executable := sharedInstallDir(t, 0o770)
 	dir := filepath.Dir(executable)
 	require.NoError(t, os.Chmod(dir, 0o770|os.ModeSticky))
@@ -230,6 +251,7 @@ func TestExecutableLock_NotWidenedInAStickyDirectory(t *testing.T) {
 // drives setfacl rather than hand-encoding an ACL blob, and skips honestly where
 // the tool or the filesystem cannot provide one.
 func TestExecutableLock_NotWidenedWhenAnACLMakesTheModeBitsAmbiguous(t *testing.T) {
+	requireACLAwarePlatform(t)
 	executable := sharedInstallDir(t, 0o770)
 	dir := filepath.Dir(executable)
 
@@ -269,6 +291,7 @@ func TestExecutableLock_NotWidenedWhenAnACLMakesTheModeBitsAmbiguous(t *testing.
 // named user who can traverse but not write the directory can then open a lock
 // that BLOCKS, without ever being able to replace the binary.
 func TestExecutableLock_NotWidenedWhenTheLockInheritsADefaultACL(t *testing.T) {
+	requireACLAwarePlatform(t)
 	executable := sharedInstallDir(t, 0o770)
 	dir := filepath.Dir(executable)
 
@@ -308,6 +331,7 @@ func TestExecutableLock_NotWidenedWhenTheLockInheritsADefaultACL(t *testing.T) {
 // A 0000 lock stands in for the window: unopenable even by its owner, which is
 // the same EACCES the racing writer sees.
 func TestExecutableLock_NonblockingReportsBusyInsteadOfDeniedWhenShared(t *testing.T) {
+	requireACLAwarePlatform(t)
 	requireUnprivileged(t)
 	executable := sharedInstallDir(t, 0o770)
 	lockPath := executableLockPath(executable)
@@ -337,6 +361,7 @@ func TestExecutableLock_NonblockingReportsBusyInsteadOfDeniedWhenShared(t *testi
 // The lock is left group-usable but owner-inaccessible, which is what an
 // already-completed widening looks like to someone outside its group.
 func TestExecutableLock_NonblockingStaysDeniedWhenTheLockIsAlreadyWidened(t *testing.T) {
+	requireACLAwarePlatform(t)
 	requireUnprivileged(t)
 	executable := sharedInstallDir(t, 0o770)
 	lockPath := executableLockPath(executable)
@@ -368,6 +393,7 @@ func TestExecutableLock_NonblockingStaysDeniedWhenTheLockIsAlreadyWidened(t *tes
 // where the first denial is already out of date. The acquisition must re-ask and
 // succeed, not report the error it was holding.
 func TestExecutableLock_NonblockingRetriesAStaleDenialAgainstAWidenedLock(t *testing.T) {
+	requireACLAwarePlatform(t)
 	requireUnprivileged(t)
 	executable := sharedInstallDir(t, 0o770)
 	lockPath := executableLockPath(executable)
@@ -414,6 +440,28 @@ func TestExecutableLock_NonblockingStaysDeniedInAPrivateDirectory(t *testing.T) 
 	require.ErrorIs(t, err, os.ErrPermission)
 }
 
+// The other side of the Linux-only decision, and the one that actually runs on
+// the macOS job: where ACL state cannot be determined, a group-writable
+// directory must NOT get a widened lock.
+//
+// Reporting "no ACL" on a platform whose ACLs this cannot see would hand that
+// platform exactly the defect the probe removes on Linux — a 0660 lock published
+// to an owning group an ACL may deny, while the ACL-authorized writer stays shut
+// out and installs unlocked. Declining costs the widening and nothing else: the
+// lock stays private, as it was before any of this.
+func TestExecutableLock_NotWidenedWherePlatformACLStateIsUnknowable(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("Linux can read POSIX ACLs directly, so it decides on the actual ACL rather than on not knowing")
+	}
+	executable := sharedInstallDir(t, 0o770)
+
+	require.NoError(t, withExecutableLock(executable, false, func() error { return nil }))
+
+	perm, _ := lockFileStat(t, executable)
+	require.Equal(t, os.FileMode(journalFileMode), perm,
+		"ACL state is undeterminable here, so the mode bits cannot be trusted to name the writers and the lock must stay private")
+}
+
 // A HARD LINK at the lock path aims the mode change at somebody else's inode.
 // O_NOFOLLOW rejects a symlink; it says nothing about a hard link, which is not
 // a separate object at all but a second name for an existing one. Anyone who can
@@ -444,6 +492,7 @@ func TestExecutableLock_DoesNotRestyleAHardLinkedTarget(t *testing.T) {
 // because this lock blocks, that hangs every future upgrade by the owner. So the
 // audience has to track the directory in BOTH directions, not ratchet open.
 func TestExecutableLock_NarrowsAgainWhenTheDirectoryIsTightened(t *testing.T) {
+	requireACLAwarePlatform(t)
 	executable := sharedInstallDir(t, 0o770)
 	dir := filepath.Dir(executable)
 
@@ -469,6 +518,7 @@ func TestExecutableLock_NarrowsAgainWhenTheDirectoryIsTightened(t *testing.T) {
 // the same EACCES the racing writer sees. Widening it from another goroutine
 // stands in for the first writer finishing its chmod.
 func TestExecutableLock_RetriesWhileAnotherWriterIsStillWideningIt(t *testing.T) {
+	requireACLAwarePlatform(t)
 	requireUnprivileged(t)
 	executable := sharedInstallDir(t, 0o770)
 	lockPath := executableLockPath(executable)
@@ -534,6 +584,7 @@ func restoreRetryBudget(retries int, delay time.Duration) {
 // HARDER failure: it returns the open error, so on a shared box the second
 // user's transactional upgrade does not merely go unlocked, it fails outright.
 func TestPrepare_SharesTheExecutableLockToo(t *testing.T) {
+	requireACLAwarePlatform(t)
 	executable := sharedInstallDir(t, 0o770)
 
 	_, err := Prepare(Plan{

--- a/internal/upgradetxn/executable_lock_sharing_test.go
+++ b/internal/upgradetxn/executable_lock_sharing_test.go
@@ -1,0 +1,168 @@
+package upgradetxn
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// sharedInstallDir builds an install directory that is GROUP-writable, the shape
+// a shared install (/usr/local/bin, a group-owned ~/.local/bin) actually takes,
+// and returns the executable inside it.
+//
+// t.TempDir() is 0700, which is why every existing lock test sees the private
+// case. The mode has to be set explicitly: os.MkdirAll applies the umask, so
+// asking for 0770 alone would silently land on 0750 under the usual 022.
+func sharedInstallDir(t *testing.T, perm os.FileMode) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "bin")
+	require.NoError(t, os.Mkdir(dir, perm))
+	require.NoError(t, os.Chmod(dir, perm))
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	require.Equal(t, perm, info.Mode().Perm(), "the test fixture must actually have the mode it is testing")
+
+	executable := filepath.Join(dir, "af")
+	require.NoError(t, os.WriteFile(executable, []byte("af binary"), 0o755))
+	return executable
+}
+
+func lockFileStat(t *testing.T, executable string) (os.FileMode, uint32) {
+	t.Helper()
+	info, err := os.Stat(executableLockPath(executable))
+	require.NoError(t, err)
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	require.True(t, ok, "need a unix stat to read the lock's group")
+	return info.Mode().Perm(), stat.Gid
+}
+
+// THE FINDING (#2948, Codex on #2897). The executable lock exists to serialise
+// every writer of one binary, across AF homes AND across users — that is the
+// whole reason it is keyed to the executable rather than to a home.
+//
+// It was created 0600. In a group-writable install directory the first user to
+// upgrade owns a lock nobody else can open, and a second user who can still
+// rename the binary gets EACCES. writeExecutableInPlace treats that as "cannot
+// take the lock" and installs UNLOCKED, so the exact interleaving this lock was
+// added to prevent is back — silently, and only for the users who did not get
+// there first.
+//
+// So: where the directory says other principals may replace the binary, the lock
+// must say they may take it.
+func TestExecutableLock_SharedWithTheDirectorysWriters(t *testing.T) {
+	executable := sharedInstallDir(t, 0o770)
+
+	require.NoError(t, withExecutableLock(executable, false, func() error { return nil }))
+
+	perm, _ := lockFileStat(t, executable)
+	require.Equal(t, os.FileMode(0o660), perm,
+		"a group-writable install directory must produce a group-writable lock: anyone who can rename the binary must be able to take the lock that guards it")
+}
+
+// The group has to MATCH the directory's, not just be present. A new file takes
+// the creator's primary group (the directory is not setgid), so a lock left at
+// 0660/creator-group is still unopenable by the other members of the shared
+// group — the same failure with an extra step.
+//
+// Single-user tests cannot see this: the temp dir's group already equals the
+// test user's primary group, so an assertion of "lock gid == dir gid" would pass
+// against completely unfixed code. Retarget the directory to a SECONDARY group
+// first, which makes the two differ and gives the assertion teeth.
+func TestExecutableLock_TakesTheDirectorysGroup(t *testing.T) {
+	executable := sharedInstallDir(t, 0o770)
+	dir := filepath.Dir(executable)
+
+	secondary, ok := secondaryGroup(t)
+	if !ok {
+		t.Skip("the test user belongs to no group other than its primary one, so a lock keeping its default group would be indistinguishable from one adopting the directory's")
+	}
+	require.NoError(t, os.Chown(dir, -1, secondary))
+	require.NoError(t, os.Chmod(dir, 0o770), "chown clears setgid; restore the mode the fixture asserts")
+
+	require.NoError(t, withExecutableLock(executable, false, func() error { return nil }))
+
+	perm, gid := lockFileStat(t, executable)
+	require.Equal(t, os.FileMode(0o660), perm)
+	require.Equal(t, secondary, int(gid),
+		"the lock must carry the install directory's group, not its creator's: 0660 against the wrong group excludes exactly the users it is meant to admit")
+}
+
+// secondaryGroup returns a group the test user is in that is NOT its primary
+// group, and whether one exists.
+func secondaryGroup(t *testing.T) (int, bool) {
+	t.Helper()
+	primary := os.Getegid()
+	groups, err := os.Getgroups()
+	require.NoError(t, err)
+	for _, gid := range groups {
+		if gid != primary {
+			return gid, true
+		}
+	}
+	return 0, false
+}
+
+// The self-heal. A lock created 0600 before this fix — or by a user whose umask
+// or directory looked different at the time — must widen on the next
+// acquisition by its owner, or the very first upgrade on a shared box would
+// poison the lock for every other user permanently.
+func TestExecutableLock_WidensAnExistingPrivateLock(t *testing.T) {
+	executable := sharedInstallDir(t, 0o770)
+	lockPath := executableLockPath(executable)
+	require.NoError(t, os.WriteFile(lockPath, nil, 0o600))
+
+	require.NoError(t, withExecutableLock(executable, false, func() error { return nil }))
+
+	perm, _ := lockFileStat(t, executable)
+	require.Equal(t, os.FileMode(0o660), perm,
+		"an existing private lock must be widened by an owner that can still chmod it")
+}
+
+// A world-writable install directory is NOT widened. The lock blocks rather than
+// failing, so a lock any local user may open is a lock any local user may hold
+// forever — every upgrade on the box hangs. #2897 rejected /tmp as the lock
+// location for exactly this reason, and the same reasoning applies to the mode.
+//
+// Nothing is lost by declining: a directory where anyone may replace the binary
+// has no integrity left for this lock to protect.
+func TestExecutableLock_NotWidenedInAWorldWritableDirectory(t *testing.T) {
+	executable := sharedInstallDir(t, 0o777)
+
+	require.NoError(t, withExecutableLock(executable, false, func() error { return nil }))
+
+	perm, _ := lockFileStat(t, executable)
+	require.Equal(t, os.FileMode(journalFileMode), perm,
+		"a world-writable directory must not get a world-usable lock: any local user could then hold it and stall every upgrade")
+}
+
+// Prepare takes the executable lock through its own acquisition rather than
+// through withExecutableLock, so it can drift. It has the same defect with a
+// HARDER failure: it returns the open error, so on a shared box the second
+// user's transactional upgrade does not merely go unlocked, it fails outright.
+func TestPrepare_SharesTheExecutableLockToo(t *testing.T) {
+	executable := sharedInstallDir(t, 0o770)
+
+	_, err := Prepare(Plan{
+		ID:             "upgrade-" + strings.Repeat("c", 32),
+		HomeDir:        t.TempDir(),
+		ExecutablePath: executable,
+		FromVersion:    "1.0.100",
+		ToVersion:      "1.0.300",
+		Candidate:      []byte("candidate-af-binary"),
+		Daemon: DaemonSnapshot{
+			WasRunning: true,
+			BootID:     "boot",
+			Owner:      DaemonOwner{Kind: SupervisionAdHoc},
+		},
+		RecoveryJob: RecoveryJob{Kind: RecoveryJobDetached},
+	})
+	require.NoError(t, err)
+
+	perm, _ := lockFileStat(t, executable)
+	require.Equal(t, os.FileMode(0o660), perm,
+		"Prepare must take the lock the same way the in-place installer does, or the two acquisitions drift and only one of them is usable on a shared install")
+}

--- a/internal/upgradetxn/install_lock.go
+++ b/internal/upgradetxn/install_lock.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -446,10 +447,22 @@ func foreignTransactionOver(executable, selfID string) (string, error) {
 // "assume ambiguity", and a probe that cannot tell simply reports false and
 // leaves the mode-bit reading in charge, which is where it was before.
 //
-// The xattr name is the Linux one. On other unixes the call fails and this
-// reports false: their ACL models differ, and inventing a cross-platform answer
-// here would be guessing rather than probing.
+// The probe below is Linux's ACL representation. Everywhere else this reports
+// AMBIGUOUS rather than absent, which is the whole point: the Linux names always
+// fail on Darwin, so reporting "no ACL" there would silently hand a Darwin
+// install exactly the defect this probe removes on Linux — a 0660 lock published
+// to an owning group an ACL may deny, and the ACL-authorized writer still shut
+// out. Determining Darwin ACL state needs the platform ACL API, and shipping an
+// implementation of it that cannot be exercised here would be guessing; refusing
+// to widen is the answer that is right without being verified.
+//
+// The effect is that the widening is Linux-only. Every other platform keeps the
+// private lock it had before this change, which costs the widening and nothing
+// else.
 func hasExtendedACL(path string) bool {
+	if runtime.GOOS != "linux" {
+		return true
+	}
 	// BOTH ACLs, and the default one is not optional. A directory can carry only
 	// a system.posix_acl_default named-user entry and no access ACL of its own, so
 	// probing the access ACL alone reports "unambiguous" for a directory whose
@@ -476,6 +489,9 @@ func hasExtendedACL(path string) bool {
 // Checking the descriptor closes that regardless of how the ACL arrived, and
 // costs no extra TOCTOU: it is the same object about to be chmod'ed.
 func lockHasInheritedACL(lock *os.File) bool {
+	if runtime.GOOS != "linux" {
+		return true
+	}
 	_, err := unix.Fgetxattr(int(lock.Fd()), "system.posix_acl_access", nil)
 	return err == nil
 }

--- a/internal/upgradetxn/install_lock.go
+++ b/internal/upgradetxn/install_lock.go
@@ -517,6 +517,12 @@ func lockHasInheritedACL(lock *os.File) bool {
 // lockDenialIsTransient is the seam the nonblocking branch calls through, so a
 // test can pin the stale-denial ordering rather than race it. Production never
 // reassigns it.
+// executableLockFreshWindow is how recently a still-private lock must have been
+// created for its denial to read as the creation race rather than as a legacy
+// private lock. Generous against the microseconds the real window takes, and far
+// below any age a leftover lock would have.
+const executableLockFreshWindow = 5 * time.Second
+
 var lockDenialIsTransient = executableLockDenialIsTransient
 
 func executableLockDenialIsTransient(lockPath string, dirGid int) bool {
@@ -532,6 +538,23 @@ func executableLockDenialIsTransient(lockPath string, dirGid int) bool {
 		return false
 	}
 	const groupUsable = 0o060
-	widened := info.Mode().Perm()&groupUsable == groupUsable && int(stat.Gid) == dirGid
-	return !widened
+	if info.Mode().Perm()&groupUsable == groupUsable && int(stat.Gid) == dirGid {
+		// Widened already, so a denial is about who we are. The caller re-asks
+		// once before trusting this, since the widening may have landed between
+		// its failed open and this stat.
+		return false
+	}
+	// Still private. That is the creation window only if the lock is NEW. A 0600
+	// lock left by a pre-change version under another user is permanently private
+	// from here — nobody but its owner can widen it — and calling that transient
+	// would defer the launch updater on every single launch, reporting success
+	// and never installing. Auto-update would be silently dead for that writer,
+	// with no error anywhere to say so.
+	//
+	// The window this is separating them by is microseconds wide in practice: a
+	// create followed immediately by an fchmod. Anything older is not a race that
+	// is about to resolve, so it falls through to the permission error and the
+	// documented unlocked-swap fallback — which is exactly what such a lock does
+	// today, before this change.
+	return time.Since(info.ModTime()) < executableLockFreshWindow
 }

--- a/internal/upgradetxn/install_lock.go
+++ b/internal/upgradetxn/install_lock.go
@@ -213,10 +213,19 @@ func acquireExecutableLock(executable string, nonblocking bool) (*os.File, error
 			//
 			// Returned without sleeping either way: the caller asked not to wait
 			// (#2951), and this reads the lock's state rather than waiting on it.
-			if !executableLockDenialIsTransient(path, gid) {
-				return lock, err
+			if lockDenialIsTransient(path, gid) {
+				return nil, ErrInstallLockBusy
 			}
-			return nil, ErrInstallLockBusy
+			// The lock reads as already widened, which normally means this denial
+			// is about who we are. But the widening may have landed BETWEEN the
+			// failed open above and that stat, in which case the error in hand is
+			// STALE, not permanent — and returning it sends the caller down the
+			// swap-with-no-lock path this whole branch exists to keep it off.
+			//
+			// Re-ask once. No sleep: the answer either changed already or it did
+			// not, and the caller asked not to wait. A second denial against a
+			// lock that is demonstrably widened is the permanent case.
+			return acquireFileLockPrepared(path, syscall.O_NOFOLLOW, nonblocking, prepare)
 		}
 		if attempt >= executableLockOpenRetries {
 			return lock, err
@@ -489,6 +498,11 @@ func lockHasInheritedACL(lock *os.File) bool {
 // stat needs only search permission on the directory, which any caller that got
 // this far already has. An absent lock means we are racing its creation, which
 // is the transient case by definition.
+// lockDenialIsTransient is the seam the nonblocking branch calls through, so a
+// test can pin the stale-denial ordering rather than race it. Production never
+// reassigns it.
+var lockDenialIsTransient = executableLockDenialIsTransient
+
 func executableLockDenialIsTransient(lockPath string, dirGid int) bool {
 	info, err := os.Lstat(lockPath)
 	if err != nil {

--- a/internal/upgradetxn/install_lock.go
+++ b/internal/upgradetxn/install_lock.go
@@ -323,6 +323,15 @@ func alignLockWithDirectoryWriters(lock *os.File, dir string) {
 		return
 	}
 
+	// An ACL the lock INHERITED from the directory's default is inert only while
+	// the mask stays narrow. Widening the mode widens the mask, which switches the
+	// inherited entries on — so this file's own ACL has to be consulted, not just
+	// the directory's. Checked before either branch, because narrowing an
+	// ACL-bearing file rewrites its mask too.
+	if lockHasInheritedACL(lock) {
+		return
+	}
+
 	gid, shared := directoryWriterGroup(dir)
 	if !shared {
 		if info.Mode().Perm() != journalFileMode {
@@ -423,7 +432,32 @@ func foreignTransactionOver(executable, selfID string) (string, error) {
 // reports false: their ACL models differ, and inventing a cross-platform answer
 // here would be guessing rather than probing.
 func hasExtendedACL(path string) bool {
-	// A zero-length read: only the error matters, never the value.
-	_, err := unix.Getxattr(path, "system.posix_acl_access", nil)
+	// BOTH ACLs, and the default one is not optional. A directory can carry only
+	// a system.posix_acl_default named-user entry and no access ACL of its own, so
+	// probing the access ACL alone reports "unambiguous" for a directory whose
+	// ACL reaches the lock by INHERITANCE rather than by being present here.
+	for _, attr := range []string{"system.posix_acl_access", "system.posix_acl_default"} {
+		// A zero-length read: only the error matters, never the value.
+		if _, err := unix.Getxattr(path, attr, nil); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// lockHasInheritedACL reports whether the OPENED lock carries an access ACL of
+// its own, read from the descriptor rather than the path.
+//
+// A file created in a directory with a default ACL inherits it, with the mask
+// intersected down by the 0600 create mode — so the inherited entries are
+// present but inert. A later Chmod(0660) does not touch those entries; it widens
+// the MASK, which switches them on. The named user in an inherited entry can
+// then open a lock that BLOCKS, without necessarily being able to write the
+// directory or replace the binary at all.
+//
+// Checking the descriptor closes that regardless of how the ACL arrived, and
+// costs no extra TOCTOU: it is the same object about to be chmod'ed.
+func lockHasInheritedACL(lock *os.File) bool {
+	_, err := unix.Fgetxattr(int(lock.Fd()), "system.posix_acl_access", nil)
 	return err == nil
 }

--- a/internal/upgradetxn/install_lock.go
+++ b/internal/upgradetxn/install_lock.go
@@ -134,6 +134,79 @@ func executableLockPath(executable string) string {
 	)
 }
 
+// acquireExecutableLock is the ONE way this package takes the executable lock.
+// Prepare and the in-place installer both go through it: they contend for the
+// same file, so an acquisition either of them spelled separately could widen on
+// one path and not the other, leaving a lock usable by whichever writer happened
+// to create it.
+//
+// The lock must be openable by every principal the install directory already
+// trusts to replace the binary, or it does not do the job it was added for
+// (#2948). Created 0600, it was openable by its creator alone: on a shared
+// install the first user to upgrade owned a lock nobody else could open, the
+// second user got EACCES, and — because a lock failure must never block an
+// install — writeExecutableInPlace logged it and swapped the binary UNLOCKED.
+// The cross-user interleave the executable key exists to prevent came back
+// silently, for everyone except the user who got there first.
+//
+// So the lock's audience is derived from the directory's: group-writable
+// directory, group-usable lock, carrying the DIRECTORY's group rather than the
+// creator's (a new file takes its creator's primary group, which on a shared box
+// is the wrong one and excludes exactly the users this is meant to admit).
+// nonblocking is threaded through rather than fixed, because #2951 gave the
+// launch path a lock acquisition that must fail fast instead of stalling a
+// start-up. Widening the mode is orthogonal to waiting for the lock and happens
+// on the descriptor either way.
+func acquireExecutableLock(executable string, nonblocking bool) (*os.File, error) {
+	return acquireFileLockPrepared(
+		executableLockPath(executable), syscall.O_NOFOLLOW, nonblocking,
+		func(lock *os.File) { shareLockWithDirectoryWriters(lock, filepath.Dir(executable)) },
+	)
+}
+
+// shareLockWithDirectoryWriters matches the lock's permissions to the install
+// directory's, best-effort.
+//
+// Best-effort is the whole contract: every step here is an accommodation for
+// OTHER writers, and we already hold a working descriptor. When the lock was
+// created by a different user, the fchmod/fchown simply fail with EPERM — that
+// user got it right when they created it, or they did not and their own next
+// acquisition repairs it. Nothing here may turn into an error that stops an
+// upgrade.
+//
+// Two directory shapes are deliberately left at 0600:
+//
+//   - Not group-writable. No other principal can replace the binary, so 0600
+//     already covers every writer and widening would only enlarge the audience
+//     of a file nobody else needs.
+//   - World-writable. The lock BLOCKS rather than failing, so a lock any local
+//     user may open is a lock any local user may hold forever, stalling every
+//     upgrade on the box. #2897 rejected /tmp as the lock location on exactly
+//     this reasoning; it applies to the mode for the same reason. Nothing is
+//     given up by declining — a directory where anyone may swap the binary has
+//     no integrity left for this lock to protect.
+func shareLockWithDirectoryWriters(lock *os.File, dir string) {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return
+	}
+	perm := info.Mode().Perm()
+	if perm&0o020 == 0 || perm&0o002 != 0 {
+		return
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return
+	}
+	// fchown/fchmod on the descriptor we already opened O_NOFOLLOW, never a
+	// path-based chmod: a path here could be swapped for a symlink between the
+	// stat and the call, and this directory is by definition writable by someone
+	// else. Group before mode, because chown clears the setuid/setgid bits and
+	// would undo a mode set first.
+	_ = lock.Chown(-1, int(stat.Gid))
+	_ = lock.Chmod(journalFileMode | 0o060)
+}
+
 // withExecutableLock runs fn holding the executable-keyed lock. Callers take it
 // AFTER the per-home preparation lock, always in that order, so two homes racing
 // the same binary cannot deadlock against each other.
@@ -142,7 +215,7 @@ func withExecutableLock(executablePath string, nonblocking bool, fn func() error
 	if err != nil {
 		return fmt.Errorf("validate executable for the upgrade lock: %w", err)
 	}
-	lock, err := acquireFileLockFlags(executableLockPath(executable), syscall.O_NOFOLLOW, nonblocking)
+	lock, err := acquireExecutableLock(executable, nonblocking)
 	if err != nil {
 		if nonblocking && errors.Is(err, ErrRecoveryActive) {
 			return ErrInstallLockBusy

--- a/internal/upgradetxn/install_lock.go
+++ b/internal/upgradetxn/install_lock.go
@@ -519,9 +519,30 @@ func lockHasInheritedACL(lock *os.File) bool {
 // reassigns it.
 // executableLockFreshWindow is how recently a still-private lock must have been
 // created for its denial to read as the creation race rather than as a legacy
-// private lock. Generous against the microseconds the real window takes, and far
-// below any age a leftover lock would have.
-const executableLockFreshWindow = 5 * time.Second
+// private lock.
+//
+// A still-private lock owned by someone else is OBSERVATIONALLY IDENTICAL in the
+// two cases that matter, and they want opposite answers:
+//
+//   - a leftover from a pre-change version, which never clears, so reporting
+//     busy defers the launch updater on every launch and silently retires
+//     auto-update;
+//   - a live creation race whose owner is merely stalled, where reporting a
+//     permission error sends the caller down the unlocked swap and lets it
+//     overlap the creator when it resumes.
+//
+// Nothing distinguishes them from here. The owner's pid is unknown, and its
+// flock cannot be probed without opening the file — which is the very thing
+// being denied. Age is the only available signal, so this is a threshold rather
+// than a decision, chosen to be wrong as rarely as possible.
+//
+// A minute is far past any create-then-fchmod pause that is not pathological —
+// those two syscalls are adjacent, and this covers a debugger, a SIGSTOP, or a
+// scheduler stall by orders of magnitude — while still far below the age of
+// anything left by a previous version. Past it, the behaviour is exactly what
+// that lock produces today without this change, so the residual case is not a
+// regression; inside it, an updater that defers costs one skipped launch.
+const executableLockFreshWindow = time.Minute
 
 var lockDenialIsTransient = executableLockDenialIsTransient
 

--- a/internal/upgradetxn/install_lock.go
+++ b/internal/upgradetxn/install_lock.go
@@ -186,27 +186,36 @@ func acquireExecutableLock(executable string, nonblocking bool) (*os.File, error
 		if err == nil || !errors.Is(err, os.ErrPermission) {
 			return lock, err
 		}
-		if _, shared := directoryWriterGroup(dir); !shared {
+		gid, shared := directoryWriterGroup(dir)
+		if !shared {
 			// A private directory. EACCES means a genuinely unauthorized caller and
 			// no amount of waiting changes the answer, so neither wait nor dress it
 			// up as contention.
 			return lock, err
 		}
 		if nonblocking {
-			// A shared directory, so this denial is very likely the transient
-			// 0600-to-0660 window of another writer's first acquisition. Report it
-			// as BUSY rather than as a permission error.
+			// A denial here is reported as BUSY only if it is TRANSIENT — the
+			// 0600-to-0660 window of another writer's first acquisition.
 			//
-			// That distinction decides what the caller does with it, and the two
-			// answers are not close. writeExecutableInPlaceWaiting defers only on
-			// ErrInstallLockBusy; on any other error it swaps the binary with
-			// NEITHER lock held, which is precisely the interleave with a live
-			// transaction this lock exists to prevent. Deferring an unattended
-			// launch-time update costs nothing — it retries next launch — while
-			// swapping unlocked can corrupt someone's rollback.
+			// That distinction decides what the caller does with it, and both wrong
+			// answers are bad in opposite directions. writeExecutableInPlaceWaiting
+			// defers only on ErrInstallLockBusy; on any other error it swaps the
+			// binary with NEITHER lock held, which is the interleave with a live
+			// transaction this lock exists to prevent. But a PERMANENT denial
+			// reported as busy is worse still: the launch updater defers, reports
+			// success, and silently never installs again.
 			//
-			// Returned without sleeping: the caller asked not to wait (#2951), and
-			// this reports the state rather than waiting out the window.
+			// "Is the directory shared" does not answer that question, which is what
+			// an earlier version of this branch got wrong. In the ownership topology
+			// this PR accepts as unfixable — a 0770 directory whose owner is not in
+			// its group, with the lock already widened to that group — the directory
+			// owner is denied permanently while the directory is genuinely shared.
+			//
+			// Returned without sleeping either way: the caller asked not to wait
+			// (#2951), and this reads the lock's state rather than waiting on it.
+			if !executableLockDenialIsTransient(path, gid) {
+				return lock, err
+			}
 			return nil, ErrInstallLockBusy
 		}
 		if attempt >= executableLockOpenRetries {
@@ -460,4 +469,39 @@ func hasExtendedACL(path string) bool {
 func lockHasInheritedACL(lock *os.File) bool {
 	_, err := unix.Fgetxattr(int(lock.Fd()), "system.posix_acl_access", nil)
 	return err == nil
+}
+
+// executableLockDenialIsTransient distinguishes a permission denial that will
+// clear on its own from one that never will, for a caller that cannot wait to
+// find out.
+//
+// The transient case is another writer's FIRST acquisition: the file must exist
+// before its mode can be adjusted, so it is briefly private between the create
+// and the fchmod. Microseconds later it is group-usable.
+//
+// The permanent case looks identical to the failed open and is only
+// distinguishable from the lock itself: once the widening has completed, the
+// group bits are set and the file carries the directory's group — so a caller
+// still denied at that point is denied for WHO IT IS, not for when it arrived.
+// The directory owner outside the directory's own group is exactly that caller,
+// and telling it to defer would silently retire its auto-update.
+//
+// stat needs only search permission on the directory, which any caller that got
+// this far already has. An absent lock means we are racing its creation, which
+// is the transient case by definition.
+func executableLockDenialIsTransient(lockPath string, dirGid int) bool {
+	info, err := os.Lstat(lockPath)
+	if err != nil {
+		return true
+	}
+	if !info.Mode().IsRegular() {
+		return false
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false
+	}
+	const groupUsable = 0o060
+	widened := info.Mode().Perm()&groupUsable == groupUsable && int(stat.Gid) == dirGid
+	return !widened
 }

--- a/internal/upgradetxn/install_lock.go
+++ b/internal/upgradetxn/install_lock.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 )
 
 // preparationLockName is the single lock that serialises publishing a
@@ -153,57 +154,137 @@ func executableLockPath(executable string) string {
 // directory, group-usable lock, carrying the DIRECTORY's group rather than the
 // creator's (a new file takes its creator's primary group, which on a shared box
 // is the wrong one and excludes exactly the users this is meant to admit).
-// nonblocking is threaded through rather than fixed, because #2951 gave the
-// launch path a lock acquisition that must fail fast instead of stalling a
-// start-up. Widening the mode is orthogonal to waiting for the lock and happens
-// on the descriptor either way.
+
+// A first acquisition in a shared directory has an unavoidable moment of private
+// state: the file must exist before its mode can be adjusted, so it is briefly
+// 0600 between the create and the fchmod. A second authorized writer landing in
+// that gap gets EACCES, and the in-place installer would swap the binary
+// unlocked — the very outcome this is closing. Retry rather than accept it.
+//
+// Retries are gated twice. On the directory actually being shared, so they never
+// delay the ordinary private-install case, where EACCES means a genuinely
+// unauthorized caller and no amount of waiting changes the answer. And on the
+// caller being willing to wait at all: #2951 gave the launch path a nonblocking
+// acquisition precisely so an unattended update cannot stall a start-up, and a
+// caller that refused to queue for the lock has not agreed to wait out someone
+// else's chmod either.
+//
+// Vars, not constants, so a test can widen the budget instead of racing a real one.
+var (
+	executableLockOpenRetries    = 4
+	executableLockOpenRetryDelay = 10 * time.Millisecond
+)
+
 func acquireExecutableLock(executable string, nonblocking bool) (*os.File, error) {
-	return acquireFileLockPrepared(
-		executableLockPath(executable), syscall.O_NOFOLLOW, nonblocking,
-		func(lock *os.File) { shareLockWithDirectoryWriters(lock, filepath.Dir(executable)) },
-	)
+	path := executableLockPath(executable)
+	dir := filepath.Dir(executable)
+	prepare := func(lock *os.File) { alignLockWithDirectoryWriters(lock, dir) }
+	for attempt := 0; ; attempt++ {
+		lock, err := acquireFileLockPrepared(path, syscall.O_NOFOLLOW, nonblocking, prepare)
+		if err == nil || nonblocking || attempt >= executableLockOpenRetries ||
+			!errors.Is(err, os.ErrPermission) {
+			return lock, err
+		}
+		if _, shared := directoryWriterGroup(dir); !shared {
+			return lock, err
+		}
+		time.Sleep(executableLockOpenRetryDelay)
+	}
 }
 
-// shareLockWithDirectoryWriters matches the lock's permissions to the install
-// directory's, best-effort.
+// directoryWriterGroup reports the group the install directory shares write
+// access with, and whether it shares at all. It is the single definition of
+// "this binary has more than one authorized writer", so the lock's mode and the
+// retry above cannot disagree about which directories are shared.
 //
-// Best-effort is the whole contract: every step here is an accommodation for
-// OTHER writers, and we already hold a working descriptor. When the lock was
-// created by a different user, the fchmod/fchown simply fail with EPERM — that
-// user got it right when they created it, or they did not and their own next
-// acquisition repairs it. Nothing here may turn into an error that stops an
-// upgrade.
-//
-// Two directory shapes are deliberately left at 0600:
-//
-//   - Not group-writable. No other principal can replace the binary, so 0600
-//     already covers every writer and widening would only enlarge the audience
-//     of a file nobody else needs.
-//   - World-writable. The lock BLOCKS rather than failing, so a lock any local
-//     user may open is a lock any local user may hold forever, stalling every
-//     upgrade on the box. #2897 rejected /tmp as the lock location on exactly
-//     this reasoning; it applies to the mode for the same reason. Nothing is
-//     given up by declining — a directory where anyone may swap the binary has
-//     no integrity left for this lock to protect.
-func shareLockWithDirectoryWriters(lock *os.File, dir string) {
+// A world-writable directory reports NOT shared. The lock BLOCKS rather than
+// failing, so a lock any local user may open is a lock any local user may hold
+// forever, stalling every upgrade on the box. #2897 rejected /tmp as the lock
+// location on exactly this reasoning; it applies to the mode for the same
+// reason. Nothing is given up by declining — a directory where anyone may swap
+// the binary has no integrity left for this lock to protect.
+func directoryWriterGroup(dir string) (int, bool) {
 	info, err := os.Stat(dir)
 	if err != nil {
-		return
+		return 0, false
 	}
 	perm := info.Mode().Perm()
 	if perm&0o020 == 0 || perm&0o002 != 0 {
+		return 0, false
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return int(stat.Gid), true
+}
+
+// alignLockWithDirectoryWriters keeps the lock's audience equal to the set of
+// principals the install directory trusts to replace the binary. Both
+// directions: a shared directory widens the lock, an unshared one narrows it
+// back. A one-way widen would leave a directory later tightened from 0770 to
+// 0750 with a 0660 lock its old group can still OPEN and hold — and because
+// this lock blocks, that group could then hang every future upgrade by the
+// owner without being able to install anything themselves.
+//
+// Best-effort is the whole contract: every step accommodates OTHER writers and
+// we already hold a working descriptor. When the lock belongs to a different
+// user the fchmod/fchown fail EPERM — that user either got it right or their
+// own next acquisition repairs it. Nothing here may become an error that stops
+// an upgrade.
+//
+// All of it operates on the descriptor already opened O_NOFOLLOW, never on the
+// path: this directory is by definition writable by someone else, so a
+// path-based chmod could be aimed at a symlink swapped in after the stat.
+func alignLockWithDirectoryWriters(lock *os.File, dir string) {
+	info, err := lock.Stat()
+	if err != nil || !info.Mode().IsRegular() {
 		return
 	}
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {
 		return
 	}
-	// fchown/fchmod on the descriptor we already opened O_NOFOLLOW, never a
-	// path-based chmod: a path here could be swapped for a symlink between the
-	// stat and the call, and this directory is by definition writable by someone
-	// else. Group before mode, because chown clears the setuid/setgid bits and
-	// would undo a mode set first.
-	_ = lock.Chown(-1, int(stat.Gid))
+	// O_NOFOLLOW rejects a SYMLINK at the lock path; it says nothing about a HARD
+	// LINK, which is not a distinct object at all but a second name for an inode
+	// that already exists. Anyone who can write this directory can leave
+	// `.af.af-upgrade.lock` pointing at the `af` binary itself, and an fchmod
+	// through that name would strip the executable bit off `af` before the swap
+	// ever started — bricking the install from a routine upgrade. Nlink is the
+	// direct test, and it guards the narrowing branch too: shrinking a linked
+	// inode to 0600 destroys it just as thoroughly.
+	//
+	// Declining to restyle is the safe answer rather than refusing the lock: it
+	// falls back to the pre-existing behaviour instead of standing between a user
+	// and their upgrade.
+	if stat.Nlink != 1 {
+		return
+	}
+
+	gid, shared := directoryWriterGroup(dir)
+	if !shared {
+		if info.Mode().Perm() != journalFileMode {
+			_ = lock.Chmod(journalFileMode)
+		}
+		return
+	}
+
+	// The group must MATCH the directory's, and the mode must not widen without
+	// it. A directory can be owned by one user and group-writable for a group
+	// that user does not belong to — they may replace the binary as its owner,
+	// but their chown to the directory's group is refused. Widening anyway would
+	// publish the lock to the CREATOR's primary group: the authorized writers
+	// still get EACCES and still install unlocked, while an unrelated group gains
+	// the ability to hold a blocking lock. Strictly worse than leaving it private,
+	// so the mode change is gated on the group being right.
+	//
+	// Group before mode, because chown clears the setuid/setgid bits and would
+	// undo a mode set first.
+	if int(stat.Gid) != gid {
+		if err := lock.Chown(-1, gid); err != nil {
+			return
+		}
+	}
 	_ = lock.Chmod(journalFileMode | 0o060)
 }
 

--- a/internal/upgradetxn/install_lock.go
+++ b/internal/upgradetxn/install_lock.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 // preparationLockName is the single lock that serialises publishing a
@@ -181,11 +183,33 @@ func acquireExecutableLock(executable string, nonblocking bool) (*os.File, error
 	prepare := func(lock *os.File) { alignLockWithDirectoryWriters(lock, dir) }
 	for attempt := 0; ; attempt++ {
 		lock, err := acquireFileLockPrepared(path, syscall.O_NOFOLLOW, nonblocking, prepare)
-		if err == nil || nonblocking || attempt >= executableLockOpenRetries ||
-			!errors.Is(err, os.ErrPermission) {
+		if err == nil || !errors.Is(err, os.ErrPermission) {
 			return lock, err
 		}
 		if _, shared := directoryWriterGroup(dir); !shared {
+			// A private directory. EACCES means a genuinely unauthorized caller and
+			// no amount of waiting changes the answer, so neither wait nor dress it
+			// up as contention.
+			return lock, err
+		}
+		if nonblocking {
+			// A shared directory, so this denial is very likely the transient
+			// 0600-to-0660 window of another writer's first acquisition. Report it
+			// as BUSY rather than as a permission error.
+			//
+			// That distinction decides what the caller does with it, and the two
+			// answers are not close. writeExecutableInPlaceWaiting defers only on
+			// ErrInstallLockBusy; on any other error it swaps the binary with
+			// NEITHER lock held, which is precisely the interleave with a live
+			// transaction this lock exists to prevent. Deferring an unattended
+			// launch-time update costs nothing — it retries next launch — while
+			// swapping unlocked can corrupt someone's rollback.
+			//
+			// Returned without sleeping: the caller asked not to wait (#2951), and
+			// this reports the state rather than waiting out the window.
+			return nil, ErrInstallLockBusy
+		}
+		if attempt >= executableLockOpenRetries {
 			return lock, err
 		}
 		time.Sleep(executableLockOpenRetryDelay)
@@ -223,6 +247,31 @@ func directoryWriterGroup(dir string) (int, bool) {
 	)
 	perm := info.Mode().Perm()
 	if perm&groupMayWrite != groupMayWrite || perm&otherMayWrite == otherMayWrite {
+		return 0, false
+	}
+	// Everything above reads the mode bits as if they described the set of
+	// principals who may replace the binary. Two things make that reading false,
+	// and the only safe response to either is to stop reading them.
+	//
+	// STICKY (e.g. 1770). Group write and search let a member CREATE entries, but
+	// the sticky bit restricts renaming and removing to the entry's owner, the
+	// directory's owner, or a privileged process — so a group member generally
+	// cannot replace a binary owned by someone else. Widening there admits
+	// exactly the principals who cannot install, handing them a blocking lock and
+	// a denial of service the private lock never had. Perm() drops this bit, so
+	// it has to be read off the full mode.
+	//
+	// EXTENDED ACLs. With a POSIX ACL present, the group class bits returned by
+	// stat are the ACL MASK, not the owning group's effective rights. A directory
+	// can grant a named user rwx while the owning group has r-x and the mask
+	// reads rwx: the mode says "group-writable", the truth is that the group
+	// cannot write and a user invisible to the mode can. Widening on that gets
+	// both halves wrong at once.
+	//
+	// Declining costs only the widening — the lock still works for its creator,
+	// and the topology behaves exactly as it did before any of this — whereas
+	// guessing wrong hands a blocking lock to non-writers.
+	if info.Mode()&os.ModeSticky != 0 || hasExtendedACL(dir) {
 		return 0, false
 	}
 	stat, ok := info.Sys().(*syscall.Stat_t)
@@ -359,4 +408,22 @@ func foreignTransactionOver(executable, selfID string) (string, error) {
 		return id, nil
 	}
 	return "", nil
+}
+
+// hasExtendedACL reports whether the path carries a POSIX access ACL, which
+// makes the group-class mode bits a MASK rather than a statement about the
+// owning group (see directoryWriterGroup).
+//
+// Presence is the whole question — the entries are never parsed. This is used
+// only to DECLINE widening, so the conservative answer on any uncertainty is
+// "assume ambiguity", and a probe that cannot tell simply reports false and
+// leaves the mode-bit reading in charge, which is where it was before.
+//
+// The xattr name is the Linux one. On other unixes the call fails and this
+// reports false: their ACL models differ, and inventing a cross-platform answer
+// here would be guessing rather than probing.
+func hasExtendedACL(path string) bool {
+	// A zero-length read: only the error matters, never the value.
+	_, err := unix.Getxattr(path, "system.posix_acl_access", nil)
+	return err == nil
 }

--- a/internal/upgradetxn/install_lock.go
+++ b/internal/upgradetxn/install_lock.go
@@ -208,8 +208,21 @@ func directoryWriterGroup(dir string) (int, bool) {
 	if err != nil {
 		return 0, false
 	}
+	// Write AND execute, for both classes. On a DIRECTORY the write bit alone
+	// confers nothing: creating, removing, or renaming an entry needs search
+	// permission too, so a class with w and no x cannot replace the binary and
+	// cannot plant the lock. Testing write alone gets both directions wrong — a
+	// 0720 directory would widen the lock to a group that cannot install
+	// anything, and a 0772 directory (group rwx, a stray other-write bit that
+	// grants no traversal) would be misread as world-writable and left private,
+	// so the group writers who really can install still get EACCES and still swap
+	// unlocked.
+	const (
+		groupMayWrite = 0o030 // group write + group search
+		otherMayWrite = 0o003 // other write + other search
+	)
 	perm := info.Mode().Perm()
-	if perm&0o020 == 0 || perm&0o002 != 0 {
+	if perm&groupMayWrite != groupMayWrite || perm&otherMayWrite == otherMayWrite {
 		return 0, false
 	}
 	stat, ok := info.Sys().(*syscall.Stat_t)

--- a/internal/upgradetxn/lock.go
+++ b/internal/upgradetxn/lock.go
@@ -62,9 +62,24 @@ func acquireFileLock(path string, nonblocking bool) (*os.File, error) {
 // symlink planted there would have this create a file somewhere it was never
 // asked to touch.
 func acquireFileLockFlags(path string, extraFlags int, nonblocking bool) (*os.File, error) {
+	return acquireFileLockPrepared(path, extraFlags, nonblocking, nil)
+}
+
+// acquireFileLockPrepared is acquireFileLockFlags with a hook that runs on the
+// open descriptor before the lock is taken. Only the executable lock uses it, to
+// widen a lock it may have just created; every other lock here is private to one
+// AF home and passes nil. The hook cannot fail the acquisition — adjusting a
+// lock we already hold a usable descriptor for is an accommodation for OTHER
+// writers, never a precondition for this one.
+func acquireFileLockPrepared(
+	path string, extraFlags int, nonblocking bool, prepare func(*os.File),
+) (*os.File, error) {
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|extraFlags, journalFileMode)
 	if err != nil {
 		return nil, err
+	}
+	if prepare != nil {
+		prepare(file)
 	}
 	operation := syscall.LOCK_EX
 	if nonblocking {

--- a/internal/upgradetxn/prepare.go
+++ b/internal/upgradetxn/prepare.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -67,7 +66,7 @@ func Prepare(stablePlan Plan) (_ *Transaction, retErr error) {
 	// would still rename over the same binary. Take the executable-keyed lock
 	// too, always after the home lock so two homes racing one binary order their
 	// acquisitions identically and cannot deadlock (#2212).
-	executableLock, err := acquireFileLockFlags(executableLockPath(executable), syscall.O_NOFOLLOW, false)
+	executableLock, err := acquireExecutableLock(executable, false)
 	if err != nil {
 		return nil, fmt.Errorf("lock the executable for upgrade: %w", err)
 	}


### PR DESCRIPTION
Follow-up to the unresolved Codex finding on #2897 (tracked in #2948).

## The finding

> When the executable lives in a group-writable shared install directory, the first user to hit this path creates the shared lock as `journalFileMode` (0600) via `acquireFileLockFlags`; a second user who can still rename the binary cannot open that existing lock. On the in-place path `writeExecutableInPlace` treats that open error as a lock failure and installs unlocked.

Verified still live on `master` (`0f19aefb`, unchanged since). Both halves check out:

- `acquireFileLockFlags` opens with `journalFileMode` (0600) — `internal/upgradetxn/lock.go`.
- `writeExecutableInPlace` logs `"cannot take the upgrade lock, so this install is not serialised against a daemon upgrade"` and calls `swap()` anyway — `commands/upgrade_interlock.go`. That fallback is correct policy and is not what changes here.

The result is the failure mode the executable key was introduced to remove: two homes — now two *users* — interleaving a swap with another home's `Prepare`. It fails silently, and only for the users who did not create the lock.

## Fix

Derive the lock's audience from the install directory's, since the directory is what decides who may replace the binary in the first place.

- Group-writable directory → lock is 0660 and carries the **directory's** group. The group half is load-bearing: a new file takes its creator's primary group, so a 0660 lock in the creator's group still excludes the other members of the shared group — the same bug with one extra step.
- `fchmod`/`fchown` on the descriptor already opened `O_NOFOLLOW`, never a path-based `chmod`: this directory is by definition writable by someone else, so a path could be swapped for a symlink between the stat and the call. Group before mode, because `chown` clears the setgid bit.
- Best-effort throughout. We already hold a usable descriptor; every step here accommodates *other* writers, so none of it may turn into an error that stops an upgrade. When the lock belongs to another user the calls fail `EPERM` and are ignored.
- An existing 0600 lock is widened by its owner on the next acquisition, so a pre-fix lock self-heals instead of poisoning the file permanently.

Two shapes deliberately stay 0600:

- **Not group-writable** — no other principal can replace the binary, so 0600 already covers every writer.
- **World-writable** — the lock *blocks* rather than failing, so a lock any local user may open is one any local user may hold forever, hanging every upgrade on the box. #2897 rejected `/tmp` as the lock location on exactly this reasoning and it applies unchanged to the mode. Nothing is given up: a directory where anyone may swap the binary has no integrity left for this lock to protect.

## Adjacent call site the finding did not name

`Prepare` spelled its own `acquireFileLockFlags(executableLockPath(...))` rather than going through `withExecutableLock`, so it had the identical defect with a **harder** failure: it returns the open error, so on a shared box the second user's transactional upgrade did not merely go unlocked, it failed outright. Both paths now go through one `acquireExecutableLock`, so the two acquisitions cannot drift again.

## Tests

New `internal/upgradetxn/executable_lock_sharing_test.go`. **4 of the 5 fail against master's code** (`0x180` = 0600 where `0x1b0` = 0660 is required) and pass after:

| test | on master |
|---|---|
| `TestExecutableLock_SharedWithTheDirectorysWriters` | FAIL |
| `TestExecutableLock_TakesTheDirectorysGroup` | FAIL |
| `TestExecutableLock_WidensAnExistingPrivateLock` | FAIL |
| `TestPrepare_SharesTheExecutableLockToo` | FAIL |
| `TestExecutableLock_NotWidenedInAWorldWritableDirectory` | PASS — it guards the fix from over-reaching, so it is *supposed* to hold both before and after |

Two details worth naming:

- The fixtures `chmod` explicitly after `os.Mkdir`, because the umask would otherwise turn a requested 0770 into 0750 and the test would assert against a directory that was never group-writable. The fixture asserts its own mode before proceeding.
- `TestExecutableLock_TakesTheDirectorysGroup` retargets the directory to a **secondary** group of the test user first. Without that, the temp dir's group already equals the creator's primary group, and `lock gid == dir gid` would pass against completely unfixed code. It skips honestly where the user has no second group. (It ran, not skipped, on the dev box and should on CI.)

Existing `TestWithExecutableLock_LeavesAPrivateLockFile` is unchanged and still passes — `t.TempDir()` is 0700, the not-group-writable case, which must stay 0600.

## Verification

`gofmt -l .`, `go build ./...`, `golangci-lint run --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` all clean. `go test ./internal/upgradetxn/` (also under `-race`) and `go test ./commands/` green. No daemon/app tests run on the dev box, per the standing rule.

## Second commit: four review findings on the widening above

The first is a hazard the widening itself introduced.

**Hard-linked lock path.** `O_NOFOLLOW` rejects a symlink; it says nothing about a hard link, which is not a separate object at all but a second name for an existing inode. Anyone who can write a shared install directory can leave `.af.af-upgrade.lock` pointing at `af` itself, and an `fchmod` through that name strips the executable bit off the binary before the swap starts. **Measured: `af` went 0755 → 0660 under the first commit.** Guarded with `Nlink != 1`, which also gates the narrowing branch — shrinking a linked inode destroys it just as thoroughly. Declining to restyle rather than refusing the lock keeps the rule that a lock problem never blocks an install.

**Widening without the group.** A directory can be owned by one user and group-writable for a group that user is not in: they may replace the binary as its owner, but their `chown` is refused. Widening anyway published the lock to the *creator's* primary group — the authorized writers still got EACCES and still installed unlocked, while an unrelated group gained the ability to hold a blocking lock. Strictly worse than private, so the mode change is gated on the group being right.

**One-way ratchet.** A directory later tightened from 0770 to 0750 kept its 0660 lock, so its former group could no longer install but could still open the known path and hold it, hanging every future upgrade by the owner. The audience now tracks the directory in both directions — which is what "the lock's audience equals the directory's writers" has to mean to be an invariant rather than a ratchet.

**The creation window.** The file must exist before its mode can be adjusted, so it is briefly 0600 even in a shared directory. Retry on EACCES, gated on the directory actually being shared via the same predicate that decides whether to widen — in a private directory EACCES means a genuinely unauthorized caller and waiting cannot change the answer. This bounds the creation window; it does not eliminate the gap, and a pre-existing 0600 lock can still be lost once to a racing writer before it self-heals. An atomic create-with-mode (temp → `link`) would close it fully and was rejected as trading a bounded retry for stray temp files and an EEXIST path to get wrong.

Three of the four new tests fail against the first commit. The fourth (no retry in a private directory) guards the retry from over-reaching and holds both before and after, like the world-writable case above.

**One arm is covered by inspection, not by a test:** the refused-`chown` case needs a directory whose group the test user is not a member of, and creating that state requires privileges the test does not have (`os.Chown` to a non-member group is itself EPERM; running as root makes the failure path unreachable instead). Saying so rather than implying the suite covers it.

## Rebase onto master: one deliberate semantic decision

This PR sat `CONFLICTING` for a while, which meant **only CodeQL ran** — four green checks on a Go PR whose Go suite had never executed. Rebased onto master; check-runs went 4 → 13.

The conflict was not textual. #2951 landed `TryWithInstallLock` and threaded a `nonblocking` flag down to the executable lock, so the launch-time updater fails fast instead of stalling a start-up. That meets the retry added here, and the two had to be reconciled rather than merged:

**The retry is now skipped entirely when `nonblocking` is set.** A caller that refused to queue for the lock has not agreed to wait out someone else's `chmod` either — honouring the retry there would reintroduce exactly the start-up stall #2951 removed, just through a different door and only on shared installs, which is the hardest kind of regression to notice. Blocking callers (`af upgrade`, `Prepare`) keep the full 4 × 10ms budget.

`nonblocking` is also passed through to the acquisition itself, so `ErrInstallLockBusy` still surfaces unchanged.

## Scope, stated plainly

Eight review findings landed on this PR. Seven were real and are fixed; one is real and cannot be fixed from inside an unprivileged process. Every one after the first was in the **classification** — deciding who may replace the binary — never in the widening mechanism itself. That is the intrinsic cost of inferring an authorization set from observations that are not atomic with the decision, so the claim is now deliberately narrow:

**The lock is widened only when the install directory's mode bits are the whole story** — Linux, no sticky bit, no ACL on the directory, no ACL inherited by the lock, group write *and* search, no world write. Anything else declines and the lock stays private, which is exactly the behaviour before this PR. Nothing regresses; the widening simply does not apply there.

Known and not fixed: a directory whose owner is not in its own group. The owner can replace the binary through the owner bits but can never open a group-owned lock, and handing them the lock needs `CAP_CHOWN`. That topology keeps its pre-PR behaviour — permission error, logged warning, unlocked swap — and is documented in the review thread rather than silently implied to be covered.

Refs #2948
Refs #2897

🤖 Generated with [Claude Code](https://claude.com/claude-code)