### PR TITLE
[HOLD] fix(daemon): re-check the session after the post-worktree hook wait

### DIFF
--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -305,6 +305,14 @@ func (m *Manager) SendPrompt(req SendPromptRequest) error {
 	// is the reliable command path automated deliveries need. This crosses the
 	// socket, so its failure is ambiguous ("never sent" vs "sent, reply lost") and
 	// is deliberately NOT tagged notAttempted — an ambiguous failure stays charged.
+	// Mark BEFORE the send. This crossing is exactly the ambiguous one the
+	// comment above describes, and for "has this session been adopted since a
+	// task run finished?" a possible delivery must count as one — otherwise a
+	// send that landed but lost its reply would leave the session eligible for
+	// an on_complete teardown that destroys the user's work (#2948). Marking
+	// first also removes the window where the prompt has landed and the mark has
+	// not.
+	instance.NotePromptDelivery()
 	if err := instance.AgentServer().SendPrompt(req.Prompt); err != nil {
 		return fmt.Errorf("failed to send prompt: %w", err)
 	}

--- a/daemon/task_session_lifecycle.go
+++ b/daemon/task_session_lifecycle.go
@@ -190,6 +190,10 @@ func (m *Manager) applyTaskSessionLifecycleOnRunEnd(repoID string, instance *ses
 	// this verb is owed to ended; see stillTheFinishedRun for why a level check
 	// on liveness cannot answer that.
 	completedAtEpoch := instance.StateEpoch()
+	// And the delivery count, because the epoch cannot see a prompt: delivery
+	// does not touch the lifecycle axes, so between a send and the poll
+	// observing the agent working the epoch still reads unchanged (#2948).
+	completedAtDeliveries := instance.PromptDeliveries()
 	hooksDone := instance.PostWorktreeHooksDone()
 	verb, err := m.taskSessionLifecycle(repoID, taskID)
 	if err != nil {
@@ -204,7 +208,7 @@ func (m *Manager) applyTaskSessionLifecycleOnRunEnd(repoID string, instance *ses
 	if verb == task.OnCompleteKeep {
 		return
 	}
-	go m.runTaskSessionLifecycle(repoID, sessionID, title, taskID, verb, completedAtEpoch, hooksDone)
+	go m.runTaskSessionLifecycle(repoID, sessionID, title, taskID, verb, completedAtEpoch, completedAtDeliveries, hooksDone)
 }
 
 // taskSessionLifecycle resolves the on_complete verb for one task in a repo.
@@ -236,7 +240,7 @@ func (m *Manager) taskSessionLifecycle(repoID, taskID string) (string, error) {
 // describes reality: a same-titled replacement now holds the key, or the user
 // picked the work back up. A verb owed to a finished run must never land on new
 // work.
-func (m *Manager) stillTheFinishedRun(repoID, sessionID, title string, completedAtEpoch uint64) bool {
+func (m *Manager) stillTheFinishedRun(repoID, sessionID, title string, completedAtEpoch, completedAtDeliveries uint64) bool {
 	m.mu.Lock()
 	instance := m.instances[daemonInstanceKey(repoID, title)]
 	m.mu.Unlock()
@@ -254,7 +258,12 @@ func (m *Manager) stillTheFinishedRun(repoID, sessionID, title string, completed
 	// axes, so a turn that starts and finishes still moves it. Unchanged epoch
 	// therefore means nothing at all has happened since the completion this verb
 	// was owed to, which is the only condition under which acting on it is safe.
-	return instance.StateEpoch() == completedAtEpoch
+	// Both, because neither alone is sufficient. The epoch catches a turn that
+	// started and finished; the delivery count catches a prompt that has landed
+	// but whose liveness edge the poll has not observed yet — the window that
+	// made the epoch-only guard wrong.
+	return instance.StateEpoch() == completedAtEpoch &&
+		instance.PromptDeliveries() == completedAtDeliveries
 }
 
 // runTaskSessionLifecycle performs the teardown on its own goroutine.
@@ -270,7 +279,7 @@ func (m *Manager) stillTheFinishedRun(repoID, sessionID, title string, completed
 // same title between the completion edge and this call cannot be reaped in the
 // original's place — the resolver only falls back to {Title, RepoID} when ID is
 // empty.
-func (m *Manager) runTaskSessionLifecycle(repoID, sessionID, title, taskID, verb string, completedAtEpoch uint64, hooksDone <-chan struct{}) {
+func (m *Manager) runTaskSessionLifecycle(repoID, sessionID, title, taskID, verb string, completedAtEpoch, completedAtDeliveries uint64, hooksDone <-chan struct{}) {
 	// post_worktree_commands can still be running: the agent's readiness and the
 	// hook run are deliberately concurrent (task.WaitForReady does not charge a
 	// slow build hook against the startup budget), so a short task can finish while
@@ -300,7 +309,7 @@ func (m *Manager) runTaskSessionLifecycle(repoID, sessionID, title, taskID, verb
 	// This is the rule applyDeferredTaskSessionLifecycle already applies across
 	// the attach deferral; the hook wait is a second place the same staleness
 	// arises, and it deserves the same answer.
-	if !m.stillTheFinishedRun(repoID, sessionID, title, completedAtEpoch) {
+	if !m.stillTheFinishedRun(repoID, sessionID, title, completedAtEpoch, completedAtDeliveries) {
 		log.InfoLog.Printf("task %s: session %q changed while its post-worktree hooks finished; leaving it in place rather than applying on_complete=%s", taskID, title, verb)
 		return
 	}

--- a/daemon/task_session_lifecycle.go
+++ b/daemon/task_session_lifecycle.go
@@ -224,6 +224,23 @@ func (m *Manager) taskSessionLifecycle(repoID, taskID string) (string, error) {
 	return task.OnCompleteKeep, nil
 }
 
+// stillTheFinishedRun reports whether the session that owed a teardown is still
+// the same session, still idle, and still not running a task.
+//
+// Any of those changing means the decision the completion edge made no longer
+// describes reality: a same-titled replacement now holds the key, or the user
+// picked the work back up. A verb owed to a finished run must never land on new
+// work.
+func (m *Manager) stillTheFinishedRun(repoID, sessionID, title string) bool {
+	m.mu.Lock()
+	instance := m.instances[daemonInstanceKey(repoID, title)]
+	m.mu.Unlock()
+	if instance == nil || instance.ID != sessionID {
+		return false
+	}
+	return instance.GetLiveness() == session.LiveReady && !instance.TaskRunActive()
+}
+
 // runTaskSessionLifecycle performs the teardown on its own goroutine.
 //
 // It reuses ArchiveSession/KillSession rather than reaching for the primitives
@@ -257,6 +274,21 @@ func (m *Manager) runTaskSessionLifecycle(repoID, sessionID, title, taskID, verb
 			return
 		}
 	}
+	// The hook wait can last minutes, and the session is visible and Ready
+	// throughout it. A user who prompts it in that window has adopted the work —
+	// it is theirs now, not the task's — so re-ask the same question the
+	// completion edge asked instead of acting on an answer that may be minutes
+	// stale. Without this, on_complete=kill|archive destroys work started after
+	// the run finished.
+	//
+	// This is the rule applyDeferredTaskSessionLifecycle already applies across
+	// the attach deferral; the hook wait is a second place the same staleness
+	// arises, and it deserves the same answer.
+	if !m.stillTheFinishedRun(repoID, sessionID, title) {
+		log.InfoLog.Printf("task %s: session %q changed while its post-worktree hooks finished; leaving it in place rather than applying on_complete=%s", taskID, title, verb)
+		return
+	}
+
 	var err error
 	switch verb {
 	case task.OnCompleteArchive:

--- a/daemon/task_session_lifecycle.go
+++ b/daemon/task_session_lifecycle.go
@@ -185,6 +185,11 @@ func (m *Manager) applyTaskSessionLifecycleOnRunEnd(repoID string, instance *ses
 	// the last time a lifecycle op keyed on a title reached the wrong worktree.
 	sessionID := instance.ID
 	title := instance.Title
+	// Captured HERE, at the completion edge, alongside the id — not read later.
+	// It is the proof that nothing has happened to this session since the run
+	// this verb is owed to ended; see stillTheFinishedRun for why a level check
+	// on liveness cannot answer that.
+	completedAtEpoch := instance.StateEpoch()
 	hooksDone := instance.PostWorktreeHooksDone()
 	verb, err := m.taskSessionLifecycle(repoID, taskID)
 	if err != nil {
@@ -199,7 +204,7 @@ func (m *Manager) applyTaskSessionLifecycleOnRunEnd(repoID string, instance *ses
 	if verb == task.OnCompleteKeep {
 		return
 	}
-	go m.runTaskSessionLifecycle(repoID, sessionID, title, taskID, verb, hooksDone)
+	go m.runTaskSessionLifecycle(repoID, sessionID, title, taskID, verb, completedAtEpoch, hooksDone)
 }
 
 // taskSessionLifecycle resolves the on_complete verb for one task in a repo.
@@ -231,14 +236,25 @@ func (m *Manager) taskSessionLifecycle(repoID, taskID string) (string, error) {
 // describes reality: a same-titled replacement now holds the key, or the user
 // picked the work back up. A verb owed to a finished run must never land on new
 // work.
-func (m *Manager) stillTheFinishedRun(repoID, sessionID, title string) bool {
+func (m *Manager) stillTheFinishedRun(repoID, sessionID, title string, completedAtEpoch uint64) bool {
 	m.mu.Lock()
 	instance := m.instances[daemonInstanceKey(repoID, title)]
 	m.mu.Unlock()
 	if instance == nil || instance.ID != sessionID {
 		return false
 	}
-	return instance.GetLiveness() == session.LiveReady && !instance.TaskRunActive()
+	// The epoch, not the current liveness, is what answers this. Liveness is a
+	// LEVEL: a user who prompts the finished session during the hook wait drives
+	// it Ready→Running→Ready, so by the time the hooks finish it reads Ready
+	// again and a level check waves the teardown through onto their work.
+	// TaskRunActive cannot help either — it is permanently false once the task's
+	// own run ends, so it cannot distinguish the task's idle from the user's.
+	//
+	// StateEpoch is an EDGE: it is bumped by every real change to the lifecycle
+	// axes, so a turn that starts and finishes still moves it. Unchanged epoch
+	// therefore means nothing at all has happened since the completion this verb
+	// was owed to, which is the only condition under which acting on it is safe.
+	return instance.StateEpoch() == completedAtEpoch
 }
 
 // runTaskSessionLifecycle performs the teardown on its own goroutine.
@@ -254,7 +270,7 @@ func (m *Manager) stillTheFinishedRun(repoID, sessionID, title string) bool {
 // same title between the completion edge and this call cannot be reaped in the
 // original's place — the resolver only falls back to {Title, RepoID} when ID is
 // empty.
-func (m *Manager) runTaskSessionLifecycle(repoID, sessionID, title, taskID, verb string, hooksDone <-chan struct{}) {
+func (m *Manager) runTaskSessionLifecycle(repoID, sessionID, title, taskID, verb string, completedAtEpoch uint64, hooksDone <-chan struct{}) {
 	// post_worktree_commands can still be running: the agent's readiness and the
 	// hook run are deliberately concurrent (task.WaitForReady does not charge a
 	// slow build hook against the startup budget), so a short task can finish while
@@ -284,7 +300,7 @@ func (m *Manager) runTaskSessionLifecycle(repoID, sessionID, title, taskID, verb
 	// This is the rule applyDeferredTaskSessionLifecycle already applies across
 	// the attach deferral; the hook wait is a second place the same staleness
 	// arises, and it deserves the same answer.
-	if !m.stillTheFinishedRun(repoID, sessionID, title) {
+	if !m.stillTheFinishedRun(repoID, sessionID, title, completedAtEpoch) {
 		log.InfoLog.Printf("task %s: session %q changed while its post-worktree hooks finished; leaving it in place rather than applying on_complete=%s", taskID, title, verb)
 		return
 	}

--- a/daemon/task_session_lifecycle_recheck_test.go
+++ b/daemon/task_session_lifecycle_recheck_test.go
@@ -1,0 +1,51 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/stretchr/testify/require"
+)
+
+// The post-worktree hook wait can last minutes with the session visible and
+// Ready. A user who prompts it in that window has adopted the work, and an
+// on_complete owed to the finished run must not land on it — otherwise
+// kill|archive destroys work started after the task completed (#2948, from
+// #2861's review).
+func TestStillTheFinishedRun(t *testing.T) {
+	newManager := func(inst *session.Instance, repoID, title string) *Manager {
+		m := &Manager{instances: map[string]*session.Instance{}}
+		if inst != nil {
+			m.instances[daemonInstanceKey(repoID, title)] = inst
+		}
+		return m
+	}
+
+	t.Run("unchanged idle run is still ours", func(t *testing.T) {
+		inst := &session.Instance{ID: "sess-1", Title: "t"}
+		inst.SetStatusForTest(session.Ready)
+		m := newManager(inst, "repo", "t")
+		require.True(t, m.stillTheFinishedRun("repo", "sess-1", "t"))
+	})
+
+	t.Run("a same-titled replacement is not ours", func(t *testing.T) {
+		inst := &session.Instance{ID: "sess-2", Title: "t"}
+		inst.SetStatusForTest(session.Ready)
+		m := newManager(inst, "repo", "t")
+		require.False(t, m.stillTheFinishedRun("repo", "sess-1", "t"),
+			"a verb owed to one session must never land on its replacement")
+	})
+
+	t.Run("a session the user set working again is not ours", func(t *testing.T) {
+		inst := &session.Instance{ID: "sess-1", Title: "t"}
+		inst.SetStatusForTest(session.Running)
+		m := newManager(inst, "repo", "t")
+		require.False(t, m.stillTheFinishedRun("repo", "sess-1", "t"),
+			"work adopted during the hook wait is the user's, not the task's")
+	})
+
+	t.Run("a vanished session is not ours", func(t *testing.T) {
+		m := newManager(nil, "repo", "t")
+		require.False(t, m.stillTheFinishedRun("repo", "sess-1", "t"))
+	})
+}

--- a/daemon/task_session_lifecycle_recheck_test.go
+++ b/daemon/task_session_lifecycle_recheck_test.go
@@ -25,7 +25,7 @@ func TestStillTheFinishedRun(t *testing.T) {
 		inst := &session.Instance{ID: "sess-1", Title: "t"}
 		inst.SetStatusForTest(session.Ready)
 		m := newManager(inst, "repo", "t")
-		require.True(t, m.stillTheFinishedRun("repo", "sess-1", "t", inst.StateEpoch()))
+		require.True(t, m.stillTheFinishedRun("repo", "sess-1", "t", inst.StateEpoch(), inst.PromptDeliveries()))
 	})
 
 	// The case a liveness level check cannot see, and the reason this uses an
@@ -38,13 +38,14 @@ func TestStillTheFinishedRun(t *testing.T) {
 		inst.SetStatusForTest(session.Ready)
 		m := newManager(inst, "repo", "t")
 		atCompletion := inst.StateEpoch()
+		atDeliveries := inst.PromptDeliveries()
 
 		require.NoError(t, inst.Transition(session.ObserveLiveness(session.LiveRunning)))
 		require.NoError(t, inst.Transition(session.ObserveLiveness(session.LiveReady)))
 
 		require.Equal(t, session.LiveReady, inst.GetLiveness(), "it looks idle again")
 		require.False(t, inst.TaskRunActive(), "and the task run is long over")
-		require.False(t, m.stillTheFinishedRun("repo", "sess-1", "t", atCompletion),
+		require.False(t, m.stillTheFinishedRun("repo", "sess-1", "t", atCompletion, atDeliveries),
 			"a turn that started and finished still moved the epoch, so the verb must not land")
 	})
 
@@ -52,7 +53,7 @@ func TestStillTheFinishedRun(t *testing.T) {
 		inst := &session.Instance{ID: "sess-2", Title: "t"}
 		inst.SetStatusForTest(session.Ready)
 		m := newManager(inst, "repo", "t")
-		require.False(t, m.stillTheFinishedRun("repo", "sess-1", "t", inst.StateEpoch()),
+		require.False(t, m.stillTheFinishedRun("repo", "sess-1", "t", inst.StateEpoch(), inst.PromptDeliveries()),
 			"a verb owed to one session must never land on its replacement")
 	})
 
@@ -61,13 +62,36 @@ func TestStillTheFinishedRun(t *testing.T) {
 		inst.SetStatusForTest(session.Ready)
 		m := newManager(inst, "repo", "t")
 		atCompletion := inst.StateEpoch()
+		atDeliveries := inst.PromptDeliveries()
 		require.NoError(t, inst.Transition(session.ObserveLiveness(session.LiveRunning)))
-		require.False(t, m.stillTheFinishedRun("repo", "sess-1", "t", atCompletion),
+		require.False(t, m.stillTheFinishedRun("repo", "sess-1", "t", atCompletion, atDeliveries),
 			"work adopted during the hook wait is the user's, not the task's")
 	})
 
 	t.Run("a vanished session is not ours", func(t *testing.T) {
 		m := newManager(nil, "repo", "t")
-		require.False(t, m.stillTheFinishedRun("repo", "sess-1", "t", 0))
+		require.False(t, m.stillTheFinishedRun("repo", "sess-1", "t", 0, 0))
 	})
+}
+
+// The case neither the liveness level NOR the epoch can see: a prompt delivered
+// during the hook wait whose liveness edge the poll has not observed yet. The
+// session still reads Ready, TaskRunActive is still false, and the epoch is
+// unchanged — every lifecycle signal says nothing happened, and the work is
+// nonetheless the user's now.
+func TestStillTheFinishedRun_APromptDeliveredDuringTheWaitIsAdoption(t *testing.T) {
+	inst := &session.Instance{ID: "sess-1", Title: "t"}
+	inst.SetStatusForTest(session.Ready)
+	m := &Manager{instances: map[string]*session.Instance{
+		daemonInstanceKey("repo", "t"): inst,
+	}}
+	atEpoch, atDeliveries := inst.StateEpoch(), inst.PromptDeliveries()
+
+	inst.NotePromptDelivery()
+
+	require.Equal(t, session.LiveReady, inst.GetLiveness(), "it still reads idle")
+	require.False(t, inst.TaskRunActive(), "and the task run is still over")
+	require.Equal(t, atEpoch, inst.StateEpoch(), "and the epoch has not moved")
+	require.False(t, m.stillTheFinishedRun("repo", "sess-1", "t", atEpoch, atDeliveries),
+		"a delivered prompt is adoption even before its liveness edge is observed")
 }

--- a/daemon/task_session_lifecycle_recheck_test.go
+++ b/daemon/task_session_lifecycle_recheck_test.go
@@ -25,27 +25,49 @@ func TestStillTheFinishedRun(t *testing.T) {
 		inst := &session.Instance{ID: "sess-1", Title: "t"}
 		inst.SetStatusForTest(session.Ready)
 		m := newManager(inst, "repo", "t")
-		require.True(t, m.stillTheFinishedRun("repo", "sess-1", "t"))
+		require.True(t, m.stillTheFinishedRun("repo", "sess-1", "t", inst.StateEpoch()))
+	})
+
+	// The case a liveness level check cannot see, and the reason this uses an
+	// epoch: the user prompts the finished session during the hook wait and the
+	// turn SETTLES BACK to Ready before the hooks end. Liveness reads Ready
+	// again and TaskRunActive is permanently false, so both look exactly like an
+	// untouched finished run — but the work is now the user's.
+	t.Run("work adopted and settled back to Ready is not ours", func(t *testing.T) {
+		inst := &session.Instance{ID: "sess-1", Title: "t"}
+		inst.SetStatusForTest(session.Ready)
+		m := newManager(inst, "repo", "t")
+		atCompletion := inst.StateEpoch()
+
+		require.NoError(t, inst.Transition(session.ObserveLiveness(session.LiveRunning)))
+		require.NoError(t, inst.Transition(session.ObserveLiveness(session.LiveReady)))
+
+		require.Equal(t, session.LiveReady, inst.GetLiveness(), "it looks idle again")
+		require.False(t, inst.TaskRunActive(), "and the task run is long over")
+		require.False(t, m.stillTheFinishedRun("repo", "sess-1", "t", atCompletion),
+			"a turn that started and finished still moved the epoch, so the verb must not land")
 	})
 
 	t.Run("a same-titled replacement is not ours", func(t *testing.T) {
 		inst := &session.Instance{ID: "sess-2", Title: "t"}
 		inst.SetStatusForTest(session.Ready)
 		m := newManager(inst, "repo", "t")
-		require.False(t, m.stillTheFinishedRun("repo", "sess-1", "t"),
+		require.False(t, m.stillTheFinishedRun("repo", "sess-1", "t", inst.StateEpoch()),
 			"a verb owed to one session must never land on its replacement")
 	})
 
-	t.Run("a session the user set working again is not ours", func(t *testing.T) {
+	t.Run("a session still working is not ours", func(t *testing.T) {
 		inst := &session.Instance{ID: "sess-1", Title: "t"}
-		inst.SetStatusForTest(session.Running)
+		inst.SetStatusForTest(session.Ready)
 		m := newManager(inst, "repo", "t")
-		require.False(t, m.stillTheFinishedRun("repo", "sess-1", "t"),
+		atCompletion := inst.StateEpoch()
+		require.NoError(t, inst.Transition(session.ObserveLiveness(session.LiveRunning)))
+		require.False(t, m.stillTheFinishedRun("repo", "sess-1", "t", atCompletion),
 			"work adopted during the hook wait is the user's, not the task's")
 	})
 
 	t.Run("a vanished session is not ours", func(t *testing.T) {
 		m := newManager(nil, "repo", "t")
-		require.False(t, m.stillTheFinishedRun("repo", "sess-1", "t"))
+		require.False(t, m.stillTheFinishedRun("repo", "sess-1", "t", 0))
 	})
 }

--- a/daemon/task_session_lifecycle_test.go
+++ b/daemon/task_session_lifecycle_test.go
@@ -376,7 +376,7 @@ func TestTaskSessionLifecycle_WaitsForPostWorktreeHooks(t *testing.T) {
 	}
 	t.Cleanup(func() { killSessionForLifecycle = prev })
 
-	go manager.runTaskSessionLifecycle(repoID, inst.ID, "nightly", "task-kill", task.OnCompleteKill, inst.StateEpoch(), hooks)
+	go manager.runTaskSessionLifecycle(repoID, inst.ID, "nightly", "task-kill", task.OnCompleteKill, inst.StateEpoch(), inst.PromptDeliveries(), hooks)
 
 	select {
 	case <-reaped:
@@ -463,7 +463,7 @@ func TestTaskSessionLifecycle_HookWaitAbandonsAnAdoptedSession(t *testing.T) {
 	}
 	t.Cleanup(func() { killSessionForLifecycle = prev })
 
-	go manager.runTaskSessionLifecycle(repoID, inst.ID, "nightly", "task-kill", task.OnCompleteKill, inst.StateEpoch(), hooks)
+	go manager.runTaskSessionLifecycle(repoID, inst.ID, "nightly", "task-kill", task.OnCompleteKill, inst.StateEpoch(), inst.PromptDeliveries(), hooks)
 
 	// The user picks the work back up while the hooks are still running.
 	require.NoError(t, inst.Transition(session.ObserveLiveness(session.LiveRunning)))

--- a/daemon/task_session_lifecycle_test.go
+++ b/daemon/task_session_lifecycle_test.go
@@ -360,6 +360,13 @@ func TestTaskSessionLifecycle_WaitsForPostWorktreeHooks(t *testing.T) {
 	inst := registerTaskSpawnedSession(t, manager, repoID, repoPath, "nightly", "task-kill")
 	stubTaskLifecycle(t, "task-kill", task.OnCompleteKill)
 
+	// Put the session in the state every production caller guarantees before it
+	// reaches the teardown: applyTaskSessionLifecycleOnRunEnd only spawns the
+	// goroutine when runEndedIntoIdle is true. The teardown re-checks that after
+	// the hook wait, so a test that drives it directly has to establish the same
+	// precondition or it is asserting against a run that never finished.
+	endRunOnIdleEdge(t, inst)
+
 	hooks := make(chan struct{})
 	reaped := make(chan struct{})
 	prev := killSessionForLifecycle
@@ -435,4 +442,36 @@ func TestTaskSessionLifecycle_ParkedIntentIsReclaimedOnTitleReuse(t *testing.T) 
 	_, stillParked := manager.deferredTaskLifecycle[key]
 	manager.mu.Unlock()
 	assert.False(t, stillParked, "a replacement session must not inherit the original's owed teardown")
+}
+
+// The guard the hook wait needed: a user who prompts the finished session while
+// post_worktree_commands are still running has adopted that work, and the verb
+// owed to the completed run must not land on it. Drives the real teardown rather
+// than the helper, so it proves the wait and the re-check are wired together.
+func TestTaskSessionLifecycle_HookWaitAbandonsAnAdoptedSession(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst := registerTaskSpawnedSession(t, manager, repoID, repoPath, "nightly", "task-kill")
+	stubTaskLifecycle(t, "task-kill", task.OnCompleteKill)
+	endRunOnIdleEdge(t, inst)
+
+	hooks := make(chan struct{})
+	reaped := make(chan struct{})
+	prev := killSessionForLifecycle
+	killSessionForLifecycle = func(m *Manager, req KillSessionRequest) error {
+		close(reaped)
+		return nil
+	}
+	t.Cleanup(func() { killSessionForLifecycle = prev })
+
+	go manager.runTaskSessionLifecycle(repoID, inst.ID, "nightly", "task-kill", task.OnCompleteKill, hooks)
+
+	// The user picks the work back up while the hooks are still running.
+	require.NoError(t, inst.Transition(session.ObserveLiveness(session.LiveRunning)))
+	close(hooks)
+
+	select {
+	case <-reaped:
+		t.Fatal("on_complete destroyed work the user adopted during the post-worktree hook wait")
+	case <-time.After(2 * time.Second):
+	}
 }

--- a/daemon/task_session_lifecycle_test.go
+++ b/daemon/task_session_lifecycle_test.go
@@ -376,7 +376,7 @@ func TestTaskSessionLifecycle_WaitsForPostWorktreeHooks(t *testing.T) {
 	}
 	t.Cleanup(func() { killSessionForLifecycle = prev })
 
-	go manager.runTaskSessionLifecycle(repoID, inst.ID, "nightly", "task-kill", task.OnCompleteKill, hooks)
+	go manager.runTaskSessionLifecycle(repoID, inst.ID, "nightly", "task-kill", task.OnCompleteKill, inst.StateEpoch(), hooks)
 
 	select {
 	case <-reaped:
@@ -463,7 +463,7 @@ func TestTaskSessionLifecycle_HookWaitAbandonsAnAdoptedSession(t *testing.T) {
 	}
 	t.Cleanup(func() { killSessionForLifecycle = prev })
 
-	go manager.runTaskSessionLifecycle(repoID, inst.ID, "nightly", "task-kill", task.OnCompleteKill, hooks)
+	go manager.runTaskSessionLifecycle(repoID, inst.ID, "nightly", "task-kill", task.OnCompleteKill, inst.StateEpoch(), hooks)
 
 	// The user picks the work back up while the hooks are still running.
 	require.NoError(t, inst.Transition(session.ObserveLiveness(session.LiveRunning)))

--- a/session/instance.go
+++ b/session/instance.go
@@ -160,6 +160,12 @@ type Instance struct {
 	// see state_epoch.go. Mutex-protected, in-memory only: it describes a window
 	// between an observation and its apply, and no such window survives a restart.
 	stateEpoch uint64
+
+	// promptDeliveries counts prompts delivered into this session. It answers
+	// "has anything been sent here since I looked?", which the lifecycle axes
+	// cannot: a delivery does not move them, and a turn that settles leaves them
+	// exactly as they were. See session/prompt_delivery.go.
+	promptDeliveries uint64
 	// agentRuntimeGeneration identifies the concrete agent process currently
 	// owning the Agent tab. Async conversation capture binds to this generation,
 	// so a result from a replaced process cannot write through a later handoff or

--- a/session/prompt_delivery.go
+++ b/session/prompt_delivery.go
@@ -1,0 +1,39 @@
+package session
+
+// Prompt-delivery marking (#2960-adjacent, #2948).
+//
+// "Has a prompt been delivered to this session since I looked?" cannot be
+// answered from lifecycle state, and several attempts to do so were wrong in the
+// same way. Liveness is a LEVEL: a user's turn drives Ready→Running→Ready, so a
+// check that runs after it settles sees an idle session and concludes nothing
+// happened. stateEpoch is closer — it moves on both of those edges — but a
+// delivery does not touch the lifecycle axes at all, so between the send and the
+// poll observing the agent working, the epoch still reads unchanged.
+//
+// Adoption is an EVENT, not a state, and it needs a counter that only delivery
+// moves. An observer captures it alongside the decision it is making and
+// compares before acting: same count → nothing was delivered in between;
+// different → something was, and a decision made before it is stale.
+
+// NotePromptDelivery records that a prompt is being delivered to this session.
+//
+// Called immediately BEFORE the send, not after, and deliberately so. The
+// daemon's delivery crosses a socket, which makes its failure ambiguous — "never
+// sent" versus "sent, reply lost" — and for the question this answers, a
+// possible delivery has to count as one. Marking first also removes the window
+// where a delivery has landed but the mark has not, which is exactly the race
+// that made the earlier lifecycle-based guards wrong.
+func (i *Instance) NotePromptDelivery() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.promptDeliveries++
+}
+
+// PromptDeliveries returns the number of prompt deliveries marked on this
+// session. Capture it before a decision and compare before applying it; the
+// value itself carries no meaning beyond "did this change".
+func (i *Instance) PromptDeliveries() uint64 {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.promptDeliveries
+}


### PR DESCRIPTION
> [!WARNING]
> **DO NOT MERGE — held deliberately. CI is green and the findings count reads zero, and neither means this is ready.**
>
> The three P1s on this PR are answered `ACCEPTED`, which the auto-gate counts as resolved. They are **acknowledged, not fixed** — I said so in each reply. The guard here is incomplete on a destructive path, and a partial guard that looks complete is worse than the gap it half-closes.
>
> Full reasoning and the shape of the real fix: https://github.com/sachiniyer/agent-factory/issues/2948#issuecomment-5198389476
>
> In short: four attempts all tried to *observe* adoption from outside the race instead of *serializing* against it. The teardown must take the same fence the delivery paths contend on (`killsInFlight` / the session op-lock), re-validate under it, and only then destroy. That is a change to how the teardown acquires the session, not another comparison.
>
> Kept as a draft rather than closed: it does catch the same-titled replacement, the settled turn, and a `SendPrompt` delivery, all of which master misses. It is a starting point, not a merge candidate.

---

From #2948 — an unresolved Codex finding on #2861, which merged without it being answered. Verified still true against current master before fixing.

## The bug

`runTaskSessionLifecycle` waits for `post_worktree_commands` to finish before archiving or killing a task-spawned session — correctly, since archive moves the worktree and kill removes it. But that wait can last minutes, and the session is visible and **Ready** throughout.

A user who prompts it in that window has adopted the work. It is theirs now, not the task's. The code went straight from `<-hooksDone` to the destructive verb, acting on a completion decision that could be minutes stale — so `on_complete=kill|archive` could destroy work started after the task finished.

## The fix

Re-ask the question the completion edge asked: same session id, still `Ready`, still no active task run. Any of those changing means the decision no longer describes reality — a same-titled replacement now holds the key, or the user picked the work back up — and a verb owed to a finished run must never land on new work.

This is not a new rule. `applyDeferredTaskSessionLifecycle` already applies exactly it across the attach deferral. The hook wait is a **second place the same staleness arises**, and it deserved the same answer rather than a second, weaker one — so the check is factored out and both paths now share it.

## Verification

Four cases: an unchanged idle run is still ours; a same-titled replacement is not; a session the user set working again is not; a vanished session is not.

Local gate: `gofmt -l .` (empty), `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh`. Daemon tests verified compiling with `go vet ./daemon/` — not executed here, per the standing rule that this package spawns real daemons on the maintainer's machine. CI runs them.

Refs #2948
Refs #2861

🤖 Generated with [Claude Code](https://claude.com/claude-code)
