### PR TITLE
fix(attach): join the stdin pump before closing its reader on the panic path

### DIFF
--- a/apiclient/attach.go
+++ b/apiclient/attach.go
@@ -233,6 +233,22 @@ func driveAttachStream(conn *websocket.Conn, handback *terminalHandback, in canc
 	// terminal report ctrl+<key> as an escape sequence, and matching 0x17 alone
 	// left the user unable to detach at all (#1832). See detachkey.go.
 	stdinDone := make(chan struct{})
+	// Unblock and JOIN the stdin pump BEFORE the deferred in.Close() above runs.
+	//
+	// Defers unwind last-registered-first, so registering this after that Close
+	// is what orders them: the descriptor is closed only once nothing is inside
+	// it. The drained exit at the bottom already did this on the normal path —
+	// but a PANIC skips the bottom entirely and runs only defers, so Close landed
+	// while this goroutine was still blocked in Read. That is a genuine data race
+	// (#2913/#2914), and because -race runs on every lane it reddened unrelated
+	// PRs whose diffs contain no attach code at all.
+	//
+	// Cancel is idempotent and a receive from a closed channel returns
+	// immediately, so this is a no-op on the path that already drained.
+	defer func() {
+		_ = in.Cancel()
+		<-stdinDone
+	}()
 	go func() {
 		defer close(stdinDone)
 		buf := make([]byte, 32)


### PR DESCRIPTION
## The race

`driveAttachStream` registers `defer in.Close()` **first**, so it runs **last**. The drained exit at the bottom does:

```go
_ = in.Cancel()
<-stdinDone
```

before returning, so on the normal path the descriptor is closed with nothing inside it.

**A panic skips the bottom entirely** and runs only defers. `Close` then lands while the stdin pump goroutine is still blocked in `in.Read`:

```
Write at 0x00c000136070 by goroutine 19:
  cancelreader.(*epollCancelReader).Close()
  apiclient.driveAttachStream.deferwrap1()   apiclient/attach.go:140
  runtime.gopanic()
Previous read at 0x00c000136070 by goroutine 21:
  cancelreader.(*epollCancelReader).wait()
  apiclient.driveAttachStream.func6()        apiclient/attach.go:240
```

## Why it is worth landing now

It is not only a bug in attach. `-race` runs on every lane, so this reddens **unrelated** PRs — #2903 is a git/archive change whose diff contains no attach code at all. While CI is the bottleneck, a race that fails other people's lanes costs more than its own blast radius.

## Fix

The cancel-and-join becomes a defer registered **after** the `Close` defer. Defers unwind last-registered-first, so it runs **before** Close on every exit path, panic included.

`Cancel` is idempotent and a receive from a closed channel returns immediately, so the drained path that already did this is unaffected — the bottom's existing cancel/join stays, and this makes the ordering hold when the bottom never runs.

## Reproduction — what I did and did not verify

**I could not reproduce it locally.** On this box, all green:

- 30× the full `apiclient` suite under `-race`
- 200× `TestAttachStream_PanicHandsTheTerminalBack` + `TestAttachTerminalHandbackHelper` under `-race`

The timing needs CI's load. I am not claiming a local red-then-green; the fix rests on:

1. **the control flow**, which is visible in the source rather than inferred — `defer in.Close()` is registered first, the panic path runs no other cleanup; and
2. **two independent reports** (#2913, #2914) carrying identical addresses and goroutine stacks.

After the change: 60× full suite plus 8× confirmation under `-race`, clean.

## Validation

- `gofmt -l .` (no output) · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `deadcode -test ./...` (no output) · `scripts/lint-file-length.sh`
- `go test ./apiclient/ -race` — the only package changed, non-daemon and non-app

No containerized suite; nothing run against `./daemon/...` or `./app/...`.

Closes #2914
Closes #2913
