### PR TITLE
fix(reset): a missing tmux socket is not proof the sessions are gone

### DIFF
--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -79,7 +79,7 @@ func testOptionsWithHome(t *testing.T, home string, fix bool, pids ...int) Optio
 	// test in a private tmux world would classify its empty socket dir by
 	// whether the developer happens to have tmux running. Tests that mean
 	// "a server IS alive" pin it themselves.
-	t.Cleanup(tmux.PinServerProbeForTest(false))
+	t.Cleanup(tmux.PinServerProbeForTest())
 	return Options{
 		Fix:            fix,
 		ConfigDir:      home,

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -73,6 +73,13 @@ func testOptions(t *testing.T, fix bool, pids ...int) Options {
 func testOptionsWithHome(t *testing.T, home string, fix bool, pids ...int) Options {
 	t.Helper()
 	t.Setenv("AGENT_FACTORY_HOME", home)
+	// Hermetic like every other fake here. Since #2875 a missing tmux socket is
+	// definitive only when no tmux server is alive to own an unlinked one, and
+	// that probe reads the HOST process table — so without pinning it, a doctor
+	// test in a private tmux world would classify its empty socket dir by
+	// whether the developer happens to have tmux running. Tests that mean
+	// "a server IS alive" pin it themselves.
+	t.Cleanup(tmux.PinServerProbeForTest(false))
 	return Options{
 		Fix:            fix,
 		ConfigDir:      home,

--- a/doctor/tmux_inspection_test.go
+++ b/doctor/tmux_inspection_test.go
@@ -172,15 +172,13 @@ func TestListedTmuxSessionsPass(t *testing.T) {
 			},
 			wantDetail: "2",
 		},
-		{
-			// The socket was never created: the ordinary answer on a machine
-			// with no tmux server.
-			name: "socket absent",
-			exec: func(t *testing.T) cmd.Executor {
-				return blindTmuxLsExec(t, "error connecting to /tmp/tmux-1000/default (No such file or directory)", 1)
-			},
-			wantDetail: "0",
-		},
+		// The socket-absent (ENOENT) diagnostic is deliberately NOT in this
+		// table. Since #2875 it is definitive only when no tmux server is alive
+		// to own an unlinked socket, so its outcome depends on the host's
+		// process table — which a doctor test cannot pin from outside
+		// session/tmux, and which differs between a dev box running tmux and a
+		// bare CI container. It is covered where the probe is reachable:
+		// session/tmux's TestSocketAbsentWithALiveServerIsNotAnEmptySessionSet.
 		{
 			// A server that exited leaves its socket behind, so the connect is
 			// refused.

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -136,13 +137,17 @@ func probeSessionStrict(cmdExec cmd.Executor, name string) (exists bool, known b
 // Exit status 1 alone is ambiguous: wrapper, policy, and unclassified connection
 // failures can return the same status while the named session remains unknown.
 // A definitive no-server answer counts too: no session can remain on a socket
-// that holds no server.
+// that holds no server — routed through NoServerRunning so the has-session
+// re-probes get the same ENOENT treatment as the listing. The finding on #2875
+// named this path explicitly: `tmux ls` may find AF sessions, the socket may then
+// be removed by a /tmp cleaner, and this fallback probe would answer ENOENT while
+// the server and its panes are still running.
 func missingTmuxSession(err error, name string) bool {
 	diagnostic, ok := tmuxExitOneDiagnostic(err)
 	if !ok {
 		return false
 	}
-	return diagnostic == "can't find session: "+name || noTmuxServerDiagnostic(diagnostic)
+	return diagnostic == "can't find session: "+name || NoServerRunning(err)
 }
 
 // NoServerRunning reports whether a failed tmux command's error is tmux's
@@ -159,7 +164,95 @@ func missingTmuxSession(err error, name string) bool {
 // this package. A second implementation is exactly how the first one spread.
 func NoServerRunning(err error) bool {
 	diagnostic, exitOne := tmuxExitOneDiagnostic(err)
-	return exitOne && noTmuxServerDiagnostic(diagnostic)
+	if !exitOne {
+		return false
+	}
+	switch classifyNoServerDiagnostic(diagnostic) {
+	case serverRefusedConnection:
+		// The socket EXISTS and refused us. Nothing is listening on it, which
+		// is self-sufficient proof: no server, so no sessions.
+		return true
+	case socketAbsent:
+		// ENOENT is NOT self-sufficient. tmux(1) documents that a socket
+		// removed by accident can be recreated by signalling the server, so a
+		// server whose socket a /tmp cleaner unlinked is still running, with
+		// live sessions and live panes, while every client gets ENOENT.
+		// Reproduced: a session and its `sleep 300` pane survived `rm -f` of
+		// the socket, and `tmux ls` answered exactly this diagnostic (#2875).
+		//
+		// It is only definitive when no tmux server is alive to own an
+		// unlinked socket — which is the ordinary case this branch exists for,
+		// a machine where tmux never ran.
+		return !tmuxServerProcessAlive()
+	default:
+		return false
+	}
+}
+
+// noServerDiagnosticKind is why tmux says there is no server, because the two
+// reasons carry different weight and collapsing them is what #2875 caught.
+type noServerDiagnosticKind int
+
+const (
+	notANoServerDiagnostic noServerDiagnosticKind = iota
+	// serverRefusedConnection: ECONNREFUSED. The socket is there; nobody is
+	// behind it. Definitive on its own.
+	serverRefusedConnection
+	// socketAbsent: ENOENT. Either no server ever created one — or one did and
+	// the socket was removed out from under it.
+	socketAbsent
+)
+
+// tmuxServerProcessAlive reports whether any tmux SERVER process is running for
+// this uid. A package var so tests can pin the answer: the real probe reads the
+// host's process table, so a developer box with tmux running would otherwise
+// give a different result from a container that has none.
+var tmuxServerProcessAlive = liveTmuxServerProcess
+
+// PinServerProbeForTest fixes the "is a tmux server alive for this uid?" answer
+// and returns the restore. It exists for internal/testguard.IsolateTmux, which
+// declares a private-socket world for a test; without it that isolation is
+// incomplete, because the probe reads the HOST process table and would see the
+// developer's own tmux servers inside a world that is supposed to have none.
+//
+// Test-only by contract, not by build tag: testguard lives in internal/ and is
+// the only caller.
+func PinServerProbeForTest(alive bool) (restore func()) {
+	prev := tmuxServerProcessAlive
+	tmuxServerProcessAlive = func() bool { return alive }
+	return func() { tmuxServerProcessAlive = prev }
+}
+
+// liveTmuxServerProcess looks for a tmux server owned by this uid.
+//
+// It answers a deliberately BROAD question — "could any live server own an
+// unlinked socket?" — rather than "is the server for THIS socket alive?", which
+// would need the server's own socket path and is not worth the machinery. The
+// asymmetry is chosen: a false "yes" costs a refused sweep the user can retry
+// after checking; a false "no" lets reset delete worktrees out from under a live
+// agent. Over-refusal is also rare in practice, because a server on the DEFAULT
+// socket has a socket file, so it answers ECONNREFUSED rather than ENOENT.
+//
+// A process table we cannot read reports TRUE, for the same reason: an
+// unreadable table is not evidence of absence.
+func liveTmuxServerProcess() bool {
+	snap, err := proctree.Snapshot()
+	if err != nil {
+		return true
+	}
+	uid := os.Getuid()
+	for pid, p := range snap {
+		// tmux renames the server task to "tmux: server" (verified on Linux),
+		// and a plain "tmux" covers builds that do not.
+		if !strings.HasPrefix(p.Comm, "tmux") {
+			continue
+		}
+		if owner, ok := proctree.UID(pid); ok && owner != uid {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 // ListSessionNames returns the name of every session on the tmux server, or an
@@ -256,16 +349,22 @@ func tmuxExitOneDiagnostic(err error) (string, bool) {
 //
 // The strings are matched in tmux's own C locale: tmux calls setlocale only for
 // LC_CTYPE, so strerror stays untranslated regardless of the user's LANG.
-func noTmuxServerDiagnostic(diagnostic string) bool {
+func classifyNoServerDiagnostic(diagnostic string) noServerDiagnosticKind {
 	if socket, refused := strings.CutPrefix(diagnostic, "no server running on "); refused {
-		return strings.TrimSpace(socket) != ""
+		if strings.TrimSpace(socket) != "" {
+			return serverRefusedConnection
+		}
+		return notANoServerDiagnostic
 	}
 	rest, connectFailure := strings.CutPrefix(diagnostic, "error connecting to ")
 	if !connectFailure {
-		return false
+		return notANoServerDiagnostic
 	}
-	socket, absent := strings.CutSuffix(rest, " (No such file or directory)")
-	return absent && strings.TrimSpace(socket) != ""
+	if socket, absent := strings.CutSuffix(rest, " (No such file or directory)"); absent &&
+		strings.TrimSpace(socket) != "" {
+		return socketAbsent
+	}
+	return notANoServerDiagnostic
 }
 
 // tmuxDiagnosticSuffix renders CommandDiagnostic as a parenthesized clause for
@@ -346,6 +445,20 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 		// Name what was unreadable AND what was therefore not done. tmux writes
 		// its reason to stderr, which the bare error swallows — `exit status 1`
 		// on its own gives the user nothing to act on.
+		//
+		// The socket-absent case gets its own sentence, because otherwise the
+		// message reads like a contradiction: tmux said the socket is missing,
+		// yet af refuses as if the state were unknown. It IS unknown, and the
+		// reason is not guessable from the diagnostic (#2875).
+		if diagnostic, exitOne := tmuxExitOneDiagnostic(err); exitOne &&
+			classifyNoServerDiagnostic(diagnostic) == socketAbsent {
+			return fmt.Errorf("could not list tmux sessions%s, but a tmux server is running for this "+
+				"user — a server whose socket is removed (a /tmp cleaner will do it) keeps running with "+
+				"its sessions alive, so the missing socket does not prove there are none. Refusing to "+
+				"sweep: no tmux session was killed. Recreate the socket by signalling the server "+
+				"(`pkill -USR1 -x -u \"$(id -u)\" tmux`) or stop the stray server, then re-run: %w",
+				tmuxDiagnosticSuffix(err), err)
+		}
 		return fmt.Errorf("could not list tmux sessions%s; refusing to sweep with the session set "+
 			"unknown — no tmux session was killed: %w", tmuxDiagnosticSuffix(err), err)
 	}

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -183,7 +185,7 @@ func NoServerRunning(err error) bool {
 		// It is only definitive when no tmux server is alive to own an
 		// unlinked socket — which is the ordinary case this branch exists for,
 		// a machine where tmux never ran.
-		return !tmuxServerProcessAlive()
+		return len(tmuxServerProcessPIDs()) == 0
 	default:
 		return false
 	}
@@ -207,7 +209,7 @@ const (
 // this uid. A package var so tests can pin the answer: the real probe reads the
 // host's process table, so a developer box with tmux running would otherwise
 // give a different result from a container that has none.
-var tmuxServerProcessAlive = liveTmuxServerProcess
+var tmuxServerProcessPIDs = liveTmuxServerPIDs
 
 // PinServerProbeForTest fixes the "is a tmux server alive for this uid?" answer
 // and returns the restore. It exists for internal/testguard.IsolateTmux, which
@@ -217,10 +219,10 @@ var tmuxServerProcessAlive = liveTmuxServerProcess
 //
 // Test-only by contract, not by build tag: testguard lives in internal/ and is
 // the only caller.
-func PinServerProbeForTest(alive bool) (restore func()) {
-	prev := tmuxServerProcessAlive
-	tmuxServerProcessAlive = func() bool { return alive }
-	return func() { tmuxServerProcessAlive = prev }
+func PinServerProbeForTest(pids ...int) (restore func()) {
+	prev := tmuxServerProcessPIDs
+	tmuxServerProcessPIDs = func() []int { return pids }
+	return func() { tmuxServerProcessPIDs = prev }
 }
 
 // liveTmuxServerProcess looks for a tmux server owned by this uid.
@@ -235,24 +237,29 @@ func PinServerProbeForTest(alive bool) (restore func()) {
 //
 // A process table we cannot read reports TRUE, for the same reason: an
 // unreadable table is not evidence of absence.
-func liveTmuxServerProcess() bool {
+func liveTmuxServerPIDs() []int {
 	snap, err := proctree.Snapshot()
 	if err != nil {
-		return true
+		// Not evidence of absence. A sentinel PID would be a lie, so report an
+		// unnamed one: callers only test emptiness, and the message degrades to
+		// "a server is running" without claiming to know which.
+		return []int{0}
 	}
 	uid := os.Getuid()
+	var pids []int
 	for pid, p := range snap {
-		// tmux renames the server task to "tmux: server" (verified on Linux),
-		// and a plain "tmux" covers builds that do not.
+		// tmux renames the server task to "tmux: server" (verified on Linux);
+		// a plain "tmux" covers builds and platforms that do not.
 		if !strings.HasPrefix(p.Comm, "tmux") {
 			continue
 		}
 		if owner, ok := proctree.UID(pid); ok && owner != uid {
 			continue
 		}
-		return true
+		pids = append(pids, pid)
 	}
-	return false
+	sort.Ints(pids)
+	return pids
 }
 
 // ListSessionNames returns the name of every session on the tmux server, or an
@@ -367,6 +374,56 @@ func classifyNoServerDiagnostic(diagnostic string) noServerDiagnosticKind {
 	return notANoServerDiagnostic
 }
 
+// describeLiveTmuxServers and recreateSocketAdvice render the socket-absent
+// refusal. They name the exact PIDs rather than a pattern because the obvious
+// pattern does not work: tmux renames the server task to "tmux: server", and
+// `pkill -x ... tmux` matches NOTHING against that — verified with pgrep, which
+// shares pkill's matching (`pgrep -x -u $(id -u) tmux` returned nothing while
+// `-x "tmux: server"` matched every server). A recovery hint that silently
+// signals nothing is worse than none: the user runs it, believes they acted, and
+// reset keeps refusing (Codex on #2956).
+//
+// Dropping -x is not the fix either. SIGUSR1's default disposition is TERMINATE,
+// so a loose name match would kill any unrelated process whose name merely
+// contains "tmux". Naming the PID is exact, portable, and cannot spray.
+func describeLiveTmuxServers(pids []int) string {
+	named := namedPIDs(pids)
+	if named == "" {
+		return "a tmux server is running for this user"
+	}
+	if len(pids) == 1 {
+		return "a tmux server is running for this user (pid " + named + ")"
+	}
+	return "tmux server(s) are running for this user (pids " + named + ")"
+}
+
+func recreateSocketAdvice(pids []int) string {
+	named := pidArgsForSignal(pids)
+	if len(named) == 0 {
+		return "Find the server (`ps -o pid,comm,args -u \"$(id -u)\"`, look for `tmux: server`), then " +
+			"signal it with `kill -USR1 <pid>` to recreate its socket — or stop it — and re-run"
+	}
+	return "Recreate its socket with " + shellsuggest.Command("kill", append([]string{"-USR1"}, named...)...) +
+		" — or stop that server — then re-run"
+}
+
+// namedPIDs renders the PIDs we can actually name; the 0 sentinel means the
+// process table could not be read, so there is no pid to print.
+func namedPIDs(pids []int) string {
+	return strings.Join(pidArgsForSignal(pids), ", ")
+}
+
+func pidArgsForSignal(pids []int) []string {
+	var out []string
+	for _, pid := range pids {
+		if pid <= 0 {
+			continue
+		}
+		out = append(out, strconv.Itoa(pid))
+	}
+	return out
+}
+
 // tmuxDiagnosticSuffix renders CommandDiagnostic as a parenthesized clause for
 // an error message, or "" when there is nothing to render.
 func tmuxDiagnosticSuffix(err error) string {
@@ -452,12 +509,11 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 		// reason is not guessable from the diagnostic (#2875).
 		if diagnostic, exitOne := tmuxExitOneDiagnostic(err); exitOne &&
 			classifyNoServerDiagnostic(diagnostic) == socketAbsent {
-			return fmt.Errorf("could not list tmux sessions%s, but a tmux server is running for this "+
-				"user — a server whose socket is removed (a /tmp cleaner will do it) keeps running with "+
-				"its sessions alive, so the missing socket does not prove there are none. Refusing to "+
-				"sweep: no tmux session was killed. Recreate the socket by signalling the server "+
-				"(`pkill -USR1 -x -u \"$(id -u)\" tmux`) or stop the stray server, then re-run: %w",
-				tmuxDiagnosticSuffix(err), err)
+			return fmt.Errorf("could not list tmux sessions%s, but %s. A server whose socket is removed "+
+				"(a /tmp cleaner will do it) keeps running with its sessions alive, so the missing socket "+
+				"does not prove there are none. Refusing to sweep: no tmux session was killed. %s: %w",
+				tmuxDiagnosticSuffix(err), describeLiveTmuxServers(tmuxServerProcessPIDs()),
+				recreateSocketAdvice(tmuxServerProcessPIDs()), err)
 		}
 		return fmt.Errorf("could not list tmux sessions%s; refusing to sweep with the session set "+
 			"unknown — no tmux session was killed: %w", tmuxDiagnosticSuffix(err), err)

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -248,9 +248,7 @@ func liveTmuxServerPIDs() []int {
 	uid := os.Getuid()
 	var pids []int
 	for pid, p := range snap {
-		// tmux renames the server task to "tmux: server" (verified on Linux);
-		// a plain "tmux" covers builds and platforms that do not.
-		if !strings.HasPrefix(p.Comm, "tmux") {
+		if !isTmuxServerComm(p.Comm) {
 			continue
 		}
 		if owner, ok := proctree.UID(pid); ok && owner != uid {
@@ -405,6 +403,22 @@ func recreateSocketAdvice(pids []int) string {
 	}
 	return "Recreate its socket with " + shellsuggest.Command("kill", append([]string{"-USR1"}, named...)...) +
 		" — or stop that server — then re-run"
+}
+
+// isTmuxServerComm reports whether a kernel task name is a tmux SERVER.
+//
+// Measured on Linux: tmux retitles its processes, and the server and a client
+// are "tmux: server" and "tmux: client" respectively. A HasPrefix(comm, "tmux")
+// test therefore counts CLIENTS as servers — and a client exists whenever
+// anyone is actually using tmux, so that mistake turns an ordinary ENOENT into
+// "a server is running", refuses the reset, and points `kill -USR1` at a process
+// that cannot recreate a server socket (Codex on #2956).
+//
+// The bare "tmux" fallback is for builds and platforms that do not retitle. It
+// is EXACT, never a prefix, for the reason above: a prefix is what swallowed
+// the client.
+func isTmuxServerComm(comm string) bool {
+	return comm == "tmux: server" || comm == "tmux"
 }
 
 // namedPIDs renders the PIDs we can actually name; the 0 sentinel means the

--- a/session/tmux/cleanup_list_test.go
+++ b/session/tmux/cleanup_list_test.go
@@ -451,3 +451,42 @@ func TestSocketAbsentWithUnreadableProcessTableStillRefuses(t *testing.T) {
 		t.Errorf("error = %q, want it to say how to FIND the server when it cannot name one", err)
 	}
 }
+
+// TestOnlyServerProcessesCountAsALiveServer guards the predicate behind the
+// socket-absent refusal (Codex on #2956).
+//
+// tmux retitles its processes, and MEASURED on Linux the server and a client are
+// "tmux: server" and "tmux: client". A HasPrefix(comm, "tmux") test counts the
+// CLIENT as a server — and a client exists whenever anyone is actually using
+// tmux, so that mistake turns an ordinary ENOENT into "a server is running",
+// refuses the reset, and aims `kill -USR1` at a process that cannot recreate a
+// server socket.
+//
+// Measured directly, by attaching a real client to a private server:
+//
+//	pid=1034121 comm='tmux: server'
+//	pid=1034153 comm='tmux: client'
+func TestOnlyServerProcessesCountAsALiveServer(t *testing.T) {
+	for _, tc := range []struct {
+		comm string
+		want bool
+	}{
+		{"tmux: server", true},
+		// The fallback for builds/platforms that do not retitle. Exact only.
+		{"tmux", true},
+		// The one that made this a bug: a client is not a server.
+		{"tmux: client", false},
+		// Neighbours a prefix match would also have swallowed.
+		{"tmuxinator", false},
+		{"tmux-mem-cpu-load", false},
+		{"tmuxp", false},
+		{"", false},
+		{"emacs", false},
+	} {
+		t.Run(tc.comm, func(t *testing.T) {
+			if got := isTmuxServerComm(tc.comm); got != tc.want {
+				t.Errorf("isTmuxServerComm(%q) = %v, want %v", tc.comm, got, tc.want)
+			}
+		})
+	}
+}

--- a/session/tmux/cleanup_list_test.go
+++ b/session/tmux/cleanup_list_test.go
@@ -51,9 +51,11 @@ esac
 // assert one thing locally and another in CI.
 func pinTmuxServerProbe(t *testing.T, alive bool) {
 	t.Helper()
-	prev := tmuxServerProcessAlive
-	tmuxServerProcessAlive = func() bool { return alive }
-	t.Cleanup(func() { tmuxServerProcessAlive = prev })
+	var pids []int
+	if alive {
+		pids = []int{4242}
+	}
+	t.Cleanup(PinServerProbeForTest(pids...))
 }
 
 // TestCleanupSessionsListFailureIsNotAnEmptySessionSet is the #2870 regression
@@ -385,5 +387,67 @@ func TestSocketAbsentWithALiveServerIsNotAnEmptySessionSet(t *testing.T) {
 				t.Errorf("the sweep continued to another tmux command after refusing (stat %s = %v)", touched, statErr)
 			}
 		})
+	}
+}
+
+// TestSocketAbsentRefusalNamesAWorkingRecovery locks the recovery hint against
+// the way the obvious one fails (Codex on #2956).
+//
+// The first version said `pkill -USR1 -x -u "$(id -u)" tmux`. tmux renames the
+// server task to "tmux: server", and pkill's -x is an EXACT command-name match,
+// so that command matches nothing at all — verified with pgrep, which shares the
+// matching: `pgrep -x -u $(id -u) tmux` returned nothing on a box with four live
+// servers, while `-x "tmux: server"` matched all four. A hint that silently
+// signals nothing is worse than no hint: the user runs it, believes they acted,
+// and reset keeps refusing.
+//
+// Dropping -x is not the fix. SIGUSR1's default disposition is TERMINATE, so a
+// loose name match would kill any unrelated process merely named like tmux.
+// Naming the PID is exact and cannot spray.
+func TestSocketAbsentRefusalNamesAWorkingRecovery(t *testing.T) {
+	touched := filepath.Join(t.TempDir(), "reached-another-tmux-command")
+	t.Cleanup(PinServerProbeForTest(4242, 4243))
+	listFailureTmuxOnPath(t, touched, "error connecting to /tmp/tmux-1000/default (No such file or directory)", 1)
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	err := CleanupSessions(cmd.MakeExecutor())
+	if err == nil {
+		t.Fatal("CleanupSessions returned nil with a live server and an absent socket")
+	}
+	msg := err.Error()
+
+	if !strings.Contains(msg, "kill -USR1 4242 4243") {
+		t.Errorf("error = %q, want a signal aimed at the exact server pids", msg)
+	}
+	if strings.Contains(msg, "pkill") {
+		t.Errorf("error = %q still suggests pkill; -x cannot match `tmux: server`, and without -x "+
+			"SIGUSR1 (default disposition: terminate) sprays onto anything named like tmux", msg)
+	}
+	for _, pid := range []string{"4242", "4243"} {
+		if !strings.Contains(msg, pid) {
+			t.Errorf("error = %q, want it to name server pid %s", msg, pid)
+		}
+	}
+}
+
+// TestSocketAbsentWithUnreadableProcessTableStillRefuses covers the branch that
+// has no pid to offer: an unreadable process table is not evidence of absence,
+// so the sweep must still refuse — and the advice must degrade to "go find it"
+// rather than print a signal aimed at nothing.
+func TestSocketAbsentWithUnreadableProcessTableStillRefuses(t *testing.T) {
+	touched := filepath.Join(t.TempDir(), "reached-another-tmux-command")
+	t.Cleanup(PinServerProbeForTest(0)) // the "could not read the table" sentinel
+	listFailureTmuxOnPath(t, touched, "error connecting to /tmp/tmux-1000/default (No such file or directory)", 1)
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	err := CleanupSessions(cmd.MakeExecutor())
+	if err == nil {
+		t.Fatal("an unreadable process table is not proof no server is running; the sweep must refuse")
+	}
+	if strings.Contains(err.Error(), "pid 0") || strings.Contains(err.Error(), "kill -USR1 0") {
+		t.Errorf("error = %q leaked the no-pid sentinel into user-facing copy", err)
+	}
+	if !strings.Contains(err.Error(), "ps -o pid,comm,args") {
+		t.Errorf("error = %q, want it to say how to FIND the server when it cannot name one", err)
 	}
 }

--- a/session/tmux/cleanup_list_test.go
+++ b/session/tmux/cleanup_list_test.go
@@ -41,6 +41,21 @@ esac
 	t.Setenv("TOUCHED_MARKER", touched)
 }
 
+// pinTmuxServerProbe fixes the answer to "is a tmux server alive for this uid?"
+// for one test.
+//
+// It has to be pinned, not observed: since #2875 the ENOENT diagnostic is
+// definitive only when NO server could own an unlinked socket, so the real probe
+// reads the host process table and a developer box with tmux running gives a
+// different answer from a container with none. A test that did not pin it would
+// assert one thing locally and another in CI.
+func pinTmuxServerProbe(t *testing.T, alive bool) {
+	t.Helper()
+	prev := tmuxServerProcessAlive
+	tmuxServerProcessAlive = func() bool { return alive }
+	t.Cleanup(func() { tmuxServerProcessAlive = prev })
+}
+
 // TestCleanupSessionsListFailureIsNotAnEmptySessionSet is the #2870 regression
 // lock: `af reset` calls CleanupSessions before it deletes worktrees, branches,
 // and records, so a FAILED listing read as "there are no sessions" licenses the
@@ -140,6 +155,9 @@ func TestCleanupSessionsListFailureIsNotAnEmptySessionSet(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			touched := filepath.Join(t.TempDir(), "reached-another-tmux-command")
+			// No server anywhere: the world in which tmux's diagnostics are the
+			// only evidence. The ENOENT-with-a-live-server case is its own test.
+			pinTmuxServerProbe(t, false)
 			listFailureTmuxOnPath(t, touched, tc.diagnostic, tc.exitCode)
 			t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 
@@ -230,6 +248,12 @@ func TestCleanupSessionsAgainstRealTmuxSocket(t *testing.T) {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 
+	// The throwaway TMUX_TMPDIR holds no server, but the HOST may well be
+	// running tmux (this was written on a box with several), and since #2875 a
+	// live server makes ENOENT ambiguous. Pin the answer to the world this test
+	// is describing: nothing else is running.
+	pinTmuxServerProbe(t, false)
+
 	// An ambient $TMUX would hand tmux the REAL server's socket and bypass
 	// TMUX_TMPDIR entirely. Empty is treated as unset by tmux.
 	t.Setenv("TMUX", "")
@@ -295,5 +319,71 @@ func TestListSessionNamesIsBounded(t *testing.T) {
 	}
 	if names != nil {
 		t.Errorf("names = %v, want nil alongside the error", names)
+	}
+}
+
+// TestSocketAbsentWithALiveServerIsNotAnEmptySessionSet is the #2875 regression:
+// the hole left in #2870's own fix.
+//
+// tmux(1) notes that a socket removed by accident can be recreated by signalling
+// the server — which is to say the SERVER SURVIVES ITS SOCKET. Reproduced by
+// hand: a session and its `sleep 300` pane stayed alive after `rm -f` of the
+// socket, and `tmux ls` answered exactly the ENOENT diagnostic that #2870
+// classified as definitive absence. `af reset` would then have deleted worktrees
+// and pruned branches with agents running — the very thing #2870 was for.
+//
+// Not hypothetical: systemd-tmpfiles clears /tmp of files untouched for 10 days
+// by default, and af tmux sessions routinely outlive that.
+//
+// Both directions are pinned, because the naive fix (drop the ENOENT branch)
+// breaks `af reset` on every machine that simply has no tmux server: a server
+// that EXITS leaves its socket behind, so a dead server answers ECONNREFUSED,
+// and ENOENT is the ordinary no-server answer.
+func TestSocketAbsentWithALiveServerIsNotAnEmptySessionSet(t *testing.T) {
+	const enoent = "error connecting to /tmp/tmux-1000/default (No such file or directory)"
+	const refused = "no server running on /tmp/tmux-1000/default"
+
+	for _, tc := range []struct {
+		name        string
+		diagnostic  string
+		serverAlive bool
+		wantAbort   bool
+	}{
+		{"socket absent, no server anywhere", enoent, false, false},
+		{"socket absent while a server is ALIVE", enoent, true, true},
+		// ECONNREFUSED is self-sufficient: the socket exists and refused us, so
+		// nothing is listening on it whatever else is running.
+		{"connection refused, no server", refused, false, false},
+		{"connection refused, another server alive elsewhere", refused, true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			touched := filepath.Join(t.TempDir(), "reached-another-tmux-command")
+			pinTmuxServerProbe(t, tc.serverAlive)
+			listFailureTmuxOnPath(t, touched, tc.diagnostic, 1)
+			t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+			err := CleanupSessions(cmd.MakeExecutor())
+
+			if !tc.wantAbort {
+				if err != nil {
+					t.Fatalf("CleanupSessions error = %v, want nil — %q with serverAlive=%v is a real "+
+						"empty session set, and refusing here blocks reset on ordinary machines",
+						err, tc.diagnostic, tc.serverAlive)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CleanupSessions returned nil for %q while a tmux server is running — the "+
+					"server outlives an unlinked socket, so this is an unreadable session set, not an "+
+					"empty one, and `af reset` would delete worktrees with agents live (#2875)", tc.diagnostic)
+			}
+			if !strings.Contains(err.Error(), "a tmux server is running") {
+				t.Errorf("error = %q, want it to explain why a missing socket is not proof of absence — "+
+					"otherwise the refusal reads as a contradiction of tmux's own diagnostic", err)
+			}
+			if _, statErr := os.Stat(touched); !os.IsNotExist(statErr) {
+				t.Errorf("the sweep continued to another tmux command after refusing (stat %s = %v)", touched, statErr)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Clears the Codex P1 on **#2875** (one of the findings tracked by #2948). It was
the hole left in that PR's own fix, and I reproduced it before fixing it.

## The defect

tmux(1) notes that a socket removed by accident can be recreated by signalling
the server — which is to say **the server survives its socket**:

```
$ tmux -S /tmp/tu/sock new-session -d -s victim 'sleep 300'
$ rm -f /tmp/tu/sock                  # what a /tmp cleaner does
$ tmux -S /tmp/tu/sock ls
error connecting to /tmp/tu/sock (No such file or directory)      # exit 1
$ pgrep -f 'sleep 300'                # the pane process
2666xxx                               # still running
```

That is exactly the diagnostic #2875 classified as *definitive absence*. So
`af reset` would read "no sessions", proceed to remove worktrees and prune
branches, and destroy work with agents live — #2870 narrowed, not eliminated.

Not hypothetical: `systemd-tmpfiles` clears `/tmp` of files untouched for 10 days
by default, and af tmux sessions routinely outlive that.

## Why the fix is not "delete the ENOENT branch"

That re-breaks `af reset` for most users. Measured on tmux 3.4, a server that
**exits** leaves its socket file behind, so a dead server answers ECONNREFUSED —
which makes ENOENT the ordinary answer on a machine where tmux never ran.

So the two diagnostics are now classified apart, which is the real content here:

| diagnostic | errno | verdict |
| --- | --- | --- |
| `no server running on <socket>` | ECONNREFUSED | **self-sufficient** — the socket exists and refused us, so nothing is listening |
| `error connecting to <socket> (No such file or directory)` | ENOENT | definitive **only** if no tmux server is alive for this uid to own an unlinked socket |

`missingTmuxSession` routes through the same classifier, because the finding
named that path too: `tmux ls` can find AF sessions, the socket can then be
removed, and the `has-session` fallback would answer ENOENT while the panes are
still running.

## The probe, and its deliberate bluntness

It asks "could **any** live server own an unlinked socket?", not "is the server
for THIS socket alive?" — the precise question needs the server's own socket path
and is not worth the machinery. The asymmetry is chosen: a false *yes* costs a
refused sweep the user can retry; a false *no* deletes a worktree out from under
a live agent. Over-refusal stays rare because a server on the default socket
**has** a socket file, so it answers ECONNREFUSED rather than ENOENT. An
unreadable process table reports "alive", for the same reason.

The refusal explains itself instead of reading as a contradiction of tmux's own
diagnostic, and names the recovery:

```
could not list tmux sessions (error connecting to … (No such file or directory)),
but a tmux server is running for this user — a server whose socket is removed
(a /tmp cleaner will do it) keeps running with its sessions alive, so the missing
socket does not prove there are none. Refusing to sweep: no tmux session was
killed. Recreate the socket by signalling the server (pkill -USR1 -x -u "$(id -u)"
tmux) or stop the stray server, then re-run
```

## Tests

`TestSocketAbsentWithALiveServerIsNotAnEmptySessionSet` pins all four corners —
ENOENT with and without a live server, ECONNREFUSED with and without — so neither
direction can regress. The live-server case fails against master.

**One honest note on test design.** The probe reads the host process table, so
its answer is *pinned* in tests rather than observed: a box running tmux (this
one has several) would otherwise assert one thing locally and another in a bare
CI container. doctor's `testOptionsWithHome` pins it alongside its other hermetic
fakes. It could not go in `testguard.IsolateTmux`, where it belongs semantically,
because `session/tmux`'s own tests import testguard — that is an import cycle.
For the same reason the ENOENT case was dropped from doctor's
`TestListedTmuxSessionsPass` table (a doctor test cannot pin the probe per-case)
and lives in `session/tmux`, with a comment saying so.

Local gate clean; `go test ./session/tmux/ ./doctor/ ./config/ ./commands/` green.

Refs #2948, Refs #2875, Refs #2870.

Deliberately not `Closes #2948` — that issue tracks 31 findings across 14 merged
PRs, and this fixes one of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
