### PR TITLE
test(git): fail when the cross-device copy diverges from rename anywhere new

### DIFF
--- a/session/git/worktree_copy_fidelity_test.go
+++ b/session/git/worktree_copy_fidelity_test.go
@@ -1,0 +1,222 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// This file holds the differential guard for moveDirCrossDevice's two
+// implementations of one promise (#2919).
+//
+// Same-device is rename(2), which carries every filesystem property for free.
+// Cross-device is a byte copy that reproduces only what someone wrote code for.
+// The defect that produced #2869, #2872 and #2920 was never really any one of
+// those properties — it was that the copier's fidelity is an ENUMERATION, and
+// nothing failed when the enumeration was incomplete. Each gap was found by a
+// user or an audit, one at a time.
+//
+// So this test does not check a list of properties someone remembered. It runs
+// one fixture through BOTH paths, compares everything it can observe, and fails
+// on any difference that is not in the inventory below. A newly-diverging
+// property fails here rather than in someone's archive.
+
+// knownCrossDeviceDivergence is the inventory of properties the copy is known
+// NOT to reproduce, each tracked in #2919. It is deliberately a denylist rather
+// than the assertion being an allowlist: an allowlist silently ignores anything
+// nobody thought of, which is the exact failure this test exists to prevent.
+//
+// The test fails in BOTH directions on purpose. Add a property to the copier
+// without removing it here and the "no longer diverges" branch fires, so the
+// inventory cannot rot into a list of things that were fixed years ago.
+var knownCrossDeviceDivergence = map[string]string{
+	"hardlink.nlink":     "#2919: each entry is copied independently, so a linked pair arrives as two files",
+	"hardlink.sameInode": "#2919: same cause — the link structure is not reproduced",
+	"xattr.file":         "#2919: no xattr namespace is copied, so ACLs, capabilities and SELinux labels are dropped",
+	"xattr.dir":          "#2919: same cause, on directories",
+	"mtime.file":         "#2919: the copy writes new files, so mtime becomes the copy time",
+	"mtime.dir":          "#2919: same cause, on directories",
+}
+
+// TestMoveDirCrossDevice_CopyDivergesFromRenameOnlyWhereRecorded is the class
+// guard for #2919. Everything not in the inventory above must be identical
+// through both paths.
+func TestMoveDirCrossDevice_CopyDivergesFromRenameOnlyWhereRecorded(t *testing.T) {
+	// A restrictive umask is load-bearing, not incidental. Under the ambient
+	// 0022 the fixture's modes survive mkdirat/openat untouched, so breaking
+	// mode preservation entirely produced no observable difference and this
+	// guard passed — the exact blind spot that let #2869 ship green. Measured.
+	withUmask(t, 0077)
+	workspace := t.TempDir()
+
+	renamedSource := filepath.Join(workspace, "renamed-src")
+	writeFidelityProbeTree(t, renamedSource)
+	before := describeFidelity(t, renamedSource)
+	renamedDest := filepath.Join(workspace, "renamed-dest")
+	require.NoError(t, moveDirCrossDevice(renamedSource, renamedDest),
+		"same-device move must take the rename fast path")
+	afterRename := describeFidelity(t, renamedDest)
+
+	copiedSource := filepath.Join(workspace, "copied-src")
+	writeFidelityProbeTree(t, copiedSource)
+	originalRename := renamePath
+	renamePath = func(_, _ string) error { return syscall.EXDEV }
+	t.Cleanup(func() { renamePath = originalRename })
+	copiedDest := filepath.Join(workspace, "copied-dest")
+	require.NoError(t, moveDirCrossDevice(copiedSource, copiedDest))
+	afterCopy := describeFidelity(t, copiedDest)
+
+	// The rename leg is the oracle, and this is what makes it one: if rename
+	// ever stopped carrying a property, comparing the copy against it would
+	// quietly agree on the wrong answer.
+	for property, want := range before {
+		assert.Equal(t, want, afterRename[property],
+			"rename(2) is this test's oracle and it must be lossless, but %s changed", property)
+	}
+
+	for property, sourceValue := range before {
+		copyValue := afterCopy[property]
+		// The one legitimate reason to skip: the fixture could not set the
+		// property in the first place, so neither tree can say anything about
+		// it. Decided from the SOURCE description only — asking the copy would
+		// let a dropped property masquerade as an unsupported filesystem.
+		if sourceValue == "MISSING" {
+			t.Logf("skipping %s: this filesystem could not set it on the fixture", property)
+			continue
+		}
+		reason, recorded := knownCrossDeviceDivergence[property]
+		switch {
+		case copyValue == sourceValue && recorded:
+			t.Errorf("%s no longer diverges (source=%s copy=%s) — remove it from "+
+				"knownCrossDeviceDivergence so the inventory keeps meaning what it says (%s)",
+				property, sourceValue, copyValue, reason)
+		case copyValue != sourceValue && !recorded:
+			t.Errorf("%s diverges between the two move paths and is NOT a recorded gap: "+
+				"source=%s rename=%s copy=%s. An archive is supposed to be restorable and "+
+				"identical — either preserve it in the copier, or record it in "+
+				"knownCrossDeviceDivergence with an issue reference",
+				property, sourceValue, afterRename[property], copyValue)
+		}
+	}
+}
+
+// writeFidelityProbeTree builds a fixture that exercises the filesystem
+// properties an archive can lose. Anything the local filesystem cannot express
+// is simply left out of the description rather than skipped silently — see
+// describeFidelity.
+func writeFidelityProbeTree(t *testing.T, root string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "dir"), 0700))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "empty-dir"), 0700))
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "hard-a"), []byte("shared payload"), 0600))
+	require.NoError(t, os.Link(filepath.Join(root, "hard-a"), filepath.Join(root, "hard-b")))
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "plain.txt"), []byte("plain"), 0600))
+	require.NoError(t, os.Symlink("plain.txt", filepath.Join(root, "link")))
+
+	sparse, err := os.Create(filepath.Join(root, "sparse.bin"))
+	require.NoError(t, err)
+	require.NoError(t, sparse.Truncate(8<<20))
+	_, err = sparse.WriteAt([]byte("payload"), 4<<20)
+	require.NoError(t, err)
+	require.NoError(t, sparse.Close())
+
+	// Best effort: a filesystem without user xattrs just omits the property.
+	_ = unix.Setxattr(filepath.Join(root, "plain.txt"), "user.af_fidelity", []byte("filevalue"), 0)
+	_ = unix.Setxattr(filepath.Join(root, "dir"), "user.af_fidelity", []byte("dirvalue"), 0)
+
+	// Explicitly, and after every node exists: os.Mkdir/os.WriteFile subtract
+	// the umask themselves, so a fixture that is merely REQUESTED at these modes
+	// is born already tightened and proves nothing.
+	for path, mode := range map[string]os.FileMode{
+		filepath.Join(root, "dir"):       0755,
+		filepath.Join(root, "empty-dir"): 0750,
+		filepath.Join(root, "plain.txt"): 0640,
+		filepath.Join(root, "hard-a"):    0664,
+	} {
+		require.NoError(t, os.Chmod(path, mode))
+	}
+
+	old := time.Unix(1_000_000_000, 0)
+	require.NoError(t, os.Chtimes(filepath.Join(root, "plain.txt"), old, old))
+	require.NoError(t, os.Chtimes(filepath.Join(root, "dir"), old, old))
+}
+
+// describeFidelity renders one tree as property → observed value. A property the
+// local filesystem cannot express is omitted entirely, so the comparison above
+// skips it instead of inventing a difference (or, worse, an agreement).
+func describeFidelity(t *testing.T, root string) map[string]string {
+	t.Helper()
+	described := map[string]string{}
+
+	var hardA syscall.Stat_t
+	require.NoError(t, syscall.Stat(filepath.Join(root, "hard-a"), &hardA))
+	described["hardlink.nlink"] = fmt.Sprintf("%d", hardA.Nlink)
+	var hardB syscall.Stat_t
+	require.NoError(t, syscall.Stat(filepath.Join(root, "hard-b"), &hardB))
+	described["hardlink.sameInode"] = fmt.Sprintf("%t", hardA.Ino == hardB.Ino)
+
+	var sparseStat syscall.Stat_t
+	require.NoError(t, syscall.Stat(filepath.Join(root, "sparse.bin"), &sparseStat))
+	described["sparse.size"] = fmt.Sprintf("%d", sparseStat.Size)
+	// Bucketed, not exact: cp --sparse=always reproduces holes at write
+	// granularity, so demanding an identical block count would fail on a
+	// faithful copy. What must not happen is the hole being allocated.
+	described["sparse.mostlyUnallocated"] = fmt.Sprintf("%t", sparseStat.Blocks*512 < sparseStat.Size/2)
+
+	// Always recorded, never omitted. An earlier version of this decided here
+	// whether the filesystem supported xattrs by re-probing the tree it was
+	// describing — which cannot tell "this filesystem has no xattrs" from "the
+	// copy dropped them", so the property was silently left out of BOTH
+	// descriptions and the comparison skipped it entirely. The capability
+	// question belongs to the source description alone, and the caller asks it.
+	for property, path := range map[string]string{
+		"xattr.file": filepath.Join(root, "plain.txt"),
+		"xattr.dir":  filepath.Join(root, "dir"),
+	} {
+		buffer := make([]byte, 64)
+		if n, err := unix.Getxattr(path, "user.af_fidelity", buffer); err == nil {
+			described[property] = string(buffer[:n])
+		} else {
+			described[property] = "MISSING"
+		}
+	}
+
+	for property, path := range map[string]string{
+		"mtime.file": filepath.Join(root, "plain.txt"),
+		"mtime.dir":  filepath.Join(root, "dir"),
+	} {
+		info, err := os.Lstat(path)
+		require.NoError(t, err)
+		described[property] = info.ModTime().UTC().Format(time.RFC3339Nano)
+	}
+
+	for property, path := range map[string]string{
+		"mode.dir":   filepath.Join(root, "dir"),
+		"mode.file":  filepath.Join(root, "plain.txt"),
+		"mode.empty": filepath.Join(root, "empty-dir"),
+		"mode.hardA": filepath.Join(root, "hard-a"),
+	} {
+		info, err := os.Lstat(path)
+		require.NoError(t, err)
+		described[property] = fmt.Sprintf("%04o", info.Mode().Perm())
+	}
+
+	target, err := os.Readlink(filepath.Join(root, "link"))
+	require.NoError(t, err)
+	described["symlink.target"] = target
+
+	contents, err := os.ReadFile(filepath.Join(root, "hard-a"))
+	require.NoError(t, err)
+	described["contents.hardA"] = string(contents)
+
+	return described
+}


### PR DESCRIPTION
Picked up #2919, which had no PR. This is the structural item from its checklist — the one that stops the class recurring rather than closing one more instance of it.

## Why a test is the fix here

#2869 (modes), #2872 (read-only directories) and #2920 (sparse files) were three instances of **one** defect: `moveDirCrossDevice` has two implementations of one promise, and the copy leg reproduces only what someone wrote code for. The copier's fidelity is an *enumeration*, and **nothing failed when the enumeration was incomplete** — so each gap was found by a user or an audit, one at a time, after shipping.

This runs one fixture through both legs, compares every property it can observe, and fails on any difference not in an explicit inventory.

## Design choices that carry weight

- **The inventory is a denylist, not an allowlist.** An allowlist silently ignores whatever nobody thought of — the exact failure being prevented.
- **It fails in both directions.** Fix a recorded gap without removing its entry and the "no longer diverges" branch fires, so the inventory can't rot into a list of things fixed long ago.
- **The rename leg is asserted lossless first.** It's the oracle; an oracle that quietly stopped carrying a property would make the copy agree with the wrong answer.
- **Sparseness is bucketed, not exact.** `cp --sparse=always` semantics reproduce holes at write granularity, so demanding an identical block count would fail on a faithful copy. What must not happen is the hole being *allocated*.

## Two defects found in the test itself

Both surfaced by trying to make it fail, not by reading it — and I think they're the most useful part of this PR:

1. **It passed with mode preservation entirely disabled.** Under the ambient umask 0022 the fixture's `0755`/`0640` survive `mkdirat`/`openat` untouched, so there was nothing to observe. That is the *same blind spot that let #2869 ship green under its own tests* — reproduced inside the guard written to prevent it. Fixed with a restrictive umask plus explicit `chmod` after creation, since `os.Mkdir`/`os.WriteFile` subtract the umask too.

2. **The xattr properties were never compared.** The capability probe asked "does this filesystem support xattrs?" by re-probing *the tree it was describing* — which cannot distinguish "no xattr support here" from "the copy dropped it". Both descriptions omitted the property, so the comparison skipped it and those inventory entries were dead code. That question belongs to the source description alone.

## Verification

Each regression class caught by breaking it one at a time:

| broken | test reports |
|---|---|
| `preserveSourceMode` → no-op | `mode.dir`, `mode.empty`, `mode.file`, `mode.hardA` diverge |
| `applyCopiedDirectoryMode` → no-op | `mode.dir`, `mode.empty` diverge |
| hole preservation → off | `sparse.mostlyUnallocated` diverges |
| recorded gap "fixed" but left listed | `symlink.target no longer diverges — remove it from the inventory` |

So #2869, #2872 and #2920 are all now guarded against silent regression, and the remaining recorded gaps (hardlinks, xattrs, mtime) stay visible in code rather than only in an issue.

`gofmt -l .` clean · `go build ./...` · `golangci-lint run --fast` · `deadcode -test ./...` · `scripts/lint-file-length.sh` · `go test ./session/git/` green. No daemon/app tests, no container suites.

Refs #2919