### PR TITLE
fix(upgrade): a failed lease release must not fail a completed recovery

### DIFF
--- a/internal/upgradetxn/recovery_actor.go
+++ b/internal/upgradetxn/recovery_actor.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"path/filepath"
 	"strings"
+
+	"github.com/sachiniyer/agent-factory/log"
 )
 
 // RecoveryInvocation is the strict internal command rendered into persistent
@@ -86,7 +88,24 @@ func runRecoveryActorWith(
 	if lease == nil {
 		return errors.New("upgrade recovery acquisition returned no lease")
 	}
-	defer func() { retErr = errors.Join(retErr, lease.Release()) }()
+	// Releasing the lease is CLEANUP, and cleanup that fails after the real work
+	// succeeded must not be reported as the work failing. Joining it into retErr
+	// turned a successful recovery into a non-zero exit — and this actor's exit
+	// code is load-bearing: every terminal path below returns nil specifically so
+	// the loaded unit's Restart=on-failure cannot undo the circuit breaker the
+	// supervisor just set. A failed release would have restarted an actor for an
+	// upgrade that had already committed or rolled back (#2960).
+	//
+	// The lease is an flock plus a file handle; both are released by the kernel
+	// when this process exits moments later, so a release error costs nothing
+	// beyond the diagnostic. It is logged rather than dropped so a genuinely
+	// stuck lock is still visible.
+	defer func() {
+		if relErr := lease.Release(); relErr != nil {
+			log.WarningLog.Printf("upgrade recovery: could not release the recovery lease for transaction %s (the recovery itself is unaffected): %v",
+				invocation.TransactionID, relErr)
+		}
+	}()
 
 	err = supervise(ctx, txn, lease)
 	if err == nil {

--- a/internal/upgradetxn/recovery_actor_test.go
+++ b/internal/upgradetxn/recovery_actor_test.go
@@ -131,3 +131,75 @@ func TestRecoveryActorRunnerMapsOnlyDisarmedTerminalOutcomesToCleanExit(t *testi
 		})
 	}
 }
+
+// Cleanup that fails after the real work succeeded must not be reported as the
+// work failing. This actor's exit code is load-bearing: every terminal path
+// returns nil precisely so the loaded unit's Restart=on-failure cannot undo the
+// circuit breaker the supervisor just set. Joining a lease-release error into
+// the return turned a committed upgrade into a non-zero exit, and the unit would
+// then restart an actor for an upgrade that had already finished (#2960).
+func TestRunRecoveryActor_LeaseReleaseFailureDoesNotFailTheRecovery(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		runErr error
+	}{
+		{name: "commit", runErr: nil},
+		{name: "abort", runErr: ErrUpgradeAborted},
+		{name: "rollback", runErr: ErrUpgradeRolledBack},
+		{name: "rollback failed circuit breaker", runErr: ErrRollbackRecoveryFailed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			txn, home, _ := prepareFixture(t)
+			invocation := RecoveryInvocation{HomeDir: home, TransactionID: txn.Journal().ID}
+			lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+			require.NoError(t, err)
+
+			// Close the handle out from under the lease so the actor's own
+			// deferred Release fails for real. Deliberately NOT calling Release
+			// here first: Release nils the handles, so a pre-call would leave the
+			// actor releasing nothing and the test would pass against the very
+			// bug it exists to catch. TestRecoveryLease_ReleaseFailsOnAClosedHandle
+			// proves this fixture actually breaks Release.
+			require.NoError(t, lease.file.Close())
+
+			err = runRecoveryActorWith(
+				context.Background(), invocation,
+				func(*Transaction) (*RecoveryLease, error) { return lease, nil },
+				func(context.Context, *Transaction, *RecoveryLease) error { return tc.runErr },
+			)
+			require.NoError(t, err,
+				"a failed lease release must not turn a completed recovery into a non-zero exit")
+		})
+	}
+}
+
+// The converse: a genuine supervision failure still fails, so the change did not
+// make the actor swallow outcomes that must reach the exit code.
+func TestRunRecoveryActor_SupervisionFailureStillFails(t *testing.T) {
+	txn, home, _ := prepareFixture(t)
+	invocation := RecoveryInvocation{HomeDir: home, TransactionID: txn.Journal().ID}
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+
+	err = runRecoveryActorWith(
+		context.Background(), invocation,
+		func(*Transaction) (*RecoveryLease, error) { return lease, nil },
+		func(context.Context, *Transaction, *RecoveryLease) error {
+			return errors.New("health probe failed")
+		},
+	)
+	require.Error(t, err)
+}
+
+// Proves the fixture the test above relies on: a closed handle really does make
+// Release fail. Kept separate because consuming the failure inside that test
+// would neutralise it — Release nils the handles, so the actor would then have
+// nothing left to fail on.
+func TestRecoveryLease_ReleaseFailsOnAClosedHandle(t *testing.T) {
+	txn, _, _ := prepareFixture(t)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+
+	require.NoError(t, lease.file.Close())
+	require.Error(t, lease.Release(), "closing the handle must make Release fail")
+}


### PR DESCRIPTION
## The bug

`runRecoveryActorWith` joined `lease.Release()` into its return value:

```go
defer func() { retErr = errors.Join(retErr, lease.Release()) }()
```

so a cleanup failure *after the real work succeeded* was reported as the work failing.

## Why it matters more than a misleading error

This actor's exit code is load-bearing. Every terminal path returns nil on purpose — the existing comment says why: *"Exit 0 so the loaded unit's runtime Restart policy cannot undo that circuit breaker."* A non-zero exit hands `Restart=on-failure` exactly the authority those returns exist to withhold.

So a failed release would have restarted a recovery actor for an upgrade that had **already committed or rolled back** — and anything consuming that exit code would conclude the upgrade did not happen, and could retry or roll back a change that actually landed.

## The fix

The release error is logged rather than joined. Nothing is lost by not returning it: the lease is an flock plus a file handle, both released by the kernel when this process exits moments later — so the error is a diagnostic, not an outcome. Logging keeps a genuinely stuck lock visible.

A supervision failure still fails, so this does not swallow outcomes that must reach the exit code.

## Verification

`TestRunRecoveryActor_LeaseReleaseFailureDoesNotFailTheRecovery` closes the lease's handle so the actor's **own deferred Release** fails for real, across all four terminal outcomes (commit, abort, rollback, rollback-failed circuit breaker).

Worth noting how that test was arrived at, because the first version was wrong: it called `Release()` in the fixture to assert the failure was real. `Release` nils the handles, so the actor was then releasing nothing and **the test passed against the unfixed code**. I caught it by mutation-testing — restoring the `errors.Join` and finding the test still green. The fixture is now proven by a separate test (`TestRecoveryLease_ReleaseFailsOnAClosedHandle`) so asserting it cannot consume it, and the mutation now correctly turns the main test red.

`TestRunRecoveryActor_SupervisionFailureStillFails` covers the converse.

Local gate: `gofmt -l .` (empty), `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh`, plus the full `internal/upgradetxn` suite. No daemon-package tests and no containerized suites — CI runs those on Linux and macOS.

Closes #2960

🤖 Generated with [Claude Code](https://claude.com/claude-code)