### PR TITLE
fix(tmux): delete the paste buffer when load-buffer fails, not only when paste does

### DIFF
--- a/session/tmux/submit.go
+++ b/session/tmux/submit.go
@@ -152,8 +152,16 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 	// session must not share a buffer, or one call's load-buffer could overwrite
 	// the other's content between its load and paste and corrupt the submit. The
 	// process token additionally keeps two af processes on a shared tmux server
-	// from colliding on the same server-scoped buffer name. `-d` clears the buffer
-	// after pasting so buffers never accumulate.
+	// from colliding on the same server-scoped buffer name.
+	//
+	// The invariant is that EVERY exit path below disposes of this buffer, because
+	// buffers are server-scoped and outlive the session: `paste-buffer -d` on the
+	// success path, and an explicit best-effort `delete-buffer` on each of the two
+	// failure paths. This comment used to say only that `-d` meant "buffers never
+	// accumulate" — true of a successful paste and false of both failures, which is
+	// how the load-side leak (#2958) stayed invisible after the paste-side one
+	// (#1536) was fixed. State the property that has to hold on every path, not the
+	// one mechanism that delivers it on one of them.
 	buf := pasteBufferName(pasteBufferProcessToken, t.sanitizedName, pasteBufferSeq.Add(1))
 
 	probe := newDeliveryProbe(text)
@@ -167,6 +175,32 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 	loadTimedOut := loadCtx.Err() != nil
 	loadCancel()
 	if err != nil {
+		// A failed load can still have CREATED the buffer. `load-buffer -` consumes
+		// stdin incrementally, so a read error part-way through — or a timeout that
+		// kills the command mid-write — leaves a partially-filled buffer behind. Since
+		// buffers are server-scoped they outlive the session, so every failed submit
+		// strands another one: the same unbounded leak #1536 closed on the paste side,
+		// reached through the other half of the two-step paste (#2958).
+		//
+		// Bounded, for the paste path's reason: the cleanup for a load that failed
+		// against a WEDGED server must not itself wedge on that server and undo the
+		// bound above.
+		//
+		// Deleting here is unconditionally safe. pasteBufferName mints a name unique to
+		// this call (per-process token + atomic seq), so this can only ever remove the
+		// buffer THIS call loaded — never a concurrent delivery's pending one.
+		delCtx, delCancel := tmuxTimeoutContext()
+		derr := t.runTmuxBounded(delCtx, "delete-buffer", "-b", buf)
+		delCancel()
+		if derr != nil {
+			// WARNING, not the ERROR its paste-side twin uses, and the difference is
+			// deliberate. After a SUCCESSFUL load the buffer certainly exists, so
+			// failing to delete it is surprising. Here the load failed, so the buffer
+			// may never have been created at all — tmux answers `no buffer <name>` and
+			// exits non-zero — and that is the expected outcome, not a fault. Logging it
+			// at ERROR would cry wolf on the common case of this very path.
+			log.WarningLog.Printf("could not delete paste buffer %q after a failed load (it may never have been created): %v", buf, derr)
+		}
 		if loadTimedOut {
 			return fmt.Errorf("%w: load-buffer after %s", ErrTmuxTimeout, tmuxCommandTimeout)
 		}

--- a/session/tmux/submit_test.go
+++ b/session/tmux/submit_test.go
@@ -541,6 +541,96 @@ func TestSubmitDeletesBufferWhenPasteFails(t *testing.T) {
 		"a failed paste must delete-buffer the same buffer it loaded, not leak it (#1536)")
 }
 
+// TestSubmitDeletesBufferWhenLoadFails is the other half of the #1536 leak,
+// filed as #2958. `load-buffer -` consumes stdin incrementally, so tmux can have
+// CREATED the named buffer before it fails — a read error part-way through, or a
+// timeout that kills the command mid-write. Buffers are server-scoped, so that
+// one outlives the session and every failed submit strands another.
+//
+// The paste-failure path was given a best-effort delete; this one returned
+// straight out. Same two-step paste, same buffer, same unbounded leak.
+func TestSubmitDeletesBufferWhenLoadFails(t *testing.T) {
+	var loadBuf, deletedBuf string
+	var loadErr = fmt.Errorf("boom: short write to stdin")
+	pasted := false
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			joined := strings.Join(c.Args, " ")
+			switch {
+			case strings.Contains(joined, "load-buffer"):
+				// tmux named (and partially filled) the buffer, THEN failed.
+				loadBuf = bufferOf(c.Args)
+				return loadErr
+			case strings.Contains(joined, "paste-buffer"):
+				pasted = true
+				return nil
+			case strings.Contains(joined, "delete-buffer"):
+				deletedBuf = bufferOf(c.Args)
+				return nil
+			}
+			return nil
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) { return []byte("content"), nil },
+	}
+
+	session := newTmuxSession("af_proj", "claude", NewMockPtyFactory(t), cmdExec)
+	const existingProvenance = "previously-accepted-completion"
+	session.lastPastedTail = existingProvenance
+
+	err := session.SendKeysCommand("a prompt whose load fails")
+	require.Error(t, err, "a failed load-buffer must surface as an error")
+	require.ErrorIs(t, err, loadErr, "the load error must be wrapped and returned")
+
+	require.NotEmpty(t, loadBuf, "load-buffer must have named a buffer")
+	require.Equal(t, loadBuf, deletedBuf,
+		"a failed load must delete-buffer the same buffer it named, not leak it: tmux buffers are "+
+			"server-scoped, so one is stranded per failed submit for the life of the server (#2958)")
+
+	// The two properties a load failure must preserve, so the cleanup cannot be
+	// mistaken for "just retry the whole delivery": nothing was pasted into the
+	// pane, and provenance from the last ACCEPTED payload is untouched.
+	require.False(t, pasted, "a failed load must not go on to paste")
+	require.Equal(t, existingProvenance, session.lastPastedTail,
+		"a failed load must not replace provenance from the last accepted payload")
+}
+
+// TestSubmitDeleteAfterFailedLoadIsBounded pins the reason the cleanup takes a
+// bounded context rather than running unbounded: a load that failed because the
+// SERVER is wedged would otherwise have its cleanup wedge on that same server,
+// undoing the bound the load itself was given. The delete must be issued and must
+// carry a deadline.
+func TestSubmitDeleteAfterFailedLoadIsBounded(t *testing.T) {
+	var sawDelete bool
+	var deleteHadDeadline bool
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			joined := strings.Join(c.Args, " ")
+			switch {
+			case strings.Contains(joined, "load-buffer"):
+				return fmt.Errorf("server wedged")
+			case strings.Contains(joined, "delete-buffer"):
+				sawDelete = true
+				// Both are set by boundedTmuxCommand and by nothing else in this
+				// package — a hand-rolled exec.Command("tmux", …), which the package
+				// does still contain for server scoping, carries neither.
+				if c.Cancel != nil && c.WaitDelay != 0 {
+					deleteHadDeadline = true
+				}
+				return nil
+			}
+			return nil
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) { return []byte("content"), nil },
+	}
+
+	session := newTmuxSession("af_proj", "claude", NewMockPtyFactory(t), cmdExec)
+	require.Error(t, session.SendKeysCommand("prompt"))
+	require.True(t, sawDelete, "a failed load must attempt the cleanup delete")
+	require.True(t, deleteHadDeadline,
+		"the cleanup delete must be bounded, or a wedged server that failed the load would wedge "+
+			"its cleanup too and defeat the load's own timeout")
+}
+
 // TestPasteBufferNameProcessTokenPreventsCrossProcessCollision is the #1536
 // Greptile guard: tmux buffers are server-scoped and the seq counter is
 // process-local, so two af processes sharing a tmux server and a session name


### PR DESCRIPTION
Closes #2958.

## The leak

`load-buffer -` streams stdin, so tmux can have **created** the named buffer
before it fails — a read error part-way through, or a timeout that kills the
command mid-write. tmux buffers are server-scoped, so the stranded buffer
outlives the session, and every failed submit adds another for the life of the
server.

It is the same leak #1536 closed on the paste side, reached through the other
half of the same two-step paste:

| step | on failure |
| --- | --- |
| `paste-buffer` | best-effort `delete-buffer` (#1536) |
| `load-buffer` | **returned straight out** |

Now symmetric: bounded, best-effort `delete-buffer` on both.

## The comment that hid it

The function said `-d` clears the buffer after pasting **so buffers never
accumulate** — true of a successful paste, false of both failure paths. That is
precisely why the load-side gap stayed invisible after the paste-side one was
fixed: the comment asserted the outcome while only one mechanism delivered it,
on one path.

It now states the invariant that has to hold on *every* exit path, and names both
issues so the next reader sees the shape rather than the mechanism.

## One deliberate asymmetry

The cleanup logs at **WARNING** where its paste-side twin logs at **ERROR**.
After a successful load the buffer certainly exists, so failing to delete it is
surprising. Here the load failed, so the buffer may never have been created —
tmux answers `no buffer <name>` and exits non-zero — and that is the *expected*
outcome of this path, not a fault. ERROR would cry wolf on the common case.

## Tests verified by mutation, not by reading

Both new tests use the mock executor (no tmux is spawned), and I checked each
actually fails for its stated reason:

- **remove the cleanup** → both fail, each with its own message;
- **keep it but make it unbounded** (`exec.Command` instead of the bounded
  helper) → **only** the boundedness test fails, since the buffer is still
  deleted.

So they are scoped to distinct properties and neither can pass for the wrong
reason. The boundedness assertion checks `Cancel` **and** `WaitDelay`, both set
by `boundedTmuxCommand` and by nothing else in the package — the package does
still contain hand-rolled `exec.Command("tmux", …)` calls for server scoping, so
that assertion is not vacuous.

## Safety of deleting

Unconditional deletion is safe here: `pasteBufferName` mints a name unique to the
call (per-process token + atomic seq), so the cleanup can only ever remove the
buffer *this* call named — never a concurrent delivery's pending one. That
property is what #1536's own cross-process test exists to protect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
