### PR TITLE
fix(daemon): prove an editor socket is dead before unlinking it (#2961)

### DIFF
--- a/commands/reset.go
+++ b/commands/reset.go
@@ -322,6 +322,16 @@ func runReset(cmd *cobra.Command, _ []string) (err error) {
 	//     unlinking a LIVE daemon's socket is the #767 failure, which the assert
 	//     above has just ruled out.
 	switch removed, sockErr := removeRuntimeSocketFn(plan.configDir); {
+	case errors.Is(sockErr, daemon.ErrLiveEditorSocket):
+		// ABORT, on the same rule step 5 states for an unreadable session set (#2870):
+		// a precondition for a safe wipe is unmet, and a warning is no safeguard once
+		// the worktree is gone. A live editor holds a running process over a worktree
+		// this reset is about to delete, so continuing would destroy the state while
+		// the editor kept running against it — and the message would have said "stop
+		// it first" while the reset did the opposite. Nothing destructive has run yet,
+		// so the abort costs the user one command.
+		err = fmt.Errorf("refusing to reset: %w", sockErr)
+		return err
 	case sockErr != nil:
 		fmt.Fprintf(out, "Could not remove the daemon sockets (%v).\n", sockErr)
 	case len(removed) > 0:

--- a/daemon/stopall.go
+++ b/daemon/stopall.go
@@ -402,6 +402,12 @@ func daemonHomeEnv(pid int) (string, bool) {
 // daemon while the first leaks forever. That is strictly worse than the stale
 // socket this function exists to clear, so "a daemon answered" is a reason to
 // stop, not a race to win.
+// ErrLiveEditorSocket reports that a socket still has a running editor behind it, so
+// it was left in place. It is a sentinel because the CALLER's response has to differ
+// from an ordinary socket error: a live editor is a precondition failure for a
+// destructive wipe, not litter to mention in passing. See the abort in commands/reset.
+var ErrLiveEditorSocket = errors.New("a running editor is still serving this socket; stop it first")
+
 func RemoveRuntimeSockets(dir string) ([]string, error) {
 	if err := pingDaemon(); err == nil {
 		return nil, errors.New("a daemon is still answering on the control socket; " +
@@ -430,16 +436,31 @@ func RemoveRuntimeSockets(dir string) ([]string, error) {
 	// Editor sockets are swept with the daemon's OWN recognizer rather than a
 	// "*.sock" glob: an operator can point AGENT_FACTORY_HOME at a directory
 	// already in use, and reset must not delete a file it did not mint. See
-	// isAbandonedVSCodeSocket for why name AND socket-ness are both checked.
+	// isVSCodeSocketFile for why name AND socket-ness are both checked.
+	//
+	// And each one must be proven DEAD first (#2961). The daemon check above is not
+	// sufficient cover for these: editors are started with Setpgid, so they do not
+	// receive the daemon's SIGHUP and routinely outlive it — "no daemon is answering"
+	// says nothing about whether an editor still is. Unlinking a live editor's socket
+	// is the #767 failure this function already refuses for the daemon's own socket,
+	// one level down: the editor keeps serving an inode with no name, and every pane
+	// on it 502s while the process lingers.
 	sockDir := filepath.Join(dir, vscodeSocketDirName)
 	entries, err := os.ReadDir(sockDir)
 	if err != nil && !os.IsNotExist(err) {
 		errs = append(errs, fmt.Errorf("read %s: %w", sockDir, err))
 	}
 	for _, e := range entries {
-		if isAbandonedVSCodeSocket(sockDir, e) {
-			remove(filepath.Join(sockDir, e.Name()))
+		if !isVSCodeSocketFile(sockDir, e) {
+			continue
 		}
+		path := filepath.Join(sockDir, e.Name())
+		if !vscodeSocketAbandoned(path, processGroupAlive) {
+			errs = append(errs, fmt.Errorf("%w: %s (removing it would strand the editor and 502 its panes — #2961)",
+				ErrLiveEditorSocket, path))
+			continue
+		}
+		remove(path)
 	}
 
 	sort.Strings(removed)

--- a/daemon/vscode_socket.go
+++ b/daemon/vscode_socket.go
@@ -5,12 +5,14 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
+	"syscall"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
@@ -43,6 +45,12 @@ const vscodeSocketDirName = "vscode"
 // the full minted name and checks the file really is a socket
 // (vscodeSocketNamePattern, isAbandonedVSCodeSocket).
 const vscodeSocketExt = ".sock"
+
+// vscodeSocketProbeTimeout bounds the connect probe that proves a socket dead.
+// A unix connect to a listening peer completes in microseconds, so this is slack
+// for a loaded box rather than a wait anyone should notice; the sweep runs once and
+// over a handful of files. A timeout counts as LIVE, never as proof of death.
+const vscodeSocketProbeTimeout = 500 * time.Millisecond
 
 // vscodeSocketMode is the socket's file mode, passed to code-server's
 // --socket-mode and applied by startOne for flavors that have no mode flag. 0600:
@@ -264,7 +272,74 @@ var vscodeSocketNamePattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{8}\.sock
 //     than followed — the sweep can never delete through a link.
 //
 // A vanished entry (err from Info) is skipped: it is already gone.
-func isAbandonedVSCodeSocket(dir string, e os.DirEntry) bool {
+// socketIsAbandoned reports whether NOTHING is serving path, and requires positive
+// evidence of that before saying yes.
+//
+// Its bias is deliberately the opposite of stopPersistedOwner's, because the two
+// are protecting against opposite mistakes. Signalling a process demands strong
+// proof of identity — signal the wrong one and you kill a stranger's work. Deleting
+// a socket name demands only a hint of life to abstain: keeping a stale file costs
+// one inode, deleting a live one costs the user a running editor with no diagnostic
+// beyond a 502. So anything unreadable, ambiguous, or merely unexpected counts as
+// LIVE here.
+//
+// Two independent signals, either of which spares the file:
+//
+//  1. The owner record. If it names a process group still alive — or the probe
+//     cannot tell — an editor is or may be running. Only a record that is readable
+//     AND definitively dead falls through.
+//  2. The socket itself. This is the direct evidence, and it is what makes the
+//     answer robust where metadata is not: an owner file may be missing (an editor
+//     from an older af), truncated, or describe a recycled pid. Nothing can accept a
+//     connection unless a listener is really there.
+func (v *vscodeSupervisor) socketIsAbandoned(path string) bool {
+	return vscodeSocketAbandoned(path, v.processGroupAlive)
+}
+
+// vscodeSocketAbandoned is socketIsAbandoned without a supervisor, so the same
+// judgement is available to RemoveRuntimeSockets — which unlinks editor sockets
+// during a reset and has no supervisor to ask. groupAlive is the liveness probe
+// (the supervisor passes its test seam; other callers pass processGroupAlive).
+//
+// Shared deliberately rather than reimplemented: "is anything still serving this
+// socket" got a different answer in each place before, and the cheaper answer was
+// the wrong one in both.
+func vscodeSocketAbandoned(path string, groupAlive func(int) (bool, error)) bool {
+	if owner, err := readVSCodeOwner(vscodeOwnerPath(path)); err == nil {
+		alive, probeErr := groupAlive(owner.PID)
+		if probeErr != nil || alive {
+			return false
+		}
+	}
+	return !vscodeSocketAccepting(path)
+}
+
+// vscodeSocketAccepting reports whether a listener answers on path.
+//
+// Only "nothing is listening" proves death, so only ECONNREFUSED (and a path that
+// is already gone) return false. Every other outcome — a timeout, a full backlog,
+// EACCES, anything unclassified — returns TRUE, because none of them establishes
+// that the socket is dead and the cost of guessing wrong is a lost editor.
+//
+// The connection is closed immediately and sends nothing; an editor treats it as a
+// client that hung up before making a request.
+func vscodeSocketAccepting(path string) bool {
+	conn, err := net.DialTimeout("unix", path, vscodeSocketProbeTimeout)
+	if err == nil {
+		_ = conn.Close()
+		return true
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+	return true
+}
+
+// isVSCodeSocketFile reports whether a directory entry has the SHAPE of an editor
+// socket this daemon family creates. It is only the name/type filter — whether the
+// socket is abandoned is socketIsAbandoned's question, and keeping the two apart is
+// what stopped the shape check from being read as a liveness check (#2961).
+func isVSCodeSocketFile(dir string, e os.DirEntry) bool {
 	if !vscodeSocketNamePattern.MatchString(e.Name()) {
 		return false
 	}
@@ -333,15 +408,31 @@ func vscodeSocketKeyPrefix(key string) string {
 // file per session, for the life of the af home. This is the counterpart of that
 // choice, not an extra.
 //
-// It runs once, on the first spawn rather than at construction, and that timing
-// is what makes it safe: a supervisor that has never spawned owns no editors, so
-// every socket in the directory is by definition abandoned. (Waiting for a spawn
-// also means a daemon that never opens an editor neither creates the directory
-// nor touches anything.) The singleton lock guarantees no other daemon owns this
-// af home meanwhile.
+// It runs once, on the first spawn rather than at construction. That timing keeps
+// a daemon which never opens an editor from creating the directory or touching
+// anything, and the singleton lock guarantees no other daemon owns this af home
+// meanwhile.
+//
+// WHAT IT MUST NOT INFER (#2961). This used to reason that "a supervisor that has
+// never spawned owns no editors, so every socket in the directory is by definition
+// abandoned". The first clause is true and the second does not follow: editors are
+// started with Setpgid, so they do NOT get the daemon's SIGHUP and keep running
+// when it dies or is upgraded. Their sockets are therefore not this supervisor's
+// and not abandoned either — they are LIVE editors belonging to a previous daemon.
+// Unlinking a unix socket while a process listens on it does not stop the process;
+// it only removes the name, so the editor keeps running, unreachable, and every
+// pane on it 502s. On a box that restarts its daemon on each upgrade, that is a
+// working editor lost per restart.
+//
+// So abandonment is now PROVEN per socket rather than inferred from the restart
+// (socketIsAbandoned): a live owner record, or anything still accepting on the
+// path, keeps the file. Live orphans are left to the owner-record reap
+// (stopPersistedOwner), which stops the PROCESS with the four identity proofs a
+// signal requires — a sweep that deletes names was never the mechanism for that.
 //
 // Best-effort throughout: a failed sweep costs litter, never correctness, and
-// must not stop an editor from starting.
+// must not stop an editor from starting. That asymmetry sets the bias — every
+// uncertain answer below keeps the socket.
 func (v *vscodeSupervisor) sweepAbandonedSockets() {
 	v.sweepOnce.Do(func() {
 		dir, err := vscodeSocketDir()
@@ -355,10 +446,13 @@ func (v *vscodeSupervisor) sweepAbandonedSockets() {
 			return
 		}
 		for _, e := range entries {
-			if !isAbandonedVSCodeSocket(dir, e) {
+			if !isVSCodeSocketFile(dir, e) {
 				continue
 			}
 			path := filepath.Join(dir, e.Name())
+			if !v.socketIsAbandoned(path) {
+				continue
+			}
 			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 				log.WarningLog.Printf("vscode: removing the abandoned socket %s failed: %v", path, err)
 			}

--- a/daemon/vscode_socket_sweep_test.go
+++ b/daemon/vscode_socket_sweep_test.go
@@ -1,0 +1,176 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+)
+
+// assertProbeFailed stands in for a liveness probe that cannot reach a verdict.
+var assertProbeFailed = errors.New("probe failed")
+
+// #2961: startup socket cleanup must PROVE a socket is dead before unlinking it.
+//
+// Editors are started with Setpgid, so they do not receive the daemon's SIGHUP and
+// keep running across a restart or an upgrade. The sweep used to reason that a
+// supervisor which has never spawned owns no editors, therefore every socket in the
+// directory is abandoned — the second clause does not follow from the first. On a box
+// that restarts its daemon on every upgrade, that cost a working editor per restart:
+// unlinking a unix socket does not stop the listener, it only removes the name, so the
+// editor lingers unreachable and every pane on it 502s.
+
+// Every test here uses testguard.SocketTempDir rather than t.TempDir: on macOS the
+// latter canonicalizes to a ~56-byte /private/var/folders/... path, and a vscode
+// socket beneath it overruns sun_path's 104-byte limit, so net.Listen fails before
+// the sweep is ever reached. Linux has 108 bytes and a short /tmp, which is why this
+// passes there and fails only on Darwin.
+
+// listeningSocket creates a real unix listener at path and returns it. This is the
+// fixture the old sweep had no way to distinguish from litter.
+func listeningSocket(t *testing.T, path string) net.Listener {
+	t.Helper()
+	l, err := net.Listen("unix", path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.Close() })
+	return l
+}
+
+// TestSweep_KeepsASocketAStillLiveEditorIsServing is the regression. A socket with a
+// live listener must survive the sweep, and must still be connectable afterwards —
+// asserting the file exists is not enough, since the bug's whole symptom is a
+// listener that outlives its name.
+func TestSweep_KeepsASocketAStillLiveEditorIsServing(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	dir, err := vscodeSocketDir()
+	require.NoError(t, err)
+
+	live := filepath.Join(dir, "93aa9bc2-a9009dfe.sock")
+	listeningSocket(t, live)
+	// The residue a SIGKILLed daemon leaves: a real socket FILE with no listener.
+	dead := filepath.Join(dir, "93aa9bc2-00bf0126.sock")
+	require.NoError(t, recreateOrphanSocket(dead))
+
+	v := newVSCodeSupervisor()
+	v.sweepAbandonedSockets()
+
+	_, err = os.Stat(live)
+	require.NoError(t, err, "a socket a live editor is serving must survive the sweep")
+	conn, derr := net.Dial("unix", live)
+	require.NoError(t, derr, "and must still be CONNECTABLE — the bug is a listener that outlives its name")
+	require.NoError(t, conn.Close())
+
+	_, err = os.Stat(dead)
+	require.True(t, os.IsNotExist(err), "a socket with nothing listening is still swept — the feature still works")
+}
+
+// recreateOrphanSocket leaves a socket FILE at path with no listener behind it, the
+// residue a SIGKILLed daemon leaves and the only thing the sweep should remove.
+func recreateOrphanSocket(path string) error {
+	l, err := net.Listen("unix", path)
+	if err != nil {
+		return err
+	}
+	if ul, ok := l.(*net.UnixListener); ok {
+		ul.SetUnlinkOnClose(false)
+	}
+	return l.Close()
+}
+
+// TestSweep_KeepsASocketWhoseOwnerIsAlive covers the second, independent signal: an
+// owner record naming a live process group spares the socket even if the connect
+// probe cannot reach a verdict. Either signal alone must be enough.
+func TestSweep_KeepsASocketWhoseOwnerIsAlive(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	dir, err := vscodeSocketDir()
+	require.NoError(t, err)
+	sock := filepath.Join(dir, "93aa9bc2-a9009dfe.sock")
+	require.NoError(t, recreateOrphanSocket(sock)) // nothing listening
+
+	owner := vscodeOwnerRecord{
+		Key: "repo/title", InstanceID: "inst", PID: 4242, StartID: 7,
+		BootID: "boot", PIDNamespace: "ns", ProcessNonce: "nonce",
+	}
+	raw, err := json.Marshal(owner)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(vscodeOwnerPath(sock), raw, 0o600))
+
+	v := newVSCodeSupervisor()
+	v.groupAlive = func(int) (bool, error) { return true, nil } // the recorded editor lives
+	v.sweepAbandonedSockets()
+
+	_, err = os.Stat(sock)
+	require.NoError(t, err, "a live owner record alone must spare the socket")
+}
+
+// TestSweep_UnknownLivenessKeepsTheSocket pins the BIAS, which is the opposite of the
+// signalling path's. stopPersistedOwner needs strong proof before it signals, because
+// signalling the wrong process kills a stranger's work. Deleting a name needs only a
+// hint of life to abstain, because a stale file costs an inode and a deleted live one
+// costs a running editor with no diagnostic beyond a 502.
+func TestSweep_UnknownLivenessKeepsTheSocket(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	dir, err := vscodeSocketDir()
+	require.NoError(t, err)
+	sock := filepath.Join(dir, "93aa9bc2-a9009dfe.sock")
+	require.NoError(t, recreateOrphanSocket(sock))
+
+	owner := vscodeOwnerRecord{
+		Key: "repo/title", InstanceID: "inst", PID: 4242, StartID: 7,
+		BootID: "boot", PIDNamespace: "ns", ProcessNonce: "nonce",
+	}
+	raw, err := json.Marshal(owner)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(vscodeOwnerPath(sock), raw, 0o600))
+
+	v := newVSCodeSupervisor()
+	v.groupAlive = func(int) (bool, error) { return false, assertProbeFailed }
+	v.sweepAbandonedSockets()
+
+	_, err = os.Stat(sock)
+	require.NoError(t, err, "an UNDECIDABLE liveness probe must keep the socket, never delete on doubt")
+}
+
+// TestRemoveRuntimeSockets_RefusesALiveEditorSocket pins the reset path's half of
+// #2961. RemoveRuntimeSockets already refuses to unlink a live DAEMON's socket and
+// explains why (#767: it keeps serving an inode with no name); editor sockets are the
+// ones that most often outlive the daemon, since Setpgid spares them its SIGHUP, so
+// "no daemon is answering" says nothing about them.
+//
+// The error is a SENTINEL because the caller must react differently: a live editor is
+// a precondition failure for a destructive wipe, not litter to mention in passing.
+func TestRemoveRuntimeSockets_RefusesALiveEditorSocket(t *testing.T) {
+	home := testguard.SocketTempDir(t)
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	dir, err := vscodeSocketDir()
+	require.NoError(t, err)
+
+	live := filepath.Join(dir, "93aa9bc2-a9009dfe.sock")
+	listeningSocket(t, live)
+	dead := filepath.Join(dir, "93aa9bc2-00bf0126.sock")
+	require.NoError(t, recreateOrphanSocket(dead))
+
+	removed, err := RemoveRuntimeSockets(home)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrLiveEditorSocket,
+		"the caller has to distinguish this from ordinary socket litter, so it must be a sentinel")
+	require.Contains(t, err.Error(), live, "and it must name the socket the operator has to deal with")
+
+	_, statErr := os.Stat(live)
+	require.NoError(t, statErr, "a live editor's socket must survive a reset attempt")
+	conn, dialErr := net.Dial("unix", live)
+	require.NoError(t, dialErr, "and stay connectable — the whole failure is a listener losing its name")
+	require.NoError(t, conn.Close())
+
+	// The genuinely stale one is still removed, so refusing is targeted rather than
+	// giving up on the whole directory.
+	require.NotContains(t, removed, live)
+	_, deadErr := os.Stat(dead)
+	require.True(t, os.IsNotExist(deadErr), "an abandoned socket is still cleared")
+}


### PR DESCRIPTION
Startup socket cleanup removed sockets that **live editors were still serving**, so a
VS Code pane 502'd after every daemon restart — and this box restarts its daemon on
each `af` upgrade.

## The bug is an inference, and the code said it out loud

`sweepAbandonedSockets`' own doc comment carried the reasoning that produced it:

> a supervisor that has never spawned owns no editors, so every socket in the
> directory is by definition abandoned

The first clause is true; the second does not follow. Editors are started with
`Setpgid`, so they never receive the daemon's SIGHUP and keep running across a restart
or upgrade. Their sockets are not this supervisor's **and not abandoned either** — they
belong to live editors from the previous daemon.

Unlinking a unix socket does not stop the listener. It removes the *name*, so the
editor lingers, unreachable, while every pane on it 502s and the process keeps its
memory. One working editor lost per restart.

## Prove it, don't infer it

`socketIsAbandoned` now requires **positive evidence of death**, from two independent
signals, either of which spares the file:

1. **The owner record** — if it names a process group still alive, or the probe cannot
   tell, an editor is or may be running.
2. **The socket itself** — anything still accepting a connection is a live listener.
   This is what makes the answer robust where metadata is not: an owner file may be
   missing (an editor from an older `af`), truncated, or name a recycled pid, but
   nothing accepts a connection unless a listener is really there.

Only `ECONNREFUSED` (or a path already gone) counts as proof of death. A timeout, a
full backlog, `EACCES`, anything unclassified — all count as **live**.

### The bias is deliberately inverted from `stopPersistedOwner`

The two guard against opposite mistakes, which is why they must not share a predicate:

| | wrong answer costs | so it demands |
|---|---|---|
| `stopPersistedOwner` (signals a process) | killing a stranger's work | strong proof of **identity** — four process proofs |
| this sweep (deletes a name) | a user's running editor, diagnosed only as a 502 | a **hint of life** to abstain |

A stale socket file costs one inode. That asymmetry sets the rule: every unreadable,
ambiguous or merely unexpected answer keeps the socket.

## The same defect, one level up

`RemoveRuntimeSockets` had it too, and the fix is shared rather than reimplemented.
That function already refuses to unlink a live **daemon's** socket and explains exactly
why (#767: "the daemon keeps serving an inode with no name") — then applied no such
check to **editor** sockets, which are precisely the ones that outlive the daemon. "No
daemon is answering" says nothing about whether an editor still is. It now reports a
live editor socket as an error instead of removing it.

`isAbandonedVSCodeSocket` is renamed `isVSCodeSocketFile`: it only ever answered the
name/type question, and its name is what let a shape check read as a liveness check.

**And the refusal has to be load-bearing, not advisory.** Review caught that returning
an error there was not enough: `commands/reset.go` printed it and continued into the
factory wipe, so the message said "stop it first" while reset deleted the session and
worktree state the live editor was still running against. `ErrLiveEditorSocket` is now
a sentinel and reset **aborts** on it, following the rule the same function already
states one step later for an unreadable session set (#2870): *a warning is no
safeguard once the worktree is gone*. Refusal stays targeted — genuinely abandoned
sockets in the same directory are still removed, so one live editor does not strand
the rest of the cleanup.

I took abort over "stop the editor first", the other option offered, because reset runs
with no daemon and a graceful stop needs the supervisor's four identity proofs before
signalling. Reaching for a signal from the CLI is how a reset kills something it cannot
prove it owns.

## Tests

- A socket with a live listener survives the sweep **and is still connectable
  afterwards** — asserting the file exists would miss the point, since the symptom is a
  listener that outlives its name.
- A socket with nothing listening is still swept, so the feature still works.
- A live owner record alone spares a socket, proving either signal suffices.
- An **undecidable** liveness probe keeps the socket, pinning the bias rather than
  leaving it to be re-derived.

Closes #2961

🤖 Generated with [Claude Code](https://claude.com/claude-code)