### PR TITLE
fix(tmux): a session that survived its kill never licenses worktree deletion

### DIFF
--- a/app/tab_hotkeys_test.go
+++ b/app/tab_hotkeys_test.go
@@ -83,6 +83,14 @@ func nameKeyedTmuxExec() (cmd_test.MockCmdExec, func(sessionName string)) {
 			return nil
 		},
 		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			// list-panes is asked for `#{pane_pid}` and its answer is PARSED, so the
+			// generic stub is not neutral there: it reads as a pane whose pid is
+			// unreadable, i.e. a process set that could not be established, which
+			// since #2962 correctly refuses cleanup. These mock sessions have no real
+			// panes, so the truthful answer is an empty list.
+			if strings.Contains(cmd.String(), "list-panes") {
+				return nil, nil
+			}
 			return []byte("content"), nil
 		},
 	}

--- a/daemon/close_tab_cleanup_test.go
+++ b/daemon/close_tab_cleanup_test.go
@@ -64,7 +64,17 @@ func unkillableTabExec(alive map[string]bool, unkillable map[string]bool) (cmd_t
 			}
 			return nil
 		},
-		OutputFunc: func(*exec.Cmd) ([]byte, error) { return []byte("content"), nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			// list-panes is asked for `#{pane_pid}` and its answer is PARSED, so the
+			// generic stub is not neutral there: it reads as a pane whose pid is
+			// unreadable, i.e. a process set that could not be established, which
+			// since #2962 correctly refuses cleanup. These mock sessions have no real
+			// panes, so the truthful answer is an empty list.
+			if strings.Contains(cmd.String(), "list-panes") {
+				return nil, nil
+			}
+			return []byte("content"), nil
+		},
 	}
 	return mockExec, func(name string) bool {
 		mu.Lock()

--- a/daemon/close_tab_test.go
+++ b/daemon/close_tab_test.go
@@ -461,7 +461,17 @@ func closeBlockingTabExec(alive map[string]bool, blockedKillName string, killSta
 			}
 			return nil
 		},
-		OutputFunc: func(*exec.Cmd) ([]byte, error) { return []byte("content"), nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			// list-panes is asked for `#{pane_pid}` and its answer is PARSED, so the
+			// generic stub is not neutral there: it reads as a pane whose pid is
+			// unreadable, i.e. a process set that could not be established, which
+			// since #2962 correctly refuses cleanup. These mock sessions have no real
+			// panes, so the truthful answer is an empty list.
+			if strings.Contains(cmd.String(), "list-panes") {
+				return nil, nil
+			}
+			return []byte("content"), nil
+		},
 	}
 	return exec, func(name string) bool {
 		mu.Lock()

--- a/daemon/create_tab_archive_test.go
+++ b/daemon/create_tab_archive_test.go
@@ -54,7 +54,17 @@ func archivableTabExec(agentName string) (cmd_test.MockCmdExec, func(string) boo
 			}
 			return nil
 		},
-		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return []byte("content"), nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			// list-panes is asked for `#{pane_pid}` and its answer is PARSED, so the
+			// generic stub is not neutral there: it reads as a pane whose pid is
+			// unreadable, i.e. a process set that could not be established, which
+			// since #2962 correctly refuses cleanup. These mock sessions have no real
+			// panes, so the truthful answer is an empty list.
+			if strings.Contains(cmd.String(), "list-panes") {
+				return nil, nil
+			}
+			return []byte("content"), nil
+		},
 	}
 	return e, func(name string) bool { return existing[name] }
 }

--- a/daemon/create_tab_test.go
+++ b/daemon/create_tab_test.go
@@ -77,7 +77,17 @@ func tabNameKeyedExec(alive map[string]bool) cmd_test.MockCmdExec {
 			}
 			return nil
 		},
-		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return []byte("content"), nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			// list-panes is asked for `#{pane_pid}` and its answer is PARSED, so the
+			// generic stub is not neutral there: it reads as a pane whose pid is
+			// unreadable, i.e. a process set that could not be established, which
+			// since #2962 correctly refuses cleanup. These mock sessions have no real
+			// panes, so the truthful answer is an empty list.
+			if strings.Contains(cmd.String(), "list-panes") {
+				return nil, nil
+			}
+			return []byte("content"), nil
+		},
 	}
 }
 

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -198,7 +198,15 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 		if killErr != nil && !session.TeardownStateUnknown(killErr) {
 			log.WarningLog.Printf("create of session %q: cleanup reported an error that does not leave its workspace state unknown; discarding the session as normal: %v", title, killErr)
 		}
-		if session.TeardownStateUnknown(killErr) && !neverSpawned {
+		// The exemption covers ONLY the pane half of "unknown". TeardownStateUnknown
+		// is true for ErrPaneMayBeLive OR ErrWorkspaceStateUnknown, and the second
+		// has nothing to do with whether a pane spawned: a worktree removal cut off
+		// mid-delete leaves a partially removed tree, and this record is the only
+		// handle on it (#2110/#2531). Suppressing retention there would release the
+		// title over a half-deleted workspace nobody can address (Codex on #2966).
+		paneOnlyUnknown := errors.Is(killErr, session.ErrPaneMayBeLive) &&
+			!errors.Is(killErr, session.ErrWorkspaceStateUnknown)
+		if session.TeardownStateUnknown(killErr) && !(neverSpawned && paneOnlyUnknown) {
 			if keepErr := m.keepFailedCreate(repo.ID, title, instance); keepErr != nil {
 				return session.InstanceData{}, fmt.Errorf("failed to start instance %q, and its cleanup could not complete safely — its workspace may still be on disk at %s and could not be recorded, so it must be cleaned up by hand: %w",
 					title, instance.GetWorktreePath(), errors.Join(serr, killErr, keepErr))

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -184,29 +184,10 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 		// workspace is already gone — tombstoning a row, holding the title and
 		// telling the user a workspace may remain would all be false.
 		killErr := instance.Kill()
-		// ErrSessionNotStarted is POSITIVE evidence, not an absence: the start path
-		// established that tmux never created a session for this instance. So an
-		// unreadable pane set during cleanup — `list-panes` cannot run because tmux
-		// itself is unavailable, say — says nothing about a live pane, because there
-		// was never a pane to be live (Codex on #2966).
-		//
-		// Without this, a create that fails before spawning leaves a permanent
-		// tombstone holding its title on any box where tmux is missing or broken:
-		// exactly the machines where creates fail. The #2962 gate is right to refuse
-		// when a pane MIGHT be writing; here we know one never existed.
-		neverSpawned := errors.Is(serr, tmux.ErrSessionNotStarted)
 		if killErr != nil && !session.TeardownStateUnknown(killErr) {
 			log.WarningLog.Printf("create of session %q: cleanup reported an error that does not leave its workspace state unknown; discarding the session as normal: %v", title, killErr)
 		}
-		// The exemption covers ONLY the pane half of "unknown". TeardownStateUnknown
-		// is true for ErrPaneMayBeLive OR ErrWorkspaceStateUnknown, and the second
-		// has nothing to do with whether a pane spawned: a worktree removal cut off
-		// mid-delete leaves a partially removed tree, and this record is the only
-		// handle on it (#2110/#2531). Suppressing retention there would release the
-		// title over a half-deleted workspace nobody can address (Codex on #2966).
-		paneOnlyUnknown := errors.Is(killErr, session.ErrPaneMayBeLive) &&
-			!errors.Is(killErr, session.ErrWorkspaceStateUnknown)
-		if session.TeardownStateUnknown(killErr) && !(neverSpawned && paneOnlyUnknown) {
+		if session.TeardownStateUnknown(killErr) {
 			if keepErr := m.keepFailedCreate(repo.ID, title, instance); keepErr != nil {
 				return session.InstanceData{}, fmt.Errorf("failed to start instance %q, and its cleanup could not complete safely — its workspace may still be on disk at %s and could not be recorded, so it must be cleaned up by hand: %w",
 					title, instance.GetWorktreePath(), errors.Join(serr, killErr, keepErr))

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -184,10 +184,21 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 		// workspace is already gone — tombstoning a row, holding the title and
 		// telling the user a workspace may remain would all be false.
 		killErr := instance.Kill()
+		// ErrSessionNotStarted is POSITIVE evidence, not an absence: the start path
+		// established that tmux never created a session for this instance. So an
+		// unreadable pane set during cleanup — `list-panes` cannot run because tmux
+		// itself is unavailable, say — says nothing about a live pane, because there
+		// was never a pane to be live (Codex on #2966).
+		//
+		// Without this, a create that fails before spawning leaves a permanent
+		// tombstone holding its title on any box where tmux is missing or broken:
+		// exactly the machines where creates fail. The #2962 gate is right to refuse
+		// when a pane MIGHT be writing; here we know one never existed.
+		neverSpawned := errors.Is(serr, tmux.ErrSessionNotStarted)
 		if killErr != nil && !session.TeardownStateUnknown(killErr) {
 			log.WarningLog.Printf("create of session %q: cleanup reported an error that does not leave its workspace state unknown; discarding the session as normal: %v", title, killErr)
 		}
-		if session.TeardownStateUnknown(killErr) {
+		if session.TeardownStateUnknown(killErr) && !neverSpawned {
 			if keepErr := m.keepFailedCreate(repo.ID, title, instance); keepErr != nil {
 				return session.InstanceData{}, fmt.Errorf("failed to start instance %q, and its cleanup could not complete safely — its workspace may still be on disk at %s and could not be recorded, so it must be cleaned up by hand: %w",
 					title, instance.GetWorktreePath(), errors.Join(serr, killErr, keepErr))

--- a/daemon/status_test.go
+++ b/daemon/status_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
@@ -186,8 +187,18 @@ func TestRefreshStatuses_DeadNilMonitorDoesNotPanic(t *testing.T) {
 	// vanished session; the nil monitor would panic HasUpdated before the fix
 	// regardless.
 	mockExec := cmd_test.MockCmdExec{
-		RunFunc:    func(*exec.Cmd) error { return errSessionAbsent },
-		OutputFunc: func(*exec.Cmd) ([]byte, error) { return []byte("content"), nil },
+		RunFunc: func(*exec.Cmd) error { return errSessionAbsent },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			// list-panes is asked for `#{pane_pid}` and its answer is PARSED, so the
+			// generic stub is not neutral there: it reads as a pane whose pid is
+			// unreadable, i.e. a process set that could not be established, which
+			// since #2962 correctly refuses cleanup. These mock sessions have no real
+			// panes, so the truthful answer is an empty list.
+			if strings.Contains(cmd.String(), "list-panes") {
+				return nil, nil
+			}
+			return []byte("content"), nil
+		},
 	}
 	ts := tmux.NewTmuxSessionFromSanitizedNameWithDeps("af_999_nil_monitor", "claude", tmux.MakePtyFactory(), mockExec)
 	backend := nilMonitorBackend{FakeBackend: session.NewFakeBackend(), ts: ts}

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -256,19 +256,29 @@ func TestLocalBackendServicesTabManagement(t *testing.T) {
 	}
 }
 
-// TestLocalBackendKillBestEffort_TmuxFails is a regression test for issue
-// #478. When the tmux teardown fails, Kill must still clear in-memory state
-// and return nil so the caller can finish removing the session from the
-// persisted instances.json. The failure is surfaced as a WarningLog entry
-// (including the instance title) for diagnosis.
+// TestLocalBackendKillBestEffort_TmuxFails is the #478 regression, NARROWED by
+// #2962 to the failures where its reasoning still holds.
+//
+// #478 says a tmux teardown failure must not block deletion: clear the in-memory
+// state, return nil, log a warning. That is right when the kill-session error is
+// the idempotent already-gone no-op (#967) — the session is dead, so nothing can
+// still be writing to the worktree the caller goes on to delete.
+//
+// It is NOT right when the session survived the kill, which is what this test
+// used to assert: `has-session` reported the session still present, and Kill
+// dropped the record and deleted the worktree anyway, over a session that may
+// still have been writing (#2962). That case now refuses; see
+// TestLocalBackendKillRefusesWhenTheSessionSurvivedTheKill.
+//
+// So this fixture models the failure #478 was actually written for.
 func TestLocalBackendKillBestEffort_TmuxFails(t *testing.T) {
 	cmdExec := cmd_test.MockCmdExec{
 		RunFunc: func(c *exec.Cmd) error {
-			// has-session reports the session still present, so the failed
-			// kill-session is a GENUINE teardown failure rather than the
-			// idempotent already-gone no-op (#967). Everything else fails.
+			// kill-session fails, and has-session reports the session GONE: the
+			// #967 idempotent no-op. A dead session cannot be writing, so the
+			// teardown has reached its goal and deletion may proceed.
 			if strings.Contains(c.String(), "has-session") {
-				return nil
+				return errors.New("can't find session")
 			}
 			return errors.New("kill failed")
 		},
@@ -284,17 +294,53 @@ func TestLocalBackendKillBestEffort_TmuxFails(t *testing.T) {
 		Tabs:    []*Tab{newAgentTab(ts)},
 	}
 
-	buf := captureWarningLog(t)
-
-	require.NoError(t, inst.Kill(), "tmux cleanup failure must not block deletion")
+	require.NoError(t, inst.Kill(), "a kill-session failure over an already-gone session must not block deletion")
 	assert.False(t, inst.Started(), "started flag should be cleared")
 	assert.Nil(t, inst.tmuxLocked(), "tmux pointer should be cleared so a retry is a clean no-op")
 
-	logged := buf.String()
-	assert.Contains(t, logged, "best-effort-tmux", "warning must include instance title for correlation in agent-factory.log")
-	assert.Contains(t, logged, "tmux cleanup for tab")
-
 	require.NoError(t, inst.Kill(), "second kill on a cleared instance must be a no-op")
+}
+
+// TestLocalBackendKillRefusesWhenTheSessionSurvivedTheKill is the #2962 half of
+// the narrowing above, and the behaviour change worth reviewing carefully.
+//
+// BEFORE: kill-session failed, has-session confirmed the session was STILL
+// ALIVE, and Kill returned nil — dropping the record and deleting the worktree
+// out from under a live pane.
+//
+// AFTER: it refuses, and the record and tmux pointer stay intact so a retry has
+// something to work with. This costs a user whose tmux cannot be killed the
+// ability to drop the record until they fix tmux; that is the same trade #1917
+// already made for a kill whose deadline tripped, and it would be incoherent to
+// block when we are merely UNSURE the session died while proceeding when we have
+// positive evidence it did not.
+func TestLocalBackendKillRefusesWhenTheSessionSurvivedTheKill(t *testing.T) {
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			// has-session reports the session still present, so the failed
+			// kill-session is a GENUINE teardown failure rather than the
+			// idempotent already-gone no-op (#967).
+			if strings.Contains(c.String(), "has-session") {
+				return nil
+			}
+			return errors.New("kill failed")
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			return nil, nil
+		},
+	}
+	ts := tmux.NewTmuxSessionWithDeps("survivor-tmux", "bash", nil, cmdExec)
+	inst := &Instance{
+		Title:   "survivor-tmux",
+		backend: &LocalBackend{},
+		started: true,
+		Tabs:    []*Tab{newAgentTab(ts)},
+	}
+
+	err := inst.Kill()
+	require.Error(t, err, "a session that survived its kill must not license deleting its worktree (#2962)")
+	assert.NotNil(t, inst.tmuxLocked(),
+		"the tmux pointer must survive a refused teardown, or the retry the error asks for has nothing to act on")
 }
 
 // TestLocalBackendKillBestEffort_WorktreeFails covers the issue #478
@@ -379,10 +425,14 @@ func TestLocalBackendKill_RecoversStaleWorktreeDir(t *testing.T) {
 func TestLocalBackendKillBestEffort_BothFail(t *testing.T) {
 	cmdExec := cmd_test.MockCmdExec{
 		RunFunc: func(c *exec.Cmd) error {
-			// has-session reports present so the failed kill-session is a
-			// genuine teardown failure, not the #967 idempotent no-op.
+			// The session is already GONE, so the failed kill-session is the #967
+			// idempotent no-op and #478's best-effort contract still applies. (A
+			// SURVIVING session now blocks the kill outright — see
+			// TestLocalBackendKillRefusesWhenTheSessionSurvivedTheKill — which
+			// would make this test about tmux rather than about the multi-component
+			// warning it exists to check.)
 			if strings.Contains(c.String(), "has-session") {
-				return nil
+				return errors.New("can't find session")
 			}
 			return errors.New("kill failed")
 		},
@@ -416,9 +466,8 @@ func TestLocalBackendKillBestEffort_BothFail(t *testing.T) {
 	assert.Nil(t, inst.gitWorktree)
 
 	logged := buf.String()
-	assert.Contains(t, logged, "tmux cleanup for tab")
 	assert.Contains(t, logged, "git worktree cleanup failed")
-	assert.Equal(t, 2, strings.Count(logged, `kill "both-fail":`), "title should appear in both component warnings")
+	assert.Contains(t, logged, `kill "both-fail":`, "title should appear in the component warning")
 }
 
 // captureWarningLog redirects log.WarningLog to a buffer for the duration of

--- a/session/tab_persist_test.go
+++ b/session/tab_persist_test.go
@@ -79,6 +79,16 @@ func nameKeyedExec(alive map[string]bool) cmd_test.MockCmdExec {
 			return nil
 		},
 		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			// list-panes is asked for `#{pane_pid}` and its answer is PARSED, so a
+			// generic "content" stub is not a neutral default — it reads as a pane
+			// whose pid is unparseable, i.e. a process set that could not be
+			// established, which since #2962 correctly refuses worktree cleanup.
+			// These sessions have no real panes, so the truthful answer is an empty
+			// list. Everything else keeps the generic stub (capture-pane content and
+			// friends assert on it).
+			if strings.Contains(cmd.String(), "list-panes") {
+				return nil, nil
+			}
 			return []byte("content"), nil
 		},
 	}

--- a/session/teardown.go
+++ b/session/teardown.go
@@ -210,8 +210,20 @@ func closeTabForDestructiveTeardown(ts *tmux.TmuxSession, verb, title, tabName s
 	if state != tmux.PaneStateKnown {
 		return stateUnknown, fmt.Errorf("%s %q: tab %q: %w", verb, title, tabName, err)
 	}
-	// tmux ANSWERED. Whatever it said, the session's fate is established, so #478's
-	// best-effort contract holds: log and let the caller drop the record.
+	// Unreachable by construction since #2962: CloseAndWaitForPaneExit returns
+	// KNOWN only after every gate passes, and each gate returns UNKNOWN with the
+	// error. It used to be able to return KNOWN alongside "kill failed, session
+	// still alive", and this branch logged exactly that and let the caller delete
+	// the worktree anyway — which was the #2962 defect, since a live session may
+	// still be writing to it.
+	//
+	// #478's best-effort contract still holds for the tmux failure it was written
+	// for: a kill-session that fails because the session is ALREADY GONE is the
+	// idempotent no-op (#967), reports no error, and drops the record as before.
+	// What no longer qualifies is a kill that failed with the session still alive.
+	//
+	// Kept rather than deleted so that if the contract moves again the failure is
+	// visible instead of silent.
 	if err != nil {
 		log.WarningLog.Printf("%s %q: tmux cleanup for tab %q failed: %v", verb, title, tabName, err)
 	}

--- a/session/tmux/close.go
+++ b/session/tmux/close.go
@@ -280,12 +280,13 @@ func (t *TmuxSession) CloseAndWaitForPaneExit() (PaneState, error) {
 		if closeErr == nil {
 			return refuse(fmt.Errorf("tmux did not establish that session %s is gone", t.sanitizedName))
 		}
-		// pidErr is joined, not dropped: when the pane query ALSO timed out, this
-		// branch runs before the timeout case below, and returning closeErr alone
-		// would erase the ErrTmuxTimeout sentinel that #1917 keeps reachable
-		// through errors.Is for callers that classify on it. errors.Join ignores a
-		// nil pidErr, so the ordinary case is unchanged.
-		return PaneStateUnknown, errors.Join(closeErr, pidErr)
+		// pidErr AND captureErr are joined, not dropped. This branch runs before
+		// the cases that would otherwise report them, so returning closeErr alone
+		// erases whichever ErrTmuxTimeout they carry — the sentinel #1917 keeps
+		// reachable through errors.Is for callers that classify on it. Both are
+		// reachable here: the pane query can time out, and so can list-panes.
+		// errors.Join ignores nils, so the ordinary case is unchanged.
+		return PaneStateUnknown, errors.Join(closeErr, pidErr, processes.captureErr)
 	case errors.Is(pidErr, ErrTmuxTimeout):
 		// A TIMED-OUT panePID is not "nothing to wait on" (#1917). The server never
 		// told us which process to wait for, so even with a successful kill we skip

--- a/session/tmux/close.go
+++ b/session/tmux/close.go
@@ -12,6 +12,11 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 )
 
+// ErrSessionVanishedBeforeCapture marks a pane-list read that failed because
+// tmux says the session does not exist. Whether that is a determinate EMPTY or a
+// lost ancestry depends on the caller: see captureSessionProcessTrees.
+var ErrSessionVanishedBeforeCapture = errors.New("tmux session was gone before its panes could be listed")
+
 // PaneState is what a bounded teardown could ESTABLISH about a tmux session, and
 // it is returned SEPARATELY from the error on purpose (#1917).
 //
@@ -275,7 +280,12 @@ func (t *TmuxSession) CloseAndWaitForPaneExit() (PaneState, error) {
 		if closeErr == nil {
 			return refuse(fmt.Errorf("tmux did not establish that session %s is gone", t.sanitizedName))
 		}
-		return PaneStateUnknown, closeErr
+		// pidErr is joined, not dropped: when the pane query ALSO timed out, this
+		// branch runs before the timeout case below, and returning closeErr alone
+		// would erase the ErrTmuxTimeout sentinel that #1917 keeps reachable
+		// through errors.Is for callers that classify on it. errors.Join ignores a
+		// nil pidErr, so the ordinary case is unchanged.
+		return PaneStateUnknown, errors.Join(closeErr, pidErr)
 	case errors.Is(pidErr, ErrTmuxTimeout):
 		// A TIMED-OUT panePID is not "nothing to wait on" (#1917). The server never
 		// told us which process to wait for, so even with a successful kill we skip
@@ -286,7 +296,7 @@ func (t *TmuxSession) CloseAndWaitForPaneExit() (PaneState, error) {
 		// to follow across teardown. A successful kill-session is not enough to
 		// prove that process stopped writing.
 		return PaneStateUnknown, errors.Join(closeErr, processErr)
-	case processes.captureErr != nil:
+	case processes.captureErr != nil && !sessionGoneWithNoPaneObserved(processes.captureErr, pidErr):
 		// The full process set was not established. A child may already have
 		// detached/reparented and still be writing after the leader exits; leader
 		// death cannot manufacture proof about descendants we failed to see.
@@ -317,6 +327,23 @@ func (t *TmuxSession) CloseAndWaitForPaneExit() (PaneState, error) {
 	// process set, which INCLUDES the pane leader. Neither depends on the PID
 	// query, so it has nothing left to tell the caller.
 	return PaneStateKnown, nil
+}
+
+// sessionGoneWithNoPaneObserved reports whether an unreadable pane set is
+// actually a determinate EMPTY.
+//
+// It is one only when BOTH reads agree the session is not there: tmux said so on
+// the pane list, AND the pane PID query never named a pane either. That is the
+// ordinary teardown of an already-exited agent, and refusing it would leave those
+// worktrees uncollectable forever.
+//
+// If a pane PID WAS observed, the same tmux answer means the opposite: the
+// session exited between the two reads, the ancestry list-panes would have
+// returned is lost, and descendants or SID members that outlive the leader are
+// unaccounted for. Leader death cannot prove they stopped writing (#1104/#802),
+// so that stays a blocker (Codex on #2966).
+func sessionGoneWithNoPaneObserved(captureErr, pidErr error) bool {
+	return pidErr != nil && errors.Is(captureErr, ErrSessionVanishedBeforeCapture)
 }
 
 // capturePaneProcess turns tmux's bare pane PID into a process-table identity

--- a/session/tmux/close.go
+++ b/session/tmux/close.go
@@ -242,56 +242,81 @@ func (t *TmuxSession) CloseAndWaitForPaneExit() (PaneState, error) {
 		// both distinctions explicit.
 		paneProcess, waitForPane, processErr = capturePaneProcess(pid)
 	}
-	state, closeErr, processes := t.close(true)
-	if pidErr != nil {
-		// A TIMED-OUT panePID is not "nothing to wait on" (#1917). It means the
-		// server never told us which process to wait for — so even if the
-		// kill-session that follows succeeds, we skip the #802 pane-exit wait and
-		// have no way to know the agent stopped writing. Returning the successful
-		// Close's KNOWN state here would tell the caller it may delete the worktree
-		// while the HUP'd agent is still flushing into it. Keep the unknown, and
-		// keep the sentinel reachable.
-		if errors.Is(pidErr, ErrTmuxTimeout) {
-			return PaneStateUnknown, errors.Join(closeErr, pidErr)
-		}
-		// Any other panePID failure means tmux ANSWERED: the session is already
-		// gone or the pane is unqueryable, so there is genuinely nothing to wait on
-		// and Close's own state stands.
-		return state, closeErr
+	closeState, closeErr, processes := t.close(true)
+
+	// ONE list of reasons the worktree may not be touched, evaluated on EVERY
+	// path (#2962). The shape this replaces returned early when panePID failed,
+	// which skipped the two process-set gates below entirely — so on that branch
+	// a list-panes that FAILED was never consulted at all, and survivors of the
+	// reap were never noticed. Three separate holes, one missing funnel.
+	//
+	// The rule each case serves: this function does not report whether tmux
+	// answered — Close does that — it reports whether the WORKTREE MAY NOW BE
+	// MUTATED. Only positive evidence that nothing is left writing licenses that,
+	// and a reason we could not obtain such evidence is not a weaker yes, it is a
+	// no. Callers gate on the state and merely LOG the error
+	// (closeTabForDestructiveTeardown), so anything short of a no here is a
+	// licence to delete.
+	refuse := func(why error) (PaneState, error) {
+		log.WarningLog.Printf("tmux session %s: %v; refusing worktree cleanup", t.sanitizedName, why)
+		return PaneStateUnknown, errors.Join(closeErr, why)
 	}
-	if processErr != nil {
+	switch {
+	case closeState != PaneStateKnown || closeErr != nil:
+		// The session's fate was not established as GONE — it either could not be
+		// determined, or the kill FAILED and the probe found the session still
+		// alive. Close reports the survivor case as KNOWN on purpose: its own
+		// contract is best-effort (#478), "tmux answered, and this session is
+		// alive". That is a fine answer to Close's question and the wrong answer
+		// to this one, because a live session may still be writing to the tree the
+		// caller is about to delete. Reaping before deleting is only an invariant
+		// if the reap is verified to have COMPLETED (#2025/#2440); a kill that was
+		// merely requested proves nothing.
+		if closeErr == nil {
+			return refuse(fmt.Errorf("tmux did not establish that session %s is gone", t.sanitizedName))
+		}
+		return PaneStateUnknown, closeErr
+	case errors.Is(pidErr, ErrTmuxTimeout):
+		// A TIMED-OUT panePID is not "nothing to wait on" (#1917). The server never
+		// told us which process to wait for, so even with a successful kill we skip
+		// the #802 pane-exit wait and cannot know the agent stopped writing.
+		return PaneStateUnknown, errors.Join(closeErr, pidErr)
+	case processErr != nil:
 		// We knew which PID tmux owned, but could not establish a process identity
 		// to follow across teardown. A successful kill-session is not enough to
-		// prove that process stopped writing, so fail closed like a timed-out PID
-		// query rather than deleting the worktree on an existence guess.
+		// prove that process stopped writing.
 		return PaneStateUnknown, errors.Join(closeErr, processErr)
-	}
-	if processes.captureErr != nil {
-		// The pane leader was known, but the full process set was not. A child may
-		// already have detached/reparented and still be writing after the leader exits;
-		// leader death cannot manufacture proof about descendants we failed to see.
-		err := fmt.Errorf("could not establish the pane's complete process tree before kill-session: %w", processes.captureErr)
-		log.WarningLog.Printf("tmux session %s: %v; refusing worktree cleanup", t.sanitizedName, err)
-		return PaneStateUnknown, errors.Join(closeErr, err)
-	}
-	if len(processes.remaining) > 0 {
+	case processes.captureErr != nil:
+		// The full process set was not established. A child may already have
+		// detached/reparented and still be writing after the leader exits; leader
+		// death cannot manufacture proof about descendants we failed to see.
+		//
+		// Reached now even when panePID failed, which is the point: that branch
+		// used to return before this check, so an unreadable pane list produced a
+		// confident "safe to delete".
+		return refuse(fmt.Errorf("could not establish the pane's complete process tree before kill-session: %w",
+			processes.captureErr))
+	case len(processes.remaining) > 0:
 		pids := make([]string, 0, len(processes.remaining))
 		for _, process := range processes.remaining {
 			pids = append(pids, strconv.Itoa(process.PID))
 		}
-		err := fmt.Errorf("pane processes %s are still alive after bounded teardown", strings.Join(pids, ", "))
-		log.WarningLog.Printf("tmux session %s: %v; refusing worktree cleanup", t.sanitizedName, err)
-		return PaneStateUnknown, errors.Join(closeErr, err)
+		return refuse(fmt.Errorf("pane processes %s are still alive after bounded teardown", strings.Join(pids, ", ")))
+	case waitForPane && !waitForProcessExit(paneProcess, paneExitWait):
+		// kill-session returning establishes only that SIGHUP was sent, not that
+		// the process stopped writing.
+		return refuse(fmt.Errorf("pane process %d is still alive %v after kill-session", pid, paneExitWait))
 	}
-	if waitForPane && !waitForProcessExit(paneProcess, paneExitWait) {
-		// kill-session returning establishes only that SIGHUP was sent, not that the
-		// process stopped writing. Unknown is the only state that keeps every
-		// destructive caller from deleting/moving the worktree on that assumption.
-		err := fmt.Errorf("pane process %d is still alive %v after kill-session", pid, paneExitWait)
-		log.WarningLog.Printf("tmux session %s: %v; refusing worktree cleanup", t.sanitizedName, err)
-		return PaneStateUnknown, errors.Join(closeErr, err)
-	}
-	return state, closeErr
+
+	// Every gate passed: tmux established the session is gone, the pane's process
+	// set was read, and nothing from it survived the bounded reap.
+	//
+	// A non-timeout pidErr is deliberately dropped here rather than reported. It
+	// means tmux answered and could not name a pane — but the session-gone fact
+	// comes from Close, and the nothing-still-writing fact comes from the captured
+	// process set, which INCLUDES the pane leader. Neither depends on the PID
+	// query, so it has nothing left to tell the caller.
+	return PaneStateKnown, nil
 }
 
 // capturePaneProcess turns tmux's bare pane PID into a process-table identity

--- a/session/tmux/close.go
+++ b/session/tmux/close.go
@@ -271,6 +271,22 @@ func (t *TmuxSession) CloseAndWaitForPaneExit() (PaneState, error) {
 	// no. Callers gate on the state and merely LOG the error
 	// (closeTabForDestructiveTeardown), so anything short of a no here is a
 	// licence to delete.
+	// When BOTH reads say the session is absent, that is a determinate empty only
+	// if nothing it spawned outlived it. tmux can no longer enumerate the
+	// ancestry — but the AF_SESSION marker SURVIVES the session, which is the
+	// same evidence CleanupSessions uses for a vanished session (#1104).
+	//
+	// Checking it here is what makes the answer independent of earlier attempts.
+	// A teardown that refused because a pane was observed and its ancestry lost
+	// gets retried (finishUserKill), and on the retry both tmux reads report
+	// absence — so without this the second attempt would launder the first
+	// attempt's lost ancestry into a clean empty and authorize deleting the
+	// worktree under a detached descendant (Codex on #2966, round 4).
+	var vanishedSurvivors error
+	if processes.captureErr != nil && sessionGoneWithNoPaneObserved(processes.captureErr, pidErr) {
+		vanishedSurvivors = t.markedProcessesOutlivingSession()
+	}
+
 	refuse := func(why error) (PaneState, error) {
 		log.WarningLog.Printf("tmux session %s: %v; refusing worktree cleanup", t.sanitizedName, why)
 		return PaneStateUnknown, errors.Join(closeErr, why)
@@ -306,6 +322,10 @@ func (t *TmuxSession) CloseAndWaitForPaneExit() (PaneState, error) {
 		// to follow across teardown. A successful kill-session is not enough to
 		// prove that process stopped writing.
 		return PaneStateUnknown, errors.Join(closeErr, processErr)
+	case vanishedSurvivors != nil:
+		// The session is gone, but the marker scan says something it spawned is
+		// not — or could not be checked at all.
+		return refuse(vanishedSurvivors)
 	case processes.captureErr != nil && !sessionGoneWithNoPaneObserved(processes.captureErr, pidErr):
 		// The full process set was not established. A child may already have
 		// detached/reparented and still be writing after the leader exits; leader
@@ -361,6 +381,31 @@ func sessionGoneWithNoPaneObserved(captureErr, pidErr error) bool {
 	// descendants never captured (Codex on #2966).
 	return errors.Is(pidErr, errPaneQueryFoundNoPane) &&
 		errors.Is(captureErr, ErrSessionVanishedBeforeCapture)
+}
+
+// markedProcessesOutlivingSession reports, WITHOUT asking tmux, whether any
+// process still carries this session's AF_SESSION marker — and returns nil only
+// when the scan RAN and found none.
+//
+// The marker is what makes a vanished session still answerable: a descendant
+// that detached and was reparented to init keeps the marker its pane gave it, so
+// it is findable even though tmux has forgotten the ancestry. A scan that could
+// not run is not evidence of absence and refuses, like every other read here.
+func (t *TmuxSession) markedProcessesOutlivingSession() error {
+	survivors, err := refreshOrphanCandidates(nil, t.sanitizedName)
+	if err != nil {
+		return fmt.Errorf("tmux session %s is gone and its surviving processes could not be checked: %w",
+			t.sanitizedName, err)
+	}
+	if len(survivors) == 0 {
+		return nil
+	}
+	pids := make([]string, 0, len(survivors))
+	for _, p := range survivors {
+		pids = append(pids, strconv.Itoa(p.PID))
+	}
+	return fmt.Errorf("tmux session %s is gone, but process(es) %s still carry its %s marker and were "+
+		"never captured", t.sanitizedName, strings.Join(pids, ", "), EnvMarkerSession)
 }
 
 // capturePaneProcess turns tmux's bare pane PID into a process-table identity

--- a/session/tmux/close.go
+++ b/session/tmux/close.go
@@ -284,7 +284,7 @@ func (t *TmuxSession) CloseAndWaitForPaneExit() (PaneState, error) {
 	// worktree under a detached descendant (Codex on #2966, round 4).
 	var vanishedSurvivors error
 	if processes.captureErr != nil && sessionGoneWithNoPaneObserved(processes.captureErr, pidErr) {
-		vanishedSurvivors = t.markedProcessesOutlivingSession()
+		vanishedSurvivors = t.sweepVanishedSessionProcesses()
 	}
 
 	refuse := func(why error) (PaneState, error) {
@@ -383,29 +383,40 @@ func sessionGoneWithNoPaneObserved(captureErr, pidErr error) bool {
 		errors.Is(captureErr, ErrSessionVanishedBeforeCapture)
 }
 
-// markedProcessesOutlivingSession reports, WITHOUT asking tmux, whether any
-// process still carries this session's AF_SESSION marker — and returns nil only
-// when the scan RAN and found none.
+// sweepVanishedSessionProcesses answers "did anything this session spawned
+// outlive it?" WITHOUT asking tmux, and acts on the answer rather than merely
+// reporting it.
 //
-// The marker is what makes a vanished session still answerable: a descendant
-// that detached and was reparented to init keeps the marker its pane gave it, so
-// it is findable even though tmux has forgotten the ancestry. A scan that could
-// not run is not evidence of absence and refuses, like every other read here.
-func (t *TmuxSession) markedProcessesOutlivingSession() error {
-	survivors, err := refreshOrphanCandidates(nil, t.sanitizedName)
+// It delegates to reapVanishedSessionProcesses, the flow CleanupSessions already
+// uses for exactly this situation (#1104/#2765), because the ad-hoc scan this
+// replaces got two things wrong that the shared flow has right (Codex on #2966,
+// round 5):
+//
+//   - OWNERSHIP. Matching on AF_SESSION alone counts a same-named process from
+//     ANOTHER agent-factory home — a leftover from a temp/dev install — as this
+//     session's survivor, refusing cleanup forever over something that is not
+//     ours. markedOrphanProcesses validates AF_HOME (and uid, and process
+//     identity) and silently skips a foreign home, while an UNATTRIBUTABLE
+//     process still blocks, which is the right split.
+//   - REAPING. Only reporting a genuine SIGHUP-immune descendant leaves the
+//     tombstone retried forever: each attempt rescans, finds it again, and never
+//     signals it, so the leak and the stuck worktree both persist. The shared
+//     flow reaps with the bounded TERM→KILL escalation and reports only what
+//     SURVIVES that.
+//
+// A home we cannot resolve is not evidence of absence: it means no candidate can
+// be attributed, so the sweep refuses.
+func (t *TmuxSession) sweepVanishedSessionProcesses() error {
+	ownHome, err := afHomeDir()
 	if err != nil {
-		return fmt.Errorf("tmux session %s is gone and its surviving processes could not be checked: %w",
-			t.sanitizedName, err)
+		return fmt.Errorf("tmux session %s is gone and its surviving processes cannot be attributed to this "+
+			"agent-factory home: %w", t.sanitizedName, err)
 	}
-	if len(survivors) == 0 {
-		return nil
-	}
-	pids := make([]string, 0, len(survivors))
-	for _, p := range survivors {
-		pids = append(pids, strconv.Itoa(p.PID))
-	}
-	return fmt.Errorf("tmux session %s is gone, but process(es) %s still carry its %s marker and were "+
-		"never captured", t.sanitizedName, strings.Join(pids, ", "), EnvMarkerSession)
+	// nil candidates and nil captureErr on purpose: there is no captured tree to
+	// refresh — the marker scan IS the evidence standing in for the ancestry tmux
+	// lost, so passing the capture failure through would make it a blocker again
+	// and defeat the point.
+	return reapVanishedSessionProcesses(t.sanitizedName, ownHome, nil, nil)
 }
 
 // capturePaneProcess turns tmux's bare pane PID into a process-table identity

--- a/session/tmux/close.go
+++ b/session/tmux/close.go
@@ -12,6 +12,15 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 )
 
+// errPaneQueryFoundNoPane marks a pane-PID query that tmux ANSWERED with no
+// pane at all — measured: `display-message -p -t '=missing:' '#{pane_pid}'`
+// exits 0 with EMPTY output for a session that does not exist.
+//
+// Distinct from every other panePID failure on purpose. "tmux gave me output I
+// could not parse" and "tmux said there is no pane" are not the same claim, and
+// only the second is evidence of absence (Codex on #2966).
+var errPaneQueryFoundNoPane = errors.New("tmux reported no pane for this session")
+
 // ErrSessionVanishedBeforeCapture marks a pane-list read that failed because
 // tmux says the session does not exist. Whether that is a determinate EMPTY or a
 // lost ancestry depends on the caller: see captureSessionProcessTrees.
@@ -344,7 +353,14 @@ func (t *TmuxSession) CloseAndWaitForPaneExit() (PaneState, error) {
 // unaccounted for. Leader death cannot prove they stopped writing (#1104/#802),
 // so that stays a blocker (Codex on #2966).
 func sessionGoneWithNoPaneObserved(captureErr, pidErr error) bool {
-	return pidErr != nil && errors.Is(captureErr, ErrSessionVanishedBeforeCapture)
+	// BOTH reads must say absence, and the pane query must say it SPECIFICALLY.
+	// `pidErr != nil` was too weak: it also covers "display-message returned
+	// output I could not parse", which happens while the session EXISTS. Pairing
+	// that with a session that then vanished before list-panes would treat a lost
+	// ancestry as an empty one and authorize deleting the worktree with detached
+	// descendants never captured (Codex on #2966).
+	return errors.Is(pidErr, errPaneQueryFoundNoPane) &&
+		errors.Is(captureErr, ErrSessionVanishedBeforeCapture)
 }
 
 // capturePaneProcess turns tmux's bare pane PID into a process-table identity
@@ -386,9 +402,19 @@ func (t *TmuxSession) panePID() (int, error) {
 		if ctx.Err() != nil {
 			return 0, fmt.Errorf("%w: display-message pane_pid after %s", ErrTmuxTimeout, tmuxCommandTimeout)
 		}
+		if missingTmuxSession(err, t.sanitizedName) {
+			return 0, errPaneQueryFoundNoPane
+		}
 		return 0, fmt.Errorf("failed to query pane pid: %w", err)
 	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(output)))
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		// tmux answered and named no pane. Measured: this is what a missing
+		// session produces — exit 0, empty output — so it is the one panePID
+		// failure that is evidence of ABSENCE rather than of an unreadable answer.
+		return 0, errPaneQueryFoundNoPane
+	}
+	pid, err := strconv.Atoi(trimmed)
 	if err != nil || pid <= 0 {
 		return 0, fmt.Errorf("unexpected pane pid output %q", string(output))
 	}

--- a/session/tmux/close_survived_kill_test.go
+++ b/session/tmux/close_survived_kill_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+
+	"github.com/sachiniyer/agent-factory/internal/proctree"
 	"time"
 )
 
@@ -310,4 +312,70 @@ has-session)     exit 1 ;;`)
 	if err != nil {
 		t.Errorf("error = %v, want nil", err)
 	}
+}
+
+// TestVanishedSessionWithASurvivingMarkedProcessRefuses is the round-4 Codex
+// finding: the determinate-empty was laundering a LOST ANCESTRY across teardown
+// attempts.
+//
+// Attempt 1 observes a pane and loses the ancestry to a racing session exit, so
+// cleanup refuses — correctly. finishUserKill then retries the tombstone, and on
+// the retry BOTH tmux reads report absence. Without an independent check the
+// retry calls that a clean empty and deletes the worktree, while a detached
+// descendant of the original pane is still writing.
+//
+// The check has to be one that does not need tmux, because tmux has forgotten
+// the session. The AF_SESSION marker outlives it: a reparented descendant still
+// carries what its pane gave it.
+func TestVanishedSessionWithASurvivingMarkedProcessRefuses(t *testing.T) {
+	const name = "af_vanished_with_survivor"
+	// A real process carrying the marker, standing in for the descendant that
+	// outlived the session — spawned, not fabricated, so the scan sees a genuine
+	// process-table entry.
+	survivor := spawnMarkedProcess(t, name)
+
+	scriptedTmuxOnPath(t, `
+display-message) exit 0 ;;
+list-panes)      echo "can't find session: `+name+`" >&2; exit 1 ;;
+kill-session)    exit 0 ;;
+has-session)     exit 1 ;;`)
+
+	ts := NewTmuxSessionFromSanitizedName(name, "")
+	state, err := ts.CloseAndWaitForPaneExit()
+
+	if state == PaneStateKnown {
+		t.Fatalf("CloseAndWaitForPaneExit = PaneStateKnown with err=%v: both tmux reads report absence, "+
+			"but pid %d still carries the session's %s marker — deleting the worktree now would do it "+
+			"under a live writer (#2962 round 4)", err, survivor, EnvMarkerSession)
+	}
+	if err == nil || !strings.Contains(err.Error(), strconv.Itoa(survivor)) {
+		t.Errorf("error = %v, want it to name the surviving process %d", err, survivor)
+	}
+}
+
+// spawnMarkedProcess starts a child carrying AF_SESSION=<name> and returns its
+// pid, cleaned up by the test.
+func spawnMarkedProcess(t *testing.T, sessionName string) int {
+	t.Helper()
+	c := exec.Command("sleep", "300")
+	c.Env = append(os.Environ(), EnvMarkerSession+"="+sessionName)
+	if err := c.Start(); err != nil {
+		t.Fatalf("spawn marked process: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = c.Process.Kill()
+		_, _ = c.Process.Wait()
+	})
+	// The scan reads /proc/<pid>/environ; wait until it is readable.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if env, err := proctree.Environ(c.Process.Pid); err == nil {
+			if v, ok := processEnvValue(env, EnvMarkerSession); ok && v == sessionName {
+				return c.Process.Pid
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Skipf("child %d environ never became readable; this fixture needs a marker-visible process", c.Process.Pid)
+	return 0
 }

--- a/session/tmux/close_survived_kill_test.go
+++ b/session/tmux/close_survived_kill_test.go
@@ -257,3 +257,57 @@ has-session)     exit 0 ;;`)
 			"combined failure — pidErr is nil here, so the capture error is the only carrier (#1917)", err)
 	}
 }
+
+// TestUnparseablePaneOutputIsNotAbsence is the third-round Codex finding: the
+// determinate-empty predicate accepted ANY pane-query failure, including one
+// from a session that plainly existed.
+//
+// Here display-message returns garbage (tmux answered, we could not read it) and
+// the session then vanishes before list-panes. That pairing is a LOST ANCESTRY —
+// detached descendants and SID members were never captured — not an empty
+// session, so cleanup must refuse.
+//
+// The sibling below pins the case that MUST still pass, so the fix is a
+// discrimination rather than a blanket refusal.
+func TestUnparseablePaneOutputIsNotAbsence(t *testing.T) {
+	scriptedTmuxOnPath(t, `
+display-message) echo "not-a-pid" ;;
+list-panes)      echo "can't find session: af_garbled" >&2; exit 1 ;;
+kill-session)    exit 0 ;;
+has-session)     exit 1 ;;`)
+
+	ts := NewTmuxSessionFromSanitizedName("af_garbled", "")
+	state, err := ts.CloseAndWaitForPaneExit()
+
+	if state == PaneStateKnown {
+		t.Fatalf("CloseAndWaitForPaneExit = PaneStateKnown with err=%v: display-message ANSWERED with "+
+			"unreadable output, which is not evidence the session was absent — pairing it with a "+
+			"vanished session treats a lost ancestry as an empty one (#2962 round 3)", err)
+	}
+	if err == nil {
+		t.Error("the refusal must say why")
+	}
+}
+
+// TestEmptyPaneOutputIsAbsence is the other half: tmux answering with NO pane is
+// what a missing session actually produces (measured: exit 0, empty output), and
+// that paired with a vanished session is a real empty set. Refusing here would
+// block every ordinary teardown of an already-exited agent.
+func TestEmptyPaneOutputIsAbsence(t *testing.T) {
+	scriptedTmuxOnPath(t, `
+display-message) exit 0 ;;
+list-panes)      echo "can't find session: af_absent" >&2; exit 1 ;;
+kill-session)    exit 0 ;;
+has-session)     exit 1 ;;`)
+
+	ts := NewTmuxSessionFromSanitizedName("af_absent", "")
+	state, err := ts.CloseAndWaitForPaneExit()
+
+	if state != PaneStateKnown {
+		t.Fatalf("CloseAndWaitForPaneExit = %v (err=%v), want PaneStateKnown: tmux answered that there "+
+			"is no pane AND no session, which is a determinate empty", state, err)
+	}
+	if err != nil {
+		t.Errorf("error = %v, want nil", err)
+	}
+}

--- a/session/tmux/close_survived_kill_test.go
+++ b/session/tmux/close_survived_kill_test.go
@@ -1,0 +1,173 @@
+package tmux
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// These tests pin the contract CloseAndWaitForPaneExit exists to provide, which
+// is narrower than Close's: not "tmux answered", but "the worktree may now be
+// deleted or moved". A session that SURVIVED its kill can never satisfy that,
+// however much else was established — it may still be writing (#2962).
+//
+// The distinction matters because of how the destructive caller gates. From
+// session/teardown.go's closeTabForDestructiveTeardown:
+//
+//	state, err := ts.CloseAndWaitForPaneExit()
+//	if state != tmux.PaneStateKnown { ...refuse... }
+//	if err != nil { log.WarningLog.Printf(...) }   // logs and PROCEEDS
+//	return stateKnown, nil
+//
+// The STATE is the gate; the error is only logged. So returning
+// PaneStateKnown alongside "error killing tmux session" is not a mixed signal
+// the caller can weigh — it is a licence to delete.
+
+// scriptedTmuxOnPath installs a fake tmux whose behaviour per subcommand is
+// given by the caller, so a test can stage the exact combination of answers that
+// a real wedged/permission-refusing server would produce.
+func scriptedTmuxOnPath(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\ncase \"$1\" in\n" + body + "\n*) exit 97 ;;\nesac\n"
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestCloseAndWaitSurvivedKillIsNeverKnown is the #2962 regression.
+//
+// Staged exactly as the report describes: the pane PID query fails for a
+// NON-timeout reason (so the existing ErrTmuxTimeout guard does not fire),
+// list-panes succeeds (so the capture-error guard does not fire), kill-session
+// fails, and has-session confirms the session is STILL THERE.
+//
+// On master this returns PaneStateKnown, and the destructive caller deletes the
+// worktree of a live session.
+func TestCloseAndWaitSurvivedKillIsNeverKnown(t *testing.T) {
+	scriptedTmuxOnPath(t, `
+display-message) echo "can't find pane" >&2; exit 1 ;;
+list-panes)      exit 0 ;;
+kill-session)    echo "cannot kill session" >&2; exit 1 ;;
+has-session)     exit 0 ;;`)
+
+	ts := NewTmuxSessionFromSanitizedName("af_survivor", "")
+	state, err := ts.CloseAndWaitForPaneExit()
+
+	if state == PaneStateKnown {
+		t.Fatalf("CloseAndWaitForPaneExit = PaneStateKnown with err=%v, but kill-session FAILED and "+
+			"has-session confirmed the session is still alive. The destructive caller gates on the "+
+			"state and only logs the error, so this deletes the worktree of a live session (#2962)", err)
+	}
+	if err == nil {
+		t.Error("a surviving session must also report why, or the caller has nothing to act on")
+	}
+}
+
+// TestCloseAndWaitSurvivedKillIsNeverKnownWithAQueryablePane covers the SAME
+// defect on the other branch, which the report does not name: when panePID
+// SUCCEEDS, the function falls through to `return state, closeErr` at the end
+// and inherits Close's KNOWN just the same.
+//
+// Reaching it needs the pane leader to be already gone (so the pane-exit wait is
+// skipped) while the session survives — an agent that exited under a session
+// tmux keeps alive, e.g. remain-on-exit or a second pane. The surviving session's
+// OTHER panes may still be writing.
+func TestCloseAndWaitSurvivedKillIsNeverKnownWithAQueryablePane(t *testing.T) {
+	deadPID := exitedPID(t)
+	scriptedTmuxOnPath(t, `
+display-message) echo "`+deadPID+`" ;;
+list-panes)      exit 0 ;;
+kill-session)    echo "cannot kill session" >&2; exit 1 ;;
+has-session)     exit 0 ;;`)
+
+	ts := NewTmuxSessionFromSanitizedName("af_survivor_two", "")
+	state, err := ts.CloseAndWaitForPaneExit()
+
+	if state == PaneStateKnown {
+		t.Fatalf("CloseAndWaitForPaneExit = PaneStateKnown with err=%v: the pane leader had already "+
+			"exited, so the pane-exit wait was skipped, and the final return handed back Close's "+
+			"KNOWN for a session that survived its kill (#2962)", err)
+	}
+	if err == nil {
+		t.Error("a surviving session must also report why")
+	}
+}
+
+// TestCloseAndWaitUnqueryablePaneStillChecksTheProcessSet is the third hole on
+// this path: when panePID fails, the old code returned EARLY, skipping the
+// capture-error and surviving-process gates entirely. A read that failed
+// (list-panes) was therefore never consulted on that branch — the same class one
+// level down.
+func TestCloseAndWaitUnqueryablePaneStillChecksTheProcessSet(t *testing.T) {
+	scriptedTmuxOnPath(t, `
+display-message) echo "can't find pane" >&2; exit 1 ;;
+list-panes)      echo "cannot list panes" >&2; exit 1 ;;
+kill-session)    exit 0 ;;
+has-session)     exit 1 ;;`)
+
+	ts := NewTmuxSessionFromSanitizedName("af_unqueryable", "")
+	state, err := ts.CloseAndWaitForPaneExit()
+
+	if state == PaneStateKnown {
+		t.Fatalf("CloseAndWaitForPaneExit = PaneStateKnown with err=%v: the pane PID was unqueryable "+
+			"AND the pane process set could not be listed, so nothing establishes that anything "+
+			"stopped writing — yet the early return skipped the capture-error gate (#2962)", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "cannot list panes") {
+		t.Errorf("error = %v, want it to name the read that failed", err)
+	}
+}
+
+// TestCloseAndWaitCleanTeardownStaysKnown is the other half of the contract, so
+// the guards above are a signal rather than a state that is always Unknown: an
+// unqueryable pane whose session IS confirmed gone and whose process set was
+// read cleanly still authorizes cleanup. Without this, the fix would strand
+// every caller whose agent had already exited.
+func TestCloseAndWaitCleanTeardownStaysKnown(t *testing.T) {
+	scriptedTmuxOnPath(t, `
+display-message) echo "can't find pane" >&2; exit 1 ;;
+list-panes)      exit 0 ;;
+kill-session)    exit 0 ;;
+has-session)     exit 1 ;;`)
+
+	ts := NewTmuxSessionFromSanitizedName("af_clean", "")
+	state, err := ts.CloseAndWaitForPaneExit()
+
+	if state != PaneStateKnown {
+		t.Fatalf("CloseAndWaitForPaneExit = %v (err=%v), want PaneStateKnown: kill-session succeeded, "+
+			"the session is confirmed gone, and the pane process set was read with nothing left — "+
+			"refusing here would block every ordinary teardown of an already-exited agent", state, err)
+	}
+	if err != nil {
+		t.Errorf("error = %v, want nil for a clean teardown", err)
+	}
+}
+
+// exitedPID returns a PID that is definitively gone: a real child, run to
+// completion and reaped, whose number the kernel has not yet reused.
+//
+// Not a large constant. That would be a guess about the host's pid space, and a
+// guess that lands on a LIVE process inverts the test it is used in — the pane
+// would look alive and the assertion would pass for the wrong reason.
+func exitedPID(t *testing.T) string {
+	t.Helper()
+	cmd := exec.Command("true")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("spawn a throwaway child: %v", err)
+	}
+	pid := cmd.Process.Pid
+	// Reaped by Run, so the number is free. Confirm the kernel agrees before a
+	// test leans on it.
+	if err := syscall.Kill(pid, 0); !errors.Is(err, syscall.ESRCH) {
+		t.Skipf("pid %d was reused between exit and check (kill(0) = %v); this fixture needs a "+
+			"definitively-gone pid", pid, err)
+	}
+	return strconv.Itoa(pid)
+}

--- a/session/tmux/close_survived_kill_test.go
+++ b/session/tmux/close_survived_kill_test.go
@@ -314,25 +314,20 @@ has-session)     exit 1 ;;`)
 	}
 }
 
-// TestVanishedSessionWithASurvivingMarkedProcessRefuses is the round-4 Codex
-// finding: the determinate-empty was laundering a LOST ANCESTRY across teardown
-// attempts.
-//
-// Attempt 1 observes a pane and loses the ancestry to a racing session exit, so
-// cleanup refuses — correctly. finishUserKill then retries the tombstone, and on
-// the retry BOTH tmux reads report absence. Without an independent check the
-// retry calls that a clean empty and deletes the worktree, while a detached
-// descendant of the original pane is still writing.
-//
-// The check has to be one that does not need tmux, because tmux has forgotten
-// the session. The AF_SESSION marker outlives it: a reparented descendant still
-// carries what its pane gave it.
-func TestVanishedSessionWithASurvivingMarkedProcessRefuses(t *testing.T) {
-	const name = "af_vanished_with_survivor"
-	// A real process carrying the marker, standing in for the descendant that
-	// outlived the session — spawned, not fabricated, so the scan sees a genuine
-	// process-table entry.
-	survivor := spawnMarkedProcess(t, name)
+// The vanished-session sweep, round 5 (Codex on #2966). Round 4 answered "did
+// anything outlive this session?" with a marker scan, but matched on AF_SESSION
+// ALONE and only REPORTED what it found. Both were wrong, in opposite
+// directions, and these three cases pin the corrected split.
+
+// TestVanishedSessionReapsAnOwnedSurvivor: a descendant carrying THIS home's
+// markers is a real escaped process. Reporting it is not enough — the tombstone
+// is retried by finishUserKill, and a scan that never signals leaves the leak and
+// the stuck worktree forever. It must be reaped, and cleanup may then proceed.
+func TestVanishedSessionReapsAnOwnedSurvivor(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	const name = "af_vanished_owned"
+	survivor := spawnMarkedProcess(t, name, home)
 
 	scriptedTmuxOnPath(t, `
 display-message) exit 0 ;;
@@ -340,25 +335,90 @@ list-panes)      echo "can't find session: `+name+`" >&2; exit 1 ;;
 kill-session)    exit 0 ;;
 has-session)     exit 1 ;;`)
 
-	ts := NewTmuxSessionFromSanitizedName(name, "")
-	state, err := ts.CloseAndWaitForPaneExit()
+	state, err := NewTmuxSessionFromSanitizedName(name, "").CloseAndWaitForPaneExit()
+
+	if state != PaneStateKnown || err != nil {
+		t.Fatalf("state=%v err=%v: the survivor was this home's, so the bounded reap should have "+
+			"eliminated it and authorized cleanup — refusing instead leaves the tombstone retrying "+
+			"forever without ever signalling the process", state, err)
+	}
+	if proctree.AliveSame(survivor) {
+		t.Errorf("pid %d survived the sweep; reporting a leak without reaping it is what round 4 got wrong", survivor.PID)
+	}
+}
+
+// TestVanishedSessionIgnoresAnotherHomesProcess: the same sanitized name can
+// exist under a DIFFERENT agent-factory home — a leftover from a temp or dev
+// install. Matching on AF_SESSION alone counted it as ours, refusing cleanup
+// forever over a process we must not touch.
+func TestVanishedSessionIgnoresAnotherHomesProcess(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	const name = "af_vanished_foreign"
+	foreign := spawnMarkedProcess(t, name, filepath.Join(t.TempDir(), "some-other-home"))
+
+	scriptedTmuxOnPath(t, `
+display-message) exit 0 ;;
+list-panes)      echo "can't find session: `+name+`" >&2; exit 1 ;;
+kill-session)    exit 0 ;;
+has-session)     exit 1 ;;`)
+
+	state, err := NewTmuxSessionFromSanitizedName(name, "").CloseAndWaitForPaneExit()
+
+	if state != PaneStateKnown || err != nil {
+		t.Fatalf("state=%v err=%v: the marked process belongs to ANOTHER af home, so it is neither our "+
+			"survivor nor ours to reap — blocking on it strands this teardown indefinitely", state, err)
+	}
+	if !proctree.AliveSame(foreign) {
+		t.Errorf("another home's process (pid %d) was killed by this teardown", foreign.PID)
+	}
+}
+
+// TestVanishedSessionRefusesAnUnattributableProcess: a process carrying this
+// session's name but NO home marker cannot be shown to be ours OR foreign. That
+// is the one case that must still block — "I could not tell" is not "not mine".
+func TestVanishedSessionRefusesAnUnattributableProcess(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	const name = "af_vanished_unattributable"
+	spawnMarkedProcess(t, name, "")
+
+	scriptedTmuxOnPath(t, `
+display-message) exit 0 ;;
+list-panes)      echo "can't find session: `+name+`" >&2; exit 1 ;;
+kill-session)    exit 0 ;;
+has-session)     exit 1 ;;`)
+
+	state, err := NewTmuxSessionFromSanitizedName(name, "").CloseAndWaitForPaneExit()
 
 	if state == PaneStateKnown {
-		t.Fatalf("CloseAndWaitForPaneExit = PaneStateKnown with err=%v: both tmux reads report absence, "+
-			"but pid %d still carries the session's %s marker — deleting the worktree now would do it "+
-			"under a live writer (#2962 round 4)", err, survivor, EnvMarkerSession)
-	}
-	if err == nil || !strings.Contains(err.Error(), strconv.Itoa(survivor)) {
-		t.Errorf("error = %v, want it to name the surviving process %d", err, survivor)
+		t.Fatalf("state=Known err=%v: a process marking this session with no %s marker cannot be "+
+			"attributed, and an unattributable process is not an absent one", err, EnvMarkerHome)
 	}
 }
 
 // spawnMarkedProcess starts a child carrying AF_SESSION=<name> and returns its
 // pid, cleaned up by the test.
-func spawnMarkedProcess(t *testing.T, sessionName string) int {
+func spawnMarkedProcess(t *testing.T, sessionName, afHome string) proctree.Process {
 	t.Helper()
 	c := exec.Command("sleep", "300")
-	c.Env = append(os.Environ(), EnvMarkerSession+"="+sessionName)
+	// A CLEAN env, not os.Environ(). processEnvValue returns the FIRST match, and
+	// this test binary runs inside a real af session — so inheriting the ambient
+	// environment puts THAT session's AF_SESSION ahead of the one appended here,
+	// and the child reads as belonging to the developer's session instead of the
+	// fixture's. Measured: the sweep then reported live pids from the running
+	// session rather than the spawned child.
+	c.Env = []string{"PATH=" + os.Getenv("PATH"), EnvMarkerSession + "=" + sessionName}
+	if afHome != "" {
+		c.Env = append(c.Env, EnvMarkerHome+"="+afHome)
+	}
+	// Its OWN kernel session, because the sweep expands a matched process to its
+	// SID members — which is scoped in production precisely because tmux makes a
+	// pane root a session leader (see captureSessionProcessTrees). A child that
+	// merely inherits the test runner's SID is not that shape: measured, the
+	// expansion then pulled in the developer's live af session processes and the
+	// fixture indicted them instead of its own child.
+	c.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	if err := c.Start(); err != nil {
 		t.Fatalf("spawn marked process: %v", err)
 	}
@@ -366,16 +426,24 @@ func spawnMarkedProcess(t *testing.T, sessionName string) int {
 		_ = c.Process.Kill()
 		_, _ = c.Process.Wait()
 	})
-	// The scan reads /proc/<pid>/environ; wait until it is readable.
+	// The scan reads /proc/<pid>/environ; wait until it is readable, then take the
+	// full process IDENTITY. A bare pid is not enough for later liveness checks:
+	// AliveSame compares (PID, StartID), so a fabricated Process{PID: n} reports
+	// "not alive" for a perfectly live process — which made an earlier version of
+	// these assertions pass vacuously.
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		if env, err := proctree.Environ(c.Process.Pid); err == nil {
 			if v, ok := processEnvValue(env, EnvMarkerSession); ok && v == sessionName {
-				return c.Process.Pid
+				p, lookupErr := proctree.Lookup(c.Process.Pid)
+				if lookupErr != nil {
+					t.Fatalf("look up spawned pid %d: %v", c.Process.Pid, lookupErr)
+				}
+				return p
 			}
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Skipf("child %d environ never became readable; this fixture needs a marker-visible process", c.Process.Pid)
-	return 0
+	return proctree.Process{}
 }

--- a/session/tmux/close_survived_kill_test.go
+++ b/session/tmux/close_survived_kill_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 )
 
 // These tests pin the contract CloseAndWaitForPaneExit exists to provide, which
@@ -170,4 +171,61 @@ func exitedPID(t *testing.T) string {
 			"definitively-gone pid", pid, err)
 	}
 	return strconv.Itoa(pid)
+}
+
+// TestSessionGoneRaceAfterAPaneWasObservedStaysUnknown is the Codex finding on
+// #2966: the determinate-empty is only sound when NO pane was ever observed.
+//
+// Here panePID names a live pane, and list-panes THEN reports the session gone.
+// That is a race, not an empty session: the ancestry list-panes would have
+// returned is lost, so descendants and SID members that outlive the leader are
+// unaccounted for. Leader death cannot prove they stopped writing (#1104/#802).
+func TestSessionGoneRaceAfterAPaneWasObservedStaysUnknown(t *testing.T) {
+	// The pane leader must be ALREADY GONE, so the pane-exit wait is skipped and
+	// this test isolates the capture gate. With a live pid it passed either way —
+	// the wait caught it — which made it assert the claim while checking something
+	// weaker.
+	deadPID := exitedPID(t)
+	scriptedTmuxOnPath(t, `
+display-message) echo "`+deadPID+`" ;;
+list-panes)      echo "can't find session: af_raced" >&2; exit 1 ;;
+kill-session)    exit 0 ;;
+has-session)     exit 1 ;;`)
+
+	ts := NewTmuxSessionFromSanitizedName("af_raced", "")
+	state, err := ts.CloseAndWaitForPaneExit()
+
+	if state == PaneStateKnown {
+		t.Fatalf("CloseAndWaitForPaneExit = PaneStateKnown with err=%v: a pane WAS observed and the "+
+			"session then vanished before list-panes, so its descendants are unaccounted for — that is "+
+			"a lost ancestry, not an empty session", err)
+	}
+	if err == nil {
+		t.Error("the race must be reported, not silently downgraded")
+	}
+}
+
+// TestPaneQueryTimeoutKeepsTheSentinelThroughACloseFailure is the other Codex
+// finding: when the pane query times out AND close also fails, the combined
+// return must still carry ErrTmuxTimeout. #1917 keeps that sentinel reachable
+// through errors.Is for callers that classify on it, and returning closeErr
+// alone erased it.
+func TestPaneQueryTimeoutKeepsTheSentinelThroughACloseFailure(t *testing.T) {
+	shortTmuxTimeout(t, 200*time.Millisecond)
+	scriptedTmuxOnPath(t, `
+display-message) sleep 300 & wait ;;
+list-panes)      exit 0 ;;
+kill-session)    echo "cannot kill session" >&2; exit 1 ;;
+has-session)     exit 0 ;;`)
+
+	ts := NewTmuxSessionFromSanitizedName("af_timeout_and_survivor", "")
+	state, err := ts.CloseAndWaitForPaneExit()
+
+	if state != PaneStateUnknown {
+		t.Fatalf("state = %v, want PaneStateUnknown", state)
+	}
+	if !errors.Is(err, ErrTmuxTimeout) {
+		t.Errorf("error = %v, want the ErrTmuxTimeout sentinel to survive the combined failure so "+
+			"callers can still classify the tmux command as timed out (#1917)", err)
+	}
 }

--- a/session/tmux/close_survived_kill_test.go
+++ b/session/tmux/close_survived_kill_test.go
@@ -229,3 +229,31 @@ has-session)     exit 0 ;;`)
 			"callers can still classify the tmux command as timed out (#1917)", err)
 	}
 }
+
+// TestCaptureTimeoutKeepsTheSentinelThroughACloseFailure is the second sentinel
+// leak (Codex on #2966, round 2). The first fix joined pidErr into the
+// survived-kill branch; list-panes can time out too, and its ErrTmuxTimeout
+// lives in processes.captureErr, which the same branch was still dropping.
+//
+// Here the pane query SUCCEEDS (so pidErr is nil and cannot carry the sentinel),
+// list-panes times out, and the kill then fails with the session still alive.
+func TestCaptureTimeoutKeepsTheSentinelThroughACloseFailure(t *testing.T) {
+	shortTmuxTimeout(t, 200*time.Millisecond)
+	livePID := strconv.Itoa(os.Getpid())
+	scriptedTmuxOnPath(t, `
+display-message) echo "`+livePID+`" ;;
+list-panes)      sleep 300 & wait ;;
+kill-session)    echo "cannot kill session" >&2; exit 1 ;;
+has-session)     exit 0 ;;`)
+
+	ts := NewTmuxSessionFromSanitizedName("af_capture_timeout", "")
+	state, err := ts.CloseAndWaitForPaneExit()
+
+	if state != PaneStateUnknown {
+		t.Fatalf("state = %v, want PaneStateUnknown", state)
+	}
+	if !errors.Is(err, ErrTmuxTimeout) {
+		t.Errorf("error = %v, want the ErrTmuxTimeout from the timed-out list-panes to survive the "+
+			"combined failure — pidErr is nil here, so the capture error is the only carrier (#1917)", err)
+	}
+}

--- a/session/tmux/close_wait_test.go
+++ b/session/tmux/close_wait_test.go
@@ -207,8 +207,21 @@ func TestCloseAndWaitForPaneExit_QueriesPaneBeforeKill(t *testing.T) {
 // TestCloseAndWaitForPaneExit_SessionGone: when the pane PID cannot be
 // queried (session already dead), the method must skip the wait and still
 // perform the Close teardown.
+//
+// The fixture states the case in the shape tmux actually produces, which matters
+// since #2962 made the destructive path distinguish a session that is GONE from a
+// pane list it could not READ. Measured against tmux 3.4 for a missing session:
+//
+//	display-message -p -t '=X:' '#{pane_pid}'  ->  exit 0, EMPTY output
+//	list-panes -s -t '=X:' -F '#{pane_pid}'    ->  exit 1, "can't find session: X"
+//
+// The bare fmt.Errorf this replaces modelled neither: it is an unclassifiable
+// failure, which now correctly refuses cleanup. That direction is covered by
+// TestCloseAndWaitUnqueryablePaneStillChecksTheProcessSet, so both outcomes stay
+// pinned rather than one being traded for the other.
 func TestCloseAndWaitForPaneExit_SessionGone(t *testing.T) {
 	killed := false
+	sessionName := toTmuxName("close-wait-gone", "")
 	cmdExec := cmd_test.MockCmdExec{
 		RunFunc: func(cmd *exec.Cmd) error {
 			if strings.Contains(cmd.String(), "kill-session") {
@@ -217,11 +230,15 @@ func TestCloseAndWaitForPaneExit_SessionGone(t *testing.T) {
 			return nil
 		},
 		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
-			return nil, fmt.Errorf("can't find session")
+			if strings.Contains(cmd.String(), "list-panes") {
+				return nil, tmuxCantFindSessionError(t, sessionName)
+			}
+			// display-message answers, with nothing: exit 0 and empty output.
+			return nil, nil
 		},
 	}
 
-	session := newTmuxSession(toTmuxName("close-wait-gone", ""), "claude", NewMockPtyFactory(t), cmdExec)
+	session := newTmuxSession(sessionName, "claude", NewMockPtyFactory(t), cmdExec)
 
 	start := time.Now()
 	state, err := session.CloseAndWaitForPaneExit()
@@ -230,4 +247,20 @@ func TestCloseAndWaitForPaneExit_SessionGone(t *testing.T) {
 		"tmux answered every command, so the pane's fate is established")
 	require.Less(t, time.Since(start), time.Second)
 	require.True(t, killed, "kill-session must still run when the pane PID is unqueryable")
+}
+
+// tmuxCantFindSessionError builds the error tmux really returns for a command
+// against a session that does not exist: an *exec.ExitError with status 1 and
+// the diagnostic on STDERR. A hand-rolled fmt.Errorf has no Stderr, so the
+// classifier that separates "gone" from "unreadable" cannot see it — the whole
+// distinction #2962 turns on.
+func tmuxCantFindSessionError(t *testing.T, sanitizedName string) error {
+	t.Helper()
+	c := exec.Command("sh", "-c", `printf "can't find session: %s\n" "$NAME" >&2; exit 1`)
+	c.Env = append(os.Environ(), "NAME="+sanitizedName)
+	_, err := c.Output()
+	if err == nil {
+		t.Fatal("the fixture must actually fail, or it proves nothing")
+	}
+	return err
 }

--- a/session/tmux/reap.go
+++ b/session/tmux/reap.go
@@ -87,19 +87,23 @@ func captureSessionProcessTrees(cmdExec cmd.Executor, sanitizedName string) ([]p
 		if ctx.Err() != nil {
 			return nil, fmt.Errorf("%w: list-panes for %s after %s", ErrTmuxTimeout, sanitizedName, tmuxCommandTimeout)
 		}
-		// tmux ANSWERED that the session is not there, which is a determinate
-		// EMPTY and not a failed read: a session that does not exist has no panes,
-		// so it has no pane processes to capture. Measured — `can't find session:
-		// <name>` on a live server, `no server running on <socket>` when the server
-		// itself is gone, both exit 1.
+		// tmux ANSWERED that the session is not there. Marked with a sentinel
+		// rather than returned as a plain failure, because whether it is a
+		// determinate EMPTY depends on something only the caller knows: whether it
+		// had already observed a pane of this session.
 		//
-		// This distinction is load-bearing for the destructive path (#2962). Its
-		// caller must refuse to touch the worktree when the pane process set could
-		// not be READ; collapsing "the session is gone" into that would refuse
-		// every teardown of an already-exited agent, which is the ordinary case and
-		// would leave those worktrees uncollectable forever.
+		//   - No pane ever observed: the session does not exist, so it has no panes
+		//     and no pane processes. A determinate empty.
+		//   - A pane WAS observed moments ago: the session exited between the two
+		//     reads, so this is a RACE, and the pane ancestry list-panes would have
+		//     returned is lost. Descendants and SID members that outlive the leader
+		//     are then unaccounted for — leader death cannot prove they stopped
+		//     writing (#1104/#802).
+		//
+		// Measured: `can't find session: <name>` on a live server, `no server
+		// running on <socket>` when the server itself is gone, both exit 1.
 		if missingTmuxSession(err, sanitizedName) {
-			return nil, nil
+			return nil, fmt.Errorf("%w: %v", ErrSessionVanishedBeforeCapture, err)
 		}
 		return nil, fmt.Errorf("cannot list panes before teardown: %w", err)
 	}

--- a/session/tmux/reap.go
+++ b/session/tmux/reap.go
@@ -87,6 +87,20 @@ func captureSessionProcessTrees(cmdExec cmd.Executor, sanitizedName string) ([]p
 		if ctx.Err() != nil {
 			return nil, fmt.Errorf("%w: list-panes for %s after %s", ErrTmuxTimeout, sanitizedName, tmuxCommandTimeout)
 		}
+		// tmux ANSWERED that the session is not there, which is a determinate
+		// EMPTY and not a failed read: a session that does not exist has no panes,
+		// so it has no pane processes to capture. Measured — `can't find session:
+		// <name>` on a live server, `no server running on <socket>` when the server
+		// itself is gone, both exit 1.
+		//
+		// This distinction is load-bearing for the destructive path (#2962). Its
+		// caller must refuse to touch the worktree when the pane process set could
+		// not be READ; collapsing "the session is gone" into that would refuse
+		// every teardown of an already-exited agent, which is the ordinary case and
+		// would leave those worktrees uncollectable forever.
+		if missingTmuxSession(err, sanitizedName) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("cannot list panes before teardown: %w", err)
 	}
 	snap, err := proctree.Snapshot()

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -316,6 +316,14 @@ func TestStartTimeoutCleanupSucceeds(t *testing.T) {
 			if strings.Contains(cmd.String(), "list-panes") {
 				return nil, tmuxCantFindSessionError(t, sessionName)
 			}
+			if strings.Contains(cmd.String(), "display-message") {
+				// Measured: for a session that does not exist, display-message
+				// exits 0 with EMPTY output. The generic "output" stub models
+				// something else entirely — tmux answering with a pane id we
+				// cannot parse — which is NOT evidence of absence and correctly
+				// refuses cleanup since #2962 round 3.
+				return nil, nil
+			}
 			return []byte("output"), nil
 		},
 	}

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -298,6 +298,7 @@ func TestStartTmuxSession(t *testing.T) {
 func TestStartTimeoutCleanupSucceeds(t *testing.T) {
 	ptyFactory := NewMockPtyFactory(t)
 
+	sessionName := toTmuxName("timeout-ok", "")
 	cmdExec := cmd_test.MockCmdExec{
 		RunFunc: func(cmd *exec.Cmd) error {
 			// Session never appears; kill-session (cleanup) succeeds.
@@ -306,10 +307,20 @@ func TestStartTimeoutCleanupSucceeds(t *testing.T) {
 			}
 			return nil
 		},
-		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return []byte("output"), nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			// list-panes must answer consistently with has-session above: this
+			// session never appeared, so tmux reports it missing rather than
+			// returning a pane list. The generic "output" stub previously used here
+			// parses as a pane whose pid is unreadable, which since #2962 correctly
+			// refuses cleanup — a different scenario from the one this test is about.
+			if strings.Contains(cmd.String(), "list-panes") {
+				return nil, tmuxCantFindSessionError(t, sessionName)
+			}
+			return []byte("output"), nil
+		},
 	}
 
-	session := newTmuxSession(toTmuxName("timeout-ok", ""), "claude", ptyFactory, cmdExec)
+	session := newTmuxSession(sessionName, "claude", ptyFactory, cmdExec)
 
 	err := session.Start(t.TempDir())
 	require.Error(t, err)


### PR DESCRIPTION
Fourth instance of the class, after #2870 (`af reset`), #2874 (`af doctor --fix`)
and #2885 (`ListProjects`). This one deletes a worktree while a session may still
be writing to it.

## Why the state is the whole story

`closeTabForDestructiveTeardown` gates on the **state** and only *logs* the error:

```go
state, err := ts.CloseAndWaitForPaneExit()
if state != tmux.PaneStateKnown { ...refuse... }
if err != nil { log.WarningLog.Printf(...) }   // logs and PROCEEDS
return stateKnown, nil
```

So `PaneStateKnown` alongside `error killing tmux session` is not a mixed signal
the caller can weigh — it is a licence to delete. (`backend_local.go`'s SwapAgent
*does* check the error afterwards, which is why it was not exposed.)

## Three holes, one missing funnel

The reported one, plus two more found while fixing it — all because the
`pidErr != nil` branch returned **early**:

1. **Reported.** `panePID` fails non-timeout, `list-panes` succeeds, kill-session
   fails, and the probe confirms the session is **alive** → `close` returns
   `PaneStateKnown` (correct for *its* best-effort contract, #478) and the early
   return handed that straight back.
2. **The final return had it too.** With `panePID` succeeding but the pane leader
   already gone, the pane-exit wait is skipped and `return state, closeErr`
   inherits the same `Known` for a session that survived its kill. The surviving
   session's *other* panes may still be writing.
3. **The early return skipped the process-set gates entirely.** On that branch a
   `list-panes` that FAILED was never consulted, and survivors of the reap were
   never noticed — the same class one level down.

`CloseAndWaitForPaneExit` now evaluates one ordered list of blockers on **every**
path, and returns `PaneStateKnown` only after all of them pass. The rule is
written at the top: this function does not report whether tmux answered — `Close`
does that — it reports whether **the worktree may now be mutated**.

On the second half of the title: a kill that was merely *requested* proves
nothing, so `closeState != PaneStateKnown || closeErr != nil` is the first
blocker. Verifying the reap COMPLETED is the established invariant (#2025/#2440).

## The regression this nearly shipped

Making the capture-error gate universal broke
`TestCloseAndWaitForPaneExit_SessionGone` — and that failure was **correct
signal**, not a stale test. Measured against tmux 3.4 for a session that is gone:

```
display-message -p -t '=X:' '#{pane_pid}'  ->  exit 0, EMPTY output
list-panes -s -t '=X:' -F '#{pane_pid}'    ->  exit 1, "can't find session: X"
```

So the ordinary already-exited agent produces a *failing* `list-panes`. Refusing
on it would have made every such teardown refuse forever and left those worktrees
uncollectable — trading a rare data-loss bug for a constant one.

The fix is the same three-valued split one level down, in
`captureSessionProcessTrees`: tmux's definitive absence (`can't find session: X`,
or `no server running on <socket>`) is a determinate **empty** — a session with no
panes has no pane processes — while any other failure stays an unreadable set.
`missingTmuxSession` already encodes exactly that judgement.

The existing fixture returned a bare `fmt.Errorf("can't find session")`, which has
no `Stderr` and so models neither case. It now produces the real shape. Both
directions stay pinned, so this is not a harness fix papering over the change:
`TestCloseAndWaitUnqueryablePaneStillChecksTheProcessSet` asserts an
*unclassifiable* `list-panes` failure still refuses. Removing the determinate-empty
branch fails `_SessionGone`; keeping it while removing the funnel fails the other three.

## Adjacent reads audited

Per the instruction that turned #2870 into #2874:

| read | failure yields |
| --- | --- |
| `r.tmux` (kill-session) | deadline recorded → `Unknown` ✓ |
| `r.probe` (has-session) | `!known` → `Unknown` ✓ |
| `captureSessionProcessTrees` | **fixed** — gone vs unreadable now distinct |
| `panePID` | timeout → `Unknown`; answered no longer skips the process gates ✓ |
| `capturePaneProcess` | snapshot error / non-ESRCH / present-but-absent → error ✓ |
| `waitForProcessExit` | false → refuse ✓ |
| `markedOrphanProcesses`, `refreshOrphanCandidates` | already return errors on snapshot/UID failure; their comments state the rule ✓ |

State-gated callers checked: `manager_persist.go`'s ghost cleanup refuses on
non-`Known` before touching the workspace (now stricter, correctly);
`start.go` uses non-destructive `Close()` and gates no destructive action on it.

## Tests

Four new, three of which fail on master at the assertion that matters — each
naming the caller behaviour that makes it dangerous. The fourth,
`TestCloseAndWaitCleanTeardownStaysKnown`, is the anti-regression direction so
the guards are a signal rather than a state that is always `Unknown`.

The dead-PID fixture spawns a real child and reaps it rather than picking a large
constant: a constant that landed on a live process would invert the test.

## ⚠️ Contract change, please review this bit

A session that survives its kill now blocks the **whole** teardown, not only the
worktree step, because `closeTabForDestructiveTeardown` gates both on one state.

|  | before | after |
| --- | --- | --- |
| kill fails, session **gone** (#967 no-op) | record dropped, worktree deleted | unchanged |
| kill fails, session **still alive** | record dropped, **worktree deleted** | **refuses**; record + worktree kept for retry |

#478 is narrowed, not discarded — the already-gone failure still logs and
proceeds. The cost is that a user whose tmux cannot be killed cannot drop the
record until they fix tmux. I took it because **#1917 already made exactly this
trade for a kill whose deadline tripped**, and it would be incoherent to block
when we are merely *unsure* the session died while proceeding when we have
positive evidence it did *not*. Say the word if you would rather scope this to
the worktree step alone and leave record deletion best-effort — that is a larger
change to `teardownTabs`, which is why I did not reach for it unasked.

`teardown.go`'s now-unreachable log branch is kept and its comment corrected
rather than left asserting the old contract.

## Fixture corrections, and their limits

Four files of test mocks answered `list-panes -F '#{pane_pid}'` with `"content"`
or `"output"`, which parses as a pane whose pid is unreadable — so they were
stubs that modelled nothing being read as evidence. Each now answers `list-panes`
truthfully while keeping its generic stub for the commands other assertions read.

**The `daemon/` and `app/` edits are reasoned, not verified.** Those suites spawn
real daemons and drive real tmux, so they are not runnable on this box. `go vet`
passes on both and the reasoning is narrow, but CI is their check.
`create_tab_archive_test.go` deliberately makes `panePID` fail; that intent is
preserved, since `display-message` still returns `"content"`.

Local gate clean; `go test ./session/tmux/ ./session/` green. Nothing was run
against the real AF home.

Closes #2962
