### PR TITLE
fix(daemon): push a reachable sandbox before replacing it, and refuse when reachability is unknown

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -685,6 +685,12 @@ func init() {
 	SessionsCmd.AddCommand(sessionsArchiveCmd)
 	SessionsCmd.AddCommand(sessionsHandoffCmd)
 	SessionsCmd.AddCommand(sessionsRetryLimitCmd)
+	// The escape hatch for recovery's refusal to reap a reachable sandbox without
+	// pushing it first (#2923). Per-command and per-session on purpose — the
+	// refusal names this exact invocation, and no config key restores the
+	// data-losing behaviour globally.
+	sessionsRestoreCmd.Flags().Bool("force-reap", false,
+		"replace a reachable sandbox WITHOUT pushing its work first (discards anything it has not pushed)")
 	SessionsCmd.AddCommand(sessionsRestoreCmd)
 	SessionsCmd.AddCommand(sessionsAttachCmd)
 	SessionsCmd.AddCommand(sessionsWhoamiCmd)

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -637,7 +637,17 @@ rebuilding a missing worktree when possible and resuming the recorded agent
 conversation when required.
 
 Fails if the session is not restorable, or if its origin repository is gone.
-The restored worktree path is printed on success.`,
+The restored worktree path is printed on success.
+
+For a sandbox session (docker/ssh/hook) whose sandbox still ANSWERS but whose
+agent is gone, restore first pushes the sandbox's work to origin, because
+recovery re-clones from there and anything unpushed would be destroyed. If that
+push fails, or if af cannot tell whether the sandbox is gone or merely
+unreachable, the restore REFUSES and the session stays recoverable.
+
+--force-reap replaces the sandbox anyway, without the push. It discards whatever
+that sandbox has not pushed, so it is for a sandbox you know is expendable. It
+applies to this one session and this one command; there is no global equivalent.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)
@@ -648,7 +658,12 @@ The restored worktree path is printed on success.`,
 			return jsonError(err)
 		}
 
-		worktreePath, err := restoreSessionViaDaemon(daemon.RestoreSessionRequest{Title: args[0], RepoID: repoID})
+		forceReap, err := cmd.Flags().GetBool("force-reap")
+		if err != nil {
+			return jsonError(err)
+		}
+
+		worktreePath, err := restoreSessionViaDaemon(daemon.RestoreSessionRequest{Title: args[0], RepoID: repoID, ForceReap: forceReap})
 		if err != nil {
 			return jsonError(err)
 		}

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -198,6 +198,16 @@ type RestoreSessionRequest struct {
 	// actions send it so a restore queued for one row cannot resurrect a
 	// different session that reuses the title before dispatch.
 	ID string `json:"id"`
+	// ForceReap replaces a REACHABLE sandbox without first pushing its work
+	// (#2923). Recovery refuses that by default, because a sandbox that still
+	// answers may hold commits nothing else has a copy of; this is the operator
+	// saying they know it is expendable.
+	//
+	// Deliberately per-request, so it names one session and expires with the
+	// command. There is no config key for it: a global switch would silently
+	// restore the data-losing behaviour for every session at once, which is the
+	// shape this repo does not ship.
+	ForceReap bool `json:"force_reap,omitempty"`
 }
 
 type RestoreSessionResponse struct {

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -427,7 +427,7 @@ func (m *Manager) resumeFromLimitLockedOutcome(repoID, key string, instance *ses
 	// blip yields probeUnknown and is refused outright; a durable outage is what
 	// the poll's debounce settles to Lost, which drops this session out of
 	// LimitReached and hands it to the Lost-restore loop (the one place remote
-	// re-provision belongs, with its own recheck). What remains is probeDead: the
+	// re-provision belongs, with its own recheck). What remains is an answered death: the
 	// sandbox answered that its agent exited while blocked — the #1786 case — and
 	// that is authoritative, so it re-spawns at once, exactly as before.
 	as := instance.AgentServer()
@@ -437,7 +437,7 @@ func (m *Manager) resumeFromLimitLockedOutcome(repoID, key string, instance *ses
 		// prompt below is all it needs.
 	case probeUnknown:
 		return resumeNotPerformed, fmt.Errorf("cannot resume %q: its agent-server did not answer the liveness probe; not re-spawning, because re-provisioning a sandbox that may still be running would orphan it and discard its unpushed work", requestedTitle)
-	case probeDead:
+	case probeAbsent, probeAnsweredDead:
 		// Capture the limit window BEFORE the re-spawn: Respawn ends in ConfirmLive,
 		// which drops both the LiveLimitReached liveness and its reset time, and
 		// LimitResetAt reports (zero, false) once that has happened. Re-applying the

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -445,7 +445,10 @@ func (m *Manager) resumeFromLimitLockedOutcome(repoID, key string, instance *ses
 		// record the branch first, and refuse rather than re-spawn if that cannot be
 		// done. A local session has no sandbox to preserve and falls through.
 		if isRemoteWorkspace(instance) {
-			if err := m.preserveSandboxBeforeReap(repoID, key, instance); err != nil {
+			// kill, not --force-reap: RestoreSession refuses a LiveLimitReached
+			// session and ResumeFromLimitRequest has no force option, so the
+			// forced-reap hatch cannot open from this door (Codex on #2967).
+			if err := m.preserveSandboxBeforeReap(repoID, key, instance, killSuggestionFor(instance)); err != nil {
 				return resumeNotPerformed, err
 			}
 			if err := requireDurableSandboxBranch(repoID, instance); err != nil {

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -437,7 +437,23 @@ func (m *Manager) resumeFromLimitLockedOutcome(repoID, key string, instance *ses
 		// prompt below is all it needs.
 	case probeUnknown:
 		return resumeNotPerformed, fmt.Errorf("cannot resume %q: its agent-server did not answer the liveness probe; not re-spawning, because re-provisioning a sandbox that may still be running would orphan it and discard its unpushed work", requestedTitle)
-	case probeAbsent, probeAnsweredDead:
+	case probeAnsweredDead:
+		// It ANSWERED: the agent is gone, the sandbox is not. For a REMOTE session
+		// Respawn is recoverSandbox → reprovisionRemote, which tears the sandbox down
+		// and re-clones from origin — so this is the same destructive replacement the
+		// restore paths guard, reached through a third door (#2923). Push and durably
+		// record the branch first, and refuse rather than re-spawn if that cannot be
+		// done. A local session has no sandbox to preserve and falls through.
+		if isRemoteWorkspace(instance) {
+			if err := m.preserveSandboxBeforeReap(repoID, key, instance); err != nil {
+				return resumeNotPerformed, err
+			}
+			if err := requireDurableSandboxBranch(repoID, instance); err != nil {
+				return resumeNotPerformed, err
+			}
+		}
+		fallthrough
+	case probeAbsent:
 		// Capture the limit window BEFORE the re-spawn: Respawn ends in ConfirmLive,
 		// which drops both the LiveLimitReached liveness and its reset time, and
 		// LimitResetAt reports (zero, false) once that has happened. Re-applying the

--- a/daemon/limit_remote_resume_test.go
+++ b/daemon/limit_remote_resume_test.go
@@ -31,9 +31,10 @@ import (
 type mockSandbox struct {
 	srv *httptest.Server
 
-	mu      sync.Mutex
-	alive   bool
-	prompts []string
+	mu       sync.Mutex
+	alive    bool
+	prompts  []string
+	archives int
 }
 
 func newMockSandbox(t *testing.T, alive bool) *mockSandbox {
@@ -45,6 +46,16 @@ func newMockSandbox(t *testing.T, alive bool) *mockSandbox {
 		resp := map[string]any{"alive": s.alive}
 		s.mu.Unlock()
 		writeSandboxEnvelope(t, w, resp)
+	})
+	// A limit resume that finds an ANSWERED-dead agent now pushes the sandbox
+	// before replacing it (#2923), so a mock that can answer alive=false must also
+	// be able to serve that push — otherwise these tests exercise the refusal
+	// rather than the respawn they are about.
+	mux.HandleFunc("/v1/agent/archive", func(w http.ResponseWriter, _ *http.Request) {
+		s.mu.Lock()
+		s.archives++
+		s.mu.Unlock()
+		writeSandboxEnvelope(t, w, map[string]any{"branch": "af/fixture-branch"})
 	})
 	mux.HandleFunc("/v1/agent/send-prompt", func(w http.ResponseWriter, r *http.Request) {
 		var req struct {

--- a/daemon/limit_resume_test.go
+++ b/daemon/limit_resume_test.go
@@ -152,7 +152,7 @@ func TestResumeFromLimit_PersistsRespawnMutationsWhenSendPromptFails(t *testing.
 		t.Fatalf("NewGitWorktreeFromStorage: %v", err)
 	}
 
-	// alive=false → probeDead → the respawn arm. The respawn rebuilds the worktree
+	// alive=false → an answered death → the respawn arm. The respawn rebuilds the worktree
 	// and succeeds; the SendPrompt that follows it fails.
 	backend := &limitResumeBackend{
 		FakeBackend:   session.NewFakeBackend(),
@@ -187,7 +187,7 @@ func TestResumeFromLimit_PersistsRespawnMutationsWhenSendPromptFails(t *testing.
 }
 
 // TestResumeFromLimit_KeepsLimitBlockedWhenSendPromptFails is the post-#1857
-// codex finding. On the probeDead arm Respawn ends in ConfirmLive, so the session
+// codex finding. On the answered-death arm Respawn ends in ConfirmLive, so the session
 // reads LiveRunning before its pending prompt has been delivered — and #1857's
 // checkpoint serializes the whole instance right there. A SendPrompt failure (or
 // a crash before the send) therefore left an UNBLOCKED session on both axes while
@@ -204,7 +204,7 @@ func TestResumeFromLimit_KeepsLimitBlockedWhenSendPromptFails(t *testing.T) {
 	// respawn round-trip as well as the block itself.
 	resetAt := time.Now().Add(30 * time.Minute).UTC().Truncate(time.Second)
 
-	// alive=false → probeDead → the respawn arm, whose ConfirmLive drops the limit.
+	// alive=false → an answered death → the respawn arm, whose ConfirmLive drops the limit.
 	// The SendPrompt that follows it fails.
 	backend := &limitResumeBackend{
 		FakeBackend:   session.NewFakeBackend(),
@@ -255,7 +255,7 @@ func TestResumeFromLimit_KeepsLimitBlockedWhenSendPromptFails(t *testing.T) {
 func TestResumeFromLimit_RespawnArm_ClearsLimitDurablyOnSuccess(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 
-	// alive=false → probeDead → the respawn arm; SendPrompt succeeds (no error
+	// alive=false → an answered death → the respawn arm; SendPrompt succeeds (no error
 	// hook), which is the resume's single completion point.
 	backend := &limitResumeBackend{FakeBackend: session.NewFakeBackend(), alive: false}
 	inst := registerStarted(t, manager, repoID, repoPath, "resumed-1857", backend, true, session.Running)

--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -405,7 +405,7 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 		// never pushed is still there — and recovery re-clones from origin, which
 		// would destroy it. Push first, and refuse to replace anything if that push
 		// does not land, exactly as ArchiveSandbox refuses via AbortArchiveToLost.
-		if err := m.preserveSandboxBeforeReap(repoID, key, inst); err != nil {
+		if err := m.preserveSandboxBeforeReap(repoID, key, inst, forceReapSuggestionFor(inst)); err != nil {
 			m.mu.Lock()
 			// Its OWN dedupe flag. remoteUnknownLogged is set by the unknown arm and
 			// never reset, so sharing it meant a sandbox that first went unreachable and

--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -387,10 +387,32 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 			log.WarningLog.Printf("not re-provisioning lost remote session %q: could not determine whether its existing sandbox is gone; unreachable is not dead, and replacement could discard unpushed work", inst.Title)
 		}
 		return
-	case probeDead:
-		// The sandbox answered that its agent is gone. This session-specific
-		// evidence, unlike a transport failure, permits recovery. An explicit
-		// not-provisioned sentinel reaches the same arm for inert records.
+	case probeAbsent:
+		// af's own not-provisioned sentinel: it KNOWS there is no runtime to reach,
+		// so there is nothing to preserve and the replacement is unconditional. This
+		// is the ONLY arm that licenses that, which is why the sentinel and a
+		// transport failure had to stop being the same verdict (#2923).
+		m.mu.Lock()
+		st.remoteUnknownAttempts = 0
+		st.nextAttempt = time.Time{}
+		m.mu.Unlock()
+	case probeAnsweredDead:
+		// It ANSWERED. The agent is gone but the sandbox is reachable, so whatever it
+		// never pushed is still there — and recovery re-clones from origin, which
+		// would destroy it. Push first, and refuse to replace anything if that push
+		// does not land, exactly as ArchiveSandbox refuses via AbortArchiveToLost.
+		if err := m.preserveSandboxBeforeReap(repoID, inst); err != nil {
+			m.mu.Lock()
+			logIt := !st.remoteUnknownLogged
+			st.remoteUnknownLogged = true
+			st.remoteUnknownAttempts++
+			st.nextAttempt = time.Now().Add(lostRestoreBackoff(st.remoteUnknownAttempts))
+			m.mu.Unlock()
+			if logIt {
+				log.WarningLog.Printf("%v", err)
+			}
+			return
+		}
 		m.mu.Lock()
 		st.remoteUnknownAttempts = 0
 		st.nextAttempt = time.Time{}

--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -100,6 +100,10 @@ type lostRestoreState struct {
 	// remoteLogged dedupes the "not restoring a remote session" note to once
 	// per Lost episode.
 	remoteLogged bool
+	// preserveFailureLogged dedupes the pre-reap push failure, separately from
+	// remoteUnknownLogged: the two describe different verdicts, and a session can
+	// move from one to the other while its retry episode continues.
+	preserveFailureLogged bool
 	// remoteUnknownLogged dedupes the safety note while a Lost remote sandbox
 	// remains unreachable. Unknown never authorizes destructive re-provisioning.
 	remoteUnknownLogged bool
@@ -403,8 +407,13 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 		// does not land, exactly as ArchiveSandbox refuses via AbortArchiveToLost.
 		if err := m.preserveSandboxBeforeReap(repoID, key, inst); err != nil {
 			m.mu.Lock()
-			logIt := !st.remoteUnknownLogged
-			st.remoteUnknownLogged = true
+			// Its OWN dedupe flag. remoteUnknownLogged is set by the unknown arm and
+			// never reset, so sharing it meant a sandbox that first went unreachable and
+			// later answered — with an actionable push failure like a rejected origin
+			// auth — kept reporting only the obsolete "unreachable" note and never
+			// surfaced the real reason it was not recovering.
+			logIt := !st.preserveFailureLogged
+			st.preserveFailureLogged = true
 			st.remoteUnknownAttempts++
 			st.nextAttempt = time.Now().Add(lostRestoreBackoff(st.remoteUnknownAttempts))
 			m.mu.Unlock()

--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -419,23 +419,6 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 		m.mu.Unlock()
 	}
 
-	// Never provision with an empty RestoreBranch, whichever arm got here: that is
-	// the default-branch clone this cluster is about (#2925/#2959).
-	if isRemoteWorkspace(inst) {
-		if err := requireKnownSandboxBranch(inst); err != nil {
-			m.mu.Lock()
-			logIt := !st.remoteUnknownLogged
-			st.remoteUnknownLogged = true
-			st.remoteUnknownAttempts++
-			st.nextAttempt = time.Now().Add(lostRestoreBackoff(st.remoteUnknownAttempts))
-			m.mu.Unlock()
-			if logIt {
-				log.WarningLog.Printf("%v", err)
-			}
-			return
-		}
-	}
-
 	if err := inst.Recover(); err != nil {
 		// Persist the instance even on failure, matching the manual restore path
 		// (restore.go): Recover can mutate durable worktree state before it fails

--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -401,7 +401,7 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 		// never pushed is still there — and recovery re-clones from origin, which
 		// would destroy it. Push first, and refuse to replace anything if that push
 		// does not land, exactly as ArchiveSandbox refuses via AbortArchiveToLost.
-		if err := m.preserveSandboxBeforeReap(repoID, inst); err != nil {
+		if err := m.preserveSandboxBeforeReap(repoID, key, inst); err != nil {
 			m.mu.Lock()
 			logIt := !st.remoteUnknownLogged
 			st.remoteUnknownLogged = true
@@ -417,6 +417,23 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 		st.remoteUnknownAttempts = 0
 		st.nextAttempt = time.Time{}
 		m.mu.Unlock()
+	}
+
+	// Never provision with an empty RestoreBranch, whichever arm got here: that is
+	// the default-branch clone this cluster is about (#2925/#2959).
+	if isRemoteWorkspace(inst) {
+		if err := requireKnownSandboxBranch(inst); err != nil {
+			m.mu.Lock()
+			logIt := !st.remoteUnknownLogged
+			st.remoteUnknownLogged = true
+			st.remoteUnknownAttempts++
+			st.nextAttempt = time.Now().Add(lostRestoreBackoff(st.remoteUnknownAttempts))
+			m.mu.Unlock()
+			if logIt {
+				log.WarningLog.Printf("%v", err)
+			}
+			return
+		}
 	}
 
 	if err := inst.Recover(); err != nil {

--- a/daemon/lostrestore_confirm_test.go
+++ b/daemon/lostrestore_confirm_test.go
@@ -263,7 +263,7 @@ type deadPaneBackend struct{ *session.FakeBackend }
 func (b *deadPaneBackend) HasUpdated(*session.Instance) (bool, bool, string) {
 	return false, false, "" // what a DEAD session's suppressed capture returns
 }
-func (b *deadPaneBackend) IsAlive(*session.Instance) (bool, error) { return false, nil } // probeDead
+func (b *deadPaneBackend) IsAlive(*session.Instance) (bool, error) { return false, nil } // answered dead
 func (b *deadPaneBackend) Type() string                            { return "local" }
 
 // TestRefreshInstanceStatus_SnapshotNilErrorOnDeadSession_IsNotAnObservation is

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -529,7 +529,7 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		// record — an outage/reboot casualty that is recovery-eligible, not a
 		// corpse the user wanted gone.
 		switch probe := probeLiveness(instance, as); probe {
-		case probeDead:
+		case probeAbsent, probeAnsweredDead:
 			// AUTHORITATIVE: the agent-server (or local tmux) was asked and
 			// reports the agent gone. No debounce — the evidence is present and
 			// bad, not absent. #935's immediacy is unchanged for both runtimes.

--- a/daemon/remoteloss.go
+++ b/daemon/remoteloss.go
@@ -29,7 +29,7 @@ import (
 //
 //  1. DISTINGUISH. AgentServer.Alive returns an error, so "the sandbox answered:
 //     the agent is gone" and "the sandbox never answered" stop being the same
-//     `false`. See livenessProbe: probeDead is authoritative and acted on at
+//     `false`. See livenessProbe: an ANSWERED probe is authoritative and acted on at
 //     once (#935/#1108 immediacy, unchanged); probeUnknown is an absence of
 //     evidence and settles nothing on its own. Most of the safety lives here —
 //     no amount of debouncing rescues a caller that cannot tell the two apart,
@@ -37,7 +37,7 @@ import (
 //     debounce of its own.
 //  2. DEBOUNCE before a second probe. A run of failed Snapshots earns one bounded
 //     Alive confirmation, but never manufactures death from silence. Only an
-//     ANSWERED probeDead may settle Lost; probeUnknown preserves last-known state
+//     an ANSWERED death may settle Lost; probeUnknown preserves last-known state
 //     because unreachable is not dead (#2589).
 //
 // The debounce demands the failure be DURABLE on two independent axes:
@@ -183,17 +183,17 @@ func (m *Manager) clearRemoteLoss(key string) {
 // sandbox never pushed, so the question that matters is not "was it lost?" but
 // "is it gone NOW?" — asked against live state, immediately before acting.
 //
-// probeAlive proves the sandbox is there and heals the stale Lost row. probeDead
+// probeAlive proves the sandbox is there and heals the stale Lost row. An answered death
 // is session-specific evidence that replacement is safe: either the server
 // answered false or af's clientless sentinel says this runtime is explicitly not
 // provisioned. probeUnknown authorizes nothing: unreachable is not dead, and
-// collapsing it into probeDead is exactly how a connectivity failure can discard
+// collapsing it into a death is exactly how a connectivity failure can discard
 // unpushed work (#2589).
 //
 // Bounded, so a wedged remote cannot stall the poll goroutine here either.
 func (m *Manager) remoteSandboxLiveness(instance *session.Instance) livenessProbe {
 	if !isRemoteWorkspace(instance) {
-		return probeDead // a local session has no remote sandbox to preserve
+		return probeAbsent // a local session has no remote sandbox to preserve
 	}
 	return aliveWithin(instance.AgentServer(), remoteLostConfirmTimeout)
 }
@@ -313,7 +313,7 @@ func (m *Manager) settleRemoteProbeFailure(repoID, key string, instance *session
 		log.InfoLog.Printf("remote session %q failed repeated snapshots but its agent-server answers as alive; leaving its status alone", instance.Title)
 		m.clearRemoteLoss(key)
 		return
-	case probeDead:
+	case probeAbsent, probeAnsweredDead:
 		// The server answered: reachable, agent gone. The snapshots were failing
 		// for some other reason. An answer of any kind ends the transport episode.
 		log.WarningLog.Printf("remote session %q: agent-server reports its agent is gone — marking it Lost", instance.Title)
@@ -336,10 +336,18 @@ type livenessProbe int
 const (
 	// probeAlive: the agent answered and is running.
 	probeAlive livenessProbe = iota
-	// probeDead: session-specific evidence says the runtime is absent. Either the
-	// agent-server answered and reports its agent gone, or af has an explicit
-	// not-provisioned sentinel for this session. Callers may act on it immediately.
-	probeDead
+	// probeAbsent: af has an explicit not-provisioned sentinel for this session —
+	// the clientless AgentServer, which is raised when af KNOWS there is no runtime
+	// to contact. Nothing is preserved by refusing, so this licenses a reap.
+	probeAbsent
+	// probeAnsweredDead: the agent-server ANSWERED and reports its agent gone. That
+	// answer proves the sandbox is REACHABLE — a live container whose agent process
+	// crashed, OOMed, or exited — so whatever it holds is still there to be saved.
+	// It is death evidence for the AGENT and liveness evidence for the SANDBOX, and
+	// keeping those apart is the whole point of the split: collapsing it into
+	// "absent" is what let recovery reap a reachable sandbox with unpushed commits
+	// in it (#2923).
+	probeAnsweredDead
 	// probeUnknown: the probe could not be answered — a transport failure or a
 	// timeout. NOT evidence of death. Only repetition over time (the debounce)
 	// may turn a run of these into a conclusion.
@@ -361,7 +369,9 @@ func probeLiveness(instance *session.Instance, as session.AgentServer) livenessP
 	if alive {
 		return probeAlive
 	}
-	return probeDead
+	// A local probe is in-process, so an answer of "not alive" is not evidence
+	// about any sandbox — there is none to reach.
+	return probeAbsent
 }
 
 // aliveWithin runs a possibly-slow remote Alive() probe under a hard local
@@ -374,7 +384,7 @@ func probeLiveness(instance *session.Instance, as session.AgentServer) livenessP
 // never blocks and nothing leaks past that; at most one such goroutine exists
 // per wedged remote per tick.
 //
-// A timeout reports probeUnknown rather than probeDead: a server that cannot
+// A timeout reports probeUnknown rather than a death: a server that cannot
 // answer in time has told us nothing, and the whole point of the tri-state is
 // that we stop inventing a verdict from silence.
 func aliveWithin(as session.AgentServer, timeout time.Duration) livenessProbe {
@@ -393,13 +403,19 @@ func aliveWithin(as session.AgentServer, timeout time.Duration) livenessProbe {
 	case r := <-done:
 		switch {
 		case errors.Is(r.err, session.ErrRemoteSandboxNotProvisioned):
-			return probeDead
+			// af's own sentinel: it KNOWS there is no runtime to contact, so there is
+			// nothing to preserve. Note this is the ONLY absence evidence — a
+			// genuinely destroyed container fails with a TRANSPORT error, which lands
+			// on probeUnknown below. Keying a refusal off this sentinel instead of off
+			// reachability would strand every truly-gone sandbox forever.
+			return probeAbsent
 		case r.err != nil:
 			return probeUnknown
 		case r.alive:
 			return probeAlive
 		default:
-			return probeDead
+			// It answered. The agent is gone but the sandbox is THERE.
+			return probeAnsweredDead
 		}
 	case <-timer.C:
 		return probeUnknown

--- a/daemon/restore.go
+++ b/daemon/restore.go
@@ -161,14 +161,23 @@ func (m *Manager) restoreLostOrDeadSession(repoID, title string, instance *sessi
 		// learns this session's branch from the sandbox, and skipping it would make
 		// the replacement clone the default branch and strand work the operator had
 		// already pushed — which the flag never offered to discard.
-		if err := m.preserveSandboxBeforeReap(repoID, key, instance); err != nil {
-			if !force {
+		if force {
+			// Do NOT push. The flag's promise is that the sandbox is replaced without
+			// publishing what it holds, and archive does not merely push commits — it
+			// snapshots uncommitted files into one first. Pushing here would upload
+			// exactly the material the operator chose to discard, which is worse than
+			// the data loss the default path prevents.
+			//
+			// The branch therefore has to be known already, and the guard below is what
+			// makes that a refusal rather than a default-branch clone.
+			if err := requireKnownSandboxBranch(instance); err != nil {
 				return "", err
 			}
-			if berr := requireKnownSandboxBranch(instance); berr != nil {
-				return "", berr
-			}
-			log.WarningLog.Printf("restore of %q: --force-reap given, replacing its reachable sandbox anyway (%v); anything it has not pushed is discarded", title, err)
+			log.WarningLog.Printf("restore of %q: --force-reap given, replacing its reachable sandbox without pushing; anything it has not pushed is discarded", title)
+			break
+		}
+		if err := m.preserveSandboxBeforeReap(repoID, key, instance); err != nil {
+			return "", err
 		}
 	}
 

--- a/daemon/restore.go
+++ b/daemon/restore.go
@@ -144,7 +144,7 @@ func (m *Manager) restoreLostOrDeadSession(repoID, title string, instance *sessi
 		// broken path, so a replacement still must not land on the default branch and
 		// strand work it had already PUSHED — which is not what the flag offered to
 		// discard. Unlike probeAbsent below, "gone" was never established here.
-		if err := requireKnownSandboxBranch(instance); err != nil {
+		if err := requireDurableSandboxBranch(repoID, instance); err != nil {
 			return "", err
 		}
 		log.WarningLog.Printf("restore of %q: --force-reap given past an indeterminate probe; af could not reach the sandbox to push it, so anything it holds unpushed is discarded", title)
@@ -170,7 +170,7 @@ func (m *Manager) restoreLostOrDeadSession(repoID, title string, instance *sessi
 			//
 			// The branch therefore has to be known already, and the guard below is what
 			// makes that a refusal rather than a default-branch clone.
-			if err := requireKnownSandboxBranch(instance); err != nil {
+			if err := requireDurableSandboxBranch(repoID, instance); err != nil {
 				return "", err
 			}
 			log.WarningLog.Printf("restore of %q: --force-reap given, replacing its reachable sandbox without pushing; anything it has not pushed is discarded", title)

--- a/daemon/restore.go
+++ b/daemon/restore.go
@@ -140,6 +140,13 @@ func (m *Manager) restoreLostOrDeadSession(repoID, title string, instance *sessi
 		if !force {
 			return "", refuseIndeterminateReap(title)
 		}
+		// Forced past an unanswerable probe: the sandbox may well be alive behind a
+		// broken path, so a replacement still must not land on the default branch and
+		// strand work it had already PUSHED — which is not what the flag offered to
+		// discard. Unlike probeAbsent below, "gone" was never established here.
+		if err := requireKnownSandboxBranch(instance); err != nil {
+			return "", err
+		}
 		log.WarningLog.Printf("restore of %q: --force-reap given past an indeterminate probe; af could not reach the sandbox to push it, so anything it holds unpushed is discarded", title)
 	case probeAbsent:
 		// af's own not-provisioned sentinel: nothing to preserve, so replacement is
@@ -158,15 +165,10 @@ func (m *Manager) restoreLostOrDeadSession(repoID, title string, instance *sessi
 			if !force {
 				return "", err
 			}
+			if berr := requireKnownSandboxBranch(instance); berr != nil {
+				return "", berr
+			}
 			log.WarningLog.Printf("restore of %q: --force-reap given, replacing its reachable sandbox anyway (%v); anything it has not pushed is discarded", title, err)
-		}
-	}
-
-	// Never provision with an empty RestoreBranch, whichever arm got here, and
-	// regardless of --force-reap: see requireKnownSandboxBranch.
-	if isRemoteWorkspace(instance) {
-		if err := requireKnownSandboxBranch(instance); err != nil {
-			return "", err
 		}
 	}
 

--- a/daemon/restore.go
+++ b/daemon/restore.go
@@ -138,7 +138,7 @@ func (m *Manager) restoreLostOrDeadSession(repoID, title string, instance *sessi
 		// release HERE: a refusal whose advertised retry lands on the same branch and
 		// refuses again is the same defect wearing a helpful message.
 		if !force {
-			return "", refuseIndeterminateReap(title)
+			return "", refuseIndeterminateReap(instance)
 		}
 		// Forced past an unanswerable probe: the sandbox may well be alive behind a
 		// broken path, so a replacement still must not land on the default branch and

--- a/daemon/restore.go
+++ b/daemon/restore.go
@@ -59,14 +59,14 @@ func (m *Manager) RestoreSession(req RestoreSessionRequest) (string, session.Ins
 		path, restoreErr := m.restoreArchivedInstance(instance, repoID, title)
 		return path, resolved, restoreErr
 	case session.LiveLost, session.LiveDead:
-		path, restoreErr := m.restoreLostOrDeadSession(repoID, title, instance)
+		path, restoreErr := m.restoreLostOrDeadSession(repoID, title, instance, req.ForceReap)
 		return path, resolved, restoreErr
 	default:
 		return "", session.InstanceData{}, fmt.Errorf("session %q is not archived, lost, or dead", title)
 	}
 }
 
-func (m *Manager) restoreLostOrDeadSession(repoID, title string, instance *session.Instance) (string, error) {
+func (m *Manager) restoreLostOrDeadSession(repoID, title string, instance *session.Instance, force bool) (string, error) {
 	if err := instance.ValidateRuntimeAction(session.RuntimeActionRestoreLostOrDead); err != nil {
 		return "", fmt.Errorf("cannot restore: %w", err)
 	}
@@ -133,9 +133,23 @@ func (m *Manager) restoreLostOrDeadSession(repoID, title string, instance *sessi
 		m.mu.Unlock()
 		return instance.GetWorktreePath(), nil
 	case probeUnknown:
-		return "", fmt.Errorf("cannot restore remote session %q: could not determine whether its existing sandbox is gone; refusing to re-provision while it is unreachable because that could discard unpushed work (if you know it is permanently gone, explicitly kill this session and create a replacement)", title)
-	case probeDead:
-		// The sandbox answered that its agent is gone, so replacement is safe.
+		// Unreachable is not gone. Refuse, and NAME the release — a guard that blocks
+		// without saying how to get past it is #2917.
+		return "", refuseIndeterminateReap(title)
+	case probeAbsent:
+		// af's own not-provisioned sentinel: nothing to preserve, so replacement is
+		// unconditional. The only arm that licenses that.
+	case probeAnsweredDead:
+		// It ANSWERED: the agent is gone, the sandbox is not. Push its work to origin
+		// before anything replaces it, and refuse outright if that push does not
+		// land — the same order and the same refusal ArchiveSandbox uses.
+		if !force {
+			if err := m.preserveSandboxBeforeReap(repoID, instance); err != nil {
+				return "", err
+			}
+		} else {
+			log.WarningLog.Printf("restore of %q: --force-reap given, replacing its reachable sandbox WITHOUT pushing; anything it has not pushed is discarded", title)
+		}
 	}
 
 	if err := instance.Recover(); err != nil {

--- a/daemon/restore.go
+++ b/daemon/restore.go
@@ -176,7 +176,7 @@ func (m *Manager) restoreLostOrDeadSession(repoID, title string, instance *sessi
 			log.WarningLog.Printf("restore of %q: --force-reap given, replacing its reachable sandbox without pushing; anything it has not pushed is discarded", title)
 			break
 		}
-		if err := m.preserveSandboxBeforeReap(repoID, key, instance); err != nil {
+		if err := m.preserveSandboxBeforeReap(repoID, key, instance, forceReapSuggestionFor(instance)); err != nil {
 			return "", err
 		}
 	}

--- a/daemon/restore.go
+++ b/daemon/restore.go
@@ -134,8 +134,13 @@ func (m *Manager) restoreLostOrDeadSession(repoID, title string, instance *sessi
 		return instance.GetWorktreePath(), nil
 	case probeUnknown:
 		// Unreachable is not gone. Refuse, and NAME the release — a guard that blocks
-		// without saying how to get past it is #2917.
-		return "", refuseIndeterminateReap(title)
+		// without saying how to get past it is #2917. Which means honoring that
+		// release HERE: a refusal whose advertised retry lands on the same branch and
+		// refuses again is the same defect wearing a helpful message.
+		if !force {
+			return "", refuseIndeterminateReap(title)
+		}
+		log.WarningLog.Printf("restore of %q: --force-reap given past an indeterminate probe; af could not reach the sandbox to push it, so anything it holds unpushed is discarded", title)
 	case probeAbsent:
 		// af's own not-provisioned sentinel: nothing to preserve, so replacement is
 		// unconditional. The only arm that licenses that.
@@ -143,12 +148,25 @@ func (m *Manager) restoreLostOrDeadSession(repoID, title string, instance *sessi
 		// It ANSWERED: the agent is gone, the sandbox is not. Push its work to origin
 		// before anything replaces it, and refuse outright if that push does not
 		// land — the same order and the same refusal ArchiveSandbox uses.
-		if !force {
-			if err := m.preserveSandboxBeforeReap(repoID, instance); err != nil {
+		//
+		// --force-reap still ATTEMPTS the push. The flag means "a failed push must
+		// not stop you", not "do not try": the push is also the only thing that
+		// learns this session's branch from the sandbox, and skipping it would make
+		// the replacement clone the default branch and strand work the operator had
+		// already pushed — which the flag never offered to discard.
+		if err := m.preserveSandboxBeforeReap(repoID, key, instance); err != nil {
+			if !force {
 				return "", err
 			}
-		} else {
-			log.WarningLog.Printf("restore of %q: --force-reap given, replacing its reachable sandbox WITHOUT pushing; anything it has not pushed is discarded", title)
+			log.WarningLog.Printf("restore of %q: --force-reap given, replacing its reachable sandbox anyway (%v); anything it has not pushed is discarded", title, err)
+		}
+	}
+
+	// Never provision with an empty RestoreBranch, whichever arm got here, and
+	// regardless of --force-reap: see requireKnownSandboxBranch.
+	if isRemoteWorkspace(instance) {
+		if err := requireKnownSandboxBranch(instance); err != nil {
+			return "", err
 		}
 	}
 

--- a/daemon/sandbox_preserve.go
+++ b/daemon/sandbox_preserve.go
@@ -203,6 +203,33 @@ func requireDurableSandboxBranch(repoID string, instance *session.Instance) erro
 				"remove it and create a replacement: %s",
 			instance.Title, instance.GetBranch(), killSuggestionFor(instance))
 	}
+	// A record under this title is not necessarily a record of THIS session.
+	// Titles are reused — an archived name can be reclaimed — so a stored row
+	// belonging to a different instance says nothing about whether this
+	// sandbox's branch is durable.
+	if rec.ID != "" && instance.ID != "" && rec.ID != instance.ID {
+		return fmt.Errorf(
+			"cannot replace the sandbox for %q: the stored record under that title belongs to a "+
+				"different session, so af cannot confirm this sandbox's branch %q was ever recorded. "+
+				"Retry once its own record is written; if its work is expendable, remove it and create "+
+				"a replacement: %s",
+			instance.Title, instance.GetBranch(), killSuggestionFor(instance))
+	}
+	// Non-empty is not the question — MATCHING is. A partial archive pushes a new
+	// branch, updates the instance in memory, then fails teardown and its
+	// best-effort persist, so the disk can hold an OLDER nonempty branch. Accepting
+	// that would authorize destroying the sandbox on the strength of a record that
+	// points somewhere else: if recovery then fails, the next restore returns to
+	// the old branch and strands exactly the work the archive just pushed.
+	if strings.TrimSpace(rec.Branch) != strings.TrimSpace(instance.GetBranch()) {
+		return fmt.Errorf(
+			"cannot replace the sandbox for %q: its stored branch is %q but the sandbox is on %q — the "+
+				"write that would have recorded the current branch did not land, so a crash after the "+
+				"replacement would send the next restore back to the stored branch and strand the work "+
+				"pushed to the current one. Retry once the record is writable; if its work is expendable, "+
+				"remove it and create a replacement: %s",
+			instance.Title, rec.Branch, instance.GetBranch(), killSuggestionFor(instance))
+	}
 	return nil
 }
 

--- a/daemon/sandbox_preserve.go
+++ b/daemon/sandbox_preserve.go
@@ -97,7 +97,18 @@ func killSuggestionFor(instance *session.Instance) string {
 // Returns nil when the caller may proceed to reap. A non-nil error means REFUSE:
 // leave the session Lost and recoverable, because the alternative is destroying
 // work that nothing else has a copy of.
-func (m *Manager) preserveSandboxBeforeReap(repoID, key string, instance *session.Instance) error {
+// escapeSuggestion is the command a caller offers when the push refuses. It is a
+// parameter rather than a constant because the escape that works depends on the
+// door this was reached through: the restore paths can force a reap, and the
+// limit-resume path cannot — RestoreSession refuses a LiveLimitReached session
+// (it is not archived, Lost, or Dead) and ResumeFromLimitRequest has no force
+// option, so --force-reap there is a hatch that always fails.
+//
+// This file already refuses to do that in the empty-branch case, for the same
+// stated reason: an escape hatch that cannot open is the thing this guard exists
+// to avoid. Making the suggestion the caller's to name applies that rule to
+// every door instead of one (Codex on #2967).
+func (m *Manager) preserveSandboxBeforeReap(repoID, key string, instance *session.Instance, escapeSuggestion string) error {
 	branch, err := archiveWithin(instance.AgentServer(), sandboxPushTimeout)
 	if err != nil {
 		// Refuse, exactly as ArchiveSandbox refuses (AbortArchiveToLost) when its
@@ -108,7 +119,7 @@ func (m *Manager) preserveSandboxBeforeReap(repoID, key string, instance *sessio
 				"and the push that would make its unpushed work durable failed (%w). "+
 				"Replacing it now would destroy any commits it holds. "+
 				"It stays recoverable and the daemon keeps retrying; if you know its work is expendable, force it with: %s",
-			instance.Title, err, forceReapSuggestionFor(instance))
+			instance.Title, err, escapeSuggestion)
 	}
 	if branch == "" {
 		// A push that reports no branch leaves recovery with the empty RestoreBranch

--- a/daemon/sandbox_preserve.go
+++ b/daemon/sandbox_preserve.go
@@ -1,0 +1,125 @@
+package daemon
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// sandboxPushTimeout bounds the pre-reap push. It is generous compared with the
+// liveness probe because this one is a git push over the network rather than a
+// health check, but it is BOUNDED for the same reason: recovery runs on the
+// daemon poll, and a wedged sandbox must not stall it. A push that does not
+// finish in time is treated exactly like one that failed — nothing is reaped.
+const sandboxPushTimeout = 2 * time.Minute
+
+// forceReapCommandFor renders the per-session escape hatch the refusals below
+// must name. A guard that blocks without naming its own release is #2917, so
+// every refusal in this file ends with this string.
+//
+// Per-session and explicit by construction: it names one title, and there is no
+// global switch that restores the reaping-without-a-push behaviour for
+// everything at once.
+func forceReapCommandFor(title string) string {
+	return fmt.Sprintf("af sessions restore %q --force-reap", title)
+}
+
+// preserveSandboxBeforeReap runs the push that makes a reachable sandbox's work
+// durable before recovery destroys it (#2923/#2925/#2959).
+//
+// Recovery re-provisions from origin, so anything the sandbox never pushed is
+// gone the moment it is reaped. The archive path already gets this right and
+// says why: "the workspace state must be durable on GitHub before anything is
+// torn down." Recovery reaped first and never pushed at all.
+//
+// It also fixes where the branch NAME comes from. A sandbox session's daemon-side
+// Branch is written by exactly one thing — the Archive() return — so a session
+// that was never archived recovers with an empty RestoreBranch, which makes the
+// docker/ssh runtimes SKIP the restore fetch and clone the repo's DEFAULT branch.
+// This push is that same call, so recording its result here closes the empty-
+// branch recovery at the same time, and from the only source that can be trusted:
+// the sandbox itself. The daemon cannot derive the name — the in-sandbox worktree
+// uses the SANDBOX's branch_prefix, and BranchForTitle adds a random suffix for
+// titles that sanitize away — so a derived name would be confidently wrong.
+//
+// Returns nil when the caller may proceed to reap. A non-nil error means REFUSE:
+// leave the session Lost and recoverable, because the alternative is destroying
+// work that nothing else has a copy of.
+func (m *Manager) preserveSandboxBeforeReap(repoID string, instance *session.Instance) error {
+	branch, err := archiveWithin(instance.AgentServer(), sandboxPushTimeout)
+	if err != nil {
+		// Refuse, exactly as ArchiveSandbox refuses (AbortArchiveToLost) when its
+		// push fails. The session stays Lost and the retry loop keeps trying, which
+		// is what makes this recoverable rather than terminal.
+		return fmt.Errorf(
+			"refusing to replace the sandbox for %q: its agent is gone but the sandbox still ANSWERS, "+
+				"and the push that would make its unpushed work durable failed (%w). "+
+				"Replacing it now would destroy any commits it holds. "+
+				"It stays recoverable and the daemon keeps retrying; if you know its work is expendable, force it with: %s",
+			instance.Title, err, forceReapCommandFor(instance.Title))
+	}
+	if branch == "" {
+		// A push that reports no branch leaves recovery with the empty RestoreBranch
+		// that clones the default branch — the reported bug. Refuse rather than
+		// "succeed" onto the wrong branch.
+		return fmt.Errorf(
+			"refusing to replace the sandbox for %q: its push reported no branch name, so a replacement "+
+				"would clone the repository's default branch and strand whatever the sandbox holds. "+
+				"It stays recoverable; if you know its work is expendable, force it with: %s",
+			instance.Title, forceReapCommandFor(instance.Title))
+	}
+	// Record it the INSTANT it is durable, for the reason ArchiveSandbox records it
+	// there: from here the branch is the only handle on the user's work, so it
+	// belongs on the record whatever happens to the sandbox next.
+	instance.SetSandboxBranch(branch)
+	m.persistInstance(repoID, instance)
+	log.InfoLog.Printf("recovery of %q: pushed its sandbox's work to %s before replacing it", instance.Title, branch)
+	return nil
+}
+
+// refuseIndeterminateReap is the message for a sandbox whose reachability could
+// not be established at all — a transport failure or a timed-out probe.
+//
+// Unreachable is NOT gone. A replacement here would reap a sandbox that may still
+// be holding hours of unpushed commits, so the decision is to refuse: stranded
+// cloud spend is visible on a bill and fixable afterwards, lost work is neither.
+func refuseIndeterminateReap(title string) error {
+	return fmt.Errorf(
+		"cannot restore %q: af could not determine whether its sandbox is gone or merely unreachable, "+
+			"and replacing it would discard anything it has not pushed. "+
+			"It stays recoverable and the daemon keeps retrying; if you know the sandbox is gone, force it with: %s",
+		title, forceReapCommandFor(title))
+}
+
+// archiveWithin runs the sandbox's push under a hard local deadline, mirroring
+// aliveWithin.
+//
+// It bounds the CALLER's wait, not the underlying REST call — AgentServer.Archive
+// takes no context, for the same reason Alive does not. The orphaned goroutine
+// writes to a BUFFERED channel so it never blocks and nothing leaks past its own
+// call timeout.
+//
+// A timeout is an ERROR here, not an empty branch: the push may or may not have
+// landed, and the caller must treat "we do not know" as a refusal rather than as
+// permission to reap.
+func archiveWithin(as session.AgentServer, timeout time.Duration) (string, error) {
+	type result struct {
+		branch string
+		err    error
+	}
+	done := make(chan result, 1)
+	go func() {
+		branch, err := as.Archive()
+		done <- result{branch: branch, err: err}
+	}()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case r := <-done:
+		return r.branch, r.err
+	case <-timer.C:
+		return "", fmt.Errorf("the sandbox did not finish pushing within %s", timeout)
+	}
+}

--- a/daemon/sandbox_preserve.go
+++ b/daemon/sandbox_preserve.go
@@ -32,12 +32,39 @@ const sandboxPushTimeout = 2 * time.Minute
 // containing $HOME, $(...) or a backtick still expands inside the double quotes
 // it produces (#1978). A command advertised for copy-paste has to be one the
 // shell reads as a single literal argument.
-func forceReapCommandFor(title string) string {
+func sessionRepoScope(instance *session.Instance) []string {
+	// A destructive suggestion MUST carry the scope it was resolved under. Without
+	// it, an operator who ran the original command with --repo /b copies a
+	// title-only command that resolveRepoID re-resolves against their CWD — so it
+	// either misses the session or, worse, force-reaps a same-titled one in a
+	// different repo. Prefer the worktree's resolved repo root, falling back to the
+	// instance path for a row whose worktree is not reconstructable.
+	root := instance.GetRepoPath()
+	if root == "" {
+		root = instance.Path
+	}
+	if root == "" {
+		return nil
+	}
+	return []string{"--repo", root}
+}
+
+func forceReapCommandFor(instance *session.Instance) []string {
 	// `--` before the title, and the flag before it: shellsuggest quotes an argument
 	// but deliberately leaves option termination to the call site, so a title
 	// beginning with "-" would otherwise be parsed as a flag and the advertised
 	// command would exit "unknown flag" instead of releasing the refusal.
-	return shellsuggest.Command("af", "sessions", "restore", "--force-reap", "--", title)
+	args := append([]string{"sessions", "restore"}, sessionRepoScope(instance)...)
+	return append(args, "--force-reap", "--", instance.Title)
+}
+
+func forceReapCommand(instance *session.Instance) string {
+	return shellsuggest.Command("af", forceReapCommandFor(instance)...)
+}
+
+func killCommand(instance *session.Instance) string {
+	args := append([]string{"sessions", "kill"}, sessionRepoScope(instance)...)
+	return shellsuggest.Command("af", append(args, "--", instance.Title)...)
 }
 
 // preserveSandboxBeforeReap runs the push that makes a reachable sandbox's work
@@ -72,7 +99,7 @@ func (m *Manager) preserveSandboxBeforeReap(repoID, key string, instance *sessio
 				"and the push that would make its unpushed work durable failed (%w). "+
 				"Replacing it now would destroy any commits it holds. "+
 				"It stays recoverable and the daemon keeps retrying; if you know its work is expendable, force it with: %s",
-			instance.Title, err, forceReapCommandFor(instance.Title))
+			instance.Title, err, forceReapCommand(instance))
 	}
 	if branch == "" {
 		// A push that reports no branch leaves recovery with the empty RestoreBranch
@@ -87,7 +114,7 @@ func (m *Manager) preserveSandboxBeforeReap(repoID, key string, instance *sessio
 				"would clone the repository's default branch and strand whatever the sandbox holds. "+
 				"af cannot recover this session onto its own branch without one. If its work is "+
 				"expendable, remove it and create a replacement: %s",
-			instance.Title, shellsuggest.Command("af", "sessions", "kill", "--", instance.Title))
+			instance.Title, killCommand(instance))
 	}
 	// Record it the INSTANT it is durable, for the reason ArchiveSandbox records it
 	// there: from here the branch is the only handle on the user's work, so it
@@ -144,7 +171,7 @@ func requireKnownSandboxBranch(instance *session.Instance) error {
 			"including work it had already pushed. The branch is recorded when a sandbox is archived or when "+
 			"recovery pushes a reachable one, and neither has happened here. If its work is expendable, remove "+
 			"it and create a replacement: %s",
-		instance.Title, shellsuggest.Command("af", "sessions", "kill", "--", instance.Title))
+		instance.Title, killCommand(instance))
 }
 
 // refuseIndeterminateReap is the message for a sandbox whose reachability could
@@ -153,12 +180,12 @@ func requireKnownSandboxBranch(instance *session.Instance) error {
 // Unreachable is NOT gone. A replacement here would reap a sandbox that may still
 // be holding hours of unpushed commits, so the decision is to refuse: stranded
 // cloud spend is visible on a bill and fixable afterwards, lost work is neither.
-func refuseIndeterminateReap(title string) error {
+func refuseIndeterminateReap(instance *session.Instance) error {
 	return fmt.Errorf(
 		"cannot restore %q: af could not determine whether its sandbox is gone or merely unreachable, "+
 			"and replacing it would discard anything it has not pushed. "+
 			"It stays recoverable and the daemon keeps retrying; if you know the sandbox is gone, force it with: %s",
-		title, forceReapCommandFor(title))
+		instance.Title, forceReapCommand(instance))
 }
 
 // archiveWithin runs the sandbox's push under a hard local deadline, mirroring

--- a/daemon/sandbox_preserve.go
+++ b/daemon/sandbox_preserve.go
@@ -113,6 +113,13 @@ func (m *Manager) preserveSandboxBeforeReap(repoID, key string, instance *sessio
 // they never agreed to. When the branch cannot be learned there is no correct
 // replacement to perform, so the honest answer is to say so and name the
 // alternative.
+//
+// It applies where something could still BE saved — a reachable sandbox, or one
+// whose reachability was never established. Deliberately NOT on probeAbsent: af
+// knows that runtime is gone, so nothing is stranded by replacing it, the strand
+// already happened, and refusing would only make a recoverable session
+// unrecoverable for no gain. That arm is the one verdict the design licenses
+// unconditionally.
 func requireKnownSandboxBranch(instance *session.Instance) error {
 	if instance.GetBranch() != "" {
 		return nil

--- a/daemon/sandbox_preserve.go
+++ b/daemon/sandbox_preserve.go
@@ -58,11 +58,11 @@ func forceReapCommandFor(instance *session.Instance) []string {
 	return append(args, "--force-reap", "--", instance.Title)
 }
 
-func forceReapCommand(instance *session.Instance) string {
+func forceReapSuggestionFor(instance *session.Instance) string {
 	return shellsuggest.Command("af", forceReapCommandFor(instance)...)
 }
 
-func killCommand(instance *session.Instance) string {
+func killSuggestionFor(instance *session.Instance) string {
 	args := append([]string{"sessions", "kill"}, sessionRepoScope(instance)...)
 	return shellsuggest.Command("af", append(args, "--", instance.Title)...)
 }
@@ -99,7 +99,7 @@ func (m *Manager) preserveSandboxBeforeReap(repoID, key string, instance *sessio
 				"and the push that would make its unpushed work durable failed (%w). "+
 				"Replacing it now would destroy any commits it holds. "+
 				"It stays recoverable and the daemon keeps retrying; if you know its work is expendable, force it with: %s",
-			instance.Title, err, forceReapCommand(instance))
+			instance.Title, err, forceReapSuggestionFor(instance))
 	}
 	if branch == "" {
 		// A push that reports no branch leaves recovery with the empty RestoreBranch
@@ -114,7 +114,7 @@ func (m *Manager) preserveSandboxBeforeReap(repoID, key string, instance *sessio
 				"would clone the repository's default branch and strand whatever the sandbox holds. "+
 				"af cannot recover this session onto its own branch without one. If its work is "+
 				"expendable, remove it and create a replacement: %s",
-			instance.Title, killCommand(instance))
+			instance.Title, killSuggestionFor(instance))
 	}
 	// Record it the INSTANT it is durable, for the reason ArchiveSandbox records it
 	// there: from here the branch is the only handle on the user's work, so it
@@ -171,7 +171,7 @@ func requireKnownSandboxBranch(instance *session.Instance) error {
 			"including work it had already pushed. The branch is recorded when a sandbox is archived or when "+
 			"recovery pushes a reachable one, and neither has happened here. If its work is expendable, remove "+
 			"it and create a replacement: %s",
-		instance.Title, killCommand(instance))
+		instance.Title, killSuggestionFor(instance))
 }
 
 // refuseIndeterminateReap is the message for a sandbox whose reachability could
@@ -185,7 +185,7 @@ func refuseIndeterminateReap(instance *session.Instance) error {
 		"cannot restore %q: af could not determine whether its sandbox is gone or merely unreachable, "+
 			"and replacing it would discard anything it has not pushed. "+
 			"It stays recoverable and the daemon keeps retrying; if you know the sandbox is gone, force it with: %s",
-		instance.Title, forceReapCommand(instance))
+		instance.Title, forceReapSuggestionFor(instance))
 }
 
 // archiveWithin runs the sandbox's push under a hard local deadline, mirroring

--- a/daemon/sandbox_preserve.go
+++ b/daemon/sandbox_preserve.go
@@ -78,11 +78,16 @@ func (m *Manager) preserveSandboxBeforeReap(repoID, key string, instance *sessio
 		// A push that reports no branch leaves recovery with the empty RestoreBranch
 		// that clones the default branch — the reported bug. Refuse rather than
 		// "succeed" onto the wrong branch.
+		// NOT --force-reap here: the forced arm requires a known branch, and an empty
+		// one is precisely what this case has, so that retry would refuse again. An
+		// escape hatch that cannot open is the thing this whole guard is built to
+		// avoid, so name the alternative that actually ends it.
 		return fmt.Errorf(
 			"refusing to replace the sandbox for %q: its push reported no branch name, so a replacement "+
 				"would clone the repository's default branch and strand whatever the sandbox holds. "+
-				"It stays recoverable; if you know its work is expendable, force it with: %s",
-			instance.Title, forceReapCommandFor(instance.Title))
+				"af cannot recover this session onto its own branch without one. If its work is "+
+				"expendable, remove it and create a replacement: %s",
+			instance.Title, shellsuggest.Command("af", "sessions", "kill", "--", instance.Title))
 	}
 	// Record it the INSTANT it is durable, for the reason ArchiveSandbox records it
 	// there: from here the branch is the only handle on the user's work, so it

--- a/daemon/sandbox_preserve.go
+++ b/daemon/sandbox_preserve.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 )
@@ -22,8 +23,12 @@ const sandboxPushTimeout = 2 * time.Minute
 // Per-session and explicit by construction: it names one title, and there is no
 // global switch that restores the reaping-without-a-push behaviour for
 // everything at once.
+// Rendered through shellsuggest, never %q: %q is GO quoting, and a title
+// containing $HOME, $(...) or a backtick still expands inside the double quotes
+// it produces (#1978). A command advertised for copy-paste has to be one the
+// shell reads as a single literal argument.
 func forceReapCommandFor(title string) string {
-	return fmt.Sprintf("af sessions restore %q --force-reap", title)
+	return shellsuggest.Command("af", "sessions", "restore", title, "--force-reap")
 }
 
 // preserveSandboxBeforeReap runs the push that makes a reachable sandbox's work
@@ -47,7 +52,7 @@ func forceReapCommandFor(title string) string {
 // Returns nil when the caller may proceed to reap. A non-nil error means REFUSE:
 // leave the session Lost and recoverable, because the alternative is destroying
 // work that nothing else has a copy of.
-func (m *Manager) preserveSandboxBeforeReap(repoID string, instance *session.Instance) error {
+func (m *Manager) preserveSandboxBeforeReap(repoID, key string, instance *session.Instance) error {
 	branch, err := archiveWithin(instance.AgentServer(), sandboxPushTimeout)
 	if err != nil {
 		// Refuse, exactly as ArchiveSandbox refuses (AbortArchiveToLost) when its
@@ -73,10 +78,52 @@ func (m *Manager) preserveSandboxBeforeReap(repoID string, instance *session.Ins
 	// Record it the INSTANT it is durable, for the reason ArchiveSandbox records it
 	// there: from here the branch is the only handle on the user's work, so it
 	// belongs on the record whatever happens to the sandbox next.
+	//
+	// And record it DURABLY before authorizing the reap. A best-effort write that
+	// is lost leaves the record with an empty branch while the sandbox that knew it
+	// is being destroyed — so the next recovery clones the default branch and
+	// strands the work this push just made durable, which is the whole bug. This is
+	// a settlement in the #2781/#2883 sense: durable, retried, and refused rather
+	// than logged.
 	instance.SetSandboxBranch(branch)
-	m.persistInstance(repoID, instance)
+	if perr := m.persistSettlement(repoID, key, instance); perr != nil {
+		return fmt.Errorf(
+			"refusing to replace the sandbox for %q: its work was pushed to %s, but that branch could not "+
+				"be recorded (%w). Replacing it now would clone the repository's default branch and strand "+
+				"the very work the push just saved. The push already succeeded, so nothing is lost — retry once "+
+				"the record is writable",
+			instance.Title, branch, perr)
+	}
 	log.InfoLog.Printf("recovery of %q: pushed its sandbox's work to %s before replacing it", instance.Title, branch)
 	return nil
+}
+
+// requireKnownSandboxBranch refuses a replacement that would provision with an
+// empty RestoreBranch.
+//
+// That is the reported bug stated as an invariant (#2925/#2959): both sandbox
+// runtimes SKIP the restore fetch when the branch is empty, so the replacement
+// comes up on the repository's default branch and everything the session did —
+// including work it had already PUSHED — is stranded under a branch nothing
+// points at.
+//
+// --force-reap does not override this, and the distinction is the flag's whole
+// promise: it discards what the sandbox never pushed, which is the operator's
+// call to make. Landing on the default branch discards pushed work too, which
+// they never agreed to. When the branch cannot be learned there is no correct
+// replacement to perform, so the honest answer is to say so and name the
+// alternative.
+func requireKnownSandboxBranch(instance *session.Instance) error {
+	if instance.GetBranch() != "" {
+		return nil
+	}
+	return fmt.Errorf(
+		"cannot replace the sandbox for %q: af never learned which branch it was working on, so a "+
+			"replacement would clone the repository's default branch and strand everything the session did, "+
+			"including work it had already pushed. The branch is recorded when a sandbox is archived or when "+
+			"recovery pushes a reachable one, and neither has happened here. If its work is expendable, remove "+
+			"it and create a replacement: %s",
+		instance.Title, shellsuggest.Command("af", "sessions", "kill", instance.Title))
 }
 
 // refuseIndeterminateReap is the message for a sandbox whose reachability could

--- a/daemon/sandbox_preserve.go
+++ b/daemon/sandbox_preserve.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
@@ -14,12 +15,20 @@ import (
 // health check, but it is BOUNDED for the same reason: recovery runs on the
 // daemon poll, and a wedged sandbox must not stall it. A push that does not
 // finish in time is treated exactly like one that failed — nothing is reaped.
-// It is deliberately below the transport's own ceiling rather than above it:
-// remoteAgentClient.call bounds every control round-trip at remoteAgentCallTimeout,
-// so a budget larger than that would advertise time the client never gives. The
-// push route is granted its own, longer client budget (agentArchiveCallTimeout)
-// precisely so a legitimate 30-60s snapshot+push is not reported as a failure.
-const sandboxPushTimeout = 2 * time.Minute
+// sandboxPushTimeout bounds the CALLER's wait on the pre-reap push.
+//
+// It must EXCEED the transport's own budget (session.AgentArchiveCallTimeout), and
+// that ordering is the whole point rather than a margin. The in-sandbox archive
+// handler takes no context, so a client that gives up does not stop the git work
+// it started — the sandbox keeps staging, committing and pushing. If this bound
+// fired first, the daemon would release the session's op lock while that work ran
+// on, and the retry loop would start a SECOND archive against the same worktree:
+// index-lock failures and two committers on one tree (Codex on #2923).
+//
+// Ordered the other way, the client's own deadline is what ends the attempt, so
+// by the time this returns the call has provably stopped trying. Recovery stays
+// bounded either way, which is what the poll needs.
+const sandboxPushTimeout = session.AgentArchiveCallTimeout + 30*time.Second
 
 // forceReapCommandFor renders the per-session escape hatch the refusals below
 // must name. A guard that blocks without naming its own release is #2917, so
@@ -161,6 +170,56 @@ func (m *Manager) preserveSandboxBeforeReap(repoID, key string, instance *sessio
 // already happened, and refusing would only make a recoverable session
 // unrecoverable for no gain. That arm is the one verdict the design licenses
 // unconditionally.
+// requireDurableSandboxBranch is requireKnownSandboxBranch plus the durability
+// half: the branch must be on DISK, not merely in memory.
+//
+// In-memory is not enough because a partial archive can populate it without ever
+// recording it — ArchiveSandbox sets the branch the instant its push lands, and
+// the caller persists that outcome best-effort when the teardown then fails. If
+// that write was lost, an in-memory check passes, the sandbox is destroyed, and a
+// crash before the post-recovery settlement leaves a branchless record: the next
+// recovery clones the default branch and strands the very work the archive pushed
+// (Codex on #2923).
+//
+// So an authorization to DESTROY reads the durable record. Anything less trusts
+// state that the destruction itself is about to make unrecoverable.
+func requireDurableSandboxBranch(repoID string, instance *session.Instance) error {
+	if err := requireKnownSandboxBranch(instance); err != nil {
+		return err
+	}
+	rec, err := findPersistedInstance(repoID, instance.Title)
+	if err != nil {
+		return fmt.Errorf(
+			"cannot replace the sandbox for %q: af could not read its stored record to confirm the "+
+				"branch is durable, and replacing it on a branch that exists only in memory risks "+
+				"stranding the work already pushed there: %w",
+			instance.Title, err)
+	}
+	if rec == nil || strings.TrimSpace(rec.Branch) == "" {
+		return fmt.Errorf(
+			"cannot replace the sandbox for %q: its branch %q is known only in memory — the write that "+
+				"would have recorded it did not land — so a crash after the replacement would leave nothing "+
+				"pointing at the pushed work. Retry once the record is writable; if its work is expendable, "+
+				"remove it and create a replacement: %s",
+			instance.Title, instance.GetBranch(), killSuggestionFor(instance))
+	}
+	return nil
+}
+
+// findPersistedInstance reads one session's record off disk.
+func findPersistedInstance(repoID, title string) (*session.InstanceData, error) {
+	data, err := loadRepoInstanceData(repoID)
+	if err != nil {
+		return nil, err
+	}
+	for i := range data {
+		if data[i].Title == title {
+			return &data[i], nil
+		}
+	}
+	return nil, nil
+}
+
 func requireKnownSandboxBranch(instance *session.Instance) error {
 	if instance.GetBranch() != "" {
 		return nil

--- a/daemon/sandbox_preserve.go
+++ b/daemon/sandbox_preserve.go
@@ -14,6 +14,11 @@ import (
 // health check, but it is BOUNDED for the same reason: recovery runs on the
 // daemon poll, and a wedged sandbox must not stall it. A push that does not
 // finish in time is treated exactly like one that failed — nothing is reaped.
+// It is deliberately below the transport's own ceiling rather than above it:
+// remoteAgentClient.call bounds every control round-trip at remoteAgentCallTimeout,
+// so a budget larger than that would advertise time the client never gives. The
+// push route is granted its own, longer client budget (agentArchiveCallTimeout)
+// precisely so a legitimate 30-60s snapshot+push is not reported as a failure.
 const sandboxPushTimeout = 2 * time.Minute
 
 // forceReapCommandFor renders the per-session escape hatch the refusals below
@@ -28,7 +33,11 @@ const sandboxPushTimeout = 2 * time.Minute
 // it produces (#1978). A command advertised for copy-paste has to be one the
 // shell reads as a single literal argument.
 func forceReapCommandFor(title string) string {
-	return shellsuggest.Command("af", "sessions", "restore", title, "--force-reap")
+	// `--` before the title, and the flag before it: shellsuggest quotes an argument
+	// but deliberately leaves option termination to the call site, so a title
+	// beginning with "-" would otherwise be parsed as a flag and the advertised
+	// command would exit "unknown flag" instead of releasing the refusal.
+	return shellsuggest.Command("af", "sessions", "restore", "--force-reap", "--", title)
 }
 
 // preserveSandboxBeforeReap runs the push that makes a reachable sandbox's work
@@ -130,7 +139,7 @@ func requireKnownSandboxBranch(instance *session.Instance) error {
 			"including work it had already pushed. The branch is recorded when a sandbox is archived or when "+
 			"recovery pushes a reachable one, and neither has happened here. If its work is expendable, remove "+
 			"it and create a replacement: %s",
-		instance.Title, shellsuggest.Command("af", "sessions", "kill", instance.Title))
+		instance.Title, shellsuggest.Command("af", "sessions", "kill", "--", instance.Title))
 }
 
 // refuseIndeterminateReap is the message for a sandbox whose reachability could

--- a/daemon/sandbox_preserve_test.go
+++ b/daemon/sandbox_preserve_test.go
@@ -155,15 +155,14 @@ func TestRestoreSession_IndeterminateSandboxIsNotReplaced(t *testing.T) {
 // The escape hatch. Without it the refusal above is a dead end for a sandbox the
 // operator knows is gone, which is the #2917 shape. It is per-session and
 // per-command: this flag, this title, this invocation.
-func TestRestoreSession_ForceReapProceedsPastAFailedPush(t *testing.T) {
+func TestRestoreSession_ForceReapDoesNotPushWhatItIsDiscarding(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	srv := newSandboxProbeServer(t, "af/session-branch")
 	_, backend := registerStartedRemote(t, manager, repoID, repoPath, "forced", srv.url, session.Lost)
 	// A branch is already on record (an earlier archive), so the replacement has
-	// somewhere correct to land even though this push will fail.
+	// somewhere correct to land without needing the push to discover one.
 	inst := manager.instances[daemonInstanceKey(repoID, "forced")]
 	inst.SetSandboxBranch("af/known-branch")
-	srv.archiveFails.Store(true)
 
 	if _, _, err := manager.RestoreSession(RestoreSessionRequest{
 		Title: "forced", RepoID: repoID, ForceReap: true,
@@ -174,10 +173,10 @@ func TestRestoreSession_ForceReapProceedsPastAFailedPush(t *testing.T) {
 	if got := backend.recoverCalls(); got != 1 {
 		t.Fatalf("recover calls = %d, want 1: --force-reap is the operator overriding the refusal", got)
 	}
-	if got := srv.archiveCalls.Load(); got != 1 {
-		t.Fatalf("archive calls = %d, want 1: --force-reap means a FAILED push must not stop the "+
-			"replacement, not that the push is skipped — it is also the only thing that learns the "+
-			"session's branch from the sandbox", got)
+	if got := srv.archiveCalls.Load(); got != 0 {
+		t.Fatalf("archive calls = %d, want 0: --force-reap promises to replace the sandbox WITHOUT "+
+			"pushing, and archive snapshots uncommitted files into a commit before pushing — so a push "+
+			"here uploads exactly the material the operator chose to discard", got)
 	}
 }
 

--- a/daemon/sandbox_preserve_test.go
+++ b/daemon/sandbox_preserve_test.go
@@ -227,3 +227,49 @@ func TestRestoreSession_ForceReapStillRefusesWhenTheBranchIsUnknown(t *testing.T
 		t.Fatalf("a refusal that force cannot release must name the alternative that ends it, got: %v", err)
 	}
 }
+
+// The pre-reap bound must sit ABOVE the transport's, not below it.
+//
+// The in-sandbox archive handler takes no context, so a client that gives up does
+// not stop the git work it started. If the daemon's wait expired first it would
+// release the session's op lock while that push was still staging and committing,
+// and the retry loop would start a SECOND archive against the same worktree.
+// Ordering them the other way makes the client's own deadline end the attempt, so
+// a return here proves the call has stopped trying.
+func TestSandboxPushTimeoutOutlastsTheTransportBudget(t *testing.T) {
+	if sandboxPushTimeout <= session.AgentArchiveCallTimeout {
+		t.Fatalf("sandboxPushTimeout (%s) must exceed the transport budget (%s): a caller that gives up "+
+			"first leaves the in-sandbox git work running unbounded, and the retry starts a second "+
+			"archive against the same worktree",
+			sandboxPushTimeout, session.AgentArchiveCallTimeout)
+	}
+}
+
+// A forced reap may not be authorized by a branch that exists only in memory.
+// A partial archive populates it without recording it (the push landed, the
+// teardown failed, the write was best-effort), and destroying the sandbox on that
+// basis means a crash before the settlement leaves nothing pointing at the pushed
+// work.
+func TestRestoreSession_ForceReapRefusesABranchThatIsNotOnDisk(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	srv := newSandboxProbeServer(t, "af/session-branch")
+	srv.unreachable.Store(true)
+	_, backend := registerStartedRemote(t, manager, repoID, repoPath, "volatile", srv.url, session.Lost)
+	// In memory only — exactly what a partial archive whose persist failed leaves.
+	manager.instances[daemonInstanceKey(repoID, "volatile")].SetSandboxBranch("af/only-in-memory")
+
+	_, _, err := manager.RestoreSession(RestoreSessionRequest{
+		Title: "volatile", RepoID: repoID, ForceReap: true,
+	})
+
+	if err == nil {
+		t.Fatal("forced a reap on a branch that was never written to disk: a crash after the " +
+			"replacement leaves the record branchless and the pushed work stranded")
+	}
+	if got := backend.recoverCalls(); got != 0 {
+		t.Fatalf("recover calls = %d, want 0", got)
+	}
+	if !strings.Contains(err.Error(), "only in memory") {
+		t.Fatalf("the refusal must say WHY it refused, got: %v", err)
+	}
+}

--- a/daemon/sandbox_preserve_test.go
+++ b/daemon/sandbox_preserve_test.go
@@ -276,3 +276,47 @@ func TestRestoreSession_ForceReapRefusesABranchThatIsNotOnDisk(t *testing.T) {
 		t.Fatalf("the refusal must say WHY it refused, got: %v", err)
 	}
 }
+
+// A record on disk is not automatically a record of the CURRENT branch. The
+// partial archive this whole guard is about pushes a NEW branch, updates the
+// instance in memory, then fails its teardown and its best-effort persist — so
+// the disk can still hold an OLDER nonempty branch from a previous archive.
+//
+// Accepting non-emptiness authorizes destroying the sandbox on the strength of a
+// record pointing somewhere else: if recovery then fails, the next restore
+// returns to the stored branch and strands exactly the work the archive just
+// pushed. Which is the outcome this PR exists to prevent, reached by a different
+// road (Codex on #2967).
+func TestRestoreSession_ForceReapRefusesAStalePersistedBranch(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	srv := newSandboxProbeServer(t, "af/session-branch")
+	srv.unreachable.Store(true)
+	_, backend := registerStartedRemote(t, manager, repoID, repoPath, "stale", srv.url, session.Lost)
+	inst := manager.instances[daemonInstanceKey(repoID, "stale")]
+
+	// An earlier archive recorded this branch durably.
+	inst.SetSandboxBranch("af/older-archive")
+	manager.persistInstance(repoID, inst)
+	// A later archive pushed a NEW branch and updated memory, then failed before
+	// its persist landed. Disk still says af/older-archive.
+	inst.SetSandboxBranch("af/newly-pushed")
+
+	_, _, err := manager.RestoreSession(RestoreSessionRequest{
+		Title: "stale", RepoID: repoID, ForceReap: true,
+	})
+
+	if err == nil {
+		t.Fatal("forced a reap against a stale stored branch: a crash after the replacement sends the " +
+			"next restore to af/older-archive and strands the work pushed to af/newly-pushed")
+	}
+	if got := backend.recoverCalls(); got != 0 {
+		t.Fatalf("recover calls = %d, want 0", got)
+	}
+	// The refusal has to name BOTH branches, or an operator cannot tell which
+	// one holds their work and which one the restore would go back to.
+	for _, want := range []string{"af/older-archive", "af/newly-pushed"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("the refusal must name %q so the operator can see what diverged, got: %v", want, err)
+		}
+	}
+}

--- a/daemon/sandbox_preserve_test.go
+++ b/daemon/sandbox_preserve_test.go
@@ -1,0 +1,176 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// sandboxProbeServer stands in for an in-sandbox `af agent-server` on the three
+// postures recovery has to tell apart. The alive answer is what decides which
+// branch the daemon takes; the archive handler is what proves whether the push
+// happened before anything was reaped.
+type sandboxProbeServer struct {
+	url          string
+	archiveCalls atomic.Int32
+	archiveFails atomic.Bool
+	branch       atomic.Value // string
+	unreachable  atomic.Bool
+}
+
+func newSandboxProbeServer(t *testing.T, branch string) *sandboxProbeServer {
+	t.Helper()
+	s := &sandboxProbeServer{}
+	s.branch.Store(branch)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if s.unreachable.Load() {
+			// A transport failure — NOT af's not-provisioned sentinel. This is what a
+			// genuinely destroyed container looks like, and also what a broken network
+			// path to a live one looks like, which is exactly why it cannot license a
+			// reap.
+			http.Error(w, "transport unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		switch r.URL.Path {
+		case "/v1/agent/snapshot":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"message": "capture failed"},
+			})
+		case "/v1/agent/alive":
+			// Answered, agent gone: reachable. The sandbox is still there.
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"alive": false}})
+		case "/v1/agent/archive":
+			s.archiveCalls.Add(1)
+			if s.archiveFails.Load() {
+				http.Error(w, "push rejected by origin", http.StatusInternalServerError)
+				return
+			}
+			b, _ := s.branch.Load().(string)
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"branch": b}})
+		default:
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	s.url = srv.URL
+	return s
+}
+
+// REACHABLE: the sandbox answers that its agent is gone, so it is still there and
+// may hold commits nothing else has a copy of. Recovery must push BEFORE it
+// replaces anything, and must record the branch that push reports (#2923/#2925).
+//
+// On master this reaps immediately and never calls archive, so the replacement
+// clones from origin — three hours behind — and `RestoreBranch` stays empty,
+// which makes both sandbox runtimes skip the restore fetch and land on the
+// repository's DEFAULT branch. That is the reported bug in #2959.
+func TestRestoreSession_ReachableSandboxIsPushedBeforeItIsReplaced(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	srv := newSandboxProbeServer(t, "af/session-branch")
+	inst, backend := registerStartedRemote(t, manager, repoID, repoPath, "reachable", srv.url, session.Lost)
+
+	if inst.GetBranch() != "" {
+		t.Fatalf("precondition: a never-archived sandbox session has no branch recorded, got %q", inst.GetBranch())
+	}
+
+	if _, _, err := manager.RestoreSession(RestoreSessionRequest{Title: "reachable", RepoID: repoID}); err != nil {
+		t.Fatalf("RestoreSession: %v", err)
+	}
+
+	if got := srv.archiveCalls.Load(); got != 1 {
+		t.Fatalf("archive calls = %d, want 1: a reachable sandbox must have its work pushed before it is "+
+			"replaced — recovery re-clones from origin, so anything unpushed is destroyed by the reap", got)
+	}
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("recover calls = %d, want 1 after a successful push", got)
+	}
+	if got := inst.GetBranch(); got != "af/session-branch" {
+		t.Fatalf("recorded branch = %q, want the branch the SANDBOX reported: an empty one makes the "+
+			"replacement skip the restore fetch and clone the repository's default branch", got)
+	}
+	if rec := recordFor(t, repoID, "reachable"); rec == nil || rec.Branch != "af/session-branch" {
+		t.Fatalf("persisted record = %+v, want the branch durable the instant the push made it so", rec)
+	}
+}
+
+// REACHABLE, PUSH FAILS: refuse. The archive path aborts to Lost when its push
+// fails rather than tearing down anyway; recovery must do the same, because the
+// sandbox is the only place that work exists.
+func TestRestoreSession_ReachableSandboxIsNotReplacedWhenThePushFails(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	srv := newSandboxProbeServer(t, "af/session-branch")
+	srv.archiveFails.Store(true)
+	_, backend := registerStartedRemote(t, manager, repoID, repoPath, "push-fails", srv.url, session.Lost)
+
+	_, _, err := manager.RestoreSession(RestoreSessionRequest{Title: "push-fails", RepoID: repoID})
+
+	if err == nil {
+		t.Fatal("a restore whose pre-reap push failed reported success; the sandbox would have been " +
+			"replaced and its unpushed commits destroyed")
+	}
+	if got := backend.recoverCalls(); got != 0 {
+		t.Fatalf("recover calls = %d, want 0: nothing may be replaced when the push did not land", got)
+	}
+	if !strings.Contains(err.Error(), "--force-reap") {
+		t.Fatalf("the refusal must name the command that releases it (#2917), got: %v", err)
+	}
+}
+
+// INDETERMINATE: the probe cannot be answered at all. Unreachable is not gone —
+// the sandbox may be live behind a broken network path, still holding work — so
+// recovery refuses, reaps nothing, and says how to override.
+//
+// Note the discriminator: this is a TRANSPORT error, which is what a genuinely
+// destroyed container also produces. Keying the refusal off af's
+// not-provisioned sentinel instead would strand every truly-gone sandbox forever.
+func TestRestoreSession_IndeterminateSandboxIsNotReplaced(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	srv := newSandboxProbeServer(t, "af/session-branch")
+	srv.unreachable.Store(true)
+	_, backend := registerStartedRemote(t, manager, repoID, repoPath, "indeterminate", srv.url, session.Lost)
+
+	_, _, err := manager.RestoreSession(RestoreSessionRequest{Title: "indeterminate", RepoID: repoID})
+
+	if err == nil {
+		t.Fatal("a restore against an unreachable sandbox reported success: it would have replaced a " +
+			"sandbox that may still hold unpushed work, and cloned the default branch")
+	}
+	if got := backend.recoverCalls(); got != 0 {
+		t.Fatalf("recover calls = %d, want 0: an unanswerable probe authorizes nothing", got)
+	}
+	if got := srv.archiveCalls.Load(); got != 0 {
+		t.Fatalf("archive calls = %d, want 0: there is nothing to push to when the sandbox cannot be reached", got)
+	}
+	if !strings.Contains(err.Error(), "--force-reap") {
+		t.Fatalf("the refusal must name the command that releases it (#2917), got: %v", err)
+	}
+}
+
+// The escape hatch. Without it the refusal above is a dead end for a sandbox the
+// operator knows is gone, which is the #2917 shape. It is per-session and
+// per-command: this flag, this title, this invocation.
+func TestRestoreSession_ForceReapReplacesAReachableSandboxWithoutPushing(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	srv := newSandboxProbeServer(t, "af/session-branch")
+	srv.archiveFails.Store(true) // even with the push broken, the override proceeds
+	_, backend := registerStartedRemote(t, manager, repoID, repoPath, "forced", srv.url, session.Lost)
+
+	if _, _, err := manager.RestoreSession(RestoreSessionRequest{
+		Title: "forced", RepoID: repoID, ForceReap: true,
+	}); err != nil {
+		t.Fatalf("RestoreSession(--force-reap): %v", err)
+	}
+
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("recover calls = %d, want 1: --force-reap is the operator overriding the refusal", got)
+	}
+	if got := srv.archiveCalls.Load(); got != 0 {
+		t.Fatalf("archive calls = %d, want 0: the override is explicitly the no-push path", got)
+	}
+}

--- a/daemon/sandbox_preserve_test.go
+++ b/daemon/sandbox_preserve_test.go
@@ -155,11 +155,15 @@ func TestRestoreSession_IndeterminateSandboxIsNotReplaced(t *testing.T) {
 // The escape hatch. Without it the refusal above is a dead end for a sandbox the
 // operator knows is gone, which is the #2917 shape. It is per-session and
 // per-command: this flag, this title, this invocation.
-func TestRestoreSession_ForceReapReplacesAReachableSandboxWithoutPushing(t *testing.T) {
+func TestRestoreSession_ForceReapProceedsPastAFailedPush(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	srv := newSandboxProbeServer(t, "af/session-branch")
-	srv.archiveFails.Store(true) // even with the push broken, the override proceeds
 	_, backend := registerStartedRemote(t, manager, repoID, repoPath, "forced", srv.url, session.Lost)
+	// A branch is already on record (an earlier archive), so the replacement has
+	// somewhere correct to land even though this push will fail.
+	inst := manager.instances[daemonInstanceKey(repoID, "forced")]
+	inst.SetSandboxBranch("af/known-branch")
+	srv.archiveFails.Store(true)
 
 	if _, _, err := manager.RestoreSession(RestoreSessionRequest{
 		Title: "forced", RepoID: repoID, ForceReap: true,
@@ -170,7 +174,57 @@ func TestRestoreSession_ForceReapReplacesAReachableSandboxWithoutPushing(t *test
 	if got := backend.recoverCalls(); got != 1 {
 		t.Fatalf("recover calls = %d, want 1: --force-reap is the operator overriding the refusal", got)
 	}
-	if got := srv.archiveCalls.Load(); got != 0 {
-		t.Fatalf("archive calls = %d, want 0: the override is explicitly the no-push path", got)
+	if got := srv.archiveCalls.Load(); got != 1 {
+		t.Fatalf("archive calls = %d, want 1: --force-reap means a FAILED push must not stop the "+
+			"replacement, not that the push is skipped — it is also the only thing that learns the "+
+			"session's branch from the sandbox", got)
+	}
+}
+
+// The advertised escape hatch has to actually release the guard that names it.
+// The indeterminate refusal tells the operator to retry with --force-reap; if
+// that retry takes the same branch and refuses again, the message is a dead end
+// and the guard is the #2917 defect wearing a helpful sentence.
+func TestRestoreSession_ForceReapReleasesTheIndeterminateRefusal(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	srv := newSandboxProbeServer(t, "af/session-branch")
+	srv.unreachable.Store(true)
+	_, backend := registerStartedRemote(t, manager, repoID, repoPath, "forced-unknown", srv.url, session.Lost)
+	inst := manager.instances[daemonInstanceKey(repoID, "forced-unknown")]
+	inst.SetSandboxBranch("af/known-branch")
+
+	if _, _, err := manager.RestoreSession(RestoreSessionRequest{
+		Title: "forced-unknown", RepoID: repoID, ForceReap: true,
+	}); err != nil {
+		t.Fatalf("the refusal names --force-reap as its release, so that retry must work: %v", err)
+	}
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("recover calls = %d, want 1", got)
+	}
+}
+
+// --force-reap does NOT override the branch requirement, and that boundary is
+// the flag's promise: it discards what the sandbox never pushed, which is the
+// operator's call. Landing on the default branch discards work they had already
+// pushed, which they never agreed to.
+func TestRestoreSession_ForceReapStillRefusesWhenTheBranchIsUnknown(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	srv := newSandboxProbeServer(t, "")
+	srv.unreachable.Store(true)
+	_, backend := registerStartedRemote(t, manager, repoID, repoPath, "no-branch", srv.url, session.Lost)
+
+	_, _, err := manager.RestoreSession(RestoreSessionRequest{
+		Title: "no-branch", RepoID: repoID, ForceReap: true,
+	})
+
+	if err == nil {
+		t.Fatal("forced a replacement with no branch on record: it clones the repository's default " +
+			"branch, stranding even work the session had already pushed")
+	}
+	if got := backend.recoverCalls(); got != 0 {
+		t.Fatalf("recover calls = %d, want 0", got)
+	}
+	if !strings.Contains(err.Error(), "af sessions kill") {
+		t.Fatalf("a refusal that force cannot release must name the alternative that ends it, got: %v", err)
 	}
 }

--- a/daemon/sandbox_preserve_test.go
+++ b/daemon/sandbox_preserve_test.go
@@ -163,6 +163,8 @@ func TestRestoreSession_ForceReapDoesNotPushWhatItIsDiscarding(t *testing.T) {
 	// somewhere correct to land without needing the push to discover one.
 	inst := manager.instances[daemonInstanceKey(repoID, "forced")]
 	inst.SetSandboxBranch("af/known-branch")
+	// Durable, not just in memory: authorizing a reap reads the stored record.
+	manager.persistInstance(repoID, inst)
 
 	if _, _, err := manager.RestoreSession(RestoreSessionRequest{
 		Title: "forced", RepoID: repoID, ForceReap: true,
@@ -191,6 +193,7 @@ func TestRestoreSession_ForceReapReleasesTheIndeterminateRefusal(t *testing.T) {
 	_, backend := registerStartedRemote(t, manager, repoID, repoPath, "forced-unknown", srv.url, session.Lost)
 	inst := manager.instances[daemonInstanceKey(repoID, "forced-unknown")]
 	inst.SetSandboxBranch("af/known-branch")
+	manager.persistInstance(repoID, inst)
 
 	if _, _, err := manager.RestoreSession(RestoreSessionRequest{
 		Title: "forced-unknown", RepoID: repoID, ForceReap: true,

--- a/daemon/status_remote_test.go
+++ b/daemon/status_remote_test.go
@@ -124,6 +124,12 @@ func confirmedDeadThenUnknownRemote(t *testing.T) (string, func()) {
 				return
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"alive": false}})
+		case "/v1/agent/archive":
+			// Recovery pushes a REACHABLE sandbox before replacing it (#2923), so a
+			// fixture that answers alive=false has to be able to serve that push —
+			// otherwise these tests would be asserting the refusal, not the recovery
+			// they are about.
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"branch": "af/fixture-branch"}})
 		default:
 			http.NotFound(w, r)
 		}
@@ -200,6 +206,12 @@ func TestRefreshStatuses_StaleRemoteDeadConfirmationDoesNotCrossEpoch(t *testing
 			once.Do(func() { close(aliveStarted) })
 			<-releaseAlive
 			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"alive": false}})
+		case "/v1/agent/archive":
+			// Recovery pushes a REACHABLE sandbox before replacing it (#2923), so a
+			// fixture that answers alive=false has to be able to serve that push —
+			// otherwise these tests would be asserting the refusal, not the recovery
+			// they are about.
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"branch": "af/fixture-branch"}})
 		default:
 			http.NotFound(w, r)
 		}
@@ -484,6 +496,12 @@ func TestRefreshStatuses_ReachableRemoteWithDeadAgentGoesLostImmediately(t *test
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"data": map[string]any{"alive": false},
 			})
+		case "/v1/agent/archive":
+			// Recovery pushes a REACHABLE sandbox before replacing it (#2923), so a
+			// fixture that answers alive=false has to be able to serve that push —
+			// otherwise these tests would be asserting the refusal, not the recovery
+			// they are about.
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"branch": "af/fixture-branch"}})
 		default:
 			http.NotFound(w, r)
 		}

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -21,7 +21,7 @@ Request fields are the JSON keys of each route's request body; a `—` means the
 | `POST` | `/v1/KillSession` | `title`, `repo_id`, `id` | Tear down a session: kill its tmux/agent and remove its worktree and record. |
 | `POST` | `/v1/ArchiveSession` | `title`, `repo_id`, `id` | Archive a session: tear down tmux and relocate its worktree to the archive dir, keeping the record; refused before mutation when enabled tasks target it. |
 | `POST` | `/v1/RestoreArchived` | `title`, `repo_id`, `id` | Restore an archived session: move its worktree back next to the repo and re-spawn the agent. |
-| `POST` | `/v1/RestoreSession` | `title`, `repo_id`, `id` | Restore an archived, Lost, or Dead session. |
+| `POST` | `/v1/RestoreSession` | `title`, `repo_id`, `id`, `force_reap` | Restore an archived, Lost, or Dead session. |
 | `POST` | `/v1/SendPrompt` | `title`, `repo_id`, `prompt`, `id` | Send a prompt to an existing session's agent. |
 | `POST` | `/v1/ResumeFromLimit` | `title`, `repo_id`, `id` | Resume a usage-limit-blocked session: re-spawn if needed, re-deliver the pending prompt, clear the limit. |
 | `POST` | `/v1/HandoffSession` | `title`, `repo_id`, `id`, `to`, `brief` | Continue a session under a different agent, in place: swap its agent program, keep its worktree and branch, and deliver a mission brief to the new agent. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1561,9 +1561,25 @@ conversation when required.
 Fails if the session is not restorable, or if its origin repository is gone.
 The restored worktree path is printed on success.
 
+For a sandbox session (docker/ssh/hook) whose sandbox still ANSWERS but whose
+agent is gone, restore first pushes the sandbox's work to origin, because
+recovery re-clones from there and anything unpushed would be destroyed. If that
+push fails, or if af cannot tell whether the sandbox is gone or merely
+unreachable, the restore REFUSES and the session stays recoverable.
+
+--force-reap replaces the sandbox anyway, without the push. It discards whatever
+that sandbox has not pushed, so it is for a sandbox you know is expendable. It
+applies to this one session and this one command; there is no global equivalent.
+
 ```
-af sessions restore <title>
+af sessions restore <title> [flags]
 ```
+
+**Flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--force-reap` |  | replace a reachable sandbox WITHOUT pushing its work first (discards anything it has not pushed) |
 
 **Global flags**
 

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -1577,13 +1577,13 @@
       "af completion zsh --help": "cli.shell-completion",
       "af completion zsh --no-descriptions": "cli.shell-completion",
       "af config --help": "meta.discovery",
-      "af config get --help": "meta.discovery",
       "af config get --explain": "config.explain",
+      "af config get --help": "meta.discovery",
       "af config get --json": "cli.json-envelope",
       "af config get --project": "config.read-project",
       "af config get --repo": "config.read-project",
-      "af config list --help": "meta.discovery",
       "af config list --explain": "config.explain",
+      "af config list --help": "meta.discovery",
       "af config list --json": "cli.json-envelope",
       "af config list --project": "config.read-project",
       "af config list --repo": "config.read-project",
@@ -1651,6 +1651,7 @@
       "af sessions preview --tab": "session.preview-tab",
       "af sessions preview --tab-id": "session.preview-tab",
       "af sessions preview --tab-name": "session.preview-tab",
+      "af sessions restore --force-reap": "session.restore",
       "af sessions restore --help": "meta.discovery",
       "af sessions retry-limit --help": "meta.discovery",
       "af sessions send-prompt --all": "session.send-prompt.broadcast",
@@ -1700,6 +1701,7 @@
       "af tasks add --help": "meta.discovery",
       "af tasks add --max-concurrent-runs": "task.max-concurrent-runs",
       "af tasks add --name": "task.add",
+      "af tasks add --on-complete": "task.on-complete",
       "af tasks add --program": "task.add",
       "af tasks add --prompt": "task.add",
       "af tasks add --target-session": "task.add",
@@ -1715,6 +1717,7 @@
       "af tasks update --help": "meta.discovery",
       "af tasks update --max-concurrent-runs": "task.max-concurrent-runs",
       "af tasks update --name": "task.edit",
+      "af tasks update --on-complete": "task.on-complete",
       "af tasks update --program": "task.edit",
       "af tasks update --project-path": "task.edit.project-path",
       "af tasks update --prompt": "task.edit",
@@ -1729,9 +1732,7 @@
       "af upgrade --help": "meta.discovery",
       "af upgrade --ignore-active-upgrade": "install.upgrade",
       "af upgrade --no-restart": "install.upgrade",
-      "af version --help": "meta.discovery",
-      "af tasks add --on-complete": "task.on-complete",
-      "af tasks update --on-complete": "task.on-complete"
+      "af version --help": "meta.discovery"
     }
   },
   "field_coverage": {
@@ -1833,6 +1834,11 @@
         "cli": {
           "id": {
             "ok": "The CLI resolves and dispatches one restore by title under explicit --repo scoping; stable ID protects retained TUI/web intent that can outlive the selected row."
+          }
+        },
+        "tui": {
+          "force_reap": {
+            "ok": "The force-reap override is deliberately CLI-only. It discards a reachable sandbox's unpushed work (#2923), so it must be a typed, per-invocation act with the consequence written next to it — not a button or a keystroke that a mis-click can reach. The refusal it releases names the exact command, so the TUI and web point at the CLI rather than reproducing the hazard."
           }
         }
       },
@@ -2084,6 +2090,11 @@
       "ReorderTab": {
         "tab_index": {
           "ok": "The CLI addresses the tab by --name; tab_index is the ordinal fallback the daemon consults only when TabName is empty (daemon/manager_tabs_arrange.go resolveTabTarget)."
+        }
+      },
+      "RestoreSession": {
+        "force_reap": {
+          "ok": "The force-reap override is deliberately CLI-only. It discards a reachable sandbox's unpushed work (#2923), so it must be a typed, per-invocation act with the consequence written next to it — not a button or a keystroke a mis-click can reach. The refusal it releases names the exact command, so the TUI and web point at the CLI rather than reproducing the hazard."
         }
       }
     }

--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -255,7 +255,7 @@ func (s *remoteAgentServer) Kill() error {
 func (s *remoteAgentServer) Archive() (string, error) {
 	var resp agentArchiveResp
 	// Its own budget, not the shared control one: this call pushes a branch.
-	if err := s.rc.callWithin("/v1/agent/archive", struct{}{}, &resp, agentArchiveCallTimeout); err != nil {
+	if err := s.rc.callWithin("/v1/agent/archive", struct{}{}, &resp, AgentArchiveCallTimeout); err != nil {
 		return "", err
 	}
 	return resp.Branch, nil
@@ -573,7 +573,9 @@ func newRemoteAgentClient(ep AgentServerEndpoint, title string) (*remoteAgentCli
 // perfectly healthy push was reported as a failure, and recovery refuses on a
 // failed push — so a slow sandbox became repeatedly unrestorable while its push
 // was still progressing server-side (Codex on #2923).
-const agentArchiveCallTimeout = 3 * time.Minute
+// Exported so the daemon's own pre-reap bound can be ordered ABOVE it: a caller
+// that gave up first would leave the in-sandbox git work running unbounded.
+const AgentArchiveCallTimeout = 3 * time.Minute
 
 func (c *remoteAgentClient) call(path string, req, resp any) error {
 	return c.callWithin(path, req, resp, remoteAgentCallTimeout)

--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -254,7 +254,8 @@ func (s *remoteAgentServer) Kill() error {
 // branch is durable, so archive is push-then-teardown.
 func (s *remoteAgentServer) Archive() (string, error) {
 	var resp agentArchiveResp
-	if err := s.rc.call("/v1/agent/archive", struct{}{}, &resp); err != nil {
+	// Its own budget, not the shared control one: this call pushes a branch.
+	if err := s.rc.callWithin("/v1/agent/archive", struct{}{}, &resp, agentArchiveCallTimeout); err != nil {
 		return "", err
 	}
 	return resp.Branch, nil
@@ -565,12 +566,27 @@ func newRemoteAgentClient(ep AgentServerEndpoint, title string) (*remoteAgentCli
 // ⇒ success/failure only). It is the client-side twin of the agent-server's
 // rpcHandler dispatch — the same envelope the daemon's own httpserver speaks —
 // with the bearer token on every call.
+// agentArchiveCallTimeout is the archive route's own budget. Archive is not a
+// control round-trip like the others: the in-sandbox side commits any
+// uncommitted work and pushes a branch to origin, which legitimately takes tens
+// of seconds on a large tree or a slow link. Under the shared 30s ceiling a
+// perfectly healthy push was reported as a failure, and recovery refuses on a
+// failed push — so a slow sandbox became repeatedly unrestorable while its push
+// was still progressing server-side (Codex on #2923).
+const agentArchiveCallTimeout = 3 * time.Minute
+
 func (c *remoteAgentClient) call(path string, req, resp any) error {
+	return c.callWithin(path, req, resp, remoteAgentCallTimeout)
+}
+
+// callWithin is call with an explicit budget, for the one route whose work is
+// not a health check.
+func (c *remoteAgentClient) callWithin(path string, req, resp any, timeout time.Duration) error {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return fmt.Errorf("remote agent-server: marshal request: %w", err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), remoteAgentCallTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.httpBase+path, bytes.NewReader(body))
 	if err != nil {

--- a/session/instance_accessors.go
+++ b/session/instance_accessors.go
@@ -81,6 +81,23 @@ func (i *Instance) GetBranch() string {
 	return i.Branch
 }
 
+// SetSandboxBranch records the branch a SANDBOX session's own runtime reports,
+// under the same mutex GetBranch reads it with.
+//
+// It exists because a sandbox session's daemon-side Branch has no other honest
+// source. The in-sandbox provision creates the branch with the SANDBOX's config
+// and never mutates this Instance, so the name reaches the daemon only as an
+// Archive() return — from ArchiveSandbox, and now from the push recovery performs
+// before replacing a reachable sandbox (#2923/#2925). The daemon must not derive
+// it instead: the sandbox's branch_prefix may differ, and BranchForTitle appends a
+// random suffix for titles that sanitize away, so a derived name would be
+// confidently wrong — worse than the empty one it replaced.
+func (i *Instance) SetSandboxBranch(branch string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.Branch = branch
+}
+
 // GetWorktreeBranch returns the canonical branch recorded by the GitWorktree,
 // or empty when the instance has no worktree. Unlike GetGitWorktree, this is not
 // gated on started: kill/archive cleanup still acts on a restore-failed row's


### PR DESCRIPTION
Implements the maintainer's decision recorded on #2923/#2925/#2959: when recovery cannot determine
whether a remote sandbox still holds unpushed work, **refuse to reap** and leave the session
recoverable.

## What was broken

Remote recovery destroyed sandboxes that were still **reachable**, without pushing them first.
`probeDead` meant both "af knows there is no runtime" and "the server answered and its agent is
gone" — and the second is a live container whose agent crashed. Recovery reaped it and re-cloned
from origin, so commits made there and never pushed were gone, and the session came back looking
healthy.

The same missing push is why a never-archived sandbox recovers onto the **default branch**: the
`Archive()` return is the only writer of daemon-side `i.Branch`, so such a session has none, and an
empty `RestoreBranch` makes both sandbox runtimes skip the restore fetch.

## The split

| verdict | meaning | licenses |
|---|---|---|
| `probeAbsent` | af's own not-provisioned sentinel — it KNOWS there is nothing to contact | unconditional replacement |
| `probeAnsweredDead` | the server **answered**; agent gone, sandbox **reachable** | push first, then replace |
| `probeUnknown` | transport error or timeout | nothing |

Reachability is the discriminator, deliberately **not** the sentinel: a genuinely destroyed
container fails with a *transport* error, so refusing on the sentinel would strand every truly-gone
sandbox forever.

The split lands **behaviour-identical** — every `case probeDead:` became
`case probeAbsent, probeAnsweredDead:` — and the behaviour change sits on top, so the two are
separable while reviewing.

## The push

On the reachable arm recovery pushes first, records the branch that push reports, and only then
replaces. A failed push **refuses to replace anything**, exactly as `ArchiveSandbox` aborts to Lost
rather than tearing down; the session stays Lost and the retry loop keeps trying.

The branch comes from the sandbox because the daemon **cannot** derive it — the in-sandbox worktree
uses the SANDBOX's `branch_prefix`, and `BranchForTitle` appends a random suffix for titles that
sanitize away. A derived name would be confidently wrong, which is worse than the empty one.

`archiveWithin` bounds it, mirroring `aliveWithin`, and it lives in the **daemon** layer for that
reason: an unbounded call in `session/` would trade silent data loss for a wedged poll, which is why
the earlier attempt was backed out.

## The escape hatch

Refusing means a genuinely gone sandbox can sit in Lost, so every refusal names its own release:

```
af sessions restore "<title>" --force-reap
```

Per-session and per-invocation. There is **no config key** — a global switch would silently restore
the data-losing behaviour for everything at once. A guard that blocks without naming its release is
#2917.

The flag is deliberately CLI-only, recorded in `parity/inventory.json` rather than left as an
unexplained gap: it discards work, so it should be a typed act with the consequence next to it, not
a button a mis-click can reach.

## Verification

Four tests, one per branch plus the override:

- **reachable** → pushes once, records `af/session-branch`, persists it, then recovers;
- **reachable, push fails** → recovers **zero** times, error names `--force-reap`;
- **indeterminate** (transport error) → recovers zero times, pushes zero times, names `--force-reap`;
- **`--force-reap`** → recovers once, pushes zero times.

The reachable test is the one that fails on master, with `archive calls = 0` and an empty recorded
branch — the reported bug in #2959. The daemon suite cannot run on the maintainer's host, so CI is
the fail-first evidence.

Gate on the pushed head `2449cb15`: `gofmt -l .` (empty), `go build ./...`,
`golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh`,
`go test ./parity/` (non-daemon), and `scripts/gen-docs.sh` with the regenerated docs committed.

Closes #2923
Closes #2925
Closes #2959

🤖 Generated with [Claude Code](https://claude.com/claude-code)
