### PR TITLE
docs: publish the nested request payloads the API reference omitted

### DIFF
--- a/commands/docs_gen.go
+++ b/commands/docs_gen.go
@@ -238,7 +238,56 @@ func writeAPIReference(path string) error {
 	}
 	b.WriteString("\n")
 
+	writeNestedRequestPayloads(&b, routes)
+
 	return os.WriteFile(path, []byte(b.String()), 0o644)
+}
+
+// writeNestedRequestPayloads spells out the routes whose body takes a nested
+// object (#2918).
+//
+// The table above lists TOP-LEVEL keys, which for a wrapper route is a single
+// opaque name: `AddTask` read as taking one field called `task`, and the
+// reference offered no way to learn what belongs inside it. That is worse than
+// omitting the route — a caller trusts the page, sends a flat payload, and gets
+// a rejection the documentation cannot explain. Anyone automating against the
+// published API had to read Go source instead, which is the one thing publishing
+// it was meant to avoid.
+//
+// Derived from the same reflected type the table's own column comes from
+// (HTTPRoute.RequestFieldPaths), so this section cannot drift from the wire
+// shape or from the row above it.
+func writeNestedRequestPayloads(b *strings.Builder, routes []daemon.HTTPRoute) {
+	type nested struct {
+		route daemon.HTTPRoute
+		paths []string
+	}
+	var withNested []nested
+	for _, r := range routes {
+		var paths []string
+		for _, p := range r.RequestFieldPaths() {
+			if strings.Contains(p, ".") {
+				paths = append(paths, p)
+			}
+		}
+		if len(paths) > 0 {
+			withNested = append(withNested, nested{route: r, paths: paths})
+		}
+	}
+	if len(withNested) == 0 {
+		return
+	}
+
+	b.WriteString("## Nested request payloads\n\n")
+	b.WriteString("The `Request fields` column above lists each body's TOP-LEVEL keys. " +
+		"Where one of those is an object, its own keys are listed here as dotted paths, " +
+		"so a request can be constructed from this page alone.\n\n")
+	b.WriteString("| Path | Nested fields |\n")
+	b.WriteString("|------|---------------|\n")
+	for _, n := range withNested {
+		b.WriteString(fmt.Sprintf("| `%s` | %s |\n", n.route.Path, strings.Join(backtickAll(n.paths), ", ")))
+	}
+	b.WriteString("\n")
 }
 
 // oneLine collapses internal whitespace/newlines to single spaces so a value

--- a/daemon/httproutes.go
+++ b/daemon/httproutes.go
@@ -359,13 +359,24 @@ func servedHTTPRoutes() []HTTPRoute {
 	out := make([]HTTPRoute, 0, len(httpRoutes)+len(internalHTTPRoutes))
 	out = append(out, httpRoutes...)
 	out = append(out, internalHTTPRoutes...)
-	fillRequestFields(out)
 	return out
 }
 
-// fillRequestFields derives each route's published top-level field names from its
-// requestType. Computed here rather than written into the table so the two cannot
-// drift: there is one statement of a route's request shape, and it is the type.
+// init derives every route's published top-level field names from its
+// requestType, IN PLACE in the authoritative tables.
+//
+// In place, not in the copies the accessors hand out (#2968 review): httpRoutes
+// is documented as the single source of truth and is read directly — by
+// TestHTTPRoutes_RequestFieldsMatchWireStruct among others — so populating only
+// the copies would leave the authoritative table saying something different from
+// what every consumer sees. Deriving here rather than writing the list into each
+// entry keeps ONE statement of a route's request shape, which is its type, so
+// the published names cannot drift from the wire struct.
+func init() {
+	fillRequestFields(httpRoutes)
+	fillRequestFields(internalHTTPRoutes)
+}
+
 func fillRequestFields(routes []HTTPRoute) {
 	for i := range routes {
 		routes[i].RequestFields = jsonFields(routes[i].requestType)
@@ -380,7 +391,6 @@ func fillRequestFields(routes []HTTPRoute) {
 func HTTPRoutes() []HTTPRoute {
 	out := make([]HTTPRoute, len(httpRoutes))
 	copy(out, httpRoutes)
-	fillRequestFields(out)
 	return out
 }
 

--- a/daemon/httproutes.go
+++ b/daemon/httproutes.go
@@ -1,9 +1,11 @@
 package daemon
 
 import (
+	"encoding/json"
 	"net/http"
 	"reflect"
 	"strings"
+	"time"
 )
 
 // The HTTP surface catalog (#1029 PR 5). httpRoutes is the SINGLE SOURCE OF
@@ -37,6 +39,28 @@ type HTTPRoute struct {
 	// Unexported: net/json skips it (so it never leaks into the catalog) and
 	// importers cannot set it.
 	handler func(*controlServer) http.HandlerFunc
+	// requestType is the RPC request struct this route decodes, kept so a consumer
+	// that needs the FULL body shape can reflect it rather than re-deriving a
+	// second, driftable list. RequestFields above is computed FROM it (see
+	// HTTPRoutes), so the published top-level names and the type can never
+	// disagree. Unexported for the same reason as handler: it never serializes.
+	requestType reflect.Type
+}
+
+// RequestFieldPaths returns the request body's JSON field paths, RECURSING into
+// struct-typed fields as dotted paths ("update.enabled"), in declaration order.
+//
+// This exists because RequestFields stops at depth 1, which published a route
+// whose body is a nested object as a single opaque key: `AddTask` advertised
+// `task` and nothing more, so the reference could not be used to construct a
+// valid request at all (#2918). A caller who read it and sent a flat payload got
+// a confusing rejection.
+//
+// Deliberately a METHOD rather than a field: encoding/json ignores methods, so
+// `af api --json` — a published contract — stays byte-identical while the
+// generated reference gains the shape it was missing.
+func (r HTTPRoute) RequestFieldPaths() []string {
+	return jsonFieldPaths(r.requestType, 0)
 }
 
 // httpRoutes is the authoritative route table. Order here is the order the
@@ -52,74 +76,74 @@ var httpRoutes = []HTTPRoute{
 
 	// Sessions.
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/CreateSession",
-		Description:   "Create a new session (git worktree + agent) in a repo.",
-		RequestFields: jsonFields(reflect.TypeOf(CreateSessionRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandlerCtx(cs.createSession) },
+		Method:      http.MethodPost,
+		Path:        "/v1/CreateSession",
+		Description: "Create a new session (git worktree + agent) in a repo.",
+		requestType: reflect.TypeOf(CreateSessionRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandlerCtx(cs.createSession) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/ListBackends",
-		Description:   "List the runtimes a session in this repo can be created on, whether the repo's config supports each, and the backend an unspecified create defaults to.",
-		RequestFields: jsonFields(reflect.TypeOf(ListBackendsRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ListBackends) },
+		Method:      http.MethodPost,
+		Path:        "/v1/ListBackends",
+		Description: "List the runtimes a session in this repo can be created on, whether the repo's config supports each, and the backend an unspecified create defaults to.",
+		requestType: reflect.TypeOf(ListBackendsRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ListBackends) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/ListPrograms",
-		Description:   "List the agent programs a session can be created with, and the program an unspecified create defaults to.",
-		RequestFields: jsonFields(reflect.TypeOf(ListProgramsRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ListPrograms) },
+		Method:      http.MethodPost,
+		Path:        "/v1/ListPrograms",
+		Description: "List the agent programs a session can be created with, and the program an unspecified create defaults to.",
+		requestType: reflect.TypeOf(ListProgramsRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ListPrograms) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/SuggestSessionName",
-		Description:   "Suggest a random, readable session name (adjective-noun) not used by any live session, for the create form's autocreate placeholder.",
-		RequestFields: jsonFields(reflect.TypeOf(SuggestSessionNameRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.SuggestSessionName) },
+		Method:      http.MethodPost,
+		Path:        "/v1/SuggestSessionName",
+		Description: "Suggest a random, readable session name (adjective-noun) not used by any live session, for the create form's autocreate placeholder.",
+		requestType: reflect.TypeOf(SuggestSessionNameRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.SuggestSessionName) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/Snapshot",
-		Description:   "List sessions from the daemon's authoritative in-memory state (empty repo_id = all repos).",
-		RequestFields: jsonFields(reflect.TypeOf(SnapshotRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.Snapshot) },
+		Method:      http.MethodPost,
+		Path:        "/v1/Snapshot",
+		Description: "List sessions from the daemon's authoritative in-memory state (empty repo_id = all repos).",
+		requestType: reflect.TypeOf(SnapshotRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.Snapshot) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/KillSession",
-		Description:   "Tear down a session: kill its tmux/agent and remove its worktree and record.",
-		RequestFields: jsonFields(reflect.TypeOf(KillSessionRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.KillSession) },
+		Method:      http.MethodPost,
+		Path:        "/v1/KillSession",
+		Description: "Tear down a session: kill its tmux/agent and remove its worktree and record.",
+		requestType: reflect.TypeOf(KillSessionRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.KillSession) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/ArchiveSession",
-		Description:   "Archive a session: tear down tmux and relocate its worktree to the archive dir, keeping the record; refused before mutation when enabled tasks target it.",
-		RequestFields: jsonFields(reflect.TypeOf(ArchiveSessionRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ArchiveSession) },
+		Method:      http.MethodPost,
+		Path:        "/v1/ArchiveSession",
+		Description: "Archive a session: tear down tmux and relocate its worktree to the archive dir, keeping the record; refused before mutation when enabled tasks target it.",
+		requestType: reflect.TypeOf(ArchiveSessionRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ArchiveSession) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/RestoreArchived",
-		Description:   "Restore an archived session: move its worktree back next to the repo and re-spawn the agent.",
-		RequestFields: jsonFields(reflect.TypeOf(RestoreArchivedRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.RestoreArchived) },
+		Method:      http.MethodPost,
+		Path:        "/v1/RestoreArchived",
+		Description: "Restore an archived session: move its worktree back next to the repo and re-spawn the agent.",
+		requestType: reflect.TypeOf(RestoreArchivedRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.RestoreArchived) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/RestoreSession",
-		Description:   "Restore an archived, Lost, or Dead session.",
-		RequestFields: jsonFields(reflect.TypeOf(RestoreSessionRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.RestoreSession) },
+		Method:      http.MethodPost,
+		Path:        "/v1/RestoreSession",
+		Description: "Restore an archived, Lost, or Dead session.",
+		requestType: reflect.TypeOf(RestoreSessionRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.RestoreSession) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/SendPrompt",
-		Description:   "Send a prompt to an existing session's agent.",
-		RequestFields: jsonFields(reflect.TypeOf(SendPromptRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.SendPrompt) },
+		Method:      http.MethodPost,
+		Path:        "/v1/SendPrompt",
+		Description: "Send a prompt to an existing session's agent.",
+		requestType: reflect.TypeOf(SendPromptRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.SendPrompt) },
 	},
 	// Promoted out of internalHTTPRoutes in #1934 — the follow-up promised in
 	// #1592 Phase 2 PR3, which then sat unwritten while the state it exits stayed
@@ -128,39 +152,39 @@ var httpRoutes = []HTTPRoute{
 	// label and title prefix — and offered no way out. The STATE was deliberately
 	// surfaced on all three surfaces; the EXIT existed on one.
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/ResumeFromLimit",
-		Description:   "Resume a usage-limit-blocked session: re-spawn if needed, re-deliver the pending prompt, clear the limit.",
-		RequestFields: jsonFields(reflect.TypeOf(ResumeFromLimitRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ResumeFromLimit) },
+		Method:      http.MethodPost,
+		Path:        "/v1/ResumeFromLimit",
+		Description: "Resume a usage-limit-blocked session: re-spawn if needed, re-deliver the pending prompt, clear the limit.",
+		requestType: reflect.TypeOf(ResumeFromLimitRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ResumeFromLimit) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/HandoffSession",
-		Description:   "Continue a session under a different agent, in place: swap its agent program, keep its worktree and branch, and deliver a mission brief to the new agent.",
-		RequestFields: jsonFields(reflect.TypeOf(HandoffSessionRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.HandoffSession) },
+		Method:      http.MethodPost,
+		Path:        "/v1/HandoffSession",
+		Description: "Continue a session under a different agent, in place: swap its agent program, keep its worktree and branch, and deliver a mission brief to the new agent.",
+		requestType: reflect.TypeOf(HandoffSessionRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.HandoffSession) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/DeleteProject",
-		Description:   "Delete a project (a repo's session grouping): archive its live sessions (restorable), tear down in-place ones, and drop its root_agents opt-in — the real git repo is untouched.",
-		RequestFields: jsonFields(reflect.TypeOf(DeleteProjectRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.DeleteProject) },
+		Method:      http.MethodPost,
+		Path:        "/v1/DeleteProject",
+		Description: "Delete a project (a repo's session grouping): archive its live sessions (restorable), tear down in-place ones, and drop its root_agents opt-in — the real git repo is untouched.",
+		requestType: reflect.TypeOf(DeleteProjectRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.DeleteProject) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/RegisterProject",
-		Description:   "Register a git checkout as a durable, sessionless project by path (expand ~, resolve the git root, validate, persist to the registry) — resolved on the daemon's filesystem, idempotent for a known checkout.",
-		RequestFields: jsonFields(reflect.TypeOf(RegisterProjectRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.RegisterProject) },
+		Method:      http.MethodPost,
+		Path:        "/v1/RegisterProject",
+		Description: "Register a git checkout as a durable, sessionless project by path (expand ~, resolve the git root, validate, persist to the registry) — resolved on the daemon's filesystem, idempotent for a known checkout.",
+		requestType: reflect.TypeOf(RegisterProjectRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.RegisterProject) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/ListProjects",
-		Description:   "List every durable project in the daemon's registry (id, last-known root, path_exists) — the read a web/TUI client unions with its derived project list.",
-		RequestFields: jsonFields(reflect.TypeOf(ListProjectsRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ListProjects) },
+		Method:      http.MethodPost,
+		Path:        "/v1/ListProjects",
+		Description: "List every durable project in the daemon's registry (id, last-known root, path_exists) — the read a web/TUI client unions with its derived project list.",
+		requestType: reflect.TypeOf(ListProjectsRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ListProjects) },
 	},
 	// The Add-project picker's read (#2788). PUBLIC, not internal: a client that
 	// cannot see the daemon host's filesystem needs it to offer anything better
@@ -168,115 +192,115 @@ var httpRoutes = []HTTPRoute{
 	// the internalHTTPRoutes note below is explicit that a verb a user could
 	// reasonably want belongs here.
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/ListDirectory",
-		Description:   "List the child DIRECTORIES of one directory on the daemon's filesystem, marking which are git checkouts — the read behind an Add-project picker. Resolves ~ and symlinks and answers with canonical paths; an unreadable directory is an error, never an empty list.",
-		RequestFields: jsonFields(reflect.TypeOf(ListDirectoryRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ListDirectory) },
+		Method:      http.MethodPost,
+		Path:        "/v1/ListDirectory",
+		Description: "List the child DIRECTORIES of one directory on the daemon's filesystem, marking which are git checkouts — the read behind an Add-project picker. Resolves ~ and symlinks and answers with canonical paths; an unreadable directory is an error, never an empty list.",
+		requestType: reflect.TypeOf(ListDirectoryRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ListDirectory) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/DeliverPrompt",
-		Description:   "Deliver a prompt to a session, auto-creating it if it does not exist yet.",
-		RequestFields: jsonFields(reflect.TypeOf(DeliverPromptRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.DeliverPrompt) },
+		Method:      http.MethodPost,
+		Path:        "/v1/DeliverPrompt",
+		Description: "Deliver a prompt to a session, auto-creating it if it does not exist yet.",
+		requestType: reflect.TypeOf(DeliverPromptRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.DeliverPrompt) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/CreateTab",
-		Description:   "Spawn a tab in a session: a process tab (command) or shell tab in the worktree, a web tab (kind=web) that iframes a url/port (localhost is daemon-proxied, external is direct), or a VS Code tab (kind=vscode) serving the session's worktree in a daemon-managed code-server (no url/port: the worktree is the target).",
-		RequestFields: jsonFields(reflect.TypeOf(CreateTabRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.CreateTab) },
+		Method:      http.MethodPost,
+		Path:        "/v1/CreateTab",
+		Description: "Spawn a tab in a session: a process tab (command) or shell tab in the worktree, a web tab (kind=web) that iframes a url/port (localhost is daemon-proxied, external is direct), or a VS Code tab (kind=vscode) serving the session's worktree in a daemon-managed code-server (no url/port: the worktree is the target).",
+		requestType: reflect.TypeOf(CreateTabRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.CreateTab) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/CloseTab",
-		Description:   "Close a non-agent tab of a session (the agent tab cannot be closed). Address the tab by tab_id (its stable id) when you have one: it wins over tab_name/tab_index, which name a tab that may since have been closed and had its name or slot reused. A tab_id that no longer resolves is refused rather than falling back — closing is destructive, so a misroute kills the wrong tab's session.",
-		RequestFields: jsonFields(reflect.TypeOf(CloseTabRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.CloseTab) },
+		Method:      http.MethodPost,
+		Path:        "/v1/CloseTab",
+		Description: "Close a non-agent tab of a session (the agent tab cannot be closed). Address the tab by tab_id (its stable id) when you have one: it wins over tab_name/tab_index, which name a tab that may since have been closed and had its name or slot reused. A tab_id that no longer resolves is refused rather than falling back — closing is destructive, so a misroute kills the wrong tab's session.",
+		requestType: reflect.TypeOf(CloseTabRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.CloseTab) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/RenameTab",
-		Description:   "Rename a tab of a session. Only web, process and VS Code tabs can be renamed — agent and shell tabs render fixed labels. The name is sanitized and made unique, so the resolved name is returned. Address the tab by tab_id (its stable id) when you have one: it wins over tab_name/tab_index, which name a tab that may since have been closed and had its name or slot reused. A tab_id that no longer resolves is refused rather than falling back.",
-		RequestFields: jsonFields(reflect.TypeOf(RenameTabRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.RenameTab) },
+		Method:      http.MethodPost,
+		Path:        "/v1/RenameTab",
+		Description: "Rename a tab of a session. Only web, process and VS Code tabs can be renamed — agent and shell tabs render fixed labels. The name is sanitized and made unique, so the resolved name is returned. Address the tab by tab_id (its stable id) when you have one: it wins over tab_name/tab_index, which name a tab that may since have been closed and had its name or slot reused. A tab_id that no longer resolves is refused rather than falling back.",
+		requestType: reflect.TypeOf(RenameTabRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.RenameTab) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/ReorderTab",
-		Description:   "Move a tab within a session's roster. Index 0 is reserved for the agent tab, so only slots 1..n-1 can be moved or targeted. Address the tab by tab_id (its stable id) when you have one — see RenameTab; it matters most here, since a reorder is what invalidates every other client's tab_index.",
-		RequestFields: jsonFields(reflect.TypeOf(ReorderTabRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ReorderTab) },
+		Method:      http.MethodPost,
+		Path:        "/v1/ReorderTab",
+		Description: "Move a tab within a session's roster. Index 0 is reserved for the agent tab, so only slots 1..n-1 can be moved or targeted. Address the tab by tab_id (its stable id) when you have one — see RenameTab; it matters most here, since a reorder is what invalidates every other client's tab_index.",
+		requestType: reflect.TypeOf(ReorderTabRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ReorderTab) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/SetPRInfo",
-		Description:   "Record or clear the GitHub PR info for a session. Address the session by id when available: it is authoritative over title/repo_id, so an asynchronous result cannot land on a different session that reused the title.",
-		RequestFields: jsonFields(reflect.TypeOf(SetPRInfoRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.SetPRInfo) },
+		Method:      http.MethodPost,
+		Path:        "/v1/SetPRInfo",
+		Description: "Record or clear the GitHub PR info for a session. Address the session by id when available: it is authoritative over title/repo_id, so an asynchronous result cannot land on a different session that reused the title.",
+		requestType: reflect.TypeOf(SetPRInfoRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.SetPRInfo) },
 	},
 
 	// Config. The read/write pair behind the web config editor; both are thin
 	// wrappers over the same config package calls the TUI and `af config set`
 	// make in-process, so the three surfaces cannot validate or write differently.
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/GetConfig",
-		Description:   "List every user-facing global config key with its purpose, type, default, and current value.",
-		RequestFields: jsonFields(reflect.TypeOf(GetConfigRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.GetConfig) },
+		Method:      http.MethodPost,
+		Path:        "/v1/GetConfig",
+		Description: "List every user-facing global config key with its purpose, type, default, and current value.",
+		requestType: reflect.TypeOf(GetConfigRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.GetConfig) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/SetConfigValue",
-		Description:   "Set one global config key, exactly as `af config set` does (validated, locked, atomic).",
-		RequestFields: jsonFields(reflect.TypeOf(SetConfigValueRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.SetConfigValue) },
+		Method:      http.MethodPost,
+		Path:        "/v1/SetConfigValue",
+		Description: "Set one global config key, exactly as `af config set` does (validated, locked, atomic).",
+		requestType: reflect.TypeOf(SetConfigValueRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.SetConfigValue) },
 	},
 
 	// Tasks.
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/ListTasks",
-		Description:   "List every task across all repos.",
-		RequestFields: jsonFields(reflect.TypeOf(ListTasksRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ListTasks) },
+		Method:      http.MethodPost,
+		Path:        "/v1/ListTasks",
+		Description: "List every task across all repos.",
+		requestType: reflect.TypeOf(ListTasksRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ListTasks) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/AddTask",
-		Description:   "Append a new task and re-arm the scheduler; an enabled archived/archiving target_session is refused before commit.",
-		RequestFields: jsonFields(reflect.TypeOf(AddTaskRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.AddTask) },
+		Method:      http.MethodPost,
+		Path:        "/v1/AddTask",
+		Description: "Append a new task and re-arm the scheduler; an enabled archived/archiving target_session is refused before commit.",
+		requestType: reflect.TypeOf(AddTaskRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.AddTask) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/UpdateTask",
-		Description:   "Apply a field-level patch to a task (only the fields in `update` are changed), preserving every unspecified field and the scheduler-owned fields; an enabled archived/archiving target_session is refused before commit.",
-		RequestFields: jsonFields(reflect.TypeOf(UpdateTaskRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.UpdateTask) },
+		Method:      http.MethodPost,
+		Path:        "/v1/UpdateTask",
+		Description: "Apply a field-level patch to a task (only the fields in `update` are changed), preserving every unspecified field and the scheduler-owned fields; an enabled archived/archiving target_session is refused before commit.",
+		requestType: reflect.TypeOf(UpdateTaskRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.UpdateTask) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/RemoveTask",
-		Description:   "Remove a task by ID.",
-		RequestFields: jsonFields(reflect.TypeOf(RemoveTaskRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.RemoveTask) },
+		Method:      http.MethodPost,
+		Path:        "/v1/RemoveTask",
+		Description: "Remove a task by ID.",
+		requestType: reflect.TypeOf(RemoveTaskRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.RemoveTask) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/RestartTask",
-		Description:   "Stop and replace one enabled watch task without overlapping its process tree.",
-		RequestFields: jsonFields(reflect.TypeOf(RestartTaskRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.RestartTask) },
+		Method:      http.MethodPost,
+		Path:        "/v1/RestartTask",
+		Description: "Stop and replace one enabled watch task without overlapping its process tree.",
+		requestType: reflect.TypeOf(RestartTaskRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.RestartTask) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/TriggerTask",
-		Description:   "Fire a cron task now through the daemon's scheduler path (refuses disabled and watch tasks).",
-		RequestFields: jsonFields(reflect.TypeOf(TriggerTaskRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.TriggerTask) },
+		Method:      http.MethodPost,
+		Path:        "/v1/TriggerTask",
+		Description: "Fire a cron task now through the daemon's scheduler path (refuses disabled and watch tasks).",
+		requestType: reflect.TypeOf(TriggerTaskRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.TriggerTask) },
 	},
 }
 
@@ -305,25 +329,25 @@ var httpRoutes = []HTTPRoute{
 // unfinished. If a user could reasonably want it, it goes above.
 var internalHTTPRoutes = []HTTPRoute{
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/Preview",
-		Description:   "Capture a session tab's content (daemon-sole-capturer render path for the TUI: remote/scroll/preview).",
-		RequestFields: jsonFields(reflect.TypeOf(PreviewRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.Preview) },
+		Method:      http.MethodPost,
+		Path:        "/v1/Preview",
+		Description: "Capture a session tab's content (daemon-sole-capturer render path for the TUI: remote/scroll/preview).",
+		requestType: reflect.TypeOf(PreviewRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.Preview) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/PauseStatusPoll",
-		Description:   "Pause the daemon's liveness poll for one attached session (best-effort attach coordination).",
-		RequestFields: jsonFields(reflect.TypeOf(PauseStatusPollRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.PauseStatusPoll) },
+		Method:      http.MethodPost,
+		Path:        "/v1/PauseStatusPoll",
+		Description: "Pause the daemon's liveness poll for one attached session (best-effort attach coordination).",
+		requestType: reflect.TypeOf(PauseStatusPollRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.PauseStatusPoll) },
 	},
 	{
-		Method:        http.MethodPost,
-		Path:          "/v1/ResumeStatusPoll",
-		Description:   "Resume the daemon's liveness poll for a session on a clean detach.",
-		RequestFields: jsonFields(reflect.TypeOf(ResumeStatusPollRequest{})),
-		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ResumeStatusPoll) },
+		Method:      http.MethodPost,
+		Path:        "/v1/ResumeStatusPoll",
+		Description: "Resume the daemon's liveness poll for a session on a clean detach.",
+		requestType: reflect.TypeOf(ResumeStatusPollRequest{}),
+		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ResumeStatusPoll) },
 	},
 }
 
@@ -335,7 +359,17 @@ func servedHTTPRoutes() []HTTPRoute {
 	out := make([]HTTPRoute, 0, len(httpRoutes)+len(internalHTTPRoutes))
 	out = append(out, httpRoutes...)
 	out = append(out, internalHTTPRoutes...)
+	fillRequestFields(out)
 	return out
+}
+
+// fillRequestFields derives each route's published top-level field names from its
+// requestType. Computed here rather than written into the table so the two cannot
+// drift: there is one statement of a route's request shape, and it is the type.
+func fillRequestFields(routes []HTTPRoute) {
+	for i := range routes {
+		routes[i].RequestFields = jsonFields(routes[i].requestType)
+	}
 }
 
 // HTTPRoutes returns a copy of the PUBLIC HTTP/JSON API catalog for discovery
@@ -346,7 +380,67 @@ func servedHTTPRoutes() []HTTPRoute {
 func HTTPRoutes() []HTTPRoute {
 	out := make([]HTTPRoute, len(httpRoutes))
 	copy(out, httpRoutes)
+	fillRequestFields(out)
 	return out
+}
+
+// maxRequestNestDepth bounds the recursive walk. Request payloads are shallow;
+// this only stops a self-referential type from looping.
+const maxRequestNestDepth = 3
+
+// jsonFieldPaths returns a request struct's JSON field paths in declaration
+// order, descending into struct-typed fields and joining with ".".
+//
+// Slices and maps are NOT descended: their element shape is a separate question
+// from "what keys does this body take", and rendering `tasks[].id` in a
+// reference that has no array syntax elsewhere would invent notation. Pointers
+// are followed, since a *T body field is the same object shape as T.
+func jsonFieldPaths(t reflect.Type, depth int) []string {
+	for t != nil && t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t == nil || t.Kind() != reflect.Struct || depth > maxRequestNestDepth {
+		return nil
+	}
+	var paths []string
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.PkgPath != "" { // unexported
+			continue
+		}
+		name := strings.Split(f.Tag.Get("json"), ",")[0]
+		if name == "-" {
+			continue
+		}
+		if name == "" {
+			name = f.Name
+		}
+		paths = append(paths, name)
+
+		ft := f.Type
+		for ft.Kind() == reflect.Pointer {
+			ft = ft.Elem()
+		}
+		if ft.Kind() != reflect.Struct || isOpaqueJSONStruct(ft) {
+			continue
+		}
+		for _, nested := range jsonFieldPaths(ft, depth+1) {
+			paths = append(paths, name+"."+nested)
+		}
+	}
+	return paths
+}
+
+// isOpaqueJSONStruct reports structs that marshal as a single value despite being
+// structs, so their internals are not keys a caller sets. time.Time is the one
+// that matters here; anything implementing json.Marshaler is treated the same,
+// because whatever it emits is not its field layout.
+func isOpaqueJSONStruct(t reflect.Type) bool {
+	if t == reflect.TypeOf(time.Time{}) {
+		return true
+	}
+	marshaler := reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+	return t.Implements(marshaler) || reflect.PointerTo(t).Implements(marshaler)
 }
 
 // jsonFields returns the JSON body field names of an RPC request struct in
@@ -355,6 +449,9 @@ func HTTPRoutes() []HTTPRoute {
 // fields (net/rpc's gob and encoding/json both skip them) and json:"-" fields
 // are omitted.
 func jsonFields(t reflect.Type) []string {
+	if t == nil {
+		return nil
+	}
 	var fields []string
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -44,3 +44,16 @@ Request fields are the JSON keys of each route's request body; a `—` means the
 | `POST` | `/v1/RestartTask` | `id`, `expect` | Stop and replace one enabled watch task without overlapping its process tree. |
 | `POST` | `/v1/TriggerTask` | `id`, `expect` | Fire a cron task now through the daemon's scheduler path (refuses disabled and watch tasks). |
 
+## Nested request payloads
+
+The `Request fields` column above lists each body's TOP-LEVEL keys. Where one of those is an object, its own keys are listed here as dotted paths, so a request can be constructed from this page alone.
+
+| Path | Nested fields |
+|------|---------------|
+| `/v1/SetPRInfo` | `pr_info.number`, `pr_info.title`, `pr_info.url`, `pr_info.state`, `pr_info.branch` |
+| `/v1/AddTask` | `task.id`, `task.name`, `task.prompt`, `task.cron_expr`, `task.watch_cmd`, `task.target_session`, `task.max_concurrent_runs`, `task.on_complete`, `task.project_path`, `task.repo_id`, `task.program`, `task.enabled`, `task.created_at`, `task.last_run_at`, `task.last_run_status` |
+| `/v1/UpdateTask` | `update.name`, `update.prompt`, `update.cron_expr`, `update.watch_cmd`, `update.target_session`, `update.max_concurrent_runs`, `update.on_complete`, `update.project_path`, `update.program`, `update.enabled`, `expect.enforce`, `expect.project_path` |
+| `/v1/RemoveTask` | `expect.enforce`, `expect.project_path` |
+| `/v1/RestartTask` | `expect.enforce`, `expect.project_path` |
+| `/v1/TriggerTask` | `expect.enforce`, `expect.project_path` |
+


### PR DESCRIPTION
Closes #2918

## The defect

`jsonFields` walks **one level**, so a route whose body field is itself a struct was published as that single opaque key:

| Route | Published | Actually accepts |
|---|---|---|
| `POST /v1/AddTask` | `task` | all 15 fields of `task.Task` |
| `POST /v1/UpdateTask` | `id`, `update`, `expect` | `update` = `task.TaskUpdate`, `expect` = `task.ProjectExpectation` |
| `POST /v1/SetPRInfo` | …, `pr_info` | `pr_info` = `session.PRInfoData` |

That is worse than omitting the route. The page states it documents every endpoint the daemon serves, so a caller trusts it, sends a flat payload, and gets a rejection the documentation cannot explain — with no recourse but reading `task.Task` in Go source, which is what publishing a contract exists to avoid. It also fails silently the other way: `{"task":{"promt":"…"}}` is *accepted*, because unknown-field strictness applies at the top level, so the caller gets a task with an empty prompt rather than an error.

The knowledge was already in the repo and never reached the docs — `parity/derive_go_test.go` implements this recursion, and its comment names the exact hazard: *"HTTPRoutes reflects only top-level fields, so a wrapper route like UpdateTask ({id, update}) would look fully covered…"*.

## What the reference gains

```
## Nested request payloads

| Path | Nested fields |
|------|---------------|
| `/v1/AddTask` | `task.id`, `task.name`, `task.prompt`, `task.cron_expr`, … |
| `/v1/UpdateTask` | `update.name`, …, `expect.enforce`, `expect.project_path` |
| `/v1/SetPRInfo` | `pr_info.number`, `pr_info.title`, `pr_info.url`, … |
```

## Docs-only — the contract is untouched, and that is verified

`RequestFieldPaths` is a **method** on `HTTPRoute`, and `encoding/json` ignores methods, so `af api --json` is unaffected. Not asserted — **measured**. Binaries built from this head and from `origin/master`, diffed:

```
af api --json: IDENTICAL — the published contract is unchanged   (10766 bytes each)
```

Reshaping `request_fields` itself stays an owner call; #2918 lists those options. This route needed no such decision.

## Design notes

The route table now carries its request **type** and `RequestFields` is computed from it, so a route's request shape is stated once and the two cannot drift.

`jsonFieldPaths` descends structs and follows pointers, but **not slices or maps** — element shape is a different question from "what keys does this body take", and inventing array notation in a reference that uses none elsewhere would be worse than omitting it. `time.Time` and anything implementing `json.Marshaler` are leaves, since whatever they emit is not their field layout. The generated output shows that working: `task.created_at` appears, its internals do not.

## Verification

- **Diffed the regenerated docs** (above) — 13 added lines, no existing row altered.
- **Drift gate confirmed per #2179**: reverting only the generated file and re-running `scripts/gen-docs.sh` leaves `git status --porcelain` reporting ` M docs/reference/api.md`, which is exactly what CI fails on. Checked that the gate really fires rather than assuming it would.
- `gofmt -l .` empty, `go build ./...`, `golangci-lint --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh`, and `./parity` — which consumes `HTTPRoutes()` and is the blast radius of the table change.

Per policy the `daemon` and `commands` packages were **not** run on the dev host; CI runs them on Linux and macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
