### PR TITLE
fix(daemon): fence the pre-lock repo resolution against a concurrent project delete

### DIFF
--- a/daemon/create_prelock_resolution_test.go
+++ b/daemon/create_prelock_resolution_test.go
@@ -1,0 +1,166 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// TestReserveCreate_RefusesADeleteThatCompletedWhileResolvingTheRepo is the
+// #2947 guard: the window BEFORE reserveCreate knows which repo it is talking
+// about.
+//
+// config.RepoFromPath is the first thing reserveCreate does, and it shells out
+// to `git rev-parse` with no context and no deadline — the same unbounded call
+// #2931 moved the manager lock off, sitting outside that lock on master too. A
+// DeleteProject can install its fence, run to completion, and remove the fence
+// entirely while it is stalled on an unreachable mount.
+//
+// #2937's per-repo delete generation cannot cover this one. Sampling it needs
+// repo.ID, and repo.ID is precisely what this call returns, so the interval from
+// entering reserveCreate to RepoFromPath returning is unfenced BY CONSTRUCTION —
+// no amount of re-reading a repo-keyed map closes a gap that precedes the key.
+// The fix is to sample something that needs no key: a monotonic counter over
+// every fence transition, taken at entry and compared against this repo's most
+// recent transition once the identity is known.
+//
+// The delete below is the real DeleteProject, so this fails if the sequence
+// stops being recorded on the production path.
+func TestReserveCreate_RefusesADeleteThatCompletedWhileResolvingTheRepo(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	inResolve := make(chan struct{})
+	releaseResolve := make(chan struct{})
+	prev := repoFromPathForCreate
+	repoFromPathForCreate = func(path string) (*config.RepoContext, error) {
+		close(inResolve)
+		<-releaseResolve
+		return prev(path)
+	}
+	t.Cleanup(func() { repoFromPathForCreate = prev })
+
+	type createResult struct {
+		release func()
+		err     error
+	}
+	results := make(chan createResult, 1)
+	go func() {
+		_, _, release, _, err := manager.reserveCreate(CreateSessionRequest{
+			RepoPath: repoPath, TitleBase: "repo-resolved-under-me", Program: "claude",
+		})
+		results <- createResult{release: release, err: err}
+	}()
+
+	select {
+	case <-inResolve:
+	case <-time.After(20 * time.Second):
+		t.Fatal("the create never reached repo resolution")
+	}
+
+	// The entire delete runs inside the window where the create does not yet know
+	// its own repo id. Nothing repo-keyed can have been sampled yet, which is the
+	// whole point.
+	_, err := manager.DeleteProject(DeleteProjectRequest{RepoID: repoID, RepoPath: repoPath})
+	require.NoError(t, err, "the delete must complete: the create has reserved nothing to block it")
+	manager.mu.Lock()
+	_, fenceStillUp := manager.projectDeletes[repoID]
+	manager.mu.Unlock()
+	require.False(t, fenceStillUp, "precondition: the fence must be down before the create resumes, so only the sequence can catch this")
+
+	close(releaseResolve)
+	var got createResult
+	select {
+	case got = <-results:
+	case <-time.After(20 * time.Second):
+		t.Fatal("the create never finished after repo resolution was released")
+	}
+	if got.release != nil {
+		got.release()
+	}
+	require.Error(t, got.err, "a create must not be admitted into a project whose delete completed while it was still resolving which project that was")
+	require.ErrorContains(t, got.err, "being deleted")
+	require.Nil(t, got.release, "a refused create must not hand back a reservation to release")
+}
+
+// The same window, but the delete is still RUNNING when repo resolution
+// finishes. Its fence never went down, so this one must be caught by the live
+// fence — and it must be caught before the backend resolvers, for the same
+// reason the already-running case is: the create is already known to be
+// impossible and must not wait on more unbounded git to be told so.
+func TestReserveCreate_RefusesADeleteStillRunningAfterResolvingTheRepo(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	inDelete := make(chan struct{})
+	releaseDelete := make(chan struct{})
+	prevDeregister := deregisterRootAgents
+	deregisterRootAgents = func(id string) ([]string, error) {
+		close(inDelete)
+		<-releaseDelete
+		return prevDeregister(id)
+	}
+	t.Cleanup(func() { deregisterRootAgents = prevDeregister })
+
+	deleted := make(chan error, 1)
+	go func() {
+		_, err := manager.DeleteProject(DeleteProjectRequest{RepoID: repoID, RepoPath: repoPath})
+		deleted <- err
+	}()
+	select {
+	case <-inDelete:
+	case <-time.After(20 * time.Second):
+		t.Fatal("the delete never reached its root-agent deregistration")
+	}
+
+	got := make(chan error, 1)
+	go func() {
+		_, _, release, _, err := manager.reserveCreate(CreateSessionRequest{
+			RepoPath: repoPath, TitleBase: "resolved-mid-delete", Program: "claude",
+		})
+		if release != nil {
+			release()
+		}
+		got <- err
+	}()
+
+	select {
+	case err := <-got:
+		require.Error(t, err, "a create must not be admitted while a delete holds this project's fence")
+		require.ErrorContains(t, err, "being deleted")
+	case <-time.After(20 * time.Second):
+		close(releaseDelete)
+		<-deleted
+		t.Fatal("the create did not refuse while a delete held the fence")
+	}
+
+	close(releaseDelete)
+	select {
+	case err := <-deleted:
+		require.NoError(t, err)
+	case <-time.After(20 * time.Second):
+		t.Fatal("the delete never completed")
+	}
+}
+
+// A delete that finished BEFORE the create started is not an overlap, and must
+// not be refused — otherwise every create in a project that was ever deleted and
+// re-created would fail forever, which is a far worse bug than the one being
+// fixed. This is the boundary the sequence comparison has to get exactly right:
+// strictly-greater, not greater-or-equal.
+func TestReserveCreate_AdmitsACreateAfterAFullyCompletedDelete(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	_, err := manager.DeleteProject(DeleteProjectRequest{RepoID: repoID, RepoPath: repoPath})
+	require.NoError(t, err)
+
+	_, _, release, _, err := manager.reserveCreate(CreateSessionRequest{
+		RepoPath: repoPath, TitleBase: "after-the-delete", Program: "claude",
+	})
+	if release != nil {
+		release()
+	}
+	require.NoError(t, err,
+		"a delete that completed before this create began is ordinary history, not a race: refusing it would strand every project that is ever deleted and re-created")
+}

--- a/daemon/deleteproject.go
+++ b/daemon/deleteproject.go
@@ -224,15 +224,7 @@ func (m *Manager) deleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 			m.projectDeletes = make(map[string]struct{})
 		}
 		m.projectDeletes[repoID] = struct{}{}
-		// Bump on INSTALL, not on removal, and under the same lock that installs
-		// the fence. A create that sampled the generation before this line and
-		// reads it again after taking m.mu sees the change whether or not the
-		// delete has finished by then, so the two checks together cover the whole
-		// interval rather than only its trailing edge.
-		if m.projectDeleteGen == nil {
-			m.projectDeleteGen = make(map[string]uint64)
-		}
-		m.projectDeleteGen[repoID]++
+		m.stampProjectDeleteLocked(repoID)
 	}
 	m.mu.Unlock()
 	if len(starting) > 0 {
@@ -242,6 +234,14 @@ func (m *Manager) deleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 	defer func() {
 		m.mu.Lock()
 		delete(m.projectDeletes, repoID)
+		// Stamp the REMOVE too, not only the install above. A create that began
+		// before this delete did samples a counter value below the install's stamp,
+		// so the install alone already covers it — but a create that began while
+		// this delete was ALREADY running samples above the install and would see
+		// nothing move. Stamping here puts the transition after that sample, which
+		// is what makes an in-progress delete visible to a create that could not
+		// have seen its start (#2947).
+		m.stampProjectDeleteLocked(repoID)
 		m.mu.Unlock()
 	}()
 

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -124,18 +124,31 @@ type Manager struct {
 	// reuse or reservation mutation. This closes the preflight-to-first-mutation
 	// gap without holding m.mu across config, task, or archive I/O.
 	projectDeletes map[string]struct{}
-	// projectDeleteGen counts completed delete ATTEMPTS per repo so a create can
-	// detect a delete that both started and finished while the create was outside
-	// m.mu. The fence above only answers "is a delete running right now", which is
-	// not the same question: reserveCreate resolves the repo and the backend kind
-	// before it can take m.mu at all (those resolvers shell out to git, and holding
-	// m.mu across them wedges the whole daemon — #2931), so a delete has room to
-	// install the fence, run, and remove it inside that gap. Sampled per repo
-	// rather than globally: a delete of some OTHER project must not refuse this
-	// create. Entries are never removed — one uint64 per repo ever deleted in this
-	// daemon's lifetime — because a reset would read equal to an old sample and
-	// silently stop fencing.
-	projectDeleteGen map[string]uint64
+	// projectDeleteSeq counts every project-delete fence TRANSITION — install and
+	// remove alike — across all repos, and projectDeleteLastSeq records the value
+	// each repo's most recent transition was stamped with. A create samples the
+	// counter and later asks whether its own repo's stamp has passed that sample.
+	//
+	// Two properties this shape has and a per-repo counter does not:
+	//
+	// It is samplable BEFORE the repo is known. reserveCreate's first act is
+	// config.RepoFromPath, itself an unbounded `git rev-parse`, and a delete can
+	// run to completion while it is stalled. Anything repo-keyed is unsamplable
+	// there by construction — the key is what that call returns (#2947). A counter
+	// needs no key, while the per-repo stamp keeps the comparison precise, so an
+	// unrelated project's delete never refuses this create.
+	//
+	// Stamping the REMOVE as well as the install is what covers a delete that was
+	// already running when the create began: its install predates the sample, but
+	// its removal does not, so the stamp still passes the sample. Deletes that
+	// finished entirely beforehand leave a stamp at or below it and are correctly
+	// ignored — that is ordinary history, not a race.
+	//
+	// Entries are never removed. A reset would read at or below an old sample and
+	// silently stop fencing; the cost is one uint64 per repo ever deleted in this
+	// daemon's lifetime.
+	projectDeleteSeq     uint64
+	projectDeleteLastSeq map[string]uint64
 	// reservedTmuxNames closes the second namespace a local create claims. Titles
 	// such as "a/b" and "a_b" can derive distinct git branches but the same
 	// positive-policy tmux name; reserving only the raw title leaves that collision
@@ -441,7 +454,7 @@ func newManagerShellForDaemon(cfg *config.Config, transactionID string) (*Manage
 		pendingCreates:         make(map[string]session.InstanceData),
 		reservedTitles:         make(map[string]struct{}),
 		projectDeletes:         make(map[string]struct{}),
-		projectDeleteGen:       make(map[string]uint64),
+		projectDeleteLastSeq:   make(map[string]uint64),
 		reservedTmuxNames:      make(map[string]string),
 		reservedRemoteNames:    make(map[string]struct{}),
 		reservedTaskRuns:       make(map[string]int),

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -258,6 +258,8 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 // Production never reassigns it.
 var backendKindForCreate = session.BackendKindFor
 
+var repoFromPathForCreate = config.RepoFromPath
+
 // projectDeleteGenLocked reads the repo's completed-delete-attempt counter. The
 // caller MUST already hold m.mu; a missing entry means no delete has ever been
 // attempted for this repo and reads as 0, which is also what a first sample sees.
@@ -321,7 +323,7 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 	if req.RepoPath == "" {
 		return nil, "", nil, nil, fmt.Errorf("repo path is required")
 	}
-	repo, err := config.RepoFromPath(req.RepoPath)
+	repo, err := repoFromPathForCreate(req.RepoPath)
 	if err != nil {
 		return nil, "", nil, nil, err
 	}

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -258,13 +258,37 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 // Production never reassigns it.
 var backendKindForCreate = session.BackendKindFor
 
-var repoFromPathForCreate = config.RepoFromPath
+// stampProjectDeleteLocked records that this repo's delete fence just changed
+// state. The caller MUST already hold m.mu — the stamp has to be atomic with the
+// fence mutation it describes, or a create could observe one without the other.
+func (m *Manager) stampProjectDeleteLocked(repoID string) {
+	if m.projectDeleteLastSeq == nil {
+		m.projectDeleteLastSeq = make(map[string]uint64)
+	}
+	m.projectDeleteSeq++
+	m.projectDeleteLastSeq[repoID] = m.projectDeleteSeq
+}
 
-// projectDeleteGenLocked reads the repo's completed-delete-attempt counter. The
-// caller MUST already hold m.mu; a missing entry means no delete has ever been
-// attempted for this repo and reads as 0, which is also what a first sample sees.
-func (m *Manager) projectDeleteGenLocked(repoID string) uint64 {
-	return m.projectDeleteGen[repoID]
+// projectDeleteSeqNow samples the fence-transition counter for a caller that
+// does not hold m.mu.
+//
+// It takes NO repo id, which is the entire point: reserveCreate must sample
+// before config.RepoFromPath, and that call is what produces the id (#2947).
+func (m *Manager) projectDeleteSeqNow() uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.projectDeleteSeq
+}
+
+// projectDeleteMovedLocked reports whether this repo's fence has changed state
+// since the given sample. The caller MUST already hold m.mu.
+//
+// Strictly greater, deliberately. A delete whose last transition is EQUAL to the
+// sample completed before the sample was taken, which is ordinary history rather
+// than a race — treating it as one would strand every project that is ever
+// deleted and re-created.
+func (m *Manager) projectDeleteMovedLocked(repoID string, since uint64) bool {
+	return m.projectDeleteLastSeq[repoID] > since
 }
 
 // projectDeleteRefusal builds the refusal every delete-fence arm returns, so the
@@ -304,25 +328,43 @@ func (m *Manager) admitTaskRunFast(repoID, taskID string, limit int) error {
 	return m.admitTaskRunLocked(repoID, taskID, limit)
 }
 
-// projectDeleteStateFor samples BOTH halves of the repo's delete state for a
-// caller that does not hold m.mu; it takes the lock itself.
-//
-// The two must be read together, in one acquisition. The generation alone
-// answers "did a delete BEGIN after this point" — it cannot answer "was a delete
-// already running AT this point", because such a delete bumped the counter
-// before the sample and removes its fence before the re-check, leaving both
-// readings identical while the delete ran to completion across the entire gap.
-func (m *Manager) projectDeleteStateFor(repoID string) (active bool, generation uint64) {
+// projectDeleteStateFor answers, in ONE acquisition, whether this repo has a
+// delete running now or has had one transition since the given sample. Both
+// readings must come from the same acquisition: taken separately they could
+// describe different instants and a delete could slip between them.
+func (m *Manager) projectDeleteStateFor(repoID string, since uint64) (active, moved bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	_, active = m.projectDeletes[repoID]
-	return active, m.projectDeleteGenLocked(repoID)
+	return active, m.projectDeleteMovedLocked(repoID, since)
 }
+
+// repoFromPathForCreate resolves the request's path to a repo identity. A
+// package var so a test can block inside it and drive a delete through the
+// window where reserveCreate does not yet know which repo it is talking about —
+// a window nothing repo-keyed can be sampled in, which is what #2947 is about.
+// Production never reassigns it.
+var repoFromPathForCreate = config.RepoFromPath
 
 func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, string, func(), *session.InstanceData, error) {
 	if req.RepoPath == "" {
 		return nil, "", nil, nil, fmt.Errorf("repo path is required")
 	}
+
+	// Sample the fence-transition counter BEFORE resolving the repo, because
+	// resolving the repo is itself part of the window (#2947).
+	//
+	// config.RepoFromPath shells out to `git rev-parse` with no context and no
+	// deadline — the same unbounded call #2931 moved the manager lock off, and it
+	// sits outside that lock here. A DeleteProject can install its fence, run to
+	// completion, and remove it while this is stalled on an unreachable mount.
+	//
+	// Nothing repo-keyed can be sampled at this point: the key is what the call
+	// below returns. That is why the counter is global and only the STAMP is per
+	// repo — the sample needs no identity, while the later comparison still has
+	// one, so another project's delete never refuses this create.
+	deleteSeq := m.projectDeleteSeqNow()
+
 	repo, err := repoFromPathForCreate(req.RepoPath)
 	if err != nil {
 		return nil, "", nil, nil, err
@@ -347,35 +389,35 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 	// damage to the one create that asked. The sibling git call this function makes
 	// under the lock (branch holds) is already bounded with its own deadline (#856);
 	// this was the path that was not.
-	// Sample the repo's delete state first, and refuse an ALREADY-RUNNING delete
-	// right here — ahead of the resolvers, not after them.
+	// Now that the identity exists, ask the two questions the sample enables, and
+	// refuse HERE — ahead of the resolvers below, not after them.
 	//
-	// Deferring this refusal until after the resolution would make a create that
-	// is already known to be impossible wait on the unbounded git below, which is
-	// exactly the stall this hoist exists to bound. Before the hoist the fence
-	// check ran ahead of backend resolution and such a create returned promptly;
-	// keeping the refusal early preserves that. It is still behind everything a
-	// refusal needs — repo identity and the task-binding check — and still ahead
-	// of every mutation, so admission order is unchanged.
+	// Deferring the refusal past the resolution would make a create that is
+	// already known to be impossible wait on more unbounded git, which is exactly
+	// the stall this hoist exists to bound. Before the hoist the fence check ran
+	// ahead of backend resolution and such a create returned promptly; refusing
+	// here preserves that. It is still behind everything a refusal needs — repo
+	// identity and the task-binding check — and ahead of every mutation, so
+	// admission order is unchanged.
 	//
-	// The sampled state plus the post-lock check cover EVERY delete overlapping
-	// the unlocked region. Writing the delete's fence interval as
-	// [install, remove] and this region as [sample, check]:
+	// Together with the post-lock check this covers EVERY delete overlapping the
+	// create. Writing the delete's fence interval as [install, remove] and the
+	// create's unlocked span as [sample, check]:
 	//
-	//   - install before sample, remove after sample -> refused immediately below
-	//   - install within the region                  -> the generation moved
-	//   - remove after check                         -> the fence is still up
+	//   - install before sample, remove after sample -> the stamp moved (remove)
+	//   - install within the span                    -> the stamp moved (install)
+	//   - fence still up when asked                  -> active, either check
 	//   - install after check                        -> the create has reserved by
 	//     then, so DeleteProject's own fail-closed preflight refuses instead
 	//
-	// The first arm is why the fence is sampled and not just the counter: such a
-	// delete bumped the generation BEFORE the sample and drops its fence BEFORE
-	// the check, so both readings match while it ran across the whole gap (#2937
-	// review). A delete that finished entirely before the sample is not an overlap
-	// at all — that is an ordinary create after a completed delete.
-	deleteActive, deleteGen := m.projectDeleteStateFor(repo.ID)
-	if deleteActive {
-		return nil, "", nil, nil, projectDeleteRefusal(req, repo.ID, true)
+	// The first arm is why the REMOVE is stamped and not only the install: such a
+	// delete began before the sample, so its install stamp cannot exceed it, and
+	// its fence may be gone by the time either check runs. A delete that finished
+	// entirely before the sample leaves a stamp at or below it and is admitted —
+	// an ordinary create after a completed delete, not a race.
+	deleteActive, deleteMoved := m.projectDeleteStateFor(repo.ID, deleteSeq)
+	if deleteActive || deleteMoved {
+		return nil, "", nil, nil, projectDeleteRefusal(req, repo.ID, deleteActive)
 	}
 
 	// Same reasoning for the task-run cap, which the hoist also moved behind the
@@ -419,11 +461,11 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	// The remaining two arms: a delete still holding its fence, and one that both
-	// started and finished while this create resolved. The already-running case
-	// returned above, before the resolvers.
+	// The re-check, against the SAME sample. It catches a delete that began, or
+	// began and finished, during the backend resolution above — the span the
+	// pre-resolver check could not see.
 	_, deleting := m.projectDeletes[repo.ID]
-	if deleting || m.projectDeleteGenLocked(repo.ID) != deleteGen {
+	if deleting || m.projectDeleteMovedLocked(repo.ID, deleteSeq) {
 		return nil, "", nil, nil, projectDeleteRefusal(req, repo.ID, deleting)
 	}
 	if err := m.refreshLocked(); err != nil {


### PR DESCRIPTION
Follow-up to #2931 / #2937, same function, the adjacent window.

#2937 has landed (`68eec747`), so this is no longer stacked — rebased onto master with `--onto`, and the diff is now only this PR's own change.

## The window

`reserveCreate`'s first act is `config.RepoFromPath`, which reaches `resolveMainRepoRoot` → `exec.Command("git", "rev-parse", …)` with **no context, no timeout and no `WaitDelay`** — the same unbounded call #2931 moved the manager lock off, sitting outside that lock here and on master. A `DeleteProject` can install its fence, run to completion and remove it while that call is stalled on an unreachable mount, after which the create is admitted into a project the user just deleted and silently re-registers it.

#2937's per-repo delete generation cannot cover this, and not for want of care: sampling it needs `repo.ID`, and `repo.ID` is what the stalled call *returns*. The interval from entering the function to `RepoFromPath` returning is unfenced **by construction** — no amount of re-reading a repo-keyed map closes a gap that precedes the key.

## Fix

Split the counter from the key. A **global** monotonic sequence over every fence transition, plus a **per-repo stamp** of that repo's most recent transition.

- The sequence needs no identity, so it can be sampled at function entry, before `RepoFromPath`.
- The stamp keeps the comparison precise, so an unrelated project's delete never refuses this create.
- One sample now covers **both** windows — repo resolution and backend resolution — replacing the previous one-guard-per-window arrangement rather than adding to it.

Two details that are load-bearing:

**The remove is stamped too, not just the install.** A delete already running when the create began has an install that predates the sample; its removal does not. Without stamping the remove, that delete is invisible to a create that could not have seen its start.

**The comparison is strictly greater.** A delete whose last transition *equals* the sample finished before the sample was taken. Treating that as a race would refuse creates forever in any project that was ever deleted and re-created — worse than the bug being fixed. The third test pins that boundary.

Coverage, writing the delete's fence interval as `[install, remove]` and the create's unlocked span as `[sample, check]`:

| delete relative to the create | caught by |
|---|---|
| install before sample, remove after sample | the stamp moved (**remove**) |
| install within the span | the stamp moved (install) |
| fence still up at either check | active |
| install after the final check | `DeleteProject`'s fail-closed preflight — the create has reserved by then |
| finished entirely before the sample | **nothing — admitted, correctly** |

## Fail-first evidence

Daemon tests are not run on the maintainer's box, so the red was recorded in CI instead: the tests-only commit was pushed first and its `Test` job came back **`failure`** on `github.com/sachiniyer/agent-factory/daemon`. (That commit was `2eaac066` when the red was recorded; after two rebases it now reads `0aff2dc8`, with the fix in `ede64c5b`.)

**Exactly one of the three is the repro, and the log says so:**

| test | at the tests-only commit | role |
|---|---|---|
| `TestReserveCreate_RefusesADeleteThatCompletedWhileResolvingTheRepo` | **FAIL** | the reported window — the repro |
| `TestReserveCreate_RefusesADeleteStillRunningAfterResolvingTheRepo` | PASS | guard — already caught by the live fence; it must keep being caught |
| `TestReserveCreate_AdmitsACreateAfterAFullyCompletedDelete` | PASS | guard — pins the strictly-greater boundary so the fix cannot pass by over-refusing |

Two of three passing on both sides is the intended shape, not weak coverage: a fix for this window could trivially be "refuse more", and those two are what make that fail. Calling all three repros would have been wrong, so this table replaces an earlier claim in the commit message that said so.

Every other `TestReserveCreate_*` in the package — 24 of them, including the three from #2937 — passed at the tests-only commit, so the new tests break nothing on their own.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./daemon/`, `golangci-lint run --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` all clean. Per the standing rule no `./daemon/...` tests were run on this host; CI runs the full package on Linux and macOS.

Closes #2947

🤖 Generated with [Claude Code](https://claude.com/claude-code)