### PR TITLE
docs(claude): stop listing deadcode as a cheap local check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,16 @@ Working style:
 - Never run `pkill tmux`/`pkill af` or bare `tmux kill-server` on a shared host; tmux teardown must name an isolated socket with `-L` or `-S`.
 - Before opening a PR run the **cheap local checks** — `gofmt -l .`,
   `go build ./...`, `golangci-lint run --timeout=3m --fast`,
-  `deadcode -test ./...`, `scripts/lint-file-length.sh` — plus `go test` on
-  **only the non-daemon package you changed**. Then push and let CI run the
-  rest, and fix what CI reports on your PR head.
+  `scripts/lint-file-length.sh` — plus `go test` on **only the non-daemon
+  package you changed**. Then push and let CI run the rest, and fix what CI
+  reports on your PR head.
+- **`deadcode -test ./...` is NOT one of them — never run it locally.** It is
+  whole-program analysis, ~375% of one core per run, and with ~15 sessions
+  doing it at once this 16-core box hit a load average of 36. It reads as cheap
+  because it prints nothing; it is not. CI runs it on every push and reports
+  unreachable code there, so a local run buys nothing CI does not already give
+  and costs the maintainer his machine. Same failure shape as the containerized
+  suites below — individually reasonable, collectively ruinous on a shared box.
 - **Do not run containerized suites as a routine pre-PR gate.** Not
   `make test-container`, not `make remote-roundtrip-container`, not
   `make playtest-container`. Each spins a container that rebuilds the whole Go
@@ -126,11 +133,16 @@ gofmt -w .
 # Must pass before opening a PR
 golangci-lint run --timeout=3m --fast
 gofmt -l .   # should produce no output
-deadcode -test ./...   # should produce no output
 scripts/lint-file-length.sh   # or: make lint-file-length
 ```
 
-Install the `deadcode` binary once with `go install golang.org/x/tools/cmd/deadcode@v0.48.0`; CI pins the same version. This project's Go floor is 1.25 (raised from 1.24 in #1592 Phase 4 PR5 to pull in the CVE-patched `golang.org/x/crypto` ≥ v0.52.0, which requires Go 1.25); deadcode must be ≥ v0.45.0 to analyze go1.25 source (older x/tools cannot).
+**Deadcode runs in CI, not here.** `deadcode -test ./...` is whole-program
+analysis — see the rule above — so read its result from CI's `Lint` job on your
+PR head instead of running it on the shared box. CI pins
+`golang.org/x/tools/cmd/deadcode@v0.48.0`. That pin matters because this
+project's Go floor is 1.25 (raised from 1.24 in #1592 Phase 4 PR5 to pull in the
+CVE-patched `golang.org/x/crypto` ≥ v0.52.0, which requires Go 1.25), and
+deadcode must be ≥ v0.45.0 to analyze go1.25 source — older x/tools cannot.
 
 **File-length lint (#1145):** `scripts/lint-file-length.sh` fails if any Go
 file exceeds its line limit — 1000 lines for production code, 1500 for


### PR DESCRIPTION
CLAUDE.md is why every session runs `deadcode -test ./...` on the shared box. The owner removed it from the local checks on 2026-08-05; the file did not catch up, and sessions read the file.

## What it cost

Whole-program analysis, ~375% of one core per run. With ~15 concurrent sessions each running it as instructed, the 16-core box hit a load average of 36. It reads as cheap precisely because it prints nothing on success.

## What changed

It was listed in **three** places, all on master before this:

| Location | Was | Now |
|---|---|---|
| the cheap-local-checks bullet | in the list | removed, and given its own prohibition beside the containerized-suite rule it shares a failure shape with |
| the `## Lint` must-pass block | `deadcode -test ./...   # should produce no output` | removed |
| line 133 | `go install golang.org/x/tools/cmd/deadcode@v0.48.0` as a setup step | kept as **CI-parity context**, not an instruction to run it here |

The corrected local list:

```
gofmt -l .                              # must be empty
go build ./...
golangci-lint run --timeout=3m --fast
scripts/lint-file-length.sh
go test ./<changed-package>/...         # non-daemon, non-app only
```

The version-pin rationale is deliberately preserved rather than deleted — the go1.25 floor still requires deadcode ≥ v0.45.0 and CI still pins v0.48.0, so a future reader debugging a CI deadcode failure needs that. It just no longer reads as "install this and run it."

## Why a doc PR rather than telling sessions

Telling sessions individually does not stick: each new one reads CLAUDE.md as its standing instructions and complies with what it says. This is the same reason the containerized-suite prohibition lives in the file rather than in anyone's head. Fixing the source is what stops it.

## Validation

Doc-only; no Go files touched. Ran the corrected list, and deliberately **not** deadcode:

- `gofmt -l .` (no output) · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `scripts/lint-file-length.sh`

CI will run deadcode, which is now the point.

Closes #2970