### PR TITLE
fix(git): carry the source's modification time across a cross-device archive

### DIFF
--- a/session/git/worktree_archive.go
+++ b/session/git/worktree_archive.go
@@ -382,8 +382,16 @@ func (g *GitWorktree) ensureRepoPresent() error {
 // moveDirCrossDevice moves src to dest, falling back to a copy+remove when the
 // two paths straddle a filesystem boundary (os.Rename returns EXDEV) — the
 // common case when the archive root lives on a different device than the repo.
-// The copy preserves file contents, modes, and symlinks, so uncommitted changes
-// survive verbatim.
+// The copy preserves file contents (holes included), modes, modification times,
+// and symlinks, so uncommitted changes survive with the properties a build or a
+// diff reads.
+//
+// It is an ENUMERATION, not a guarantee of equivalence: rename(2) carries every
+// filesystem property for free and this reproduces only what it is written to
+// reproduce. Hardlink structure and extended attributes are still dropped —
+// worktree_copy_fidelity_test.go holds the measured inventory of what diverges,
+// and "survive verbatim" was the claim that let #2869, #2872 and #2919 each be
+// found one property at a time (#2919).
 func moveDirCrossDevice(src, dest string) (returnErr error) {
 	renameErr := renamePath(src, dest)
 	if renameErr == nil {

--- a/session/git/worktree_copy_fidelity_test.go
+++ b/session/git/worktree_copy_fidelity_test.go
@@ -41,8 +41,6 @@ var knownCrossDeviceDivergence = map[string]string{
 	"hardlink.sameInode": "#2919: same cause — the link structure is not reproduced",
 	"xattr.file":         "#2919: no xattr namespace is copied, so ACLs, capabilities and SELinux labels are dropped",
 	"xattr.dir":          "#2919: same cause, on directories",
-	"mtime.file":         "#2919: the copy writes new files, so mtime becomes the copy time",
-	"mtime.dir":          "#2919: same cause, on directories",
 }
 
 // TestMoveDirCrossDevice_CopyDivergesFromRenameOnlyWhereRecorded is the class

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -453,7 +454,15 @@ func applyCopiedDirectoryMode(source, destination *os.File, destinationPath stri
 			destinationPath, err,
 		)
 	}
-	return preserveSourceMode(int(destination.Fd()), info.Mode(), destinationPath, "directory")
+	if err := preserveSourceMode(int(destination.Fd()), info.Mode(), destinationPath, "directory"); err != nil {
+		return err
+	}
+	// Same moment, same reason as the mode: this level is complete, so no further
+	// entry is created here to push mtime forward again. Descendants are filled
+	// through their own descriptors, which touches THEIR mtime, not this one.
+	// "." resolves against the directory's own descriptor, so this needs no
+	// parent handle (#2919).
+	return preserveSourceTimes(int(destination.Fd()), ".", info.ModTime(), 0, destinationPath, "directory")
 }
 
 // holeCopyChunk is the read granularity of the hole-preserving copy. It is a
@@ -553,6 +562,36 @@ func preserveSourceMode(destinationFD int, sourceMode os.FileMode, destinationPa
 	return nil
 }
 
+// preserveSourceTimes carries the source's modification time onto the copy.
+//
+// rename(2) keeps mtime for free, so the same-device archive always has. The
+// cross-device copy reproduces only what it is written to reproduce, and a fresh
+// mtime is not a cosmetic difference: every incremental build system, and
+// anything that compares a file against a stamp, reads a rebuilt-everything tree
+// out of an archive restore (#2919).
+//
+// Only mtime is set. atime is left with UTIME_OMIT because it is not a property
+// worth reproducing — reading the source to copy it already changed it, so there
+// is no faithful value to carry.
+//
+// UtimesNanoAt takes a parent descriptor and a name rather than a file
+// descriptor, which is what lets one helper serve files, directories (name ".")
+// and symlinks (AT_SYMLINK_NOFOLLOW) — and keeps it portable, since the Stat_t
+// timespec fields are spelled differently on linux and darwin.
+func preserveSourceTimes(parentFD int, name string, modTime time.Time, flags int, destinationPath, kind string) error {
+	times := []unix.Timespec{
+		{Sec: 0, Nsec: unix.UTIME_OMIT},
+		unix.NsecToTimespec(modTime.UnixNano()),
+	}
+	if err := unix.UtimesNanoAt(parentFD, name, times, flags); err != nil {
+		return fmt.Errorf(
+			"cannot move worktree across filesystems: failed to preserve modification time on destination %s %s: %w",
+			kind, destinationPath, err,
+		)
+	}
+	return nil
+}
+
 func copiedDirectoryHasChildren(directory *copiedDirectory) bool {
 	for _, entry := range directory.entries {
 		if entry.directory != nil {
@@ -642,6 +681,14 @@ func copyRegularFileAtWithIdentity(
 	// step, once there is nothing half-written left to expose. The already-open
 	// descriptor keeps its write access regardless of the new mode.
 	if err := preserveSourceMode(outFD, info.Mode(), destinationPath, "file"); err != nil {
+		_ = out.Close()
+		return created, err
+	}
+	// Last, after every write: each write to this file would push mtime forward
+	// again, so stamping it before the contents were done would be undone.
+	if err := preserveSourceTimes(
+		int(destination.Fd()), filepath.Base(destinationPath), info.ModTime(), 0, destinationPath, "file",
+	); err != nil {
 		_ = out.Close()
 		return created, err
 	}


### PR DESCRIPTION
## What

`rename(2)` carries every filesystem property for free, so the same-device archive always preserved mtime. The cross-device copy reproduces only what it is written to reproduce, and stamped every copied file and directory with the **copy time**.

Measured in #2919:

| property | source | rename | copy |
|---|---|---|---|
| mtime | 2001-09-09 | 2001-09-09 | **now** |

Not cosmetic: every incremental build system, and anything comparing a file against a stamp, reads a rebuilt-everything tree out of an archive restore — and **which filesystem `AF_HOME` sits on decides whether a user gets that.**

## How

- **Files** take mtime after the contents and the mode, since each write would push it forward again.
- **Directories** take theirs at the same moment the mode is applied — the level is complete, and descendants are filled through their own descriptors, which touches *their* mtime, not this one.
- **atime is deliberately not set** (`UTIME_OMIT`): reading the source to copy it already changed atime, so there is no faithful value to carry.
- `UtimesNanoAt` takes a parent descriptor and a name, so one helper serves files and directories (name `"."`) and stays portable — the `Stat_t` timespec fields are spelled differently on linux and darwin, which a `Futimens`-plus-`Stat_t` approach would have forced me to split by build tag.

## The inventory caught it

`worktree_copy_fidelity_test.go` already held the measured divergence list from #2919, and it failed the moment mtime stopped diverging:

```
mtime.file no longer diverges (source=2001-09-09T01:46:40Z copy=2001-09-09T01:46:40Z)
— remove it from knownCrossDeviceDivergence so the inventory keeps meaning what it says
```

Both mtime entries are removed. It still records **hardlink structure** and **xattrs**, which remain dropped.

## Scope — why `Refs`, not `Closes`

**This does not close #2919.** That issue is the sweep over the whole class, and two properties are still dropped:

- **hardlinks** — needs an inode→path map across the walk, and a decision about what to do when a link's partner is outside the tree;
- **xattrs** — needs `Listxattr`/`Getxattr`/`Setxattr` with linux/darwin divergence, and a policy for namespaces a restore may not be permitted to write (`security.*`).

Both are real work with real design questions, and bundling them into a change that is otherwise small and verifiable would make this harder to review while CI is the constraint. #2919 stays open with those two named, and its inventory test is the thing that keeps them honest.

I also corrected the contract in `worktree_archive.go`. It claimed the copy made uncommitted changes "survive verbatim" — the sentence that let #2869, #2872 and #2919 each be found one property at a time. It now states what is enumerated and points at the inventory for what is not.

## Validation

- `gofmt -l .` (no output) · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `scripts/lint-file-length.sh`
- `go test ./session/git/` — the only package changed, non-daemon and non-app

Per the current rule I did not run `deadcode` locally; CI runs it. No containerized suites, nothing against `./daemon/...` or `./app/...`.

Refs #2919
