### PR TITLE
fix(git): carry the source mtime across a cross-device archive

### DIFF
--- a/session/git/worktree_copy_fidelity_test.go
+++ b/session/git/worktree_copy_fidelity_test.go
@@ -41,8 +41,7 @@ var knownCrossDeviceDivergence = map[string]string{
 	"hardlink.sameInode": "#2919: same cause — the link structure is not reproduced",
 	"xattr.file":         "#2919: no xattr namespace is copied, so ACLs, capabilities and SELinux labels are dropped",
 	"xattr.dir":          "#2919: same cause, on directories",
-	"mtime.file":         "#2919: the copy writes new files, so mtime becomes the copy time",
-	"mtime.dir":          "#2919: same cause, on directories",
+	"mtime.symlink":      "#2919: a symlink's mtime needs an lstat through the parent descriptor, whose timespec field is spelled differently on Linux and Darwin — the one place this property does need the platform split, so it is tracked rather than half-done",
 }
 
 // TestMoveDirCrossDevice_CopyDivergesFromRenameOnlyWhereRecorded is the class
@@ -190,9 +189,13 @@ func describeFidelity(t *testing.T, root string) map[string]string {
 		}
 	}
 
+	// The symlink is described too, even though it is a recorded gap: an
+	// undescribed property is not a tracked gap, it is an invisible one, and this
+	// test exists because the copier's fidelity used to be exactly that.
 	for property, path := range map[string]string{
-		"mtime.file": filepath.Join(root, "plain.txt"),
-		"mtime.dir":  filepath.Join(root, "dir"),
+		"mtime.file":    filepath.Join(root, "plain.txt"),
+		"mtime.dir":     filepath.Join(root, "dir"),
+		"mtime.symlink": filepath.Join(root, "link"),
 	} {
 		info, err := os.Lstat(path)
 		require.NoError(t, err)

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -263,6 +264,15 @@ func copyDirectoryContents(source, destination *os.File, sourcePath, destination
 			err = applyCopiedDirectoryMode(
 				sourceDirectory, destinationDirectory, directoryRoutePath(destinationPath, components),
 			)
+			if err == nil {
+				// Same moment, same reason as the mode above: this level is complete,
+				// so nothing will write into this directory again and move its mtime.
+				// Descendants are filled through their own descriptors, which changes
+				// THEIR mtimes, not this one's (#2919).
+				err = applyCopiedDirectoryModTime(
+					sourceDirectory, destinationDirectory, directoryRoutePath(destinationPath, components),
+				)
+			}
 		}
 		_ = destinationDirectory.Close()
 		_ = sourceDirectory.Close()
@@ -438,6 +448,18 @@ func copySymlinkEntry(
 //
 // Only owner bits are added. No other user gains access to the staging tree at
 // any point, whatever the source's mode says.
+// applyCopiedDirectoryModTime stamps a finished directory with its source's
+// modification time. It names the directory as "." against its own descriptor,
+// which is how a directory addresses itself without a path and without
+// AT_EMPTY_PATH — see preserveSourceModTime.
+func applyCopiedDirectoryModTime(source, destination *os.File, destinationPath string) error {
+	info, err := source.Stat()
+	if err != nil {
+		return fmt.Errorf("cannot move worktree across filesystems: failed to read source directory times for %s: %w", destinationPath, err)
+	}
+	return preserveSourceModTime(int(destination.Fd()), ".", info.ModTime(), destinationPath, "directory")
+}
+
 func workingDirectoryMode(sourceMode os.FileMode) uint32 {
 	return uint32(sourceMode.Perm()) | 0o700
 }
@@ -543,6 +565,32 @@ func isAllZero(chunk []byte) bool {
 // Setuid, setgid and sticky bits sit outside Perm() and are not carried over,
 // which is the behavior this copier has always had. Symlinks are skipped
 // entirely: Linux ignores their mode bits and offers no fchmod for them.
+// preserveSourceModTime carries the source's modification time onto a node the
+// copy just created, so a restored worktree does not look newer than the build
+// outputs it produced (#2919). rename(2) carries it for free; the copy has to be
+// told, and every property the copy is not told about is one it silently drops.
+//
+// Anchored on the PARENT descriptor plus a name, never on the node's own fd.
+// That is what keeps it both descriptor-anchored and portable: setting times
+// through a file's own descriptor wants utimensat(fd, "", …, AT_EMPTY_PATH),
+// which is Linux-only, so #2919 expected this to need a Linux/Darwin split. It
+// does not — utimensat against the parent is POSIX, and a directory passes "."
+// against its own descriptor to name itself.
+//
+// atime is left alone (UTIME_OMIT) rather than set to the source's. An archive
+// has no business claiming a read that never happened, and restoring it would
+// need the platform-split stat field this spelling exists to avoid.
+func preserveSourceModTime(parentFD int, name string, modTime time.Time, destinationPath, kind string) error {
+	times := []unix.Timespec{
+		{Sec: 0, Nsec: unix.UTIME_OMIT},
+		unix.NsecToTimespec(modTime.UnixNano()),
+	}
+	if err := unix.UtimesNanoAt(parentFD, name, times, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return fmt.Errorf("cannot move worktree across filesystems: failed to preserve %s modification time on %s: %w", kind, destinationPath, err)
+	}
+	return nil
+}
+
 func preserveSourceMode(destinationFD int, sourceMode os.FileMode, destinationPath, kind string) error {
 	if err := unix.Fchmod(destinationFD, uint32(sourceMode.Perm())); err != nil {
 		return fmt.Errorf(
@@ -642,6 +690,12 @@ func copyRegularFileAtWithIdentity(
 	// step, once there is nothing half-written left to expose. The already-open
 	// descriptor keeps its write access regardless of the new mode.
 	if err := preserveSourceMode(outFD, info.Mode(), destinationPath, "file"); err != nil {
+		_ = out.Close()
+		return created, err
+	}
+	// After the contents too, and for the same reason: writing them is what moves
+	// the mtime, so stamping it earlier would just be overwritten.
+	if err := preserveSourceModTime(int(destination.Fd()), name, info.ModTime(), destinationPath, "file"); err != nil {
 		_ = out.Close()
 		return created, err
 	}


### PR DESCRIPTION
## Summary

Third item on the #2919 checklist, split out the way sparse files were (#2920 → #2939). The cross-device copy writes new files, so every restored node carried the copy time: a restored worktree looks newer than the build outputs it produced, the next build redoes everything, and git re-hashes files whose index stat data no longer matches.

Files take their mtime after the contents and the mode, for the same reason the mode waits — writing the contents is what moves the mtime. Directories take theirs at the seam where their level is already complete, the same moment `applyCopiedDirectoryMode` uses and for the same reason: descendants are filled through their own descriptors afterwards, which moves *their* mtimes, not this one's.

## No Linux/Darwin split, contrary to the issue's estimate

#2919 expected this to need one, because setting times through a node's own descriptor wants `utimensat(fd, "", …, AT_EMPTY_PATH)` and that is Linux-only. Anchoring on the **parent** descriptor plus a name avoids it entirely — `utimensat` against a parent is POSIX, and a directory names itself as `"."` against its own descriptor. The copier stays descriptor-anchored, and there are no build tags.

`atime` is deliberately **not** restored (`UTIME_OMIT`). An archive has no business claiming a read that never happened, and restoring it would need the very platform-split stat field this spelling exists to avoid.

## The symlink gap is now tracked, not silent

Symlinks are the one place the split is genuinely required: an lstat through the parent descriptor, whose timespec field is `Mtim` on Linux and `Mtimespec` on Darwin. Rather than half-do it, symlink mtime is now **described by the fixture** and **recorded in `knownCrossDeviceDivergence`**.

That distinction is the point of #2919 and worth stating: the fixture contained a symlink all along but never described its mtime, so the gap was not a tracked one — it was an invisible one, the exact shape that let #2869 and #2872 be found one at a time by users. Describing it converts it into a failing test for whoever fixes it.

## Fail-first, all three directions measured

| | |
| --- | --- |
| remove `mtime.file`/`mtime.dir` **before** the copier change | guard fails on both, naming source/rename/copy: `source=2001-09-09T01:46:40Z rename=2001-09-09T01:46:40Z copy=2026-08-05T22:34:03Z` |
| after the copier change | both match; entries removed |
| remove the new `mtime.symlink` entry | guard fails — so it records a real observed divergence rather than decorating the list |

## Validation

Local checks per the current list — `deadcode` deliberately not run, CI does it:

- `gofmt -l .` (empty), `go build ./...`, `golangci-lint run --timeout=3m --fast`, `scripts/lint-file-length.sh`
- `go test ./session/git` — the only package touched, full package green (34s), including every `TestMoveDirCrossDevice_*` identity/rollback guard

Closes #2975
