### PR TITLE
fix(sandbox): refuse recovery when af cannot name the branch to restore (#2925)

### DIFF
--- a/session/archive_sandbox.go
+++ b/session/archive_sandbox.go
@@ -3,6 +3,7 @@ package session
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/sachiniyer/agent-factory/log"
 )
@@ -166,6 +167,41 @@ func (i *Instance) reprovisionRemote() error {
 	i.mu.RUnlock()
 	if backend == nil {
 		return fmt.Errorf("cannot re-provision session %q: no backend on record", i.Title)
+	}
+	// REFUSE rather than restore onto whatever the clone happens to check out
+	// (#2925/#2959). Both sandbox runtimes gate the restore fetch on a non-empty
+	// RestoreBranch (sandbox_provision.go, backend_docker.go), so an empty one does
+	// not fail — it silently skips the fetch and leaves the fresh sandbox on the
+	// repo's DEFAULT branch, which the restore then reports as a success. The
+	// session comes back Running, on main, with none of its work.
+	//
+	// A sandbox session's daemon-side Branch is written by exactly one thing: the
+	// archive, from the as.Archive() return. The in-sandbox provision that names the
+	// branch runs INSIDE the sandbox and never mutates this Instance. So a session
+	// that was never archived reaches here with "" — and that is precisely the Lost
+	// session the restore loop is trying to save.
+	//
+	// Refusing is not a lesser fix than deriving the name. The daemon COULD compute
+	// git.BranchForTitle(cfg.BranchPrefix, title) as the create path does for its
+	// held-branch check, but the sandbox derives its own branch through
+	// git.NewGitWorktree → config.LoadConfig(), which reads the SANDBOX's config: a
+	// different branch_prefix there yields a different branch, and restoring onto a
+	// confidently wrong branch is worse than refusing, because it looks like it
+	// worked. Making recovery SUCCEED here needs the sandbox to report its branch
+	// back (provision result or agent-server snapshot); until it does, the honest
+	// answer is that af cannot name the branch.
+	//
+	// Placed before reapRemoteRuntimeForReplacement below, so a refusal destroys
+	// nothing: the row stays Lost, killable, and eligible for a later attempt. The
+	// restore loop treats this as a failed attempt, so its existing exponential
+	// backoff and one-time ERROR escalation (#1108/#1128) carry the message without
+	// logging it every poll tick.
+	if strings.TrimSpace(spec.RestoreBranch) == "" {
+		return fmt.Errorf("cannot re-provision session %q: af has no record of the branch it was working on, "+
+			"so a replacement sandbox would come up on the repository's default branch and report that as a successful restore. "+
+			"A sandbox session's branch is recorded when it is archived, and this one never was. "+
+			"Its work is only on origin if something pushed it — look for a branch named after the session "+
+			"(`git ls-remote --heads origin` in %s) before removing the session", i.Title, i.Path)
 	}
 	kind, err := backendKindForType(backend.Type())
 	if err != nil {

--- a/session/archive_sandbox_branch_test.go
+++ b/session/archive_sandbox_branch_test.go
@@ -1,0 +1,110 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The #2925/#2959 regression suite.
+//
+// A sandbox session's daemon-side Branch is written by exactly one thing — the
+// archive, from the as.Archive() return. The in-sandbox provision that names the
+// branch runs INSIDE the sandbox and never mutates the daemon's Instance. So a
+// sandbox that was never archived reaches recovery with Branch == "", and both
+// runtimes gate their restore fetch on RestoreBranch being non-empty: an empty
+// one does not fail, it skips the fetch. The replacement came up on the repo's
+// DEFAULT branch and the restore reported success — the session back Running, on
+// main, with none of its work, and no record of the branch it had been on.
+
+// TestReprovisionRemote_RefusesWhenTheBranchIsUnknown is the headline
+// assertion: recovery must refuse, not restore onto whatever the clone left
+// checked out.
+func TestReprovisionRemote_RefusesWhenTheBranchIsUnknown(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		branch string
+	}{
+		{name: "never archived", branch: ""},
+		// Whitespace is the same absence wearing a different hat: the runtimes
+		// TrimSpace before testing it, so " " skips the fetch exactly as "" does.
+		{name: "blank", branch: "   "},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			provisioned := false
+			reaped := false
+			rt := &branchGuardRuntime{provisioned: &provisioned}
+			restoreRuntime := SetRuntimeForTest(BackendDocker, func() Runtime { return rt })
+			defer restoreRuntime()
+
+			i := &Instance{
+				Title:   "worker",
+				Path:    t.TempDir(),
+				Branch:  tc.branch,
+				backend: newInertSandboxBackend("docker"),
+				runtimeTeardown: func() error {
+					reaped = true
+					return nil
+				},
+			}
+
+			err := i.reprovisionRemote()
+
+			require.Error(t, err, "a sandbox with no recorded branch must not be re-provisioned onto the default branch")
+			assert.Contains(t, err.Error(), "no record of the branch",
+				"the error must say WHY it refused, not just that it failed")
+			assert.Contains(t, err.Error(), "worker", "the error must name the session")
+
+			// The refusal has to come before anything destructive. Reaping the old
+			// sandbox and THEN refusing would destroy the one thing that might still
+			// hold the work — the #2923 failure this issue compounds with.
+			assert.False(t, reaped, "a refused re-provision must not reap the previous sandbox")
+			assert.False(t, provisioned, "a refused re-provision must not provision a replacement")
+		})
+	}
+}
+
+// TestReprovisionRemote_ProceedsWhenTheBranchIsKnown is the other half: the
+// guard must not block the ordinary archived-restore path, where the archive
+// recorded the branch. Without this, "refuse everything" would pass the test
+// above while breaking every real restore.
+func TestReprovisionRemote_ProceedsWhenTheBranchIsKnown(t *testing.T) {
+	provisioned := false
+	fresh := &dockerBackend{containerID: "fresh"}
+	rt := &branchGuardRuntime{provisioned: &provisioned, backend: fresh}
+	restoreRuntime := SetRuntimeForTest(BackendDocker, func() Runtime { return rt })
+	defer restoreRuntime()
+
+	i := &Instance{
+		Title:           "worker",
+		Path:            t.TempDir(),
+		Branch:          "af/worker",
+		backend:         newInertSandboxBackend("docker"),
+		runtimeTeardown: func() error { return nil },
+	}
+
+	require.NoError(t, i.reprovisionRemote())
+	assert.True(t, provisioned, "a session whose branch is on record must still restore")
+	assert.Equal(t, "af/worker", rt.sawBranch, "the recorded branch must reach the runtime as RestoreBranch")
+	assert.Same(t, fresh, i.GetBackend())
+}
+
+// branchGuardRuntime records whether it was provisioned and with which branch,
+// so a test can tell "refused before provisioning" from "provisioned onto the
+// wrong branch" — the two outcomes this issue is about.
+type branchGuardRuntime struct {
+	provisioned *bool
+	backend     Backend
+	sawBranch   string
+}
+
+func (r *branchGuardRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
+	*r.provisioned = true
+	r.sawBranch = spec.RestoreBranch
+	backend := r.backend
+	if backend == nil {
+		backend = &dockerBackend{containerID: "fresh"}
+	}
+	return ProvisionResult{Backend: backend, Teardown: func() error { return nil }}, nil
+}


### PR DESCRIPTION
A sandbox session's daemon-side `Branch` has exactly **one** writer: the archive, from the `as.Archive()` return. The in-sandbox provision that names the branch runs *inside* the sandbox and never mutates the daemon's Instance. So a sandbox that was never archived reaches recovery with `Branch == ""`.

Both runtimes gate the restore fetch on `RestoreBranch` being non-empty (`sandbox_provision.go:115`, `backend_docker.go:444`), and an empty one **does not fail — it skips the fetch**. The replacement came up on the repository's default branch and the restore reported success: the session back `Running`, on `main`, with none of its work, and nothing left pointing at the branch it had been on.

The tree already spelled this consequence out — in `ArchiveSandbox`, as the justification for recording the branch early. That reasoning was applied to archive and never to Lost-recovery, which reaches the identical code with the identical empty field.

## The fix

`reprovisionRemote` refuses when it cannot name the branch.

**Placement is load-bearing.** The guard sits *before* `reapRemoteRuntimeForReplacement`, so a refusal destroys nothing — the row stays Lost, killable, and eligible for a later attempt. Refusing *after* the reap would have destroyed the one thing that might still hold the work, which is exactly the #2923 failure this issue compounds with.

## I checked the round trip the issue asked about — and it does not hold

The issue flagged one thing to settle before implementing: whether the daemon can safely derive the name with `git.BranchForTitle(cfg.BranchPrefix, title)`, as the create path already does for its held-branch check.

**It cannot.** The sandbox derives its branch through `git.NewGitWorktree`, which calls `config.LoadConfig()` — reading the **sandbox's** config, not the daemon's:

```go
func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, branchname string, err error) {
	cfg, err := config.LoadConfig()          // ← the SANDBOX's config
	branchName := fmt.Sprintf("%s%s", cfg.BranchPrefix, sessionName)
```

A different `branch_prefix` in the sandbox image yields a different branch, so a daemon-derived name can be confidently wrong — and restoring onto a confidently wrong branch is worse than refusing, because it looks like it worked. Making recovery *succeed* needs the sandbox to report its branch back (through the provision result or the agent-server snapshot). That is a larger change and a real one; until it lands, the honest answer is that af cannot name the branch, which is what this PR says out loud.

This is the issue's own unconditional requirement: *"Either way, recovery should refuse rather than silently land on the default branch when it cannot name the branch it is supposed to restore."*

## Noise

The restore loop treats the refusal as a failed attempt, so its existing exponential backoff and one-time ERROR escalation (#1108/#1128) carry the message. It does not log every poll tick.

## Watched it fail first

With the guard disabled, `reprovisionRemote` **returns nil** for an empty branch after provisioning a replacement — the reported bug, reproduced:

```
Error: An error is expected but got nil.
Messages: a sandbox with no recorded branch must not be re-provisioned onto the default branch
```

Both subtests (`""` and whitespace, since the runtimes `TrimSpace`) fail. The refusal test also asserts nothing was reaped and nothing provisioned, so a guard placed after the destructive step would fail it.

A companion test pins that a session whose branch **is** on record still restores, and that the recorded branch reaches the runtime as `RestoreBranch` — so "refuse everything" cannot pass.

## Gate

`gofmt -l .` (empty) · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `scripts/lint-file-length.sh` · `go test ./session/` — the one changed package, non-daemon. No containerized suite, nothing under `daemon/` or `app/` run on this host, no local `deadcode`; CI covers those.

Closes #2925
Closes #2959

🤖 Generated with [Claude Code](https://claude.com/claude-code)
