### PR TITLE
fix(git): carry mtime across a cross-device archive

### DIFF
--- a/session/git/worktree_copy_fidelity_test.go
+++ b/session/git/worktree_copy_fidelity_test.go
@@ -41,8 +41,10 @@ var knownCrossDeviceDivergence = map[string]string{
 	"hardlink.sameInode": "#2919: same cause — the link structure is not reproduced",
 	"xattr.file":         "#2919: no xattr namespace is copied, so ACLs, capabilities and SELinux labels are dropped",
 	"xattr.dir":          "#2919: same cause, on directories",
-	"mtime.file":         "#2919: the copy writes new files, so mtime becomes the copy time",
-	"mtime.dir":          "#2919: same cause, on directories",
+	// mtime.file and mtime.dir were here until preserveSourceTimes landed. Left
+	// as a note rather than silence: symlink mtime is still NOT restored, and it
+	// is absent from this inventory only because no probe measures it. Add one
+	// and this guard will fail, which is the intended way to find it.
 }
 
 // TestMoveDirCrossDevice_CopyDivergesFromRenameOnlyWhereRecorded is the class

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -421,6 +422,12 @@ func copySymlinkEntry(
 	if err != nil || !destinationIdentity.same(confirmedIdentity) || destinationLink != link {
 		return created, fmt.Errorf("cannot move worktree across filesystems: destination symlink %s changed while it was copied", destinationPath)
 	}
+	// Symlink mtime is deliberately NOT restored here; see #2919. Reading the
+	// link's own timestamp needs Fstatat plus the Mtim/Mtimespec split this
+	// helper exists to avoid, and no probe measures it, so preserving it would
+	// mean unverified code in the one function that must never lose bytes. The
+	// fidelity guard is a denylist: add a symlink-mtime probe and it fails,
+	// pointing here.
 	return created, nil
 }
 
@@ -453,7 +460,14 @@ func applyCopiedDirectoryMode(source, destination *os.File, destinationPath stri
 			destinationPath, err,
 		)
 	}
-	return preserveSourceMode(int(destination.Fd()), info.Mode(), destinationPath, "directory")
+	if err := preserveSourceMode(int(destination.Fd()), info.Mode(), destinationPath, "directory"); err != nil {
+		return err
+	}
+	// Timestamps last, and only here: every child creation bumps this
+	// directory's mtime, so setting it before the level is complete would be
+	// overwritten by the next entry. "." resolves to the directory itself
+	// through its own descriptor.
+	return preserveSourceTimes(int(destination.Fd()), ".", info.ModTime(), destinationPath, "directory")
 }
 
 // holeCopyChunk is the read granularity of the hole-preserving copy. It is a
@@ -520,6 +534,47 @@ func isAllZero(chunk []byte) bool {
 		}
 	}
 	return true
+}
+
+// preserveSourceTimes gives a copied node the source's access and modification
+// times. rename(2) carries them for free, so only the cross-device leg pays
+// (#2919): a restored worktree whose every file looked newer than its build
+// outputs rebuilt from scratch, and git re-hashed files whose stat data it could
+// otherwise have trusted.
+//
+// Anchored on a directory descriptor plus a name, NOT on the node's own
+// descriptor. The descriptor-anchored spelling needs AT_EMPTY_PATH, which is
+// Linux-only, and this package builds for darwin too. A directory names itself
+// as "." relative to its own fd, which is portable and cannot be a symlink.
+//
+// nofollow is required for symlinks and harmless elsewhere: every other caller
+// has already proven what the name points at, and a copy must never reach
+// through a link it is reproducing.
+func preserveSourceTimes(dirFD int, name string, modTime time.Time, destinationPath, kind string) error {
+	// Read through os.FileInfo.ModTime rather than syscall.Stat_t: the timespec
+	// fields are spelled Mtim on linux and Mtimespec on darwin, and this package
+	// builds for both.
+	//
+	// Both fields are set from mtime, which APPROXIMATES atime rather than
+	// preserving it. Preserving it exactly means reading the source atime out of
+	// syscall.Stat_t, which is the same Mtim/Mtimespec split above; UTIME_OMIT
+	// would avoid that but its value differs between linux and darwin, so it
+	// needs the split too (caught by GOOS=darwin, not by review).
+	//
+	// That trade is deliberate and does not regress anything: today the copy
+	// leaves atime at the copy time, which diverges from rename just as much,
+	// and no probe measures atime because relatime makes it approximate for
+	// every reader. mtime is the field that matters — build systems and git's
+	// index-stat shortcut read it — and it becomes exactly right.
+	spec := unix.NsecToTimespec(modTime.UnixNano())
+	times := []unix.Timespec{spec, spec}
+	if err := unix.UtimesNanoAt(dirFD, name, times, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return fmt.Errorf(
+			"cannot move worktree across filesystems: failed to restore the source timestamps on destination %s %s: %w",
+			kind, destinationPath, err,
+		)
+	}
+	return nil
 }
 
 // preserveSourceMode restores a source node's permission bits on the descriptor
@@ -642,6 +697,11 @@ func copyRegularFileAtWithIdentity(
 	// step, once there is nothing half-written left to expose. The already-open
 	// descriptor keeps its write access regardless of the new mode.
 	if err := preserveSourceMode(outFD, info.Mode(), destinationPath, "file"); err != nil {
+		_ = out.Close()
+		return created, err
+	}
+	// After the contents too: every write moves mtime forward again.
+	if err := preserveSourceTimes(int(destination.Fd()), filepath.Base(destinationPath), info.ModTime(), destinationPath, "file"); err != nil {
 		_ = out.Close()
 		return created, err
 	}


### PR DESCRIPTION
Third item on #2919's checklist. `rename(2)` carries every filesystem property
for free; the cross-device copy reproduces only what it was written to
reproduce, and mtime was not on the list — so which filesystem `$AF_HOME` sits
on decided whether a restored worktree kept its timestamps.

Concretely: every file arrived newer than the build outputs it feeds, so the
next build redid everything, and git's index-stat shortcut re-hashed files it
could otherwise have trusted.

## Ordering, which is the whole implementation

- **Directories** are set once their own level is complete, alongside the mode
  and for the same reason: every child creation bumps the parent's mtime, so
  setting it earlier is immediately overwritten. `applyCopiedDirectoryMode`
  already ran exactly there, so this rides the existing seam.
- **Files** are set after the contents, since every write moves mtime forward.

## The portability split #2919 predicted, and where it actually was

Anchored on a **directory descriptor plus a name**, not on the node's own
descriptor: the descriptor-anchored spelling needs `AT_EMPTY_PATH`, which is
Linux-only. A directory names itself as `"."` relative to its own fd — portable,
and cannot be a symlink. `AT_SYMLINK_NOFOLLOW` throughout, because a copy must
never reach through a link it is reproducing.

The split turned out to be one layer further in than the issue guessed. I first
wrote `UTIME_OMIT` to leave atime alone — and **`GOOS=darwin go build` rejected
it**: the constant is `(1<<30)-2` on Linux and `-2` on Darwin. Review would not
have caught that; a 3-second cross-compile did.

So **atime is approximated** (set from mtime) rather than preserved. Preserving
it needs the source atime out of `syscall.Stat_t`, whose timespec field is
`Mtim` on linux and `Mtimespec` on darwin. Nothing regresses: the copy leaves
atime at the *copy time* today, which diverges from rename just as much; no
probe measures it; and relatime makes it approximate for every reader anyway.
mtime — the field build systems and git actually read — becomes exact.

## Deliberately not done

**Symlink mtime is still not restored**, and the omission is recorded in the
code and in the inventory rather than left silent. Reading a link's own
timestamp needs `Fstatat` plus that same `Stat_t` split, and no probe measures
it, so preserving it would mean unverified code in the one function that must
never lose worktree bytes. The guard is a denylist — add a probe and it fails,
pointing straight at the comment that explains why.

The other two checklist items are untouched: **xattrs** need the design call the
issue names (which namespaces; what to do when `security.*` needs privilege),
and **hardlinks** need an inode→first-path map threaded through the copy
manifest. Neither is a copy-paste of this one.

## Tests

**No new test, on purpose.** #2957's differential guard already covers this and
fails in *both* directions, which is what made the change verifiable:

```
mtime.file no longer diverges (source=2001-09-09T01:46:40Z copy=2001-09-09T01:46:40Z)
  — remove it from knownCrossDeviceDivergence so the inventory keeps meaning what it says
mtime.dir  no longer diverges …
```

That is the watch-it-fail step — the guard fired on the fix before the inventory
was touched — and it passes once the two entries come out. Adding a bespoke
mtime test alongside it would assert the same thing in a weaker way.

`go test ./session/git/` passes in full (24.7s).

## Gate

`gofmt -l .` (empty), `go build ./...`, `GOOS=darwin go build ./session/...`,
`golangci-lint run --timeout=3m --fast`, `scripts/lint-file-length.sh`,
`go test ./session/git/`. No `deadcode` locally (CI runs it), no containerized
suites, nothing against `./daemon/...` or `./app/...`.

Refs #2919

-- Captain Claude
