### PR TITLE
fix(archive): preserve mtime across a cross-device worktree move

### DIFF
--- a/session/git/worktree_copy_fidelity_test.go
+++ b/session/git/worktree_copy_fidelity_test.go
@@ -41,8 +41,6 @@ var knownCrossDeviceDivergence = map[string]string{
 	"hardlink.sameInode": "#2919: same cause — the link structure is not reproduced",
 	"xattr.file":         "#2919: no xattr namespace is copied, so ACLs, capabilities and SELinux labels are dropped",
 	"xattr.dir":          "#2919: same cause, on directories",
-	"mtime.file":         "#2919: the copy writes new files, so mtime becomes the copy time",
-	"mtime.dir":          "#2919: same cause, on directories",
 }
 
 // TestMoveDirCrossDevice_CopyDivergesFromRenameOnlyWhereRecorded is the class

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"sort"
 
+	"time"
+
 	"golang.org/x/sys/unix"
 )
 
@@ -261,6 +263,15 @@ func copyDirectoryContents(source, destination *os.File, sourcePath, destination
 			// is free: a read-only source directory takes its mode now rather
 			// than blocking its own contents (#2872).
 			err = applyCopiedDirectoryMode(
+				sourceDirectory, destinationDirectory, directoryRoutePath(destinationPath, components),
+			)
+		}
+		if err == nil {
+			// The same seam, for the same reason: creating an entry inside a
+			// directory updates that directory's mtime, and this level has just
+			// stopped gaining entries. Descendants are filled through their own
+			// descriptors, which does not touch this one.
+			err = preserveCopiedDirectoryModTime(
 				sourceDirectory, destinationDirectory, directoryRoutePath(destinationPath, components),
 			)
 		}
@@ -543,6 +554,50 @@ func isAllZero(chunk []byte) bool {
 // Setuid, setgid and sticky bits sit outside Perm() and are not carried over,
 // which is the behavior this copier has always had. Symlinks are skipped
 // entirely: Linux ignores their mode bits and offers no fchmod for them.
+// preserveSourceModTime stamps a destination node with its source's mtime.
+//
+// The copy creates every node fresh, so without this a restored tree looks newer
+// than the outputs built from it: the next build redoes everything, and git
+// re-hashes files whose stat data it could otherwise have trusted.
+//
+// Anchored at a directory descriptor plus a name rather than at the node's own
+// descriptor. The descriptor-anchored spelling needs AT_EMPTY_PATH, which is
+// Linux-only and would force a build-tag split; utimensat(dirfd, name) is POSIX
+// and reaches nanosecond precision on both platforms. A directory passes its own
+// descriptor with ".", which names the directory itself.
+//
+// atime is left alone with UTIME_OMIT rather than copied. Reading a file updates
+// it, so it is not a property the two paths could agree on anyway, and asking for
+// the source's value means reaching into Stat_t fields spelled differently per
+// platform — the split this spelling exists to avoid.
+func preserveSourceModTime(dirFD int, name string, modTime time.Time, destinationPath, kind string) error {
+	times := []unix.Timespec{
+		{Nsec: unix.UTIME_OMIT},
+		unix.NsecToTimespec(modTime.UnixNano()),
+	}
+	if err := unix.UtimesNanoAt(dirFD, name, times, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return fmt.Errorf(
+			"cannot move worktree across filesystems: failed to preserve %s modification time for %s: %w",
+			kind, destinationPath, err,
+		)
+	}
+	return nil
+}
+
+// preserveCopiedDirectoryModTime stamps a finished destination directory with its
+// source's mtime. "." names the directory the descriptor already refers to, so
+// this needs neither the parent nor AT_EMPTY_PATH.
+func preserveCopiedDirectoryModTime(source, destination *os.File, destinationPath string) error {
+	sourceInfo, err := source.Stat()
+	if err != nil {
+		return fmt.Errorf(
+			"cannot move worktree across filesystems: failed to read source modification time for %s: %w",
+			destinationPath, err,
+		)
+	}
+	return preserveSourceModTime(int(destination.Fd()), ".", sourceInfo.ModTime(), destinationPath, "directory")
+}
+
 func preserveSourceMode(destinationFD int, sourceMode os.FileMode, destinationPath, kind string) error {
 	if err := unix.Fchmod(destinationFD, uint32(sourceMode.Perm())); err != nil {
 		return fmt.Errorf(
@@ -642,6 +697,14 @@ func copyRegularFileAtWithIdentity(
 	// step, once there is nothing half-written left to expose. The already-open
 	// descriptor keeps its write access regardless of the new mode.
 	if err := preserveSourceMode(outFD, info.Mode(), destinationPath, "file"); err != nil {
+		_ = out.Close()
+		return created, err
+	}
+	// After the contents too: copyContentsPreservingHoles ftruncates to reproduce
+	// holes, and that write is itself an mtime update.
+	if err := preserveSourceModTime(
+		int(destination.Fd()), name, info.ModTime(), destinationPath, "file",
+	); err != nil {
 		_ = out.Close()
 		return created, err
 	}


### PR DESCRIPTION
## What

Third checklist item of #2919 — the one the issue marked cheap. Nobody had it.

Same-device archive is `rename(2)`, which carries mtime for free. Cross-device is
a byte copy that creates every node fresh, so a restored tree came back stamped
with the copy time:

| property | source | rename | copy (before) | copy (after) |
|---|---|---|---|---|
| `mtime.file` | 2001-09-09 | 2001-09-09 | **now** | 2001-09-09 |
| `mtime.dir` | 2001-09-09 | 2001-09-09 | **now** | 2001-09-09 |

Not cosmetic: every file looks newer than the outputs built from it, so the next
build redoes everything, and git's index stores stat data — a restored worktree
re-hashes files it could otherwise have trusted.

## Where the calls go, and why there

**Files** take their mtime after the contents *and* after the mode.
`copyContentsPreservingHoles` ftruncates to reproduce holes, and that write is
itself an mtime update, so this has to be last.

**Directories** take theirs at the seam #2872 already established for the mode —
the moment a level stops gaining entries. Creating an entry inside a directory
bumps that directory's mtime, and descendants are filled through their own
descriptors, so it is both the first moment the value is final and the last
moment it is free. Reusing that seam rather than adding a second pass means there
is one place where "this directory is finished" is decided.

## No platform split

The issue expected one, since the descriptor-anchored spelling needs
`AT_EMPTY_PATH` and that is Linux-only. It isn't needed: `utimensat(dirfd, name)`
is POSIX, reaches nanosecond precision on both platforms, and a directory passes
its own descriptor with `"."` to name itself. So this stays one file with no
build tags — worth noting because the microsecond fallback (`futimes`) would have
failed the differential test on macOS, which compares RFC3339**Nano**.

`atime` is deliberately left alone with `UTIME_OMIT`. Reading a file updates it,
so it is not a property the two paths could ever agree on, and asking for the
source's value means reaching into `Stat_t` fields spelled differently per
platform — the split this spelling exists to avoid.

## Verification

The differential test from #2957 is a denylist that fails in **both** directions,
and I watched it do both:

- with the fix in but the entries still listed —
  `mtime.dir no longer diverges (source=2001-09-09T01:46:40Z copy=2001-09-09T01:46:40Z)
  — remove it from knownCrossDeviceDivergence`
- with either preservation call deleted —
  `mtime.file diverges between the two move paths and is NOT a recorded gap:
  source=2001-09-09 rename=2001-09-09 copy=2026-08-05T22:36:45Z`

Both inventory entries removed. Local checks per the current rules: `gofmt -l .`
(empty), `go build ./...`, `golangci-lint --fast`, `scripts/lint-file-length.sh`,
and `go test ./session/git/` — non-daemon, non-app. No `deadcode` (CI runs it),
no containerized suites, nothing under `daemon/` or `app/`.

## Scope

Only mtime. `#2919` remains open for extended attributes (needs the design call
on `security.*` namespaces) and hardlinks (needs an inode→first-path map threaded
through the copy manifest). Symlink mtime is untouched: the fidelity probe does
not measure it, and I did not want to add unmeasured behaviour to a copier whose
whole defect class is unverified assumptions.

Refs #2919

🤖 Generated with [Claude Code](https://claude.com/claude-code)
