### PR TITLE
fix(git): carry mtime across a cross-device archive (#2919)

### DIFF
--- a/session/git/worktree_copy_fidelity_test.go
+++ b/session/git/worktree_copy_fidelity_test.go
@@ -41,8 +41,6 @@ var knownCrossDeviceDivergence = map[string]string{
 	"hardlink.sameInode": "#2919: same cause — the link structure is not reproduced",
 	"xattr.file":         "#2919: no xattr namespace is copied, so ACLs, capabilities and SELinux labels are dropped",
 	"xattr.dir":          "#2919: same cause, on directories",
-	"mtime.file":         "#2919: the copy writes new files, so mtime becomes the copy time",
-	"mtime.dir":          "#2919: same cause, on directories",
 }
 
 // TestMoveDirCrossDevice_CopyDivergesFromRenameOnlyWhereRecorded is the class

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -228,6 +228,22 @@ func copyTreeWithIdentities(src, dest string) (*copiedTreeIdentities, error) {
 		}
 		return nil, err
 	}
+	// The tree root last, for the same post-order reason as every directory inside
+	// it: writing the children bumped it. rename(2) carries the root's timestamps
+	// like any other, so leaving them at the copy time would be a divergence the
+	// fidelity guard does not probe only because it probes entries INSIDE the root
+	// (#2919).
+	var sourceRootStat unix.Stat_t
+	if err := unix.Fstat(int(source.Fd()), &sourceRootStat); err != nil {
+		copied.close()
+		return nil, fmt.Errorf(
+			"cannot move worktree across filesystems: failed to read the source root timestamps for %s: %w", src, err,
+		)
+	}
+	if err := preserveSourceTimes(int(destParent.Fd()), destName, &sourceRootStat, dest, "directory"); err != nil {
+		copied.close()
+		return nil, err
+	}
 	return copied, nil
 }
 
@@ -331,6 +347,18 @@ func copyDirectoryLevel(
 			directory.entries = append(directory.entries, entry)
 		}
 		if err != nil {
+			return err
+		}
+		// Post-order for a directory: copyDirectoryEntry above has already written
+		// every child, and each of those writes bumped this entry's mtime. Stamping
+		// before the recursion would be immediately undone (#2919).
+		kind := "file"
+		if inspected.fileType == unix.S_IFDIR {
+			kind = "directory"
+		} else if inspected.fileType == unix.S_IFLNK {
+			kind = "symlink"
+		}
+		if err := preserveSourceTimes(int(destination.Fd()), name, stat, childDestinationPath, kind); err != nil {
 			return err
 		}
 	}
@@ -548,6 +576,43 @@ func preserveSourceMode(destinationFD int, sourceMode os.FileMode, destinationPa
 		return fmt.Errorf(
 			"cannot move worktree across filesystems: failed to preserve mode %#o on destination %s %s: %w",
 			sourceMode.Perm(), kind, destinationPath, err,
+		)
+	}
+	return nil
+}
+
+// preserveSourceTimes stamps the destination entry with the source's access and
+// modification times (#2919).
+//
+// Anchored to the parent DIRECTORY descriptor plus a name, not to a path and not
+// to the entry's own descriptor. Both halves of that are deliberate:
+//
+//   - parent-fd + name keeps the descriptor-anchored discipline the rest of this
+//     copier uses, so a worktree process cannot swap what the name resolves to
+//     between creating the node and stamping it (#2708/#2714);
+//   - AT_SYMLINK_NOFOLLOW stamps a SYMLINK itself rather than its target, which
+//     matters because the target may live outside the tree being archived — a
+//     copier that followed here would mutate a file it was never asked to touch.
+//
+// UtimesNanoAt with a name is also what avoids a platform split: the
+// descriptor-only spelling needs AT_EMPTY_PATH, which is Linux-only.
+//
+// #2919 expected the timestamp READ to need a Linux/Darwin split too, on the
+// grounds that Darwin spells the stat fields Atimespec/Mtimespec. It does not, at
+// the x/sys this repo pins: golang.org/x/sys@v0.47.0's ztypes_darwin_arm64.go
+// declares Atim/Mtim exactly as Linux does. Verified by cross-compiling —
+// GOOS=darwin caught the Atimespec spelling as undefined, which is how the split
+// turned out to be unnecessary rather than merely untested.
+//
+// Ordering is the caller's job. A directory's mtime must be stamped only after
+// its children exist, since creating them updates it; copyDirectoryLevel calls
+// this after the recursive copy of an entry returns, which is post-order.
+func preserveSourceTimes(parentFD int, name string, stat *unix.Stat_t, destinationPath, kind string) error {
+	times := []unix.Timespec{stat.Atim, stat.Mtim}
+	if err := unix.UtimesNanoAt(parentFD, name, times, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return fmt.Errorf(
+			"cannot move worktree across filesystems: failed to preserve timestamps on destination %s %s: %w",
+			kind, destinationPath, err,
 		)
 	}
 	return nil


### PR DESCRIPTION
Closes the `mtime` box on #2919's checklist. **Deliberately no `Closes` line** — see the
end.

## The defect

`moveDirCrossDevice` has two implementations of one promise. Same-device is
`rename(2)`, which carries every filesystem property for free. Cross-device is a byte
copy that reproduces only what it was written to reproduce — so every file and
directory arrived stamped with the **copy time**, and which filesystem `$AF_HOME` sits
on decided which behavior a user got.

The concrete cost: a worktree with a build tree archives and restores, every file now
looks newer than its outputs, and the next build redoes everything. Git's index stores
stat data too, so a restored worktree re-hashes files it could otherwise have trusted.

## The fix

Timestamps are stamped from the source stat via
`UtimesNanoAt(parentFD, name, …, AT_SYMLINK_NOFOLLOW)`. Three deliberate choices:

- **Parent-descriptor + name, not a path.** Keeps the descriptor discipline the rest of
  this copier uses (#2708/#2714), so a worktree process cannot swap what the name
  resolves to between the node being created and being stamped.
- **`AT_SYMLINK_NOFOLLOW`** stamps a symlink *itself* rather than its target — the
  target may live outside the tree being archived, and a copier that followed here
  would mutate a file it was never asked to touch.
- **Post-order, and that is load-bearing.** Creating children bumps a directory's
  mtime, so a directory is stamped only after the recursive copy of its contents
  returns. The tree **root** is stamped last for the same reason; the fidelity guard
  probes entries *inside* the root rather than the root itself, so this would otherwise
  have stayed a silent divergence.

## The platform split the issue called for is not needed

#2919 records mtime as "cheap; the descriptor-anchored spelling needs a Linux/Darwin
split, since `AT_EMPTY_PATH` is Linux-only", and expected the timestamp **read** to need
one too because Darwin historically spells the stat fields `Atimespec`/`Mtimespec`.

Neither holds here:

- anchoring to **parent-fd + name** rather than to the entry's own descriptor avoids
  `AT_EMPTY_PATH` entirely, and `UtimesNanoAt` exists on both platforms;
- at the `x/sys` this repo pins, `golang.org/x/sys@v0.47.0`'s
  `ztypes_darwin_arm64.go` declares **`Atim`/`Mtim`**, exactly as Linux does.

I had already written the three-file split before checking, and it came back out.
`GOOS=darwin` is what caught it — it rejected `Atimespec` as undefined. Both
`GOOS=linux` and `GOOS=darwin` build.

## Watched it fail, in both directions

The #2957 guard makes this cheap, and it fires both ways by design:

| state | result |
| --- | --- |
| fix applied, inventory untouched | **FAIL** — `mtime.file`/`mtime.dir` *"no longer diverges — remove it from knownCrossDeviceDivergence"* |
| stamping removed (mutation), inventory updated | **FAIL** — `source=2001-09-09T01:46:40Z rename=2001-09-09T01:46:40Z copy=2026-08-05T22:37:08Z` |
| fix applied, inventory updated | **ok** |

Both `mtime.*` entries are now gone from `knownCrossDeviceDivergence`, so the inventory
keeps meaning what it says.

## Why there is no `Closes` line

#2919 is a checklist with three remaining boxes. This closes one; **xattrs** (which
needs a design call on which namespaces, and what to do when `security.*` cannot be set
without privilege) and **hardlinks** (which needs an inode→first-path map threaded
through the copy manifest) stay open, and stay recorded in the inventory so the next
person gets a failing test pointing at them.

A `Closes #2919` here would close the issue with two thirds of its checklist undone,
which is the opposite of what the convention is for. `Refs #2919` instead — please
retitle or split the issue if you would rather it be tracked per-item.

## Gate

`gofmt -l .` (empty) · `go build ./...` · `GOOS=darwin go build ./session/...` ·
`golangci-lint --fast` · `scripts/lint-file-length.sh` · `go test ./session/git/`
(the changed package, non-daemon and non-app) — **ok, 24.8s**.

No `deadcode` and no containerized suite, per the current local-checks rule; CI runs
both.

Refs #2919
