### PR TITLE
fix(git): keep source mtimes through a cross-device archive (#2919)

### DIFF
--- a/session/git/worktree_copy_fidelity_test.go
+++ b/session/git/worktree_copy_fidelity_test.go
@@ -41,8 +41,7 @@ var knownCrossDeviceDivergence = map[string]string{
 	"hardlink.sameInode": "#2919: same cause — the link structure is not reproduced",
 	"xattr.file":         "#2919: no xattr namespace is copied, so ACLs, capabilities and SELinux labels are dropped",
 	"xattr.dir":          "#2919: same cause, on directories",
-	"mtime.file":         "#2919: the copy writes new files, so mtime becomes the copy time",
-	"mtime.dir":          "#2919: same cause, on directories",
+	"mtime.symlink":      "#2919: the link's own mtime is not set — no portable dirfd-relative lstat, and the target's mtime is what tools read",
 }
 
 // TestMoveDirCrossDevice_CopyDivergesFromRenameOnlyWhereRecorded is the class
@@ -148,6 +147,15 @@ func writeFidelityProbeTree(t *testing.T, root string) {
 	old := time.Unix(1_000_000_000, 0)
 	require.NoError(t, os.Chtimes(filepath.Join(root, "plain.txt"), old, old))
 	require.NoError(t, os.Chtimes(filepath.Join(root, "dir"), old, old))
+	// The LINK's own mtime, not its target's — os.Chtimes follows symlinks, so it
+	// would stamp plain.txt a second time and leave the link reading "now". Without
+	// this the mtime.symlink probe would still show a divergence, but only because
+	// the two fixtures are created at different moments; stamping it means the probe
+	// fails for the reason it claims.
+	stamp := unix.NsecToTimespec(old.UnixNano())
+	require.NoError(t, unix.UtimesNanoAt(
+		unix.AT_FDCWD, filepath.Join(root, "link"), []unix.Timespec{stamp, stamp}, unix.AT_SYMLINK_NOFOLLOW,
+	))
 }
 
 // describeFidelity renders one tree as property → observed value. A property the
@@ -193,6 +201,10 @@ func describeFidelity(t *testing.T, root string) map[string]string {
 	for property, path := range map[string]string{
 		"mtime.file": filepath.Join(root, "plain.txt"),
 		"mtime.dir":  filepath.Join(root, "dir"),
+		// The link's OWN mtime, via Lstat rather than Stat. Measured even though it
+		// is not yet preserved: an unmeasured gap is exactly how this class kept
+		// recurring — a property nobody listed could not fail anything.
+		"mtime.symlink": filepath.Join(root, "link"),
 	} {
 		info, err := os.Lstat(path)
 		require.NoError(t, err)

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -424,6 +425,36 @@ func copySymlinkEntry(
 	return created, nil
 }
 
+// preserveSourceModTime gives a freshly created destination node the modification
+// time its source carries. rename(2) keeps mtime for free; the copy writes new
+// nodes, so without this every restored file and directory dates from the archive
+// rather than from when the work was done (#2919). A worktree carrying a build
+// tree then looks entirely newer than its outputs, so the next build redoes all of
+// it, and git — which stores stat data in the index — re-hashes files it could
+// otherwise have trusted.
+//
+// Anchored to a directory descriptor plus a name, like every other mutation here,
+// and AT_SYMLINK_NOFOLLOW so a name swapped for a symlink between creation and
+// this call cannot redirect the timestamp onto another file. A directory passes
+// its OWN descriptor with "." — that addresses the directory itself without
+// AT_EMPTY_PATH, which is Linux-only.
+//
+// Both slots are set to the source mtime because there is no portable way to set
+// one and leave the other: UTIME_OMIT is not defined on darwin. atime is
+// therefore NOT preserved, deliberately — it is rewritten by any read, most
+// filesystems mount relatime so it is already approximate, and nothing in a
+// worktree depends on it. mtime is the property tools actually read.
+func preserveSourceModTime(dirFD int, name string, sourceModTime time.Time, destinationPath, kind string) error {
+	stamp := unix.NsecToTimespec(sourceModTime.UnixNano())
+	if err := unix.UtimesNanoAt(dirFD, name, []unix.Timespec{stamp, stamp}, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return fmt.Errorf(
+			"cannot move worktree across filesystems: failed to preserve the source modification time on destination %s %s: %w",
+			kind, destinationPath, err,
+		)
+	}
+	return nil
+}
+
 // workingDirectoryMode is the mode a destination directory is created with while
 // the copy is still filling it.
 //
@@ -453,7 +484,15 @@ func applyCopiedDirectoryMode(source, destination *os.File, destinationPath stri
 			destinationPath, err,
 		)
 	}
-	return preserveSourceMode(int(destination.Fd()), info.Mode(), destinationPath, "directory")
+	if err := preserveSourceMode(int(destination.Fd()), info.Mode(), destinationPath, "directory"); err != nil {
+		return err
+	}
+	// Same moment as the mode, and for the same reason: this level is complete, so
+	// nothing further will be created directly in this directory to move its mtime
+	// again. Descendants are filled through their own descriptors, which changes
+	// THEIR mtimes, not this one. "." names this directory through its own
+	// descriptor, so the root of the copy needs no parent to address it.
+	return preserveSourceModTime(int(destination.Fd()), ".", info.ModTime(), destinationPath, "directory")
 }
 
 // holeCopyChunk is the read granularity of the hole-preserving copy. It is a
@@ -642,6 +681,14 @@ func copyRegularFileAtWithIdentity(
 	// step, once there is nothing half-written left to expose. The already-open
 	// descriptor keeps its write access regardless of the new mode.
 	if err := preserveSourceMode(outFD, info.Mode(), destinationPath, "file"); err != nil {
+		_ = out.Close()
+		return created, err
+	}
+	// Last, after every write: the contents are what move mtime, so stamping it
+	// before the copy would simply be overwritten.
+	if err := preserveSourceModTime(
+		int(destination.Fd()), filepath.Base(destinationPath), info.ModTime(), destinationPath, "file",
+	); err != nil {
 		_ = out.Close()
 		return created, err
 	}


### PR DESCRIPTION
Third box on #2919's checklist: the cross-device archive copy reset every mtime.

Refs #2919 — **deliberately not `Closes`**. Extended attributes and hardlinks are still
open on that checklist, and the xattr item needs the design call the issue itself asks
for (which namespaces, and what to do when `security.*` cannot be set without
privilege). Closing the issue on a third of it would lose the two remaining items.

## What was wrong

`rename(2)` carries mtime for free. The cross-device copy writes new nodes, so every
restored file and directory dated from the archive rather than from when the work was
done — and which filesystem `$AF_HOME` sits on decided which behaviour a user got.

Not cosmetic: a worktree carrying a build tree comes back looking entirely newer than
its outputs, so the next build redoes all of it, and git stores stat data in the index,
so a restored worktree re-hashes files it could otherwise have trusted.

## Where the stamp goes

- **Files** — after the contents. Writes are what move mtime, so stamping first would
  simply be overwritten.
- **Directories** — at the same moment as their mode, which is the first point at which
  nothing further is created directly in them. Descendants are filled through their own
  descriptors, which moves *their* mtimes, not the parent's.

Two spellings worth review:

- A directory passes **its own descriptor with `"."`** to address itself. That sidesteps
  `AT_EMPTY_PATH` being Linux-only, so **the platform split the issue anticipated turned
  out not to be needed** — `UtimesNanoAt` covers both platforms as-is (`GOOS=darwin go
  build ./session/...` confirms it compiles).
- Both time slots are set to the source mtime, because `UTIME_OMIT` is not defined on
  darwin and atime therefore cannot portably be left alone. **atime is deliberately not
  preserved**: any read rewrites it, relatime already makes it approximate, and nothing
  in a worktree depends on it. The guard does not measure atime, so this is stated here
  rather than implied by a passing test.

## The remaining gap is now guarded, not silent

The **symlink's own** mtime is still not preserved — there is no portable
dirfd-relative lstat, and the target's mtime is what tools read. Rather than leave that
as another unlisted property, the guard now **measures** `mtime.symlink` and records it
in `knownCrossDeviceDivergence`. That is the whole point of the issue: fidelity was an
enumeration, and nothing failed when the enumeration was incomplete — so a gap I am
choosing not to close should still be able to fail a test.

The fixture also stamps the link through `UtimesNanoAt` with `AT_SYMLINK_NOFOLLOW`,
because `os.Chtimes` **follows** symlinks: it would have stamped the target a second
time and left the probe diverging only because the two fixtures are built at different
moments — passing for a reason unrelated to what it claims.

## Verification

**Watched the guard fail first**, with the copier's stamp neutralised:

```
mtime.file diverges between the two move paths and is NOT a recorded gap:
  source=2001-09-09T01:46:40Z rename=2001-09-09T01:46:40Z copy=2026-08-05T22:37:41Z
mtime.dir  diverges ... source=2001-09-09T01:46:40Z rename=2001-09-09T01:46:40Z copy=2026-08-05T22:37:41Z
```

Green with the fix, and `go test ./session/git/` passes in full (22.8s).

Local checks per the current rule — `gofmt -l .` clean, `go build ./...` ok,
`golangci-lint run --timeout=3m --fast` clean, `scripts/lint-file-length.sh` passed,
`go test ./session/git/` (the non-daemon, non-app package I changed). No `deadcode`
locally, no containerized suites, nothing against `./daemon/...` or `./app/...` — CI
runs those, including the macOS leg this change needs.

Co-Authored-By: Captain Claude <noreply@anthropic.com>
