### PR TITLE
fix(upgrade): let a staged artifact say whether it is live (#2212 gate 4)

### DIFF
--- a/internal/upgradetxn/artifact_owner.go
+++ b/internal/upgradetxn/artifact_owner.go
@@ -1,0 +1,277 @@
+package upgradetxn
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/internal/proctree"
+)
+
+// The staged binary artifacts beside an executable are the ONLY thing one af home
+// can see of another's upgrade transaction, and #2212 gate 4 is about what they are
+// allowed to mean.
+//
+// foreignTransactionOver used to decide from the FILENAME alone: a
+// `.<base>.af-upgrade-<id>.previous` present meant "a live transaction owns this
+// binary", so Prepare refused. Cleanup that died after removing active.json but
+// before deleting PreviousBinaryPath leaves exactly that file with nothing behind
+// it — and the inference then blocks every future upgrade over that executable,
+// permanently. The asymmetry is what makes it a gate: the in-place installer has
+// --ignore-active-upgrade, while a daemon-owned upgrade has no escape hatch at all,
+// so one stray dotfile fails every unattended upgrade until a human deletes it. That
+// is the unoverridable-block shape this epic has already been bitten by (#2859).
+//
+// The three obvious repairs are all wrong, and stay rejected:
+//
+//   - READ THE OWNING JOURNAL — impossible from the filename, which names a
+//     transaction id and no home, with no registry to resolve one against. That is
+//     precisely why the artifact scan exists.
+//   - AGE THE ARTIFACT OUT — a timestamp is never authority for overwriting a binary
+//     a live transaction may still be preserving as its rollback source.
+//   - GIVE THE DAEMON AN OVERRIDE — an unattended actor silently stepping over a
+//     safety interlock is worse than the block it replaces.
+//
+// So the artifact is made SELF-DESCRIBING instead: alongside the staged binaries,
+// Prepare writes an owner sidecar naming the transaction's home and the process that
+// staged it. "Inert leftover" becomes a positive observation rather than an
+// inference, and the cross-home objection dissolves — the sidecar carries the very
+// pointer the filename lacked.
+//
+// FAIL-CLOSED ON DOUBT. An artifact with no readable sidecar keeps blocking exactly
+// as it does today: it may have been staged by an af that predates this contract, or
+// by a live transaction whose sidecar we simply cannot read, and neither is a licence
+// to overwrite a binary. Only a sidecar that positively shows a finished transaction
+// AND a dead owner unblocks. The narrow window that leaves — an artifact staged
+// between this change and an operator's next upgrade — is bounded by activation being
+// off by default, so no unattended path can reach it.
+
+// artifactOwnerExt is the sidecar's suffix, sharing the `.<base>.af-upgrade-<id>`
+// stem with the binaries it describes so one glob finds a transaction's whole
+// footprint and cleanup cannot forget a member.
+const artifactOwnerExt = ".owner.json"
+
+// artifactOwnerMode keeps the sidecar readable by other homes' daemons — it carries
+// no secret, only a home path and process identity — while staying owner-writable.
+const artifactOwnerMode os.FileMode = 0o644
+
+// artifactOwner is what a staged artifact says about itself. Every field exists to
+// answer one question a filename cannot.
+type artifactOwner struct {
+	// ID ties the sidecar to its artifacts, so a stale sidecar beside a different
+	// transaction's binaries is detectable rather than silently authoritative.
+	ID string `json:"id"`
+	// HomeDir is the AF home whose journal governs this transaction. It is the
+	// pointer the filename never had, and it is what lets another home ask the only
+	// question that actually settles liveness: is that transaction still active?
+	HomeDir string `json:"home_dir"`
+	// PID, StartID and BootID identify the process that staged the artifacts, so a
+	// crashed prepare is distinguishable from one still running. StartID is compared
+	// for equality only; BootID scopes it, since neither pid nor start stamp carries
+	// authority across a reboot.
+	PID     int    `json:"pid"`
+	StartID uint64 `json:"start_id"`
+	BootID  string `json:"boot_id"`
+	// PIDNamespace scopes PID and StartID. BootID is host-global while both of those
+	// are interpreted in the OBSERVER's namespace, so without this a dead stager's
+	// tuple can match an unrelated long-running process in a scanning namespace and
+	// block the executable forever — af homes in different namespaces do share one
+	// executable (container sessions).
+	PIDNamespace string `json:"pid_namespace_id"`
+	// Journalled records that the transaction reached the point where its journal is
+	// the authority. Before it, "no active.json" means the prepare has not written one
+	// YET and only the stager's liveness can tell live from crashed; after it, the
+	// journal's absence is the transaction being OVER, whatever the stager is doing.
+	// Without this distinction a daemon that survives a failed cleanup keeps its own
+	// inert artifact blocking — the headline case of #2212 gate 4, half unfixed.
+	Journalled bool `json:"journalled"`
+}
+
+// artifactOwnerPath is the sidecar beside the staged binaries for one transaction.
+func artifactOwnerPath(executable, id string) string {
+	previous, _ := binaryArtifactPaths(executable, id)
+	return strings.TrimSuffix(previous, ".previous") + artifactOwnerExt
+}
+
+// captureArtifactOwner records the calling process as the stager of id's artifacts.
+// An identity that cannot be captured is an error rather than a partial record: a
+// sidecar missing its process proofs would read as "unknown" forever and block the
+// executable, which is the failure this whole change removes.
+func captureArtifactOwner(home, id string) (artifactOwner, error) {
+	pid := os.Getpid()
+	self, err := proctree.Lookup(pid)
+	if err != nil {
+		return artifactOwner{}, fmt.Errorf("determine upgrade artifact owner identity: %w", err)
+	}
+	bootID, err := proctree.BootID()
+	if err != nil {
+		return artifactOwner{}, fmt.Errorf("determine kernel boot identity for upgrade artifact owner: %w", err)
+	}
+	pidNamespace, err := proctree.PIDNamespaceID()
+	if err != nil {
+		return artifactOwner{}, fmt.Errorf("determine PID namespace for upgrade artifact owner: %w", err)
+	}
+	return artifactOwner{
+		ID: id, HomeDir: home, PID: pid, StartID: self.StartID,
+		BootID: bootID, PIDNamespace: pidNamespace,
+	}, nil
+}
+
+// writeArtifactOwner persists the sidecar durably, because it is read by processes
+// that will decide whether they may overwrite an executable: a record that survived
+// the crash only partially would be worse than none.
+func writeArtifactOwner(path string, owner artifactOwner) error {
+	raw, err := json.MarshalIndent(owner, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode upgrade artifact owner: %w", err)
+	}
+	return durableAtomicWriteFile(path, append(raw, '\n'), artifactOwnerMode)
+}
+
+// readArtifactOwner loads the sidecar for id. A record missing any field it is meant
+// to prove with is rejected rather than half-trusted, so a truncated write reads as
+// "unknown" and keeps the artifact blocking.
+func readArtifactOwner(path, id string) (artifactOwner, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // a path this package composed from its own artifact naming
+	if err != nil {
+		return artifactOwner{}, err
+	}
+	var owner artifactOwner
+	if err := json.Unmarshal(raw, &owner); err != nil {
+		return artifactOwner{}, fmt.Errorf("decode upgrade artifact owner %s: %w", path, err)
+	}
+	// PID 1 is legitimate: af runs as a container entrypoint, and rejecting it would
+	// make that home's artifacts unreadable — hence permanently blocking.
+	if owner.ID != id || owner.HomeDir == "" || owner.PID < 1 || owner.StartID == 0 ||
+		owner.BootID == "" || owner.PIDNamespace == "" {
+		return artifactOwner{}, fmt.Errorf("upgrade artifact owner %s is incomplete", path)
+	}
+	return owner, nil
+}
+
+// artifactIsInert reports whether the transaction behind an artifact is definitively
+// OVER, so the executable is free. It answers false for anything it cannot establish.
+//
+// Two conditions, and BOTH must hold. They are separate because they rule out
+// different survivors:
+//
+//  1. The owning home has no active journal. That is the authoritative statement
+//     that the transaction finished — and it is reachable only because the sidecar
+//     names the home. A transaction whose process died mid-flight but whose journal
+//     is still active is RESUMABLE, and its `.previous` is the rollback source; a
+//     second transaction publishing over that executable would leave the two
+//     interleaved. Liveness of the process alone would miss exactly that case.
+//  2. The staging process is gone. A prepare still running has not written its
+//     journal yet, so an absent active.json would otherwise read as "finished" during
+//     the very window the interlock exists for.
+//
+// A boot change makes the process half moot rather than ambiguous: no pid recorded
+// under a previous boot identifies anything now, so the process is gone by
+// construction and only the journal question remains.
+func artifactIsInert(executable, id string) (bool, error) {
+	owner, err := readArtifactOwner(artifactOwnerPath(executable, id), id)
+	if err != nil {
+		// Unreadable, absent, or incomplete: not a licence to overwrite a binary.
+		// Pre-contract artifacts land here and keep blocking, exactly as today.
+		return false, nil
+	}
+	// A missing HOME is not a missing journal. An unmounted or absent home makes Lstat
+	// on the journal report ErrNotExist for a reason that says nothing about the
+	// transaction, so the two are distinguished before either is trusted.
+	//
+	// The HOME is what must exist, not its upgrade root: a transaction that finished
+	// cleanly may have taken the upgrade tree with it, and that is precisely the state
+	// this function is looking for.
+	if _, err := os.Lstat(owner.HomeDir); err != nil {
+		return false, nil
+	}
+	// The active journal must be THIS artifact's transaction, not merely any. A home
+	// that finished transaction A and later started B over a different executable
+	// would otherwise present B's active.json as proof that A is still live, and A's
+	// leftover would block that executable for every other home, forever.
+	active, err := readJournal(activeJournalPath(owner.HomeDir))
+	switch {
+	case err == nil:
+		if active.ID == owner.ID {
+			return false, nil // this transaction really is still active
+		}
+		// A different transaction is active in that home; it says nothing about ours.
+	case errors.Is(err, ErrNoActiveTransaction):
+		// No active transaction at all — the state this function is looking for.
+		// readJournal reports absence as this sentinel, not as os.ErrNotExist.
+	default:
+		return false, nil // could not read the owning home: unknown is not inert
+	}
+	if owner.Journalled {
+		// Past the journal handoff, the JOURNAL is the authority and it says finished.
+		// Stager liveness must not be consulted here: a daemon that survives a failed
+		// cleanup is still running, and gating on it would keep its own inert artifact
+		// blocking forever — which is the failure this whole change removes.
+		return true, nil
+	}
+	// Before the handoff there is no journal to have been removed, so "absent" cannot
+	// mean finished. Only the stager can distinguish a prepare still running from one
+	// that crashed mid-staging.
+	alive, err := artifactOwnerAlive(owner)
+	if err != nil {
+		return false, nil
+	}
+	return !alive, nil
+}
+
+// artifactOwnerAlive reports whether the recorded staging process is still running as
+// the SAME process instance. It compares pid AND start stamp under the recorded boot
+// identity, so a recycled pid is not mistaken for the original.
+func artifactOwnerAlive(owner artifactOwner) (bool, error) {
+	bootID, err := proctree.BootID()
+	if err != nil {
+		return false, err
+	}
+	if bootID != owner.BootID {
+		// A mismatch normally means another boot, where the recorded pid names nothing.
+		// But proctree.BootID DELIBERATELY falls back to the PID-namespace id under a
+		// subset=pid procfs, so two containers sharing this executable get different
+		// ids within one host boot. Reading that as death would declare a LIVE
+		// pre-journal stager in a sibling container dead and let a second transaction
+		// publish over the same binary — the interlock failing open, which is far worse
+		// than the block it guards.
+		if proctree.BootIDIsFallback(bootID) || proctree.BootIDIsFallback(owner.BootID) {
+			return false, fmt.Errorf("upgrade artifact owner boot identity is namespace-scoped; liveness is undecidable from here")
+		}
+		return false, nil
+	}
+	pidNamespace, err := proctree.PIDNamespaceID()
+	if err != nil {
+		return false, err
+	}
+	if pidNamespace != owner.PIDNamespace {
+		// The recorded pid is not interpretable here, so it cannot be shown dead —
+		// and a tuple that happens to match a local process would be a coincidence,
+		// not the stager. Unknown, which the caller treats as live.
+		return false, fmt.Errorf("upgrade artifact owner pid %d belongs to another PID namespace", owner.PID)
+	}
+	current, err := proctree.Lookup(owner.PID)
+	if err != nil {
+		// ErrProcessExited is a POSITIVE statement that the pid named a process which
+		// has exited but not yet been reaped (darwin reports this where Linux simply
+		// has no /proc entry). Treating it as an error made a plainly dead stager read
+		// as unknown, so the leftover kept blocking — on macOS only.
+		if errors.Is(err, os.ErrNotExist) || errors.Is(err, proctree.ErrProcessExited) {
+			return false, nil
+		}
+		return false, err
+	}
+	return current.StartID == owner.StartID, nil
+}
+
+// removeArtifactOwner deletes the sidecar. Called wherever the staged binaries are
+// removed, so the sidecar never outlives the artifacts it describes — a sidecar
+// without binaries is harmless, but one that lingers is a record nobody can act on.
+func removeArtifactOwner(executable, id string) error {
+	if err := os.Remove(artifactOwnerPath(executable, id)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove upgrade artifact owner: %w", err)
+	}
+	return nil
+}

--- a/internal/upgradetxn/artifact_owner_test.go
+++ b/internal/upgradetxn/artifact_owner_test.go
@@ -1,0 +1,276 @@
+package upgradetxn
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/internal/proctree"
+)
+
+// deadOwner builds a complete sidecar for a stager that is definitively gone, scoped
+// to this boot and PID namespace so only its LIVENESS is what the test varies.
+func deadOwner(t *testing.T, id, home string) artifactOwner {
+	t.Helper()
+	ns, err := proctree.PIDNamespaceID()
+	if err != nil {
+		t.Fatalf("PIDNamespaceID: %v", err)
+	}
+	return artifactOwner{
+		ID: id, HomeDir: home, PID: 999999, StartID: 42,
+		BootID: currentBootIDForTest(t), PIDNamespace: ns,
+	}
+}
+
+// currentBootIDForTest returns this kernel's boot identity, so a fixture owner is
+// scoped to the boot the test runs in.
+func currentBootIDForTest(t *testing.T) string {
+	t.Helper()
+	id, err := proctree.BootID()
+	if err != nil {
+		t.Fatalf("BootID: %v", err)
+	}
+	return id
+}
+
+// #2212 gate 4: a staged artifact must say whether it is LIVE, so an inert leftover
+// stops blocking every future upgrade over the executable.
+//
+// The old scan read the filename alone, so a `.previous` left behind when cleanup
+// died after removing active.json but before deleting PreviousBinaryPath read as a
+// live foreign transaction — and Prepare refused forever, with no escape hatch for a
+// daemon-owned upgrade.
+
+// stageArtifact writes a `.previous` for id beside executable, with an optional owner
+// sidecar, and returns the executable path.
+func stageArtifact(t *testing.T, dir, id string, owner *artifactOwner) string {
+	t.Helper()
+	executable := filepath.Join(dir, "af")
+	if err := os.WriteFile(executable, []byte("binary"), 0o755); err != nil { //nolint:gosec // test fixture
+		t.Fatalf("write executable: %v", err)
+	}
+	previous, _ := binaryArtifactPaths(executable, id)
+	if err := os.WriteFile(previous, []byte("previous"), 0o755); err != nil { //nolint:gosec // test fixture
+		t.Fatalf("write previous artifact: %v", err)
+	}
+	if owner != nil {
+		if err := writeArtifactOwner(artifactOwnerPath(executable, id), *owner); err != nil {
+			t.Fatalf("write owner: %v", err)
+		}
+	}
+	return executable
+}
+
+// TestForeignTransaction_InertLeftoverDoesNotBlock is the regression. The owning home
+// has no active journal and the staging process is gone, so the artifact is a
+// leftover and must not be reported as a live foreign transaction.
+func TestForeignTransaction_InertLeftoverDoesNotBlock(t *testing.T) {
+	dir := t.TempDir()
+	home := t.TempDir() // no active.json: the transaction finished
+	owner := deadOwner(t, "dead", home)
+	owner.Journalled = true
+	executable := stageArtifact(t, dir, "dead", &owner)
+
+	foreign, err := foreignTransactionOver(executable, "mine")
+	if err != nil {
+		t.Fatalf("foreignTransactionOver: %v", err)
+	}
+	if foreign != "" {
+		t.Fatalf("an inert leftover must not block a new transaction; got foreign=%q", foreign)
+	}
+}
+
+// TestForeignTransaction_ActiveJournalStillBlocks is the half that keeps the
+// interlock real. The staging process is gone, but the owning home's journal is still
+// active — so the transaction is RESUMABLE and its `.previous` is the rollback source.
+// Process liveness alone would have missed this and let two transactions interleave
+// over one executable.
+func TestForeignTransaction_ActiveJournalStillBlocks(t *testing.T) {
+	dir := t.TempDir()
+	home := t.TempDir()
+	active := activeJournalPath(home)
+	if err := os.MkdirAll(filepath.Dir(active), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// The active journal must NAME this artifact's transaction: a home running some
+	// OTHER transaction says nothing about this one.
+	if err := os.WriteFile(active, []byte(`{"id":"crashed"}`), 0o600); err != nil {
+		t.Fatalf("write active journal: %v", err)
+	}
+	owner := deadOwner(t, "crashed", home)
+	owner.Journalled = true
+	executable := stageArtifact(t, dir, "crashed", &owner)
+
+	foreign, err := foreignTransactionOver(executable, "mine")
+	if err != nil {
+		t.Fatalf("foreignTransactionOver: %v", err)
+	}
+	if foreign != "crashed" {
+		t.Fatalf("a resumable transaction must still block; got foreign=%q", foreign)
+	}
+}
+
+// TestForeignTransaction_LiveOwnerStillBlocks covers the other survivor: a prepare
+// still running has not written its journal yet, so an absent active.json would read
+// as "finished" during the very window the interlock exists for.
+func TestForeignTransaction_LiveOwnerStillBlocks(t *testing.T) {
+	dir := t.TempDir()
+	home := t.TempDir() // no active.json yet — mid-prepare
+	self, err := captureArtifactOwner(home, "running")
+	if err != nil {
+		t.Fatalf("captureArtifactOwner: %v", err)
+	}
+	executable := stageArtifact(t, dir, "running", &self)
+
+	foreign, err := foreignTransactionOver(executable, "mine")
+	if err != nil {
+		t.Fatalf("foreignTransactionOver: %v", err)
+	}
+	if foreign != "running" {
+		t.Fatalf("a live staging process must still block; got foreign=%q", foreign)
+	}
+}
+
+// TestForeignTransaction_UnknownArtifactFailsClosed pins the bias. An artifact with
+// no readable sidecar — one staged by an af predating this contract, or a truncated
+// write — keeps blocking exactly as it does today. Unknown is never a licence to
+// overwrite a binary.
+func TestForeignTransaction_UnknownArtifactFailsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		owner *artifactOwner
+	}{
+		{"no sidecar at all", nil},
+		{"incomplete record", &artifactOwner{ID: "old", HomeDir: "", PID: 0}},
+		{"no pid namespace (pre-contract)", &artifactOwner{ID: "old", HomeDir: t.TempDir(), PID: 4242, StartID: 7, BootID: currentBootIDForTest(t)}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			executable := stageArtifact(t, t.TempDir(), "old", tc.owner)
+			foreign, err := foreignTransactionOver(executable, "mine")
+			if err != nil {
+				t.Fatalf("foreignTransactionOver: %v", err)
+			}
+			if foreign != "old" {
+				t.Fatalf("an artifact we cannot read must keep blocking; got foreign=%q", foreign)
+			}
+		})
+	}
+}
+
+// TestArtifactOwner_MismatchedIDIsNotAuthoritative: a sidecar left beside a DIFFERENT
+// transaction's binaries must not speak for them, or a stale record could unblock an
+// artifact it never described.
+func TestArtifactOwner_MismatchedIDIsNotAuthoritative(t *testing.T) {
+	dir := t.TempDir()
+	home := t.TempDir()
+	executable := filepath.Join(dir, "af")
+	if err := os.WriteFile(executable, []byte("binary"), 0o755); err != nil { //nolint:gosec // test fixture
+		t.Fatalf("write executable: %v", err)
+	}
+	// A sidecar claiming id "other", written at id "dead"'s path.
+	owner := deadOwner(t, "other", home)
+	if err := writeArtifactOwner(artifactOwnerPath(executable, "dead"), owner); err != nil {
+		t.Fatalf("write owner: %v", err)
+	}
+	if _, err := readArtifactOwner(artifactOwnerPath(executable, "dead"), "dead"); err == nil {
+		t.Fatal("a sidecar naming another transaction must be rejected, not trusted")
+	}
+}
+
+// TestForeignTransaction_SurvivingStagerDoesNotBlockAfterJournalRemoval is the
+// headline case, and my first cut only fixed half of it.
+//
+// When AbortPreparedTransaction removes active.json and cleanup then fails before
+// deleting `.previous` — a recovery unit that no longer matches, say — the initiating
+// daemon is STILL RUNNING. Gating on stager liveness kept that daemon's own inert
+// artifact blocking forever, which is exactly the failure this change exists to
+// remove. Past the journal handoff the journal is the authority, whatever the stager
+// is doing.
+func TestForeignTransaction_SurvivingStagerDoesNotBlockAfterJournalRemoval(t *testing.T) {
+	dir := t.TempDir()
+	home := t.TempDir() // journal already removed
+	if err := os.MkdirAll(upgradeRoot(home), 0o700); err != nil {
+		t.Fatalf("mkdir upgrade root: %v", err)
+	}
+	// The stager is THIS process — alive by construction.
+	self, err := captureArtifactOwner(home, "aborted")
+	if err != nil {
+		t.Fatalf("captureArtifactOwner: %v", err)
+	}
+	self.Journalled = true
+	executable := stageArtifact(t, dir, "aborted", &self)
+
+	foreign, err := foreignTransactionOver(executable, "mine")
+	if err != nil {
+		t.Fatalf("foreignTransactionOver: %v", err)
+	}
+	if foreign != "" {
+		t.Fatalf("a live daemon's OWN finished transaction must not block; got foreign=%q", foreign)
+	}
+}
+
+// TestForeignTransaction_MissingHomeIsNotAFinishedTransaction: an unmounted or absent
+// home makes the journal Lstat report ErrNotExist for a reason that says nothing about
+// the transaction. Declaring it finished there would authorize overwriting a binary on
+// the strength of a filesystem being unavailable.
+func TestForeignTransaction_MissingHomeIsNotAFinishedTransaction(t *testing.T) {
+	dir := t.TempDir()
+	owner := deadOwner(t, "gone", filepath.Join(t.TempDir(), "not-mounted"))
+	owner.Journalled = true
+	executable := stageArtifact(t, dir, "gone", &owner)
+
+	foreign, err := foreignTransactionOver(executable, "mine")
+	if err != nil {
+		t.Fatalf("foreignTransactionOver: %v", err)
+	}
+	if foreign != "gone" {
+		t.Fatalf("an unreachable home must not read as a finished transaction; got foreign=%q", foreign)
+	}
+}
+
+// TestArtifactOwner_PIDOneIsValid: af runs as a container entrypoint, so pid 1 is a
+// legitimate stager. Rejecting it made that home's sidecar unreadable, which means
+// permanently blocking — the very outcome under repair.
+func TestArtifactOwner_PIDOneIsValid(t *testing.T) {
+	dir := t.TempDir()
+	owner := deadOwner(t, "pid1", t.TempDir())
+	owner.PID = 1
+	executable := filepath.Join(dir, "af")
+	if err := os.WriteFile(executable, []byte("binary"), 0o755); err != nil { //nolint:gosec // test fixture
+		t.Fatalf("write executable: %v", err)
+	}
+	path := artifactOwnerPath(executable, "pid1")
+	if err := writeArtifactOwner(path, owner); err != nil {
+		t.Fatalf("write owner: %v", err)
+	}
+	if _, err := readArtifactOwner(path, "pid1"); err != nil {
+		t.Fatalf("pid 1 is a legitimate container entrypoint owner: %v", err)
+	}
+}
+
+// TestForeignTransaction_ADifferentActiveTransactionDoesNotRevive: a home that
+// finished transaction A and later started B over another executable must not present
+// B's active.json as proof that A is live. Presence alone would have blocked A's
+// executable for every other home, permanently.
+func TestForeignTransaction_ADifferentActiveTransactionDoesNotRevive(t *testing.T) {
+	dir := t.TempDir()
+	home := t.TempDir()
+	active := activeJournalPath(home)
+	if err := os.MkdirAll(filepath.Dir(active), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(active, []byte(`{"id":"transaction-b"}`), 0o600); err != nil {
+		t.Fatalf("write active journal: %v", err)
+	}
+	owner := deadOwner(t, "transaction-a", home)
+	owner.Journalled = true
+	executable := stageArtifact(t, dir, "transaction-a", &owner)
+
+	foreign, err := foreignTransactionOver(executable, "mine")
+	if err != nil {
+		t.Fatalf("foreignTransactionOver: %v", err)
+	}
+	if foreign != "" {
+		t.Fatalf("another transaction's journal must not revive a finished one; got foreign=%q", foreign)
+	}
+}

--- a/internal/upgradetxn/install_lock.go
+++ b/internal/upgradetxn/install_lock.go
@@ -155,7 +155,7 @@ func withExecutableLock(executablePath string, nonblocking bool, fn func() error
 	return fn()
 }
 
-// foreignTransactionOver returns the id of a transaction other than selfID that
+// foreignTransactionOver returns the id of a LIVE transaction other than selfID that
 // has staged a preserved-previous binary beside executable, or "" when none has.
 //
 // It exists because a transaction is home-scoped while the executable is not.
@@ -187,6 +187,18 @@ func foreignTransactionOver(executable, selfID string) (string, error) {
 		}
 		id := strings.TrimSuffix(strings.TrimPrefix(name, prefix), ".previous")
 		if id == "" || id == selfID {
+			continue
+		}
+		// Present is not the same as LIVE. Cleanup that died after removing
+		// active.json but before deleting PreviousBinaryPath leaves this exact file
+		// with nothing behind it, and treating the name as proof blocks every future
+		// upgrade over this executable forever — with no escape hatch for a
+		// daemon-owned upgrade (#2212 gate 4). Ask the artifact instead.
+		inert, err := artifactIsInert(executable, id)
+		if err != nil {
+			return "", err
+		}
+		if inert {
 			continue
 		}
 		return id, nil

--- a/internal/upgradetxn/prepare.go
+++ b/internal/upgradetxn/prepare.go
@@ -181,6 +181,39 @@ func Prepare(stablePlan Plan) (_ *Transaction, retErr error) {
 		}
 	}
 
+	// The artifacts must say who owns them BEFORE they exist, or the window between
+	// staging and describing is one where another home reads them as anonymous — and
+	// an anonymous artifact blocks forever by design (#2212 gate 4).
+	//
+	// Written AFTER the collision check above, never before: an id whose artifacts
+	// already belong to an earlier attempt or another home must be refused untouched.
+	// Writing first would overwrite that owner's record and then delete it on the way
+	// out, leaving THEIR binaries anonymous — manufacturing the permanent block this
+	// change exists to remove.
+	ownerRecord, err := captureArtifactOwner(home, stablePlan.ID)
+	if err != nil {
+		return nil, err
+	}
+	ownerPath := artifactOwnerPath(executable, stablePlan.ID)
+	if _, err := os.Lstat(ownerPath); err == nil {
+		return nil, fmt.Errorf("upgrade artifact owner already exists at %s", ownerPath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("inspect upgrade artifact owner %s: %w", ownerPath, err)
+	}
+	if err := writeArtifactOwner(ownerPath, ownerRecord); err != nil {
+		return nil, err
+	}
+	// Removed in its OWN defer, registered before the binaries are appended to
+	// createdArtifacts so it runs after that loop (defers are LIFO). A cleanup that
+	// dies partway must leave an owner record with no binaries — which blocks nothing
+	// — rather than binaries with no owner, which block this executable forever.
+	defer func() {
+		if published {
+			return
+		}
+		_ = os.Remove(ownerPath)
+	}()
+
 	mode := executableInfo.Mode().Perm()
 	createdArtifacts = append(createdArtifacts, previousPath)
 	if err := durableAtomicWriteFile(previousPath, previousBinary, mode); err != nil {
@@ -226,5 +259,27 @@ func Prepare(stablePlan Plan) (_ *Transaction, retErr error) {
 		return nil, fmt.Errorf("publish upgrade journal: %w", err)
 	}
 	published = true
+	// Hand authority to the journal. From here the journal's ABSENCE means the
+	// transaction is over, so a later scan must stop consulting this process's
+	// liveness: a daemon that survives a failed cleanup is still running, and gating
+	// on it would keep its own inert artifact blocking forever.
+	//
+	// Written after the journal is durable so the two can never disagree in the
+	// dangerous direction — a sidecar claiming the handoff before the journal exists
+	// would let a crash mid-publish read as finished.
+	//
+	// REQUIRED, not best-effort. A silent failure here leaves the sidecar saying
+	// pre-handoff while the journal exists, and the pre-handoff rule consults stager
+	// liveness — so a later abort that removes active.json but fails to delete
+	// .previous would block this executable permanently, which is precisely the defect
+	// under repair. Failing loudly here costs one retry; succeeding quietly costs the
+	// guarantee.
+	ownerRecord.Journalled = true
+	if err := writeArtifactOwner(ownerPath, ownerRecord); err != nil {
+		if abortErr := (&Transaction{journal: journal}).abort(); abortErr != nil {
+			return nil, fmt.Errorf("mark artifact owner journalled: %w (and rolling the transaction back failed: %v)", err, abortErr)
+		}
+		return nil, fmt.Errorf("mark artifact owner journalled: %w", err)
+	}
 	return &Transaction{journal: journal}, nil
 }

--- a/internal/upgradetxn/storage.go
+++ b/internal/upgradetxn/storage.go
@@ -828,6 +828,14 @@ func (t *Transaction) cleanupInactiveArtifacts() error {
 	if err := removeDurableFile(t.journal.PreviousBinaryPath); err != nil {
 		return fmt.Errorf("remove previous-binary cleanup actor: %w", err)
 	}
+	// The sidecar goes with the binaries it describes, and AFTER them on purpose: if
+	// this crashes between the two, what survives is an artifact-less owner record,
+	// which blocks nothing. Removing it first would leave the reverse — a `.previous`
+	// with no owner, which blocks this executable forever, i.e. the very leftover
+	// this contract exists to make impossible (#2212 gate 4).
+	if err := removeArtifactOwner(t.journal.ExecutablePath, t.journal.ID); err != nil {
+		return err
+	}
 	if err := removeDurableFile(recoveryLockPath(t.journal.HomeDir, t.journal.ID)); err != nil {
 		return fmt.Errorf("remove inactive recovery lock: %w", err)
 	}


### PR DESCRIPTION
**#2212 gate 4** from the running gate list — the one self-contained item on it. Not
the epic, not the default flip: activation stays off.

## The bug

`foreignTransactionOver` decided from the **filename alone**. A
`.<base>.af-upgrade-<id>.previous` left behind when cleanup died *after* removing
`active.json` but *before* deleting `PreviousBinaryPath` read as a live foreign
transaction, and `Prepare` refused.

The asymmetry is what makes it a gate rather than a nuisance: the in-place installer
has `--ignore-active-upgrade`, while an **opted-in daemon has no escape hatch at all**.
One stray dotfile beside a shared executable fails every future daemon-owned upgrade
until a human deletes it — the unoverridable-block shape this epic was already bitten
by (#2859).

## Why the obvious repairs stay rejected

Recorded on the issue, and I agree with all three:

- **Read the owning journal** — impossible from a filename that names a transaction id
  and no home, with no registry to resolve one against. That is *why* the scan exists.
- **Age the artifact out** — a timestamp is never authority for overwriting a binary a
  live transaction may still be preserving as its rollback source.
- **Give the daemon an override** — an unattended actor silently stepping over a safety
  interlock is worse than the block.

## What this does

Makes the artifact **self-describing**. `Prepare` writes an owner sidecar beside the
staged binaries naming the transaction's **home** and the process that staged it, and
the scan asks it. "Inert leftover" becomes a positive observation instead of an
inference — and the cross-home objection dissolves, because the sidecar carries the
pointer the filename lacked.

**Inert requires BOTH conditions**, because they rule out different survivors:

| condition | the survivor it rules out |
|---|---|
| owning home has no active journal | a transaction whose process died mid-flight but is **resumable** — its `.previous` is the rollback source, and publishing over that executable would interleave the two |
| staging process is gone | a prepare **still running**, which has not written its journal yet, so an absent `active.json` would read as "finished" during the exact window the interlock exists for |

Process liveness alone misses the first; journal absence alone misses the second. This
is why an flock held by the owner is *not* sufficient here — a transaction can outlive
the process that started it.

**Fail-closed on doubt.** An artifact with no readable sidecar keeps blocking exactly as
today: it may predate this contract, or belong to a live transaction whose sidecar we
cannot read, and neither is a licence to overwrite a binary. The window that leaves is
bounded by activation being off by default, so no unattended path reaches it.

**Ordering.** The sidecar is removed *after* the binaries it describes. A crash between
the two then leaves an artifact-less owner record, which blocks nothing — rather than
the reverse, a `.previous` with no owner, which is the very leftover this makes
impossible.

## Tests

`go test ./internal/upgradetxn/` — non-daemon, so run locally:

- an inert leftover (no active journal, dead stager) no longer blocks;
- a **resumable** transaction (dead stager, journal still active) still blocks;
- a **live** stager (no journal yet) still blocks;
- an unreadable or incomplete sidecar still blocks — the bias, pinned;
- a sidecar naming a *different* transaction is rejected rather than trusted.

## Scope

Deliberately avoids `prepare.go`'s lock region, since #2952 is open there and already
conflicting. The one edit to that file is in the artifact-staging block, well clear of
it.

Refs #2212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
