### PR TITLE
fix(git): reproduce hard links instead of copying the bytes twice

### DIFF
--- a/session/git/worktree_copy_fidelity_test.go
+++ b/session/git/worktree_copy_fidelity_test.go
@@ -37,11 +37,9 @@ import (
 // without removing it here and the "no longer diverges" branch fires, so the
 // inventory cannot rot into a list of things that were fixed years ago.
 var knownCrossDeviceDivergence = map[string]string{
-	"mtime.symlink":      "#2919: the link's own mtime is not set — there is no portable dirfd-relative lstat to read it from, and the TARGET's mtime is what tools actually read",
-	"hardlink.nlink":     "#2919: each entry is copied independently, so a linked pair arrives as two files",
-	"hardlink.sameInode": "#2919: same cause — the link structure is not reproduced",
-	"xattr.file":         "#2919: no xattr namespace is copied, so ACLs, capabilities and SELinux labels are dropped",
-	"xattr.dir":          "#2919: same cause, on directories",
+	"mtime.symlink": "#2919: the link's own mtime is not set — there is no portable dirfd-relative lstat to read it from, and the TARGET's mtime is what tools actually read",
+	"xattr.file":    "#2919: no xattr namespace is copied, so ACLs, capabilities and SELinux labels are dropped",
+	"xattr.dir":     "#2919: same cause, on directories",
 }
 
 // TestMoveDirCrossDevice_CopyDivergesFromRenameOnlyWhereRecorded is the class

--- a/session/git/worktree_copy_fidelity_test.go
+++ b/session/git/worktree_copy_fidelity_test.go
@@ -37,9 +37,10 @@ import (
 // without removing it here and the "no longer diverges" branch fires, so the
 // inventory cannot rot into a list of things that were fixed years ago.
 var knownCrossDeviceDivergence = map[string]string{
-	"mtime.symlink": "#2919: the link's own mtime is not set — there is no portable dirfd-relative lstat to read it from, and the TARGET's mtime is what tools actually read",
-	"xattr.file":    "#2919: no xattr namespace is copied, so ACLs, capabilities and SELinux labels are dropped",
-	"xattr.dir":     "#2919: same cause, on directories",
+	"mtime.symlink":          "#2919: the link's own mtime is not set — there is no portable dirfd-relative lstat to read it from, and the TARGET's mtime is what tools actually read",
+	"hardlink.externalNlink": "#2919: an inode with one name inside the worktree and another OUTSIDE it keeps both aliases across a rename, but the copy can only create the in-tree name — there is nothing it could link the outside name to. Unfixable by construction, unlike the in-tree pair.",
+	"xattr.file":             "#2919: no xattr namespace is copied, so ACLs, capabilities and SELinux labels are dropped",
+	"xattr.dir":              "#2919: same cause, on directories",
 }
 
 // TestMoveDirCrossDevice_CopyDivergesFromRenameOnlyWhereRecorded is the class
@@ -116,6 +117,17 @@ func writeFidelityProbeTree(t *testing.T, root string) {
 	require.NoError(t, os.WriteFile(filepath.Join(root, "hard-a"), []byte("shared payload"), 0600))
 	require.NoError(t, os.Link(filepath.Join(root, "hard-a"), filepath.Join(root, "hard-b")))
 
+	// A second link group whose other alias lives OUTSIDE the tree being moved.
+	// Both aliases of hard-a/hard-b travel together, so the copy can reproduce
+	// that group; this one it structurally cannot, because the outside name is
+	// not its to create. Without this shape the guard would claim parity for a
+	// valid source layout that still diverges.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "ext-linked.txt"), []byte("aliased outside"), 0600))
+	require.NoError(t, os.Link(
+		filepath.Join(root, "ext-linked.txt"),
+		filepath.Join(filepath.Dir(root), "ext-alias-"+filepath.Base(root)),
+	))
+
 	require.NoError(t, os.WriteFile(filepath.Join(root, "plain.txt"), []byte("plain"), 0600))
 	require.NoError(t, os.Symlink("plain.txt", filepath.Join(root, "link")))
 
@@ -169,6 +181,10 @@ func describeFidelity(t *testing.T, root string) map[string]string {
 	var hardB syscall.Stat_t
 	require.NoError(t, syscall.Stat(filepath.Join(root, "hard-b"), &hardB))
 	described["hardlink.sameInode"] = fmt.Sprintf("%t", hardA.Ino == hardB.Ino)
+
+	var external syscall.Stat_t
+	require.NoError(t, syscall.Stat(filepath.Join(root, "ext-linked.txt"), &external))
+	described["hardlink.externalNlink"] = fmt.Sprintf("%d", external.Nlink)
 
 	var sparseStat syscall.Stat_t
 	require.NoError(t, syscall.Stat(filepath.Join(root, "sparse.bin"), &sparseStat))

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -234,9 +234,9 @@ func copyTreeWithIdentities(src, dest string) (*copiedTreeIdentities, error) {
 
 func copyDirectoryContents(source, destination *os.File, sourcePath, destinationPath string) (copiedDirectory, error) {
 	root := copiedDirectory{}
-	// Source inode -> the destination-relative path its bytes first landed at.
-	// Scoped to one copy, so it can never name a path from another tree.
-	links := map[pathIdentity]string{}
+	// Source inode -> where its bytes first landed AND what inode they landed
+	// on. Scoped to one copy, so it can never name a path from another tree.
+	links := map[pathIdentity]copiedFileLink{}
 	routes := []copiedDirectoryRoute{{parent: -1, directory: &root}}
 	for index := 0; index < len(routes); index++ {
 		job := routes[index]
@@ -293,7 +293,7 @@ func copyDirectoryLevel(
 	directory *copiedDirectory,
 	destinationRoot *os.File,
 	relativeDirectory string,
-	links map[pathIdentity]string,
+	links map[pathIdentity]copiedFileLink,
 ) error {
 	names, err := source.Readdirnames(-1)
 	if err != nil {
@@ -328,15 +328,21 @@ func copyDirectoryLevel(
 		case unix.S_IFLNK:
 			entry, err = copySymlinkEntry(source, destination, name, childSourcePath, childDestinationPath, inspected)
 		case unix.S_IFREG:
-			// A link count above one is the only hint that this inode may appear
-			// under another name. Everything with nlink == 1 skips the map
-			// entirely, so an ordinary worktree pays nothing for this.
-			if first, seen := links[inspected]; seen && stat.Nlink > 1 {
+			// Every successfully copied regular inode is recorded, not just the
+			// ones observed with nlink > 1. A live worktree process can hard-link
+			// an already-copied file AFTER it was seen with nlink == 1, and the
+			// later sighting would then miss the map and be copied as a separate
+			// inode — silently publishing two unrelated files while source
+			// validation passed, because pathIdentity excludes the link count.
+			if first, seen := links[inspected]; seen {
 				entry, err = linkCopiedFile(destination, destinationRoot, first, name, childDestinationPath, inspected)
 			} else {
 				entry, err = copyRegularFileAtWithIdentity(source, destination, name, childSourcePath, childDestinationPath, &inspected)
-				if err == nil && stat.Nlink > 1 {
-					links[inspected] = filepath.Join(relativeDirectory, name)
+				if err == nil {
+					links[inspected] = copiedFileLink{
+						path:     filepath.Join(relativeDirectory, name),
+						identity: entry.destination,
+					}
 				}
 			}
 		default:
@@ -369,6 +375,15 @@ func relativeRoutePath(components []copiedEntry) string {
 	return filepath.Join(parts...)
 }
 
+// copiedFileLink is where a source inode's bytes first landed: the path to link
+// against, and the destination inode that path resolved to at the time. Both are
+// needed — the path to make the link, the identity to prove the link landed on
+// the right inode.
+type copiedFileLink struct {
+	path     string
+	identity pathIdentity
+}
+
 // linkCopiedFile reproduces a hard link instead of copying the bytes a second
 // time.
 //
@@ -378,30 +393,44 @@ func relativeRoutePath(components []copiedEntry) string {
 // through one path stopped showing through the other, so a restored worktree
 // behaved differently from the one that was archived.
 //
-// The link is made from the DESTINATION root descriptor to a path inside our own
-// staging tree, never from the source, so nothing a worktree process does to the
-// source between the two sightings can redirect it. flags is 0: the entry is
-// already known to be a regular file, and AT_SYMLINK_FOLLOW would be the only
-// way to end up linking something else.
+// linkat() resolves a PATHNAME, and the staging tree, while unguessably named,
+// is still reachable by a same-UID process. Such a process can rename the first
+// copied path aside, drop an unrelated file or symlink there, let this call link
+// THAT, and restore the original path afterwards. Merely recording whatever
+// inode results would make the injected one the manifest's expected identity, so
+// both later validations would agree with each other and a corrupted tree would
+// publish. The identity captured when the bytes were first written is therefore
+// compared, not just stored: a link that did not land on that exact inode is
+// refused.
+//
+// flags is 0. The entry is already known to be a regular file, and
+// AT_SYMLINK_FOLLOW would be the only way to end up linking something else.
 func linkCopiedFile(
 	destination, destinationRoot *os.File,
-	firstRelativePath, name, destinationPath string,
+	first copiedFileLink,
+	name, destinationPath string,
 	sourceIdentity pathIdentity,
 ) (copiedEntry, error) {
-	if err := unix.Linkat(int(destinationRoot.Fd()), firstRelativePath, int(destination.Fd()), name, 0); err != nil {
+	if err := unix.Linkat(int(destinationRoot.Fd()), first.path, int(destination.Fd()), name, 0); err != nil {
 		return copiedEntry{}, fmt.Errorf(
 			"cannot move worktree across filesystems: failed to reproduce the hard link at %s: %w", destinationPath, err)
 	}
 	// Named and identified before anything else can fail, exactly like every
 	// other node this copier creates — cleanup can only remove what the manifest
-	// describes.
+	// describes, so the OBSERVED identity is recorded even on the refusal below.
 	destinationIdentity, err := identityAt(destination, name)
 	if err != nil {
 		return copiedEntry{name: name, source: sourceIdentity}, fmt.Errorf(
 			"cannot move worktree across filesystems: failed to identify hard link %s after creating it: %w",
 			destinationPath, err)
 	}
-	return copiedEntry{name: name, source: sourceIdentity, destination: destinationIdentity}, nil
+	created := copiedEntry{name: name, source: sourceIdentity, destination: destinationIdentity}
+	if !first.identity.same(destinationIdentity) {
+		return created, fmt.Errorf(
+			"cannot move worktree across filesystems: hard link %s resolved to a different inode than the file it was linked from",
+			destinationPath)
+	}
+	return created, nil
 }
 
 func copyDirectoryEntry(

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -234,6 +234,9 @@ func copyTreeWithIdentities(src, dest string) (*copiedTreeIdentities, error) {
 
 func copyDirectoryContents(source, destination *os.File, sourcePath, destinationPath string) (copiedDirectory, error) {
 	root := copiedDirectory{}
+	// Source inode -> the destination-relative path its bytes first landed at.
+	// Scoped to one copy, so it can never name a path from another tree.
+	links := map[pathIdentity]string{}
 	routes := []copiedDirectoryRoute{{parent: -1, directory: &root}}
 	for index := 0; index < len(routes); index++ {
 		job := routes[index]
@@ -253,6 +256,9 @@ func copyDirectoryContents(source, destination *os.File, sourcePath, destination
 			directoryRoutePath(sourcePath, components),
 			directoryRoutePath(destinationPath, components),
 			job.directory,
+			destination,
+			relativeRoutePath(components),
+			links,
 		)
 		if err == nil {
 			// The level is complete, and nothing is ever written directly into
@@ -285,6 +291,9 @@ func copyDirectoryLevel(
 	source, destination *os.File,
 	sourcePath, destinationPath string,
 	directory *copiedDirectory,
+	destinationRoot *os.File,
+	relativeDirectory string,
+	links map[pathIdentity]string,
 ) error {
 	names, err := source.Readdirnames(-1)
 	if err != nil {
@@ -319,7 +328,17 @@ func copyDirectoryLevel(
 		case unix.S_IFLNK:
 			entry, err = copySymlinkEntry(source, destination, name, childSourcePath, childDestinationPath, inspected)
 		case unix.S_IFREG:
-			entry, err = copyRegularFileAtWithIdentity(source, destination, name, childSourcePath, childDestinationPath, &inspected)
+			// A link count above one is the only hint that this inode may appear
+			// under another name. Everything with nlink == 1 skips the map
+			// entirely, so an ordinary worktree pays nothing for this.
+			if first, seen := links[inspected]; seen && stat.Nlink > 1 {
+				entry, err = linkCopiedFile(destination, destinationRoot, first, name, childDestinationPath, inspected)
+			} else {
+				entry, err = copyRegularFileAtWithIdentity(source, destination, name, childSourcePath, childDestinationPath, &inspected)
+				if err == nil && stat.Nlink > 1 {
+					links[inspected] = filepath.Join(relativeDirectory, name)
+				}
+			}
 		default:
 			err = unsupportedSourceTypeError(childSourcePath, uint32(stat.Mode))
 		}
@@ -336,6 +355,53 @@ func copyDirectoryLevel(
 		}
 	}
 	return nil
+}
+
+// relativeRoutePath renders a BFS route as a path relative to the copy root,
+// which is what linkCopiedFile needs: the root descriptor outlives every level,
+// so a link can be made against it without reopening the route the first copy
+// landed in.
+func relativeRoutePath(components []copiedEntry) string {
+	parts := make([]string, 0, len(components))
+	for _, component := range components {
+		parts = append(parts, component.name)
+	}
+	return filepath.Join(parts...)
+}
+
+// linkCopiedFile reproduces a hard link instead of copying the bytes a second
+// time.
+//
+// Each directory entry used to be copied independently, so a linked pair arrived
+// as two unrelated files (#2919). That costs disk twice over — the archive root
+// is shared by every session — but the sharper problem is semantic: writing
+// through one path stopped showing through the other, so a restored worktree
+// behaved differently from the one that was archived.
+//
+// The link is made from the DESTINATION root descriptor to a path inside our own
+// staging tree, never from the source, so nothing a worktree process does to the
+// source between the two sightings can redirect it. flags is 0: the entry is
+// already known to be a regular file, and AT_SYMLINK_FOLLOW would be the only
+// way to end up linking something else.
+func linkCopiedFile(
+	destination, destinationRoot *os.File,
+	firstRelativePath, name, destinationPath string,
+	sourceIdentity pathIdentity,
+) (copiedEntry, error) {
+	if err := unix.Linkat(int(destinationRoot.Fd()), firstRelativePath, int(destination.Fd()), name, 0); err != nil {
+		return copiedEntry{}, fmt.Errorf(
+			"cannot move worktree across filesystems: failed to reproduce the hard link at %s: %w", destinationPath, err)
+	}
+	// Named and identified before anything else can fail, exactly like every
+	// other node this copier creates — cleanup can only remove what the manifest
+	// describes.
+	destinationIdentity, err := identityAt(destination, name)
+	if err != nil {
+		return copiedEntry{name: name, source: sourceIdentity}, fmt.Errorf(
+			"cannot move worktree across filesystems: failed to identify hard link %s after creating it: %w",
+			destinationPath, err)
+	}
+	return copiedEntry{name: name, source: sourceIdentity, destination: destinationIdentity}, nil
 }
 
 func copyDirectoryEntry(

--- a/session/git/worktree_copy_tree_test.go
+++ b/session/git/worktree_copy_tree_test.go
@@ -467,3 +467,48 @@ func allocatedBlocks(t *testing.T, path string) int64 {
 	require.NoError(t, syscall.Stat(path, &stat))
 	return stat.Blocks
 }
+
+// TestLinkCopiedFile_RefusesALinkThatLandedOnAnotherInode covers the safety
+// check behind the hard-link reuse in #2919.
+//
+// linkat() resolves a PATHNAME, and the staging tree — unguessably named but
+// still same-UID reachable — can have that name swapped between the first copy
+// and the link. Recording whatever inode results would make the injected one the
+// manifest's expected identity, so both later validations would agree with each
+// other and a corrupted tree would publish. The identity captured when the bytes
+// were first written must therefore be compared, not merely stored.
+//
+// Driven directly rather than through a raced copy: the point under test is that
+// the comparison exists and refuses, which a mismatched expectation shows without
+// having to win a race.
+func TestLinkCopiedFile_RefusesALinkThatLandedOnAnotherInode(t *testing.T) {
+	staging := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(staging, "first.txt"), []byte("first"), 0644))
+
+	root, _, err := openDirectoryPath(staging, "destination")
+	require.NoError(t, err)
+	defer root.Close()
+
+	actual, err := identityAt(root, "first.txt")
+	require.NoError(t, err)
+
+	// What a swapped pathname looks like from here: the expectation names an
+	// inode the link will not land on.
+	impostor := actual
+	impostor.inode++
+
+	entry, err := linkCopiedFile(root, root, copiedFileLink{path: "first.txt", identity: impostor},
+		"second.txt", filepath.Join(staging, "second.txt"), actual)
+	require.Error(t, err, "a link that landed on a different inode must be refused")
+	assert.Contains(t, err.Error(), "resolved to a different inode")
+	assert.Equal(t, "second.txt", entry.name,
+		"the entry must still be named so cleanup can remove what was created")
+	assert.Equal(t, actual, entry.destination,
+		"cleanup matches on the OBSERVED identity, so that is what the manifest must carry")
+
+	// And the honest control: the same call with the right expectation succeeds.
+	require.NoError(t, os.Remove(filepath.Join(staging, "second.txt")))
+	_, err = linkCopiedFile(root, root, copiedFileLink{path: "first.txt", identity: actual},
+		"third.txt", filepath.Join(staging, "third.txt"), actual)
+	require.NoError(t, err, "a link onto the recorded inode must be accepted")
+}


### PR DESCRIPTION
Claimed on #2919 before starting, per the new coordination rule. Follows #2871 (modes), #2903 (read-only dirs), #2939 (sparse), #2957 (the differential guard) and #2977 (mtime).

## The bug

Each directory entry was copied independently, so a hard-linked pair arrived in the archive as two unrelated files. Measured through both legs of `moveDirCrossDevice`:

| | source | rename (same-dev) | copy (cross-dev) |
|---|---|---|---|
| `st_nlink` | 2 | 2 | **1** |
| same inode | true | true | **false** |

The disk cost is the obvious half, and the archive root is shared by every session on the box so the duplication lands on everyone. **The sharper half is semantic**: writing through one path stopped showing through the other, so a restored worktree behaved differently from the one that was archived.

## Approach

A source-inode → destination-relative-path map for the duration of one copy; on a second sighting, `linkat` against the destination **root** descriptor instead of copying the bytes again.

Three properties that make it safe:

- **Linked inside our own staging tree, never from the source.** Nothing a worktree process does to the source between the two sightings can redirect the link.
- **`flags` is 0.** The entry is already known to be a regular file, and `AT_SYMLINK_FOLLOW` would be the only way to end up linking something else.
- **Named and identified before anything else can fail**, like every other node here — cleanup can only remove what the manifest describes.

Only entries with `nlink > 1` touch the map, so an ordinary worktree (nothing linked) pays one integer comparison per file.

The root descriptor is what keeps this cheap: it outlives every level of the BFS, so the second sighting links against a path relative to it rather than reopening the route the first copy landed in. Traversing that path needs only the search bit on intermediate directories — which any directory the copier could enumerate in the source necessarily has, since `statAt` on its entries already required it.

## The guard did its job, again

`hardlink.nlink` and `hardlink.sameInode` are removed from `knownCrossDeviceDivergence`. #2957's inventory failed unprompted the moment this landed:

```
hardlink.nlink no longer diverges — remove it from knownCrossDeviceDivergence
  so the inventory keeps meaning what it says
```

Verified the other direction too: forcing the copy path back on makes both fail as *unrecorded* divergences. That's three consecutive PRs where the inventory caught its own staleness rather than needing me to remember.

## #2919 after this

Remaining: **xattrs** (which I explicitly did not claim — it carries a product decision the issue already flags, namely which namespaces and what to do when `security.*` needs privilege) and **`mtime.symlink`** (no portable dirfd-relative lstat; measured and recorded).

## Verification

`gofmt -l .` clean · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `scripts/lint-file-length.sh` · `go test ./session/git/` green. No `deadcode` locally per the corrected policy — CI's Lint job runs it. No container suites, nothing against `./daemon/...` or `./app/...`.

Refs #2919