### PR TITLE
fix(archive): preserve a symlink's own mtime across a cross-device move

### DIFF
--- a/session/git/worktree_copy_fidelity_test.go
+++ b/session/git/worktree_copy_fidelity_test.go
@@ -37,7 +37,6 @@ import (
 // without removing it here and the "no longer diverges" branch fires, so the
 // inventory cannot rot into a list of things that were fixed years ago.
 var knownCrossDeviceDivergence = map[string]string{
-	"mtime.symlink":      "#2919: the link's own mtime is not set — there is no portable dirfd-relative lstat to read it from, and the TARGET's mtime is what tools actually read",
 	"hardlink.nlink":     "#2919: each entry is copied independently, so a linked pair arrives as two files",
 	"hardlink.sameInode": "#2919: same cause — the link structure is not reproduced",
 	"xattr.file":         "#2919: no xattr namespace is copied, so ACLs, capabilities and SELinux labels are dropped",
@@ -201,9 +200,10 @@ func describeFidelity(t *testing.T, root string) map[string]string {
 	for property, path := range map[string]string{
 		"mtime.file": filepath.Join(root, "plain.txt"),
 		"mtime.dir":  filepath.Join(root, "dir"),
-		// The link's OWN mtime, via Lstat. Measured even though it is not
-		// preserved: an unmeasured gap is exactly how this class kept
-		// recurring — a property nobody listed could not fail anything.
+		// The link's OWN mtime, via Lstat — not its target's. Listing it here
+		// while it was still unpreserved is what made fixing it a one-line
+		// change with a test already watching: a property nobody measures
+		// cannot fail anything, which is how this class kept recurring.
 		"mtime.symlink": filepath.Join(root, "link"),
 	} {
 		info, err := os.Lstat(path)

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -397,10 +397,15 @@ func copySymlinkEntry(
 	if err != nil {
 		return copiedEntry{}, err
 	}
-	current, err := identityAt(source, name)
-	if err != nil || !inspected.same(current) {
+	// One stat serves both questions: is this still the node we inspected, and
+	// what is its own mtime. Reading them separately would let the link be
+	// replaced between the two, so the timestamp written could belong to a
+	// different node than the one whose identity was confirmed.
+	sourceStat, err := statAt(source, name)
+	if err != nil || !inspected.same(identityFromStat(sourceStat)) {
 		return copiedEntry{}, fmt.Errorf("cannot move worktree across filesystems: source symlink %s changed while it was copied", sourcePath)
 	}
+	sourceModTime := time.Unix(sourceStat.Mtim.Unix())
 	if err := unix.Symlinkat(link, int(destination.Fd()), name); err != nil {
 		return copiedEntry{}, fmt.Errorf("cannot move worktree across filesystems: failed to create destination symlink %s exclusively: %w", destinationPath, err)
 	}
@@ -421,6 +426,18 @@ func copySymlinkEntry(
 	confirmedIdentity, err := identityAt(destination, name)
 	if err != nil || !destinationIdentity.same(confirmedIdentity) || destinationLink != link {
 		return created, fmt.Errorf("cannot move worktree across filesystems: destination symlink %s changed while it was copied", destinationPath)
+	}
+	// The LINK's own mtime, not its target's (#2919). preserveSourceModTime
+	// passes AT_SYMLINK_NOFOLLOW, so this stamps the symlink itself; without it
+	// the copy reads "now" while the same-device rename preserves it, which is
+	// one move behaving two ways depending on which filesystem the archive root
+	// happens to sit on — the same divergence the mode and file-mtime work
+	// closed.
+	//
+	// Last, after the identity re-check, for the ordering reason the directory
+	// stamp documents: anything written to a node afterwards restamps it.
+	if err := preserveSourceModTime(int(destination.Fd()), name, sourceModTime, destinationPath, "symlink"); err != nil {
+		return created, err
 	}
 	return created, nil
 }


### PR DESCRIPTION
Refs #2919 — the **symlink timestamps** sub-item only. xattrs and hardlink structure remain open and are untouched here.

Claimed on the issue before starting, per the new protocol.

## The gap

A same-device archive is `rename(2)` and keeps every timestamp. The cross-device copy stamped symlinks at copy time — so one move behaved two ways depending on which filesystem the archive root happened to sit on, which is the divergence the mode work (#2869) and the file-mtime work already closed for other node types.

`copySymlinkEntry` created the link, identified it, ran the post-create hook and re-verified the target — but never called `preserveSourceModTime`. Files and directories both get that call; symlinks were the one that didn't.

## The recorded reason was wrong, and that is the interesting part

The inventory entry tracking this gap said:

> the link's own mtime is not set — **there is no portable dirfd-relative lstat to read it from**, and the TARGET's mtime is what tools actually read

Neither half holds. `statAt` **is** a dirfd-relative lstat (`unix.Fstatat` with `AT_SYMLINK_NOFOLLOW`), and this very function already called it through `identityAt`, on the exact node in question. `preserveSourceModTime` likewise already passes `AT_SYMLINK_NOFOLLOW`, so it stamps the link rather than its target.

Both halves of the mechanism were already present and already wired to this code path. Nothing blocked the fix except the belief that something did — and a *false* obstacle in an inventory is worse than no entry at all, because it stops the next person from looking.

## Correctness details

One stat now answers both questions — *is this still the node we inspected* and *what is its mtime* — so the timestamp written cannot belong to a node other than the one whose identity was confirmed. Reading them separately would leave a window for the link to be replaced between the two, which matters in a copier whose entire premise is that a worktree process can replace any pathname mid-copy.

The stamp goes **last**, after the identity re-check, for the ordering reason the directory stamp already documents: anything written to a node afterwards restamps it.

## Verification

Watched it fail first, and the existing harness did the work. `knownCrossDeviceDivergence` fails in **both** directions by design, so implementing the fix while `mtime.symlink` was still listed produced:

```
mtime.symlink no longer diverges (source=2001-09-09T01:46:40Z copy=2001-09-09T01:46:40Z)
 — remove it from knownCrossDeviceDivergence so the inventory keeps meaning what it says
```

Both sides now carry the fixture's stamped time rather than "now". Removing the entry turns it green.

That property had been deliberately **measured but unpreserved** — the harness comment says an unmeasured gap is how this class kept recurring. That decision is exactly what made this a one-line change with a test already watching, and I have updated the comment to say so rather than leaving it claiming the property is unpreserved.

Local gate: full `./session/git` package (23.7s, the package I changed — non-daemon, non-app), `gofmt -l .` empty, `go build ./...`, `golangci-lint --fast`, `scripts/lint-file-length.sh`. No `deadcode`, no containerized suite, nothing against `./daemon/...` or `./app/...` — CI runs those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
