### PR TITLE
fix(git): stamp a copied symlink with the link's own mtime

### DIFF
--- a/session/git/worktree_copy_fidelity_test.go
+++ b/session/git/worktree_copy_fidelity_test.go
@@ -37,7 +37,6 @@ import (
 // without removing it here and the "no longer diverges" branch fires, so the
 // inventory cannot rot into a list of things that were fixed years ago.
 var knownCrossDeviceDivergence = map[string]string{
-	"mtime.symlink":      "#2919: the link's own mtime is not set — there is no portable dirfd-relative lstat to read it from, and the TARGET's mtime is what tools actually read",
 	"hardlink.nlink":     "#2919: each entry is copied independently, so a linked pair arrives as two files",
 	"hardlink.sameInode": "#2919: same cause — the link structure is not reproduced",
 	"xattr.file":         "#2919: no xattr namespace is copied, so ACLs, capabilities and SELinux labels are dropped",

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -397,12 +397,24 @@ func copySymlinkEntry(
 	if err != nil {
 		return copiedEntry{}, err
 	}
-	current, err := identityAt(source, name)
-	if err != nil || !inspected.same(current) {
+	// One stat serves both the identity re-check and the timestamp: sampling the
+	// source twice would open a second window in which the name could be swapped
+	// between the two reads, and the copier's whole discipline is that a fact
+	// about a name is only good for the sample it came from.
+	sourceStat, err := statAt(source, name)
+	if err != nil || !inspected.same(identityFromStat(sourceStat)) {
 		return copiedEntry{}, fmt.Errorf("cannot move worktree across filesystems: source symlink %s changed while it was copied", sourcePath)
 	}
 	if err := unix.Symlinkat(link, int(destination.Fd()), name); err != nil {
 		return copiedEntry{}, fmt.Errorf("cannot move worktree across filesystems: failed to create destination symlink %s exclusively: %w", destinationPath, err)
+	}
+	// The LINK's own mtime, not its target's. preserveSourceModTime already
+	// passes AT_SYMLINK_NOFOLLOW, so this stamps the link itself and can never
+	// follow it out of the tree — the same reason that flag is there for files.
+	if err := preserveSourceModTime(
+		int(destination.Fd()), name, symlinkModTime(sourceStat), destinationPath, "symlink",
+	); err != nil {
+		return copiedEntry{}, err
 	}
 	// Identify the node right after creating it: every later step can fail, and
 	// the caller can only record what it can name and identify.
@@ -552,6 +564,24 @@ func isAllZero(chunk []byte) bool {
 // therefore NOT preserved, deliberately — it is rewritten by any read, most
 // filesystems mount relatime so it is already approximate, and nothing in a
 // worktree depends on it. mtime is the property tools actually read.
+// symlinkModTime reads a link's own modification time out of the stat that
+// identified it.
+//
+// No build tag, and that is worth recording because the inventory entry this
+// replaces said there was "no portable dirfd-relative lstat to read it from".
+// There is: statAt is one, used on every entry already. The field spelling is
+// portable too — x/sys/unix.Stat_t calls it Mtim on Linux, darwin and the BSDs
+// alike. Mtimespec is the STDLIB syscall.Stat_t spelling on darwin, which is a
+// different type this copier does not use. Verified by cross-building, not by
+// reading: GOOS=darwin and GOOS=freebsd.
+//
+// TimespecToNsec rather than Sec/Nsec arithmetic, because Timespec's field
+// widths differ by platform and that mismatch only appears on the platform you
+// are not building for.
+func symlinkModTime(stat *unix.Stat_t) time.Time {
+	return time.Unix(0, unix.TimespecToNsec(stat.Mtim))
+}
+
 func preserveSourceModTime(dirFD int, name string, sourceModTime time.Time, destinationPath, kind string) error {
 	stamp := unix.NsecToTimespec(sourceModTime.UnixNano())
 	if err := unix.UtimesNanoAt(dirFD, name, []unix.Timespec{stamp, stamp}, unix.AT_SYMLINK_NOFOLLOW); err != nil {


### PR DESCRIPTION
## Summary

Last timestamp item on #2919, after #2977 landed files and directories. Claimed on the issue before starting, per the new protocol.

`copySymlinkEntry` created the link with `Symlinkat` and never stamped it, so a restored symlink carried the archive time while `rename(2)` kept the original. Through the differential guard:

```
mtime.symlink diverges: source=2001-09-09T01:46:40Z rename=2001-09-09T01:46:40Z copy=2026-08-06T00:16:46Z
```

## The recorded gap's reasoning was wrong, and that is why it was still on the list

The inventory entry said *"there is no portable dirfd-relative lstat to read it from, and the TARGET's mtime is what tools actually read."*

- **There is one, already in this file.** `statAt` is `unix.Fstatat(dirfd, name, &stat, AT_SYMLINK_NOFOLLOW)`, called on every entry in `copyDirectoryLevel`.
- **The field spelling is portable too**, which is the part I got wrong first. `x/sys/unix.Stat_t` calls it `Mtim` on Linux, darwin **and** the BSDs. `Mtimespec` is the **stdlib** `syscall.Stat_t` spelling on darwin — a different type this copier does not use. That distinction is exactly why #2977's first draft needed a build tag and this needs none.
- **The target argument does not settle it.** `rename(2)` preserves the link's own mtime, so the two paths still disagree, and that disagreement is the contract #2919 is about. tar and rsync both preserve it.

I wrote the entry being removed here, so I am also the one who put the wrong reason on the list.

## One stat, not two

The identity re-check and the timestamp now come from the same `statAt`. Sampling the source twice would open a second window in which the name could be swapped between the reads, and this copier's discipline is that a fact about a name is only good for the sample it came from. `preserveSourceModTime` already passes `AT_SYMLINK_NOFOLLOW`, so it stamps the link rather than following it out of the tree.

## Verified by cross-building, not by reading

This is the direct lesson from my own closed attempt at the mtime item (#2976): it claimed portability, passed **both Linux lanes**, and failed to *build* on macOS because `unix.UTIME_OMIT` is Linux-only. A green Linux CI validates nothing about darwin.

So this one was cross-built first — and it caught a real error immediately. My first draft assumed `Mtimespec` and added a `linux`/`!linux` split; `GOOS=darwin` and `GOOS=freebsd` both rejected it in seconds, which is how I found that `unix.Stat_t` needs no split at all. The split files are gone.

| | |
| --- | --- |
| `go build ./...` | pass |
| `GOOS=darwin go build ./...` | pass |
| `GOOS=freebsd go build ./...` | pass |

## Validation

Fail-first: removing `mtime.symlink` from `knownCrossDeviceDivergence` before the change fails the guard, naming source/rename/copy. After it, the entry is gone and the guard passes.

Local checks per the current list — `deadcode` not run, CI does it:

- `gofmt -l .` (empty), `go build ./...`, `golangci-lint run --timeout=3m --fast`, `scripts/lint-file-length.sh`
- `go test ./session/git` — the only package touched, full package green (24s)

Closes #2988
