### PR TITLE
fix(git): stop a far-future mtime wrapping to 1901 on a cross-device archive

### DIFF
--- a/session/git/worktree_copy_timerange_test.go
+++ b/session/git/worktree_copy_timerange_test.go
@@ -1,0 +1,60 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// A filesystem timestamp beyond Go's UnixNano range must survive the
+// cross-device copy, or be refused — never silently wrapped.
+//
+// time.Time.UnixNano() is only defined for 1678–2262 and wraps outside it, so
+// the first spelling of preserveSourceModTime reproduced a far-future node
+// centuries off while reporting success. ext4 with 256-byte inodes stores
+// mtimes to 2446, so this is representable, not hypothetical: the copy claimed
+// to preserve a timestamp it had corrupted.
+//
+// The rename path is the oracle, exactly as the fidelity guard uses it — it
+// never reads the file, so it carries any value the filesystem can hold.
+func TestMoveDirCrossDevice_FarFutureMtimeIsNotWrapped(t *testing.T) {
+	// 2300-01-01T00:00:00Z — inside ext4's range, outside UnixNano's.
+	const farFutureSec = 10413792000
+	if _, err := unix.TimeToTimespec(time.Unix(farFutureSec, 0)); err != nil {
+		t.Skipf("this platform cannot represent the probe timestamp: %v", err)
+	}
+
+	workspace := t.TempDir()
+	src := filepath.Join(workspace, "src")
+	require.NoError(t, os.MkdirAll(src, 0o700))
+	probe := filepath.Join(src, "far-future.txt")
+	require.NoError(t, os.WriteFile(probe, []byte("x"), 0o600))
+
+	// Set it through unix directly: os.Chtimes goes via UnixNano and would wrap
+	// the fixture itself, which would make this test pass for the wrong reason.
+	stamp := unix.Timespec{Sec: farFutureSec}
+	if err := unix.UtimesNanoAt(unix.AT_FDCWD, probe, []unix.Timespec{stamp, stamp}, 0); err != nil {
+		t.Skipf("this filesystem cannot store a 2300 mtime: %v", err)
+	}
+	sourceInfo, err := os.Lstat(probe)
+	require.NoError(t, err)
+	require.Equal(t, int64(farFutureSec), sourceInfo.ModTime().Unix(),
+		"precondition: the fixture really carries the far-future stamp")
+
+	original := renamePath
+	renamePath = func(_, _ string) error { return syscall.EXDEV }
+	t.Cleanup(func() { renamePath = original })
+
+	dest := filepath.Join(workspace, "dest")
+	require.NoError(t, moveDirCrossDevice(src, dest))
+
+	copiedInfo, err := os.Lstat(filepath.Join(dest, "far-future.txt"))
+	require.NoError(t, err)
+	require.Equal(t, int64(farFutureSec), copiedInfo.ModTime().Unix(),
+		"the copy must reproduce the source mtime, not a value wrapped through UnixNano")
+}

--- a/session/git/worktree_copy_timerange_test.go
+++ b/session/git/worktree_copy_timerange_test.go
@@ -41,10 +41,18 @@ func TestMoveDirCrossDevice_FarFutureMtimeIsNotWrapped(t *testing.T) {
 	if err := unix.UtimesNanoAt(unix.AT_FDCWD, probe, []unix.Timespec{stamp, stamp}, 0); err != nil {
 		t.Skipf("this filesystem cannot store a 2300 mtime: %v", err)
 	}
+	// Read back, and SKIP rather than fail if the filesystem did not keep it.
+	// utimensat reports success on APFS and then clamps to 9223372036 — which is
+	// exactly UnixNano's own ceiling (2262-04-11), so on macOS the wrap this test
+	// is about is not reachable: the filesystem cannot hold a value outside the
+	// range that wraps. Checking the WRITE succeeded is not enough; only the
+	// read-back says whether the fixture carries what the test needs.
 	sourceInfo, err := os.Lstat(probe)
 	require.NoError(t, err)
-	require.Equal(t, int64(farFutureSec), sourceInfo.ModTime().Unix(),
-		"precondition: the fixture really carries the far-future stamp")
+	if sourceInfo.ModTime().Unix() != farFutureSec {
+		t.Skipf("this filesystem clamped the probe mtime to %d, so an out-of-UnixNano-range value cannot be stored here",
+			sourceInfo.ModTime().Unix())
+	}
 
 	original := renamePath
 	renamePath = func(_, _ string) error { return syscall.EXDEV }

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -553,7 +553,19 @@ func isAllZero(chunk []byte) bool {
 // filesystems mount relatime so it is already approximate, and nothing in a
 // worktree depends on it. mtime is the property tools actually read.
 func preserveSourceModTime(dirFD int, name string, sourceModTime time.Time, destinationPath, kind string) error {
-	stamp := unix.NsecToTimespec(sourceModTime.UnixNano())
+	// TimeToTimespec, not NsecToTimespec(t.UnixNano()). UnixNano is only defined
+	// for 1678–2262 and wraps silently outside it, while a filesystem can hold
+	// timestamps well beyond that (ext4 with 256-byte inodes reaches 2446). The
+	// wrapped spelling reproduced such a node CENTURIES off and still reported
+	// success; this one converts seconds and nanoseconds separately and refuses
+	// a value the platform cannot represent.
+	stamp, err := unix.TimeToTimespec(sourceModTime)
+	if err != nil {
+		return fmt.Errorf(
+			"cannot move worktree across filesystems: source modification time %s on %s %s is out of range for this platform: %w",
+			sourceModTime.UTC().Format(time.RFC3339), kind, destinationPath, err,
+		)
+	}
 	if err := unix.UtimesNanoAt(dirFD, name, []unix.Timespec{stamp, stamp}, unix.AT_SYMLINK_NOFOLLOW); err != nil {
 		return fmt.Errorf(
 			"cannot move worktree across filesystems: failed to preserve the source modification time on destination %s %s: %w",


### PR DESCRIPTION
A shipped defect in the merged mtime work, not a checklist item — both remaining
items on #2919 (symlink timestamps, xattrs) are claimed by other sessions.

## The bug

`preserveSourceModTime` converted through `unix.NsecToTimespec(t.UnixNano())`.
`UnixNano` is only defined for **1678–2262** and wraps silently outside it, while
a filesystem can hold timestamps well past that — ext4 with 256-byte inodes
reaches 2446.

Measured rather than reasoned. A probe stamped `2300-01-01` arrives as:

```
expected: 10413792000   (2300-01-01)
actual:   -2147483648   (1901-12-13)
```

A 400-year error, reported as success, on the path whose entire job this change
series is to make faithful.

`unix.TimeToTimespec` converts seconds and nanoseconds separately and reports a
range error, so a value the platform genuinely cannot represent now fails the
archive **with the timestamp named** rather than being silently corrupted. That
matches the rest of this path, which refuses rather than guesses everywhere else.

## The test, and the trap in writing it

The fixture is stamped through `unix.UtimesNanoAt`, **not** `os.Chtimes` —
`os.Chtimes` goes through `UnixNano` itself, so it would wrap the fixture and the
test would pass for the wrong reason while proving nothing. It skips (not fails)
where the platform or filesystem cannot hold the value, and the rename leg stays
the oracle for what "faithful" means, exactly as #2957's guard uses it.

**Mutation-verified**: restoring the shipped spelling produces the numbers above.

## Provenance

Raised by Codex against #2979 — my duplicate of the mtime work, closed during the
six-way consolidation — and carried into #2977, which merged 41 minutes after I
relayed it and before it was addressed. Three other findings from that review
also transferred; they are written up on #2977, including one where I had to
correct myself: I called the non-searchable-directory case a regression and it is
not, it was already broken before #2977 and the reorder I suggested does not fix
it. That one is recorded on #2919 as a separate pre-existing defect, unclaimed.

## Gate

`gofmt -l .` (empty), `go build ./...`, `GOOS=darwin go build ./session/...`,
`golangci-lint run --timeout=3m --fast`, `scripts/lint-file-length.sh`,
`go test ./session/git/` (22.8s, full package). No `deadcode` locally, no
containerized suites, nothing against `./daemon/...` or `./app/...`.

Refs #2919

-- Captain Claude
