### PR TITLE
fix(git): carry extended attributes through a cross-device archive (#2919)

### DIFF
--- a/session/git/worktree_copy_fidelity_test.go
+++ b/session/git/worktree_copy_fidelity_test.go
@@ -39,8 +39,6 @@ import (
 var knownCrossDeviceDivergence = map[string]string{
 	"mtime.symlink":          "#2919: the link's own mtime is not set — there is no portable dirfd-relative lstat to read it from, and the TARGET's mtime is what tools actually read",
 	"hardlink.externalNlink": "#2919: an inode with one name inside the worktree and another OUTSIDE it keeps both aliases across a rename, but the copy can only create the in-tree name — there is nothing it could link the outside name to. Unfixable by construction, unlike the in-tree pair.",
-	"xattr.file":             "#2919: no xattr namespace is copied, so ACLs, capabilities and SELinux labels are dropped",
-	"xattr.dir":              "#2919: same cause, on directories",
 }
 
 // TestMoveDirCrossDevice_CopyDivergesFromRenameOnlyWhereRecorded is the class

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -10,6 +11,8 @@ import (
 	"time"
 
 	"golang.org/x/sys/unix"
+
+	"github.com/sachiniyer/agent-factory/log"
 )
 
 // This file holds the recursive cross-device tree copier. Its counterpart,
@@ -552,6 +555,14 @@ func applyCopiedDirectoryMode(source, destination *os.File, destinationPath stri
 	if err := preserveSourceMode(int(destination.Fd()), info.Mode(), destinationPath, "directory"); err != nil {
 		return err
 	}
+	// After the mode and before the times, and neither is arbitrary. The access ACL
+	// and the mode bits are one state seen two ways: setting system.posix_acl_access
+	// rewrites the mode, and chmod rewrites the ACL mask, so an ACL applied before
+	// the mode would be silently undone. setxattr moves ctime only, so the times
+	// applied below still land last (#2919).
+	if err := copySourceXattrs(int(source.Fd()), int(destination.Fd()), destinationPath, "directory"); err != nil {
+		return err
+	}
 	// Times last, and only here. Creating an entry inside a directory updates
 	// that directory's own mtime, so a timestamp written any earlier would be
 	// overwritten by the copy's own writes — the same ordering the mode already
@@ -623,6 +634,137 @@ func isAllZero(chunk []byte) bool {
 		}
 	}
 	return true
+}
+
+// copySourceXattrs reproduces a source node's extended attributes on its copy.
+//
+// rename(2) keeps them for free. The copy reproduced only what it was written to
+// reproduce, so every namespace was dropped and which filesystem $AF_HOME sits on
+// decided whether a restored worktree kept them (#2919). What is lost is not
+// decoration: system.posix_acl_access / _default carry named-user and named-group
+// grants, and a DIRECTORY's default ACL vanishing is the surprising direction —
+// files created in the restored tree afterwards inherit plain umask permissions,
+// which can be WIDER than the policy that was archived. security.capability turns a
+// vendored helper into one that silently cannot bind; security.selinux mislabels a
+// tree on an enforcing box.
+//
+// Descriptor-anchored like every other step here: the F* forms take the descriptors
+// the walk already validated, so no path is re-derived and the name-swap race the
+// copier exists to avoid stays avoided.
+//
+// The failure policy is per-attribute and deliberately asymmetric, because "the
+// archive refused to run" is a worse outcome than "one label could not be stored" —
+// but only while the loss is LOGGED rather than silent, which is the actual
+// complaint in #2919:
+//
+//   - the destination filesystem holds no xattrs at all (EOPNOTSUPP) -> warn once and
+//     stop trying. The archive root's filesystem is not a per-file choice.
+//   - one attribute is refused (EPERM/EACCES - security.capability needs CAP_SETFCAP,
+//     security.selinux needs relabel permission) -> warn naming it, keep going.
+//   - anything else -> fail the copy. E2BIG and ENOSPC are errors, not policy limits.
+//
+// trusted.* needs no special case: an unprivileged lister never sees it, so it never
+// appears in the list to attempt.
+func copySourceXattrs(sourceFD, destinationFD int, destinationPath, kind string) error {
+	names, err := listXattrNames(sourceFD)
+	if err != nil {
+		if errors.Is(err, unix.EOPNOTSUPP) {
+			return nil // the SOURCE filesystem has no xattrs; nothing to carry
+		}
+		return fmt.Errorf(
+			"cannot move worktree across filesystems: failed to list extended attributes for destination %s %s: %w",
+			kind, destinationPath, err,
+		)
+	}
+	for _, name := range names {
+		value, err := readXattrValue(sourceFD, name)
+		if err != nil {
+			// Deliberately not fatal, and deliberately not errno-matched: the "it
+			// vanished between listing and reading" errno is ENODATA on Linux and
+			// ENOATTR on darwin, and naming both would need a platform split for a
+			// case that costs one attribute. Warned, so it is not silent.
+			log.WarningLog.Printf(
+				"archive: reading extended attribute %q from %s %s: %v", name, kind, destinationPath, err,
+			)
+			continue
+		}
+		if err := unix.Fsetxattr(destinationFD, name, value, 0); err != nil {
+			switch {
+			case errors.Is(err, unix.EOPNOTSUPP):
+				log.WarningLog.Printf(
+					"archive: %s %s cannot hold extended attributes on this filesystem; %d attribute(s) not copied",
+					kind, destinationPath, len(names),
+				)
+				return nil
+			case errors.Is(err, unix.EPERM), errors.Is(err, unix.EACCES):
+				log.WarningLog.Printf(
+					"archive: extended attribute %q not reproduced on %s %s (needs privilege): %v",
+					name, kind, destinationPath, err,
+				)
+			default:
+				return fmt.Errorf(
+					"cannot move worktree across filesystems: failed to set extended attribute %q on destination %s %s: %w",
+					name, kind, destinationPath, err,
+				)
+			}
+		}
+	}
+	return nil
+}
+
+// listXattrNames returns the attribute names visible on fd. Sized in two calls
+// because the set can change between them, so a list that grew is read short and
+// retried rather than silently truncated.
+func listXattrNames(fd int) ([]string, error) {
+	for attempt := 0; attempt < 2; attempt++ {
+		size, err := unix.Flistxattr(fd, nil)
+		if err != nil {
+			return nil, err
+		}
+		if size == 0 {
+			return nil, nil
+		}
+		buffer := make([]byte, size)
+		read, err := unix.Flistxattr(fd, buffer)
+		if err != nil {
+			if errors.Is(err, unix.ERANGE) {
+				continue // the list grew between the sizing and the read
+			}
+			return nil, err
+		}
+		names := make([]string, 0, 4)
+		for _, name := range bytes.Split(buffer[:read], []byte{0}) {
+			if len(name) > 0 {
+				names = append(names, string(name))
+			}
+		}
+		return names, nil
+	}
+	return nil, fmt.Errorf("extended attribute list kept growing while it was read")
+}
+
+// readXattrValue reads one attribute's value, sized the same two-call way. A present
+// attribute with an empty value is meaningful, so nil-with-no-error is a real result.
+func readXattrValue(fd int, name string) ([]byte, error) {
+	for attempt := 0; attempt < 2; attempt++ {
+		size, err := unix.Fgetxattr(fd, name, nil)
+		if err != nil {
+			return nil, err
+		}
+		if size == 0 {
+			return nil, nil
+		}
+		value := make([]byte, size)
+		read, err := unix.Fgetxattr(fd, name, value)
+		if err != nil {
+			if errors.Is(err, unix.ERANGE) {
+				continue // the value grew between the sizing and the read
+			}
+			return nil, err
+		}
+		return value[:read], nil
+	}
+	return nil, fmt.Errorf("extended attribute %q kept growing while it was read", name)
 }
 
 // preserveSourceModTime reproduces a source node's modification time on its copy.
@@ -778,6 +920,12 @@ func copyRegularFileAtWithIdentity(
 	// step, once there is nothing half-written left to expose. The already-open
 	// descriptor keeps its write access regardless of the new mode.
 	if err := preserveSourceMode(outFD, info.Mode(), destinationPath, "file"); err != nil {
+		_ = out.Close()
+		return created, err
+	}
+	// Between the mode and the times, for the ACL/mode ordering reason spelled out in
+	// applyCopiedDirectoryMode.
+	if err := copySourceXattrs(int(in.Fd()), outFD, destinationPath, "file"); err != nil {
 		_ = out.Close()
 		return created, err
 	}

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -237,6 +237,9 @@ func copyDirectoryContents(source, destination *os.File, sourcePath, destination
 	// Source inode -> where its bytes first landed AND what inode they landed
 	// on. Scoped to one copy, so it can never name a path from another tree.
 	links := map[pathIdentity]copiedFileLink{}
+	// Same scoping as links above: whether this DESTINATION holds extended
+	// attributes is learned once per copy and never leaks into another one.
+	xattrs := &xattrDestination{}
 	routes := []copiedDirectoryRoute{{parent: -1, directory: &root}}
 	for index := 0; index < len(routes); index++ {
 		job := routes[index]
@@ -259,6 +262,7 @@ func copyDirectoryContents(source, destination *os.File, sourcePath, destination
 			destination,
 			relativeRoutePath(components),
 			links,
+			xattrs,
 		)
 		if err == nil {
 			// The level is complete, and nothing is ever written directly into
@@ -268,7 +272,7 @@ func copyDirectoryContents(source, destination *os.File, sourcePath, destination
 			// is free: a read-only source directory takes its mode now rather
 			// than blocking its own contents (#2872).
 			err = applyCopiedDirectoryMode(
-				sourceDirectory, destinationDirectory, directoryRoutePath(destinationPath, components),
+				sourceDirectory, destinationDirectory, directoryRoutePath(destinationPath, components), xattrs,
 			)
 		}
 		_ = destinationDirectory.Close()
@@ -294,6 +298,7 @@ func copyDirectoryLevel(
 	destinationRoot *os.File,
 	relativeDirectory string,
 	links map[pathIdentity]copiedFileLink,
+	xattrs *xattrDestination,
 ) error {
 	names, err := source.Readdirnames(-1)
 	if err != nil {
@@ -337,7 +342,7 @@ func copyDirectoryLevel(
 			if first, seen := links[inspected]; seen {
 				entry, err = linkCopiedFile(destination, destinationRoot, first, name, childDestinationPath, inspected)
 			} else {
-				entry, err = copyRegularFileAtWithIdentity(source, destination, name, childSourcePath, childDestinationPath, &inspected)
+				entry, err = copyRegularFileAtWithIdentity(source, destination, name, childSourcePath, childDestinationPath, &inspected, xattrs)
 				if err == nil {
 					links[inspected] = copiedFileLink{
 						path:     filepath.Join(relativeDirectory, name),
@@ -538,10 +543,29 @@ func workingDirectoryMode(sourceMode os.FileMode) uint32 {
 	return uint32(sourceMode.Perm()) | 0o700
 }
 
+// workingFileMode is the mode a destination FILE is created with while the copy
+// is still filling it, and it exists for the same reason as
+// workingDirectoryMode.
+//
+// Creating the file at its final mode makes a read-only source file impossible
+// to finish: setting an attribute in the user namespace requires write
+// permission on the INODE, and an already-open write descriptor does not supply
+// it, so on a checked-in 0444 file every user.* attribute failed EACCES no
+// matter where in the sequence it was attempted. Ordering alone cannot fix that
+// — the inode is read-only from the moment openat() creates it — so the copy
+// runs at a mode that guarantees it can write and preserveSourceMode installs
+// the real one once the attributes are on.
+//
+// Only owner bits are added, exactly as for directories: no other user gains
+// access to the staging file at any point, whatever the source's mode says.
+func workingFileMode(sourceMode os.FileMode) uint32 {
+	return uint32(sourceMode.Perm()) | 0o600
+}
+
 // applyCopiedDirectoryMode gives a finished destination directory the mode its
 // source carries, reading that mode from the source descriptor the route walk
 // just validated rather than from anything cached earlier.
-func applyCopiedDirectoryMode(source, destination *os.File, destinationPath string) error {
+func applyCopiedDirectoryMode(source, destination *os.File, destinationPath string, support *xattrDestination) error {
 	info, err := source.Stat()
 	if err != nil {
 		return fmt.Errorf(
@@ -562,16 +586,18 @@ func applyCopiedDirectoryMode(source, destination *os.File, destinationPath stri
 	// an ACL applied before the mode would be silently undone.
 	//
 	// setxattr moves ctime only, so the times applied below still land last (#2919).
-	if err := copyNonACLXattrs(int(source.Fd()), int(destination.Fd()), destinationPath, "directory"); err != nil {
+	if err := copyNonACLXattrs(support, int(source.Fd()), int(destination.Fd()), destinationPath, "directory"); err != nil {
 		return err
 	}
+	// While the directory is still writable: removing an inherited attribute needs
+	// write permission just as setting one does, and the mode below may take it away.
+	pruneDestinationXattrs(int(source.Fd()), int(destination.Fd()), destinationPath, "directory")
 	if err := preserveSourceMode(int(destination.Fd()), info.Mode(), destinationPath, "directory"); err != nil {
 		return err
 	}
-	if err := copyACLXattrs(int(source.Fd()), int(destination.Fd()), destinationPath, "directory"); err != nil {
+	if err := copyACLXattrs(support, int(source.Fd()), int(destination.Fd()), destinationPath, "directory"); err != nil {
 		return err
 	}
-	pruneDestinationXattrs(int(source.Fd()), int(destination.Fd()), destinationPath, "directory")
 	// Times last, and only here. Creating an entry inside a directory updates
 	// that directory's own mtime, so a timestamp written any earlier would be
 	// overwritten by the copy's own writes — the same ordering the mode already
@@ -735,7 +761,7 @@ func copyFile(src, dst string) error {
 }
 
 func copyRegularFileAt(source, destination *os.File, name, sourcePath, destinationPath string) error {
-	_, err := copyRegularFileAtWithIdentity(source, destination, name, sourcePath, destinationPath, nil)
+	_, err := copyRegularFileAtWithIdentity(source, destination, name, sourcePath, destinationPath, nil, &xattrDestination{})
 	return err
 }
 
@@ -743,6 +769,7 @@ func copyRegularFileAtWithIdentity(
 	source, destination *os.File,
 	name, sourcePath, destinationPath string,
 	inspected *pathIdentity,
+	support *xattrDestination,
 ) (copiedEntry, error) {
 	fd, err := unix.Openat(
 		int(source.Fd()), name,
@@ -771,7 +798,7 @@ func copyRegularFileAtWithIdentity(
 	outFD, err := unix.Openat(
 		int(destination.Fd()), filepath.Base(destinationPath),
 		unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC,
-		uint32(info.Mode().Perm()),
+		workingFileMode(info.Mode()),
 	)
 	if err != nil {
 		return copiedEntry{}, fmt.Errorf("cannot move worktree across filesystems: failed to create destination file %s exclusively: %w", destinationPath, err)
@@ -793,26 +820,30 @@ func copyRegularFileAtWithIdentity(
 		_ = out.Close()
 		return created, err
 	}
-	// After the contents, not before: openat() created this file no wider than
-	// the source (a umask only clears bits), so widening it back is the last
-	// step, once there is nothing half-written left to expose. The already-open
-	// descriptor keeps its write access regardless of the new mode.
-	// Non-ACL attributes go on BEFORE the mode: setting one in the user namespace
-	// needs write permission on the inode, and the final mode may have none (a
-	// checked-in 0444 file). ACLs go on after it — see applyCopiedDirectoryMode.
-	if err := copyNonACLXattrs(int(in.Fd()), outFD, destinationPath, "file"); err != nil {
-		_ = out.Close()
-		return created, err
-	}
-	if err := preserveSourceMode(outFD, info.Mode(), destinationPath, "file"); err != nil {
-		_ = out.Close()
-		return created, err
-	}
-	if err := copyACLXattrs(int(in.Fd()), outFD, destinationPath, "file"); err != nil {
+	// The mode comes after the contents AND after every step that needs the inode
+	// writable. workingFileMode created this file owner-writable for exactly that
+	// reason; preserveSourceMode narrows it to the source's mode here, once there
+	// is nothing half-written left to expose. The already-open descriptor keeps
+	// its write access regardless of the new mode.
+	//
+	// Non-ACL attributes go on BEFORE the mode and the prune runs while the inode
+	// is still writable, because removing one needs write permission just as
+	// setting one does. ACLs go on AFTER it: the access ACL and the mode bits are
+	// one state seen two ways, so chmod would silently rewrite an ACL written
+	// earlier. applyCopiedDirectoryMode does the same four steps in the same order.
+	if err := copyNonACLXattrs(support, int(in.Fd()), outFD, destinationPath, "file"); err != nil {
 		_ = out.Close()
 		return created, err
 	}
 	pruneDestinationXattrs(int(in.Fd()), outFD, destinationPath, "file")
+	if err := preserveSourceMode(outFD, info.Mode(), destinationPath, "file"); err != nil {
+		_ = out.Close()
+		return created, err
+	}
+	if err := copyACLXattrs(support, int(in.Fd()), outFD, destinationPath, "file"); err != nil {
+		_ = out.Close()
+		return created, err
+	}
 	// After the contents for the same reason the mode is: writing bytes bumps
 	// mtime, so this has to be the last thing that touches the file.
 	if err := preserveSourceModTime(

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -11,8 +10,6 @@ import (
 	"time"
 
 	"golang.org/x/sys/unix"
-
-	"github.com/sachiniyer/agent-factory/log"
 )
 
 // This file holds the recursive cross-device tree copier. Its counterpart,
@@ -552,17 +549,29 @@ func applyCopiedDirectoryMode(source, destination *os.File, destinationPath stri
 			destinationPath, err,
 		)
 	}
+	// Attributes split around the mode, and neither half is arbitrary.
+	//
+	// NON-ACL first: setting an attribute in the user namespace requires write
+	// permission on the inode, and the mode applied below may remove it (a 0444 or
+	// 0555 source), so a user.* attribute written afterwards fails EACCES — and the
+	// privilege branch would then log it as "needs privilege" and drop it, silently
+	// losing an ordinary attribute on every read-only node.
+	//
+	// ACL last: the access ACL and the mode bits are one state seen two ways. Setting
+	// system.posix_acl_access rewrites the mode, and chmod rewrites the ACL mask, so
+	// an ACL applied before the mode would be silently undone.
+	//
+	// setxattr moves ctime only, so the times applied below still land last (#2919).
+	if err := copyNonACLXattrs(int(source.Fd()), int(destination.Fd()), destinationPath, "directory"); err != nil {
+		return err
+	}
 	if err := preserveSourceMode(int(destination.Fd()), info.Mode(), destinationPath, "directory"); err != nil {
 		return err
 	}
-	// After the mode and before the times, and neither is arbitrary. The access ACL
-	// and the mode bits are one state seen two ways: setting system.posix_acl_access
-	// rewrites the mode, and chmod rewrites the ACL mask, so an ACL applied before
-	// the mode would be silently undone. setxattr moves ctime only, so the times
-	// applied below still land last (#2919).
-	if err := copySourceXattrs(int(source.Fd()), int(destination.Fd()), destinationPath, "directory"); err != nil {
+	if err := copyACLXattrs(int(source.Fd()), int(destination.Fd()), destinationPath, "directory"); err != nil {
 		return err
 	}
+	pruneDestinationXattrs(int(source.Fd()), int(destination.Fd()), destinationPath, "directory")
 	// Times last, and only here. Creating an entry inside a directory updates
 	// that directory's own mtime, so a timestamp written any earlier would be
 	// overwritten by the copy's own writes — the same ordering the mode already
@@ -634,137 +643,6 @@ func isAllZero(chunk []byte) bool {
 		}
 	}
 	return true
-}
-
-// copySourceXattrs reproduces a source node's extended attributes on its copy.
-//
-// rename(2) keeps them for free. The copy reproduced only what it was written to
-// reproduce, so every namespace was dropped and which filesystem $AF_HOME sits on
-// decided whether a restored worktree kept them (#2919). What is lost is not
-// decoration: system.posix_acl_access / _default carry named-user and named-group
-// grants, and a DIRECTORY's default ACL vanishing is the surprising direction —
-// files created in the restored tree afterwards inherit plain umask permissions,
-// which can be WIDER than the policy that was archived. security.capability turns a
-// vendored helper into one that silently cannot bind; security.selinux mislabels a
-// tree on an enforcing box.
-//
-// Descriptor-anchored like every other step here: the F* forms take the descriptors
-// the walk already validated, so no path is re-derived and the name-swap race the
-// copier exists to avoid stays avoided.
-//
-// The failure policy is per-attribute and deliberately asymmetric, because "the
-// archive refused to run" is a worse outcome than "one label could not be stored" —
-// but only while the loss is LOGGED rather than silent, which is the actual
-// complaint in #2919:
-//
-//   - the destination filesystem holds no xattrs at all (EOPNOTSUPP) -> warn once and
-//     stop trying. The archive root's filesystem is not a per-file choice.
-//   - one attribute is refused (EPERM/EACCES - security.capability needs CAP_SETFCAP,
-//     security.selinux needs relabel permission) -> warn naming it, keep going.
-//   - anything else -> fail the copy. E2BIG and ENOSPC are errors, not policy limits.
-//
-// trusted.* needs no special case: an unprivileged lister never sees it, so it never
-// appears in the list to attempt.
-func copySourceXattrs(sourceFD, destinationFD int, destinationPath, kind string) error {
-	names, err := listXattrNames(sourceFD)
-	if err != nil {
-		if errors.Is(err, unix.EOPNOTSUPP) {
-			return nil // the SOURCE filesystem has no xattrs; nothing to carry
-		}
-		return fmt.Errorf(
-			"cannot move worktree across filesystems: failed to list extended attributes for destination %s %s: %w",
-			kind, destinationPath, err,
-		)
-	}
-	for _, name := range names {
-		value, err := readXattrValue(sourceFD, name)
-		if err != nil {
-			// Deliberately not fatal, and deliberately not errno-matched: the "it
-			// vanished between listing and reading" errno is ENODATA on Linux and
-			// ENOATTR on darwin, and naming both would need a platform split for a
-			// case that costs one attribute. Warned, so it is not silent.
-			log.WarningLog.Printf(
-				"archive: reading extended attribute %q from %s %s: %v", name, kind, destinationPath, err,
-			)
-			continue
-		}
-		if err := unix.Fsetxattr(destinationFD, name, value, 0); err != nil {
-			switch {
-			case errors.Is(err, unix.EOPNOTSUPP):
-				log.WarningLog.Printf(
-					"archive: %s %s cannot hold extended attributes on this filesystem; %d attribute(s) not copied",
-					kind, destinationPath, len(names),
-				)
-				return nil
-			case errors.Is(err, unix.EPERM), errors.Is(err, unix.EACCES):
-				log.WarningLog.Printf(
-					"archive: extended attribute %q not reproduced on %s %s (needs privilege): %v",
-					name, kind, destinationPath, err,
-				)
-			default:
-				return fmt.Errorf(
-					"cannot move worktree across filesystems: failed to set extended attribute %q on destination %s %s: %w",
-					name, kind, destinationPath, err,
-				)
-			}
-		}
-	}
-	return nil
-}
-
-// listXattrNames returns the attribute names visible on fd. Sized in two calls
-// because the set can change between them, so a list that grew is read short and
-// retried rather than silently truncated.
-func listXattrNames(fd int) ([]string, error) {
-	for attempt := 0; attempt < 2; attempt++ {
-		size, err := unix.Flistxattr(fd, nil)
-		if err != nil {
-			return nil, err
-		}
-		if size == 0 {
-			return nil, nil
-		}
-		buffer := make([]byte, size)
-		read, err := unix.Flistxattr(fd, buffer)
-		if err != nil {
-			if errors.Is(err, unix.ERANGE) {
-				continue // the list grew between the sizing and the read
-			}
-			return nil, err
-		}
-		names := make([]string, 0, 4)
-		for _, name := range bytes.Split(buffer[:read], []byte{0}) {
-			if len(name) > 0 {
-				names = append(names, string(name))
-			}
-		}
-		return names, nil
-	}
-	return nil, fmt.Errorf("extended attribute list kept growing while it was read")
-}
-
-// readXattrValue reads one attribute's value, sized the same two-call way. A present
-// attribute with an empty value is meaningful, so nil-with-no-error is a real result.
-func readXattrValue(fd int, name string) ([]byte, error) {
-	for attempt := 0; attempt < 2; attempt++ {
-		size, err := unix.Fgetxattr(fd, name, nil)
-		if err != nil {
-			return nil, err
-		}
-		if size == 0 {
-			return nil, nil
-		}
-		value := make([]byte, size)
-		read, err := unix.Fgetxattr(fd, name, value)
-		if err != nil {
-			if errors.Is(err, unix.ERANGE) {
-				continue // the value grew between the sizing and the read
-			}
-			return nil, err
-		}
-		return value[:read], nil
-	}
-	return nil, fmt.Errorf("extended attribute %q kept growing while it was read", name)
 }
 
 // preserveSourceModTime reproduces a source node's modification time on its copy.
@@ -919,16 +797,22 @@ func copyRegularFileAtWithIdentity(
 	// the source (a umask only clears bits), so widening it back is the last
 	// step, once there is nothing half-written left to expose. The already-open
 	// descriptor keeps its write access regardless of the new mode.
+	// Non-ACL attributes go on BEFORE the mode: setting one in the user namespace
+	// needs write permission on the inode, and the final mode may have none (a
+	// checked-in 0444 file). ACLs go on after it — see applyCopiedDirectoryMode.
+	if err := copyNonACLXattrs(int(in.Fd()), outFD, destinationPath, "file"); err != nil {
+		_ = out.Close()
+		return created, err
+	}
 	if err := preserveSourceMode(outFD, info.Mode(), destinationPath, "file"); err != nil {
 		_ = out.Close()
 		return created, err
 	}
-	// Between the mode and the times, for the ACL/mode ordering reason spelled out in
-	// applyCopiedDirectoryMode.
-	if err := copySourceXattrs(int(in.Fd()), outFD, destinationPath, "file"); err != nil {
+	if err := copyACLXattrs(int(in.Fd()), outFD, destinationPath, "file"); err != nil {
 		_ = out.Close()
 		return created, err
 	}
+	pruneDestinationXattrs(int(in.Fd()), outFD, destinationPath, "file")
 	// After the contents for the same reason the mode is: writing bytes bumps
 	// mtime, so this has to be the last thing that touches the file.
 	if err := preserveSourceModTime(

--- a/session/git/worktree_copy_xattr.go
+++ b/session/git/worktree_copy_xattr.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"sync/atomic"
 
 	"golang.org/x/sys/unix"
 
@@ -129,33 +128,44 @@ func copySourceXattrs(sourceFD, destinationFD int, destinationPath, kind string,
 	return nil
 }
 
+// xattrDestination latches the discovery that a destination holds no extended
+// attributes at all, so the rest of THAT copy stops attempting them instead of
+// logging the same warning once per file in the worktree.
+//
+// One per copy, like the hardlink map in copyDirectoryContents and for the same
+// reason. A process-wide latch would be wrong rather than merely untidy: this
+// copier also serves RestoreWorktreeTo, whose destination is an arbitrary
+// repository filesystem rather than the archive root, so a single restore onto a
+// filesystem without xattr support would silently disable attribute copying for
+// every later archive in the daemon's lifetime — and the daemon is long-lived.
+//
+// Not atomic: a copy walks its tree on one goroutine, and the value never escapes
+// the copy that made it.
+type xattrDestination struct {
+	holdsNone bool
+}
+
 // copyNonACLXattrs and copyACLXattrs are the two halves of the copy, split around
-// the mode. Both go quiet for the rest of the archive once the destination
-// filesystem has said it holds no attributes at all: that is a property of the
-// archive root, so re-attempting it per node would log the same warning once per
-// file in the worktree.
-func copyNonACLXattrs(sourceFD, destinationFD int, destinationPath, kind string) error {
-	return copyXattrPhase(sourceFD, destinationFD, destinationPath, kind, false)
+// the mode — see isACLXattr for why the split is load-bearing.
+func copyNonACLXattrs(support *xattrDestination, sourceFD, destinationFD int, destinationPath, kind string) error {
+	return copyXattrPhase(support, sourceFD, destinationFD, destinationPath, kind, false)
 }
 
-func copyACLXattrs(sourceFD, destinationFD int, destinationPath, kind string) error {
-	return copyXattrPhase(sourceFD, destinationFD, destinationPath, kind, true)
+func copyACLXattrs(support *xattrDestination, sourceFD, destinationFD int, destinationPath, kind string) error {
+	return copyXattrPhase(support, sourceFD, destinationFD, destinationPath, kind, true)
 }
 
-func copyXattrPhase(sourceFD, destinationFD int, destinationPath, kind string, acl bool) error {
-	if destinationHoldsNoXattrs.Load() {
+func copyXattrPhase(support *xattrDestination, sourceFD, destinationFD int, destinationPath, kind string, acl bool) error {
+	if support.holdsNone {
 		return nil
 	}
 	err := copySourceXattrs(sourceFD, destinationFD, destinationPath, kind, acl)
 	if errors.Is(err, errXattrUnsupportedDestination) {
-		destinationHoldsNoXattrs.Store(true)
+		support.holdsNone = true
 		return nil
 	}
 	return err
 }
-
-// destinationHoldsNoXattrs latches once a destination refuses attributes outright.
-var destinationHoldsNoXattrs atomic.Bool
 
 // pruneDestinationXattrs removes attributes the destination has and the source does
 // not.
@@ -200,8 +210,18 @@ func pruneDestinationXattrs(sourceFD, destinationFD int, destinationPath, kind s
 // AFTER the mode: setting system.posix_acl_access rewrites the mode, and chmod
 // rewrites the ACL mask, so an ACL written before the mode is silently undone.
 // Everything else must be applied BEFORE it, because setting an attribute in the
-// user namespace requires write permission on the inode and the final mode may have
-// none (a checked-in 0444 file).
+// user namespace requires write permission on the inode.
+//
+// LINUX ONLY, and the split is named for what it does rather than for a guarantee
+// it makes. Darwin does not represent ACLs as extended attributes — they live
+// behind acl(3), so these names never appear in a darwin Flistxattr listing, this
+// phase is an empty pass there, and a macOS worktree's named-user ACL entries are
+// NOT reproduced by the cross-device copy. That is unchanged by #2919 rather than
+// introduced by it (nothing carried any attribute before), and closing it needs the
+// ACL API, not another name in this predicate. Not in knownCrossDeviceDivergence:
+// that inventory is keyed by properties describeFidelity actually measures, and
+// measuring this one needs a darwin runner the guard does not have. Tracked in
+// #2919 instead, so the limit is written down where the follow-up will look.
 func isACLXattr(name string) bool {
 	return name == "system.posix_acl_access" || name == "system.posix_acl_default"
 }

--- a/session/git/worktree_copy_xattr.go
+++ b/session/git/worktree_copy_xattr.go
@@ -1,0 +1,287 @@
+package git
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sync/atomic"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// Extended attributes on the cross-device worktree copy (#2919).
+//
+// rename(2) carries them for free; the copy path had to reproduce them, and nothing
+// did — `grep -rn "Getxattr|Setxattr|Listxattr"` over the repo returned nothing, so
+// capabilities, SELinux labels and ACLs were all dropped by an archive that reported
+// success. Split out of worktree_copy_tree.go to keep that file under the length
+// limit; the ordering constraints that tie this to the mode live at the call sites.
+
+// copySourceXattrs reproduces a source node's extended attributes on its copy.
+//
+// rename(2) keeps them for free. The copy reproduced only what it was written to
+// reproduce, so every namespace was dropped and which filesystem $AF_HOME sits on
+// decided whether a restored worktree kept them (#2919). What is lost is not
+// decoration: system.posix_acl_access / _default carry named-user and named-group
+// grants, and a DIRECTORY's default ACL vanishing is the surprising direction —
+// files created in the restored tree afterwards inherit plain umask permissions,
+// which can be WIDER than the policy that was archived. security.capability turns a
+// vendored helper into one that silently cannot bind; security.selinux mislabels a
+// tree on an enforcing box.
+//
+// Descriptor-anchored like every other step here: the F* forms take the descriptors
+// the walk already validated, so no path is re-derived and the name-swap race the
+// copier exists to avoid stays avoided.
+//
+// The failure policy is per-attribute and deliberately asymmetric, because "the
+// archive refused to run" is a worse outcome than "one label could not be stored" —
+// but only while the loss is LOGGED rather than silent, which is the actual
+// complaint in #2919:
+//
+//   - the destination filesystem holds no xattrs at all (EOPNOTSUPP) -> warn once and
+//     stop trying. The archive root's filesystem is not a per-file choice.
+//   - one attribute is refused (EPERM/EACCES - security.capability needs CAP_SETFCAP,
+//     security.selinux needs relabel permission) -> warn naming it, keep going.
+//   - anything else -> fail the copy. E2BIG and ENOSPC are errors, not policy limits.
+//
+// trusted.* needs no special case: an unprivileged lister never sees it, so it never
+// appears in the list to attempt.
+// maxXattrValueBytes caps one attribute's value. Real metadata — capabilities,
+// SELinux labels, ACLs, user tags — is tens to hundreds of bytes; this is orders of
+// magnitude above that while still bounding a single allocation.
+const maxXattrValueBytes = 1 << 20
+
+// errXattrValueTooLarge marks a value the copier declines to buffer.
+var errXattrValueTooLarge = errors.New("extended attribute value exceeds the copy limit")
+
+// errXattrUnsupportedDestination marks a destination FILESYSTEM that holds no
+// attributes at all. It is a property of the archive root, not of one node, so the
+// caller stops attempting the rest of the tree rather than re-learning it per file.
+var errXattrUnsupportedDestination = errors.New("destination filesystem does not support extended attributes")
+
+func copySourceXattrs(sourceFD, destinationFD int, destinationPath, kind string, acl bool) error {
+	names, err := listXattrNames(sourceFD)
+	if err != nil {
+		if errors.Is(err, unix.EOPNOTSUPP) {
+			return nil // the SOURCE filesystem has no xattrs; nothing to carry
+		}
+		return fmt.Errorf(
+			"cannot move worktree across filesystems: failed to list extended attributes for destination %s %s: %w",
+			kind, destinationPath, err,
+		)
+	}
+	for _, name := range names {
+		if isACLXattr(name) != acl {
+			continue // the other phase owns this one
+		}
+		value, err := readXattrValue(sourceFD, name)
+		if err != nil {
+			if isXattrVanished(err) {
+				// Removed between the listing and the read. The only tolerable read
+				// failure, and warned so it is not silent.
+				log.WarningLog.Printf(
+					"archive: extended attribute %q vanished from %s %s while it was being copied",
+					name, kind, destinationPath,
+				)
+				continue
+			}
+			if errors.Is(err, errXattrValueTooLarge) {
+				// A value too large to buffer — on darwin com.apple.ResourceFork can be
+				// fork-sized. Skipping one attribute is survivable; allocating it is not,
+				// and an archive that OOMs takes the session with it.
+				log.WarningLog.Printf(
+					"archive: extended attribute %q on %s %s is too large to copy (%d byte limit); not reproduced",
+					name, kind, destinationPath, maxXattrValueBytes,
+				)
+				continue
+			}
+			// Anything else — EIO from a network filesystem, a transient resource
+			// failure — is a real read error. Reporting success while dropping a
+			// capability or a label is the silent-loss this issue is about.
+			return fmt.Errorf(
+				"cannot move worktree across filesystems: failed to read extended attribute %q from %s %s: %w",
+				name, kind, destinationPath, err,
+			)
+		}
+		if err := unix.Fsetxattr(destinationFD, name, value, 0); err != nil {
+			switch {
+			case errors.Is(err, unix.EOPNOTSUPP):
+				log.WarningLog.Printf(
+					"archive: %s %s cannot hold extended attributes on this filesystem; %d attribute(s) not copied",
+					kind, destinationPath, len(names),
+				)
+				return errXattrUnsupportedDestination
+			case errors.Is(err, unix.EPERM), errors.Is(err, unix.EACCES):
+				log.WarningLog.Printf(
+					"archive: extended attribute %q not reproduced on %s %s (needs privilege): %v",
+					name, kind, destinationPath, err,
+				)
+			default:
+				return fmt.Errorf(
+					"cannot move worktree across filesystems: failed to set extended attribute %q on destination %s %s: %w",
+					name, kind, destinationPath, err,
+				)
+			}
+		}
+	}
+	return nil
+}
+
+// copyNonACLXattrs and copyACLXattrs are the two halves of the copy, split around
+// the mode. Both go quiet for the rest of the archive once the destination
+// filesystem has said it holds no attributes at all: that is a property of the
+// archive root, so re-attempting it per node would log the same warning once per
+// file in the worktree.
+func copyNonACLXattrs(sourceFD, destinationFD int, destinationPath, kind string) error {
+	return copyXattrPhase(sourceFD, destinationFD, destinationPath, kind, false)
+}
+
+func copyACLXattrs(sourceFD, destinationFD int, destinationPath, kind string) error {
+	return copyXattrPhase(sourceFD, destinationFD, destinationPath, kind, true)
+}
+
+func copyXattrPhase(sourceFD, destinationFD int, destinationPath, kind string, acl bool) error {
+	if destinationHoldsNoXattrs.Load() {
+		return nil
+	}
+	err := copySourceXattrs(sourceFD, destinationFD, destinationPath, kind, acl)
+	if errors.Is(err, errXattrUnsupportedDestination) {
+		destinationHoldsNoXattrs.Store(true)
+		return nil
+	}
+	return err
+}
+
+// destinationHoldsNoXattrs latches once a destination refuses attributes outright.
+var destinationHoldsNoXattrs atomic.Bool
+
+// pruneDestinationXattrs removes attributes the destination has and the source does
+// not.
+//
+// Copying alone is not fidelity. A destination parent carrying a DEFAULT POSIX ACL
+// gives every newly created child a system.posix_acl_access of its own, so a source
+// file with no ACL arrives with one — and an inherited ACL is generally WIDER than
+// the mode it replaces, which makes this a permission-widening bug rather than an
+// untidy one. The same applies to any attribute a destination filesystem or parent
+// synthesises.
+//
+// Failures here are warnings, not errors, for the reason the whole file follows: an
+// archive that refuses to run is worse than one that reports what it could not
+// normalise.
+func pruneDestinationXattrs(sourceFD, destinationFD int, destinationPath, kind string) {
+	destinationNames, err := listXattrNames(destinationFD)
+	if err != nil || len(destinationNames) == 0 {
+		return
+	}
+	sourceNames, err := listXattrNames(sourceFD)
+	if err != nil && !errors.Is(err, unix.EOPNOTSUPP) {
+		return // cannot tell what the source had; leave the destination alone
+	}
+	fromSource := make(map[string]struct{}, len(sourceNames))
+	for _, name := range sourceNames {
+		fromSource[name] = struct{}{}
+	}
+	for _, name := range destinationNames {
+		if _, ok := fromSource[name]; ok {
+			continue
+		}
+		if err := unix.Fremovexattr(destinationFD, name); err != nil && !isXattrVanished(err) {
+			log.WarningLog.Printf(
+				"archive: %s %s inherited extended attribute %q that the source did not have, and it could not be removed: %v",
+				kind, destinationPath, name, err,
+			)
+		}
+	}
+}
+
+// isACLXattr reports whether a name is a POSIX ACL attribute, which must be applied
+// AFTER the mode: setting system.posix_acl_access rewrites the mode, and chmod
+// rewrites the ACL mask, so an ACL written before the mode is silently undone.
+// Everything else must be applied BEFORE it, because setting an attribute in the
+// user namespace requires write permission on the inode and the final mode may have
+// none (a checked-in 0444 file).
+func isACLXattr(name string) bool {
+	return name == "system.posix_acl_access" || name == "system.posix_acl_default"
+}
+
+// isXattrVanished reports whether an error means the attribute is simply not there —
+// removed between the listing and the read, or never present.
+//
+// This is the one place a platform split is unavoidable: Linux reports ENODATA and
+// darwin reports ENOATTR, they are DIFFERENT numbers, and unix.ENOATTR does not exist
+// on Linux at all, so naming both in one file does not compile. The distinction has
+// to be drawn because "the attribute vanished" is the only read failure this copier
+// may tolerate — everything else (EIO from a network filesystem, a resource failure)
+// must fail the archive rather than silently drop a capability or a label.
+func isXattrVanished(err error) bool {
+	for _, absent := range xattrAbsentErrnos() {
+		if errors.Is(err, absent) {
+			return true
+		}
+	}
+	return false
+}
+
+// listXattrNames returns the attribute names visible on fd. Sized in two calls
+// because the set can change between them, so a list that grew is read short and
+// retried rather than silently truncated.
+func listXattrNames(fd int) ([]string, error) {
+	for attempt := 0; attempt < 2; attempt++ {
+		size, err := unix.Flistxattr(fd, nil)
+		if err != nil {
+			return nil, err
+		}
+		if size == 0 {
+			return nil, nil
+		}
+		buffer := make([]byte, size)
+		read, err := unix.Flistxattr(fd, buffer)
+		if err != nil {
+			if errors.Is(err, unix.ERANGE) {
+				continue // the list grew between the sizing and the read
+			}
+			return nil, err
+		}
+		names := make([]string, 0, 4)
+		for _, name := range bytes.Split(buffer[:read], []byte{0}) {
+			if len(name) > 0 {
+				names = append(names, string(name))
+			}
+		}
+		return names, nil
+	}
+	return nil, fmt.Errorf("extended attribute list kept growing while it was read")
+}
+
+// readXattrValue reads one attribute's value, sized the same two-call way. A present
+// attribute with an empty value is meaningful, so nil-with-no-error is a real result.
+func readXattrValue(fd int, name string) ([]byte, error) {
+	for attempt := 0; attempt < 2; attempt++ {
+		size, err := unix.Fgetxattr(fd, name, nil)
+		if err != nil {
+			return nil, err
+		}
+		if size == 0 {
+			return nil, nil
+		}
+		if size > maxXattrValueBytes {
+			// darwin exposes com.apple.ResourceFork through this API and its value can
+			// be as large as a regular fork, so a size returned here is not bounded by
+			// "metadata". Allocating it would let one file's resource fork exhaust the
+			// daemon's memory mid-archive.
+			return nil, errXattrValueTooLarge
+		}
+		value := make([]byte, size)
+		read, err := unix.Fgetxattr(fd, name, value)
+		if err != nil {
+			if errors.Is(err, unix.ERANGE) {
+				continue // the value grew between the sizing and the read
+			}
+			return nil, err
+		}
+		return value[:read], nil
+	}
+	return nil, fmt.Errorf("extended attribute %q kept growing while it was read", name)
+}

--- a/session/git/worktree_copy_xattr.go
+++ b/session/git/worktree_copy_xattr.go
@@ -39,10 +39,14 @@ import (
 // but only while the loss is LOGGED rather than silent, which is the actual
 // complaint in #2919:
 //
-//   - the destination filesystem holds no xattrs at all (EOPNOTSUPP) -> warn once and
-//     stop trying. The archive root's filesystem is not a per-file choice.
+//   - the destination filesystem holds no xattrs at all -> warn once and stop trying.
+//     The archive root's filesystem is not a per-file choice. Proven by asking the
+//     destination descriptor, never inferred from one rejected name: EOPNOTSUPP also
+//     comes back per NAMESPACE, and a destination that stores user.* fine can still
+//     refuse a security.* attribute.
 //   - one attribute is refused (EPERM/EACCES - security.capability needs CAP_SETFCAP,
-//     security.selinux needs relabel permission) -> warn naming it, keep going.
+//     security.selinux needs relabel permission; or a namespace this filesystem does
+//     not implement) -> warn naming it, keep going.
 //   - anything else -> fail the copy. E2BIG and ENOSPC are errors, not policy limits.
 //
 // trusted.* needs no special case: an unprivileged lister never sees it, so it never
@@ -63,7 +67,7 @@ var errXattrUnsupportedDestination = errors.New("destination filesystem does not
 func copySourceXattrs(sourceFD, destinationFD int, destinationPath, kind string, acl bool) error {
 	names, err := listXattrNames(sourceFD)
 	if err != nil {
-		if errors.Is(err, unix.EOPNOTSUPP) {
+		if isXattrUnsupported(err) {
 			return nil // the SOURCE filesystem has no xattrs; nothing to carry
 		}
 		return fmt.Errorf(
@@ -106,10 +110,22 @@ func copySourceXattrs(sourceFD, destinationFD int, destinationPath, kind string,
 		}
 		if err := unix.Fsetxattr(destinationFD, name, value, 0); err != nil {
 			switch {
-			case errors.Is(err, unix.EOPNOTSUPP):
+			case isXattrUnsupported(err):
+				// EOPNOTSUPP here is per-NAME, not per-filesystem: a destination that
+				// stores user.* happily can still reject a namespace it does not
+				// implement. Latching on the first one would skip every remaining
+				// attribute on this node AND on every later node, so the filesystem-wide
+				// claim has to be established independently before it is believed.
+				if !destinationRejectsAllXattrs(destinationFD) {
+					log.WarningLog.Printf(
+						"archive: extended attribute %q not reproduced on %s %s (this destination does not implement that namespace): %v",
+						name, kind, destinationPath, err,
+					)
+					continue
+				}
 				log.WarningLog.Printf(
-					"archive: %s %s cannot hold extended attributes on this filesystem; %d attribute(s) not copied",
-					kind, destinationPath, len(names),
+					"archive: %s %s cannot hold extended attributes on this filesystem; none were copied",
+					kind, destinationPath,
 				)
 				return errXattrUnsupportedDestination
 			case errors.Is(err, unix.EPERM), errors.Is(err, unix.EACCES):
@@ -182,12 +198,33 @@ func copyXattrPhase(support *xattrDestination, sourceFD, destinationFD int, dest
 // normalise.
 func pruneDestinationXattrs(sourceFD, destinationFD int, destinationPath, kind string) {
 	destinationNames, err := listXattrNames(destinationFD)
-	if err != nil || len(destinationNames) == 0 {
+	if err != nil {
+		// A destination that holds no attributes at all has nothing to normalise and is
+		// not worth a warning. Anything else — EIO, ENOMEM — means the check did not
+		// happen, and staying silent about that is how an inherited ACL rides along
+		// while the archive reports success.
+		if !isXattrUnsupported(err) {
+			log.WarningLog.Printf(
+				"archive: could not list extended attributes on %s %s to check for inherited ones; any the destination added are left in place: %v",
+				kind, destinationPath, err,
+			)
+		}
+		return
+	}
+	if len(destinationNames) == 0 {
 		return
 	}
 	sourceNames, err := listXattrNames(sourceFD)
-	if err != nil && !errors.Is(err, unix.EOPNOTSUPP) {
-		return // cannot tell what the source had; leave the destination alone
+	if err != nil && !isXattrUnsupported(err) {
+		// Cannot tell what the source had, so leave the destination alone rather than
+		// remove something the source may well have carried — but say so, because an
+		// inherited ACL surviving is the permission-widening case this helper exists
+		// to prevent.
+		log.WarningLog.Printf(
+			"archive: could not list the source's extended attributes while normalising %s %s; any the destination inherited are left in place: %v",
+			kind, destinationPath, err,
+		)
+		return
 	}
 	fromSource := make(map[string]struct{}, len(sourceNames))
 	for _, name := range sourceNames {
@@ -224,6 +261,35 @@ func pruneDestinationXattrs(sourceFD, destinationFD int, destinationPath, kind s
 // #2919 instead, so the limit is written down where the follow-up will look.
 func isACLXattr(name string) bool {
 	return name == "system.posix_acl_access" || name == "system.posix_acl_default"
+}
+
+// destinationRejectsAllXattrs reports whether a destination holds no extended
+// attributes AT ALL, as opposed to having refused one particular name.
+//
+// Asked of the destination descriptor itself, because that is the only thing that
+// can answer it: a listing that comes back unsupported means the filesystem does not
+// implement xattrs, while a listing that succeeds proves it does and that the refusal
+// was about the one namespace. Without this the first rejected security.* attribute
+// would convince the copier that the whole filesystem was attribute-less and make it
+// skip the user.* and ACL attributes it could have stored.
+func destinationRejectsAllXattrs(destinationFD int) bool {
+	_, err := unix.Flistxattr(destinationFD, nil)
+	return isXattrUnsupported(err)
+}
+
+// isXattrUnsupported reports whether an error means extended attributes are not
+// available here at all. Platform-split for the same reason as isXattrVanished, and
+// with a sharper consequence: darwin spells this ENOTSUP (0x2d) where Linux returns
+// EOPNOTSUPP (0x5f) and makes the two names one value, so matching only EOPNOTSUPP
+// would send every unsupported macOS destination down the "unexpected error" path and
+// fail the archive outright instead of degrading to a warning.
+func isXattrUnsupported(err error) bool {
+	for _, unsupported := range xattrUnsupportedErrnos() {
+		if errors.Is(err, unsupported) {
+			return true
+		}
+	}
+	return false
 }
 
 // isXattrVanished reports whether an error means the attribute is simply not there —

--- a/session/git/worktree_copy_xattr_darwin.go
+++ b/session/git/worktree_copy_xattr_darwin.go
@@ -9,3 +9,11 @@ import "golang.org/x/sys/unix"
 // is a distinct errno on this platform and a filesystem may report it.
 // See isXattrVanished for why this is platform-split rather than a single list.
 func xattrAbsentErrnos() []error { return []error{unix.ENOATTR, unix.ENODATA} }
+
+// xattrUnsupportedErrnos is what darwin returns when extended attributes are not
+// available at all. Both spellings are listed because on this platform they are
+// DIFFERENT errnos — ENOTSUP is 0x2d and EOPNOTSUPP is 0x66, where Linux makes them
+// one value — and the xattr syscalls here return ENOTSUP. Matching only EOPNOTSUPP
+// would send an unsupported destination down the "unexpected error" path and fail the
+// whole archive on macOS.
+func xattrUnsupportedErrnos() []error { return []error{unix.ENOTSUP, unix.EOPNOTSUPP} }

--- a/session/git/worktree_copy_xattr_darwin.go
+++ b/session/git/worktree_copy_xattr_darwin.go
@@ -1,0 +1,11 @@
+//go:build darwin
+
+package git
+
+import "golang.org/x/sys/unix"
+
+// xattrAbsentErrnos is what darwin returns when an extended attribute is not present.
+// ENOATTR is the one the xattr syscalls actually use; ENODATA is listed too because it
+// is a distinct errno on this platform and a filesystem may report it.
+// See isXattrVanished for why this is platform-split rather than a single list.
+func xattrAbsentErrnos() []error { return []error{unix.ENOATTR, unix.ENODATA} }

--- a/session/git/worktree_copy_xattr_linux.go
+++ b/session/git/worktree_copy_xattr_linux.go
@@ -7,3 +7,9 @@ import "golang.org/x/sys/unix"
 // xattrAbsentErrnos is what Linux returns when an extended attribute is not present.
 // See isXattrVanished for why this is platform-split rather than a single list.
 func xattrAbsentErrnos() []error { return []error{unix.ENODATA} }
+
+// xattrUnsupportedErrnos is what Linux returns when extended attributes are not
+// available at all. ENOTSUP and EOPNOTSUPP are the SAME value here (0x5f), so one
+// entry covers both spellings; on darwin they are different numbers, which is why
+// this is split alongside xattrAbsentErrnos.
+func xattrUnsupportedErrnos() []error { return []error{unix.EOPNOTSUPP} }

--- a/session/git/worktree_copy_xattr_linux.go
+++ b/session/git/worktree_copy_xattr_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package git
+
+import "golang.org/x/sys/unix"
+
+// xattrAbsentErrnos is what Linux returns when an extended attribute is not present.
+// See isXattrVanished for why this is platform-split rather than a single list.
+func xattrAbsentErrnos() []error { return []error{unix.ENODATA} }

--- a/session/git/worktree_copy_xattr_test.go
+++ b/session/git/worktree_copy_xattr_test.go
@@ -1,0 +1,99 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// The fidelity guard (worktree_copy_fidelity_test.go) proves ONE attribute survives
+// the cross-device copy. These pin the parts of #2919's xattr work that a
+// single-attribute probe cannot see: several attributes on one node, a present
+// attribute whose value is EMPTY — which is meaningful and which a "size 0 means
+// absent" reading would silently drop — and that a node with no attributes at all
+// copies cleanly rather than erroring on an empty list.
+
+// xattrCapableDir skips the test when the filesystem under t.TempDir() cannot hold
+// user.* attributes. Probed by WRITING to the source tree, not by inspecting a tree
+// built later: asking the wrong tree is how the fidelity guard once dropped its xattr
+// comparison entirely while still reporting a pass (#2919).
+func xattrCapableDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	probe := filepath.Join(dir, ".xattr-probe")
+	require.NoError(t, os.WriteFile(probe, []byte("x"), 0o600))
+	if err := unix.Setxattr(probe, "user.af_probe", []byte("1"), 0); err != nil {
+		t.Skipf("filesystem under %s does not support user.* extended attributes: %v", dir, err)
+	}
+	require.NoError(t, os.Remove(probe))
+	return dir
+}
+
+func readAttr(t *testing.T, path, name string) []byte {
+	t.Helper()
+	size, err := unix.Getxattr(path, name, nil)
+	require.NoError(t, err, "attribute %q must exist on %s", name, path)
+	if size == 0 {
+		return nil
+	}
+	value := make([]byte, size)
+	read, err := unix.Getxattr(path, name, value)
+	require.NoError(t, err)
+	return value[:read]
+}
+
+func TestCopyTree_ReproducesEveryVisibleXattrIncludingEmptyValues(t *testing.T) {
+	workspace := xattrCapableDir(t)
+	source := filepath.Join(workspace, "src")
+	require.NoError(t, os.MkdirAll(filepath.Join(source, "dir"), 0o700))
+	file := filepath.Join(source, "dir", "carrier.txt")
+	require.NoError(t, os.WriteFile(file, []byte("payload"), 0o640))
+
+	// Two attributes, and one of them EMPTY. An empty value is not the same as an
+	// absent attribute, and the two-call sizing makes it easy to conflate them.
+	require.NoError(t, unix.Setxattr(file, "user.af_one", []byte("first"), 0))
+	require.NoError(t, unix.Setxattr(file, "user.af_empty", []byte{}, 0))
+	require.NoError(t, unix.Setxattr(filepath.Join(source, "dir"), "user.af_dir", []byte("ondir"), 0))
+
+	destination := filepath.Join(workspace, "dst")
+	require.NoError(t, copyTree(source, destination))
+
+	copied := filepath.Join(destination, "dir", "carrier.txt")
+	require.Equal(t, []byte("first"), readAttr(t, copied, "user.af_one"))
+	require.Empty(t, readAttr(t, copied, "user.af_empty"),
+		"a present attribute with an empty value must arrive present, not dropped")
+	require.Equal(t, []byte("ondir"), readAttr(t, filepath.Join(destination, "dir"), "user.af_dir"),
+		"directories carry attributes too — a lost DEFAULT ACL is the dangerous case")
+
+	// The names must round-trip as a set, so an extra or missing attribute fails here
+	// rather than only when someone asks for the one that vanished.
+	names, err := listXattrNames(int(mustOpen(t, copied).Fd()))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"user.af_one", "user.af_empty"}, names)
+}
+
+func TestCopyTree_NodeWithNoXattrsCopiesCleanly(t *testing.T) {
+	workspace := xattrCapableDir(t)
+	source := filepath.Join(workspace, "src")
+	require.NoError(t, os.MkdirAll(source, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(source, "bare.txt"), []byte("no attrs"), 0o600))
+
+	destination := filepath.Join(workspace, "dst")
+	require.NoError(t, copyTree(source, destination),
+		"an empty attribute list must not be read as an error")
+
+	body, err := os.ReadFile(filepath.Join(destination, "bare.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "no attrs", string(body))
+}
+
+func mustOpen(t *testing.T, path string) *os.File {
+	t.Helper()
+	handle, err := os.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = handle.Close() })
+	return handle
+}

--- a/session/git/worktree_copy_xattr_test.go
+++ b/session/git/worktree_copy_xattr_test.go
@@ -141,14 +141,19 @@ func mustOpen(t *testing.T, path string) *os.File {
 // on, so an ordinary attribute was lost silently on every read-only node in the tree.
 func TestCopyTree_CopiesXattrsOntoReadOnlyNodes(t *testing.T) {
 	source, destination := xattrFixture(t)
+	// Attribute FIRST, then chmod. Setting a user.* attribute needs write permission
+	// on the inode, so a fixture built read-only cannot be given one — the first
+	// version of this test tried, took the EACCES for "this filesystem has no user
+	// xattrs", and SKIPPED. It reported green on every run without once exercising
+	// the ordering it exists to pin.
 	readOnly := filepath.Join(source, "locked.txt")
-	require.NoError(t, os.WriteFile(readOnly, []byte("contents"), 0o444))
-	if err := unix.Setxattr(readOnly, "user.af_locked", []byte("kept"), 0); err != nil {
-		t.Skipf("this filesystem does not support user xattrs: %v", err)
-	}
+	require.NoError(t, os.WriteFile(readOnly, []byte("contents"), 0o644))
+	require.NoError(t, unix.Setxattr(readOnly, "user.af_locked", []byte("kept"), 0))
+	require.NoError(t, os.Chmod(readOnly, 0o444))
 	readOnlyDir := filepath.Join(source, "lockeddir")
-	require.NoError(t, os.Mkdir(readOnlyDir, 0o555))
+	require.NoError(t, os.Mkdir(readOnlyDir, 0o755))
 	require.NoError(t, unix.Setxattr(readOnlyDir, "user.af_lockeddir", []byte("kept"), 0))
+	require.NoError(t, os.Chmod(readOnlyDir, 0o555))
 
 	require.NoError(t, moveDirCrossDevice(source, destination))
 

--- a/session/git/worktree_copy_xattr_test.go
+++ b/session/git/worktree_copy_xattr_test.go
@@ -133,12 +133,17 @@ func mustOpen(t *testing.T, path string) *os.File {
 	return handle
 }
 
-// TestCopyTree_CopiesXattrsOntoReadOnlyNodes is the P1 from review, and the ordering
-// it pins is not cosmetic. Setting an attribute in the user namespace requires write
-// permission on the INODE — an already-open write descriptor does not satisfy it — so
-// with the mode applied first, every user.* attribute on a checked-in 0444 file
-// failed EACCES. The privilege branch then logged it as "needs privilege" and carried
-// on, so an ordinary attribute was lost silently on every read-only node in the tree.
+// TestCopyTree_CopiesXattrsOntoReadOnlyNodes is the P1 from review, and what it pins
+// is the CREATION mode, not the ordering. Setting an attribute in the user namespace
+// requires write permission on the INODE, and an already-open write descriptor does
+// not satisfy it. openat() created the destination at the source's mode, so a
+// checked-in 0444 file was read-only from the moment it existed and every user.*
+// attribute failed EACCES wherever in the sequence it was attempted — reordering the
+// call could not help, which is how the first attempt at this fix passed review while
+// changing nothing. The privilege branch then logged the EACCES as "needs privilege"
+// and carried on, losing an ordinary attribute silently on every read-only node.
+//
+// workingFileMode is the fix: create owner-writable, apply the real mode last.
 func TestCopyTree_CopiesXattrsOntoReadOnlyNodes(t *testing.T) {
 	source, destination := xattrFixture(t)
 	// Attribute FIRST, then chmod. Setting a user.* attribute needs write permission
@@ -201,4 +206,32 @@ func TestCopyTree_DropsDestinationOnlyXattrs(t *testing.T) {
 	// only what the source lacks, never what it has.
 	require.Contains(t, listAttrs(t, filepath.Join(second, "plain.txt")), "user.af_inherited")
 	require.Equal(t, []byte("yes"), readAttr(t, filepath.Join(second, "plain.txt"), "user.af_kept"))
+}
+
+// TestDestinationRejectsAllXattrs_OnlyWhenTheListingSaysSo pins the distinction the
+// latch depends on. EOPNOTSUPP comes back per NAMESPACE as well as per filesystem, so
+// "one attribute was refused" is not evidence that the destination holds none — and
+// acting on it would skip every remaining attribute on this node and on every later
+// node in the copy. The predicate must consult the destination descriptor itself.
+func TestDestinationRejectsAllXattrs_OnlyWhenTheListingSaysSo(t *testing.T) {
+	dir := xattrCapableDir(t)
+	path := filepath.Join(dir, "holder.txt")
+	require.NoError(t, os.WriteFile(path, []byte("x"), 0o600))
+	handle := mustOpen(t, path)
+
+	require.False(t, destinationRejectsAllXattrs(int(handle.Fd())),
+		"a filesystem whose listing succeeds does support attributes, whatever a single "+
+			"rejected namespace reported")
+
+	// And the errno classifier underneath it must accept the spelling THIS platform
+	// uses, not just the Linux one: darwin returns ENOTSUP (0x2d) where Linux returns
+	// EOPNOTSUPP (0x5f) and treats the two names as one value. Matching only the Linux
+	// spelling would drop an unsupported darwin destination into the "unexpected error"
+	// branch and fail the whole archive instead of warning.
+	for _, unsupported := range xattrUnsupportedErrnos() {
+		require.True(t, isXattrUnsupported(unsupported),
+			"every errno this platform reports as unsupported must classify as unsupported")
+	}
+	require.False(t, isXattrUnsupported(unix.EIO),
+		"a real I/O failure must not be mistaken for an attribute-less filesystem")
 }

--- a/session/git/worktree_copy_xattr_test.go
+++ b/session/git/worktree_copy_xattr_test.go
@@ -1,8 +1,10 @@
 package git
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,6 +32,39 @@ func xattrCapableDir(t *testing.T) string {
 	}
 	require.NoError(t, os.Remove(probe))
 	return dir
+}
+
+// xattrFixture is a source/destination pair on an xattr-capable filesystem, with the
+// cross-device path forced so moveDirCrossDevice really copies rather than renames.
+func xattrFixture(t *testing.T) (source, destination string) {
+	t.Helper()
+	workspace := xattrCapableDir(t)
+	source = filepath.Join(workspace, "src")
+	require.NoError(t, os.MkdirAll(source, 0o755))
+	original := renamePath
+	renamePath = func(_, _ string) error { return syscall.EXDEV }
+	t.Cleanup(func() { renamePath = original })
+	return source, filepath.Join(workspace, "dst")
+}
+
+// listAttrs returns the attribute names present on path.
+func listAttrs(t *testing.T, path string) []string {
+	t.Helper()
+	size, err := unix.Listxattr(path, nil)
+	require.NoError(t, err)
+	if size == 0 {
+		return nil
+	}
+	buffer := make([]byte, size)
+	read, err := unix.Listxattr(path, buffer)
+	require.NoError(t, err)
+	var names []string
+	for _, name := range bytes.Split(buffer[:read], []byte{0}) {
+		if len(name) > 0 {
+			names = append(names, string(name))
+		}
+	}
+	return names
 }
 
 func readAttr(t *testing.T, path, name string) []byte {
@@ -96,4 +131,69 @@ func mustOpen(t *testing.T, path string) *os.File {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = handle.Close() })
 	return handle
+}
+
+// TestCopyTree_CopiesXattrsOntoReadOnlyNodes is the P1 from review, and the ordering
+// it pins is not cosmetic. Setting an attribute in the user namespace requires write
+// permission on the INODE — an already-open write descriptor does not satisfy it — so
+// with the mode applied first, every user.* attribute on a checked-in 0444 file
+// failed EACCES. The privilege branch then logged it as "needs privilege" and carried
+// on, so an ordinary attribute was lost silently on every read-only node in the tree.
+func TestCopyTree_CopiesXattrsOntoReadOnlyNodes(t *testing.T) {
+	source, destination := xattrFixture(t)
+	readOnly := filepath.Join(source, "locked.txt")
+	require.NoError(t, os.WriteFile(readOnly, []byte("contents"), 0o444))
+	if err := unix.Setxattr(readOnly, "user.af_locked", []byte("kept"), 0); err != nil {
+		t.Skipf("this filesystem does not support user xattrs: %v", err)
+	}
+	readOnlyDir := filepath.Join(source, "lockeddir")
+	require.NoError(t, os.Mkdir(readOnlyDir, 0o555))
+	require.NoError(t, unix.Setxattr(readOnlyDir, "user.af_lockeddir", []byte("kept"), 0))
+
+	require.NoError(t, moveDirCrossDevice(source, destination))
+
+	require.Equal(t, []byte("kept"), readAttr(t, filepath.Join(destination, "locked.txt"), "user.af_locked"),
+		"a 0444 file must keep its attributes — the mode must not be applied before they are written")
+	require.Equal(t, []byte("kept"), readAttr(t, filepath.Join(destination, "lockeddir"), "user.af_lockeddir"),
+		"and a 0555 directory likewise")
+
+	// The mode itself must still land, so the fix cannot have simply left nodes writable.
+	info, err := os.Stat(filepath.Join(destination, "locked.txt"))
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o444), info.Mode().Perm())
+}
+
+// TestCopyTree_DropsDestinationOnlyXattrs pins the other P1. A destination parent
+// carrying a DEFAULT POSIX ACL gives every newly created child a
+// system.posix_acl_access of its own, so a source file with no ACL arrives with one —
+// and an inherited ACL is generally WIDER than the mode it replaces, making this a
+// permission-widening divergence rather than an untidy one.
+//
+// Simulated with a user.* attribute rather than a real default ACL: the mechanism
+// under test is "the destination has an attribute the source does not", and a user
+// attribute exercises it on any filesystem, where setting a default ACL needs tooling
+// this test cannot assume.
+func TestCopyTree_DropsDestinationOnlyXattrs(t *testing.T) {
+	source, destination := xattrFixture(t)
+	file := filepath.Join(source, "plain.txt")
+	require.NoError(t, os.WriteFile(file, []byte("contents"), 0o644))
+	if err := unix.Setxattr(file, "user.af_kept", []byte("yes"), 0); err != nil {
+		t.Skipf("this filesystem does not support user xattrs: %v", err)
+	}
+
+	require.NoError(t, moveDirCrossDevice(source, destination))
+	copied := filepath.Join(destination, "plain.txt")
+
+	// Stand in for the inherited attribute, then re-run the copy step against a source
+	// that never had it.
+	require.NoError(t, unix.Setxattr(copied, "user.af_inherited", []byte("from-parent"), 0))
+	names := listAttrs(t, copied)
+	require.Contains(t, names, "user.af_inherited")
+
+	second := filepath.Join(filepath.Dir(destination), "dst2")
+	require.NoError(t, moveDirCrossDevice(destination, second))
+	// The second copy's source DID have it, so it is carried — the prune must remove
+	// only what the source lacks, never what it has.
+	require.Contains(t, listAttrs(t, filepath.Join(second, "plain.txt")), "user.af_inherited")
+	require.Equal(t, []byte("yes"), readAttr(t, filepath.Join(second, "plain.txt"), "user.af_kept"))
 }


### PR DESCRIPTION
The last unchecked box on #2919. Claimed on the issue before starting, with the design
call stated up front so it could be vetoed cheaply rather than in review.

Refs #2919 — **not `Closes`**: symlink timestamps is claimed by two other sessions, and
closing the epic out from under them would lose that item.

## What was lost

`rename(2)` keeps extended attributes for free. The copy reproduced only what it was
written to reproduce, so every namespace was dropped — and which filesystem `$AF_HOME`
sits on decided whether a restored worktree kept them.

Not decoration:

- `system.posix_acl_access` / `_default` carry named-user and named-group grants. A
  **directory's default ACL** vanishing is the surprising direction: files created in the
  restored tree afterwards inherit plain umask permissions, which can be **wider** than
  the policy that was archived.
- `security.capability` — a vendored helper silently loses the capability it needs to bind.
- `security.selinux` — a tree comes back mislabeled on an enforcing box.

## Design call (as claimed on the issue)

**Descriptor-anchored**, like the rest of the copier: `Fgetxattr`/`Flistxattr`/`Fsetxattr`
take the descriptors the walk already validated, so no path is re-derived from an fd and
the name-swap race the copier exists to avoid stays avoided. Both platforms have the F*
forms — worth noting my first grep looked in the wrong files and found only the path-based
ones, which would have forced either `/proc/self/fd` or a raw syscall.

**Ordering is load-bearing**, and it is why this sits between the mode and the times: the
access ACL and the mode bits are one state seen two ways. Setting `system.posix_acl_access`
rewrites the mode, and `chmod` rewrites the ACL mask — so an ACL applied *before* the mode
is silently undone. `setxattr` moves ctime only, so the times still land last.

**Failure policy, per-attribute and deliberately asymmetric.** An archive that refuses to
run is a worse outcome than one that could not store a label — but only while the loss is
*logged* rather than silent, which is #2919's actual complaint:

| condition | behaviour |
| --- | --- |
| destination fs holds no xattrs (`EOPNOTSUPP`) | warn **once**, stop trying |
| one attribute refused (`EPERM`/`EACCES`) | warn naming it, keep going |
| anything else (`E2BIG`, `ENOSPC`, …) | **fail the copy** — errors, not policy |

`trusted.*` needs no special case: an unprivileged lister never sees it, so it never
appears in the list to attempt.

## Verification

`xattr.file` / `xattr.dir` come off `knownCrossDeviceDivergence`, so the guard proves this
rather than this description asserting it. **Watched it fail first** with the listing
stubbed out:

```
xattr.dir  diverges ... source=dirvalue  rename=dirvalue  copy=MISSING
xattr.file diverges ... source=filevalue rename=filevalue copy=MISSING
```

Two new tests cover what a single-attribute probe cannot:

- several attributes on one node, and the **names round-trip as a set**, so an extra or
  missing one fails here rather than only when someone asks for the one that vanished;
- a present attribute whose value is **empty** — meaningful, and exactly what a "size 0
  means absent" reading would silently drop;
- a node with **no** attributes, so an empty list is not read as an error.

The support probe **writes to the source tree** rather than inspecting a tree built later:
asking the wrong tree is how the fidelity guard once dropped its xattr comparison entirely
while still reporting a pass, which that test's own comments record.

**What the guard does not cover, stated rather than implied:** an unprivileged fixture
cannot create `security.capability` or a SELinux label, so the privileged namespaces are
exercised by the policy code and not by a test. That limit is in the code comment and here.

Local checks per the current rule — `gofmt -l .` clean, `go build ./...` ok (plus
`GOOS=darwin go build ./session/...`, since this is syscall code), `golangci-lint --fast`
clean, `scripts/lint-file-length.sh` passed, `go test ./session/git/` green in full (23s).
No `deadcode` locally, no containerized suites, nothing against `./daemon/...` or
`./app/...` — CI runs those, including the macOS leg this needs.

Co-Authored-By: Captain Claude <noreply@anthropic.com>
