### PR TITLE
test(upgrade): guard #2212's expected-pre-image check

### DIFF
--- a/internal/upgradetxn/prepare_preimage_test.go
+++ b/internal/upgradetxn/prepare_preimage_test.go
@@ -1,0 +1,90 @@
+package upgradetxn
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The expected-pre-image check is #2212's gate against a stale candidate: the
+// daemon fingerprints the executable at start, downloads for minutes, and must
+// not then install over a binary an `af upgrade` replaced in the meantime — or
+// the transaction preserves the NEWER binary as its rollback target and installs
+// an OLDER candidate over it, so a later rollback silently reverts the install.
+//
+// The caller cannot make this check for itself. Anything it compares happens
+// before Prepare takes the locks, leaving a window an in-place install lands in.
+// Only the comparison Prepare makes — inside both locks, against the very bytes
+// it is about to preserve — cannot be raced, which is why the digest is carried
+// in the Plan rather than checked by the caller.
+//
+// The engine side had no test. daemon/update_driver_test.go covers the daemon
+// refusing to activate without a baseline; nothing exercised the refusal itself,
+// so the gate could regress with every daemon-side test still green.
+func preimagePlan(t *testing.T, executable, expected string) Plan {
+	t.Helper()
+	return Plan{
+		ID:                     "upgrade-" + strings.Repeat("d", 32),
+		HomeDir:                t.TempDir(),
+		ExecutablePath:         executable,
+		FromVersion:            "1.0.100",
+		ToVersion:              "1.0.300",
+		Candidate:              []byte("candidate-af-binary"),
+		ExpectedPreviousSHA256: expected,
+		Daemon: DaemonSnapshot{
+			WasRunning: true,
+			BootID:     "boot",
+			Owner:      DaemonOwner{Kind: SupervisionAdHoc},
+		},
+		RecoveryJob: RecoveryJob{Kind: RecoveryJobDetached},
+	}
+}
+
+// The refusal. The executable is replaced after the caller observed it, which is
+// exactly what an `af upgrade` during the daemon's download does.
+func TestPrepare_RefusesWhenTheExecutableChangedSinceTheCallerObservedIt(t *testing.T) {
+	executable := lockTestExecutable(t)
+	observed := digest([]byte("af binary"))
+	require.Equal(t, observed, digest(mustRead(t, executable)),
+		"precondition: the digest under test must be the one the fixture actually has")
+
+	// Somebody else's in-place install lands between the caller's observation
+	// and this Prepare.
+	require.NoError(t, os.WriteFile(executable, []byte("a DIFFERENT af binary"), 0o755))
+
+	_, err := Prepare(preimagePlan(t, executable, observed))
+	require.Error(t, err, "a transaction planned against bytes that are no longer there must refuse")
+	require.ErrorContains(t, err, "changed since the caller last observed it")
+	require.ErrorContains(t, err, observed, "the error must name the digest that was planned against")
+}
+
+// The matching case still proceeds, so the refusal cannot pass by refusing
+// everything — the failure mode that would make every daemon-owned upgrade fail
+// closed forever and be far worse than the race it guards.
+func TestPrepare_ProceedsWhenTheExpectedPreImageStillMatches(t *testing.T) {
+	executable := lockTestExecutable(t)
+
+	txn, err := Prepare(preimagePlan(t, executable, digest(mustRead(t, executable))))
+	require.NoError(t, err, "an unchanged executable must not be refused")
+	require.NotNil(t, txn)
+}
+
+// An unset digest keeps the pre-#2908 behaviour, which is what every in-place
+// caller relies on: the field is opt-in, and only the daemon path supplies it.
+func TestPrepare_SkipsThePreImageCheckWhenTheCallerSuppliedNone(t *testing.T) {
+	executable := lockTestExecutable(t)
+	require.NoError(t, os.WriteFile(executable, []byte("replaced out from under the plan"), 0o755))
+
+	txn, err := Prepare(preimagePlan(t, executable, ""))
+	require.NoError(t, err, "a caller that supplied no expectation must not be held to one")
+	require.NotNil(t, txn)
+}
+
+func mustRead(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return data
+}


### PR DESCRIPTION
Gate 3 on #2212 — expected-pre-image verification inside the install lock — turns out to be **already implemented and wired**. This adds the test it did not have, and closes the gate on the list rather than re-building it.

## What I found

I claimed this gate expecting to build it. Checking first, per "verify the issue still reproduces":

- `Plan.ExpectedPreviousSHA256` exists (`internal/upgradetxn/transaction.go`).
- `Prepare` verifies it **inside both locks**, against the same bytes it snapshots as the rollback binary — the one place the comparison cannot be raced (`prepare.go`).
- The daemon supplies it: `newUpdateDriver` takes the baseline at daemon start "while the on-disk binary is still the one this process exec'd from", and passes it through `triggerUpgradeActivation` into the `Plan`.
- It **fails closed**: `baselineErr != nil` returns `updateCheckFailed` and activation is refused, rather than proceeding with an empty expectation.

All of it landed in `477d0bdb` — #2908 itself. The gate note was written from #2908's *review*, and the airtight form went in before that PR merged, so the note describes a state that no longer existed by merge time.

## What was actually missing

The engine-side check had **no test**. `daemon/update_driver_test.go` covers the daemon refusing to activate without a baseline; nothing exercised the refusal itself. The comparison could be deleted and every daemon-side test would still pass — on a gate that becomes load-bearing the moment `AGENT_FACTORY_DAEMON_UPGRADE` flips default-on, which is precisely when a silent regression costs the most.

## This PR

Three cases, so the refusal cannot pass by refusing everything — which would fail every daemon-owned upgrade closed forever and be worse than the race it guards:

| test | asserts |
|---|---|
| `RefusesWhenTheExecutableChangedSinceTheCallerObservedIt` | the refusal fires, and the error names the digest that was planned against |
| `ProceedsWhenTheExpectedPreImageStillMatches` | an unchanged executable is not refused |
| `SkipsThePreImageCheckWhenTheCallerSuppliedNone` | the opt-in behaviour every in-place caller relies on is preserved |

**Verified by mutation, not assumed.** Disabling the production check makes the refusal test fail with `An error is expected but got nil`, while the other two keep passing. That is what separates these from tests that merely execute the code — the repo has been bitten by green tests asserting the claim while checking something weaker.

Test-only; no production change.

Refs #2212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
