### PR TITLE
feat(quota): af quota — report per-agent usage honestly, never a guessed number

### DIFF
--- a/commands/quotacmd.go
+++ b/commands/quotacmd.go
@@ -1,0 +1,130 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/quota"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/spf13/cobra"
+)
+
+// quotaCmd is `af quota` (#2983 Part 1): what af can honestly say about each
+// agent CLI's usage, and — just as importantly — what it cannot.
+//
+// Read-only. It reads the local session records and reports; it starts nothing,
+// contacts no provider, and touches no session.
+//
+// The command exists because the answer a user wants ("how much is left?") is
+// currently unobtainable without leaving af, and the tempting way to provide it
+// is to estimate — summing token counts out of provider transcripts, say. That
+// measures SPEND, not entitlement, and presenting it as a quota would be a
+// confident answer to a question nothing here can answer. So this reports the
+// ceiling as "not reported" for every provider, and puts the real signal af does
+// have — its own sessions parked at a usage wall, with the reset time it
+// recorded — on a separate axis that cannot be mistaken for it.
+var quotaCmd = &cobra.Command{
+	Use:   "quota",
+	Short: "Show usage-limit status for each agent CLI",
+	Long: `Show what af knows about each agent CLI's usage limits.
+
+Two different things, kept apart on purpose:
+
+  QUOTA     what the provider reports about the account's ceiling. af has no
+            quota API for any supported agent today, so every row reads
+            "not reported". That is af declining to guess, not a ceiling of zero.
+
+  OBSERVED  what af has seen in its OWN sessions — a session parked at a usage
+            wall, and the reset time recorded with it. Real signal even where the
+            provider exposes nothing.
+
+Read-only: it reads local session records and starts nothing.`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		records, skipped, err := config.LoadAllRepoInstancesReportingSkips()
+		if err != nil {
+			return fmt.Errorf("cannot read session records: %w", err)
+		}
+
+		states, unreadable := quotaSessionStates(records)
+		report := quota.Build(tmux.SupportedPrograms, states)
+		if err := quota.Render(cmd.OutOrStdout(), report, time.Now()); err != nil {
+			return err
+		}
+
+		// An under-read report must never look complete. A repo whose records
+		// could not be read may hold sessions parked at a limit, so staying silent
+		// would render a confident "no limit seen" built on a failed read — the
+		// exact shape this repo keeps paying for. Reported after the table so the
+		// caveat attaches to what was just shown.
+		if len(skipped) > 0 {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"\nwarning: %d project record file(s) could not be read, so this report is INCOMPLETE; "+
+					"sessions in them are not counted above: %v\n", len(skipped), skipped)
+		}
+		if unreadable > 0 {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"\nwarning: %d project record file(s) could not be parsed and were skipped, so this "+
+					"report is INCOMPLETE\n", unreadable)
+		}
+		return nil
+	},
+}
+
+// quotaSessionStates projects the on-disk records into the minimal shape the
+// quota package needs, and reports how many record blobs could not be parsed.
+//
+// The count is returned rather than swallowed for the same reason the skip list
+// is: a record that would not parse might have been the parked one, and a report
+// that quietly drops it reads as authoritative.
+func quotaSessionStates(records map[string]json.RawMessage) ([]quota.SessionState, int) {
+	states := []quota.SessionState{}
+	unreadable := 0
+	for _, raw := range records {
+		var data []session.InstanceData
+		if err := json.Unmarshal(raw, &data); err != nil {
+			unreadable++
+			continue
+		}
+		for _, instance := range data {
+			// Archived and killed rows are not running an agent, so they say
+			// nothing about current usage and must not pad the counts.
+			if instance.Liveness == session.LiveArchived || instance.UserKilled {
+				continue
+			}
+			states = append(states, quota.SessionState{
+				Program:      quotaAgentName(instance.Program),
+				LimitReached: instance.Liveness == session.LiveLimitReached,
+				ResetAt:      instance.LimitResetAt,
+			})
+		}
+	}
+	return states, unreadable
+}
+
+// quotaAgentName maps a session's recorded program to the canonical agent enum.
+//
+// InstanceData.Program holds the RESOLVED command, not the enum: with
+// program_overrides configured it is a whole command line
+// ("/usr/local/bin/claude --dangerously-skip-permissions"), so grouping on it
+// raw produces one row per flag combination and splits an agent's sessions
+// across rows that all read like separate agents. Found by running the command
+// against this box rather than by reading the type.
+//
+// tmux.DetectAgentFromCommand is the existing answer and already handles the
+// cases a naive filepath.Base would not — wrapper prefixes (`ionice -c 3
+// claude`), leading env assignments, and `env VAR=x claude` — matching only when
+// a token's base equals a supported name verbatim, so /opt/claude-wrapper/run
+// never matches on substring.
+//
+// A command it cannot attribute is returned UNCHANGED rather than dropped or
+// bucketed as "unknown": those sessions are real, and hiding them would
+// under-report exactly the way an invented number over-reports.
+func quotaAgentName(program string) string {
+	if agent := tmux.DetectAgentFromCommand(program); agent != "" {
+		return agent
+	}
+	return program
+}

--- a/commands/quotacmd.go
+++ b/commands/quotacmd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/apiclient"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/quota"
 	"github.com/sachiniyer/agent-factory/session"
@@ -43,6 +44,22 @@ Two different things, kept apart on purpose:
 
 Read-only: it reads local session records and starts nothing.`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		// --daemon-url / AF_DAEMON_URL promises to target a REMOTE daemon. This
+		// command reads local record files, which describe this host and no other,
+		// so honouring the flag by ignoring it would hand an operator a
+		// valid-looking quota report for the wrong machine — the precise failure
+		// this command exists to avoid, arriving through the target rather than
+		// through a guessed number. Refuse instead. apiclient.IsRemoteTarget is the
+		// established seam for exactly this: its doc names suppressing the local
+		// disk fallback, because a remote read has no local disk to fall back to.
+		//
+		// Refusing rather than fetching is a scope choice, not a verdict on the
+		// feature: serving this remotely needs the daemon to expose the report, and
+		// an honest error today beats a wrong answer today (#2983).
+		if apiclient.IsRemoteTarget() {
+			return fmt.Errorf("af quota reads this machine's session records and cannot report on a remote daemon; " +
+				"unset --daemon-url/AF_DAEMON_URL to report on this host, or run af quota on the daemon's host")
+		}
 		records, skipped, err := config.LoadAllRepoInstancesReportingSkips()
 		if err != nil {
 			return fmt.Errorf("cannot read session records: %w", err)
@@ -89,19 +106,44 @@ func quotaSessionStates(records map[string]json.RawMessage) ([]quota.SessionStat
 			continue
 		}
 		for _, instance := range data {
-			// Archived and killed rows are not running an agent, so they say
-			// nothing about current usage and must not pad the counts.
-			if instance.Liveness == session.LiveArchived || instance.UserKilled {
+			// Resolve the EFFECTIVE liveness rather than reading data.Liveness:
+			// a pre-#1195 record carries the zero value there while its real state
+			// lives in the legacy status field, so a direct comparison classifies an
+			// old archived row as live and counts it as a running session.
+			liveness := session.EffectiveLiveness(instance)
+			if !quotaAgentIsRunning(liveness) || instance.UserKilled {
 				continue
 			}
 			states = append(states, quota.SessionState{
 				Program:      quotaAgentName(instance.Program),
-				LimitReached: instance.Liveness == session.LiveLimitReached,
+				LimitReached: liveness == session.LiveLimitReached,
 				ResetAt:      instance.LimitResetAt,
 			})
 		}
 	}
 	return states, unreadable
+}
+
+// quotaAgentIsRunning reports whether a record still has an agent process behind
+// it, and is therefore evidence about CURRENT usage.
+//
+// An allowlist, not a denylist of inert states. The report's claims are
+// "N session(s) running" and "no limit seen", so a state this function has not
+// considered must not silently become evidence of a healthy account — the same
+// reason the quota axis defaults to "not reported". LivenessUnset lands here too:
+// a record whose state cannot be resolved is not proof of a running agent.
+//
+// LiveLimitReached counts as running deliberately: the agent IS there, parked at
+// the wall, and that parking is the strongest signal this report has.
+// Lost and Dead do not: their agent vanished, so counting them inflates the
+// session totals and turns a machine full of dead rows into "no limit seen".
+func quotaAgentIsRunning(liveness session.Liveness) bool {
+	switch liveness {
+	case session.LiveRunning, session.LiveReady, session.LiveLimitReached:
+		return true
+	default:
+		return false
+	}
 }
 
 // quotaAgentName maps a session's recorded program to the canonical agent enum.

--- a/commands/quotacmd_test.go
+++ b/commands/quotacmd_test.go
@@ -73,6 +73,60 @@ func TestQuotaSessionStates_ExcludesInertRowsAndCarriesLimitState(t *testing.T) 
 	}
 }
 
+// Codex #2996: the filter must exclude every state with no running agent, and
+// must resolve liveness through the ROLLFORWARD — a pre-#1195 record carries the
+// zero Liveness while its real state lives in the legacy status field, so reading
+// data.Liveness directly counts an old archived row as a running session.
+func TestQuotaSessionStates_ExcludesVanishedAgentsAndLegacyArchivedRecords(t *testing.T) {
+	raw, err := json.Marshal([]session.InstanceData{
+		{Title: "running", Program: "claude", Liveness: session.LiveRunning},
+		{Title: "ready", Program: "claude", Liveness: session.LiveReady},
+		{Title: "parked", Program: "claude", Liveness: session.LiveLimitReached},
+		// Agent vanished: counting these turns a box full of dead rows into
+		// "N session(s) running, none parked at a limit".
+		{Title: "lost", Program: "claude", Liveness: session.LiveLost},
+		{Title: "dead", Program: "claude", Liveness: session.LiveDead},
+		// Pre-#1195: Liveness unset, real state in the legacy status field. A
+		// legacy RUNNING record is the fixture that makes the rollforward
+		// load-bearing — a legacy ARCHIVED one is excluded either way by the
+		// allowlist, so it proves nothing. Without the rollforward this row
+		// resolves to LivenessUnset and is dropped: a real session UNDER-reported,
+		// which is the same dishonesty as inventing one. Verified by mutation.
+		{Title: "legacy-running", Program: "claude", Status: session.Running},
+		{Title: "legacy-archived", Program: "claude", Status: session.Archived},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	states, _ := quotaSessionStates(map[string]json.RawMessage{"repo": raw})
+	if len(states) != 4 {
+		t.Fatalf("states = %d, want 4 (running, ready, limit-reached, legacy-running): lost/dead have "+
+			"no agent, the legacy ARCHIVED row must resolve to archived, and the legacy RUNNING row "+
+			"must resolve to running rather than being dropped as unset", len(states))
+	}
+	parked := 0
+	for _, state := range states {
+		if state.LimitReached {
+			parked++
+		}
+	}
+	if parked != 1 {
+		t.Fatalf("parked = %d, want 1: a limit-reached session still HAS an agent and is the report's strongest signal", parked)
+	}
+}
+
+// A state nobody considered must not become evidence of a healthy account, which
+// is why the running check is an allowlist.
+func TestQuotaAgentIsRunning_UnsetLivenessIsNotRunning(t *testing.T) {
+	if quotaAgentIsRunning(session.LivenessUnset) {
+		t.Fatal("an unresolvable liveness was treated as a running agent; it is not evidence of anything")
+	}
+	if !quotaAgentIsRunning(session.LiveLimitReached) {
+		t.Fatal("a limit-reached session has an agent parked at the wall and must count")
+	}
+}
+
 // A record blob that will not parse is COUNTED, never silently dropped: it might
 // have been the parked one, and a report that hides it reads as authoritative.
 func TestQuotaSessionStates_CountsUnparseableRecordsRatherThanHidingThem(t *testing.T) {

--- a/commands/quotacmd_test.go
+++ b/commands/quotacmd_test.go
@@ -1,0 +1,88 @@
+package commands
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// quotaAgentName exists because of a bug that only appeared when the command was
+// run against a real AF home: InstanceData.Program is the RESOLVED command, not
+// the agent enum, so with program_overrides configured the table grew a row
+// titled "/home/…/claude --dangerously-skip-permissions" beside the real
+// "claude" row — the same agent, reported twice, each undercounted.
+func TestQuotaAgentName_CollapsesResolvedCommandsToTheAgentEnum(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		program string
+		want    string
+	}{
+		{"bare enum", "claude", "claude"},
+		{"absolute path with flags", "/home/u/.local/bin/claude --dangerously-skip-permissions", "claude"},
+		{"wrapper prefix", "ionice -c 3 codex", "codex"},
+		{"env assignment prefix", "FOO=bar gemini", "gemini"},
+		// Not attributable: kept verbatim rather than dropped or bucketed. The
+		// session is real, and hiding it under-reports.
+		{"unrelated command", "/opt/claude-wrapper/run", "/opt/claude-wrapper/run"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := quotaAgentName(tc.program); got != tc.want {
+				t.Fatalf("quotaAgentName(%q) = %q, want %q", tc.program, got, tc.want)
+			}
+		})
+	}
+}
+
+// Archived and tombstoned rows are not running an agent, so they must not pad
+// the session counts the report presents as current usage.
+func TestQuotaSessionStates_ExcludesInertRowsAndCarriesLimitState(t *testing.T) {
+	reset := time.Unix(1_700_000_000, 0).UTC()
+	raw, err := json.Marshal([]session.InstanceData{
+		{Title: "live", Program: "claude", Liveness: session.LiveRunning},
+		{Title: "parked", Program: "codex", Liveness: session.LiveLimitReached, LimitResetAt: reset},
+		{Title: "archived", Program: "claude", Liveness: session.LiveArchived},
+		{Title: "killed", Program: "claude", Liveness: session.LiveRunning, UserKilled: true},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	states, unreadable := quotaSessionStates(map[string]json.RawMessage{"repo": raw})
+	if unreadable != 0 {
+		t.Fatalf("unreadable = %d, want 0", unreadable)
+	}
+	if len(states) != 2 {
+		t.Fatalf("states = %d (%+v), want 2: archived and tombstoned rows run no agent", len(states), states)
+	}
+	var parked int
+	for _, state := range states {
+		if state.LimitReached {
+			parked++
+			if state.Program != "codex" {
+				t.Fatalf("parked session program = %q, want codex", state.Program)
+			}
+			if !state.ResetAt.Equal(reset) {
+				t.Fatalf("ResetAt = %v, want %v carried through", state.ResetAt, reset)
+			}
+		}
+	}
+	if parked != 1 {
+		t.Fatalf("parked = %d, want 1", parked)
+	}
+}
+
+// A record blob that will not parse is COUNTED, never silently dropped: it might
+// have been the parked one, and a report that hides it reads as authoritative.
+func TestQuotaSessionStates_CountsUnparseableRecordsRatherThanHidingThem(t *testing.T) {
+	states, unreadable := quotaSessionStates(map[string]json.RawMessage{
+		"broken": json.RawMessage(`{"not":"an array"}`),
+	})
+	if unreadable != 1 {
+		t.Fatalf("unreadable = %d, want 1: an unparseable record must be reported, not swallowed", unreadable)
+	}
+	if len(states) != 0 {
+		t.Fatalf("states = %d, want 0", len(states))
+	}
+}

--- a/commands/root.go
+++ b/commands/root.go
@@ -317,6 +317,7 @@ func init() {
 	rootCmd.AddCommand(agentServerCmd)
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(tokenCmd)
+	rootCmd.AddCommand(quotaCmd)
 	rootCmd.AddCommand(api.SessionsCmd)
 	rootCmd.AddCommand(api.TasksCmd)
 	rootCmd.AddCommand(api.ProjectsCmd)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -37,6 +37,7 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 - [`af projects delete`](#af-projects-delete) — Delete a project, archiving its restorable sessions
 - [`af projects list`](#af-projects-list) — List registered projects
 - [`af projects rebind`](#af-projects-rebind) — Rebind a registered project after its checkout moves
+- [`af quota`](#af-quota) — Show usage-limit status for each agent CLI
 - [`af reset`](#af-reset) — Factory-reset Agent Factory: remove AF sessions, tasks, project registrations, worktrees, and state (keeps repos and config)
 - [`af sessions`](#af-sessions) — Manage sessions
 - [`af sessions archive`](#af-sessions-archive) — Finish with a session by archiving it for later restore
@@ -105,6 +106,7 @@ af [flags]
 - [`af doctor`](#af-doctor) — Diagnose setup, daemon health, and leaked session resources
 - [`af keys`](#af-keys) — Show the effective TUI key bindings (defaults plus [keys] rebinds)
 - [`af projects`](#af-projects) — Manage projects and durable registrations
+- [`af quota`](#af-quota) — Show usage-limit status for each agent CLI
 - [`af reset`](#af-reset) — Factory-reset Agent Factory: remove AF sessions, tasks, project registrations, worktrees, and state (keeps repos and config)
 - [`af sessions`](#af-sessions) — Manage sessions
 - [`af tasks`](#af-tasks) — Manage tasks
@@ -1131,6 +1133,35 @@ af projects rebind <project-id> <path>
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this http:// or ws:// URL instead of the local unix socket (env: AF_DAEMON_URL). The daemon is HTTP-only; terminate TLS at your own proxy if needed. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
+
+## af quota
+
+Show usage-limit status for each agent CLI
+
+Show what af knows about each agent CLI's usage limits.
+
+Two different things, kept apart on purpose:
+
+  QUOTA     what the provider reports about the account's ceiling. af has no
+            quota API for any supported agent today, so every row reads
+            "not reported". That is af declining to guess, not a ceiling of zero.
+
+  OBSERVED  what af has seen in its OWN sessions — a session parked at a usage
+            wall, and the reset time recorded with it. Real signal even where the
+            provider exposes nothing.
+
+Read-only: it reads local session records and starts nothing.
+
+```
+af quota
+```
+
+**Global flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--daemon-url` | `string` | Target a REMOTE daemon at this http:// or ws:// URL instead of the local unix socket (env: AF_DAEMON_URL). The daemon is HTTP-only; terminate TLS at your own proxy if needed. |
 | `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af reset

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -1362,6 +1362,25 @@
       },
       "verdict": "unclear",
       "notes": "#1904 added tab reorder to the CLI (tab-reorder --index) and web (ReorderTab, drag in the tab bar). No TUI affordance. Same owner call as session.tab.rename. Not filed."
+    },
+    {
+      "id": "quota.usage-report",
+      "title": "Report usage-limit status per agent CLI",
+      "tui": {
+        "status": "no",
+        "pointer": ""
+      },
+      "web": {
+        "status": "no",
+        "pointer": ""
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "commands/quotacmd.go:29"
+      },
+      "verdict": "real-gap",
+      "issue": "#2983",
+      "notes": "#2983 Part 1 ships the CLI only; the issue also asks for a TUI/web panel, so tui and web are a real GAP rather than n/a and are recorded as such. The report keeps provider ENTITLEMENT (always \"not reported\" — no supported agent exposes a quota surface af can read) apart from af's own OBSERVATION of sessions parked at a usage wall, so a surface that renders it must preserve that separation: a blank or zero quota cell reads as exhausted, which is the failure the command exists to avoid."
     }
   ],
   "ledger": {
@@ -1400,6 +1419,7 @@
       "af projects delete": "project.delete",
       "af projects list": "project.list",
       "af projects rebind": "project.rebind",
+      "af quota": "quota.usage-report",
       "af reset": "install.reset",
       "af sessions archive": "session.archive",
       "af sessions attach": "session.attach",
@@ -1577,13 +1597,13 @@
       "af completion zsh --help": "cli.shell-completion",
       "af completion zsh --no-descriptions": "cli.shell-completion",
       "af config --help": "meta.discovery",
-      "af config get --help": "meta.discovery",
       "af config get --explain": "config.explain",
+      "af config get --help": "meta.discovery",
       "af config get --json": "cli.json-envelope",
       "af config get --project": "config.read-project",
       "af config get --repo": "config.read-project",
-      "af config list --help": "meta.discovery",
       "af config list --explain": "config.explain",
+      "af config list --help": "meta.discovery",
       "af config list --json": "cli.json-envelope",
       "af config list --project": "config.read-project",
       "af config list --repo": "config.read-project",
@@ -1621,6 +1641,7 @@
       "af projects delete --help": "meta.discovery",
       "af projects list --help": "meta.discovery",
       "af projects rebind --help": "meta.discovery",
+      "af quota --help": "meta.discovery",
       "af reset --force": "install.reset",
       "af reset --help": "meta.discovery",
       "af reset --yes": "install.reset",
@@ -1700,6 +1721,7 @@
       "af tasks add --help": "meta.discovery",
       "af tasks add --max-concurrent-runs": "task.max-concurrent-runs",
       "af tasks add --name": "task.add",
+      "af tasks add --on-complete": "task.on-complete",
       "af tasks add --program": "task.add",
       "af tasks add --prompt": "task.add",
       "af tasks add --target-session": "task.add",
@@ -1715,6 +1737,7 @@
       "af tasks update --help": "meta.discovery",
       "af tasks update --max-concurrent-runs": "task.max-concurrent-runs",
       "af tasks update --name": "task.edit",
+      "af tasks update --on-complete": "task.on-complete",
       "af tasks update --program": "task.edit",
       "af tasks update --project-path": "task.edit.project-path",
       "af tasks update --prompt": "task.edit",
@@ -1729,9 +1752,7 @@
       "af upgrade --help": "meta.discovery",
       "af upgrade --ignore-active-upgrade": "install.upgrade",
       "af upgrade --no-restart": "install.upgrade",
-      "af version --help": "meta.discovery",
-      "af tasks add --on-complete": "task.on-complete",
-      "af tasks update --on-complete": "task.on-complete"
+      "af version --help": "meta.discovery"
     }
   },
   "field_coverage": {

--- a/quota/quota.go
+++ b/quota/quota.go
@@ -1,0 +1,244 @@
+// Package quota answers "how much is left, and on which account?" for the agent
+// CLIs af is configured to run (#2983 Part 1).
+//
+// The whole design turns on one rule, which is why it is enforced by the types
+// rather than by the renderer: NO PROVIDER'S ENTITLEMENT MAY BE GUESSED. af has
+// no quota endpoint for any supported agent today, so the honest answer to
+// "what is your ceiling?" is "not reported" — and this repo's recurring failure
+// shape is precisely the other thing, a fabricated number or a blank cell that a
+// reader scans as zero (see the fabricated-negative class: a denied read, an
+// unanswerable probe, and a missing datum have all been rendered here as
+// confident answers).
+//
+// So Entitlement is not a number with a "valid" flag, and it is not a string
+// that might be empty. It is a closed enum whose zero value is EntitlementNotReported,
+// which means a caller that forgets to set it, or a provider added later with no
+// integration, degrades to the truthful answer instead of to zero.
+//
+// What af CAN say honestly is what it has OBSERVED: its own sessions parking at a
+// usage-limit wall, and the reset time it recorded when they did. That is real
+// signal even where the provider offers no endpoint, and it is reported on a
+// separate axis so it is never confused with entitlement.
+package quota
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Entitlement is what a provider says about the account's ceiling.
+//
+// One value today, deliberately. Adding a provider integration means adding a
+// value here AND the code that can produce it; until then every provider reports
+// the zero value, which is the truth. A bool would have invited "false means
+// zero"; an int would have invited a rendered 0.
+type Entitlement int
+
+const (
+	// EntitlementNotReported: af has no way to read this provider's ceiling. The
+	// ZERO VALUE on purpose — an unhandled provider tells the truth by default.
+	EntitlementNotReported Entitlement = iota
+)
+
+// String renders the entitlement for humans. It never returns an empty string,
+// because a blank cell in a quota table reads as zero remaining.
+func (e Entitlement) String() string {
+	switch e {
+	case EntitlementNotReported:
+		return "not reported"
+	default:
+		return "not reported"
+	}
+}
+
+// Observation is what af itself has seen about an agent, independent of anything
+// the provider exposes. It is a separate axis from Entitlement so a reader can
+// never mistake "af watched a session hit a wall" for "the provider told us the
+// quota".
+type Observation int
+
+const (
+	// ObservationNone: af has no sessions for this agent, so it has observed
+	// nothing either way. The zero value, and NOT the same as "healthy" — an
+	// agent nobody has run is not evidence of available quota.
+	ObservationNone Observation = iota
+	// ObservationNoLimitSeen: af has run sessions on this agent and none is
+	// currently parked at a usage limit. Evidence about af's sessions, never a
+	// claim about the account's ceiling.
+	ObservationNoLimitSeen
+	// ObservationLimitReached: at least one session is parked at this agent's
+	// usage-limit wall right now. The strongest signal af has, and it comes from
+	// af's own watching rather than from the provider.
+	ObservationLimitReached
+)
+
+func (o Observation) String() string {
+	switch o {
+	case ObservationLimitReached:
+		return "limit reached"
+	case ObservationNoLimitSeen:
+		return "no limit seen"
+	default:
+		return "no sessions"
+	}
+}
+
+// AgentQuota is one row: everything af can honestly say about one agent CLI.
+type AgentQuota struct {
+	// Program is the canonical agent name (claude, codex, …).
+	Program string
+	// Entitlement is what the provider reports. See the package comment.
+	Entitlement Entitlement
+	// Observation is what af has seen for itself.
+	Observation Observation
+	// Sessions is how many of af's sessions currently use this agent.
+	Sessions int
+	// LimitedSessions is how many of those are parked at a usage limit.
+	LimitedSessions int
+	// ResetAt is the EARLIEST recorded reset time among the limited sessions, or
+	// nil when none was parseable. Nil is meaningful and must render as unknown:
+	// a limit with no reset time is common (not every provider states one), and
+	// showing a zero time would invent a deadline in 1970.
+	ResetAt *time.Time
+}
+
+// Report is the full answer, one row per configured agent.
+type Report struct {
+	Agents []AgentQuota
+}
+
+// SessionState is the minimal projection Build needs, so this package depends on
+// no session/daemon types and stays trivially testable.
+type SessionState struct {
+	// Program is the agent the session runs.
+	Program string
+	// LimitReached is whether the session is parked at a usage-limit wall.
+	LimitReached bool
+	// ResetAt is the recorded reset time for that limit; zero when none was
+	// parsed. Only read when LimitReached.
+	ResetAt time.Time
+}
+
+// Build assembles the report for the given configured agents from af's own
+// session state.
+//
+// programs is the canonical configured list, and every one of them gets a row
+// even when no session uses it: an agent missing from the table is
+// indistinguishable from an agent with nothing to report, and the point of this
+// command is to answer for every configured CLI.
+//
+// A session naming an agent outside programs still gets a row, because it is
+// real and hiding it would under-report. That is the only way rows are added.
+func Build(programs []string, sessions []SessionState) Report {
+	rows := map[string]*AgentQuota{}
+	order := []string{}
+	ensure := func(name string) *AgentQuota {
+		if row, ok := rows[name]; ok {
+			return row
+		}
+		row := &AgentQuota{Program: name, Entitlement: EntitlementNotReported}
+		rows[name] = row
+		order = append(order, name)
+		return row
+	}
+	for _, program := range programs {
+		if program = strings.TrimSpace(program); program != "" {
+			ensure(program)
+		}
+	}
+	for _, state := range sessions {
+		program := strings.TrimSpace(state.Program)
+		if program == "" {
+			continue
+		}
+		row := ensure(program)
+		row.Sessions++
+		if !state.LimitReached {
+			continue
+		}
+		row.LimitedSessions++
+		if state.ResetAt.IsZero() {
+			continue
+		}
+		// Earliest reset wins: it is the soonest the user could resume anything.
+		if row.ResetAt == nil || state.ResetAt.Before(*row.ResetAt) {
+			at := state.ResetAt
+			row.ResetAt = &at
+		}
+	}
+	report := Report{Agents: make([]AgentQuota, 0, len(order))}
+	for _, name := range order {
+		row := rows[name]
+		switch {
+		case row.LimitedSessions > 0:
+			row.Observation = ObservationLimitReached
+		case row.Sessions > 0:
+			row.Observation = ObservationNoLimitSeen
+		default:
+			row.Observation = ObservationNone
+		}
+		report.Agents = append(report.Agents, *row)
+	}
+	sort.SliceStable(report.Agents, func(i, j int) bool {
+		return report.Agents[i].Program < report.Agents[j].Program
+	})
+	return report
+}
+
+// Render writes the human-readable table.
+//
+// Every cell is filled. There is no branch that can emit an empty column, which
+// is the rendering half of the rule the types enforce: a blank in a quota table
+// is read as zero remaining, and af does not know that about any provider.
+func Render(w io.Writer, report Report, now time.Time) error {
+	if len(report.Agents) == 0 {
+		_, err := fmt.Fprintln(w, "No agent CLIs are configured, so there is nothing to report.")
+		return err
+	}
+	width := len("AGENT")
+	for _, agent := range report.Agents {
+		if len(agent.Program) > width {
+			width = len(agent.Program)
+		}
+	}
+	if _, err := fmt.Fprintf(w, "%-*s  %-13s  %-13s  %s\n", width, "AGENT", "QUOTA", "OBSERVED", "DETAIL"); err != nil {
+		return err
+	}
+	for _, agent := range report.Agents {
+		if _, err := fmt.Fprintf(w, "%-*s  %-13s  %-13s  %s\n",
+			width, agent.Program, agent.Entitlement, agent.Observation, detail(agent, now),
+		); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprint(w, "\nQUOTA is what the provider reports. af has no quota API for any supported\n"+
+		"agent today, so every row reads \"not reported\" — that is af declining to\n"+
+		"guess a ceiling, not a ceiling of zero. OBSERVED is what af has seen in its\n"+
+		"own sessions, which is real signal even where the provider offers nothing.\n")
+	return err
+}
+
+// detail is the per-row sentence. It states what was observed and, when a
+// session is parked, when it resets — saying so explicitly when that is unknown
+// rather than leaving the column blank.
+func detail(agent AgentQuota, now time.Time) string {
+	switch agent.Observation {
+	case ObservationLimitReached:
+		base := fmt.Sprintf("%d of %d session(s) parked at a usage limit", agent.LimitedSessions, agent.Sessions)
+		if agent.ResetAt == nil {
+			return base + "; no reset time was reported with it"
+		}
+		remaining := agent.ResetAt.Sub(now)
+		if remaining <= 0 {
+			return base + fmt.Sprintf("; earliest reset %s has passed, so a retry is due", agent.ResetAt.UTC().Format(time.RFC3339))
+		}
+		return base + fmt.Sprintf("; earliest reset %s (in %s)", agent.ResetAt.UTC().Format(time.RFC3339), remaining.Round(time.Minute))
+	case ObservationNoLimitSeen:
+		return fmt.Sprintf("%d session(s) running, none parked at a limit", agent.Sessions)
+	default:
+		return "configured, but af has no sessions running it"
+	}
+}

--- a/quota/quota_test.go
+++ b/quota/quota_test.go
@@ -1,0 +1,149 @@
+package quota
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The constraint this package exists to hold (#2983): a provider that exposes no
+// quota surface must render as "not reported" — never a guessed number, and
+// never a blank that a reader scans as zero remaining.
+//
+// These tests are written against the RENDERED output rather than the struct,
+// because the failure mode is what a user sees. A type can be impeccable and
+// still print an empty cell.
+
+func TestRender_NeverEmitsABlankOrZeroQuotaCell(t *testing.T) {
+	report := Build([]string{"claude", "codex", "aider"}, nil)
+	var out bytes.Buffer
+	if err := Render(&out, report, time.Unix(1_700_000_000, 0)); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	rendered := out.String()
+
+	for _, program := range []string{"claude", "codex", "aider"} {
+		line := lineFor(t, rendered, program)
+		if !strings.Contains(line, "not reported") {
+			t.Fatalf("row for %q does not say \"not reported\": %q", program, line)
+		}
+		// The specific failure this guards: a number where af has no data.
+		if strings.Contains(line, " 0 ") || strings.Contains(line, "0%") {
+			t.Fatalf("row for %q rendered a zero-looking quota, which reads as exhausted: %q", program, line)
+		}
+	}
+	if strings.Contains(rendered, "  \n") {
+		t.Fatal("a row ended in blank columns; an empty quota cell reads as zero remaining")
+	}
+}
+
+// A configured agent nobody has run must still appear. An absent row is
+// indistinguishable from "nothing to report", and answering for every configured
+// CLI is the point of the command.
+func TestBuild_ConfiguredAgentWithNoSessionsStillGetsARow(t *testing.T) {
+	report := Build([]string{"claude", "gemini"}, []SessionState{{Program: "claude"}})
+	if len(report.Agents) != 2 {
+		t.Fatalf("agents = %d, want a row per configured agent", len(report.Agents))
+	}
+	gemini := agentNamed(t, report, "gemini")
+	if gemini.Observation != ObservationNone {
+		t.Fatalf("gemini observation = %v, want ObservationNone", gemini.Observation)
+	}
+	// Never conflate "nobody ran it" with "it has quota".
+	if gemini.Observation == ObservationNoLimitSeen {
+		t.Fatal("an agent nobody has run was reported as having seen no limit, which reads as healthy")
+	}
+	if gemini.Entitlement != EntitlementNotReported {
+		t.Fatalf("gemini entitlement = %v, want EntitlementNotReported", gemini.Entitlement)
+	}
+}
+
+// The observation axis is what af can honestly say, and it must come from af's
+// own sessions rather than from anything claimed about the provider.
+func TestBuild_ParkedSessionSurfacesAsAnObservationWithItsEarliestReset(t *testing.T) {
+	early := time.Unix(1_700_000_000, 0)
+	late := early.Add(2 * time.Hour)
+	report := Build([]string{"codex"}, []SessionState{
+		{Program: "codex", LimitReached: true, ResetAt: late},
+		{Program: "codex", LimitReached: true, ResetAt: early},
+		{Program: "codex"},
+	})
+	codex := agentNamed(t, report, "codex")
+	if codex.Observation != ObservationLimitReached {
+		t.Fatalf("observation = %v, want ObservationLimitReached", codex.Observation)
+	}
+	if codex.Sessions != 3 || codex.LimitedSessions != 2 {
+		t.Fatalf("sessions=%d limited=%d, want 3 and 2", codex.Sessions, codex.LimitedSessions)
+	}
+	if codex.ResetAt == nil || !codex.ResetAt.Equal(early) {
+		t.Fatalf("ResetAt = %v, want the EARLIEST (%v): it is the soonest anything can resume", codex.ResetAt, early)
+	}
+	// And the observation must never be mistaken for entitlement.
+	if codex.Entitlement != EntitlementNotReported {
+		t.Fatal("observing a limit was promoted into a claim about the provider's ceiling")
+	}
+}
+
+// A limit with no parseable reset time is common. It must say so rather than
+// render a zero time, which would invent a deadline in 1970.
+func TestRender_LimitWithoutResetTimeSaysSoRatherThanShowingZero(t *testing.T) {
+	report := Build([]string{"amp"}, []SessionState{{Program: "amp", LimitReached: true}})
+	var out bytes.Buffer
+	if err := Render(&out, report, time.Unix(1_700_000_000, 0)); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	line := lineFor(t, out.String(), "amp")
+	if !strings.Contains(line, "no reset time was reported") {
+		t.Fatalf("a limit with no reset time must say so, got: %q", line)
+	}
+	if strings.Contains(line, "1970") {
+		t.Fatalf("a missing reset time rendered as the zero time: %q", line)
+	}
+}
+
+// The zero value of Entitlement is the truthful answer, so a provider added
+// later with no integration degrades to "not reported" rather than to zero.
+func TestEntitlementZeroValueIsNotReported(t *testing.T) {
+	var unset Entitlement
+	if unset != EntitlementNotReported {
+		t.Fatal("the zero Entitlement is not EntitlementNotReported; an unhandled provider would not default to the truth")
+	}
+	if got := unset.String(); got != "not reported" {
+		t.Fatalf("zero Entitlement renders %q, want \"not reported\"", got)
+	}
+	if strings.TrimSpace(unset.String()) == "" {
+		t.Fatal("Entitlement rendered empty; a blank quota cell reads as zero remaining")
+	}
+}
+
+// A session naming an agent outside the configured list is real and must not be
+// hidden — under-reporting is the same class of dishonesty as over-reporting.
+func TestBuild_UnconfiguredAgentWithLiveSessionsIsStillReported(t *testing.T) {
+	report := Build([]string{"claude"}, []SessionState{{Program: "devin"}})
+	if agentNamed(t, report, "devin").Sessions != 1 {
+		t.Fatal("a running agent outside the configured list was dropped from the report")
+	}
+}
+
+func agentNamed(t *testing.T, report Report, program string) AgentQuota {
+	t.Helper()
+	for _, agent := range report.Agents {
+		if agent.Program == program {
+			return agent
+		}
+	}
+	t.Fatalf("no row for %q in %+v", program, report.Agents)
+	return AgentQuota{}
+}
+
+func lineFor(t *testing.T, rendered, program string) string {
+	t.Helper()
+	for _, line := range strings.Split(rendered, "\n") {
+		if strings.HasPrefix(line, program) {
+			return line
+		}
+	}
+	t.Fatalf("no rendered row for %q in:\n%s", program, rendered)
+	return ""
+}

--- a/session/git/worktree_copy_timerange_test.go
+++ b/session/git/worktree_copy_timerange_test.go
@@ -1,0 +1,68 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// A filesystem timestamp beyond Go's UnixNano range must survive the
+// cross-device copy, or be refused — never silently wrapped.
+//
+// time.Time.UnixNano() is only defined for 1678–2262 and wraps outside it, so
+// the first spelling of preserveSourceModTime reproduced a far-future node
+// centuries off while reporting success. ext4 with 256-byte inodes stores
+// mtimes to 2446, so this is representable, not hypothetical: the copy claimed
+// to preserve a timestamp it had corrupted.
+//
+// The rename path is the oracle, exactly as the fidelity guard uses it — it
+// never reads the file, so it carries any value the filesystem can hold.
+func TestMoveDirCrossDevice_FarFutureMtimeIsNotWrapped(t *testing.T) {
+	// 2300-01-01T00:00:00Z — inside ext4's range, outside UnixNano's.
+	const farFutureSec = 10413792000
+	if _, err := unix.TimeToTimespec(time.Unix(farFutureSec, 0)); err != nil {
+		t.Skipf("this platform cannot represent the probe timestamp: %v", err)
+	}
+
+	workspace := t.TempDir()
+	src := filepath.Join(workspace, "src")
+	require.NoError(t, os.MkdirAll(src, 0o700))
+	probe := filepath.Join(src, "far-future.txt")
+	require.NoError(t, os.WriteFile(probe, []byte("x"), 0o600))
+
+	// Set it through unix directly: os.Chtimes goes via UnixNano and would wrap
+	// the fixture itself, which would make this test pass for the wrong reason.
+	stamp := unix.Timespec{Sec: farFutureSec}
+	if err := unix.UtimesNanoAt(unix.AT_FDCWD, probe, []unix.Timespec{stamp, stamp}, 0); err != nil {
+		t.Skipf("this filesystem cannot store a 2300 mtime: %v", err)
+	}
+	// Read back, and SKIP rather than fail if the filesystem did not keep it.
+	// utimensat reports success on APFS and then clamps to 9223372036 — which is
+	// exactly UnixNano's own ceiling (2262-04-11), so on macOS the wrap this test
+	// is about is not reachable: the filesystem cannot hold a value outside the
+	// range that wraps. Checking the WRITE succeeded is not enough; only the
+	// read-back says whether the fixture carries what the test needs.
+	sourceInfo, err := os.Lstat(probe)
+	require.NoError(t, err)
+	if sourceInfo.ModTime().Unix() != farFutureSec {
+		t.Skipf("this filesystem clamped the probe mtime to %d, so an out-of-UnixNano-range value cannot be stored here",
+			sourceInfo.ModTime().Unix())
+	}
+
+	original := renamePath
+	renamePath = func(_, _ string) error { return syscall.EXDEV }
+	t.Cleanup(func() { renamePath = original })
+
+	dest := filepath.Join(workspace, "dest")
+	require.NoError(t, moveDirCrossDevice(src, dest))
+
+	copiedInfo, err := os.Lstat(filepath.Join(dest, "far-future.txt"))
+	require.NoError(t, err)
+	require.Equal(t, int64(farFutureSec), copiedInfo.ModTime().Unix(),
+		"the copy must reproduce the source mtime, not a value wrapped through UnixNano")
+}

--- a/session/git/worktree_copy_xattr.go
+++ b/session/git/worktree_copy_xattr.go
@@ -1,0 +1,373 @@
+package git
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// Extended attributes on the cross-device worktree copy (#2919).
+//
+// rename(2) carries them for free; the copy path had to reproduce them, and nothing
+// did — `grep -rn "Getxattr|Setxattr|Listxattr"` over the repo returned nothing, so
+// capabilities, SELinux labels and ACLs were all dropped by an archive that reported
+// success. Split out of worktree_copy_tree.go to keep that file under the length
+// limit; the ordering constraints that tie this to the mode live at the call sites.
+
+// copySourceXattrs reproduces a source node's extended attributes on its copy.
+//
+// rename(2) keeps them for free. The copy reproduced only what it was written to
+// reproduce, so every namespace was dropped and which filesystem $AF_HOME sits on
+// decided whether a restored worktree kept them (#2919). What is lost is not
+// decoration: system.posix_acl_access / _default carry named-user and named-group
+// grants, and a DIRECTORY's default ACL vanishing is the surprising direction —
+// files created in the restored tree afterwards inherit plain umask permissions,
+// which can be WIDER than the policy that was archived. security.capability turns a
+// vendored helper into one that silently cannot bind; security.selinux mislabels a
+// tree on an enforcing box.
+//
+// Descriptor-anchored like every other step here: the F* forms take the descriptors
+// the walk already validated, so no path is re-derived and the name-swap race the
+// copier exists to avoid stays avoided.
+//
+// The failure policy is per-attribute and deliberately asymmetric, because "the
+// archive refused to run" is a worse outcome than "one label could not be stored" —
+// but only while the loss is LOGGED rather than silent, which is the actual
+// complaint in #2919:
+//
+//   - the destination filesystem holds no xattrs at all -> warn once and stop trying.
+//     The archive root's filesystem is not a per-file choice. Proven by asking the
+//     destination descriptor, never inferred from one rejected name: EOPNOTSUPP also
+//     comes back per NAMESPACE, and a destination that stores user.* fine can still
+//     refuse a security.* attribute.
+//   - one attribute is refused (EPERM/EACCES - security.capability needs CAP_SETFCAP,
+//     security.selinux needs relabel permission; or a namespace this filesystem does
+//     not implement) -> warn naming it, keep going.
+//   - anything else -> fail the copy. E2BIG and ENOSPC are errors, not policy limits.
+//
+// trusted.* needs no special case: an unprivileged lister never sees it, so it never
+// appears in the list to attempt.
+// maxXattrValueBytes caps one attribute's value. Real metadata — capabilities,
+// SELinux labels, ACLs, user tags — is tens to hundreds of bytes; this is orders of
+// magnitude above that while still bounding a single allocation.
+const maxXattrValueBytes = 1 << 20
+
+// errXattrValueTooLarge marks a value the copier declines to buffer.
+var errXattrValueTooLarge = errors.New("extended attribute value exceeds the copy limit")
+
+// errXattrUnsupportedDestination marks a destination FILESYSTEM that holds no
+// attributes at all. It is a property of the archive root, not of one node, so the
+// caller stops attempting the rest of the tree rather than re-learning it per file.
+var errXattrUnsupportedDestination = errors.New("destination filesystem does not support extended attributes")
+
+func copySourceXattrs(sourceFD, destinationFD int, destinationPath, kind string, acl bool) error {
+	names, err := listXattrNames(sourceFD)
+	if err != nil {
+		if isXattrUnsupported(err) {
+			return nil // the SOURCE filesystem has no xattrs; nothing to carry
+		}
+		return fmt.Errorf(
+			"cannot move worktree across filesystems: failed to list extended attributes for destination %s %s: %w",
+			kind, destinationPath, err,
+		)
+	}
+	for _, name := range names {
+		if isACLXattr(name) != acl {
+			continue // the other phase owns this one
+		}
+		value, err := readXattrValue(sourceFD, name)
+		if err != nil {
+			if isXattrVanished(err) {
+				// Removed between the listing and the read. The only tolerable read
+				// failure, and warned so it is not silent.
+				log.WarningLog.Printf(
+					"archive: extended attribute %q vanished from %s %s while it was being copied",
+					name, kind, destinationPath,
+				)
+				continue
+			}
+			if errors.Is(err, errXattrValueTooLarge) {
+				// A value too large to buffer — on darwin com.apple.ResourceFork can be
+				// fork-sized. Skipping one attribute is survivable; allocating it is not,
+				// and an archive that OOMs takes the session with it.
+				log.WarningLog.Printf(
+					"archive: extended attribute %q on %s %s is too large to copy (%d byte limit); not reproduced",
+					name, kind, destinationPath, maxXattrValueBytes,
+				)
+				continue
+			}
+			// Anything else — EIO from a network filesystem, a transient resource
+			// failure — is a real read error. Reporting success while dropping a
+			// capability or a label is the silent-loss this issue is about.
+			return fmt.Errorf(
+				"cannot move worktree across filesystems: failed to read extended attribute %q from %s %s: %w",
+				name, kind, destinationPath, err,
+			)
+		}
+		if err := unix.Fsetxattr(destinationFD, name, value, 0); err != nil {
+			switch {
+			case isXattrUnsupported(err):
+				// EOPNOTSUPP here is per-NAME, not per-filesystem: a destination that
+				// stores user.* happily can still reject a namespace it does not
+				// implement. Latching on the first one would skip every remaining
+				// attribute on this node AND on every later node, so the filesystem-wide
+				// claim has to be established independently before it is believed.
+				if !destinationRejectsAllXattrs(destinationFD) {
+					log.WarningLog.Printf(
+						"archive: extended attribute %q not reproduced on %s %s (this destination does not implement that namespace): %v",
+						name, kind, destinationPath, err,
+					)
+					continue
+				}
+				log.WarningLog.Printf(
+					"archive: %s %s cannot hold extended attributes on this filesystem; none were copied",
+					kind, destinationPath,
+				)
+				return errXattrUnsupportedDestination
+			case errors.Is(err, unix.EPERM), errors.Is(err, unix.EACCES):
+				log.WarningLog.Printf(
+					"archive: extended attribute %q not reproduced on %s %s (needs privilege): %v",
+					name, kind, destinationPath, err,
+				)
+			default:
+				return fmt.Errorf(
+					"cannot move worktree across filesystems: failed to set extended attribute %q on destination %s %s: %w",
+					name, kind, destinationPath, err,
+				)
+			}
+		}
+	}
+	return nil
+}
+
+// xattrDestination latches the discovery that a destination holds no extended
+// attributes at all, so the rest of THAT copy stops attempting them instead of
+// logging the same warning once per file in the worktree.
+//
+// One per copy, like the hardlink map in copyDirectoryContents and for the same
+// reason. A process-wide latch would be wrong rather than merely untidy: this
+// copier also serves RestoreWorktreeTo, whose destination is an arbitrary
+// repository filesystem rather than the archive root, so a single restore onto a
+// filesystem without xattr support would silently disable attribute copying for
+// every later archive in the daemon's lifetime — and the daemon is long-lived.
+//
+// Not atomic: a copy walks its tree on one goroutine, and the value never escapes
+// the copy that made it.
+type xattrDestination struct {
+	holdsNone bool
+}
+
+// copyNonACLXattrs and copyACLXattrs are the two halves of the copy, split around
+// the mode — see isACLXattr for why the split is load-bearing.
+func copyNonACLXattrs(support *xattrDestination, sourceFD, destinationFD int, destinationPath, kind string) error {
+	return copyXattrPhase(support, sourceFD, destinationFD, destinationPath, kind, false)
+}
+
+func copyACLXattrs(support *xattrDestination, sourceFD, destinationFD int, destinationPath, kind string) error {
+	return copyXattrPhase(support, sourceFD, destinationFD, destinationPath, kind, true)
+}
+
+func copyXattrPhase(support *xattrDestination, sourceFD, destinationFD int, destinationPath, kind string, acl bool) error {
+	if support.holdsNone {
+		return nil
+	}
+	err := copySourceXattrs(sourceFD, destinationFD, destinationPath, kind, acl)
+	if errors.Is(err, errXattrUnsupportedDestination) {
+		support.holdsNone = true
+		return nil
+	}
+	return err
+}
+
+// pruneDestinationXattrs removes attributes the destination has and the source does
+// not.
+//
+// Copying alone is not fidelity. A destination parent carrying a DEFAULT POSIX ACL
+// gives every newly created child a system.posix_acl_access of its own, so a source
+// file with no ACL arrives with one — and an inherited ACL is generally WIDER than
+// the mode it replaces, which makes this a permission-widening bug rather than an
+// untidy one. The same applies to any attribute a destination filesystem or parent
+// synthesises.
+//
+// Failures here are warnings, not errors, for the reason the whole file follows: an
+// archive that refuses to run is worse than one that reports what it could not
+// normalise.
+func pruneDestinationXattrs(sourceFD, destinationFD int, destinationPath, kind string) {
+	destinationNames, err := listXattrNames(destinationFD)
+	if err != nil {
+		// A destination that holds no attributes at all has nothing to normalise and is
+		// not worth a warning. Anything else — EIO, ENOMEM — means the check did not
+		// happen, and staying silent about that is how an inherited ACL rides along
+		// while the archive reports success.
+		if !isXattrUnsupported(err) {
+			log.WarningLog.Printf(
+				"archive: could not list extended attributes on %s %s to check for inherited ones; any the destination added are left in place: %v",
+				kind, destinationPath, err,
+			)
+		}
+		return
+	}
+	if len(destinationNames) == 0 {
+		return
+	}
+	sourceNames, err := listXattrNames(sourceFD)
+	if err != nil && !isXattrUnsupported(err) {
+		// Cannot tell what the source had, so leave the destination alone rather than
+		// remove something the source may well have carried — but say so, because an
+		// inherited ACL surviving is the permission-widening case this helper exists
+		// to prevent.
+		log.WarningLog.Printf(
+			"archive: could not list the source's extended attributes while normalising %s %s; any the destination inherited are left in place: %v",
+			kind, destinationPath, err,
+		)
+		return
+	}
+	fromSource := make(map[string]struct{}, len(sourceNames))
+	for _, name := range sourceNames {
+		fromSource[name] = struct{}{}
+	}
+	for _, name := range destinationNames {
+		if _, ok := fromSource[name]; ok {
+			continue
+		}
+		if err := unix.Fremovexattr(destinationFD, name); err != nil && !isXattrVanished(err) {
+			log.WarningLog.Printf(
+				"archive: %s %s inherited extended attribute %q that the source did not have, and it could not be removed: %v",
+				kind, destinationPath, name, err,
+			)
+		}
+	}
+}
+
+// isACLXattr reports whether a name is a POSIX ACL attribute, which must be applied
+// AFTER the mode: setting system.posix_acl_access rewrites the mode, and chmod
+// rewrites the ACL mask, so an ACL written before the mode is silently undone.
+// Everything else must be applied BEFORE it, because setting an attribute in the
+// user namespace requires write permission on the inode.
+//
+// LINUX ONLY, and the split is named for what it does rather than for a guarantee
+// it makes. Darwin does not represent ACLs as extended attributes — they live
+// behind acl(3), so these names never appear in a darwin Flistxattr listing, this
+// phase is an empty pass there, and a macOS worktree's named-user ACL entries are
+// NOT reproduced by the cross-device copy. That is unchanged by #2919 rather than
+// introduced by it (nothing carried any attribute before), and closing it needs the
+// ACL API, not another name in this predicate. Not in knownCrossDeviceDivergence:
+// that inventory is keyed by properties describeFidelity actually measures, and
+// measuring this one needs a darwin runner the guard does not have. Tracked in
+// #2919 instead, so the limit is written down where the follow-up will look.
+func isACLXattr(name string) bool {
+	return name == "system.posix_acl_access" || name == "system.posix_acl_default"
+}
+
+// destinationRejectsAllXattrs reports whether a destination holds no extended
+// attributes AT ALL, as opposed to having refused one particular name.
+//
+// Asked of the destination descriptor itself, because that is the only thing that
+// can answer it: a listing that comes back unsupported means the filesystem does not
+// implement xattrs, while a listing that succeeds proves it does and that the refusal
+// was about the one namespace. Without this the first rejected security.* attribute
+// would convince the copier that the whole filesystem was attribute-less and make it
+// skip the user.* and ACL attributes it could have stored.
+func destinationRejectsAllXattrs(destinationFD int) bool {
+	_, err := unix.Flistxattr(destinationFD, nil)
+	return isXattrUnsupported(err)
+}
+
+// isXattrUnsupported reports whether an error means extended attributes are not
+// available here at all. Platform-split for the same reason as isXattrVanished, and
+// with a sharper consequence: darwin spells this ENOTSUP (0x2d) where Linux returns
+// EOPNOTSUPP (0x5f) and makes the two names one value, so matching only EOPNOTSUPP
+// would send every unsupported macOS destination down the "unexpected error" path and
+// fail the archive outright instead of degrading to a warning.
+func isXattrUnsupported(err error) bool {
+	for _, unsupported := range xattrUnsupportedErrnos() {
+		if errors.Is(err, unsupported) {
+			return true
+		}
+	}
+	return false
+}
+
+// isXattrVanished reports whether an error means the attribute is simply not there —
+// removed between the listing and the read, or never present.
+//
+// This is the one place a platform split is unavoidable: Linux reports ENODATA and
+// darwin reports ENOATTR, they are DIFFERENT numbers, and unix.ENOATTR does not exist
+// on Linux at all, so naming both in one file does not compile. The distinction has
+// to be drawn because "the attribute vanished" is the only read failure this copier
+// may tolerate — everything else (EIO from a network filesystem, a resource failure)
+// must fail the archive rather than silently drop a capability or a label.
+func isXattrVanished(err error) bool {
+	for _, absent := range xattrAbsentErrnos() {
+		if errors.Is(err, absent) {
+			return true
+		}
+	}
+	return false
+}
+
+// listXattrNames returns the attribute names visible on fd. Sized in two calls
+// because the set can change between them, so a list that grew is read short and
+// retried rather than silently truncated.
+func listXattrNames(fd int) ([]string, error) {
+	for attempt := 0; attempt < 2; attempt++ {
+		size, err := unix.Flistxattr(fd, nil)
+		if err != nil {
+			return nil, err
+		}
+		if size == 0 {
+			return nil, nil
+		}
+		buffer := make([]byte, size)
+		read, err := unix.Flistxattr(fd, buffer)
+		if err != nil {
+			if errors.Is(err, unix.ERANGE) {
+				continue // the list grew between the sizing and the read
+			}
+			return nil, err
+		}
+		names := make([]string, 0, 4)
+		for _, name := range bytes.Split(buffer[:read], []byte{0}) {
+			if len(name) > 0 {
+				names = append(names, string(name))
+			}
+		}
+		return names, nil
+	}
+	return nil, fmt.Errorf("extended attribute list kept growing while it was read")
+}
+
+// readXattrValue reads one attribute's value, sized the same two-call way. A present
+// attribute with an empty value is meaningful, so nil-with-no-error is a real result.
+func readXattrValue(fd int, name string) ([]byte, error) {
+	for attempt := 0; attempt < 2; attempt++ {
+		size, err := unix.Fgetxattr(fd, name, nil)
+		if err != nil {
+			return nil, err
+		}
+		if size == 0 {
+			return nil, nil
+		}
+		if size > maxXattrValueBytes {
+			// darwin exposes com.apple.ResourceFork through this API and its value can
+			// be as large as a regular fork, so a size returned here is not bounded by
+			// "metadata". Allocating it would let one file's resource fork exhaust the
+			// daemon's memory mid-archive.
+			return nil, errXattrValueTooLarge
+		}
+		value := make([]byte, size)
+		read, err := unix.Fgetxattr(fd, name, value)
+		if err != nil {
+			if errors.Is(err, unix.ERANGE) {
+				continue // the value grew between the sizing and the read
+			}
+			return nil, err
+		}
+		return value[:read], nil
+	}
+	return nil, fmt.Errorf("extended attribute %q kept growing while it was read", name)
+}

--- a/session/git/worktree_copy_xattr_darwin.go
+++ b/session/git/worktree_copy_xattr_darwin.go
@@ -1,0 +1,19 @@
+//go:build darwin
+
+package git
+
+import "golang.org/x/sys/unix"
+
+// xattrAbsentErrnos is what darwin returns when an extended attribute is not present.
+// ENOATTR is the one the xattr syscalls actually use; ENODATA is listed too because it
+// is a distinct errno on this platform and a filesystem may report it.
+// See isXattrVanished for why this is platform-split rather than a single list.
+func xattrAbsentErrnos() []error { return []error{unix.ENOATTR, unix.ENODATA} }
+
+// xattrUnsupportedErrnos is what darwin returns when extended attributes are not
+// available at all. Both spellings are listed because on this platform they are
+// DIFFERENT errnos — ENOTSUP is 0x2d and EOPNOTSUPP is 0x66, where Linux makes them
+// one value — and the xattr syscalls here return ENOTSUP. Matching only EOPNOTSUPP
+// would send an unsupported destination down the "unexpected error" path and fail the
+// whole archive on macOS.
+func xattrUnsupportedErrnos() []error { return []error{unix.ENOTSUP, unix.EOPNOTSUPP} }

--- a/session/git/worktree_copy_xattr_linux.go
+++ b/session/git/worktree_copy_xattr_linux.go
@@ -1,0 +1,15 @@
+//go:build linux
+
+package git
+
+import "golang.org/x/sys/unix"
+
+// xattrAbsentErrnos is what Linux returns when an extended attribute is not present.
+// See isXattrVanished for why this is platform-split rather than a single list.
+func xattrAbsentErrnos() []error { return []error{unix.ENODATA} }
+
+// xattrUnsupportedErrnos is what Linux returns when extended attributes are not
+// available at all. ENOTSUP and EOPNOTSUPP are the SAME value here (0x5f), so one
+// entry covers both spellings; on darwin they are different numbers, which is why
+// this is split alongside xattrAbsentErrnos.
+func xattrUnsupportedErrnos() []error { return []error{unix.EOPNOTSUPP} }

--- a/session/git/worktree_copy_xattr_test.go
+++ b/session/git/worktree_copy_xattr_test.go
@@ -1,0 +1,237 @@
+package git
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// The fidelity guard (worktree_copy_fidelity_test.go) proves ONE attribute survives
+// the cross-device copy. These pin the parts of #2919's xattr work that a
+// single-attribute probe cannot see: several attributes on one node, a present
+// attribute whose value is EMPTY — which is meaningful and which a "size 0 means
+// absent" reading would silently drop — and that a node with no attributes at all
+// copies cleanly rather than erroring on an empty list.
+
+// xattrCapableDir skips the test when the filesystem under t.TempDir() cannot hold
+// user.* attributes. Probed by WRITING to the source tree, not by inspecting a tree
+// built later: asking the wrong tree is how the fidelity guard once dropped its xattr
+// comparison entirely while still reporting a pass (#2919).
+func xattrCapableDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	probe := filepath.Join(dir, ".xattr-probe")
+	require.NoError(t, os.WriteFile(probe, []byte("x"), 0o600))
+	if err := unix.Setxattr(probe, "user.af_probe", []byte("1"), 0); err != nil {
+		t.Skipf("filesystem under %s does not support user.* extended attributes: %v", dir, err)
+	}
+	require.NoError(t, os.Remove(probe))
+	return dir
+}
+
+// xattrFixture is a source/destination pair on an xattr-capable filesystem, with the
+// cross-device path forced so moveDirCrossDevice really copies rather than renames.
+func xattrFixture(t *testing.T) (source, destination string) {
+	t.Helper()
+	workspace := xattrCapableDir(t)
+	source = filepath.Join(workspace, "src")
+	require.NoError(t, os.MkdirAll(source, 0o755))
+	original := renamePath
+	renamePath = func(_, _ string) error { return syscall.EXDEV }
+	t.Cleanup(func() { renamePath = original })
+	return source, filepath.Join(workspace, "dst")
+}
+
+// listAttrs returns the attribute names present on path.
+func listAttrs(t *testing.T, path string) []string {
+	t.Helper()
+	size, err := unix.Listxattr(path, nil)
+	require.NoError(t, err)
+	if size == 0 {
+		return nil
+	}
+	buffer := make([]byte, size)
+	read, err := unix.Listxattr(path, buffer)
+	require.NoError(t, err)
+	var names []string
+	for _, name := range bytes.Split(buffer[:read], []byte{0}) {
+		if len(name) > 0 {
+			names = append(names, string(name))
+		}
+	}
+	return names
+}
+
+func readAttr(t *testing.T, path, name string) []byte {
+	t.Helper()
+	size, err := unix.Getxattr(path, name, nil)
+	require.NoError(t, err, "attribute %q must exist on %s", name, path)
+	if size == 0 {
+		return nil
+	}
+	value := make([]byte, size)
+	read, err := unix.Getxattr(path, name, value)
+	require.NoError(t, err)
+	return value[:read]
+}
+
+func TestCopyTree_ReproducesEveryVisibleXattrIncludingEmptyValues(t *testing.T) {
+	workspace := xattrCapableDir(t)
+	source := filepath.Join(workspace, "src")
+	require.NoError(t, os.MkdirAll(filepath.Join(source, "dir"), 0o700))
+	file := filepath.Join(source, "dir", "carrier.txt")
+	require.NoError(t, os.WriteFile(file, []byte("payload"), 0o640))
+
+	// Two attributes, and one of them EMPTY. An empty value is not the same as an
+	// absent attribute, and the two-call sizing makes it easy to conflate them.
+	require.NoError(t, unix.Setxattr(file, "user.af_one", []byte("first"), 0))
+	require.NoError(t, unix.Setxattr(file, "user.af_empty", []byte{}, 0))
+	require.NoError(t, unix.Setxattr(filepath.Join(source, "dir"), "user.af_dir", []byte("ondir"), 0))
+
+	destination := filepath.Join(workspace, "dst")
+	require.NoError(t, copyTree(source, destination))
+
+	copied := filepath.Join(destination, "dir", "carrier.txt")
+	require.Equal(t, []byte("first"), readAttr(t, copied, "user.af_one"))
+	require.Empty(t, readAttr(t, copied, "user.af_empty"),
+		"a present attribute with an empty value must arrive present, not dropped")
+	require.Equal(t, []byte("ondir"), readAttr(t, filepath.Join(destination, "dir"), "user.af_dir"),
+		"directories carry attributes too — a lost DEFAULT ACL is the dangerous case")
+
+	// The names must round-trip as a set, so an extra or missing attribute fails here
+	// rather than only when someone asks for the one that vanished.
+	names, err := listXattrNames(int(mustOpen(t, copied).Fd()))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"user.af_one", "user.af_empty"}, names)
+}
+
+func TestCopyTree_NodeWithNoXattrsCopiesCleanly(t *testing.T) {
+	workspace := xattrCapableDir(t)
+	source := filepath.Join(workspace, "src")
+	require.NoError(t, os.MkdirAll(source, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(source, "bare.txt"), []byte("no attrs"), 0o600))
+
+	destination := filepath.Join(workspace, "dst")
+	require.NoError(t, copyTree(source, destination),
+		"an empty attribute list must not be read as an error")
+
+	body, err := os.ReadFile(filepath.Join(destination, "bare.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "no attrs", string(body))
+}
+
+func mustOpen(t *testing.T, path string) *os.File {
+	t.Helper()
+	handle, err := os.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = handle.Close() })
+	return handle
+}
+
+// TestCopyTree_CopiesXattrsOntoReadOnlyNodes is the P1 from review, and what it pins
+// is the CREATION mode, not the ordering. Setting an attribute in the user namespace
+// requires write permission on the INODE, and an already-open write descriptor does
+// not satisfy it. openat() created the destination at the source's mode, so a
+// checked-in 0444 file was read-only from the moment it existed and every user.*
+// attribute failed EACCES wherever in the sequence it was attempted — reordering the
+// call could not help, which is how the first attempt at this fix passed review while
+// changing nothing. The privilege branch then logged the EACCES as "needs privilege"
+// and carried on, losing an ordinary attribute silently on every read-only node.
+//
+// workingFileMode is the fix: create owner-writable, apply the real mode last.
+func TestCopyTree_CopiesXattrsOntoReadOnlyNodes(t *testing.T) {
+	source, destination := xattrFixture(t)
+	// Attribute FIRST, then chmod. Setting a user.* attribute needs write permission
+	// on the inode, so a fixture built read-only cannot be given one — the first
+	// version of this test tried, took the EACCES for "this filesystem has no user
+	// xattrs", and SKIPPED. It reported green on every run without once exercising
+	// the ordering it exists to pin.
+	readOnly := filepath.Join(source, "locked.txt")
+	require.NoError(t, os.WriteFile(readOnly, []byte("contents"), 0o644))
+	require.NoError(t, unix.Setxattr(readOnly, "user.af_locked", []byte("kept"), 0))
+	require.NoError(t, os.Chmod(readOnly, 0o444))
+	readOnlyDir := filepath.Join(source, "lockeddir")
+	require.NoError(t, os.Mkdir(readOnlyDir, 0o755))
+	require.NoError(t, unix.Setxattr(readOnlyDir, "user.af_lockeddir", []byte("kept"), 0))
+	require.NoError(t, os.Chmod(readOnlyDir, 0o555))
+
+	require.NoError(t, moveDirCrossDevice(source, destination))
+
+	require.Equal(t, []byte("kept"), readAttr(t, filepath.Join(destination, "locked.txt"), "user.af_locked"),
+		"a 0444 file must keep its attributes — the mode must not be applied before they are written")
+	require.Equal(t, []byte("kept"), readAttr(t, filepath.Join(destination, "lockeddir"), "user.af_lockeddir"),
+		"and a 0555 directory likewise")
+
+	// The mode itself must still land, so the fix cannot have simply left nodes writable.
+	info, err := os.Stat(filepath.Join(destination, "locked.txt"))
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o444), info.Mode().Perm())
+}
+
+// TestCopyTree_DropsDestinationOnlyXattrs pins the other P1. A destination parent
+// carrying a DEFAULT POSIX ACL gives every newly created child a
+// system.posix_acl_access of its own, so a source file with no ACL arrives with one —
+// and an inherited ACL is generally WIDER than the mode it replaces, making this a
+// permission-widening divergence rather than an untidy one.
+//
+// Simulated with a user.* attribute rather than a real default ACL: the mechanism
+// under test is "the destination has an attribute the source does not", and a user
+// attribute exercises it on any filesystem, where setting a default ACL needs tooling
+// this test cannot assume.
+func TestCopyTree_DropsDestinationOnlyXattrs(t *testing.T) {
+	source, destination := xattrFixture(t)
+	file := filepath.Join(source, "plain.txt")
+	require.NoError(t, os.WriteFile(file, []byte("contents"), 0o644))
+	if err := unix.Setxattr(file, "user.af_kept", []byte("yes"), 0); err != nil {
+		t.Skipf("this filesystem does not support user xattrs: %v", err)
+	}
+
+	require.NoError(t, moveDirCrossDevice(source, destination))
+	copied := filepath.Join(destination, "plain.txt")
+
+	// Stand in for the inherited attribute, then re-run the copy step against a source
+	// that never had it.
+	require.NoError(t, unix.Setxattr(copied, "user.af_inherited", []byte("from-parent"), 0))
+	names := listAttrs(t, copied)
+	require.Contains(t, names, "user.af_inherited")
+
+	second := filepath.Join(filepath.Dir(destination), "dst2")
+	require.NoError(t, moveDirCrossDevice(destination, second))
+	// The second copy's source DID have it, so it is carried — the prune must remove
+	// only what the source lacks, never what it has.
+	require.Contains(t, listAttrs(t, filepath.Join(second, "plain.txt")), "user.af_inherited")
+	require.Equal(t, []byte("yes"), readAttr(t, filepath.Join(second, "plain.txt"), "user.af_kept"))
+}
+
+// TestDestinationRejectsAllXattrs_OnlyWhenTheListingSaysSo pins the distinction the
+// latch depends on. EOPNOTSUPP comes back per NAMESPACE as well as per filesystem, so
+// "one attribute was refused" is not evidence that the destination holds none — and
+// acting on it would skip every remaining attribute on this node and on every later
+// node in the copy. The predicate must consult the destination descriptor itself.
+func TestDestinationRejectsAllXattrs_OnlyWhenTheListingSaysSo(t *testing.T) {
+	dir := xattrCapableDir(t)
+	path := filepath.Join(dir, "holder.txt")
+	require.NoError(t, os.WriteFile(path, []byte("x"), 0o600))
+	handle := mustOpen(t, path)
+
+	require.False(t, destinationRejectsAllXattrs(int(handle.Fd())),
+		"a filesystem whose listing succeeds does support attributes, whatever a single "+
+			"rejected namespace reported")
+
+	// And the errno classifier underneath it must accept the spelling THIS platform
+	// uses, not just the Linux one: darwin returns ENOTSUP (0x2d) where Linux returns
+	// EOPNOTSUPP (0x5f) and treats the two names as one value. Matching only the Linux
+	// spelling would drop an unsupported darwin destination into the "unexpected error"
+	// branch and fail the whole archive instead of warning.
+	for _, unsupported := range xattrUnsupportedErrnos() {
+		require.True(t, isXattrUnsupported(unsupported),
+			"every errno this platform reports as unsupported must classify as unsupported")
+	}
+	require.False(t, isXattrUnsupported(unix.EIO),
+		"a real I/O failure must not be mistaken for an attribute-less filesystem")
+}

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -588,3 +588,18 @@ func livenessFromData(data InstanceData) Liveness {
 func IsArchivedData(data InstanceData) bool {
 	return livenessFromData(data) == LiveArchived
 }
+
+// EffectiveLiveness resolves the liveness a serialized record actually has,
+// applying the same rollforward IsArchivedData relies on: prefer the `liveness`
+// field, fall back to the legacy `status` int for records written before #1195.
+//
+// Exported because reading data.Liveness directly is a trap for any caller that
+// iterates records rather than live instances — a pre-#1195 record carries the
+// ZERO liveness (LivenessUnset) while its real state lives in the legacy status,
+// so a direct comparison silently misclassifies it as "not archived", "not lost",
+// and so on. IsArchivedData answers one question; this answers the general one
+// for callers that must distinguish several states (#2983's quota report needs
+// "is an agent actually running", which is four states wide).
+func EffectiveLiveness(data InstanceData) Liveness {
+	return livenessFromData(data)
+}

--- a/session/tmux/close_survived_kill_test.go
+++ b/session/tmux/close_survived_kill_test.go
@@ -1,0 +1,449 @@
+package tmux
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/internal/proctree"
+	"time"
+)
+
+// These tests pin the contract CloseAndWaitForPaneExit exists to provide, which
+// is narrower than Close's: not "tmux answered", but "the worktree may now be
+// deleted or moved". A session that SURVIVED its kill can never satisfy that,
+// however much else was established — it may still be writing (#2962).
+//
+// The distinction matters because of how the destructive caller gates. From
+// session/teardown.go's closeTabForDestructiveTeardown:
+//
+//	state, err := ts.CloseAndWaitForPaneExit()
+//	if state != tmux.PaneStateKnown { ...refuse... }
+//	if err != nil { log.WarningLog.Printf(...) }   // logs and PROCEEDS
+//	return stateKnown, nil
+//
+// The STATE is the gate; the error is only logged. So returning
+// PaneStateKnown alongside "error killing tmux session" is not a mixed signal
+// the caller can weigh — it is a licence to delete.
+
+// scriptedTmuxOnPath installs a fake tmux whose behaviour per subcommand is
+// given by the caller, so a test can stage the exact combination of answers that
+// a real wedged/permission-refusing server would produce.
+func scriptedTmuxOnPath(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\ncase \"$1\" in\n" + body + "\n*) exit 97 ;;\nesac\n"
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestCloseAndWaitSurvivedKillIsNeverKnown is the #2962 regression.
+//
+// Staged exactly as the report describes: the pane PID query fails for a
+// NON-timeout reason (so the existing ErrTmuxTimeout guard does not fire),
+// list-panes succeeds (so the capture-error guard does not fire), kill-session
+// fails, and has-session confirms the session is STILL THERE.
+//
+// On master this returns PaneStateKnown, and the destructive caller deletes the
+// worktree of a live session.
+func TestCloseAndWaitSurvivedKillIsNeverKnown(t *testing.T) {
+	scriptedTmuxOnPath(t, `
+display-message) echo "can't find pane" >&2; exit 1 ;;
+list-panes)      exit 0 ;;
+kill-session)    echo "cannot kill session" >&2; exit 1 ;;
+has-session)     exit 0 ;;`)
+
+	ts := NewTmuxSessionFromSanitizedName("af_survivor", "")
+	state, err := ts.CloseAndWaitForPaneExit()
+
+	if state == PaneStateKnown {
+		t.Fatalf("CloseAndWaitForPaneExit = PaneStateKnown with err=%v, but kill-session FAILED and "+
+			"has-session confirmed the session is still alive. The destructive caller gates on the "+
+			"state and only logs the error, so this deletes the worktree of a live session (#2962)", err)
+	}
+	if err == nil {
+		t.Error("a surviving session must also report why, or the caller has nothing to act on")
+	}
+}
+
+// TestCloseAndWaitSurvivedKillIsNeverKnownWithAQueryablePane covers the SAME
+// defect on the other branch, which the report does not name: when panePID
+// SUCCEEDS, the function falls through to `return state, closeErr` at the end
+// and inherits Close's KNOWN just the same.
+//
+// Reaching it needs the pane leader to be already gone (so the pane-exit wait is
+// skipped) while the session survives — an agent that exited under a session
+// tmux keeps alive, e.g. remain-on-exit or a second pane. The surviving session's
+// OTHER panes may still be writing.
+func TestCloseAndWaitSurvivedKillIsNeverKnownWithAQueryablePane(t *testing.T) {
+	deadPID := exitedPID(t)
+	scriptedTmuxOnPath(t, `
+display-message) echo "`+deadPID+`" ;;
+list-panes)      exit 0 ;;
+kill-session)    echo "cannot kill session" >&2; exit 1 ;;
+has-session)     exit 0 ;;`)
+
+	ts := NewTmuxSessionFromSanitizedName("af_survivor_two", "")
+	state, err := ts.CloseAndWaitForPaneExit()
+
+	if state == PaneStateKnown {
+		t.Fatalf("CloseAndWaitForPaneExit = PaneStateKnown with err=%v: the pane leader had already "+
+			"exited, so the pane-exit wait was skipped, and the final return handed back Close's "+
+			"KNOWN for a session that survived its kill (#2962)", err)
+	}
+	if err == nil {
+		t.Error("a surviving session must also report why")
+	}
+}
+
+// TestCloseAndWaitUnqueryablePaneStillChecksTheProcessSet is the third hole on
+// this path: when panePID fails, the old code returned EARLY, skipping the
+// capture-error and surviving-process gates entirely. A read that failed
+// (list-panes) was therefore never consulted on that branch — the same class one
+// level down.
+func TestCloseAndWaitUnqueryablePaneStillChecksTheProcessSet(t *testing.T) {
+	scriptedTmuxOnPath(t, `
+display-message) echo "can't find pane" >&2; exit 1 ;;
+list-panes)      echo "cannot list panes" >&2; exit 1 ;;
+kill-session)    exit 0 ;;
+has-session)     exit 1 ;;`)
+
+	ts := NewTmuxSessionFromSanitizedName("af_unqueryable", "")
+	state, err := ts.CloseAndWaitForPaneExit()
+
+	if state == PaneStateKnown {
+		t.Fatalf("CloseAndWaitForPaneExit = PaneStateKnown with err=%v: the pane PID was unqueryable "+
+			"AND the pane process set could not be listed, so nothing establishes that anything "+
+			"stopped writing — yet the early return skipped the capture-error gate (#2962)", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "cannot list panes") {
+		t.Errorf("error = %v, want it to name the read that failed", err)
+	}
+}
+
+// TestCloseAndWaitCleanTeardownStaysKnown is the other half of the contract, so
+// the guards above are a signal rather than a state that is always Unknown: an
+// unqueryable pane whose session IS confirmed gone and whose process set was
+// read cleanly still authorizes cleanup. Without this, the fix would strand
+// every caller whose agent had already exited.
+func TestCloseAndWaitCleanTeardownStaysKnown(t *testing.T) {
+	scriptedTmuxOnPath(t, `
+display-message) echo "can't find pane" >&2; exit 1 ;;
+list-panes)      exit 0 ;;
+kill-session)    exit 0 ;;
+has-session)     exit 1 ;;`)
+
+	ts := NewTmuxSessionFromSanitizedName("af_clean", "")
+	state, err := ts.CloseAndWaitForPaneExit()
+
+	if state != PaneStateKnown {
+		t.Fatalf("CloseAndWaitForPaneExit = %v (err=%v), want PaneStateKnown: kill-session succeeded, "+
+			"the session is confirmed gone, and the pane process set was read with nothing left — "+
+			"refusing here would block every ordinary teardown of an already-exited agent", state, err)
+	}
+	if err != nil {
+		t.Errorf("error = %v, want nil for a clean teardown", err)
+	}
+}
+
+// exitedPID returns a PID that is definitively gone: a real child, run to
+// completion and reaped, whose number the kernel has not yet reused.
+//
+// Not a large constant. That would be a guess about the host's pid space, and a
+// guess that lands on a LIVE process inverts the test it is used in — the pane
+// would look alive and the assertion would pass for the wrong reason.
+func exitedPID(t *testing.T) string {
+	t.Helper()
+	cmd := exec.Command("true")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("spawn a throwaway child: %v", err)
+	}
+	pid := cmd.Process.Pid
+	// Reaped by Run, so the number is free. Confirm the kernel agrees before a
+	// test leans on it.
+	if err := syscall.Kill(pid, 0); !errors.Is(err, syscall.ESRCH) {
+		t.Skipf("pid %d was reused between exit and check (kill(0) = %v); this fixture needs a "+
+			"definitively-gone pid", pid, err)
+	}
+	return strconv.Itoa(pid)
+}
+
+// TestSessionGoneRaceAfterAPaneWasObservedStaysUnknown is the Codex finding on
+// #2966: the determinate-empty is only sound when NO pane was ever observed.
+//
+// Here panePID names a live pane, and list-panes THEN reports the session gone.
+// That is a race, not an empty session: the ancestry list-panes would have
+// returned is lost, so descendants and SID members that outlive the leader are
+// unaccounted for. Leader death cannot prove they stopped writing (#1104/#802).
+func TestSessionGoneRaceAfterAPaneWasObservedStaysUnknown(t *testing.T) {
+	// The pane leader must be ALREADY GONE, so the pane-exit wait is skipped and
+	// this test isolates the capture gate. With a live pid it passed either way —
+	// the wait caught it — which made it assert the claim while checking something
+	// weaker.
+	deadPID := exitedPID(t)
+	scriptedTmuxOnPath(t, `
+display-message) echo "`+deadPID+`" ;;
+list-panes)      echo "can't find session: af_raced" >&2; exit 1 ;;
+kill-session)    exit 0 ;;
+has-session)     exit 1 ;;`)
+
+	ts := NewTmuxSessionFromSanitizedName("af_raced", "")
+	state, err := ts.CloseAndWaitForPaneExit()
+
+	if state == PaneStateKnown {
+		t.Fatalf("CloseAndWaitForPaneExit = PaneStateKnown with err=%v: a pane WAS observed and the "+
+			"session then vanished before list-panes, so its descendants are unaccounted for — that is "+
+			"a lost ancestry, not an empty session", err)
+	}
+	if err == nil {
+		t.Error("the race must be reported, not silently downgraded")
+	}
+}
+
+// TestPaneQueryTimeoutKeepsTheSentinelThroughACloseFailure is the other Codex
+// finding: when the pane query times out AND close also fails, the combined
+// return must still carry ErrTmuxTimeout. #1917 keeps that sentinel reachable
+// through errors.Is for callers that classify on it, and returning closeErr
+// alone erased it.
+func TestPaneQueryTimeoutKeepsTheSentinelThroughACloseFailure(t *testing.T) {
+	shortTmuxTimeout(t, 200*time.Millisecond)
+	scriptedTmuxOnPath(t, `
+display-message) sleep 300 & wait ;;
+list-panes)      exit 0 ;;
+kill-session)    echo "cannot kill session" >&2; exit 1 ;;
+has-session)     exit 0 ;;`)
+
+	ts := NewTmuxSessionFromSanitizedName("af_timeout_and_survivor", "")
+	state, err := ts.CloseAndWaitForPaneExit()
+
+	if state != PaneStateUnknown {
+		t.Fatalf("state = %v, want PaneStateUnknown", state)
+	}
+	if !errors.Is(err, ErrTmuxTimeout) {
+		t.Errorf("error = %v, want the ErrTmuxTimeout sentinel to survive the combined failure so "+
+			"callers can still classify the tmux command as timed out (#1917)", err)
+	}
+}
+
+// TestCaptureTimeoutKeepsTheSentinelThroughACloseFailure is the second sentinel
+// leak (Codex on #2966, round 2). The first fix joined pidErr into the
+// survived-kill branch; list-panes can time out too, and its ErrTmuxTimeout
+// lives in processes.captureErr, which the same branch was still dropping.
+//
+// Here the pane query SUCCEEDS (so pidErr is nil and cannot carry the sentinel),
+// list-panes times out, and the kill then fails with the session still alive.
+func TestCaptureTimeoutKeepsTheSentinelThroughACloseFailure(t *testing.T) {
+	shortTmuxTimeout(t, 200*time.Millisecond)
+	livePID := strconv.Itoa(os.Getpid())
+	scriptedTmuxOnPath(t, `
+display-message) echo "`+livePID+`" ;;
+list-panes)      sleep 300 & wait ;;
+kill-session)    echo "cannot kill session" >&2; exit 1 ;;
+has-session)     exit 0 ;;`)
+
+	ts := NewTmuxSessionFromSanitizedName("af_capture_timeout", "")
+	state, err := ts.CloseAndWaitForPaneExit()
+
+	if state != PaneStateUnknown {
+		t.Fatalf("state = %v, want PaneStateUnknown", state)
+	}
+	if !errors.Is(err, ErrTmuxTimeout) {
+		t.Errorf("error = %v, want the ErrTmuxTimeout from the timed-out list-panes to survive the "+
+			"combined failure — pidErr is nil here, so the capture error is the only carrier (#1917)", err)
+	}
+}
+
+// TestUnparseablePaneOutputIsNotAbsence is the third-round Codex finding: the
+// determinate-empty predicate accepted ANY pane-query failure, including one
+// from a session that plainly existed.
+//
+// Here display-message returns garbage (tmux answered, we could not read it) and
+// the session then vanishes before list-panes. That pairing is a LOST ANCESTRY —
+// detached descendants and SID members were never captured — not an empty
+// session, so cleanup must refuse.
+//
+// The sibling below pins the case that MUST still pass, so the fix is a
+// discrimination rather than a blanket refusal.
+func TestUnparseablePaneOutputIsNotAbsence(t *testing.T) {
+	scriptedTmuxOnPath(t, `
+display-message) echo "not-a-pid" ;;
+list-panes)      echo "can't find session: af_garbled" >&2; exit 1 ;;
+kill-session)    exit 0 ;;
+has-session)     exit 1 ;;`)
+
+	ts := NewTmuxSessionFromSanitizedName("af_garbled", "")
+	state, err := ts.CloseAndWaitForPaneExit()
+
+	if state == PaneStateKnown {
+		t.Fatalf("CloseAndWaitForPaneExit = PaneStateKnown with err=%v: display-message ANSWERED with "+
+			"unreadable output, which is not evidence the session was absent — pairing it with a "+
+			"vanished session treats a lost ancestry as an empty one (#2962 round 3)", err)
+	}
+	if err == nil {
+		t.Error("the refusal must say why")
+	}
+}
+
+// TestEmptyPaneOutputIsAbsence is the other half: tmux answering with NO pane is
+// what a missing session actually produces (measured: exit 0, empty output), and
+// that paired with a vanished session is a real empty set. Refusing here would
+// block every ordinary teardown of an already-exited agent.
+func TestEmptyPaneOutputIsAbsence(t *testing.T) {
+	scriptedTmuxOnPath(t, `
+display-message) exit 0 ;;
+list-panes)      echo "can't find session: af_absent" >&2; exit 1 ;;
+kill-session)    exit 0 ;;
+has-session)     exit 1 ;;`)
+
+	ts := NewTmuxSessionFromSanitizedName("af_absent", "")
+	state, err := ts.CloseAndWaitForPaneExit()
+
+	if state != PaneStateKnown {
+		t.Fatalf("CloseAndWaitForPaneExit = %v (err=%v), want PaneStateKnown: tmux answered that there "+
+			"is no pane AND no session, which is a determinate empty", state, err)
+	}
+	if err != nil {
+		t.Errorf("error = %v, want nil", err)
+	}
+}
+
+// The vanished-session sweep, round 5 (Codex on #2966). Round 4 answered "did
+// anything outlive this session?" with a marker scan, but matched on AF_SESSION
+// ALONE and only REPORTED what it found. Both were wrong, in opposite
+// directions, and these three cases pin the corrected split.
+
+// TestVanishedSessionReapsAnOwnedSurvivor: a descendant carrying THIS home's
+// markers is a real escaped process. Reporting it is not enough — the tombstone
+// is retried by finishUserKill, and a scan that never signals leaves the leak and
+// the stuck worktree forever. It must be reaped, and cleanup may then proceed.
+func TestVanishedSessionReapsAnOwnedSurvivor(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	const name = "af_vanished_owned"
+	survivor := spawnMarkedProcess(t, name, home)
+
+	scriptedTmuxOnPath(t, `
+display-message) exit 0 ;;
+list-panes)      echo "can't find session: `+name+`" >&2; exit 1 ;;
+kill-session)    exit 0 ;;
+has-session)     exit 1 ;;`)
+
+	state, err := NewTmuxSessionFromSanitizedName(name, "").CloseAndWaitForPaneExit()
+
+	if state != PaneStateKnown || err != nil {
+		t.Fatalf("state=%v err=%v: the survivor was this home's, so the bounded reap should have "+
+			"eliminated it and authorized cleanup — refusing instead leaves the tombstone retrying "+
+			"forever without ever signalling the process", state, err)
+	}
+	if proctree.AliveSame(survivor) {
+		t.Errorf("pid %d survived the sweep; reporting a leak without reaping it is what round 4 got wrong", survivor.PID)
+	}
+}
+
+// TestVanishedSessionIgnoresAnotherHomesProcess: the same sanitized name can
+// exist under a DIFFERENT agent-factory home — a leftover from a temp or dev
+// install. Matching on AF_SESSION alone counted it as ours, refusing cleanup
+// forever over a process we must not touch.
+func TestVanishedSessionIgnoresAnotherHomesProcess(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	const name = "af_vanished_foreign"
+	foreign := spawnMarkedProcess(t, name, filepath.Join(t.TempDir(), "some-other-home"))
+
+	scriptedTmuxOnPath(t, `
+display-message) exit 0 ;;
+list-panes)      echo "can't find session: `+name+`" >&2; exit 1 ;;
+kill-session)    exit 0 ;;
+has-session)     exit 1 ;;`)
+
+	state, err := NewTmuxSessionFromSanitizedName(name, "").CloseAndWaitForPaneExit()
+
+	if state != PaneStateKnown || err != nil {
+		t.Fatalf("state=%v err=%v: the marked process belongs to ANOTHER af home, so it is neither our "+
+			"survivor nor ours to reap — blocking on it strands this teardown indefinitely", state, err)
+	}
+	if !proctree.AliveSame(foreign) {
+		t.Errorf("another home's process (pid %d) was killed by this teardown", foreign.PID)
+	}
+}
+
+// TestVanishedSessionRefusesAnUnattributableProcess: a process carrying this
+// session's name but NO home marker cannot be shown to be ours OR foreign. That
+// is the one case that must still block — "I could not tell" is not "not mine".
+func TestVanishedSessionRefusesAnUnattributableProcess(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	const name = "af_vanished_unattributable"
+	spawnMarkedProcess(t, name, "")
+
+	scriptedTmuxOnPath(t, `
+display-message) exit 0 ;;
+list-panes)      echo "can't find session: `+name+`" >&2; exit 1 ;;
+kill-session)    exit 0 ;;
+has-session)     exit 1 ;;`)
+
+	state, err := NewTmuxSessionFromSanitizedName(name, "").CloseAndWaitForPaneExit()
+
+	if state == PaneStateKnown {
+		t.Fatalf("state=Known err=%v: a process marking this session with no %s marker cannot be "+
+			"attributed, and an unattributable process is not an absent one", err, EnvMarkerHome)
+	}
+}
+
+// spawnMarkedProcess starts a child carrying AF_SESSION=<name> and returns its
+// pid, cleaned up by the test.
+func spawnMarkedProcess(t *testing.T, sessionName, afHome string) proctree.Process {
+	t.Helper()
+	c := exec.Command("sleep", "300")
+	// A CLEAN env, not os.Environ(). processEnvValue returns the FIRST match, and
+	// this test binary runs inside a real af session — so inheriting the ambient
+	// environment puts THAT session's AF_SESSION ahead of the one appended here,
+	// and the child reads as belonging to the developer's session instead of the
+	// fixture's. Measured: the sweep then reported live pids from the running
+	// session rather than the spawned child.
+	c.Env = []string{"PATH=" + os.Getenv("PATH"), EnvMarkerSession + "=" + sessionName}
+	if afHome != "" {
+		c.Env = append(c.Env, EnvMarkerHome+"="+afHome)
+	}
+	// Its OWN kernel session, because the sweep expands a matched process to its
+	// SID members — which is scoped in production precisely because tmux makes a
+	// pane root a session leader (see captureSessionProcessTrees). A child that
+	// merely inherits the test runner's SID is not that shape: measured, the
+	// expansion then pulled in the developer's live af session processes and the
+	// fixture indicted them instead of its own child.
+	c.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := c.Start(); err != nil {
+		t.Fatalf("spawn marked process: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = c.Process.Kill()
+		_, _ = c.Process.Wait()
+	})
+	// The scan reads /proc/<pid>/environ; wait until it is readable, then take the
+	// full process IDENTITY. A bare pid is not enough for later liveness checks:
+	// AliveSame compares (PID, StartID), so a fabricated Process{PID: n} reports
+	// "not alive" for a perfectly live process — which made an earlier version of
+	// these assertions pass vacuously.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if env, err := proctree.Environ(c.Process.Pid); err == nil {
+			if v, ok := processEnvValue(env, EnvMarkerSession); ok && v == sessionName {
+				p, lookupErr := proctree.Lookup(c.Process.Pid)
+				if lookupErr != nil {
+					t.Fatalf("look up spawned pid %d: %v", c.Process.Pid, lookupErr)
+				}
+				return p
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Skipf("child %d environ never became readable; this fixture needs a marker-visible process", c.Process.Pid)
+	return proctree.Process{}
+}

--- a/session/tmux/submit.go
+++ b/session/tmux/submit.go
@@ -152,8 +152,16 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 	// session must not share a buffer, or one call's load-buffer could overwrite
 	// the other's content between its load and paste and corrupt the submit. The
 	// process token additionally keeps two af processes on a shared tmux server
-	// from colliding on the same server-scoped buffer name. `-d` clears the buffer
-	// after pasting so buffers never accumulate.
+	// from colliding on the same server-scoped buffer name.
+	//
+	// The invariant is that EVERY exit path below disposes of this buffer, because
+	// buffers are server-scoped and outlive the session: `paste-buffer -d` on the
+	// success path, and an explicit best-effort `delete-buffer` on each of the two
+	// failure paths. This comment used to say only that `-d` meant "buffers never
+	// accumulate" — true of a successful paste and false of both failures, which is
+	// how the load-side leak (#2958) stayed invisible after the paste-side one
+	// (#1536) was fixed. State the property that has to hold on every path, not the
+	// one mechanism that delivers it on one of them.
 	buf := pasteBufferName(pasteBufferProcessToken, t.sanitizedName, pasteBufferSeq.Add(1))
 
 	probe := newDeliveryProbe(text)
@@ -167,6 +175,32 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 	loadTimedOut := loadCtx.Err() != nil
 	loadCancel()
 	if err != nil {
+		// A failed load can still have CREATED the buffer. `load-buffer -` consumes
+		// stdin incrementally, so a read error part-way through — or a timeout that
+		// kills the command mid-write — leaves a partially-filled buffer behind. Since
+		// buffers are server-scoped they outlive the session, so every failed submit
+		// strands another one: the same unbounded leak #1536 closed on the paste side,
+		// reached through the other half of the two-step paste (#2958).
+		//
+		// Bounded, for the paste path's reason: the cleanup for a load that failed
+		// against a WEDGED server must not itself wedge on that server and undo the
+		// bound above.
+		//
+		// Deleting here is unconditionally safe. pasteBufferName mints a name unique to
+		// this call (per-process token + atomic seq), so this can only ever remove the
+		// buffer THIS call loaded — never a concurrent delivery's pending one.
+		delCtx, delCancel := tmuxTimeoutContext()
+		derr := t.runTmuxBounded(delCtx, "delete-buffer", "-b", buf)
+		delCancel()
+		if derr != nil {
+			// WARNING, not the ERROR its paste-side twin uses, and the difference is
+			// deliberate. After a SUCCESSFUL load the buffer certainly exists, so
+			// failing to delete it is surprising. Here the load failed, so the buffer
+			// may never have been created at all — tmux answers `no buffer <name>` and
+			// exits non-zero — and that is the expected outcome, not a fault. Logging it
+			// at ERROR would cry wolf on the common case of this very path.
+			log.WarningLog.Printf("could not delete paste buffer %q after a failed load (it may never have been created): %v", buf, derr)
+		}
 		if loadTimedOut {
 			return fmt.Errorf("%w: load-buffer after %s", ErrTmuxTimeout, tmuxCommandTimeout)
 		}

--- a/session/tmux/submit_test.go
+++ b/session/tmux/submit_test.go
@@ -541,6 +541,96 @@ func TestSubmitDeletesBufferWhenPasteFails(t *testing.T) {
 		"a failed paste must delete-buffer the same buffer it loaded, not leak it (#1536)")
 }
 
+// TestSubmitDeletesBufferWhenLoadFails is the other half of the #1536 leak,
+// filed as #2958. `load-buffer -` consumes stdin incrementally, so tmux can have
+// CREATED the named buffer before it fails — a read error part-way through, or a
+// timeout that kills the command mid-write. Buffers are server-scoped, so that
+// one outlives the session and every failed submit strands another.
+//
+// The paste-failure path was given a best-effort delete; this one returned
+// straight out. Same two-step paste, same buffer, same unbounded leak.
+func TestSubmitDeletesBufferWhenLoadFails(t *testing.T) {
+	var loadBuf, deletedBuf string
+	var loadErr = fmt.Errorf("boom: short write to stdin")
+	pasted := false
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			joined := strings.Join(c.Args, " ")
+			switch {
+			case strings.Contains(joined, "load-buffer"):
+				// tmux named (and partially filled) the buffer, THEN failed.
+				loadBuf = bufferOf(c.Args)
+				return loadErr
+			case strings.Contains(joined, "paste-buffer"):
+				pasted = true
+				return nil
+			case strings.Contains(joined, "delete-buffer"):
+				deletedBuf = bufferOf(c.Args)
+				return nil
+			}
+			return nil
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) { return []byte("content"), nil },
+	}
+
+	session := newTmuxSession("af_proj", "claude", NewMockPtyFactory(t), cmdExec)
+	const existingProvenance = "previously-accepted-completion"
+	session.lastPastedTail = existingProvenance
+
+	err := session.SendKeysCommand("a prompt whose load fails")
+	require.Error(t, err, "a failed load-buffer must surface as an error")
+	require.ErrorIs(t, err, loadErr, "the load error must be wrapped and returned")
+
+	require.NotEmpty(t, loadBuf, "load-buffer must have named a buffer")
+	require.Equal(t, loadBuf, deletedBuf,
+		"a failed load must delete-buffer the same buffer it named, not leak it: tmux buffers are "+
+			"server-scoped, so one is stranded per failed submit for the life of the server (#2958)")
+
+	// The two properties a load failure must preserve, so the cleanup cannot be
+	// mistaken for "just retry the whole delivery": nothing was pasted into the
+	// pane, and provenance from the last ACCEPTED payload is untouched.
+	require.False(t, pasted, "a failed load must not go on to paste")
+	require.Equal(t, existingProvenance, session.lastPastedTail,
+		"a failed load must not replace provenance from the last accepted payload")
+}
+
+// TestSubmitDeleteAfterFailedLoadIsBounded pins the reason the cleanup takes a
+// bounded context rather than running unbounded: a load that failed because the
+// SERVER is wedged would otherwise have its cleanup wedge on that same server,
+// undoing the bound the load itself was given. The delete must be issued and must
+// carry a deadline.
+func TestSubmitDeleteAfterFailedLoadIsBounded(t *testing.T) {
+	var sawDelete bool
+	var deleteHadDeadline bool
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			joined := strings.Join(c.Args, " ")
+			switch {
+			case strings.Contains(joined, "load-buffer"):
+				return fmt.Errorf("server wedged")
+			case strings.Contains(joined, "delete-buffer"):
+				sawDelete = true
+				// Both are set by boundedTmuxCommand and by nothing else in this
+				// package — a hand-rolled exec.Command("tmux", …), which the package
+				// does still contain for server scoping, carries neither.
+				if c.Cancel != nil && c.WaitDelay != 0 {
+					deleteHadDeadline = true
+				}
+				return nil
+			}
+			return nil
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) { return []byte("content"), nil },
+	}
+
+	session := newTmuxSession("af_proj", "claude", NewMockPtyFactory(t), cmdExec)
+	require.Error(t, session.SendKeysCommand("prompt"))
+	require.True(t, sawDelete, "a failed load must attempt the cleanup delete")
+	require.True(t, deleteHadDeadline,
+		"the cleanup delete must be bounded, or a wedged server that failed the load would wedge "+
+			"its cleanup too and defeat the load's own timeout")
+}
+
 // TestPasteBufferNameProcessTokenPreventsCrossProcessCollision is the #1536
 // Greptile guard: tmux buffers are server-scoped and the seq counter is
 // process-local, so two af processes sharing a tmux server and a session name


### PR DESCRIPTION
Refs #2983 — **Part 1 only**.

This deliberately does **not** carry a `Closes`, because #2983 tracks two asks and
Part 2 (multiple accounts per agent) is untouched. Closing it here would orphan
that. Say the word and I'll split Part 2 into its own issue so #2983 can close.

## The constraint this is built around

The question — "how much is left, and on which account?" — cannot be answered
locally today, and the tempting way to answer it anyway is to estimate: sum the
`usage` fields out of provider transcripts. That measures **spend**, not
entitlement, and presenting it as a quota would be a confident answer to a
question nothing here can answer. This repo's recurring failure shape is exactly
that.

So the report keeps two things on separate axes:

| column | meaning |
| --- | --- |
| **QUOTA** | what the provider says about the ceiling. No supported agent exposes one af can read, so every row reads `not reported` — af declining to guess, **not** a ceiling of zero. |
| **OBSERVED** | what af has seen in its own sessions: a session parked at a usage wall, and the reset time recorded with it. Real signal even where the provider offers nothing. |

## The rule is enforced by the type, not the renderer

A type can be impeccable and still print an empty cell, so:

- `Entitlement` is a closed enum whose **zero value** is `EntitlementNotReported`
  — a provider added later with no integration degrades to the truth rather than
  to zero;
- its `String()` never returns `""`, because a blank cell in a quota table reads
  as exhausted;
- the tests assert on **rendered output**, since that is what a user actually
  sees.

## Under-reporting is the same dishonesty as over-reporting

- every configured agent gets a row, including ones nobody has run — an absent
  row is indistinguishable from "nothing to report";
- `no sessions` is a distinct state from `no limit seen`: an agent nobody ran is
  not evidence of available quota;
- an agent running outside the configured list is still reported;
- a limit with no parseable reset time says so, instead of rendering the zero
  time as a 1970 deadline;
- record files that could not be read or parsed produce an explicit
  **INCOMPLETE** warning — the unreadable one may have been the parked session.

## Running it caught a bug reading did not

Against a real AF home the table grew a row titled
`/home/…/claude --dangerously-skip-permissions` beside `claude`:
`InstanceData.Program` is the **resolved command**, not the agent enum, so with
`program_overrides` set one agent was reported twice and each row undercounted.

Fixed with the existing `tmux.DetectAgentFromCommand`, which already handles the
cases a naive `filepath.Base` would not — wrapper prefixes (`ionice -c 3
claude`), `env VAR=x claude`, and matching only on a verbatim base so
`/opt/claude-wrapper/run` never matches on substring. A command it cannot
attribute is kept **verbatim** rather than dropped or bucketed as "unknown".

Sample against this box (22 sessions, collapsed correctly):

```
AGENT     QUOTA          OBSERVED       DETAIL
aider     not reported   no sessions    configured, but af has no sessions running it
claude    not reported   no limit seen  22 session(s) running, none parked at a limit
codex     not reported   no limit seen  1 session(s) running, none parked at a limit
```

## Scope notes

`docs/reference/cli.md` is regenerated by `scripts/gen-docs.sh`, so the
docs-drift gate stays green. No provider is probed and no credential is touched —
Part 2's security-adjacent work is entirely absent by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
