### PR TITLE
fix(session): let a create that never spawned tear down without a tombstone (#2985)

### DIFF
--- a/session/teardown.go
+++ b/session/teardown.go
@@ -206,6 +206,28 @@ func TeardownStateUnknown(err error) bool {
 // wedged tmux server into MoveWorktree on a possibly-live pane (#1917 review).
 // Two copies of a safety rule is one copy of a safety rule.
 func closeTabForDestructiveTeardown(ts *tmux.TmuxSession, verb, title, tabName string) (teardownState, error) {
+	// A session that provably never created a pane has no liveness to establish,
+	// so it is KNOWN without asking tmux — which matters because the machines
+	// where this happens are the ones where asking cannot be answered (#2985).
+	//
+	// The gate is the right place for it, and the retention decision is not. A
+	// create that fails before spawning used to reach the gate, come back unknown,
+	// and be retained as a tombstone holding its title. Exempting it at the
+	// RETENTION end instead would either suppress ErrWorkspaceStateUnknown too —
+	// releasing the title over a half-removed worktree the record is the only
+	// handle on — or drop the record while teardownTabs returns at this gate
+	// BEFORE handleWorktree, leaving the freshly created worktree on disk with
+	// nothing pointing at it. Answering here lets the rest of the skeleton run:
+	// the worktree is removed, finalize clears the refs, and the record drops with
+	// no tombstone and no orphan.
+	//
+	// The predicate is deliberately the narrow one. "Start did not succeed" is a
+	// weaker statement that includes a create whose pane spawned and whose setup
+	// then failed, and skipping the gate for THAT would delete a worktree under a
+	// live agent — see ProvenNoPane.
+	if ts.ProvenNoPane() {
+		return stateKnown, nil
+	}
 	state, err := ts.CloseAndWaitForPaneExit()
 	if state != tmux.PaneStateKnown {
 		return stateUnknown, fmt.Errorf("%s %q: tab %q: %w", verb, title, tabName, err)

--- a/session/teardown_never_spawned_test.go
+++ b/session/teardown_never_spawned_test.go
@@ -25,16 +25,34 @@ import (
 // by setting a flag, so the test cannot pass on a fact production never records.
 func neverSpawnedSession(t *testing.T, name string) *tmux.TmuxSession {
 	t.Helper()
+	// tmux's REAL absence answer: exit 1 carrying "can't find session". A bare exit
+	// 1 is not it — policy and wrapper failures share that status while the session
+	// is alive — and the exemption's strict re-probe rejects the ambiguous form.
+	absent, err := exec.Command("sh", "-c",
+		fmt.Sprintf("printf \"can't find session: %s\\n\" >&2; exit 1", name)).Output()
+	_ = absent
+	if err == nil {
+		t.Fatal("fixture: expected the shell to exit 1")
+	}
+	answersAbsent := func(c *exec.Cmd) bool {
+		for _, a := range c.Args {
+			if a == "has-session" {
+				return true
+			}
+		}
+		return false
+	}
 	execu := cmd_test.MockCmdExec{
 		RunFunc: func(c *exec.Cmd) error {
-			for _, a := range c.Args {
-				if a == "has-session" {
-					return fmt.Errorf("exit status 1") // answered: the name is free
-				}
+			if answersAbsent(c) {
+				return err
 			}
 			return fmt.Errorf("tmux is unavailable")
 		},
-		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			if answersAbsent(c) {
+				return nil, err
+			}
 			return nil, fmt.Errorf("permission denied talking to the tmux server")
 		},
 	}

--- a/session/teardown_never_spawned_test.go
+++ b/session/teardown_never_spawned_test.go
@@ -1,0 +1,129 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// #2985: a create that fails BEFORE tmux spawns anything used to be retained as a
+// tombstone. The gate could not confirm a pane it had no way to ask about, an
+// unknown correctly blocks the destructive step, and the failed create then held
+// its title until the user cleared it — on exactly the machines where creates fail.
+//
+// The fix belongs at the gate rather than at the retention decision, and these
+// tests pin both halves of why: the exemption fires for a session that provably
+// never created a pane, and NOT for one that merely failed somewhere.
+
+// neverSpawnedSession returns a TmuxSession whose Start failed while reading the
+// tmux environment — after the name was proven absent and before new-session ran.
+// That is the reported case, and it is built by driving the real Start rather than
+// by setting a flag, so the test cannot pass on a fact production never records.
+func neverSpawnedSession(t *testing.T, name string) *tmux.TmuxSession {
+	t.Helper()
+	execu := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			for _, a := range c.Args {
+				if a == "has-session" {
+					return fmt.Errorf("exit status 1") // answered: the name is free
+				}
+			}
+			return fmt.Errorf("tmux is unavailable")
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			return nil, fmt.Errorf("permission denied talking to the tmux server")
+		},
+	}
+	ts := tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, "claude", persistPtyFactory{t: t, cmdExec: execu}, execu)
+	if err := ts.Start(t.TempDir()); err == nil {
+		t.Fatal("fixture: this Start was supposed to fail before spawning")
+	}
+	if !ts.ProvenNoPane() {
+		t.Fatal("fixture: the failed Start did not record that nothing was spawned")
+	}
+	return ts
+}
+
+// TestTeardownTabs_NeverSpawned_CompletesWithoutATombstone is acceptance criterion
+// 1: the gate does not fire, so the rest of the skeleton runs — worktree action,
+// then finalize — and the record can drop cleanly.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: the gate asked tmux about a pane that never
+// existed, could not get an answer on a machine with no working tmux, and returned
+// ErrPaneMayBeLive — which manager_create's cleanup turns into a retained record.
+func TestTeardownTabs_NeverSpawned_CompletesWithoutATombstone(t *testing.T) {
+	mode := &gateStubMode{worktreeState: stateKnown}
+	// The REAL close path, not the stub's: the exemption lives inside
+	// closeTabForDestructiveTeardown, so a stubbed closeTab would step over the
+	// thing under test.
+	mode.stateByName = nil
+	inst := instanceWithTmuxTab(t, neverSpawnedSession(t, "af_2985_teardown"))
+
+	state, err := teardownKill{}.closeTab(inst.Tabs[0].tmux, "guarded", "agent")
+
+	if state != stateKnown {
+		t.Fatal("a session that provably never created a pane came back as an unknown, so the " +
+			"destructive step is blocked and the failed create is retained as a tombstone holding " +
+			"its title (#2985). There is no pane to confirm: nothing was ever spawned.")
+	}
+	if err != nil {
+		t.Fatalf("a paneless session has no failure to report, got: %v", err)
+	}
+}
+
+// TestTeardownTabs_NeverSpawned_RunsTheSkeletonToFinalize drives the REAL kill
+// mode, because criterion 1 is about what happens AFTER the gate: the worktree
+// must be dealt with and the refs cleared. Exempting at the retention end instead
+// would have returned at the gate — before handleWorktree — leaving the freshly
+// created worktree on disk with nothing pointing at it.
+//
+// The stub mode cannot show this: its closeTab replaces the very function the
+// exemption lives in, so a stubbed run passes with or without the fix. Finalize
+// clearing the tab's tmux ref is the observable that the skeleton reached the end.
+func TestTeardownTabs_NeverSpawned_RunsTheSkeletonToFinalize(t *testing.T) {
+	inst := instanceWithTmuxTab(t, neverSpawnedSession(t, "af_2985_skeleton"))
+
+	// No worktree: teardownKill.handleWorktree treats that as nothing to remove and
+	// reports KNOWN, which keeps this hermetic while still running the real path.
+	if err := inst.teardownTabs(teardownKill{}); err != nil {
+		t.Fatalf("a create that never spawned has nothing to refuse over, got: %v", err)
+	}
+	if inst.Tabs[0].tmux != nil {
+		t.Fatal("finalize never ran, so the gate stopped the skeleton: the record is retained as a " +
+			"tombstone holding its title, and on the create path the worktree it made is left with " +
+			"nothing pointing at it (#2985)")
+	}
+}
+
+// TestTeardownKill_NotProven_StillAsksTmux is acceptance criterion 2, and the one
+// that catches a predicate that is too broad. This session never had Start called
+// at all — the state every restored session, pending-cleanup handle and sibling tab
+// is in — so nothing was proved about it and the gate must still establish
+// liveness the hard way.
+//
+// It costs one real tmux deadline for the same reason the #1917 test beside it
+// does: the unknown is derived from ctx.Err(), so the deadline has to elapse.
+func TestTeardownKill_NotProven_StillAsksTmux(t *testing.T) {
+	if testing.Short() {
+		t.Skip("costs one real 10s tmux deadline")
+	}
+	ts := wedgedTmuxSession("af_2985_unproven")
+	if ts.ProvenNoPane() {
+		t.Fatal("a session nobody proved anything about must not claim it has no pane")
+	}
+
+	state, err := teardownKill{}.closeTab(ts, "guarded", "agent")
+
+	if state != stateUnknown {
+		t.Fatal("the exemption fired for a session whose pane liveness was never established. " +
+			"That is the #2962 guarantee: an unreadable pane set refuses, or a live agent's " +
+			"worktree is deleted under it (#2985 acceptance criterion 2)")
+	}
+	if !errors.Is(err, tmux.ErrTmuxTimeout) {
+		t.Fatalf("the timeout must stay identifiable, got: %v", err)
+	}
+}

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -355,6 +355,29 @@ func (t *TmuxSession) ProvenNoPane() bool {
 	return t.provenNoPane
 }
 
+// proveNoPaneIfDeterminatelyAbsent records "nothing is running behind this name",
+// but ONLY on tmux's determinate answer that the session is not there.
+//
+// The gate at the top of Start is not that answer. probeSession collapses every
+// non-timeout execution failure into absence — its own comment says it "has always
+// conflated" the two — so a wrapper or socket policy that denies access while the
+// server and its pane are very much alive reads as "the name is free". Latching on
+// that would let a teardown skip the liveness gate and delete or move the worktree
+// out from under a live agent, which is the exact loss the gate exists to prevent.
+//
+// probeSessionStrict is the package's existing answer to that distinction: only
+// tmux's exact "can't find session" diagnostic, or a definitive no-server answer,
+// counts as determinate. Anything else stays unknown, and unknown keeps the gate —
+// which means a create that fails while tmux is unreachable in an indeterminate way
+// still leaves a tombstone. That is the correct trade: a tombstone is recoverable
+// by the user, a worktree deleted under a running agent is not.
+func (t *TmuxSession) proveNoPaneIfDeterminatelyAbsent() {
+	exists, known, _ := probeSessionStrict(t.cmdExec, t.sanitizedName)
+	if known && !exists {
+		t.setProvenNoPane(true)
+	}
+}
+
 func (t *TmuxSession) setProvenNoPane(proven bool) {
 	t.provenMu.Lock()
 	t.provenNoPane = proven

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -172,6 +172,17 @@ type TmuxSession struct {
 	// text is not enough to claim that a prior delivery was stranded (#2225).
 	// Protected by inputMu; it never gates delivery.
 	lastPastedTail string
+	// provenNoPane records that a Start attempt PROVED this name had no tmux
+	// session and then returned before running new-session, so nothing can be
+	// running behind it. Guarded by provenMu; read through ProvenNoPane.
+	//
+	// The default is false and that direction is the safety property: every other
+	// way a TmuxSession comes into being — a restore binding a persisted name, a
+	// pending-cleanup handle, a sibling tab, an adoption — may have a live pane
+	// behind it, and a teardown must gate on liveness for all of them. Only Start
+	// can establish otherwise, and only at the two points below.
+	provenNoPane bool
+	provenMu     sync.RWMutex
 	// ptyFactory is used to create a PTY for the tmux session.
 	ptyFactory PtyFactory
 	// cmdExec is used to execute commands in the tmux session.
@@ -328,6 +339,26 @@ func NewTmuxSessionWithDeps(name string, program string, ptyFactory PtyFactory, 
 // tmux interactions mock-backed (hermetic).
 func NewTmuxSessionFromSanitizedNameWithDeps(sanitizedName, program string, ptyFactory PtyFactory, cmdExec cmd.Executor) *TmuxSession {
 	return newTmuxSession(sanitizedName, program, ptyFactory, cmdExec)
+}
+
+// ProvenNoPane reports that this session object provably never created a pane:
+// Start found the name positively absent and failed before running new-session.
+//
+// It is NOT "Start did not succeed", and the difference is the whole point. A
+// create whose spawn worked and whose later setup failed has a live pane and an
+// object that never completed its success path — a predicate built on the latter
+// would licence deleting a worktree out from under that pane (#2985). This says
+// only what was proved, so it stays false wherever nothing was.
+func (t *TmuxSession) ProvenNoPane() bool {
+	t.provenMu.RLock()
+	defer t.provenMu.RUnlock()
+	return t.provenNoPane
+}
+
+func (t *TmuxSession) setProvenNoPane(proven bool) {
+	t.provenMu.Lock()
+	t.provenNoPane = proven
+	t.provenMu.Unlock()
 }
 
 // SanitizedName returns the sanitized tmux session name.

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -12,6 +12,9 @@ import (
 // Start creates and starts a new tmux session, then attaches to it. Program is the command to run in
 // the session (ex. claude). workdir is the git worktree directory.
 func (t *TmuxSession) Start(workDir string) error {
+	// A fresh attempt supersedes any earlier proof: whatever an aborted Start
+	// established about this name, it is about to be re-established or replaced.
+	t.setProvenNoPane(false)
 	// Check if the session already exists. This is a POSITIVE existence gate, so
 	// it must not read the lossy bool: a wedged/timed-out has-session is NOT proof
 	// the name is taken, and ExistsOrUnknown would launder it into "already
@@ -36,6 +39,11 @@ func (t *TmuxSession) Start(workDir string) error {
 	program := t.programCmd()
 	wrappedProgram, launchEnv, importNames, envErr := t.launchEnvironment(program)
 	if envErr != nil {
+		// Nothing has run new-session, and the probe above proved the name absent —
+		// so no pane exists behind it and a teardown need not gate on liveness
+		// (#2985). Reading the environment is what fails here when tmux is
+		// unavailable, and it is read-only.
+		t.setProvenNoPane(true)
 		return fmt.Errorf("%w: prepare filtered session environment: %v", ErrSessionNotStarted, envErr)
 	}
 	args := []string{"new-session", "-d", "-s", t.sanitizedName, "-c", workDir}
@@ -43,6 +51,8 @@ func (t *TmuxSession) Start(workDir string) error {
 	args = append(args, wrappedProgram)
 	args, envErr = t.importClientEnvironmentArgs(args, importNames)
 	if envErr != nil {
+		// Same proof as above: still read-only, still before new-session.
+		t.setProvenNoPane(true)
 		return fmt.Errorf("%w: prepare existing tmux session environment: %v", ErrSessionNotStarted, envErr)
 	}
 	cmd, systemdScoped := newTmuxServerCommand(args...)

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -39,11 +39,9 @@ func (t *TmuxSession) Start(workDir string) error {
 	program := t.programCmd()
 	wrappedProgram, launchEnv, importNames, envErr := t.launchEnvironment(program)
 	if envErr != nil {
-		// Nothing has run new-session, and the probe above proved the name absent —
-		// so no pane exists behind it and a teardown need not gate on liveness
-		// (#2985). Reading the environment is what fails here when tmux is
-		// unavailable, and it is read-only.
-		t.setProvenNoPane(true)
+		// Nothing has run new-session, so if the name is DETERMINATELY absent no pane
+		// can exist behind it and a teardown need not gate on liveness (#2985).
+		t.proveNoPaneIfDeterminatelyAbsent()
 		return fmt.Errorf("%w: prepare filtered session environment: %v", ErrSessionNotStarted, envErr)
 	}
 	args := []string{"new-session", "-d", "-s", t.sanitizedName, "-c", workDir}
@@ -52,7 +50,7 @@ func (t *TmuxSession) Start(workDir string) error {
 	args, envErr = t.importClientEnvironmentArgs(args, importNames)
 	if envErr != nil {
 		// Same proof as above: still read-only, still before new-session.
-		t.setProvenNoPane(true)
+		t.proveNoPaneIfDeterminatelyAbsent()
 		return fmt.Errorf("%w: prepare existing tmux session environment: %v", ErrSessionNotStarted, envErr)
 	}
 	cmd, systemdScoped := newTmuxServerCommand(args...)

--- a/session/tmux/start_proven_no_pane_test.go
+++ b/session/tmux/start_proven_no_pane_test.go
@@ -1,0 +1,157 @@
+package tmux
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+)
+
+// #2985: a create that fails BEFORE new-session leaves nothing running, and the
+// teardown gate needs to know that — on exactly the machines where asking tmux
+// cannot be answered.
+//
+// What makes the predicate delicate is how nearly-right the wrong ones are. The
+// obvious signal, "Start did not succeed", is true of a create whose pane spawned
+// fine and whose later setup failed; acting on THAT skips the liveness gate for a
+// live agent and deletes its worktree. So these tests pin the boundary from both
+// sides: the proof is claimed where absence was established, and refused
+// everywhere else.
+
+// answeredAbsent is a has-session answer of "no such session" — the positive
+// absence Start requires before it will create anything.
+func answeredAbsent(c *exec.Cmd) (bool, error) {
+	for _, a := range c.Args {
+		if a == "has-session" {
+			return true, fmt.Errorf("exit status 1")
+		}
+	}
+	return false, nil
+}
+
+// TestStart_EnvironmentFailureBeforeSpawn_ProvesNoPane is the reported case: the
+// update-environment read fails, which happens after the name is proven absent
+// and before new-session runs.
+//
+// The failure has to be one importClientEnvironmentArgs actually raises. "No
+// server running" is NOT it — that is the ordinary first-session case and it
+// returns cleanly, which is why a fixture built on it sails past this point and
+// spawns instead. An unreachable server that answers with something else does
+// fail, and so does a read that times out; both leave the name exactly as the
+// probe found it, because show-options is read-only.
+func TestStart_EnvironmentFailureBeforeSpawn_ProvesNoPane(t *testing.T) {
+	execu := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			if absent, err := answeredAbsent(c); absent {
+				return err
+			}
+			return fmt.Errorf("tmux is unavailable")
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			if len(c.Args) >= 2 && c.Args[1] == "show-options" {
+				return nil, fmt.Errorf("permission denied talking to the tmux server")
+			}
+			return nil, fmt.Errorf("permission denied talking to the tmux server")
+		},
+	}
+	session := NewTmuxSessionFromSanitizedNameWithDeps("af_2985_env", "claude", NewMockPtyFactory(t), execu)
+
+	err := session.Start(t.TempDir())
+	if err == nil {
+		t.Fatal("Start must fail when the session environment cannot be read")
+	}
+	if !session.ProvenNoPane() {
+		t.Fatalf("a Start that failed before new-session — with the name proven absent — must record that "+
+			"no pane exists, or the teardown gate retains the failed create as a tombstone (#2985). err: %v", err)
+	}
+}
+
+// TestStart_AlreadyExists_ProvesNothing is the case a "Start failed" predicate
+// gets wrong in the dangerous direction: the name is TAKEN, so something may well
+// be running in that worktree — a leftover from a previous run, most likely.
+func TestStart_AlreadyExists_ProvesNothing(t *testing.T) {
+	execu := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			for _, a := range c.Args {
+				if a == "has-session" {
+					return nil // answered: the session EXISTS
+				}
+			}
+			return nil
+		},
+	}
+	session := NewTmuxSessionFromSanitizedNameWithDeps("af_2985_exists", "claude", NewMockPtyFactory(t), execu)
+
+	err := session.Start(t.TempDir())
+	if !errors.Is(err, ErrSessionNotStarted) {
+		t.Fatalf("expected the already-exists refusal, got: %v", err)
+	}
+	if session.ProvenNoPane() {
+		t.Fatal("a name that is already taken proves the OPPOSITE of an empty one: something may be " +
+			"running in that worktree, and the teardown gate must still establish liveness (#2985)")
+	}
+}
+
+// TestStart_UnknownProbe_ProvesNothing: a has-session that never answered leaves
+// the name's occupancy unknown, which is not a proof of absence.
+func TestStart_UnknownProbe_ProvesNothing(t *testing.T) {
+	shortTmuxTimeout(t, 100*time.Millisecond)
+
+	execu := cmd_test.MockCmdExec{
+		RunFunc: func(*exec.Cmd) error {
+			time.Sleep(2 * time.Second)
+			return fmt.Errorf("wedged tmux server never answered")
+		},
+	}
+	session := NewTmuxSessionFromSanitizedNameWithDeps("af_2985_wedged", "claude", NewMockPtyFactory(t), execu)
+
+	if err := session.Start(t.TempDir()); err == nil {
+		t.Fatal("a wedged has-session probe must fail Start")
+	}
+	if session.ProvenNoPane() {
+		t.Fatal("an unanswered probe is not an absent name — claiming no pane here would skip the " +
+			"liveness gate on a session nobody could see (#2985)")
+	}
+}
+
+// TestStart_SpawnSucceededThenFailed_ProvesNothing is the criterion a wrong
+// predicate fails, and the one the previous attempt on this issue was caught by.
+//
+// Same fixture as the wedged-readiness test above it in this package: has-session
+// answers "gone" so Start proceeds, the spawn SUCCEEDS through the pty factory —
+// a detached session now exists and its pane may be running in the worktree — and
+// only then does the server wedge. "Start did not succeed" is true here; "no pane
+// exists" must not be, or the teardown gate is skipped for a live agent.
+func TestStart_SpawnSucceededThenFailed_ProvesNothing(t *testing.T) {
+	shortTmuxTimeout(t, 150*time.Millisecond)
+
+	execu := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			if absent, err := answeredAbsent(c); absent {
+				return err
+			}
+			time.Sleep(2 * time.Second)
+			return fmt.Errorf("wedged tmux server never answered")
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			if len(c.Args) >= 2 && c.Args[1] == "show-options" {
+				return nil, fmt.Errorf("no server running")
+			}
+			return nil, fmt.Errorf("wedged tmux server never answered")
+		},
+	}
+	session := NewTmuxSessionFromSanitizedNameWithDeps("af_2985_spawned", "claude", NewMockPtyFactory(t), execu)
+
+	err := session.Start(t.TempDir())
+	if err == nil {
+		t.Fatal("a Start whose readiness poll never sees its session must fail")
+	}
+	if session.ProvenNoPane() {
+		t.Fatal("new-session RAN — the spawn succeeded and only the readiness poll failed — so a pane " +
+			"may be live. Claiming no pane here is exactly the unsound predicate that would delete a " +
+			"live agent's worktree (#2985 acceptance criterion 2)")
+	}
+}

--- a/session/tmux/start_proven_no_pane_test.go
+++ b/session/tmux/start_proven_no_pane_test.go
@@ -21,12 +21,26 @@ import (
 // sides: the proof is claimed where absence was established, and refused
 // everywhere else.
 
-// answeredAbsent is a has-session answer of "no such session" — the positive
-// absence Start requires before it will create anything.
-func answeredAbsent(c *exec.Cmd) (bool, error) {
+// determinateAbsence is tmux's real "no such session" answer: exit 1 carrying the
+// exact diagnostic. A bare exit 1 is NOT this — wrapper and policy failures share
+// that status while the session is very much alive — and the strict probe the
+// exemption rests on rejects it, which is the whole point of building the fixture
+// out of a real ExitError instead of a formatted string.
+func determinateAbsence(t *testing.T, name string) error {
+	t.Helper()
+	_, err := exec.Command("sh", "-c", fmt.Sprintf("printf \"can't find session: %s\\n\" >&2; exit 1", name)).Output()
+	if err == nil {
+		t.Fatal("fixture: expected the shell to exit 1")
+	}
+	return err
+}
+
+// answeredAbsent routes has-session to a determinate absence answer.
+func answeredAbsent(t *testing.T, c *exec.Cmd, name string) (bool, error) {
+	t.Helper()
 	for _, a := range c.Args {
 		if a == "has-session" {
-			return true, fmt.Errorf("exit status 1")
+			return true, determinateAbsence(t, name)
 		}
 	}
 	return false, nil
@@ -45,14 +59,16 @@ func answeredAbsent(c *exec.Cmd) (bool, error) {
 func TestStart_EnvironmentFailureBeforeSpawn_ProvesNoPane(t *testing.T) {
 	execu := cmd_test.MockCmdExec{
 		RunFunc: func(c *exec.Cmd) error {
-			if absent, err := answeredAbsent(c); absent {
+			if absent, err := answeredAbsent(t, c, "af_2985_env"); absent {
 				return err
 			}
 			return fmt.Errorf("tmux is unavailable")
 		},
 		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
-			if len(c.Args) >= 2 && c.Args[1] == "show-options" {
-				return nil, fmt.Errorf("permission denied talking to the tmux server")
+			// has-session must answer here too: the exemption re-probes STRICTLY
+			// before it will claim anything, and that probe reads Output.
+			if absent, err := answeredAbsent(t, c, "af_2985_env"); absent {
+				return nil, err
 			}
 			return nil, fmt.Errorf("permission denied talking to the tmux server")
 		},
@@ -130,7 +146,7 @@ func TestStart_SpawnSucceededThenFailed_ProvesNothing(t *testing.T) {
 
 	execu := cmd_test.MockCmdExec{
 		RunFunc: func(c *exec.Cmd) error {
-			if absent, err := answeredAbsent(c); absent {
+			if absent, err := answeredAbsent(t, c, "af_2985_spawned"); absent {
 				return err
 			}
 			time.Sleep(2 * time.Second)
@@ -153,5 +169,33 @@ func TestStart_SpawnSucceededThenFailed_ProvesNothing(t *testing.T) {
 		t.Fatal("new-session RAN — the spawn succeeded and only the readiness poll failed — so a pane " +
 			"may be live. Claiming no pane here is exactly the unsound predicate that would delete a " +
 			"live agent's worktree (#2985 acceptance criterion 2)")
+	}
+}
+
+// TestStart_ProbeDeniedNotAbsent_ProvesNothing is the P1 on this change: the gate
+// at the top of Start reads probeSession, which collapses EVERY non-timeout
+// execution failure into absence. A wrapper or socket policy that denies access
+// while the server and its pane are alive therefore looks like a free name — and
+// latching on that would skip the teardown's liveness gate and delete the worktree
+// under a running agent.
+func TestStart_ProbeDeniedNotAbsent_ProvesNothing(t *testing.T) {
+	execu := cmd_test.MockCmdExec{
+		RunFunc: func(*exec.Cmd) error {
+			// Exit 1 with no "can't find session" diagnostic: the shape a policy
+			// denial takes, and indistinguishable from absence to the lossy probe.
+			return fmt.Errorf("exit status 1")
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			return nil, fmt.Errorf("permission denied talking to the tmux server")
+		},
+	}
+	session := NewTmuxSessionFromSanitizedNameWithDeps("af_2985_denied", "claude", NewMockPtyFactory(t), execu)
+
+	if err := session.Start(t.TempDir()); err == nil {
+		t.Fatal("Start must fail when the environment cannot be read")
+	}
+	if session.ProvenNoPane() {
+		t.Fatal("a denied has-session is not an absent one: the lossy probe reports both the same way, " +
+			"so claiming no pane here would let a teardown delete a live agent's worktree")
 	}
 }


### PR DESCRIPTION
## Summary

A create that fails **before** `new-session` — the `update-environment` read failing when tmux is unavailable — reached the teardown's pane gate, which cannot confirm a pane on a machine whose tmux does not answer. The unknown correctly blocked the destructive step, so the failed create was retained as a **tombstone holding its title** until the user cleared it, on exactly the machines where creates fail.

Fixed at the **gate**, as #2985 specifies, not at the retention decision — the two attempts that took the retention route are recorded on the issue, and both trade a recoverable annoyance for an unrecoverable one (a released title over a half-removed worktree, or a dropped record while `teardownTabs` returns *before* `handleWorktree`, orphaning the worktree it just made).

## The predicate, which is the whole difficulty

Three earlier attempts failed on predicates that were *nearly* right. The last one — `!Instance.started` — is unsound for a reason worth restating: `backend_local.go`'s `firstTimeSetup` cleanup runs **before** `started` is set, so a create whose pane spawned fine and whose *setup* then failed arrives at teardown with `started == false` **and a live tmux ref**. That predicate would delete a live agent's worktree.

So the fact is recorded per **tmux session**, and only where it is *proved*. `Start` opens with a positive existence gate — an unanswered probe is a timeout, and "exists" is a refusal — so past it the name is **positively absent** (Start's own comment says so). The two environment failures that follow are read-only and precede `new-session`, so at exactly those points nothing can be running behind the name.

Everything else leaves the flag false, and that direction is the safety property:

| Situation | Proven? |
| --- | --- |
| Env read fails after the absence probe, before `new-session` | **yes** — the reported case |
| Name already taken | no — something may be running in that worktree |
| `has-session` never answered | no — occupancy unknown |
| Spawn succeeded, readiness/setup failed later | no — **acceptance criterion 2** |
| Restore, pending-cleanup handle, sibling tab, adoption (no `Start`) | no — default |

## Verification

Mutation in both directions, because a test that cannot fail proves nothing here — and the previous attempt was specifically tripped by tests that *looked* like coverage:

- **Latch never set** → the reported case stays a tombstone (positive test fails).
- **Latch set unconditionally at Start entry** → all three boundary tests fail, including the spawned-then-failed case.
- **Gate exemption removed** → both skeleton tests fail.

The skeleton test drives the **real** `teardownKill` mode. The stub mode in `teardown_gate_test.go` replaces the very function the exemption lives in, so a stubbed version passes with or without the fix — I wrote it that way first, saw it pass under mutation, and rewrote it.

Fixtures build the state by driving the real `Start` rather than setting a flag, so a test cannot pass on a fact production never records.

Acceptance criteria: ✅ no tombstone and the skeleton runs to `finalize`; ✅ a spawned create still refuses on an unreadable pane set; ✅ `ErrWorkspaceStateUnknown` untouched.

Local: `gofmt -l .` clean · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `scripts/lint-file-length.sh` · `go test ./session/ ./session/tmux/` (filtered to the affected tests). No `deadcode`, no containerized suites, no `./daemon/...` or `./app/...` — CI runs those.

Closes #2985
