### PR TITLE
[dead end] fix(upgrade): re-snapshot upgrade metadata after the daemon stops writing (#2212 gate 2)

### DIFF
--- a/daemon/lifecycle.go
+++ b/daemon/lifecycle.go
@@ -79,11 +79,18 @@ type daemonLifecycle struct {
 	// probation. It gates mutation ADMISSION; transactionID is kept for the whole
 	// boot as the supervisor's IDENTITY (#1947), so the two never conflate.
 	released bool
-	// quiescing is set when this daemon has authorized an upgrade activation and is
-	// handing off. It closes admission (the daemon is about to exit) and drives the
-	// reported DaemonPhaseQuiescing so a stuck hand-off is visible, not silent.
+	// quiescing is set when this daemon has committed to an upgrade hand-off and is
+	// closing admission. It closes admission and drives the reported
+	// DaemonPhaseQuiescing so a stuck hand-off is visible, not silent.
 	quiescing bool
-	listeners DaemonListenerStatus
+	// phaseBeforeQuiesce is what to go back to if the hand-off does not happen. The
+	// quiesce is now taken BEFORE the activation is authorized (#2212 gate 2), so a
+	// failure between the two must be able to resume rather than leave a daemon that
+	// refuses every mutation until something restarts it. Restoring the recorded
+	// phase rather than assuming DaemonPhaseReady keeps resumeServing honest if it is
+	// ever reached from another phase.
+	phaseBeforeQuiesce DaemonPhase
+	listeners          DaemonListenerStatus
 }
 
 const daemonBootIDBytes = 16
@@ -144,15 +151,43 @@ func (l *daemonLifecycle) markReady() error {
 }
 
 // markQuiescing moves a ready daemon into the upgrade hand-off: it stops admitting
-// new mutations and reports DaemonPhaseQuiescing. The activation trigger calls it
-// AFTER AuthorizeActivation and BEFORE the daemon exits to free the socket for the
-// validated candidate, so no mutation races the hand-off window and a daemon stuck
-// mid-hand-off is visible rather than reporting ready. Idempotent.
+// new mutations and reports DaemonPhaseQuiescing, so no mutation races the hand-off
+// window and a daemon stuck mid-hand-off is visible rather than reporting ready.
+// Idempotent.
+//
+// It is taken once the recovery actor has PROVEN supervisor_ready and before the
+// metadata snapshot is brought forward — not after AuthorizeActivation as it once
+// was. The snapshot the actor restores on rollback has to describe a daemon that had
+// already stopped writing, or the rollback discards every mutation admitted while
+// the hand-off was being set up (#2212 gate 2). Because this now happens before the
+// point of no return, resumeServing exists for the paths that fail after it.
 func (l *daemonLifecycle) markQuiescing() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	if !l.quiescing {
+		l.phaseBeforeQuiesce = l.phase
+	}
 	l.quiescing = true
 	l.phase = DaemonPhaseQuiescing
+}
+
+// resumeServing lifts a quiesce whose hand-off did not happen, so a daemon that
+// stopped admitting in preparation for an upgrade goes back to serving instead of
+// refusing every mutation until something restarts it.
+//
+// Only ever correct BEFORE AuthorizeActivation. Past that the actor is licensed to
+// replace this process and a daemon that resumed would be writing to a home another
+// binary is about to restore. Every caller is on a failure path that returns without
+// authorizing. Idempotent.
+func (l *daemonLifecycle) resumeServing() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.quiescing {
+		return
+	}
+	l.quiescing = false
+	l.phase = l.phaseBeforeQuiesce
+	l.phaseBeforeQuiesce = ""
 }
 
 // releaseUpgradeProbation lifts an upgrade candidate's probation once its

--- a/daemon/upgrade_trigger.go
+++ b/daemon/upgrade_trigger.go
@@ -38,7 +38,8 @@ var (
 	upgradeAuthorizeActivationFn   = func(txn *upgradetxn.Transaction, transactionID, nonce string) error {
 		return txn.AuthorizeActivation(transactionID, nonce)
 	}
-	upgradeAbortPreparedFn = upgradetxn.AbortPreparedTransaction
+	upgradeAbortPreparedFn   = upgradetxn.AbortPreparedTransaction
+	upgradeRefreshMetadataFn = func(txn *upgradetxn.Transaction) error { return txn.RefreshMetadataSnapshot() }
 )
 
 // triggerUpgradeActivation is the OLD-daemon side of an upgrade activation, run
@@ -52,9 +53,12 @@ var (
 // observation, never an error being nil/non-nil: AwaitSupervisorReady proves the
 // actor took the lease AND reached supervisor_ready before AuthorizeActivation
 // consents, and an actor that never gets there is a LOUD error that leaves the
-// daemon serving — never an assumed success. Only after authorizing does the daemon
-// quiesce (stop admitting, report DaemonPhaseQuiescing so a stuck hand-off is
-// visible) and exit; the actor's StopPrevious then confirms it is gone.
+// daemon serving — never an assumed success. The daemon quiesces (stops admitting,
+// reports DaemonPhaseQuiescing so a stuck hand-off is visible) once the actor is
+// proven ready and BEFORE it authorizes, so the metadata snapshot it refreshes in
+// between describes a daemon that had already stopped writing (#2212 gate 2); any
+// failure before authorization resumes serving. It exits after authorizing, and the
+// actor's StopPrevious then confirms it is gone.
 func triggerUpgradeActivation(ctx context.Context, lifecycle *daemonLifecycle, requestExit func(), candidate []byte, toVersion, expectedPreviousSHA256 string) error {
 	plan, err := captureUpgradePlan(lifecycle, candidate, toVersion, expectedPreviousSHA256)
 	if err != nil {
@@ -87,15 +91,38 @@ func triggerUpgradeActivation(ctx context.Context, lifecycle *daemonLifecycle, r
 		// wedged, and surface the failure loudly — never an assumed success.
 		return abortPrepared(fmt.Errorf("upgrade recovery actor did not reach supervisor_ready; daemon keeps serving: %w", err))
 	}
+	// Stop admitting BEFORE the snapshot is brought forward, and bring it forward
+	// before authorizing. Prepare snapshotted instances.json and tasks.json above,
+	// and everything since — InstallAndStart plus a supervisor-ready grace measured
+	// in minutes — ran on a fully live daemon. Restoring that snapshot on rollback
+	// would discard every mutation from the window (#2212 gate 2). The order here is
+	// the fix: quiesce, re-snapshot what was actually serving, then authorize.
+	//
+	// This window is the only place the re-snapshot is safe. The actor has PROVEN
+	// supervisor_ready, so it exists; it has not been authorized, so it cannot yet
+	// commit or roll back, so nothing can be reading the snapshot while it is
+	// rewritten.
+	lifecycle.markQuiescing()
+	if err := upgradeRefreshMetadataFn(txn); err != nil {
+		// Nothing is authorized, so this daemon is still the one serving. Resume
+		// admitting and abort — a daemon left quiescing here would refuse every
+		// mutation until something restarted it, which is a worse outcome than a
+		// missed upgrade.
+		lifecycle.resumeServing()
+		return abortPrepared(fmt.Errorf("refresh the upgrade metadata snapshot: %w", err))
+	}
 	if err := upgradeAuthorizeActivationFn(txn, journal.ID, journal.RecoveryNonce); err != nil {
 		// The actor is at supervisor_ready and owns the transaction; its own
 		// supervisor_ready deadline times out and aborts. Do not abort from here
-		// (abortPrepared would refuse anyway) — just surface the failure.
+		// (abortPrepared would refuse anyway) — but do resume serving, because the
+		// quiesce above was taken in anticipation of a hand-off that is not
+		// happening.
+		lifecycle.resumeServing()
 		return fmt.Errorf("authorize upgrade activation: %w", err)
 	}
-	// Authorized: the actor is greenlit to replace us. Stop admitting new work so no
-	// mutation races the hand-off, report DaemonPhaseQuiescing, then free the socket.
-	lifecycle.markQuiescing()
+	// Authorized: the actor is greenlit to replace us. Admission is already closed
+	// and the snapshot already describes a daemon that stopped writing; free the
+	// socket.
 	log.InfoLog.Printf("upgrade activation authorized for transaction %s; quiescing and exiting for the candidate", journal.ID)
 	requestExit()
 	return nil

--- a/daemon/upgrade_trigger_test.go
+++ b/daemon/upgrade_trigger_test.go
@@ -98,13 +98,15 @@ func stubTriggerEnv(t *testing.T) (string, string, []byte) {
 		adhoc   func(string) error
 		stop    func() (bool, error)
 		wait    func() error
+		refresh func(*upgradetxn.Transaction) error
 		vg      time.Duration
 		vp      time.Duration
 	}{
 		upgradeTriggerExecutableFn, upgradeTriggerVersionFn, upgradeRecoveryJobControllerFn,
 		upgradeAwaitSupervisorReadyFn, upgradeAuthorizeActivationFn, upgradeRecoveryHealthFn,
 		launchCandidateDaemonFn, releaseCandidateProbationFn, startPreviousViaUnitFn,
-		startPreviousAdHocFn, stopDaemonFn, waitForShutdownFn, upgradeValidateGrace, upgradeValidatePoll,
+		startPreviousAdHocFn, stopDaemonFn, waitForShutdownFn, upgradeRefreshMetadataFn,
+		upgradeValidateGrace, upgradeValidatePoll,
 	}
 	t.Cleanup(func() {
 		upgradeTriggerExecutableFn = restore.exe
@@ -117,6 +119,7 @@ func stubTriggerEnv(t *testing.T) (string, string, []byte) {
 		releaseCandidateProbationFn = restore.release
 		startPreviousViaUnitFn = restore.unit
 		startPreviousAdHocFn = restore.adhoc
+		upgradeRefreshMetadataFn = restore.refresh
 		stopDaemonFn = restore.stop
 		waitForShutdownFn = restore.wait
 		upgradeValidateGrace, upgradeValidatePoll = restore.vg, restore.vp
@@ -158,6 +161,15 @@ func TestTriggerUpgradeActivation_AuthorizesThenQuiescesAndExits(t *testing.T) {
 		events = append(events, "await-ready")
 		return nil
 	}
+	upgradeRefreshMetadataFn = func(*upgradetxn.Transaction) error {
+		// The snapshot is only worth refreshing if admission is already closed —
+		// that is the whole point of #2212 gate 2, so assert it here rather than
+		// trusting the call order to stay put.
+		require.Equal(t, DaemonPhaseQuiescing, lifecycle.snapshot().phase,
+			"the daemon must have stopped admitting BEFORE the metadata is re-snapshotted")
+		events = append(events, "refresh")
+		return nil
+	}
 	upgradeAuthorizeActivationFn = func(_ *upgradetxn.Transaction, id, nonce string) error {
 		require.NotEmpty(t, id)
 		require.NotEmpty(t, nonce, "the trigger must authorize with the journal's recovery nonce")
@@ -171,7 +183,8 @@ func TestTriggerUpgradeActivation_AuthorizesThenQuiescesAndExits(t *testing.T) {
 	}
 
 	require.NoError(t, triggerUpgradeActivation(context.Background(), lifecycle, requestExit, candidate, "1.0.200", ""))
-	require.Equal(t, []string{"await-ready", "authorize", "exit"}, events)
+	require.Equal(t, []string{"await-ready", "refresh", "authorize", "exit"}, events,
+		"quiesce and re-snapshot sit between proving the actor ready and authorizing it")
 	require.Equal(t, DaemonPhaseQuiescing, lifecycle.snapshot().phase)
 	require.Error(t, lifecycle.mutationAdmissionError(), "a quiescing daemon must refuse mutations")
 	require.True(t, IsDaemonQuiescingErr(lifecycle.mutationAdmissionError()))
@@ -412,4 +425,36 @@ func TestUpgradeTrigger_CapturedJournalRollsBack(t *testing.T) {
 	require.NoError(t, startPreviousDaemon(ctx, journal))
 	require.NoError(t, validatePreviousDaemon(ctx, journal), "the previous daemon must be restored")
 	require.Empty(t, state.txnID, "the restored previous daemon carries no transaction id")
+}
+
+// A failed metadata refresh must leave the daemon SERVING.
+//
+// The quiesce is taken before authorization now (#2212 gate 2), so this is a window
+// that did not previously exist: a failure between the two would strand a daemon
+// that refuses every mutation until something restarts it. A missed upgrade is a far
+// better outcome than a live daemon that has stopped admitting work, and nothing
+// else would notice — the daemon is up, answering, and rejecting everything.
+func TestTriggerUpgradeActivation_RefreshFailureResumesServing(t *testing.T) {
+	_, _, candidate := stubTriggerEnv(t)
+	lifecycle := readyLifecycle(t)
+
+	upgradeAwaitSupervisorReadyFn = func(context.Context, string, time.Time) error { return nil }
+	upgradeRefreshMetadataFn = func(*upgradetxn.Transaction) error {
+		return errors.New("could not re-snapshot the metadata")
+	}
+	authorized := false
+	upgradeAuthorizeActivationFn = func(*upgradetxn.Transaction, string, string) error {
+		authorized = true
+		return nil
+	}
+	exited := false
+
+	err := triggerUpgradeActivation(
+		context.Background(), lifecycle, func() { exited = true }, candidate, "1.0.200", "")
+	require.Error(t, err)
+	require.False(t, authorized,
+		"a snapshot that could not be brought forward must not be authorized over — that is the data loss")
+	require.False(t, exited, "and the daemon must not hand off")
+	require.Equal(t, DaemonPhaseReady, lifecycle.snapshot().phase, "the daemon must resume serving")
+	require.NoError(t, lifecycle.mutationAdmissionError(), "and must admit mutations again")
 }

--- a/internal/upgradetxn/refresh.go
+++ b/internal/upgradetxn/refresh.go
@@ -1,0 +1,185 @@
+package upgradetxn
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Refreshing the metadata snapshot (#2212 gate 2).
+//
+// Prepare snapshots instances.json and tasks.json before the recovery actor is
+// installed, and the daemon does not stop admitting mutations until it has
+// authorized activation. Between those two points sits InstallAndStart plus
+// AwaitSupervisorReady, whose grace is a full minute, and the daemon is entirely
+// live for all of it — control RPCs admitted, scheduler and poll loops running.
+// A rollback restores the older snapshot, so every write from that window is
+// discarded: the data-loss shape #2572's manifest exists to prevent, reintroduced
+// by ordering rather than by a missing guarantee.
+//
+// The fix is to re-capture once the daemon has stopped admitting, so the bytes the
+// actor would restore are the bytes that were actually serving.
+
+// metadataDirName is the generation-0 directory Prepare writes.
+const metadataDirName = "metadata"
+
+// RefreshMetadataSnapshot re-captures the transaction's metadata files and swaps
+// the journal onto the new set.
+//
+// Callable only at PhaseSupervisorReady, and that is the whole safety argument
+// rather than a formality. The actor has proven it holds the lease and is ready,
+// so it exists and can be relied on — but it has NOT been authorized, and
+// authorization is what licenses it to commit or roll back. So this runs in the one
+// window where the snapshot can be rewritten with no possibility of a restore
+// reading it concurrently. Refreshing after AuthorizeActivation would race the
+// actor's own rollback against a half-written snapshot directory.
+//
+// The new generation is written to its own directory and the journal is swapped
+// afterwards, never rewritten in place. A crash at any instant therefore leaves the
+// journal naming exactly one complete set whose digests match its bytes: either the
+// old generation or the new one. Rewriting the existing files would leave a window
+// where the recorded SHA256s belong to bytes that are no longer there, and the
+// integrity check on the rollback path would refuse to restore — turning a
+// crash-during-upgrade into an unrecoverable home, which is strictly worse than the
+// stale snapshot this is fixing.
+//
+// The superseded generation is deliberately left on disk. It costs a copy of two
+// small JSON files inside a directory that Cleanup removes wholesale, and keeping it
+// means a journal that somehow still names the old set can still be honoured.
+func (t *Transaction) RefreshMetadataSnapshot() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	home := t.journal.HomeDir
+	current, err := readJournal(activeJournalPath(home))
+	if err != nil {
+		return fmt.Errorf("read the active upgrade journal: %w", err)
+	}
+	if err := validateJournal(home, current); err != nil {
+		return fmt.Errorf("validate the active upgrade journal: %w", err)
+	}
+	// Identity before phase: a journal for a DIFFERENT transaction that happens to
+	// be at supervisor_ready would otherwise pass the phase check and have this
+	// transaction's snapshot written over it.
+	if current.ID != t.journal.ID {
+		return fmt.Errorf(
+			"active upgrade transaction is %q, not %q; refusing to refresh another transaction's metadata snapshot",
+			current.ID, t.journal.ID,
+		)
+	}
+	if current.Phase != PhaseSupervisorReady {
+		return fmt.Errorf(
+			"upgrade metadata can only be re-snapshotted while the actor is ready and not yet authorized (phase %s, need %s)",
+			current.Phase, PhaseSupervisorReady,
+		)
+	}
+	if len(current.Metadata) == 0 {
+		return nil // nothing was snapshotted, so there is nothing to bring forward
+	}
+
+	// Rebuild the path list from the journal, in the recorded ORDER: the snapshot
+	// filenames are index-derived, so a reordered list would still produce a
+	// valid-looking set with each file's bytes filed under another file's name.
+	// Journal paths are already home-relative, which is the form MetadataPaths takes.
+	paths := make([]string, 0, len(current.Metadata))
+	for _, entry := range current.Metadata {
+		paths = append(paths, entry.Path)
+	}
+
+	txnDir := transactionDir(home, current.ID)
+	generation := nextMetadataGeneration(current.Metadata)
+	directory := filepath.Join(txnDir, metadataGenerationDir(generation))
+	if err := createDurableDirectory(txnDir, directory, transactionDirMode); err != nil {
+		return fmt.Errorf("create refreshed metadata snapshot directory: %w", err)
+	}
+	snapshots, err := snapshotMetadataInto(home, directory, paths)
+	if err != nil {
+		return fmt.Errorf("re-snapshot upgrade metadata: %w", err)
+	}
+
+	next := current
+	next.Metadata = snapshots
+	next.UpdatedAt = time.Now().UTC()
+	if err := validateJournal(home, next); err != nil {
+		return fmt.Errorf("validate the refreshed upgrade journal: %w", err)
+	}
+	// The swap. persistJournal writes and fsyncs atomically, so the journal names the
+	// old generation until this returns and the new one afterwards, never a mix.
+	if err := persistJournal(activeJournalPath(home), next); err != nil {
+		return fmt.Errorf("publish the refreshed upgrade journal: %w", err)
+	}
+	t.journal = next
+	return nil
+}
+
+// metadataGenerationDir names the directory holding one generation of snapshots.
+// Generation 0 keeps Prepare's original "metadata" name so a journal written by an
+// older binary still resolves.
+func metadataGenerationDir(generation int) string {
+	if generation == 0 {
+		return metadataDirName
+	}
+	return metadataDirName + "-" + strconv.Itoa(generation)
+}
+
+// nextMetadataGeneration reads the generation in use from the snapshot paths the
+// journal already names, rather than from a counter held in memory. A Transaction
+// can be reconstructed from disk, so an in-memory counter would restart at zero and
+// hand back a directory that is already populated.
+func nextMetadataGeneration(snapshots []MetadataSnapshot) int {
+	highest := 0
+	for _, entry := range snapshots {
+		if entry.SnapshotPath == "" {
+			continue // the file did not exist when it was captured; no directory to read
+		}
+		base := filepath.Base(filepath.Dir(entry.SnapshotPath))
+		if base == metadataDirName {
+			continue // generation 0
+		}
+		suffix, found := strings.CutPrefix(base, metadataDirName+"-")
+		if !found {
+			continue
+		}
+		if value, err := strconv.Atoi(suffix); err == nil && value > highest {
+			highest = value
+		}
+	}
+	return highest + 1
+}
+
+// validMetadataSnapshotPath confines a journal's SnapshotPath to a location this
+// transaction could itself have written.
+//
+// It replaces an equality check against one derived path, and the strictness is the
+// point rather than the shape: the rollback path READS these files back over the
+// live home, so a journal free to name any path would be a write-anywhere primitive
+// on recovery. Widening it to accept refreshed generations must not widen it to
+// accept anything else, so every component is still pinned — the parent must be this
+// transaction's own directory, the filename must be the index-derived one, and the
+// only freedom is which generation directory holds it.
+func validMetadataSnapshotPath(txnDir string, index int, path string) bool {
+	if path == "" {
+		return false
+	}
+	if filepath.Base(path) != fmt.Sprintf("%04d.snapshot", index) {
+		return false
+	}
+	directory := filepath.Dir(path)
+	if filepath.Dir(directory) != txnDir {
+		return false
+	}
+	base := filepath.Base(directory)
+	if base == metadataDirName {
+		return true // generation 0, written by Prepare
+	}
+	suffix, found := strings.CutPrefix(base, metadataDirName+"-")
+	if !found {
+		return false
+	}
+	generation, err := strconv.Atoi(suffix)
+	// Atoi accepts "+1", "-1" and leading zeros, all of which would name a directory
+	// other than the one metadataGenerationDir produces. Round-tripping rejects them.
+	return err == nil && generation >= 1 && metadataGenerationDir(generation) == base
+}

--- a/internal/upgradetxn/refresh_test.go
+++ b/internal/upgradetxn/refresh_test.go
@@ -1,0 +1,134 @@
+package upgradetxn
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// refreshFixture prepares a transaction over one metadata file and returns the
+// transaction, the home, and the metadata path.
+func refreshFixture(t *testing.T) (*Transaction, string, string) {
+	t.Helper()
+	home := t.TempDir()
+	metadata := filepath.Join(home, "instances.json")
+	require.NoError(t, os.WriteFile(metadata, []byte(`{"serving":"before"}`), 0o644))
+
+	plan := basicPreparePlan(t, home, "txn-refresh-0001")
+	plan.MetadataPaths = []string{"instances.json"}
+	txn, err := Prepare(plan)
+	require.NoError(t, err)
+	return txn, home, metadata
+}
+
+// TestRefreshMetadataSnapshot_CapturesWritesMadeAfterPrepare is #2212 gate 2.
+//
+// Prepare snapshots the metadata, and the daemon then stays fully live through
+// InstallAndStart and AwaitSupervisorReady — a 60s grace — before it stops
+// admitting mutations. A rollback restores the snapshot, so every write in that
+// window is silently discarded.
+//
+// The fixture writes in exactly that window, and the first assertion proves the
+// window is real before the refresh is asked to close it: without that, a passing
+// test could mean the refresh worked OR that the fixture never diverged.
+func TestRefreshMetadataSnapshot_CapturesWritesMadeAfterPrepare(t *testing.T) {
+	txn, _, metadata := refreshFixture(t)
+
+	// The daemon is still serving here — this is the write that used to be lost.
+	require.NoError(t, os.WriteFile(metadata, []byte(`{"serving":"after"}`), 0o644))
+
+	staged := txn.Journal().Metadata
+	require.Len(t, staged, 1)
+	before, err := os.ReadFile(staged[0].SnapshotPath)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"serving":"before"}`, string(before),
+		"premise: the staged snapshot is stale, so a rollback here would discard the later write")
+
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	defer func() { _ = lease.Release() }()
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+
+	require.NoError(t, txn.RefreshMetadataSnapshot())
+
+	refreshed := txn.Journal().Metadata
+	require.Len(t, refreshed, 1)
+	after, err := os.ReadFile(refreshed[0].SnapshotPath)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"serving":"after"}`, string(after),
+		"the bytes the actor would restore must be the bytes that were actually serving")
+	require.Equal(t, digest([]byte(`{"serving":"after"}`)), refreshed[0].SHA256,
+		"the recorded digest must describe the refreshed bytes, or the rollback integrity check refuses them")
+
+	// The journal on disk must carry the refresh, not just the in-memory copy: the
+	// actor reads the journal, never this process's struct.
+	reloaded, err := readJournal(activeJournalPath(txn.Journal().HomeDir))
+	require.NoError(t, err)
+	require.Equal(t, refreshed[0].SHA256, reloaded.Metadata[0].SHA256)
+}
+
+// TestRefreshMetadataSnapshot_WritesANewGenerationAndKeepsTheOld pins the
+// crash-safety property. Rewriting the snapshot in place would leave a window where
+// the journal's recorded digests describe bytes that are no longer on disk, and the
+// rollback path's integrity check would then refuse to restore — a crash mid-upgrade
+// becoming an unrecoverable home, which is worse than the staleness being fixed.
+func TestRefreshMetadataSnapshot_WritesANewGenerationAndKeepsTheOld(t *testing.T) {
+	txn, _, metadata := refreshFixture(t)
+	original := txn.Journal().Metadata[0].SnapshotPath
+	require.NoError(t, os.WriteFile(metadata, []byte(`{"serving":"after"}`), 0o644))
+
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	defer func() { _ = lease.Release() }()
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, txn.RefreshMetadataSnapshot())
+
+	refreshedPath := txn.Journal().Metadata[0].SnapshotPath
+	require.NotEqual(t, original, refreshedPath,
+		"the refresh must write a new generation rather than overwrite the set the journal names")
+
+	superseded, err := os.ReadFile(original)
+	require.NoError(t, err, "the superseded generation must survive, so a journal naming it stays honourable")
+	require.JSONEq(t, `{"serving":"before"}`, string(superseded))
+}
+
+// TestRefreshMetadataSnapshot_RefusesOutsideTheReadyWindow is the safety argument,
+// asserted rather than asserted-in-a-comment. Before supervisor_ready no actor is
+// proven to exist; after authorization the actor may commit or roll back at any
+// moment, and rewriting the snapshot directory underneath a running restore is the
+// race this window exists to avoid.
+func TestRefreshMetadataSnapshot_RefusesOutsideTheReadyWindow(t *testing.T) {
+	txn, _, _ := refreshFixture(t)
+
+	require.Error(t, txn.RefreshMetadataSnapshot(),
+		"at PhasePrepared no actor has proven readiness; refreshing is not licensed yet")
+
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	defer func() { _ = lease.Release() }()
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, txn.RefreshMetadataSnapshot(), "the ready window is the one place it is allowed")
+
+	require.NoError(t, lease.Advance(PhaseDaemonStopping))
+	require.Error(t, txn.RefreshMetadataSnapshot(),
+		"past the ready window the actor owns the transaction and may be restoring; refuse")
+}
+
+// TestNextMetadataGeneration_ReadsTheGenerationFromDisk pins that the counter comes
+// from the journal's own paths. A Transaction can be reconstructed from disk by a
+// later process, so an in-memory counter would restart at zero and hand back a
+// directory that is already populated.
+func TestNextMetadataGeneration_ReadsTheGenerationFromDisk(t *testing.T) {
+	require.Equal(t, 1, nextMetadataGeneration(nil), "no snapshots yet means the first refresh is generation 1")
+	require.Equal(t, 1, nextMetadataGeneration([]MetadataSnapshot{
+		{SnapshotPath: filepath.Join("/txn", metadataDirName, "0000.snapshot")},
+	}), "Prepare's directory is generation 0")
+	require.Equal(t, 3, nextMetadataGeneration([]MetadataSnapshot{
+		{SnapshotPath: filepath.Join("/txn", metadataDirName+"-2", "0000.snapshot")},
+	}))
+	require.Equal(t, 1, nextMetadataGeneration([]MetadataSnapshot{
+		{Path: "gone.json"}, // never existed, so it carries no snapshot path to read
+	}))
+}

--- a/internal/upgradetxn/storage.go
+++ b/internal/upgradetxn/storage.go
@@ -22,9 +22,18 @@ var (
 )
 
 func snapshotMetadata(home, txnDir string, paths []string) ([]MetadataSnapshot, error) {
+	return snapshotMetadataInto(home, filepath.Join(txnDir, metadataDirName), paths)
+}
+
+// snapshotMetadataInto captures into a caller-chosen directory so a refresh can
+// write a NEW generation rather than overwriting the set the journal currently
+// points at. See RefreshMetadataSnapshot for why that matters: a crash midway
+// through an in-place rewrite would leave the journal naming snapshots whose bytes
+// no longer match their recorded digests, and a rollback would then refuse to
+// restore the very state it exists to protect.
+func snapshotMetadataInto(home, metadataDir string, paths []string) ([]MetadataSnapshot, error) {
 	seen := make(map[string]struct{}, len(paths))
 	snapshots := make([]MetadataSnapshot, 0, len(paths))
-	metadataDir := filepath.Join(txnDir, "metadata")
 	for index, path := range paths {
 		relative, target, err := validateMetadataPath(home, path)
 		if err != nil {
@@ -313,8 +322,7 @@ func validateJournal(home string, journal Journal) error {
 			}
 			continue
 		}
-		expectedSnapshot := filepath.Join(txnDir, "metadata", fmt.Sprintf("%04d.snapshot", index))
-		if metadata.SnapshotPath != expectedSnapshot || !validDigest(metadata.SHA256) {
+		if !validMetadataSnapshotPath(txnDir, index, metadata.SnapshotPath) || !validDigest(metadata.SHA256) {
 			return fmt.Errorf("metadata snapshot %q does not match the transaction", relative)
 		}
 		if metadata.Mode == 0 || os.FileMode(metadata.Mode)&^os.ModePerm != 0 {


### PR DESCRIPTION
## #2212 gate 2 — the metadata snapshot is taken ~60s before the daemon stops writing

`Prepare` snapshots `instances.json` and `tasks.json`, then `InstallAndStart` and `AwaitSupervisorReady` run — a 60s grace — with the daemon **entirely live**: control RPCs admitted, scheduler and poll loops running. `markQuiescing` came afterwards. A rollback restores the older snapshot, so every mutation from that window is discarded.

This is the data-loss shape #2572's manifest exists to prevent, reintroduced by ordering rather than by a missing guarantee. It is not reachable today — activation is off by default — which is why it is a gate rather than a bug report.

## Why neither option from the write-up

The 18:43 comment framed the choice as **quiesce before `Prepare`** (needs an un-quiesce path that does not exist) versus **split `Prepare` into reserve-then-snapshot** (engine work). Both move the *one* snapshot earlier or later, and both pay for it.

The harm is not that the snapshot is early. It is that it is **stale**. So take a second one once the daemon has stopped admitting: `Prepare` keeps its early snapshot and its crash-safety, and `RefreshMetadataSnapshot` brings it forward. No reserve/snapshot split, and the un-quiesce path shrinks to a narrow failure window instead of covering the whole 60s grace.

## The window is the safety argument

The refresh is callable **only at `PhaseSupervisorReady`**, and that is load-bearing:

- Before it, no actor has proven it exists.
- After `AuthorizeActivation`, the actor is licensed to commit or roll back **at any moment** — rewriting the snapshot directory underneath a running restore.

`PhaseSupervisorReady` is the one window where the actor is known to exist and known not to be restoring. The phase check enforces it, and identity is checked *before* phase so a journal belonging to a different transaction cannot be written over. `TestRefreshMetadataSnapshot_RefusesOutsideTheReadyWindow` drives all three phases rather than asserting the window in a comment.

## Generations, because a crash here must not be unrecoverable

Each refresh writes a **new** generation directory and swaps the journal afterwards. Rewriting in place would leave a window where the journal's recorded digests describe bytes that are no longer on disk — and the rollback integrity check would then refuse to restore, turning a crash mid-upgrade into an unrecoverable home. That is strictly worse than the staleness being fixed.

`validateJournal` is widened to accept generation directories while staying a path-injection guard — the rollback path reads these files back *over the live home*, so a journal free to name any path would be a write-anywhere primitive on recovery. Parent must be this transaction's own directory, filename must be the index-derived one, and the generation must round-trip through the name it was derived from, so `+1` and `007` are rejected.

## The new failure window, closed

The quiesce now precedes the point of no return, so `resumeServing` restores the recorded prior phase on every path that fails before authorizing. A daemon left quiescing there would stay up, answer, and refuse every mutation until something restarted it — worse than a missed upgrade, and silent. `TestTriggerUpgradeActivation_RefreshFailureResumesServing` covers it.

## What this does NOT close — stated because it will not show in the diff

**In-flight mutations are not drained.** `markQuiescing` stops *new* admissions; a control mutation already inside its handler can still land after the refresh. `requireStateMutationAdmission` is a pure predicate with no release handle, so a bounded drain means converting ~26 call sites to acquire/release, and a missed `defer` there hangs the hand-off. That belongs in its own slice.

**Scheduler and poll loops are not gated.** `markQuiescing` is consulted only by `mutationAdmissionError`, whose sole production caller is `controlServer.requireMutationAdmission`. The design comment's spec says a quiesce must "stop admitting new scheduler fires/control mutations"; this closes the control half. The scheduler has `Start`/`Stop`, so gating it means stop-and-restart on the resume path — again its own slice.

Both residuals are now **microseconds-to-milliseconds** rather than the 60-second window, but they are not zero, and I am not recording this gate as fully closed. I will post both to #2212 as follow-on items so the next session starts from an accurate list.

## Testing

- `internal/upgradetxn` — full package green locally (non-daemon).
- `daemon/` — **not run locally**, per the standing rule that daemon tests spawn real daemons beside live sessions. Pushed for CI. The happy-path trigger test now pins the order `await-ready → refresh → authorize → exit` and asserts the daemon is already quiescing when the refresh runs.

Refs #2212