### PR TITLE
fix(session): fence a limit-resume respawn against the status poll

### DIFF
--- a/api/sessions_watch.go
+++ b/api/sessions_watch.go
@@ -121,6 +121,12 @@ func describeWatchState(d *session.InstanceData) string {
 		// distinct pending op (session/activity.go classifies it as such), not the
 		// generic "working" the liveness fallback below would otherwise report (#2530).
 		return "being replaced"
+	case session.OpRespawning:
+		// A limit resume re-spawning the runtime (#2997). Named rather than left to
+		// the liveness fallback for the same reason as OpReplacing above: it is a
+		// distinct pending op, and "blocked on a usage limit" would describe the
+		// state the resume is in the middle of leaving.
+		return "being respawned"
 	}
 	switch d.Liveness {
 	case session.LiveRunning:

--- a/app/sync.go
+++ b/app/sync.go
@@ -786,6 +786,16 @@ func adoptSnapshotOp(inst *session.Instance, op session.InFlightOp, lv session.L
 	if inst.GetInFlightOp() == op {
 		return false
 	}
+	// OpRespawning is the daemon's internal fence against its own status poll
+	// (#2997), not a client overlay: it composes to the settled liveness, so there
+	// is nothing here to mirror. Returning before the ClearOp below matters — the
+	// unrecognized-op default sits AFTER it, so falling through would drop this
+	// TUI's own in-flight overlay on the way to doing nothing, and report no change
+	// while having made one. Nothing clears an adopted OpRespawning either, because
+	// nothing adopts it.
+	if op == session.OpRespawning {
+		return false
+	}
 	if inst.GetInFlightOp() != session.OpNone {
 		_ = inst.Transition(session.ClearOp())
 	}

--- a/app/sync.go
+++ b/app/sync.go
@@ -778,22 +778,21 @@ func reconcileSnapshotOp(inst *session.Instance, op session.InFlightOp, lv sessi
 		// resulting liveness (running, limit-parked, or startup-unknown).
 		_ = inst.Transition(session.ClearOp())
 		return true
+	case session.OpRespawning:
+		// Same contract for the limit-resume fence (#2997), and for the same reason:
+		// a respawn settles to running, back to limit-parked, or to lost, so keying
+		// the release on any particular liveness would strand the fence on the
+		// others. This clause is what makes adopting the op above safe — and unlike
+		// OpCreating, a missed release would not even show, since OpRespawning
+		// composes to the settled liveness rather than masking it as Loading.
+		_ = inst.Transition(session.ClearOp())
+		return true
 	}
 	return false
 }
 
 func adoptSnapshotOp(inst *session.Instance, op session.InFlightOp, lv session.Liveness) bool {
 	if inst.GetInFlightOp() == op {
-		return false
-	}
-	// OpRespawning is the daemon's internal fence against its own status poll
-	// (#2997), not a client overlay: it composes to the settled liveness, so there
-	// is nothing here to mirror. Returning before the ClearOp below matters — the
-	// unrecognized-op default sits AFTER it, so falling through would drop this
-	// TUI's own in-flight overlay on the way to doing nothing, and report no change
-	// while having made one. Nothing clears an adopted OpRespawning either, because
-	// nothing adopts it.
-	if op == session.OpRespawning {
 		return false
 	}
 	if inst.GetInFlightOp() != session.OpNone {
@@ -815,6 +814,17 @@ func adoptSnapshotOp(inst *session.Instance, op session.InFlightOp, lv session.L
 		err = inst.Transition(session.MarkRestoring())
 	case session.OpReplacing:
 		err = inst.Transition(session.BeginHandoff())
+	case session.OpRespawning:
+		// A limit resume re-spawning the runtime (#2997). Adopted for ACTION GATING,
+		// not for display: it composes to the settled liveness, so mirroring it
+		// changes no pixel. Without it this TUI's own
+		// ValidateRuntimeAction(RuntimeActionHandoff) reads OpNone and opens the
+		// picker, and the daemon then refuses the selected handoff because its
+		// authoritative instance still carries the fence — an action offered and
+		// then rejected. The settle path below must clear it; see there for why
+		// adopting is safe here in a way adopting OpCreating on an established row
+		// was not.
+		err = inst.Transition(session.BeginRespawn())
 	default:
 		return false
 	}

--- a/app/sync.go
+++ b/app/sync.go
@@ -823,6 +823,13 @@ func (m *home) reconcileSnapshotOp(inst *session.Instance, op session.InFlightOp
 		// OpCreating, a missed release would not even show, since OpRespawning
 		// composes to the settled liveness rather than masking it as Loading.
 		_ = inst.Transition(session.ClearOp())
+		// Drop the provenance with the op, exactly as the three cases above do
+		// (#3005/#3006 landed after this case was written). Leaving it is benign only
+		// by accident — vetoesReconcile short-circuits on OpNone, so the stale entry is
+		// never read — but it survives pruneTo for as long as the row is live, and the
+		// next path that consults provenance without checking the op first would
+		// inherit a wrong answer.
+		m.adoptedSnapshotOps.forget(inst)
 		return true
 	}
 	return false

--- a/app/sync.go
+++ b/app/sync.go
@@ -815,9 +815,15 @@ func adoptSnapshotOp(inst *session.Instance, op session.InFlightOp, lv session.L
 	case session.OpReplacing:
 		err = inst.Transition(session.BeginHandoff())
 	case session.OpRespawning:
-		// A limit resume re-spawning the runtime (#2997). Adopted for ACTION GATING,
-		// not for display: it composes to the settled liveness, so mirroring it
-		// changes no pixel. Without it this TUI's own
+		// A limit resume re-spawning the runtime (#2997). Adopted so this TUI's action
+		// gating agrees with the daemon that owns the fence. It DOES also change how
+		// the row reads, which an earlier version of this comment wrongly denied:
+		// ui/tree/render.go masks the liveness glyph for any non-None op, so a
+		// respawning row shows the blank working glyph rather than its limit diamond,
+		// and web/src/status.ts classifies it as working (project.ts counts it that
+		// way). That is consistent with every other op and with #1766 — a resume in
+		// flight IS work in flight — and the "[limit] resets …" title prefix still
+		// renders throughout, so the state is not hidden. Without adopting, this TUI's own
 		// ValidateRuntimeAction(RuntimeActionHandoff) reads OpNone and opens the
 		// picker, and the daemon then refuses the selected handoff because its
 		// authoritative instance still carries the fence — an action offered and

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -385,19 +385,28 @@ func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.In
 	return err
 }
 
-// publishSessionSnapshot pushes this session's current projection to clients under
-// the repo ordering lock, the same discipline the resume's completion event uses:
-// session.updated replaces a client's whole session projection, so letting one race a
-// newer tab mutation could put the client back on an older roster.
+// publishSessionSnapshot pushes this session's current projection to clients while
+// holding the repo ordering lock, the same discipline the resume's completion event
+// and every tab mutation keep: session.updated replaces a client's whole session
+// projection, so letting one race a newer tab mutation puts the client back on an
+// older roster.
 //
 // Deliberately does NOT persist. The op axis is scrubbed before disk anyway, and these
 // are transient fence transitions — the durable checkpoints stay where they were.
 func (m *Manager) publishSessionSnapshot(repoID string, instance *session.Instance) {
 	repoStartLock := m.startLockForRepo(repoID)
 	repoStartLock.Lock()
-	data := instance.ToInstanceData()
-	repoStartLock.Unlock()
-	m.publishEvent(agentproto.EventSessionUpdated, data)
+	defer repoStartLock.Unlock()
+	// Publish INSIDE the critical section, which is the whole point of taking the lock
+	// and the part an earlier version of this helper got wrong while claiming otherwise.
+	// session.updated replaces a client's entire session projection, so snapshotting
+	// here and publishing after the unlock lets an overlapping tab create/close publish
+	// its newer whole-session payload first and this stale one last — the new tab
+	// vanishes, or the closed one comes back, until an unrelated update or a reconnect.
+	// Same ordering the tab mutations keep (daemon/manager_tabs.go) and the resume's own
+	// completion event keeps; publishEvent is non-blocking, so holding the lock across
+	// it cannot stall on a slow subscriber.
+	m.publishEvent(agentproto.EventSessionUpdated, instance.ToInstanceData())
 }
 
 func (m *Manager) resumeFromLimitLockedOutcome(repoID, key string, instance *session.Instance, requestedTitle string) (resumeFromLimitOutcome, error) {

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -430,6 +430,21 @@ func (m *Manager) resumeFromLimitLockedOutcome(repoID, key string, instance *ses
 	// re-provision belongs, with its own recheck). What remains is an answered death: the
 	// sandbox answered that its agent exited while blocked — the #1786 case — and
 	// that is authoritative, so it re-spawns at once, exactly as before.
+	// Raise the resume's fence BEFORE the probe, so it covers the whole destructive
+	// sequence rather than only the re-spawn (#2997, #3004 review). The
+	// preserve-then-record phase below is a network git push and the longest part of
+	// this function; run unfenced, a status tick lands in it, observes the dead agent,
+	// and applies LiveLost while no op is in flight — after which this resume fails
+	// its own precondition and the queued prompt is never delivered.
+	//
+	// Deferred release covers every exit: it is a no-op once Respawn's ConfirmLive has
+	// cleared the op on the success path, and it is what keeps a refused or failed
+	// resume from stranding the session as permanently busy.
+	if err := instance.BeginLimitResume(); err != nil {
+		return resumeNotPerformed, fmt.Errorf("cannot resume %q: %w", requestedTitle, err)
+	}
+	defer instance.EndLimitResume()
+
 	as := instance.AgentServer()
 	switch probe := probeLiveness(instance, as); probe {
 	case probeAlive:

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -565,6 +565,16 @@ func (m *Manager) resumeFromLimitLockedOutcome(repoID, key string, instance *ses
 	// The prompt landed: this is the resume's single completion point, and the only
 	// place the limit block is lifted on either arm.
 	instance.ClearLimitReached()
+	// Lower the fence HERE, before the completion payload is built (#3004 review).
+	// Every destructive phase is behind us, and the projection published below carries
+	// the op axis: on the live-stall arm nothing else lowers it — there is no Respawn
+	// and so no ConfirmLive — so the event would advertise a busy row and the deferred
+	// release would then clear it in memory with no second event to correct the
+	// clients. The web rail is event-driven, so it would keep suppressing that row's
+	// lifecycle and kill controls until an unrelated update or a reconnect. The defer
+	// above stays as the safety net for the error returns, where it is the only
+	// release; after this call it is a no-op.
+	instance.EndLimitResume()
 
 	// The cleared limit is itself durable state worth a checkpoint. On the respawn
 	// arm this is the second write; that is deliberate — the first one records the

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -385,6 +385,21 @@ func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.In
 	return err
 }
 
+// publishSessionSnapshot pushes this session's current projection to clients under
+// the repo ordering lock, the same discipline the resume's completion event uses:
+// session.updated replaces a client's whole session projection, so letting one race a
+// newer tab mutation could put the client back on an older roster.
+//
+// Deliberately does NOT persist. The op axis is scrubbed before disk anyway, and these
+// are transient fence transitions — the durable checkpoints stay where they were.
+func (m *Manager) publishSessionSnapshot(repoID string, instance *session.Instance) {
+	repoStartLock := m.startLockForRepo(repoID)
+	repoStartLock.Lock()
+	data := instance.ToInstanceData()
+	repoStartLock.Unlock()
+	m.publishEvent(agentproto.EventSessionUpdated, data)
+}
+
 func (m *Manager) resumeFromLimitLockedOutcome(repoID, key string, instance *session.Instance, requestedTitle string) (resumeFromLimitOutcome, error) {
 	// Set by the respawn arm's settlement below and reported at the very end, so a
 	// failed durable write neither aborts the resume nor disappears from it.
@@ -443,7 +458,22 @@ func (m *Manager) resumeFromLimitLockedOutcome(repoID, key string, instance *ses
 	if err := instance.BeginLimitResume(); err != nil {
 		return resumeNotPerformed, fmt.Errorf("cannot resume %q: %w", requestedTitle, err)
 	}
-	defer instance.EndLimitResume()
+	// Tell the clients. The web rail is event-driven and performs no optimistic update
+	// for a resume, so without this an already-connected client keeps the PRE-fence
+	// can_kill / lifecycle / handoff / Retry controls for the whole operation — which
+	// for a remote preserve-and-provision is a long time, and for an automatic resume
+	// is a window the user never opted into. The projection gates would then be
+	// correct and invisible, and a press would land on a busy error or the 30s kill
+	// timeout they were added to prevent.
+	m.publishSessionSnapshot(repoID, instance)
+	// The deferred release publishes too, but ONLY when it actually lowered the fence:
+	// on the success path the explicit release below has already done so and the
+	// completion event carries the settled row, so a second event here would be noise.
+	defer func() {
+		if instance.EndLimitResume() {
+			m.publishSessionSnapshot(repoID, instance)
+		}
+	}()
 
 	as := instance.AgentServer()
 	switch probe := probeLiveness(instance, as); probe {
@@ -512,7 +542,13 @@ func (m *Manager) resumeFromLimitLockedOutcome(repoID, key string, instance *ses
 		// No hot-loop risk from re-parking: the auto-resume scheduler sets its
 		// backoff gate BEFORE firing (limitResumeAttempted), so a resume that keeps
 		// failing here backs off exponentially instead of hammering.
-		instance.SetLimitReached(resetAt)
+		// Under the resume's own fence, which is still up: ConfirmLive preserves it
+		// through prompt delivery now (#2997), and the plain SetLimitReached refuses
+		// while any op is in flight — it would no-op here and lose this episode's
+		// reset time, which the auto-resume scheduler schedules off.
+		if perr := instance.ReparkLimitUnderResumeFence(resetAt); perr != nil {
+			return resumeNotPerformed, fmt.Errorf("failed to restore the limit window for %q: %w", requestedTitle, perr)
+		}
 		// Write the respawn's durable state NOW, not at the end of the happy path
 		// (#1854). Respawn shares LocalBackend.respawn, so reaching this line can mean
 		// it rebuilt a vanished worktree — recreating the branch, flipping
@@ -574,7 +610,7 @@ func (m *Manager) resumeFromLimitLockedOutcome(repoID, key string, instance *ses
 	// lifecycle and kill controls until an unrelated update or a reconnect. The defer
 	// above stays as the safety net for the error returns, where it is the only
 	// release; after this call it is a no-op.
-	instance.EndLimitResume()
+	_ = instance.EndLimitResume()
 
 	// The cleared limit is itself durable state worth a checkpoint. On the respawn
 	// arm this is the second write; that is deliberate — the first one records the

--- a/daemon/limit_resume_test.go
+++ b/daemon/limit_resume_test.go
@@ -285,9 +285,11 @@ func TestResumeFromLimit_RespawnArm_ClearsLimitDurablyOnSuccess(t *testing.T) {
 }
 
 // TestResumeFromLimit_PublishesRunningTransition pins the event-plane half of a
-// successful limit resume. The resume mutates and persists the session directly,
-// so the next status poll snapshots LiveRunning as its "before" state and cannot
-// reconstruct the missing LimitReached -> Running transition for other clients.
+// successful limit resume: the busy announcement when its fence goes up, and the
+// LimitReached -> Running transition when it lands. The resume mutates and persists
+// the session directly, so the next status poll snapshots LiveRunning as its "before"
+// state and cannot reconstruct that transition for other clients — and the fence is
+// invisible to a client that is never told about it.
 func TestResumeFromLimit_PublishesRunningTransition(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	backend := &limitResumeBackend{FakeBackend: session.NewFakeBackend(), alive: true}
@@ -299,9 +301,32 @@ func TestResumeFromLimit_PublishesRunningTransition(t *testing.T) {
 		t.Fatalf("resumeFromLimit returned %v, want nil", err)
 	}
 
+	// A resume now announces itself TWICE, and BOTH are contracts.
+	//
+	// First that the row is busy (#2997): clients gate their controls on the projected
+	// op and perform no optimistic update for a resume, so without this event an
+	// already-connected TUI or web client keeps offering Kill / Archive / Handoff /
+	// Retry for the whole operation — and a press then lands on a busy error or the 30s
+	// kill timeout those gates exist to prevent.
+	fenced := drainNextSessionEvent(t, events, agentproto.EventSessionUpdated)
+	if fenced.InFlightOp != session.OpRespawning {
+		t.Fatalf("first session.updated in-flight op = %v, want OpRespawning (the busy announcement)", fenced.InFlightOp)
+	}
+	if fenced.Liveness != session.LiveLimitReached {
+		t.Fatalf("fenced session.updated liveness = %v, want LiveLimitReached — the fence must not disturb the liveness the resume validated against", fenced.Liveness)
+	}
+
+	// Then that it came back. This is the half that was always here and must never be
+	// traded away: the resume mutates and persists directly, so the next status poll
+	// snapshots LiveRunning as its "before" state and cannot reconstruct the missing
+	// LimitReached -> Running transition for other clients. Someone waiting out a usage
+	// limit is watching exactly this row.
 	updated := drainNextSessionEvent(t, events, agentproto.EventSessionUpdated)
 	if updated.Liveness != session.LiveRunning {
 		t.Fatalf("session.updated liveness = %v, want LiveRunning", updated.Liveness)
+	}
+	if updated.InFlightOp != session.OpNone {
+		t.Fatalf("resumed session.updated in-flight op = %v, want OpNone — the fence must be released before the completion payload is built, or the row stays busy on every client", updated.InFlightOp)
 	}
 	if updated.ID != inst.ID || updated.Title != inst.Title {
 		t.Fatalf("session.updated identity = (%q, %q), want (%q, %q)", updated.ID, updated.Title, inst.ID, inst.Title)

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -258,7 +258,18 @@ func (m *Manager) observeTaskRunWhilePaused(repoID, key string, instance *sessio
 	before := instance.GetLiveness()
 	beforeReset, _ := instance.LimitResetAt()
 	taskRunWasActive := instance.TaskRunActive()
-	epoch := instance.StateEpoch() // see refreshInstanceStatus (#2135)
+	// Paired with the op axis, and skipped on, for the same reason as the plain poll
+	// (#2997). This is a SECOND path out of refreshInstanceStatus and it returns
+	// before that one's paired check, so it needs its own: the op skip up there ran
+	// earlier in the tick, and a fence raised since would leave this helper reading a
+	// post-fence epoch. Its observation would then look current and be APPLIED — here
+	// that means settling LiveReady from the empty snapshot of a runtime being torn
+	// down, which ends the task run early and leaves a failed respawn unretryable.
+	op, epoch := instance.InFlightOpAndEpoch()
+	if op != session.OpNone {
+		m.clearRemoteLoss(key)
+		return
+	}
 	obs, err := instance.AgentServer().Snapshot()
 	// Whatever happened, no loss episode survives an attach (see above).
 	m.clearRemoteLoss(key)

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -444,7 +444,19 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 	// the conclusion it draws from that capture is still about the state it
 	// observed — or whether a resume/kill/archive has moved the session on since
 	// (#2135). See resolveIdleLiveness and session/state_epoch.go.
-	epoch := instance.StateEpoch()
+	//
+	// Read together with the op axis, and re-check it here (#2997). The skip above
+	// ran earlier in this tick: a fence raised in between has already been passed,
+	// and the epoch captured after it would make this tick's observation look
+	// current and be APPLIED to a session an operation owns. Reading both at once
+	// makes the epoch necessarily older than any later fence, so the guard drops the
+	// observation instead. Clearing the episode matches every other skip above — a
+	// tick we did not observe cannot be part of a consecutive run (#1794).
+	op, epoch := instance.InFlightOpAndEpoch()
+	if op != session.OpNone {
+		m.clearRemoteLoss(key)
+		return
+	}
 	// Select the AgentServer only after capturing the epoch. A remote runtime swap
 	// replaces this handle; taking the handle first could pair the outgoing server
 	// with the incoming runtime's epoch and make a stale observation look current.

--- a/session/activity.go
+++ b/session/activity.go
@@ -72,11 +72,11 @@ func ClassifyActivity(data InstanceData) (Activity, string) {
 	if data.PendingHandoffMission != "" {
 		return ActivityPending, ""
 	}
-	// Any operation in flight (create, kill, archive, restore) means the session
+	// Any operation in flight (create, kill, archive, restore, respawn) means the session
 	// is mid-transition; wait for it to settle rather than reporting the
 	// transient composed status.
 	switch data.InFlightOp {
-	case OpCreating, OpKilling, OpArchiving, OpRestoring, OpReplacing:
+	case OpCreating, OpKilling, OpArchiving, OpRestoring, OpReplacing, OpRespawning:
 		return ActivityPending, ""
 	}
 

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -3,6 +3,8 @@ package session
 import (
 	"fmt"
 	"strings"
+
+	"github.com/sachiniyer/agent-factory/log"
 )
 
 // currentBackend snapshots the instance's backend under i.mu (#2096). The
@@ -64,7 +66,55 @@ func (i *Instance) Respawn() error {
 	if err := i.ValidateRuntimeAction(RuntimeActionResumeLimit); err != nil {
 		return fmt.Errorf("respawn: %w", err)
 	}
-	return i.currentBackend().Respawn(i)
+	// Raise the in-flight fence for the whole re-spawn (#2997). A REMOTE respawn
+	// pushes the sandbox's unpushed work and re-provisions a fresh one, which
+	// outlasts the status poll interval — and the poll's own skip is keyed on the
+	// instance-visible op (daemon/manager_status.go: "the poll must not probe a
+	// session whose tmux is being spun up/torn down and mark it Lost"). This
+	// operation advertised nothing, so that skip never engaged: the poll observed
+	// the sandbox being torn down BY THIS CALL, read it as an independent death,
+	// and applied ObserveLiveness(LiveLost) — which is the unconditional daemon-truth
+	// edge and preserves only the op axis, so LiveLimitReached was overwritten
+	// underneath a resume that was still running. The resume then failed its own
+	// RuntimeActionResumeLimit precondition, and Lost recovery could later clear the
+	// limit without delivering the queued prompt, so the user's work silently never
+	// ran.
+	//
+	// AFTER the validation above, not before: that validation requires OpNone, so a
+	// fence raised first would reject the very call it is protecting.
+	//
+	// OpCreating rather than a new op: a respawn is creating a fresh runtime, it
+	// composes to the Loading status the UI already renders for that, and — the
+	// load-bearing part — ConfirmLive is allowed from OpCreating and clears it, so
+	// the success path already ends with the fence down and needs no new edge.
+	if err := i.Transition(BeginCreate()); err != nil {
+		return fmt.Errorf("respawn: %w", err)
+	}
+	if err := i.currentBackend().Respawn(i); err != nil {
+		// Lower the fence on the way out. Without this a failed respawn leaves the
+		// session permanently busy: the poll skips it forever and every runtime
+		// action refuses it as in-flight — a strand worse than the clobber.
+		i.clearRespawnFence()
+		return err
+	}
+	// Success normally ends in ConfirmLive, which clears the op. A backend that
+	// returns without reaching it must not leave the fence standing either.
+	i.clearRespawnFence()
+	return nil
+}
+
+// clearRespawnFence lowers the Respawn fence if it is still up. ClearOp is
+// unconditionally legal (it only ever moves the op axis back to None and leaves
+// liveness alone), but it is applied only when this call's own OpCreating is still
+// present, so a concurrent kill/archive overlay that superseded it is not cleared
+// out from under its owner.
+func (i *Instance) clearRespawnFence() {
+	if i.GetInFlightOp() != OpCreating {
+		return
+	}
+	if err := i.Transition(ClearOp()); err != nil {
+		log.WarningLog.Printf("respawn: clearing the in-flight fence for %q: %v", i.Title, err)
+	}
 }
 
 // PrepareAgentSwap resolves and validates the incoming launch while the outgoing

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -101,6 +101,10 @@ func (i *Instance) BeginLimitResume() error {
 // session permanently busy — the poll skips it forever and every runtime action and
 // lifecycle control refuses it as in-flight — which is worse than the clobber this
 // whole mechanism exists to prevent.
+// ClearOp is unconditionally legal (it only ever moves the op axis back to None and
+// leaves liveness alone), so the OpRespawning check is not about legality: it makes
+// sure a kill or archive overlay that SUPERSEDED this fence is not cleared out from
+// under its own owner.
 func (i *Instance) EndLimitResume() {
 	if i.GetInFlightOp() != OpRespawning {
 		return
@@ -122,20 +126,6 @@ func (i *Instance) Respawn() error {
 		return fmt.Errorf("respawn of %q requires the limit-resume fence (in-flight op is %s)", i.Title, opLabel(op))
 	}
 	return i.currentBackend().Respawn(i)
-}
-
-// clearRespawnFence lowers the Respawn fence if it is still up. ClearOp is
-// unconditionally legal (it only ever moves the op axis back to None and leaves
-// liveness alone), but it is applied only when this call's own OpRespawning is still
-// present, so a concurrent kill/archive overlay that superseded it is not cleared
-// out from under its owner.
-func (i *Instance) clearRespawnFence() {
-	if i.GetInFlightOp() != OpRespawning {
-		return
-	}
-	if err := i.Transition(ClearOp()); err != nil {
-		log.WarningLog.Printf("respawn: clearing the in-flight fence for %q: %v", i.Title, err)
-	}
 }
 
 // PrepareAgentSwap resolves and validates the incoming launch while the outgoing

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -62,63 +62,66 @@ func (i *Instance) Recover() error {
 // while blocked at a limit wall: that session is LiveLimitReached, which Recover's
 // !Lost guard rejects, but the re-spawn mechanics are identical. The caller owns
 // the precondition, enforced here before the guard-free backend core runs.
-func (i *Instance) Respawn() error {
-	// Raise the in-flight fence for the whole re-spawn (#2997). A REMOTE respawn
-	// pushes the sandbox's unpushed work and re-provisions a fresh one, which
-	// outlasts the status poll interval — and the poll's own skip is keyed on the
-	// instance-visible op (daemon/manager_status.go: "the poll must not probe a
-	// session whose tmux is being spun up/torn down and mark it Lost"). This
-	// operation advertised nothing, so that skip never engaged: the poll observed
-	// the sandbox being torn down BY THIS CALL, read it as an independent death,
-	// and applied ObserveLiveness(LiveLost) — the unconditional daemon-truth edge,
-	// which preserves only the op axis, so LiveLimitReached was overwritten
-	// underneath a resume that was still running. The resume then failed its own
-	// RuntimeActionResumeLimit precondition, and Lost recovery could later clear the
-	// limit without delivering the queued prompt, so the user's work silently never
-	// ran.
-	//
-	// Raising it also closes the window on the other side. A poll that already
-	// passed the skip captured a state epoch before this transition, and every real
-	// lifecycle change advances that epoch, so its ObserveLiveness(...).AtEpoch()
-	// is DROPPED rather than applied (#2135, session/transition.go). The fence does
-	// not merely make later polls skip.
-	//
-	// OpRespawning rather than OpCreating: this session is already established, and
-	// a create overlay on an established row is wrong in ways that reach past this
-	// package — see the OpRespawning doc comment.
-	if err := i.beginRespawnFence(); err != nil {
-		return fmt.Errorf("respawn: %w", err)
-	}
-	if err := i.currentBackend().Respawn(i); err != nil {
-		// Lower the fence on the way out. Without this a failed respawn leaves the
-		// session permanently busy: the poll skips it forever and every runtime
-		// action refuses it as in-flight — a strand worse than the clobber.
-		i.clearRespawnFence()
-		return err
-	}
-	// Success normally ends in ConfirmLive, which clears the op. A backend that
-	// returns without reaching it must not leave the fence standing either.
-	i.clearRespawnFence()
-	return nil
-}
-
-// beginRespawnFence validates the limit-resume precondition and raises the fence
-// in ONE critical section. Splitting them was a real race (#3004 review finding):
-// ValidateRuntimeAction takes the read lock and RELEASES it, so a status poll
-// could land ObserveLiveness(LiveLost) in the gap before the fence went up. That
-// observation is CURRENT, so the epoch guard cannot help — it is not a stale
-// decision — and tkBeginRespawn preserves whatever liveness it finds, so the
-// backend would have re-spawned a session the daemon had just declared Lost and
-// the failure path would have left it there, unretryable. Holding i.mu across both
-// is the fix; see lifecycleViewLocked, which documents this as the pattern, and
-// SwapAgentProgram, which already uses it.
-func (i *Instance) beginRespawnFence() error {
+// BeginLimitResume validates the limit-resume precondition and raises the
+// OpRespawning fence for the WHOLE resume, in one critical section. The caller owns
+// it until EndLimitResume (or until ConfirmLive clears it on success).
+//
+// It is a separate method from Respawn for the reason SwapAgentProgram and
+// RecordHandoffSwap are separate: the two legal orderings are made explicit rather
+// than folded into one re-entrant call that silently does different things.
+//
+// The fence must cover the resume's whole destructive sequence, not just the backend
+// call (#2997, and #3004 review). For an answered-dead REMOTE agent the daemon
+// probes, then pushes the sandbox's unpushed work and durably records its branch,
+// and only then re-spawns. That push is a network git operation and the longest
+// phase of the resume; run unfenced it is exactly the window the poll walks into,
+// observing the dead agent and applying LiveLost while no op is in flight. The
+// resume then loses its own precondition and refuses, so the queued prompt is never
+// delivered — the harm the fence exists to prevent, reached before the fence existed.
+//
+// Validation and the raise share i.mu because splitting them is its own race: a
+// current observation landing in the gap is not stale, so the epoch guard cannot
+// drop it, and tkBeginRespawn is keyed on the op axis alone — it would happily fence
+// a liveness that had just been clobbered. See lifecycleViewLocked, which documents
+// this as the pattern.
+func (i *Instance) BeginLimitResume() error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	if err := i.lifecycleViewLocked().ValidateRuntimeAction(RuntimeActionResumeLimit); err != nil {
 		return err
 	}
 	return i.transitionLocked(BeginRespawn())
+}
+
+// EndLimitResume lowers the fence BeginLimitResume raised. Safe to defer
+// unconditionally: it is a no-op once ConfirmLive has cleared the op on the success
+// path, and it never disturbs an op some other owner raised.
+//
+// Lowering it is not optional on the failure paths. A stranded fence leaves the
+// session permanently busy — the poll skips it forever and every runtime action and
+// lifecycle control refuses it as in-flight — which is worse than the clobber this
+// whole mechanism exists to prevent.
+func (i *Instance) EndLimitResume() {
+	if i.GetInFlightOp() != OpRespawning {
+		return
+	}
+	if err := i.Transition(ClearOp()); err != nil {
+		log.WarningLog.Printf("limit resume: clearing the in-flight fence for %q: %v", i.Title, err)
+	}
+}
+
+// Respawn re-spawns this session's runtime. It REQUIRES the caller to hold the
+// limit-resume fence (BeginLimitResume): the fence has to be up before the daemon's
+// probe-and-preserve phase, which runs well before this call, so raising one here
+// would be too late to protect the sequence it belongs to.
+//
+// On success the backend ends in ConfirmLive, which is allowed from OpRespawning and
+// clears it. On failure the fence stays up and the caller's EndLimitResume lowers it.
+func (i *Instance) Respawn() error {
+	if op := i.GetInFlightOp(); op != OpRespawning {
+		return fmt.Errorf("respawn of %q requires the limit-resume fence (in-flight op is %s)", i.Title, opLabel(op))
+	}
+	return i.currentBackend().Respawn(i)
 }
 
 // clearRespawnFence lowers the Respawn fence if it is still up. ClearOp is

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -73,21 +73,27 @@ func (i *Instance) Respawn() error {
 	// session whose tmux is being spun up/torn down and mark it Lost"). This
 	// operation advertised nothing, so that skip never engaged: the poll observed
 	// the sandbox being torn down BY THIS CALL, read it as an independent death,
-	// and applied ObserveLiveness(LiveLost) — which is the unconditional daemon-truth
-	// edge and preserves only the op axis, so LiveLimitReached was overwritten
-	// underneath a resume that was still running. The resume then failed its own
-	// RuntimeActionResumeLimit precondition, and Lost recovery could later clear the
-	// limit without delivering the queued prompt, so the user's work silently never
-	// ran.
+	// and applied ObserveLiveness(LiveLost) — which is the unconditional
+	// daemon-truth edge and preserves only the op axis, so LiveLimitReached was
+	// overwritten underneath a resume that was still running. The resume then failed
+	// its own RuntimeActionResumeLimit precondition, and Lost recovery could later
+	// clear the limit without delivering the queued prompt, so the user's work
+	// silently never ran.
 	//
 	// AFTER the validation above, not before: that validation requires OpNone, so a
 	// fence raised first would reject the very call it is protecting.
 	//
-	// OpCreating rather than a new op: a respawn is creating a fresh runtime, it
-	// composes to the Loading status the UI already renders for that, and — the
-	// load-bearing part — ConfirmLive is allowed from OpCreating and clears it, so
-	// the success path already ends with the fence down and needs no new edge.
-	if err := i.Transition(BeginCreate()); err != nil {
+	// Raising it also closes the window on the other side. A poll that already
+	// passed the skip captured a state epoch before this transition, and every real
+	// lifecycle change advances that epoch, so its ObserveLiveness(...).AtEpoch()
+	// is DROPPED rather than applied (#2135, session/transition.go). The fence does
+	// not merely make later polls skip.
+	//
+	// OpRespawning rather than OpCreating: this session is already established, and
+	// a create overlay on an established row is wrong in ways that reach past this
+	// package — see the OpRespawning doc comment. The fence needs to be an op, not a
+	// display state.
+	if err := i.Transition(BeginRespawn()); err != nil {
 		return fmt.Errorf("respawn: %w", err)
 	}
 	if err := i.currentBackend().Respawn(i); err != nil {
@@ -105,11 +111,11 @@ func (i *Instance) Respawn() error {
 
 // clearRespawnFence lowers the Respawn fence if it is still up. ClearOp is
 // unconditionally legal (it only ever moves the op axis back to None and leaves
-// liveness alone), but it is applied only when this call's own OpCreating is still
+// liveness alone), but it is applied only when this call's own OpRespawning is still
 // present, so a concurrent kill/archive overlay that superseded it is not cleared
 // out from under its owner.
 func (i *Instance) clearRespawnFence() {
-	if i.GetInFlightOp() != OpCreating {
+	if i.GetInFlightOp() != OpRespawning {
 		return
 	}
 	if err := i.Transition(ClearOp()); err != nil {

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -105,13 +105,18 @@ func (i *Instance) BeginLimitResume() error {
 // leaves liveness alone), so the OpRespawning check is not about legality: it makes
 // sure a kill or archive overlay that SUPERSEDED this fence is not cleared out from
 // under its own owner.
-func (i *Instance) EndLimitResume() {
+// Reports whether it actually lowered the fence, so a caller that must announce the
+// released state to its clients can tell an effective release from a no-op and not
+// publish a duplicate settled event on the path that already published one.
+func (i *Instance) EndLimitResume() bool {
 	if i.GetInFlightOp() != OpRespawning {
-		return
+		return false
 	}
 	if err := i.Transition(ClearOp()); err != nil {
 		log.WarningLog.Printf("limit resume: clearing the in-flight fence for %q: %v", i.Title, err)
+		return false
 	}
+	return true
 }
 
 // Respawn re-spawns this session's runtime. It REQUIRES the caller to hold the

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -63,9 +63,6 @@ func (i *Instance) Recover() error {
 // !Lost guard rejects, but the re-spawn mechanics are identical. The caller owns
 // the precondition, enforced here before the guard-free backend core runs.
 func (i *Instance) Respawn() error {
-	if err := i.ValidateRuntimeAction(RuntimeActionResumeLimit); err != nil {
-		return fmt.Errorf("respawn: %w", err)
-	}
 	// Raise the in-flight fence for the whole re-spawn (#2997). A REMOTE respawn
 	// pushes the sandbox's unpushed work and re-provisions a fresh one, which
 	// outlasts the status poll interval — and the poll's own skip is keyed on the
@@ -73,15 +70,12 @@ func (i *Instance) Respawn() error {
 	// session whose tmux is being spun up/torn down and mark it Lost"). This
 	// operation advertised nothing, so that skip never engaged: the poll observed
 	// the sandbox being torn down BY THIS CALL, read it as an independent death,
-	// and applied ObserveLiveness(LiveLost) — which is the unconditional
-	// daemon-truth edge and preserves only the op axis, so LiveLimitReached was
-	// overwritten underneath a resume that was still running. The resume then failed
-	// its own RuntimeActionResumeLimit precondition, and Lost recovery could later
-	// clear the limit without delivering the queued prompt, so the user's work
-	// silently never ran.
-	//
-	// AFTER the validation above, not before: that validation requires OpNone, so a
-	// fence raised first would reject the very call it is protecting.
+	// and applied ObserveLiveness(LiveLost) — the unconditional daemon-truth edge,
+	// which preserves only the op axis, so LiveLimitReached was overwritten
+	// underneath a resume that was still running. The resume then failed its own
+	// RuntimeActionResumeLimit precondition, and Lost recovery could later clear the
+	// limit without delivering the queued prompt, so the user's work silently never
+	// ran.
 	//
 	// Raising it also closes the window on the other side. A poll that already
 	// passed the skip captured a state epoch before this transition, and every real
@@ -91,9 +85,8 @@ func (i *Instance) Respawn() error {
 	//
 	// OpRespawning rather than OpCreating: this session is already established, and
 	// a create overlay on an established row is wrong in ways that reach past this
-	// package — see the OpRespawning doc comment. The fence needs to be an op, not a
-	// display state.
-	if err := i.Transition(BeginRespawn()); err != nil {
+	// package — see the OpRespawning doc comment.
+	if err := i.beginRespawnFence(); err != nil {
 		return fmt.Errorf("respawn: %w", err)
 	}
 	if err := i.currentBackend().Respawn(i); err != nil {
@@ -107,6 +100,25 @@ func (i *Instance) Respawn() error {
 	// returns without reaching it must not leave the fence standing either.
 	i.clearRespawnFence()
 	return nil
+}
+
+// beginRespawnFence validates the limit-resume precondition and raises the fence
+// in ONE critical section. Splitting them was a real race (#3004 review finding):
+// ValidateRuntimeAction takes the read lock and RELEASES it, so a status poll
+// could land ObserveLiveness(LiveLost) in the gap before the fence went up. That
+// observation is CURRENT, so the epoch guard cannot help — it is not a stale
+// decision — and tkBeginRespawn preserves whatever liveness it finds, so the
+// backend would have re-spawned a session the daemon had just declared Lost and
+// the failure path would have left it there, unretryable. Holding i.mu across both
+// is the fix; see lifecycleViewLocked, which documents this as the pattern, and
+// SwapAgentProgram, which already uses it.
+func (i *Instance) beginRespawnFence() error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if err := i.lifecycleViewLocked().ValidateRuntimeAction(RuntimeActionResumeLimit); err != nil {
+		return err
+	}
+	return i.transitionLocked(BeginRespawn())
 }
 
 // clearRespawnFence lowers the Respawn fence if it is still up. ClearOp is

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -563,6 +563,35 @@ func (i *Instance) SetLimitResetAt(resetAt time.Time) {
 // daemon poll re-resolves its real state on the next tick and the [limit] badge
 // clears (#1146). A no-op when the instance is not limit-blocked, so the resume
 // action (and PR3's scheduler) can call it unconditionally.
+// ReparkLimitUnderResumeFence restores a limit window while the caller holds the
+// resume fence. It is the transaction-owned twin of SetLimitReached, in the same
+// shape as RecordHandoffSwap is to SwapAgentProgram: the plain setter refuses while
+// ANY op is in flight, which is right for every other writer and wrong for the one
+// that owns the operation.
+//
+// The resume needs it because it re-parks BEFORE delivering its prompt (#2997). With
+// the fence held across that stretch — which is what keeps the poll from settling the
+// fresh runtime Ready and ending the task run — the plain setter would no-op and this
+// episode's reset time would be lost, leaving the auto-resume scheduler nothing to
+// schedule off. Silently, too: it reports the refusal only through a bool that path
+// had no reason to read.
+//
+// Refuses unless OpRespawning is actually held, so it cannot become a back door
+// around the guard it deliberately steps past.
+func (i *Instance) ReparkLimitUnderResumeFence(resetAt time.Time) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.inFlightOp != OpRespawning {
+		return fmt.Errorf("re-parking the limit for %q requires the resume fence (in-flight op is %s)",
+			i.Title, opLabel(i.inFlightOp))
+	}
+	lv, op, prevReset := i.lifecycleStateLocked()
+	i.liveness = LiveLimitReached
+	i.limitResetAt = resetAt
+	i.noteStateChangeLocked(lv, op, prevReset)
+	return nil
+}
+
 func (i *Instance) ClearLimitReached() {
 	i.mu.Lock()
 	defer i.mu.Unlock()

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -133,11 +133,21 @@ func opIsTeardown(op InFlightOp) bool {
 // Restore on the archived result) is precisely the mutation the fence exists to
 // refuse. A kill tombstone likewise admits no competing archive/restore action:
 // its only valid transition is finishing teardown. Resting rows restore; every
+// A respawning row (#2997) is inside the limit-resume fence for the same reason a
+// replacing one is: ArchiveSession would tear down and relocate a worktree the
+// respawn is provisioning into, and RuntimeActionResumeLimit refuses while an op is
+// in flight, so both verbs it could show would be refused on press — the #2500
+// defect above. It deliberately does NOT join canKillFor: tkBeginKill is allowed
+// from ANY state by explicit design ("a kill supersedes any in-flight op"), so Kill
+// genuinely works during a respawn, and a remote provision that hangs is exactly
+// when a user needs it. Hiding a control that works would remove the escape hatch.
+// Resting rows restore; every
 // other settled row archives. Kill addressability is intentionally independent
 // (CanKill): a retained tombstone or startup-unknown row must remain removable
 // without becoming attachable, archivable, or restorable.
 func lifecycleActionFor(id string, liveness Liveness, op InFlightOp, startupStateUnknown, userKilled bool) LifecycleAction {
-	if id == "" || op == OpCreating || op == OpReplacing || opIsTeardown(op) || startupStateUnknown || userKilled {
+	if id == "" || op == OpCreating || op == OpReplacing || op == OpRespawning ||
+		opIsTeardown(op) || startupStateUnknown || userKilled {
 		return LifecycleActionNone
 	}
 	switch liveness {

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -137,11 +137,7 @@ func opIsTeardown(op InFlightOp) bool {
 // replacing one is: ArchiveSession would tear down and relocate a worktree the
 // respawn is provisioning into, and RuntimeActionResumeLimit refuses while an op is
 // in flight, so both verbs it could show would be refused on press — the #2500
-// defect above. It deliberately does NOT join canKillFor: tkBeginKill is allowed
-// from ANY state by explicit design ("a kill supersedes any in-flight op"), so Kill
-// genuinely works during a respawn, and a remote provision that hangs is exactly
-// when a user needs it. Hiding a control that works would remove the escape hatch.
-// Resting rows restore; every
+// defect above. Resting rows restore; every
 // other settled row archives. Kill addressability is intentionally independent
 // (CanKill): a retained tombstone or startup-unknown row must remain removable
 // without becoming attachable, archivable, or restorable.
@@ -165,8 +161,23 @@ func lifecycleActionFor(id string, liveness Liveness, op InFlightOp, startupStat
 // down (OpKilling/OpArchiving) has a kill/archive in flight, so a second one is
 // the "kill already in progress" refusal the fence exists to prevent (#2500); and
 // an id-less legacy row cannot address the destructive API without guessing.
+//
+// A respawning row (#2997) is excluded for a reason the transition table alone does
+// NOT show, and reading only the table gets this backwards: tkBeginKill is
+// allowedFrom-always ("a kill supersedes any in-flight op"), which looks like Kill
+// works during any op. It does not work during THIS one, because the daemon must
+// traverse a lock to reach that transition — KillSession waits opLockTimeout (30s,
+// daemon/killbound.go) for the per-session operation lock and then returns
+// errKillBusy WITHOUT applying BeginKill (daemon/manager_sessions.go), while the
+// limit resume holds that same lock for the entire respawn (daemon/limit.go). So
+// advertising Kill here promises a supersede that is really a 30-second wait
+// followed by "try again". Hiding it is honest; making it genuinely interrupt the
+// owning operation is a separate change to the kill path, and until then a hung
+// remote provision is bounded by the backend's own deadlines rather than by a user
+// gesture. The same is already true of OpCreating/OpReplacing/teardown above.
 func canKillFor(id string, op InFlightOp) bool {
-	return id != "" && op != OpCreating && op != OpReplacing && !opIsTeardown(op)
+	return id != "" && op != OpCreating && op != OpReplacing && op != OpRespawning &&
+		!opIsTeardown(op)
 }
 
 // LifecycleAction returns the shared lifecycle verb for this instance. TUI menus

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -79,6 +79,23 @@ const (
 	// The status poll must not observe the close/start gap or settle a result from
 	// the outgoing pane after the incoming pane has taken its place.
 	OpReplacing
+	// OpRespawning: a limit resume is re-spawning an EXISTING session's runtime —
+	// for a remote backend, pushing the old sandbox's work and provisioning a fresh
+	// one, which outlasts a poll interval (#2997). Its only job is to be an
+	// in-flight op: refreshInstanceStatus skips a session that has one, and raising
+	// it advances the state epoch so an observation the poll already decided is
+	// dropped rather than applied.
+	//
+	// Deliberately NOT a client overlay, which is what separates it from
+	// OpCreating. A respawn acts on a session that is already established, so
+	// composeStatus lets it fall through to the settled liveness instead of masking
+	// it with Loading. Masking it would be wrong twice over: SaveInstances drops
+	// ordinary Loading rows, so a shutdown checkpoint mid-respawn would erase an
+	// established session's only on-disk record and orphan its workspace; and the
+	// TUI's reconcile clears adopted overlays per-op, so a create overlay it never
+	// expected on an established row would strand it as Loading with its lifecycle
+	// actions disabled until restart. There is nothing here for a client to mirror.
+	OpRespawning
 )
 
 // LifecycleAction is the session domain's answer to which reversible lifecycle

--- a/session/respawn_fence_test.go
+++ b/session/respawn_fence_test.go
@@ -270,3 +270,52 @@ func TestRespawningRowOffersNeitherArchiveNorKill(t *testing.T) {
 	require.Equal(t, LifecycleActionArchive, i.LifecycleAction(), "and the verb comes back")
 	require.True(t, i.CanKill(), "as does Kill")
 }
+
+// #3004 review finding 10 (P1): a third distinct window, and the one my earlier test
+// structurally cannot reach — it captures the epoch BEFORE the fence, so it only ever
+// exercises a stale observation. Here the poll passes its op skip, the fence goes up,
+// and only THEN does the poll capture its epoch. The observation is now current, so
+// the epoch guard has no reason to drop it, and it clobbers the liveness of a session
+// an operation already owns.
+//
+// The fix is to read the op and the epoch together, so this test asserts the property
+// the daemon poll relies on rather than re-implementing the poll: an epoch obtained
+// alongside an OpNone reading is necessarily older than any fence raised afterwards.
+func TestInFlightOpAndEpochLeavesNoWindowBetweenTheSkipAndTheEpoch(t *testing.T) {
+	i := limitBlockedInstance(t, newRespawnProbe())
+
+	// What the poll used to do: skip on the op, then capture the epoch separately.
+	// The fence slips in between the two reads.
+	require.Equal(t, OpNone, i.GetInFlightOp(), "the skip passes")
+	require.NoError(t, i.Transition(BeginRespawn()))
+	staleReadEpoch := i.StateEpoch()
+
+	// That epoch is post-fence, so the observation settles as CURRENT and lands —
+	// this is the defect, asserted rather than described.
+	require.NoError(t, i.Transition(ObserveLiveness(LiveLost).AtEpoch(staleReadEpoch)))
+	require.Equal(t, LiveLost, i.GetLiveness(),
+		"reading the epoch after the fence is what let the clobber through")
+
+	// Reading both together instead: the op reading is what tells the poll to skip,
+	// and it cannot disagree with the epoch it was read beside.
+	j := limitBlockedInstance(t, newRespawnProbe())
+	op, epoch := j.InFlightOpAndEpoch()
+	require.Equal(t, OpNone, op)
+	require.NoError(t, j.Transition(BeginRespawn()), "the fence goes up after the paired read")
+
+	require.NoError(t, j.Transition(ObserveLiveness(LiveLost).AtEpoch(epoch)))
+	require.Equal(t, LiveLimitReached, j.GetLiveness(),
+		"an epoch read beside an OpNone op is older than any later fence, so the guard drops it")
+	require.Equal(t, OpRespawning, j.GetInFlightOp())
+}
+
+// And the paired read reports a fence that is already up, which is what makes the
+// caller's skip correct rather than merely well-timed.
+func TestInFlightOpAndEpochReportsAFenceAlreadyRaised(t *testing.T) {
+	i := limitBlockedInstance(t, newRespawnProbe())
+	require.NoError(t, i.Transition(BeginRespawn()))
+
+	op, epoch := i.InFlightOpAndEpoch()
+	require.Equal(t, OpRespawning, op, "the caller must skip on this")
+	require.Equal(t, i.StateEpoch(), epoch)
+}

--- a/session/respawn_fence_test.go
+++ b/session/respawn_fence_test.go
@@ -380,3 +380,30 @@ func TestEndLimitResumeLeavesAnotherOwnersOpAlone(t *testing.T) {
 	i.EndLimitResume()
 	require.Equal(t, OpKilling, i.GetInFlightOp(), "the kill still owns the session")
 }
+
+// #3004 review finding 13 (P1): the fence is PROJECTED, so when it is lowered
+// relative to building a completion payload is load-bearing. The daemon publishes
+// session.updated from ToInstanceData(), and the web rail is event-driven — so a
+// payload built while the fence is up advertises a busy row, and lowering the fence
+// afterwards in memory produces no second event to correct it. The row then keeps its
+// lifecycle and kill controls suppressed until an unrelated update or a reconnect.
+//
+// This asserts the projection fact the daemon's ordering depends on, so that making
+// the op unprojected (which would quietly invalidate that reasoning) fails here.
+func TestTheRespawnFenceIsProjectedSoItsReleaseOrderMatters(t *testing.T) {
+	i := limitBlockedInstance(t, newRespawnProbe())
+	i.ID = "projected-fence-id"
+
+	require.NoError(t, i.BeginLimitResume())
+	fenced := i.ToInstanceData()
+	require.Equal(t, OpRespawning, fenced.InFlightOp,
+		"a payload built while fenced tells every client the row is busy")
+	require.Equal(t, LifecycleActionNone, fenced.LifecycleAction, "with its controls withheld")
+	require.False(t, fenced.CanKill)
+
+	i.EndLimitResume()
+	settled := i.ToInstanceData()
+	require.Equal(t, OpNone, settled.InFlightOp, "so the fence must be down BEFORE the payload is built")
+	require.Equal(t, LifecycleActionArchive, settled.LifecycleAction)
+	require.True(t, settled.CanKill)
+}

--- a/session/respawn_fence_test.go
+++ b/session/respawn_fence_test.go
@@ -207,3 +207,63 @@ func TestRespawnFenceRefusesACompetingRuntimeAction(t *testing.T) {
 	require.NoError(t, i.ValidateRuntimeAction(RuntimeActionHandoff),
 		"and the action comes back once the fence is down")
 }
+
+// #3004 review finding 5 (P1): the one window the epoch guard genuinely cannot
+// close. An observation landing BETWEEN the precondition check and the fence is
+// CURRENT, not stale, so nothing drops it — and the raw fence edge does not re-check
+// liveness (next test), so a validate that ran under an earlier, already-released
+// lock cannot protect it. beginRespawnFence holds i.mu across both.
+func TestBeginRespawnFenceRefusesAClobberedPrecondition(t *testing.T) {
+	i := limitBlockedInstance(t, newRespawnProbe())
+	require.NoError(t, i.Transition(ObserveLiveness(LiveLost)), "the poll's observation lands")
+
+	require.Error(t, i.beginRespawnFence(), "a session the daemon just declared Lost is not resumable")
+	require.Equal(t, OpNone, i.GetInFlightOp(), "and no fence was raised on the way out")
+}
+
+// Why that check has to live inside the fence's own critical section rather than
+// ahead of it: tkBeginRespawn is keyed on the OP axis alone, so the edge itself will
+// happily raise the fence over a clobbered liveness. This test is the reason
+// beginRespawnFence exists; if the edge is ever given a liveness precondition
+// instead, note that a legitimate loss of this race would then fire the
+// illegal-transition hook (a panic under test), which is why the guard is a
+// validating chokepoint and not an allowedFrom predicate.
+func TestTheBareRespawnEdgeDoesNotCheckLiveness(t *testing.T) {
+	i := limitBlockedInstance(t, newRespawnProbe())
+	require.NoError(t, i.Transition(ObserveLiveness(LiveLost)))
+
+	require.NoError(t, i.Transition(BeginRespawn()), "the bare edge checks only the op axis")
+	require.Equal(t, LiveLost, i.GetLiveness(), "so it fences a session with no limit to resume from")
+}
+
+// And the composite: Respawn refuses without ever reaching the backend.
+func TestRespawnDoesNotReachTheBackendOnAClobberedPrecondition(t *testing.T) {
+	probe := newRespawnProbe()
+	i := limitBlockedInstance(t, probe)
+	require.NoError(t, i.Transition(ObserveLiveness(LiveLost)))
+
+	require.Error(t, i.Respawn())
+	require.Equal(t, LivenessUnset, probe.livenessDuring, "the backend must never have been called")
+	require.Equal(t, OpNone, i.GetInFlightOp())
+}
+
+// #3004 review finding 6 (P2): the #2500 defect class — a fenced row still offering
+// a verb that its own fence refuses on press. Archive is the one that applies here;
+// see lifecycleActionFor for why Kill deliberately stays available.
+func TestRespawningRowOffersNoArchiveButStaysKillable(t *testing.T) {
+	i := limitBlockedInstance(t, newRespawnProbe())
+	i.ID = "respawn-gate-id"
+	require.Equal(t, LifecycleActionArchive, i.LifecycleAction(),
+		"a limit-parked row archives before the resume starts")
+
+	require.NoError(t, i.Transition(BeginRespawn()))
+
+	require.Equal(t, LifecycleActionNone, i.LifecycleAction(),
+		"Archive would tear down a worktree the respawn is provisioning into")
+	require.True(t, i.CanKill(),
+		"Kill must survive the fence: tkBeginKill is legal from any state, and a hung "+
+			"remote provision is exactly when a user needs the escape hatch")
+
+	i.clearRespawnFence()
+	require.Equal(t, LifecycleActionArchive, i.LifecycleAction(), "and the verb comes back")
+}

--- a/session/respawn_fence_test.go
+++ b/session/respawn_fence_test.go
@@ -54,6 +54,8 @@ func TestRespawn_FencesTheOperationAgainstTheStatusPoll(t *testing.T) {
 	probe.confirmLive = true
 	i := limitBlockedInstance(t, probe)
 
+	require.NoError(t, i.BeginLimitResume(), "the caller raises the fence for the whole resume")
+	defer i.EndLimitResume()
 	require.NoError(t, i.Respawn())
 
 	require.Equal(t, OpRespawning, probe.opDuring,
@@ -73,10 +75,14 @@ func TestRespawn_LowersTheFenceWhenTheBackendFails(t *testing.T) {
 	probe.err = boom
 	i := limitBlockedInstance(t, probe)
 
+	require.NoError(t, i.BeginLimitResume())
 	require.ErrorIs(t, i.Respawn(), boom)
-
 	require.Equal(t, OpRespawning, probe.opDuring, "the fence was up while the work ran")
-	require.Equal(t, OpNone, i.GetInFlightOp(), "and is down again once it failed")
+	require.Equal(t, OpRespawning, i.GetInFlightOp(),
+		"a failed Respawn leaves the fence for its owner to lower — never silently")
+
+	i.EndLimitResume()
+	require.Equal(t, OpNone, i.GetInFlightOp(), "and the owner lowers it")
 	require.Equal(t, LiveLimitReached, i.GetLiveness(),
 		"a failed respawn leaves the session where it was — still resumable")
 	require.NoError(t, i.ValidateRuntimeAction(RuntimeActionResumeLimit),
@@ -89,7 +95,12 @@ func TestRespawn_LowersTheFenceWhenTheBackendSkipsConfirmLive(t *testing.T) {
 	probe := newRespawnProbe()
 	i := limitBlockedInstance(t, probe)
 
+	require.NoError(t, i.BeginLimitResume())
 	require.NoError(t, i.Respawn())
+
+	// EndLimitResume is deferred unconditionally by the daemon, so it has to be safe
+	// on the path where the backend never reached ConfirmLive as well.
+	i.EndLimitResume()
 	require.Equal(t, OpNone, i.GetInFlightOp())
 }
 
@@ -100,7 +111,8 @@ func TestRespawn_RefusesWhenAnotherOpAlreadyOwnsTheSession(t *testing.T) {
 	i := limitBlockedInstance(t, probe)
 	require.NoError(t, i.Transition(BeginKill()))
 
-	require.Error(t, i.Respawn(), "a session another op owns is not respawnable")
+	require.Error(t, i.BeginLimitResume(), "a session another op owns is not resumable")
+	require.Error(t, i.Respawn(), "and Respawn refuses without the fence rather than proceeding")
 	require.Equal(t, OpKilling, i.GetInFlightOp(), "and the owner's op is untouched")
 	require.Equal(t, InFlightOp(0), probe.opDuring, "the backend was never reached")
 }
@@ -145,7 +157,7 @@ func TestRespawnFenceDropsAPollObservationDecidedBeforeItWasRaised(t *testing.T)
 	require.Equal(t, LiveLimitReached, i.GetLiveness(),
 		"a stale observation must not clobber the liveness the running resume depends on")
 	require.Equal(t, OpRespawning, i.GetInFlightOp(), "and the fence still stands")
-	i.clearRespawnFence()
+	i.EndLimitResume()
 	require.NoError(t, i.ValidateRuntimeAction(RuntimeActionResumeLimit),
 		"once the fence is down the resume can be retried")
 }
@@ -203,7 +215,7 @@ func TestRespawnFenceRefusesACompetingRuntimeAction(t *testing.T) {
 	require.Error(t, i.ValidateRuntimeAction(RuntimeActionHandoff),
 		"a session mid-respawn must refuse a handoff, on whichever side asks")
 
-	i.clearRespawnFence()
+	i.EndLimitResume()
 	require.NoError(t, i.ValidateRuntimeAction(RuntimeActionHandoff),
 		"and the action comes back once the fence is down")
 }
@@ -212,19 +224,19 @@ func TestRespawnFenceRefusesACompetingRuntimeAction(t *testing.T) {
 // close. An observation landing BETWEEN the precondition check and the fence is
 // CURRENT, not stale, so nothing drops it — and the raw fence edge does not re-check
 // liveness (next test), so a validate that ran under an earlier, already-released
-// lock cannot protect it. beginRespawnFence holds i.mu across both.
-func TestBeginRespawnFenceRefusesAClobberedPrecondition(t *testing.T) {
+// lock cannot protect it. BeginLimitResume holds i.mu across both.
+func TestBeginLimitResumeRefusesAClobberedPrecondition(t *testing.T) {
 	i := limitBlockedInstance(t, newRespawnProbe())
 	require.NoError(t, i.Transition(ObserveLiveness(LiveLost)), "the poll's observation lands")
 
-	require.Error(t, i.beginRespawnFence(), "a session the daemon just declared Lost is not resumable")
+	require.Error(t, i.BeginLimitResume(), "a session the daemon just declared Lost is not resumable")
 	require.Equal(t, OpNone, i.GetInFlightOp(), "and no fence was raised on the way out")
 }
 
 // Why that check has to live inside the fence's own critical section rather than
 // ahead of it: tkBeginRespawn is keyed on the OP axis alone, so the edge itself will
 // happily raise the fence over a clobbered liveness. This test is the reason
-// beginRespawnFence exists; if the edge is ever given a liveness precondition
+// BeginLimitResume exists; if the edge is ever given a liveness precondition
 // instead, note that a legitimate loss of this race would then fire the
 // illegal-transition hook (a panic under test), which is why the guard is a
 // validating chokepoint and not an allowedFrom predicate.
@@ -242,6 +254,7 @@ func TestRespawnDoesNotReachTheBackendOnAClobberedPrecondition(t *testing.T) {
 	i := limitBlockedInstance(t, probe)
 	require.NoError(t, i.Transition(ObserveLiveness(LiveLost)))
 
+	require.Error(t, i.BeginLimitResume())
 	require.Error(t, i.Respawn())
 	require.Equal(t, LivenessUnset, probe.livenessDuring, "the backend must never have been called")
 	require.Equal(t, OpNone, i.GetInFlightOp())
@@ -266,7 +279,7 @@ func TestRespawningRowOffersNeitherArchiveNorKill(t *testing.T) {
 		"Kill cannot supersede this fence — KillSession times out on the op lock the "+
 			"resume holds, so advertising it promises a supersede it cannot perform")
 
-	i.clearRespawnFence()
+	i.EndLimitResume()
 	require.Equal(t, LifecycleActionArchive, i.LifecycleAction(), "and the verb comes back")
 	require.True(t, i.CanKill(), "as does Kill")
 }
@@ -318,4 +331,52 @@ func TestInFlightOpAndEpochReportsAFenceAlreadyRaised(t *testing.T) {
 	op, epoch := i.InFlightOpAndEpoch()
 	require.Equal(t, OpRespawning, op, "the caller must skip on this")
 	require.Equal(t, i.StateEpoch(), epoch)
+}
+
+// #3004 review finding 11 (P1), and the mechanism #2997 actually described: the
+// daemon probes, then PUSHES the sandbox's unpushed work and records its branch, and
+// only then re-spawns. Fencing the backend call alone left that push — a network git
+// operation, the longest phase of the resume — unprotected. Respawn therefore
+// REQUIRES the fence rather than raising its own, so the ownership cannot silently
+// slide back to being too late.
+func TestRespawnRequiresTheFenceItsCallerOwns(t *testing.T) {
+	probe := newRespawnProbe()
+	i := limitBlockedInstance(t, probe)
+
+	err := i.Respawn()
+	require.Error(t, err, "Respawn must not raise a fence of its own — that would be after the push")
+	require.Contains(t, err.Error(), "requires the limit-resume fence")
+	require.Equal(t, LivenessUnset, probe.livenessDuring, "and it must not reach the backend")
+	require.Equal(t, OpNone, i.GetInFlightOp(), "nor leave a fence behind")
+}
+
+// The fence has to be available to a caller BEFORE any of the destructive phases,
+// and it must preserve the precondition those phases run under.
+func TestBeginLimitResumeFencesTheWholeSequenceWithoutDisturbingLiveness(t *testing.T) {
+	i := limitBlockedInstance(t, newRespawnProbe())
+
+	require.NoError(t, i.BeginLimitResume())
+	require.Equal(t, OpRespawning, i.GetInFlightOp(),
+		"the push and the re-provision both run behind this")
+	require.Equal(t, LiveLimitReached, i.GetLiveness(),
+		"and the precondition the resume validated against survives its own operation")
+
+	// Which is what makes the poll skip for the whole sequence, not just the tail.
+	require.NoError(t, i.Transition(ObserveLiveness(LiveLost).AtEpoch(i.StateEpoch()-1)),
+		"an observation from before the fence is dropped")
+	require.Equal(t, LiveLimitReached, i.GetLiveness())
+
+	i.EndLimitResume()
+	require.Equal(t, OpNone, i.GetInFlightOp())
+	require.NoError(t, i.ValidateRuntimeAction(RuntimeActionResumeLimit), "still retryable")
+}
+
+// EndLimitResume must never touch an op it does not own — the daemon defers it
+// unconditionally, so a session that moved on under another owner has to be left alone.
+func TestEndLimitResumeLeavesAnotherOwnersOpAlone(t *testing.T) {
+	i := limitBlockedInstance(t, newRespawnProbe())
+	require.NoError(t, i.Transition(BeginKill()))
+
+	i.EndLimitResume()
+	require.Equal(t, OpKilling, i.GetInFlightOp(), "the kill still owns the session")
 }

--- a/session/respawn_fence_test.go
+++ b/session/respawn_fence_test.go
@@ -56,11 +56,12 @@ func TestRespawn_FencesTheOperationAgainstTheStatusPoll(t *testing.T) {
 
 	require.NoError(t, i.Respawn())
 
-	require.Equal(t, OpCreating, probe.opDuring,
+	require.Equal(t, OpRespawning, probe.opDuring,
 		"the poll's skip is keyed on the instance-visible op, so a long respawn must advertise one")
 	require.Equal(t, LiveLimitReached, probe.livenessDuring,
 		"raising the fence must not disturb the liveness the resume path depends on")
 	require.Equal(t, OpNone, i.GetInFlightOp(), "ConfirmLive clears the fence on the success path")
+	require.Equal(t, LiveRunning, i.GetLiveness(), "and the respawned runtime settles live")
 }
 
 // The other half, and the more dangerous one to get wrong: a failed respawn must not
@@ -74,7 +75,7 @@ func TestRespawn_LowersTheFenceWhenTheBackendFails(t *testing.T) {
 
 	require.ErrorIs(t, i.Respawn(), boom)
 
-	require.Equal(t, OpCreating, probe.opDuring, "the fence was up while the work ran")
+	require.Equal(t, OpRespawning, probe.opDuring, "the fence was up while the work ran")
 	require.Equal(t, OpNone, i.GetInFlightOp(), "and is down again once it failed")
 	require.Equal(t, LiveLimitReached, i.GetLiveness(),
 		"a failed respawn leaves the session where it was — still resumable")
@@ -118,4 +119,70 @@ func TestObserveLivenessClobbersALimitBlockedSessionThatIsNotFenced(t *testing.T
 	err := i.ValidateRuntimeAction(RuntimeActionResumeLimit)
 	require.Error(t, err, "the resume's own precondition is gone")
 	require.Contains(t, err.Error(), "not blocked on a usage limit")
+}
+
+// #3004 review finding 1 claimed the fence only makes LATER polls skip, leaving a
+// window where a poll that already passed the skip applies its observation anyway.
+// It does not: the fence transition itself advances the state epoch, and the poll's
+// applies are epoch-scoped (daemon/manager_status.go:536, daemon/remoteloss.go:326
+// — both .AtEpoch(epoch) taken BEFORE the probe), so a decision drawn before the
+// fence is dropped at the chokepoint rather than applied. This is #2135 doing the
+// job it was built for; the test exists so nobody has to re-derive that.
+func TestRespawnFenceDropsAPollObservationDecidedBeforeItWasRaised(t *testing.T) {
+	probe := newRespawnProbe()
+	i := limitBlockedInstance(t, probe)
+
+	// The poll captures the epoch, then probes — slowly, against a remote sandbox.
+	pollEpoch := i.StateEpoch()
+
+	// The resume raises the fence while that probe is still in flight.
+	require.NoError(t, i.Transition(BeginRespawn()))
+	require.NotEqual(t, pollEpoch, i.StateEpoch(), "raising the fence must advance the epoch")
+
+	// The probe now comes back and settles the death it saw — which was OUR teardown.
+	require.NoError(t, i.Transition(ObserveLiveness(LiveLost).AtEpoch(pollEpoch)))
+
+	require.Equal(t, LiveLimitReached, i.GetLiveness(),
+		"a stale observation must not clobber the liveness the running resume depends on")
+	require.Equal(t, OpRespawning, i.GetInFlightOp(), "and the fence still stands")
+	i.clearRespawnFence()
+	require.NoError(t, i.ValidateRuntimeAction(RuntimeActionResumeLimit),
+		"once the fence is down the resume can be retried")
+}
+
+// The same poll observation is NOT dropped when it is genuinely current — the guard
+// is an epoch check, not a blanket refusal, so real deaths still land.
+func TestAnUnstaleObservationStillLands(t *testing.T) {
+	i := limitBlockedInstance(t, newRespawnProbe())
+	require.NoError(t, i.Transition(ObserveLiveness(LiveLost).AtEpoch(i.StateEpoch())))
+	require.Equal(t, LiveLost, i.GetLiveness())
+}
+
+// #3004 review finding 2, asserted where the harm actually happens rather than via
+// composeStatus: SaveInstances drops ordinary Loading/Deleting rows, so a fence that
+// composed to Loading would make a shutdown checkpoint erase an established
+// session's only on-disk record — and the checkpoint is wholesale per repo, so any
+// OTHER started session in the same repo triggers it.
+func TestSaveInstances_KeepsARespawningRowAlongsideStartedSibling(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := t.TempDir()
+	state := newMockStorage()
+
+	sibling := &Instance{Title: "sibling", Path: repoPath, started: true, liveness: LiveRunning}
+	respawning := &Instance{ID: "respawn-id", Title: "respawning", Path: repoPath, Program: "claude", started: true, liveness: LiveReady}
+	require.NoError(t, respawning.Transition(ObserveLiveness(LiveLimitReached)))
+	require.NoError(t, respawning.Transition(BeginRespawn()))
+
+	storage, err := NewStorage(state, "")
+	require.NoError(t, err)
+	require.NoError(t, storage.SaveInstances([]*Instance{sibling, respawning}))
+
+	for _, row := range readDisk(t, state, repoPath) {
+		if row.Title == respawning.Title {
+			require.NotEqual(t, Loading, row.Status,
+				"a respawn fence must not present as Loading — that is the value the retention skip drops")
+			return
+		}
+	}
+	t.Fatal("the shutdown checkpoint dropped the respawning row; the next daemon start would orphan its workspace")
 }

--- a/session/respawn_fence_test.go
+++ b/session/respawn_fence_test.go
@@ -247,10 +247,12 @@ func TestRespawnDoesNotReachTheBackendOnAClobberedPrecondition(t *testing.T) {
 	require.Equal(t, OpNone, i.GetInFlightOp())
 }
 
-// #3004 review finding 6 (P2): the #2500 defect class — a fenced row still offering
-// a verb that its own fence refuses on press. Archive is the one that applies here;
-// see lifecycleActionFor for why Kill deliberately stays available.
-func TestRespawningRowOffersNoArchiveButStaysKillable(t *testing.T) {
+// #3004 review findings 6 and 9 (P2): the #2500 defect class — a fenced row still
+// offering a verb that its own fence refuses on press. Both verbs apply. Kill looks
+// like an exception because tkBeginKill is allowedFrom-always, but the daemon cannot
+// REACH that transition during a respawn: it waits 30s for the per-session op lock
+// the resume holds and then returns errKillBusy. See canKillFor.
+func TestRespawningRowOffersNeitherArchiveNorKill(t *testing.T) {
 	i := limitBlockedInstance(t, newRespawnProbe())
 	i.ID = "respawn-gate-id"
 	require.Equal(t, LifecycleActionArchive, i.LifecycleAction(),
@@ -260,10 +262,11 @@ func TestRespawningRowOffersNoArchiveButStaysKillable(t *testing.T) {
 
 	require.Equal(t, LifecycleActionNone, i.LifecycleAction(),
 		"Archive would tear down a worktree the respawn is provisioning into")
-	require.True(t, i.CanKill(),
-		"Kill must survive the fence: tkBeginKill is legal from any state, and a hung "+
-			"remote provision is exactly when a user needs the escape hatch")
+	require.False(t, i.CanKill(),
+		"Kill cannot supersede this fence — KillSession times out on the op lock the "+
+			"resume holds, so advertising it promises a supersede it cannot perform")
 
 	i.clearRespawnFence()
 	require.Equal(t, LifecycleActionArchive, i.LifecycleAction(), "and the verb comes back")
+	require.True(t, i.CanKill(), "as does Kill")
 }

--- a/session/respawn_fence_test.go
+++ b/session/respawn_fence_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -62,8 +63,11 @@ func TestRespawn_FencesTheOperationAgainstTheStatusPoll(t *testing.T) {
 		"the poll's skip is keyed on the instance-visible op, so a long respawn must advertise one")
 	require.Equal(t, LiveLimitReached, probe.livenessDuring,
 		"raising the fence must not disturb the liveness the resume path depends on")
-	require.Equal(t, OpNone, i.GetInFlightOp(), "ConfirmLive clears the fence on the success path")
+	require.Equal(t, OpRespawning, i.GetInFlightOp(),
+		"ConfirmLive must NOT clear it: the resume still has to re-park and deliver the prompt")
 	require.Equal(t, LiveRunning, i.GetLiveness(), "and the respawned runtime settles live")
+	require.True(t, i.EndLimitResume(), "the resume's owner lowers it when the prompt has landed")
+	require.Equal(t, OpNone, i.GetInFlightOp())
 }
 
 // The other half, and the more dangerous one to get wrong: a failed respawn must not
@@ -406,4 +410,72 @@ func TestTheRespawnFenceIsProjectedSoItsReleaseOrderMatters(t *testing.T) {
 	require.Equal(t, OpNone, settled.InFlightOp, "so the fence must be down BEFORE the payload is built")
 	require.Equal(t, LifecycleActionArchive, settled.LifecycleAction)
 	require.True(t, settled.CanKill)
+}
+
+// #3004 review finding 14 (P1): the resume is not over when its runtime comes up. It
+// still re-parks this episode's limit window and delivers the queued prompt, and the
+// poll must not settle the fresh, still-idle agent Ready in that stretch — an idle
+// observation is the one edge that ENDS a task run, and taskRunActive only ever goes
+// true→false, so the prompt would land on a session no longer counted against the
+// watch-task concurrency cap.
+func TestConfirmLiveKeepsTheResumeFenceForPromptDelivery(t *testing.T) {
+	i := limitBlockedInstance(t, newRespawnProbe())
+	require.NoError(t, i.BeginLimitResume())
+
+	require.NoError(t, i.Transition(ConfirmLive()))
+	require.Equal(t, LiveRunning, i.GetLiveness(), "the runtime is up")
+	require.Equal(t, OpRespawning, i.GetInFlightOp(), "and the resume still owns the session")
+
+	require.True(t, i.EndLimitResume())
+	require.Equal(t, OpNone, i.GetInFlightOp())
+}
+
+// ConfirmLive still clears every other op — the carve-out is for the respawn fence
+// alone, not a change to what completing a create or a restore means.
+func TestConfirmLiveStillClearsACreate(t *testing.T) {
+	i := &Instance{liveness: LiveReady, Title: "creating", started: true, backend: newRespawnProbe()}
+	require.NoError(t, i.Transition(BeginCreate()))
+
+	require.NoError(t, i.Transition(ConfirmLive()))
+	require.Equal(t, OpNone, i.GetInFlightOp(), "a completed create is finished when its runtime is live")
+}
+
+// Holding the fence through delivery collides with SetLimitReached, which refuses
+// while ANY op is in flight — and refuses by returning a bool the daemon never read,
+// so following the review's advice literally would have LOST this episode's reset
+// time in silence and left the auto-resume scheduler nothing to schedule off. The
+// transaction-owned twin is what makes the longer fence safe.
+func TestReparkUnderTheFenceWhereThePlainSetterSilentlyNoOps(t *testing.T) {
+	reset := time.Now().Add(42 * time.Minute).UTC()
+	i := limitBlockedInstance(t, newRespawnProbe())
+	require.NoError(t, i.BeginLimitResume())
+	require.NoError(t, i.Transition(ConfirmLive()))
+	require.Equal(t, LiveRunning, i.GetLiveness())
+
+	// What the daemon used to call. It reports nothing to this caller and changes
+	// nothing — the failure mode the fenced twin exists to remove.
+	i.SetLimitReached(reset)
+	require.Equal(t, LiveRunning, i.GetLiveness(), "the plain setter no-ops under a fence")
+
+	require.NoError(t, i.ReparkLimitUnderResumeFence(reset))
+	require.Equal(t, LiveLimitReached, i.GetLiveness(), "the episode's window is restored")
+	got, ok := i.LimitResetAt()
+	require.True(t, ok)
+	require.WithinDuration(t, reset, got, time.Second, "with THIS episode's reset time, not a zeroed one")
+
+	// And it is not a back door: it refuses when the fence it names is not held.
+	i.ClearLimitReached()
+	require.True(t, i.EndLimitResume())
+	require.Error(t, i.ReparkLimitUnderResumeFence(reset), "no fence, no privileged re-park")
+}
+
+// #3004 review finding 15 (P2): the release has to be distinguishable from a no-op,
+// because the caller publishes a settled projection only when it actually released —
+// otherwise the success path, which already published one, emits a duplicate.
+func TestEndLimitResumeReportsWhetherItReleased(t *testing.T) {
+	i := limitBlockedInstance(t, newRespawnProbe())
+	require.NoError(t, i.BeginLimitResume())
+
+	require.True(t, i.EndLimitResume(), "the first call lowered it")
+	require.False(t, i.EndLimitResume(), "the deferred second call must not re-announce")
 }

--- a/session/respawn_fence_test.go
+++ b/session/respawn_fence_test.go
@@ -1,0 +1,121 @@
+package session
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// respawnProbeBackend records what the instance looked like DURING Respawn, which
+// is the only moment the fence matters — the poll runs concurrently with the
+// backend call, not before or after it.
+type respawnProbeBackend struct {
+	*FakeBackend
+	opDuring       InFlightOp
+	livenessDuring Liveness
+	err            error
+	confirmLive    bool
+}
+
+func newRespawnProbe() *respawnProbeBackend {
+	return &respawnProbeBackend{FakeBackend: NewFakeBackend()}
+}
+
+func (b *respawnProbeBackend) Respawn(i *Instance) error {
+	b.opDuring = i.GetInFlightOp()
+	b.livenessDuring = i.GetLiveness()
+	if b.err != nil {
+		return b.err
+	}
+	if b.confirmLive {
+		// What a real backend does on success, and what clears the fence for free.
+		_ = i.Transition(ConfirmLive())
+	}
+	return nil
+}
+
+func limitBlockedInstance(t *testing.T, backend Backend) *Instance {
+	t.Helper()
+	i := &Instance{liveness: LiveReady, Title: "fenced", started: true, backend: backend}
+	require.NoError(t, i.Transition(ObserveLiveness(LiveLimitReached)))
+	require.NoError(t, i.ValidateRuntimeAction(RuntimeActionResumeLimit))
+	return i
+}
+
+// The regression #2997 finding 1 describes: a remote respawn pushes and
+// re-provisions, which outlasts the poll interval. The poll skips a session with an
+// op in flight, so the fence has to be UP for the whole backend call — otherwise the
+// poll reads the teardown this call is performing as an independent death and
+// overwrites LiveLimitReached, destroying the precondition of the resume that is
+// still running.
+func TestRespawn_FencesTheOperationAgainstTheStatusPoll(t *testing.T) {
+	probe := newRespawnProbe()
+	probe.confirmLive = true
+	i := limitBlockedInstance(t, probe)
+
+	require.NoError(t, i.Respawn())
+
+	require.Equal(t, OpCreating, probe.opDuring,
+		"the poll's skip is keyed on the instance-visible op, so a long respawn must advertise one")
+	require.Equal(t, LiveLimitReached, probe.livenessDuring,
+		"raising the fence must not disturb the liveness the resume path depends on")
+	require.Equal(t, OpNone, i.GetInFlightOp(), "ConfirmLive clears the fence on the success path")
+}
+
+// The other half, and the more dangerous one to get wrong: a failed respawn must not
+// leave the fence standing. A permanently busy session is skipped by the poll forever
+// and refused by every runtime action — a worse outcome than the clobber being fixed.
+func TestRespawn_LowersTheFenceWhenTheBackendFails(t *testing.T) {
+	boom := errors.New("provision failed")
+	probe := newRespawnProbe()
+	probe.err = boom
+	i := limitBlockedInstance(t, probe)
+
+	require.ErrorIs(t, i.Respawn(), boom)
+
+	require.Equal(t, OpCreating, probe.opDuring, "the fence was up while the work ran")
+	require.Equal(t, OpNone, i.GetInFlightOp(), "and is down again once it failed")
+	require.Equal(t, LiveLimitReached, i.GetLiveness(),
+		"a failed respawn leaves the session where it was — still resumable")
+	require.NoError(t, i.ValidateRuntimeAction(RuntimeActionResumeLimit),
+		"the user must be able to retry the resume after a failure")
+}
+
+// A backend that returns success without reaching ConfirmLive must not strand the
+// fence either — the cleanup is not conditional on which path the backend took.
+func TestRespawn_LowersTheFenceWhenTheBackendSkipsConfirmLive(t *testing.T) {
+	probe := newRespawnProbe()
+	i := limitBlockedInstance(t, probe)
+
+	require.NoError(t, i.Respawn())
+	require.Equal(t, OpNone, i.GetInFlightOp())
+}
+
+// The precondition is checked BEFORE the fence goes up, because the validation
+// itself requires OpNone — a fence raised first would reject the call it protects.
+func TestRespawn_RefusesWhenAnotherOpAlreadyOwnsTheSession(t *testing.T) {
+	probe := newRespawnProbe()
+	i := limitBlockedInstance(t, probe)
+	require.NoError(t, i.Transition(BeginKill()))
+
+	require.Error(t, i.Respawn(), "a session another op owns is not respawnable")
+	require.Equal(t, OpKilling, i.GetInFlightOp(), "and the owner's op is untouched")
+	require.Equal(t, InFlightOp(0), probe.opDuring, "the backend was never reached")
+}
+
+// Why the fence is needed at all, stated as an executable fact rather than a
+// comment: the poll's liveness edge is allowedFrom-always and keeps the op it
+// finds, so if it lands mid-respawn it overwrites LiveLimitReached with whatever
+// the half-torn-down session looks like — and that is the exact precondition the
+// in-flight resume validated against. The resume then cannot be retried.
+func TestObserveLivenessClobbersALimitBlockedSessionThatIsNotFenced(t *testing.T) {
+	i := limitBlockedInstance(t, newRespawnProbe())
+
+	// What refreshInstanceStatus applies when it does NOT skip.
+	require.NoError(t, i.Transition(ObserveLiveness(LiveLost)))
+
+	err := i.ValidateRuntimeAction(RuntimeActionResumeLimit)
+	require.Error(t, err, "the resume's own precondition is gone")
+	require.Contains(t, err.Error(), "not blocked on a usage limit")
+}

--- a/session/respawn_fence_test.go
+++ b/session/respawn_fence_test.go
@@ -186,3 +186,24 @@ func TestSaveInstances_KeepsARespawningRowAlongsideStartedSibling(t *testing.T) 
 	}
 	t.Fatal("the shutdown checkpoint dropped the respawning row; the next daemon start would orphan its workspace")
 }
+
+// #3004 review finding 4 (P2): the fence has to gate ACTIONS, not just the poll.
+// The TUI re-derives RuntimeActionHandoff on its own instance (app/handle_handoff.go)
+// while the daemon re-validates on its authoritative one (daemon/handoff.go), so a
+// fence the TUI does not mirror means the picker opens and the daemon then refuses
+// the selected handoff. This pins the session-side contract that agreement rests on:
+// the fence refuses a competing runtime action, and lowering it restores the action.
+// The mirroring itself is app/sync.go's reconcile, covered by CI.
+func TestRespawnFenceRefusesACompetingRuntimeAction(t *testing.T) {
+	i := limitBlockedInstance(t, newRespawnProbe())
+	require.NoError(t, i.ValidateRuntimeAction(RuntimeActionHandoff),
+		"a limit-parked session is handoff-able before the resume starts")
+
+	require.NoError(t, i.Transition(BeginRespawn()))
+	require.Error(t, i.ValidateRuntimeAction(RuntimeActionHandoff),
+		"a session mid-respawn must refuse a handoff, on whichever side asks")
+
+	i.clearRespawnFence()
+	require.NoError(t, i.ValidateRuntimeAction(RuntimeActionHandoff),
+		"and the action comes back once the fence is down")
+}

--- a/session/state_epoch.go
+++ b/session/state_epoch.go
@@ -47,6 +47,27 @@ func (i *Instance) StateEpoch() uint64 {
 	return i.stateEpoch
 }
 
+// InFlightOpAndEpoch reads the op axis and the state epoch TOGETHER under one lock.
+//
+// An observer that reads them separately has a window that neither read closes on
+// its own (#2997). The daemon poll skips a session that has an op in flight and,
+// further down, captures the epoch its observation will be scoped to. If a fence
+// goes up BETWEEN those two reads, the skip has already passed and the epoch it then
+// captures is the POST-fence one — so the observation it settles minutes later looks
+// current, is applied rather than dropped, and overwrites the liveness the in-flight
+// operation depends on. That is the same clobber the fence exists to prevent,
+// reached by a path the fence cannot see.
+//
+// Reading both at once removes the window instead of narrowing it: the epoch is
+// necessarily from a moment when the op was None, so any fence raised afterwards
+// advances it and the epoch guard drops the observation. Callers must skip on a
+// non-None op here, not merely earlier.
+func (i *Instance) InFlightOpAndEpoch() (InFlightOp, uint64) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.inFlightOp, i.stateEpoch
+}
+
 // lifecycleStateLocked captures the state the epoch tracks: both axes plus the
 // usage-limit reset time. Caller holds i.mu.
 func (i *Instance) lifecycleStateLocked() (Liveness, InFlightOp, time.Time) {

--- a/session/transition.go
+++ b/session/transition.go
@@ -516,7 +516,15 @@ func SetIllegalTransitionHook(fn func(msg string)) (restore func()) {
 func (i *Instance) Transition(ev TransitionEvent) error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
+	return i.transitionLocked(ev)
+}
 
+// transitionLocked is Transition's already-locked half. Caller holds i.mu for
+// writing. It exists so a chokepoint that must validate and mutate in ONE critical
+// section can do both without releasing the lock between them — see
+// lifecycleViewLocked, and beginRespawnFence for a case where the gap was a real
+// race (#2997).
+func (i *Instance) transitionLocked(ev TransitionEvent) error {
 	if ev.epochScoped && i.stateEpoch != ev.epoch {
 		// The decision behind this event was drawn from an observation that a newer
 		// authoritative transition has since superseded. Drop it — silently and

--- a/session/transition.go
+++ b/session/transition.go
@@ -59,6 +59,7 @@ const (
 	tkParkHandoff
 	tkAbortHandoff
 	tkClearOp
+	tkBeginRespawn
 	numTransitionKinds
 )
 
@@ -98,6 +99,8 @@ func (k transitionKind) String() string {
 		return "AbortHandoff"
 	case tkClearOp:
 		return "ClearOp"
+	case tkBeginRespawn:
+		return "BeginRespawn"
 	}
 	return fmt.Sprintf("transitionKind(%d)", int(k))
 }
@@ -126,6 +129,10 @@ func (ev TransitionEvent) AtEpoch(epoch uint64) TransitionEvent {
 	ev.epochScoped = true
 	return ev
 }
+
+// BeginRespawn raises the OpRespawning fence for a limit resume re-spawning an
+// established session's runtime (#2997). Liveness is preserved.
+func BeginRespawn() TransitionEvent { return TransitionEvent{kind: tkBeginRespawn} }
 
 // BeginCreate overlays OpCreating for an optimistic create (was SetStatus(Loading)).
 func BeginCreate() TransitionEvent { return TransitionEvent{kind: tkBeginCreate} }
@@ -320,6 +327,17 @@ type edgeSpec struct {
 // enforcement of I1–I4 lives here as a from-state predicate, not as a guard
 // scattered across the daemon/app call sites.
 var transitionTable = map[transitionKind]edgeSpec{
+	// A limit resume re-spawning an established session's runtime (#2997). It
+	// preserves liveness — the session is still the limit-blocked one the resume
+	// validated against, and the resume's own precondition must survive its own
+	// operation — and requires OpNone so it cannot start under a teardown.
+	tkBeginRespawn: {
+		allowedFrom: func(s stateAxes) bool { return s.op == OpNone },
+		target:      func(s stateAxes, _ TransitionEvent) stateAxes { return stateAxes{s.liveness, OpRespawning} },
+		// Re-spawning a runtime continues the session's run; it neither opens nor
+		// closes one.
+		run: runKeep,
+	},
 	tkBeginCreate: {
 		allowedFrom: func(s stateAxes) bool { return s.op == OpNone },
 		target:      func(s stateAxes, _ TransitionEvent) stateAxes { return stateAxes{s.liveness, OpCreating} },
@@ -327,7 +345,9 @@ var transitionTable = map[transitionKind]edgeSpec{
 		run: runKeep,
 	},
 	tkConfirmLive: {
-		allowedFrom:      func(s stateAxes) bool { return s.op == OpNone || s.op == OpCreating || s.op == OpRestoring },
+		allowedFrom: func(s stateAxes) bool {
+			return s.op == OpNone || s.op == OpCreating || s.op == OpRestoring || s.op == OpRespawning
+		},
 		target:           func(stateAxes, TransitionEvent) stateAxes { return stateAxes{LiveRunning, OpNone} },
 		yieldWhenBlocked: true,
 		// A spawn completing says the agent is up, not that its work is done. It
@@ -614,6 +634,8 @@ func opLabel(op InFlightOp) string {
 		return "Restoring"
 	case OpReplacing:
 		return "Replacing"
+	case OpRespawning:
+		return "Respawning"
 	}
 	return fmt.Sprintf("InFlightOp(%d)", int(op))
 }

--- a/session/transition.go
+++ b/session/transition.go
@@ -522,7 +522,7 @@ func (i *Instance) Transition(ev TransitionEvent) error {
 // transitionLocked is Transition's already-locked half. Caller holds i.mu for
 // writing. It exists so a chokepoint that must validate and mutate in ONE critical
 // section can do both without releasing the lock between them — see
-// lifecycleViewLocked, and beginRespawnFence for a case where the gap was a real
+// lifecycleViewLocked, and BeginLimitResume for a case where the gap was a real
 // race (#2997).
 func (i *Instance) transitionLocked(ev TransitionEvent) error {
 	if ev.epochScoped && i.stateEpoch != ev.epoch {

--- a/session/transition.go
+++ b/session/transition.go
@@ -348,7 +348,19 @@ var transitionTable = map[transitionKind]edgeSpec{
 		allowedFrom: func(s stateAxes) bool {
 			return s.op == OpNone || s.op == OpCreating || s.op == OpRestoring || s.op == OpRespawning
 		},
-		target:           func(stateAxes, TransitionEvent) stateAxes { return stateAxes{LiveRunning, OpNone} },
+		target: func(s stateAxes, _ TransitionEvent) stateAxes {
+			if s.op == OpRespawning {
+				// A limit resume is NOT over when its runtime comes up (#2997). It still has
+				// to re-park this episode's limit window and deliver the queued prompt, and
+				// clearing the fence here would unfence exactly that stretch: the poll would
+				// see a freshly spawned, still-idle agent, settle it Ready, and END THE TASK
+				// RUN — taskRunActive only ever goes true→false — so the prompt would land on
+				// a session no longer counted against the watch-task concurrency cap. The
+				// resume's own EndLimitResume lowers it once the prompt has landed.
+				return stateAxes{LiveRunning, OpRespawning}
+			}
+			return stateAxes{LiveRunning, OpNone}
+		},
 		yieldWhenBlocked: true,
 		// A spawn completing says the agent is up, not that its work is done. It
 		// cannot REOPEN a finished run either: the marker only ever goes true→false,

--- a/session/transition_test.go
+++ b/session/transition_test.go
@@ -55,6 +55,9 @@ func TestTransitionTable_RunEffectsAreTheAgreedTable(t *testing.T) {
 		// Opening/booting the session: the run is under way.
 		tkBeginCreate: runKeep,
 		tkConfirmLive: runKeep,
+		// Re-spawning an established session's runtime after a usage limit (#2997)
+		// continues its run; it neither opens nor closes one.
+		tkBeginRespawn: runKeep,
 		// The only edge that can settle the agent idle, which is what ends a run.
 		tkObserveLiveness: runEndsOnIdleEdge,
 		// Kill overlays: revertible, so they decide nothing. The tombstone and the

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -444,7 +444,11 @@ func (m *Menu) addInstanceOptions() {
 	// actually blocked at a limit wall — c re-spawns (if the agent exited) and
 	// resumes it. Kept off the bar for every normal session so it never clutters
 	// the hints.
-	if m.instance != nil && m.instance.LimitReached() {
+	// Not while an operation owns the session (#2997): a resume already in flight
+	// keeps the row LiveLimitReached by design — the fence preserves liveness — so
+	// LimitReached() alone would keep advertising `c` for a retry that
+	// RuntimeActionResumeLimit then refuses as busy.
+	if m.instance != nil && m.instance.LimitReached() && m.instance.GetInFlightOp() == session.OpNone {
 		actionGroup = append(actionGroup, keys.KeyLimitRetry)
 		// Handoff (#2013) is the OTHER answer to a limit wall: `c` waits for this
 		// agent's window to reset, `H` continues the work under a different one.

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -9657,7 +9657,9 @@ var InFlightOp = {
   Creating: 1,
   Killing: 2,
   Archiving: 3,
-  Restoring: 4
+  Restoring: 4,
+  Replacing: 5,
+  Respawning: 6
 };
 var Status = {
   Running: 0,
@@ -9743,7 +9745,7 @@ function isArchived(s) {
   return livenessOf(s) === Liveness.Archived;
 }
 function isLimitReached(s) {
-  return livenessOf(s) === Liveness.LimitReached;
+  return livenessOf(s) === Liveness.LimitReached && (s.in_flight_op ?? InFlightOp.None) === InFlightOp.None;
 }
 function canHandoff(s) {
   return s.can_handoff === true;

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "d3e6251d0fd7";
+const VERSION = "6a602172c74f";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/status.ts
+++ b/web/src/status.ts
@@ -169,9 +169,13 @@ export function isArchived(s: SessionData): boolean {
  *
  *  An in-flight operation withholds it (#2997). A resume already running keeps the
  *  row LiveLimitReached by design — its fence preserves liveness — so liveness alone
- *  would advertise a Retry the daemon then refuses as busy. This gates the ACTION
- *  only; the diamond and "[limit] resets …" prefix come from rowStatus/rowTitle and
- *  still render the state throughout. */
+ *  would advertise a Retry the daemon then refuses as busy.
+ *
+ *  This gates the action. It is NOT the whole story for display, and an earlier
+ *  version of this note claimed otherwise: rowStatus above returns WORKING for any
+ *  in-flight op, so a respawning row shows no diamond and isWorking() counts it as
+ *  working (project.ts). Only the "[limit] resets …" prefix from rowTitle survives,
+ *  because that arm keys on liveness. Consistent with every other op and #1766. */
 export function isLimitReached(s: SessionData): boolean {
   return (
     livenessOf(s) === Liveness.LimitReached &&

--- a/web/src/status.ts
+++ b/web/src/status.ts
@@ -165,9 +165,18 @@ export function isArchived(s: SessionData): boolean {
  *  with an explanatory error otherwise (app/handle_actions.go handleLimitRetry).
  *  Reading the liveness rather than the mere presence of `limit_reset_at` is the
  *  point: a session can be limit-blocked with no parsed reset time yet, and a
- *  resumed one keeps its stale reset timestamp in the projection. */
+ *  resumed one keeps its stale reset timestamp in the projection.
+ *
+ *  An in-flight operation withholds it (#2997). A resume already running keeps the
+ *  row LiveLimitReached by design — its fence preserves liveness — so liveness alone
+ *  would advertise a Retry the daemon then refuses as busy. This gates the ACTION
+ *  only; the diamond and "[limit] resets …" prefix come from rowStatus/rowTitle and
+ *  still render the state throughout. */
 export function isLimitReached(s: SessionData): boolean {
-  return livenessOf(s) === Liveness.LimitReached;
+  return (
+    livenessOf(s) === Liveness.LimitReached &&
+    (s.in_flight_op ?? InFlightOp.None) === InFlightOp.None
+  );
 }
 
 /** True when this session's agent can be handed off to a different one in place

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -48,6 +48,8 @@ export const InFlightOp = {
   Killing: 2,
   Archiving: 3,
   Restoring: 4,
+  Replacing: 5,
+  Respawning: 6,
 } as const;
 
 /** session.LifecycleAction: the daemon-owned archive/restore verb for a row.


### PR DESCRIPTION
## The defect

A REMOTE respawn pushes the sandbox's unpushed work and re-provisions a fresh one. That outlasts the status poll interval.

The poll already refuses to touch a busy session — `refreshInstanceStatus` skips on `GetInFlightOp() != OpNone`, so it cannot mark a session Lost while its tmux is being spun up or torn down. But `Instance.Respawn()` advertised no operation, so that skip never engaged. The poll observed the sandbox being torn down *by the resume itself*, read it as an independent death, and applied `ObserveLiveness(LiveLost)` — the unconditional daemon-truth edge, which preserves only the op axis. `LiveLimitReached` was overwritten underneath a running resume, so the resume failed its own `RuntimeActionResumeLimit` precondition — and automatic Lost recovery could later clear the limit **without delivering the pending resume prompt**, so the user's queued work silently never ran.

This was the one long sandbox operation missing the fence. Archive already has it: `BeginArchive` at `daemon/archive.go:495`, the push inside `ArchiveSandbox()` at 499, `CommitArchive` at 510 (#1195 Phase 2d).

## Three windows, not one

The fence's width never changed across review. What changed is that a fence is not one check — it is a set of moments where the poll and the operation can interleave, and each needed its own answer.

1. **An observation decided *before* the fence.** Raising the fence is a real lifecycle change, so it advances the state epoch (`state_epoch.go`), and the poll's applies are epoch-scoped (`manager_status.go:536`, `remoteloss.go:326`). Such an observation is dropped at the chokepoint (#2135). No code needed — but the original comment gave an incomplete account of *why* the fence was safe, which is now written down.

2. **An observation landing between the precondition check and the fence.** This one is *current*, so the epoch guard has nothing to reject, and `tkBeginRespawn` is keyed on the op axis alone — so the backend would have re-spawned a session the daemon had just declared Lost, and the failure path would leave it there. `beginRespawnFence` now holds `i.mu` across both, the pattern `lifecycleViewLocked` documents and `SwapAgentProgram` already uses. It stays a validating chokepoint rather than an `allowedFrom` predicate: losing this race is legitimate, and an `allowedFrom` rejection fires the illegal-transition hook, which panics under test.

3. **An observation decided *after* the fence with a post-fence epoch.** The poll's skip runs near the top of the tick and its epoch is captured ~55 lines later; a fence raised in between is invisible to both, so the observation looks current and applies. `InFlightOpAndEpoch` reads op and epoch under one lock and the poll skips on that paired reading — which removes the window rather than narrowing it, since an epoch read beside an `OpNone` op is necessarily older than any later fence.

## The fence covers the whole resume, not the re-spawn

`Respawn()` was the wrong place to raise it. For an answered-dead remote agent the daemon probes, then **pushes** the sandbox's unpushed work and durably records its branch, and only then re-spawns — and that push is a network git operation, the longest phase of the resume. Fencing only the backend call left it exposed, which is the mechanism #2997 itself described.

`BeginLimitResume` is now raised before the probe in `resumeFromLimitLockedOutcome`, with `defer EndLimitResume()` covering every exit, and `Respawn` **requires** the fence rather than raising its own — so the ownership cannot slide back to being too late. That split follows `SwapAgentProgram`/`RecordHandoffSwap`, whose comment says making both legal orderings explicit beats one re-entrant call.

It also does not end when the runtime comes up. `ConfirmLive` **preserves** `OpRespawning` (and clears every other op exactly as before), because the resume still has to re-park this episode's limit window and deliver the queued prompt — and a tick in that stretch settles the fresh, still-idle agent `Ready`, which is the one edge that *ends a task run*. The prompt would then land on a session no longer counted against the watch-task concurrency cap.

Holding the fence that far collides with `SetLimitReached`, which refuses while any op is in flight and reports the refusal only through a bool the daemon never read — so the obvious version of this change would have lost the episode's reset time **in silence** and left the auto-resume scheduler nothing to schedule off. `ReparkLimitUnderResumeFence` is the transaction-owned twin (again the `RecordHandoffSwap` shape) and refuses unless the fence is actually held, so it is not a back door around that guard.

## The fence is announced, not just enforced

Gating controls on a projected op does nothing if clients are never told the op changed: the rail is event-driven and performs no optimistic update for a resume, so an already-connected client kept its pre-fence Kill / Archive / Handoff / Retry affordances for the whole operation, and a press landed on a busy error or the 30s kill timeout the gates exist to prevent.

The fence is now published on raise and on release, **inside** the repo ordering lock — `session.updated` replaces a client's entire session projection, so a publish that races a tab mutation can make a new tab vanish or a closed one reappear. `EndLimitResume` reports whether it actually released, so the deferred cleanup announces a real release and the success path does not emit a duplicate.

`TestResumeFromLimit_PublishesRunningTransition` now pins both events in order: the busy announcement (`OpRespawning` + `LiveLimitReached`), then the `LimitReached → Running` transition — with `OpNone` asserted on that payload, which is what fails if the fence is ever released after the completion payload is built rather than before.

## `OpRespawning`, not `OpCreating`

The first version reused `OpCreating`. That was wrong because a respawn acts on an **established** session while a create does not:

- `composeStatus` overlays `OpCreating` as `Loading`, and `SaveInstances` drops ordinary `Loading` rows (`storage.go:398`). A shutdown checkpoint mid-respawn would rewrite that repo's file without the row — and the checkpoint is wholesale per repo, so any *other* started session triggers it. The next daemon start would lose an established session's only record and orphan its workspace.
- The TUI adopts a snapshot `OpCreating` as a create placeholder, but the settle path clears only archiving/killing/restoring/replacing — so the overlay was never released, stranding the row as Loading with lifecycle actions disabled until restart.

`OpRespawning` falls through `composeStatus` to the settled liveness, which fixes the persistence drop and is the honest projection: a session mid-resume is still the limit-blocked session the resume validated against. The TUI adopts it *and* releases it on an `OpNone` snapshot, unconditionally — a respawn ends running, back to limit-parked, or lost, so keying the release on one liveness would strand it on the others.

Adoption is for **action gating**: `app/handle_handoff.go` re-derives `RuntimeActionHandoff` on the TUI's own instance while `daemon/handoff.go` re-validates authoritatively, so an unmirrored fence means the picker opens and the daemon then refuses the selection.

## Action gates

A fenced row must not offer a verb its own fence refuses on press — the #2500 defect, which `opIsTeardown`'s comment describes exactly. `lifecycleActionFor` and `canKillFor` both exclude `OpRespawning`, and the Retry hint is withheld while an op is in flight on **both** surfaces (`ui/menu.go`, `web/src/status.ts`) so they cannot drift. The Retry case is easy to miss: the fence *preserves* `LiveLimitReached` by design, so a liveness-only gate keeps advertising a retry the daemon refuses as busy.

`canKillFor` deserves a note, because the transition table gets it backwards. `tkBeginKill` is `allowedFrom`-always — "a kill supersedes any in-flight op" — which reads as though Kill works during any operation. It does not work during this one: `KillSession` waits `opLockTimeout` (30s) for the per-session op lock and returns `errKillBusy` **without applying `BeginKill`**, while the resume holds that lock throughout. So Kill here is a 30-second wait followed by "try again", and hiding it is the honest answer. Making it genuinely interrupt the owning operation is a separate change to the kill path; that gap already applies to `OpCreating`, `OpReplacing`, and the teardown ops.

This also completes the web `InFlightOp` mirror, which was **already** missing `Replacing: 5` from #2013 — `types.ts` calls that a breaking omission in its own header.

## What the fence does change

A respawning row reads as working: `render.go` masks the liveness glyph for any non-`None` op and `rowStatus` mirrors it, so the limit diamond is replaced by the blank working glyph and `project.ts` counts the row as working. That is kept deliberately — a resume in flight is work in flight, and it matches every other op and #1766 — and the `[limit] resets …` prefix still renders, because `rowTitle`'s limit arm keys on liveness. An earlier version of this PR claimed the fence was invisible; it is not, and the comments now say so.

## Verification

Every assertion was watched failing first, and two were discarded for not doing so:

- Remove the fence → the probe backend sees `OpNone` during the respawn.
- Swap `BeginRespawn` for `BeginCreate` → the retention test fails with *"the shutdown checkpoint dropped the respawning row"*, reproducing the persistence finding under the old code.
- Capture the epoch after the fence → `LiveLost` lands, which is window 3 asserted as a defect before the paired read is shown to prevent it.

The retention test drives a real `SaveInstances` with a started sibling and reads the row back off disk (following `storage_retain_test.go`) rather than asserting the weaker `composeStatus` proxy. A concurrency stress test written for window 2 reported the backend reached 300/300 with the clobber never landing inside the window — it would have passed against the broken code, so it was deleted rather than kept as decoration. The atomicity there is structural (one critical section), not test-guarded, and that is stated rather than implied.

The repo's own exhaustiveness guard caught the new transition kind (`TestTransitionTable_RunEffectsAreTheAgreedTable`); it is entered in the ledger with its reasoning.

Local: `gofmt -l .` clean · `go build ./...` · `golangci-lint run --timeout=3m --fast` clean · `scripts/lint-file-length.sh` passed · `go test ./session/ ./api/ ./ui/...` ok · `npm test` in `web/` 527 pass. Per policy no containerized suites and no `./daemon/...` or `./app/...` runs on this host — those two packages are covered by CI, and each review reply says so rather than implying local verification.

## Scope: this fixes finding 1 of #2997, and does NOT close the issue

#2997 bundles two findings. This PR fixes the first one thoroughly — three interleaving windows plus the preserve-then-push phase the issue named — and deliberately does **not** claim the second.

Earlier in this PR I argued finding 2's harm did not reproduce. That was wrong and is [retracted on the issue](https://github.com/sachiniyer/agent-factory/issues/2997#issuecomment-5200608737). Two of my supporting claims ("`archiveWithin` is not in the tree", "`preserveSandboxBeforeReap` is not in the tree") were false negatives from a grep that failed on a shell glob, which I read as an empty result. A third was misleading: `rpcHandler` is *defined* in `daemon/httpserver.go`, but `agentserver_headless.go:211` is where `/v1/agent/archive` is registered through it, so the issue named the right file. And my `taskTargetMu`/`BeginArchive` argument was about the daemon's own `Manager.ArchiveSession` — a different layer from the **sandbox's** archive handler, which is what finding 2 is about. A daemon-side mutex bounds nothing inside the sandbox.

So finding 2 stands: a client deadline ends the request while the sandbox keeps running `git status`/`add`/`commit`, and a retry can overlap a still-running archive on the same worktree. It needs a decision about what cancellation means between `add` and `commit`, which is its own change. **#2997 stays open for it.**

One review finding is also filed separately: #3005, the TUI reconcile's inability to distinguish a daemon-adopted op from a local optimistic one. It predates this PR and applies to `OpArchiving`, `OpRestoring`, and `OpReplacing` too, so special-casing one op would leave an unsound predicate in place for three others.

Refs #2997


🤖 Generated with [Claude Code](https://claude.com/claude-code)
