### PR TITLE
fix(tui): record whether an in-flight op was adopted from a snapshot

### DIFF
--- a/app/adopted_ops.go
+++ b/app/adopted_ops.go
@@ -1,0 +1,91 @@
+package app
+
+import "github.com/sachiniyer/agent-factory/session"
+
+// Provenance for in-flight ops on TUI rows (#3005).
+//
+// Two reconcile guards refuse to touch a row that has any op in flight: the
+// same-title-different-session swap and the absent-from-snapshot removal. Both
+// exist for LOCAL optimistic ops, and their comments say so — a create
+// placeholder or an optimistic kill owns its own identity transition through its
+// completion handler (instanceStartedMsg / instanceKilledMsg, by pointer
+// identity, #808/#844), so the reconcile must not race it.
+//
+// adoptSnapshotOp then started mirroring DAEMON-owned ops onto the same field:
+// OpArchiving, OpRestoring, OpReplacing, OpRespawning. Those have no local
+// completion handler. Their only release is a later snapshot reporting OpNone
+// for the SAME identity — so if the session is killed, or killed and recreated
+// under the same title, before that snapshot arrives, the release never comes.
+// Both guards then refuse forever and the row outlives its session: a corpse on
+// the rail, attached to nothing, not removable, with its lifecycle controls
+// suppressed. Restarting the TUI is the only recovery.
+//
+// The guard was asking "does something own this row's transition?" and answering
+// "does this row have an op?" Those coincided until snapshot adoption landed
+// (#1436).
+//
+// Provenance is RECORDED, never inferred. Inference by op KIND does not work in
+// either direction: the TUI locally begins restores and archives, and the daemon
+// projects OpCreating and OpKilling — so no op value is exclusively local or
+// exclusively adopted. It is the same lesson as #2953, where four attempts tried
+// to observe a fact from outside instead of recording it at the moment it was
+// true.
+//
+// The record is a (pointer, op) PAIR, which is what makes it self-correcting: a
+// local transition that changes the op leaves the recorded value no longer
+// matching, so the row reads as locally owned again without every local call site
+// having to remember to clear anything. Pointer-keyed for the same reason the
+// completion handlers are — a same-title successor is a different row and must
+// not inherit its predecessor's provenance.
+type adoptedOps map[*session.Instance]session.InFlightOp
+
+// note records that op on inst came from a daemon snapshot rather than a local
+// optimistic transition.
+func (a adoptedOps) note(inst *session.Instance, op session.InFlightOp) {
+	if inst == nil {
+		return
+	}
+	if op == session.OpNone {
+		delete(a, inst)
+		return
+	}
+	a[inst] = op
+}
+
+// owns reports whether inst's CURRENT op was adopted from a snapshot — i.e.
+// whether no local completion handler is waiting on it.
+//
+// The op is compared, not merely the presence of an entry: if a local transition
+// has since moved the row to a different op, that op is locally owned and the
+// stale entry must not speak for it.
+func (a adoptedOps) owns(inst *session.Instance) bool {
+	if inst == nil {
+		return false
+	}
+	op := inst.GetInFlightOp()
+	if op == session.OpNone {
+		return false
+	}
+	recorded, ok := a[inst]
+	return ok && recorded == op
+}
+
+// forget drops a row's provenance. Called where a row leaves the store, so the
+// map cannot outlive the instances it describes.
+func (a adoptedOps) forget(inst *session.Instance) {
+	delete(a, inst)
+}
+
+// vetoesReconcile reports whether inst's in-flight op should stop the reconcile
+// from swapping or removing the row.
+//
+// This is the question both guards actually meant to ask. A LOCAL op vetoes:
+// its completion handler owns the transition and the reconcile would orphan the
+// handshake. An ADOPTED op does not: nothing local is waiting on it, and the
+// snapshot is authoritative about whether the session still exists.
+func (a adoptedOps) vetoesReconcile(inst *session.Instance) bool {
+	if inst.GetInFlightOp() == session.OpNone {
+		return false
+	}
+	return !a.owns(inst)
+}

--- a/app/adopted_ops.go
+++ b/app/adopted_ops.go
@@ -89,3 +89,17 @@ func (a adoptedOps) vetoesReconcile(inst *session.Instance) bool {
 	}
 	return !a.owns(inst)
 }
+
+// adoptedOpsFor returns the model's provenance map, creating it on first write.
+//
+// Lazy rather than constructor-only because a `home` is built as a bare literal
+// in several places (test helpers especially), and a nil map is fine to READ from
+// but panics on assignment. Making the write path self-initializing means
+// provenance cannot depend on which constructor a row arrived through — the exact
+// kind of coupling that would make this correct in production and nil in a test.
+func (m *home) adoptedOpsFor() adoptedOps {
+	if m.adoptedSnapshotOps == nil {
+		m.adoptedSnapshotOps = adoptedOps{}
+	}
+	return m.adoptedSnapshotOps
+}

--- a/app/adopted_ops.go
+++ b/app/adopted_ops.go
@@ -76,6 +76,32 @@ func (a adoptedOps) forget(inst *session.Instance) {
 	delete(a, inst)
 }
 
+// pruneTo drops every entry whose instance is no longer among live.
+//
+// Chasing each lifecycle exit individually is what would rot: a row can leave the
+// store through a project switch, a removal, a swap, or a local transition that
+// clears the op without any snapshot involved, and each new exit added later
+// would have to remember this map. Since the key is a pointer, a missed exit
+// leaks the entry AND keeps the instance reachable, so the map would quietly
+// become the thing preventing garbage collection of the rows it describes.
+//
+// Reconciling against the store instead makes the map self-correcting: whatever
+// path a row left by, its entry is gone on the next snapshot.
+func (a adoptedOps) pruneTo(live []*session.Instance) {
+	if len(a) == 0 {
+		return
+	}
+	keep := make(map[*session.Instance]struct{}, len(live))
+	for _, inst := range live {
+		keep[inst] = struct{}{}
+	}
+	for inst := range a {
+		if _, ok := keep[inst]; !ok {
+			delete(a, inst)
+		}
+	}
+}
+
 // vetoesReconcile reports whether inst's in-flight op should stop the reconcile
 // from swapping or removing the row.
 //

--- a/app/adopted_ops_test.go
+++ b/app/adopted_ops_test.go
@@ -110,3 +110,38 @@ func TestAdoptedOps_AlreadyCarriedOpIsStillRecorded(t *testing.T) {
 	require.False(t, m.adoptedSnapshotOps.vetoesReconcile(inst),
 		"a snapshot reporting the op this row already carries is still evidence the daemon owns it")
 }
+
+// Provenance must not outlive the rows it describes. The key is a pointer, so a
+// leaked entry does not merely waste a map slot — it keeps the instance
+// reachable, making this map the thing that prevents collection of the corpses it
+// was added to help remove.
+func TestAdoptedOps_PruneDropsRowsThatLeftTheStore(t *testing.T) {
+	kept := liveInstance(t, "kept")
+	gone := liveInstance(t, "gone")
+	a := adoptedOps{}
+	a.note(kept, session.OpReplacing)
+	a.note(gone, session.OpArchiving)
+
+	a.pruneTo([]*session.Instance{kept})
+
+	require.Len(t, a, 1, "an entry whose row left the store must be dropped whatever route it left by")
+	_, stillThere := a[gone]
+	require.False(t, stillThere)
+	_, survives := a[kept]
+	require.True(t, survives, "a live row keeps its provenance")
+}
+
+// A row built directly FROM a snapshot can already carry a daemon-owned op — the
+// cold-start path. It is just as adopted as one mirrored onto an existing row,
+// and without recording it there the very first reconcile after launch treats it
+// as local and vetoes forever.
+func TestAdoptedOps_NoteRecordsAnOpCarriedFromConstruction(t *testing.T) {
+	inst := liveInstance(t, "cold-start")
+	require.NoError(t, inst.Transition(session.BeginHandoff()))
+
+	a := adoptedOps{}
+	a.note(inst, inst.GetInFlightOp())
+
+	require.False(t, a.vetoesReconcile(inst),
+		"an op a snapshot-built row arrived carrying is adopted, not local")
+}

--- a/app/adopted_ops_test.go
+++ b/app/adopted_ops_test.go
@@ -1,0 +1,112 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+func liveInstance(t *testing.T, title string) *session.Instance {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title: title, Path: t.TempDir(), Program: "claude",
+	})
+	require.NoError(t, err)
+	require.NoError(t, inst.Transition(session.ObserveLiveness(session.LiveRunning)))
+	return inst
+}
+
+// A row carrying a DAEMON-adopted op must not veto the reconcile (#3005).
+//
+// The two guards exist for LOCAL optimistic ops, whose completion handler owns
+// the identity transition by pointer identity (#808/#844). An op adopted from a
+// snapshot has no such handler: its only release is a later OpNone snapshot for
+// the SAME identity, which never arrives once the session is killed — or killed
+// and recreated under the same title. Vetoing on it leaves a corpse on the rail
+// that no snapshot can remove and only a TUI restart clears.
+func TestAdoptedOps_DaemonOpDoesNotVetoReconcile(t *testing.T) {
+	inst := liveInstance(t, "worker")
+	m := &home{adoptedSnapshotOps: adoptedOps{}}
+
+	// The daemon projects a handoff; the TUI mirrors it.
+	require.True(t, m.reconcileSnapshotOp(inst, session.OpReplacing, session.LiveRunning))
+	require.Equal(t, session.OpReplacing, inst.GetInFlightOp())
+
+	require.False(t, m.adoptedSnapshotOps.vetoesReconcile(inst),
+		"an adopted daemon op has no local completion handler waiting on it, so it must not "+
+			"stop the reconcile from swapping or removing the row — the release it is waiting for "+
+			"only ever arrives as an OpNone snapshot for this identity, and a killed or recreated "+
+			"session never produces one")
+}
+
+// The other half, and the reason this is provenance rather than a blanket
+// removal of the guard: a LOCAL op must still veto. Its completion handler owns
+// the transition, and letting the reconcile swap or remove the row underneath it
+// orphans the handshake and leaves two same-title rows (#808).
+func TestAdoptedOps_LocalOpStillVetoesReconcile(t *testing.T) {
+	inst := liveInstance(t, "worker")
+	m := &home{adoptedSnapshotOps: adoptedOps{}}
+
+	// An optimistic local kill — no snapshot involved.
+	require.NoError(t, inst.Transition(session.BeginKill()))
+
+	require.True(t, m.adoptedSnapshotOps.vetoesReconcile(inst),
+		"a locally owned op must still veto: instanceKilledMsg owns this row's transition")
+}
+
+// Provenance is a (pointer, op) PAIR, and this is what that buys: a local
+// transition that moves the row to a DIFFERENT op leaves the recorded value no
+// longer matching, so the row reads as locally owned again — without every local
+// call site having to remember to clear anything.
+func TestAdoptedOps_LocalTransitionSupersedesAdoptedProvenance(t *testing.T) {
+	inst := liveInstance(t, "worker")
+	m := &home{adoptedSnapshotOps: adoptedOps{}}
+
+	require.True(t, m.reconcileSnapshotOp(inst, session.OpReplacing, session.LiveRunning))
+	require.False(t, m.adoptedSnapshotOps.vetoesReconcile(inst))
+
+	// The user now kills it locally. The row's op changes out from under the
+	// recorded provenance.
+	require.NoError(t, inst.Transition(session.ClearOp()))
+	require.NoError(t, inst.Transition(session.BeginKill()))
+
+	require.True(t, m.adoptedSnapshotOps.vetoesReconcile(inst),
+		"a stale adoption record must not speak for an op a local transition has since replaced")
+}
+
+// A same-title successor is a different row and must not inherit its
+// predecessor's provenance — the same pointer-identity rule the completion
+// handlers use.
+func TestAdoptedOps_SuccessorDoesNotInheritProvenance(t *testing.T) {
+	old := liveInstance(t, "worker")
+	m := &home{adoptedSnapshotOps: adoptedOps{}}
+	require.True(t, m.reconcileSnapshotOp(old, session.OpReplacing, session.LiveRunning))
+
+	successor := liveInstance(t, "worker")
+	require.NoError(t, successor.Transition(session.BeginKill()))
+
+	require.True(t, m.adoptedSnapshotOps.vetoesReconcile(successor),
+		"the successor's own local op must veto; provenance is keyed by pointer, not by title")
+}
+
+// An op the daemon reports for a row that already carries it must still be
+// recorded. Otherwise a row adopted before this tracking existed — or on an
+// earlier reconcile pass — stays permanently unrecorded and keeps vetoing, which
+// is the original bug with extra steps.
+func TestAdoptedOps_AlreadyCarriedOpIsStillRecorded(t *testing.T) {
+	inst := liveInstance(t, "worker")
+	m := &home{adoptedSnapshotOps: adoptedOps{}}
+
+	// The row carries OpReplacing with nothing recorded, as it would after a
+	// reconcile that predates the provenance map.
+	require.NoError(t, inst.Transition(session.BeginHandoff()))
+	require.True(t, m.adoptedSnapshotOps.vetoesReconcile(inst))
+
+	// The daemon reports the same op again.
+	m.reconcileSnapshotOp(inst, session.OpReplacing, session.LiveRunning)
+
+	require.False(t, m.adoptedSnapshotOps.vetoesReconcile(inst),
+		"a snapshot reporting the op this row already carries is still evidence the daemon owns it")
+}

--- a/app/handoff_reconcile_test.go
+++ b/app/handoff_reconcile_test.go
@@ -19,9 +19,15 @@ func TestReconcileSnapshotOp_AdoptsAndSettlesHandoffFence(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, inst.Transition(session.ObserveLiveness(session.LiveRunning)))
 
-	require.True(t, reconcileSnapshotOp(inst, session.OpReplacing, session.LiveRunning))
-	require.Equal(t, session.OpReplacing, inst.GetInFlightOp())
+	m := &home{adoptedSnapshotOps: adoptedOps{}}
 
-	require.True(t, reconcileSnapshotOp(inst, session.OpNone, session.LiveRunning))
+	require.True(t, m.reconcileSnapshotOp(inst, session.OpReplacing, session.LiveRunning))
+	require.Equal(t, session.OpReplacing, inst.GetInFlightOp())
+	require.True(t, m.adoptedSnapshotOps.owns(inst),
+		"an op mirrored from the daemon snapshot must be recorded as adopted (#3005)")
+
+	require.True(t, m.reconcileSnapshotOp(inst, session.OpNone, session.LiveRunning))
 	require.Equal(t, session.OpNone, inst.GetInFlightOp())
+	require.False(t, m.adoptedSnapshotOps.owns(inst),
+		"releasing the fence must release its provenance with it")
 }

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -85,6 +85,11 @@ type home struct {
 	// to. Used to resolve and persist the in-repo .agent-factory/config.json.
 	repoRoot string
 
+	// adoptedSnapshotOps separates daemon-adopted in-flight ops from local
+	// optimistic ones, which the reconcile guards must treat oppositely (#3005).
+	// The reasoning lives on the type, in app/adopted_ops.go.
+	adoptedSnapshotOps adoptedOps
+
 	// snapshotFetcher fetches the daemon's authoritative session snapshot for
 	// this repo. It is a PER-home field, not a package global, precisely because
 	// fetchSnapshotCmd reads it from an off-loop tea.Cmd goroutine: a shared
@@ -501,34 +506,35 @@ func newHome(ctx context.Context, program string, repo *config.RepoContext) *hom
 	errBox := ui.NewErrBox()
 
 	h := &home{
-		alarmBanner:      ui.NewAlarmBanner(),
-		ctx:              ctx,
-		store:            proj,
-		menu:             menu,
-		errBox:           errBox,
-		paneWindows:      make(map[int]*ui.TabbedWindow),
-		lastPaneCapture:  make(map[int]time.Time),
-		paneJumpIntent:   make(map[int]uint64),
-		liveTerms:        make(map[int]liveTermAttachment),
-		liveKeys:         make(map[int]string),
-		automations:      ui.NewAutomationsPane(proj),
-		projects:         ui.NewProjectsPane(),
-		statusBar:        ui.NewStatusBar(menu, errBox),
-		hooksPane:        ui.NewHooksPane(),
-		configPane:       ui.NewConfigPane(),
-		ring:             layout.NewRing(layout.RegionTree, layout.RegionAutomations, layout.RegionProjects),
-		zones:            zones.NewRegistry(),
-		mouseClock:       time.Now,
-		snapshotFetcher:  snapshotThroughDaemon,
-		previewFetcher:   previewThroughDaemon,
-		pauseStatusPoll:  pauseStatusPollThroughDaemon,
-		resumeStatusPoll: resumeStatusPollThroughDaemon,
-		appConfig:        appConfig,
-		program:          program,
-		repoID:           repoID,
-		repoRoot:         repoRoot,
-		state:            stateDefault,
-		appState:         appState,
+		adoptedSnapshotOps: adoptedOps{},
+		alarmBanner:        ui.NewAlarmBanner(),
+		ctx:                ctx,
+		store:              proj,
+		menu:               menu,
+		errBox:             errBox,
+		paneWindows:        make(map[int]*ui.TabbedWindow),
+		lastPaneCapture:    make(map[int]time.Time),
+		paneJumpIntent:     make(map[int]uint64),
+		liveTerms:          make(map[int]liveTermAttachment),
+		liveKeys:           make(map[int]string),
+		automations:        ui.NewAutomationsPane(proj),
+		projects:           ui.NewProjectsPane(),
+		statusBar:          ui.NewStatusBar(menu, errBox),
+		hooksPane:          ui.NewHooksPane(),
+		configPane:         ui.NewConfigPane(),
+		ring:               layout.NewRing(layout.RegionTree, layout.RegionAutomations, layout.RegionProjects),
+		zones:              zones.NewRegistry(),
+		mouseClock:         time.Now,
+		snapshotFetcher:    snapshotThroughDaemon,
+		previewFetcher:     previewThroughDaemon,
+		pauseStatusPoll:    pauseStatusPollThroughDaemon,
+		resumeStatusPoll:   resumeStatusPollThroughDaemon,
+		appConfig:          appConfig,
+		program:            program,
+		repoID:             repoID,
+		repoRoot:           repoRoot,
+		state:              stateDefault,
+		appState:           appState,
 	}
 	h.sidebar = ui.NewSidebar(proj)
 	h.wireZoneRegistry()

--- a/app/sync.go
+++ b/app/sync.go
@@ -186,6 +186,10 @@ func (m *home) materializeSnapshot(data []session.InstanceData) {
 			log.WarningLog.Printf("skipping session %q from snapshot: %v", d.Title, err)
 			continue
 		}
+		// A row BUILT from a snapshot can already carry a daemon-owned op, and it is
+		// just as adopted as one mirrored onto an existing row — the cold-start
+		// variant of the same corpse (#3005).
+		m.adoptedOpsFor().note(inst, inst.GetInFlightOp())
 		m.store.AddInstance(inst)()
 	}
 }
@@ -490,8 +494,13 @@ func (m *home) reconcileSnapshot(data []session.InstanceData) bool {
 			if m.adoptedSnapshotOps.vetoesReconcile(inst) {
 				continue
 			}
-			m.adoptedSnapshotOps.forget(inst)
+			// Only on SUCCESS: swapInstanceFromSnapshot returns false and leaves the
+			// old row in place when the replacement cannot be built, and forgetting
+			// first would reclassify its adopted op as local — vetoing every later
+			// retry and turning a transient build failure into the permanent stale row
+			// this change exists to prevent.
 			if m.swapInstanceFromSnapshot(d) {
+				m.adoptedSnapshotOps.forget(inst)
 				changed = true
 			}
 			continue
@@ -549,6 +558,12 @@ func (m *home) reconcileSnapshot(data []session.InstanceData) bool {
 		m.adoptedSnapshotOps.forget(inst)
 		changed = true
 	}
+	// Provenance is keyed by pointer, so an entry for a row that has left the store
+	// by ANY route — removal, swap, project switch — would leak and keep that
+	// instance reachable. Reconciling the map against the live set here covers every
+	// exit without each one having to remember this map (#3005).
+	m.adoptedSnapshotOps.pruneTo(m.store.GetInstances())
+
 	// Prune panes whose backing session can no longer render — a removed
 	// instance takes its open panes with it (#1088), and a session archived out
 	// of band (`af sessions archive` while the TUI runs, #1028) leaves its pane
@@ -601,6 +616,7 @@ func (m *home) addInstanceFromSnapshot(d session.InstanceData) bool {
 		log.WarningLog.Printf("failed to build instance %q from snapshot: %v", d.Title, err)
 		return false
 	}
+	m.adoptedOpsFor().note(inst, inst.GetInFlightOp())
 	m.store.AddInstance(inst)()
 	return true
 }

--- a/app/sync.go
+++ b/app/sync.go
@@ -481,9 +481,16 @@ func (m *home) reconcileSnapshot(data []session.InstanceData) bool {
 			// own completion handler (instanceStartedMsg/instanceKilledMsg, which
 			// use pointer identity); swapping it here would orphan that handshake
 			// and leave two same-title rows (#808). Leave it and let the op resolve.
-			if inst.GetInFlightOp() != session.OpNone {
+			//
+			// Only a LOCAL op vetoes. An op adopted from a daemon snapshot has no
+			// completion handler waiting on it, so there is no handshake to orphan —
+			// and its release only ever arrives as a later OpNone snapshot for THIS
+			// identity, which by definition never comes once the title has been
+			// recreated. Vetoing on it left the corpse on the rail forever (#3005).
+			if m.adoptedSnapshotOps.vetoesReconcile(inst) {
 				continue
 			}
+			m.adoptedSnapshotOps.forget(inst)
 			if m.swapInstanceFromSnapshot(d) {
 				changed = true
 			}
@@ -527,13 +534,19 @@ func (m *home) reconcileSnapshot(data []session.InstanceData) bool {
 		if _, ok := snapByTitle[inst.Title]; ok {
 			continue
 		}
-		if inst.GetInFlightOp() != session.OpNone {
+		// Same distinction as the identity swap above: a local op owns its own
+		// removal through its completion handler, an adopted one does not, and the
+		// snapshot is authoritative about whether the session still exists (#3005).
+		if m.adoptedSnapshotOps.vetoesReconcile(inst) {
 			continue
 		}
 		toRemove = append(toRemove, inst)
 	}
 	for _, inst := range toRemove {
 		m.store.RemoveInstanceByTitle(inst.Title)
+		// The map is keyed by pointer, so an entry for a row that has left the store
+		// would never be read again but would keep the instance alive.
+		m.adoptedSnapshotOps.forget(inst)
 		changed = true
 	}
 	// Prune panes whose backing session can no longer render — a removed
@@ -665,7 +678,7 @@ func (m *home) updateInstanceFromSnapshot(inst *session.Instance, d session.Inst
 	// one of those determinate outcomes arrives; the snapshot op still stays
 	// scrubbed because no daemon process owns it after the tombstone commit.
 	preserveKillRetry := tombstoned && inst.GetInFlightOp() == session.OpKilling
-	if !preserveKillRetry && reconcileSnapshotOp(inst, snapshotOp, lv) {
+	if !preserveKillRetry && m.reconcileSnapshotOp(inst, snapshotOp, lv) {
 		changed = true
 	}
 	// Mirror the usage-limit reset time (#1146) alongside the liveness. It's
@@ -756,20 +769,22 @@ func (m *home) updateInstanceFromSnapshot(inst *session.Instance, d session.Inst
 // outcome. Snapshot ops are transient but authoritative for daemon-side
 // archive/restore windows (#1436); terminal snapshots carry OpNone and clear
 // stale overlays through the Transition chokepoint.
-func reconcileSnapshotOp(inst *session.Instance, op session.InFlightOp, lv session.Liveness) bool {
+func (m *home) reconcileSnapshotOp(inst *session.Instance, op session.InFlightOp, lv session.Liveness) bool {
 	if op != session.OpNone {
-		return adoptSnapshotOp(inst, op, lv)
+		return m.adoptSnapshotOp(inst, op, lv)
 	}
 
 	switch inst.GetInFlightOp() {
 	case session.OpArchiving, session.OpKilling:
 		if lv == session.LiveArchived || lv == session.LiveLost {
 			_ = inst.Transition(session.ClearOp())
+			m.adoptedSnapshotOps.forget(inst)
 			return true
 		}
 	case session.OpRestoring:
 		if lv != session.LiveArchived {
 			_ = inst.Transition(session.ClearOp())
+			m.adoptedSnapshotOps.forget(inst)
 			return true
 		}
 	case session.OpReplacing:
@@ -777,13 +792,19 @@ func reconcileSnapshotOp(inst *session.Instance, op session.InFlightOp, lv sessi
 		// to OpNone, the projection must release the same fence regardless of the
 		// resulting liveness (running, limit-parked, or startup-unknown).
 		_ = inst.Transition(session.ClearOp())
+		m.adoptedSnapshotOps.forget(inst)
 		return true
 	}
 	return false
 }
 
-func adoptSnapshotOp(inst *session.Instance, op session.InFlightOp, lv session.Liveness) bool {
+func (m *home) adoptSnapshotOp(inst *session.Instance, op session.InFlightOp, lv session.Liveness) bool {
 	if inst.GetInFlightOp() == op {
+		// Already carrying it, but provenance may not be recorded yet — a row whose
+		// op the daemon reported before this build learned to track it, or one this
+		// reconcile adopted on an earlier pass. Record it either way: the guards ask
+		// about the CURRENT op, not about who set it first.
+		m.adoptedSnapshotOps.note(inst, op)
 		return false
 	}
 	if inst.GetInFlightOp() != session.OpNone {
@@ -798,6 +819,7 @@ func adoptSnapshotOp(inst *session.Instance, op session.InFlightOp, lv session.L
 		err = inst.Transition(session.BeginKill())
 	case session.OpArchiving:
 		if lv == session.LiveArchived {
+			m.adoptedSnapshotOps.note(inst, op)
 			return true
 		}
 		err = inst.Transition(session.BeginArchive())
@@ -812,6 +834,9 @@ func adoptSnapshotOp(inst *session.Instance, op session.InFlightOp, lv session.L
 		log.WarningLog.Printf("failed to adopt snapshot op %v for %q: %v", op, inst.Title, err)
 		return false
 	}
+	// The row now carries a DAEMON-owned op with no local completion handler
+	// waiting on it. Recorded here, at the only moment the fact is known (#3005).
+	m.adoptedSnapshotOps.note(inst, op)
 	return true
 }
 

--- a/app/sync.go
+++ b/app/sync.go
@@ -631,6 +631,11 @@ func (m *home) swapInstanceFromSnapshot(d session.InstanceData) bool {
 		log.WarningLog.Printf("failed to build recreated instance %q from snapshot: %v", d.Title, err)
 		return false
 	}
+	// The replacement can arrive already carrying a daemon-owned op, exactly like
+	// the other two snapshot builders. Recorded here so the NEW pointer starts with
+	// provenance — without it the successor inherits the original defect the moment
+	// its own identity changes (#3005).
+	m.adoptedOpsFor().note(inst, inst.GetInFlightOp())
 	// ReplaceInstance re-points any open panes at the rebuilt instance, but
 	// the recreated session's tab SET may differ from the corpse's — capture
 	// the outgoing slot→identity list so the shared pane reconcile can close

--- a/app/sync.go
+++ b/app/sync.go
@@ -804,7 +804,7 @@ func (m *home) adoptSnapshotOp(inst *session.Instance, op session.InFlightOp, lv
 		// op the daemon reported before this build learned to track it, or one this
 		// reconcile adopted on an earlier pass. Record it either way: the guards ask
 		// about the CURRENT op, not about who set it first.
-		m.adoptedSnapshotOps.note(inst, op)
+		m.adoptedOpsFor().note(inst, op)
 		return false
 	}
 	if inst.GetInFlightOp() != session.OpNone {
@@ -819,7 +819,7 @@ func (m *home) adoptSnapshotOp(inst *session.Instance, op session.InFlightOp, lv
 		err = inst.Transition(session.BeginKill())
 	case session.OpArchiving:
 		if lv == session.LiveArchived {
-			m.adoptedSnapshotOps.note(inst, op)
+			m.adoptedOpsFor().note(inst, op)
 			return true
 		}
 		err = inst.Transition(session.BeginArchive())
@@ -836,7 +836,7 @@ func (m *home) adoptSnapshotOp(inst *session.Instance, op session.InFlightOp, lv
 	}
 	// The row now carries a DAEMON-owned op with no local completion handler
 	// waiting on it. Recorded here, at the only moment the fact is known (#3005).
-	m.adoptedSnapshotOps.note(inst, op)
+	m.adoptedOpsFor().note(inst, op)
 	return true
 }
 


### PR DESCRIPTION
## The gap

Two reconcile guards refuse to touch a row that has any op in flight — the
same-title-different-session swap (`app/sync.go`) and the absent-from-snapshot removal. Both exist
for **local optimistic** ops, whose completion handler owns the identity transition by pointer
identity (#808/#844); racing it would orphan the handshake and leave two same-title rows.

`adoptSnapshotOp` then started mirroring **daemon-owned** ops onto the same field — `OpArchiving`,
`OpRestoring`, `OpReplacing`, `OpRespawning`. Those have no local completion handler. Their only
release is a later snapshot reporting `OpNone` for the **same identity**, so a session killed — or
killed and recreated under the same title — before that snapshot never produces one. Both guards
then refuse forever and the row outlives its session: a corpse on the rail, attached to nothing, not
removable, lifecycle controls suppressed, clearable only by restarting the TUI.

The guard was asking *"does something own this row's transition?"* and answering *"does this row
have an op?"*. Those coincided until snapshot adoption landed (#1436).

## Why provenance is recorded, not inferred

Option 1 from the issue. Inference by op **kind** does not work in either direction: the TUI locally
begins restores and archives, and the daemon projects `OpCreating` and `OpKilling` — no op value is
exclusively local or exclusively adopted. Option 2 (key the release on identity) closes the reported
case but leaves the guard still answering the wrong question, so the next op added to
`adoptSnapshotOp` reopens it.

This is the #2953 lesson applied: four attempts there tried to *observe* a fact from outside the
race instead of *recording* it where it was true. Adoption is an event — it is recorded at the one
moment it is known.

## The shape

`adoptedOps` is a `map[*session.Instance]session.InFlightOp` on the model, and the record is a
**(pointer, op) pair** rather than a flag. That is what makes it self-correcting: a local transition
that moves the row to a different op leaves the recorded value no longer matching, so the row reads
as locally owned again — without every local call site having to remember to clear anything.
Pointer-keyed so a same-title successor cannot inherit its predecessor's provenance, the same rule
the completion handlers use. Forgotten when the op is released, when the row is swapped, and when it
leaves the store, so the map cannot outlive the instances it describes.

Both guards now call `vetoesReconcile`, which is the question they always meant to ask.

## Verification

Five tests. The first is the reproduction — an adopted `OpReplacing` must not veto the reconcile,
which on master it does:

- an adopted daemon op does **not** veto;
- a local op **still** vetoes (this is why it is provenance and not just deleting the guard);
- a local transition supersedes a stale adoption record;
- a same-title successor does not inherit provenance;
- an op the row **already carries** is still recorded — otherwise a row adopted on an earlier pass
  stays permanently unrecorded and keeps vetoing, which is the original bug with extra steps.

The existing `TestReconcileSnapshotOp_AdoptsAndSettlesHandoffFence` is extended to assert provenance
is taken on adoption and released with the fence.

`app/` tests are left to CI per the host policy — they drive real tmux beside the maintainer's live
sessions. Verified compiling with `go vet ./app/`.

Gate on the pushed head `aacc5945`: `gofmt -l .` (empty), `go build ./...`,
`golangci-lint run --timeout=3m --fast`, `scripts/lint-file-length.sh`.

Closes #3005

🤖 Generated with [Claude Code](https://claude.com/claude-code)
