### PR TITLE
feat(hook): let a provisioning hook return an ssh host, not an endpoint (#2847 slice 1)

### DIFF
--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -287,7 +287,14 @@ func TestStartNewRemoteInvalidHooksStillErrors(t *testing.T) {
 	assert.Equal(t, stateDefault, h.state)
 	assert.Nil(t, h.namingInstance)
 	assert.Equal(t, 0, h.store.NumInstances())
+	// The fixture is still invalid under the #2847 contract — it sets neither
+	// provision_cmd nor launch_cmd — so the assertion that invalid hooks error
+	// stands unchanged. It is STRENGTHENED to require both keys be named: a repo
+	// on the ssh-host contract that is sent to fix launch_cmd would be edited in
+	// the wrong place, which is the failure an error message exists to prevent.
 	assert.Contains(t, h.errBox.FullError(), "remote_hooks.launch_cmd")
+	assert.Contains(t, h.errBox.FullError(), "remote_hooks.provision_cmd",
+		"an invalid hook config must name BOTH contracts, or a provision_cmd user is sent to the wrong key")
 }
 
 // TestCancelNamingRemovesZombieAfterSelectionDrift is the regression guard for

--- a/config/repo_config.go
+++ b/config/repo_config.go
@@ -30,6 +30,12 @@ type RemoteHooks struct {
 	// endpoint JSON (see the type doc). Invoked with --name/--repo/--branch and
 	// an optional --program flag (see docs/remote-hooks.md).
 	LaunchCmd string `json:"launch_cmd" toml:"launch_cmd"`
+	// ProvisionCmd is the ssh-host alternative to LaunchCmd (#2847): it makes a
+	// machine and prints {host, host_key, [user], [port]} — no agent-server, no
+	// bearer token, no tunnel. af reaches it with the sandbox transport and runs
+	// the workspace itself. Exactly one of provision_cmd / launch_cmd is set;
+	// Validate rejects both, since they answer the same question differently.
+	ProvisionCmd string `json:"provision_cmd,omitempty" toml:"provision_cmd,omitempty"`
 	// DeleteCmd reaps the provisioned sandbox. Invoked with --name <slug>.
 	DeleteCmd string `json:"delete_cmd" toml:"delete_cmd"`
 
@@ -71,13 +77,31 @@ func (h RemoteHooks) Validate() error {
 			"{\"url\",\"token\"}, and delete_cmd reaps it. "+
 			"Delete list_cmd/attach_cmd/terminal_cmd and follow the migration recipe in docs/remote-hooks.md", removed)
 	}
-	if strings.TrimSpace(h.LaunchCmd) == "" {
-		return fmt.Errorf("remote_hooks.launch_cmd is required")
+	launch := strings.TrimSpace(h.LaunchCmd) != ""
+	provision := strings.TrimSpace(h.ProvisionCmd) != ""
+	switch {
+	case launch && provision:
+		// Both answer "how does this session get a workspace", differently. Picking
+		// one silently would make the other's absence look like a config that
+		// works, so refuse and make the operator say which contract they are on.
+		return fmt.Errorf("remote_hooks sets both provision_cmd and launch_cmd; they are alternatives, not layers — " +
+			"provision_cmd returns an ssh host and af runs the agent-server itself, launch_cmd returns an " +
+			"{\"url\",\"token\"} endpoint the script stands up. Keep one (see docs/remote-hooks.md)")
+	case !launch && !provision:
+		return fmt.Errorf("remote_hooks requires provision_cmd (return an ssh host; af does the rest) " +
+			"or launch_cmd (return an {\"url\",\"token\"} endpoint you stood up yourself) — see docs/remote-hooks.md")
 	}
 	if strings.TrimSpace(h.DeleteCmd) == "" {
 		return fmt.Errorf("remote_hooks.delete_cmd is required")
 	}
 	return nil
+}
+
+// UsesProvisionCmd reports whether this repo is on the ssh-host contract (#2847)
+// rather than the endpoint contract. Validate guarantees exactly one is set, so
+// this is the discriminator the runtime switches on.
+func (h RemoteHooks) UsesProvisionCmd() bool {
+	return strings.TrimSpace(h.ProvisionCmd) != ""
 }
 
 // removedKeyInUse returns the name of the first removed pre-PR7 hook key present

--- a/config/repo_config.go
+++ b/config/repo_config.go
@@ -84,12 +84,17 @@ func (h RemoteHooks) Validate() error {
 		// Both answer "how does this session get a workspace", differently. Picking
 		// one silently would make the other's absence look like a config that
 		// works, so refuse and make the operator say which contract they are on.
-		return fmt.Errorf("remote_hooks sets both provision_cmd and launch_cmd; they are alternatives, not layers — " +
+		return fmt.Errorf("remote_hooks.provision_cmd and remote_hooks.launch_cmd are alternatives, not layers — " +
 			"provision_cmd returns an ssh host and af runs the agent-server itself, launch_cmd returns an " +
-			"{\"url\",\"token\"} endpoint the script stands up. Keep one (see docs/remote-hooks.md)")
+			"{\"url\",\"token\"} endpoint the script stands up. Set exactly one (see docs/remote-hooks.md)")
 	case !launch && !provision:
-		return fmt.Errorf("remote_hooks requires provision_cmd (return an ssh host; af does the rest) " +
-			"or launch_cmd (return an {\"url\",\"token\"} endpoint you stood up yourself) — see docs/remote-hooks.md")
+		// Dotted paths, matching the delete_cmd error below and every other config
+		// message: the key is what the reader has to go edit, so it must be
+		// greppable and unambiguous. Naming BOTH keys is the point — a message that
+		// named only launch_cmd would send a provision_cmd user to fix the wrong one.
+		return fmt.Errorf("remote_hooks.provision_cmd or remote_hooks.launch_cmd is required — " +
+			"provision_cmd returns an ssh host and af runs the agent-server itself; launch_cmd returns an " +
+			"{\"url\",\"token\"} endpoint you stood up yourself (see docs/remote-hooks.md)")
 	}
 	if strings.TrimSpace(h.DeleteCmd) == "" {
 		return fmt.Errorf("remote_hooks.delete_cmd is required")

--- a/config/repo_config.go
+++ b/config/repo_config.go
@@ -132,6 +132,7 @@ func (h RemoteHooks) removedKeyInUse() string {
 // mutated.
 func (h RemoteHooks) resolveCommandPaths(repoRoot string) *RemoteHooks {
 	h.LaunchCmd = resolveHookCommandPath(repoRoot, h.LaunchCmd)
+	h.ProvisionCmd = resolveHookCommandPath(repoRoot, h.ProvisionCmd)
 	h.DeleteCmd = resolveHookCommandPath(repoRoot, h.DeleteCmd)
 	return &h
 }
@@ -261,4 +262,11 @@ func SaveRepoConfig(repoID string, cfg *RepoConfig) error {
 		return fmt.Errorf("failed to marshal repo config: %w", err)
 	}
 	return AtomicWriteFile(path, data, 0644)
+}
+
+// ResolveCommandPathsForTest exposes resolveCommandPaths to tests in other
+// packages, which need to assert that every hook command — including
+// provision_cmd — is made absolute against the repo root before exec sees it.
+func (h RemoteHooks) ResolveCommandPathsForTest(repoRoot string) *RemoteHooks {
+	return h.resolveCommandPaths(repoRoot)
 }

--- a/config/repo_config_test.go
+++ b/config/repo_config_test.go
@@ -272,15 +272,17 @@ func TestRemoteHooksValidate(t *testing.T) {
 		// an error when there is no provision_cmd either — and the message has to
 		// name both, or it sends a provision_cmd user to fix the wrong key.
 		{"neither command", func(h *RemoteHooks) { h.LaunchCmd = "" },
-			"remote_hooks requires provision_cmd (return an ssh host; af does the rest) or launch_cmd " +
-				"(return an {\"url\",\"token\"} endpoint you stood up yourself) — see docs/remote-hooks.md"},
+			"remote_hooks.provision_cmd or remote_hooks.launch_cmd is required — provision_cmd returns an " +
+				"ssh host and af runs the agent-server itself; launch_cmd returns an {\"url\",\"token\"} " +
+				"endpoint you stood up yourself (see docs/remote-hooks.md)"},
 		{"whitespace launch_cmd is still neither", func(h *RemoteHooks) { h.LaunchCmd = "   " },
-			"remote_hooks requires provision_cmd (return an ssh host; af does the rest) or launch_cmd " +
-				"(return an {\"url\",\"token\"} endpoint you stood up yourself) — see docs/remote-hooks.md"},
+			"remote_hooks.provision_cmd or remote_hooks.launch_cmd is required — provision_cmd returns an " +
+				"ssh host and af runs the agent-server itself; launch_cmd returns an {\"url\",\"token\"} " +
+				"endpoint you stood up yourself (see docs/remote-hooks.md)"},
 		{"both contracts at once", func(h *RemoteHooks) { h.ProvisionCmd = "./provision.sh" },
-			"remote_hooks sets both provision_cmd and launch_cmd; they are alternatives, not layers — " +
+			"remote_hooks.provision_cmd and remote_hooks.launch_cmd are alternatives, not layers — " +
 				"provision_cmd returns an ssh host and af runs the agent-server itself, launch_cmd returns an " +
-				"{\"url\",\"token\"} endpoint the script stands up. Keep one (see docs/remote-hooks.md)"},
+				"{\"url\",\"token\"} endpoint the script stands up. Set exactly one (see docs/remote-hooks.md)"},
 		{"empty delete_cmd", func(h *RemoteHooks) { h.DeleteCmd = "" }, "remote_hooks.delete_cmd is required"},
 		{"whitespace delete_cmd", func(h *RemoteHooks) { h.DeleteCmd = "   " }, "remote_hooks.delete_cmd is required"},
 	}

--- a/config/repo_config_test.go
+++ b/config/repo_config_test.go
@@ -255,13 +255,32 @@ func TestRemoteHooksValidate(t *testing.T) {
 		assert.NoError(t, full().Validate())
 	})
 
+	t.Run("provision_cmd alone is a complete config", func(t *testing.T) {
+		h := full()
+		h.LaunchCmd = ""
+		h.ProvisionCmd = "./.agent-factory/hooks/provision.sh"
+		assert.NoError(t, h.Validate(), "the ssh-host contract needs no launch_cmd (#2847)")
+		assert.True(t, h.UsesProvisionCmd())
+	})
+
 	cases := []struct {
 		name    string
 		mutate  func(*RemoteHooks)
 		wantMsg string
 	}{
-		{"empty launch_cmd", func(h *RemoteHooks) { h.LaunchCmd = "" }, "remote_hooks.launch_cmd is required"},
-		{"whitespace launch_cmd", func(h *RemoteHooks) { h.LaunchCmd = "   " }, "remote_hooks.launch_cmd is required"},
+		// Since #2847 a repo may be on EITHER contract, so "no launch_cmd" is only
+		// an error when there is no provision_cmd either — and the message has to
+		// name both, or it sends a provision_cmd user to fix the wrong key.
+		{"neither command", func(h *RemoteHooks) { h.LaunchCmd = "" },
+			"remote_hooks requires provision_cmd (return an ssh host; af does the rest) or launch_cmd " +
+				"(return an {\"url\",\"token\"} endpoint you stood up yourself) — see docs/remote-hooks.md"},
+		{"whitespace launch_cmd is still neither", func(h *RemoteHooks) { h.LaunchCmd = "   " },
+			"remote_hooks requires provision_cmd (return an ssh host; af does the rest) or launch_cmd " +
+				"(return an {\"url\",\"token\"} endpoint you stood up yourself) — see docs/remote-hooks.md"},
+		{"both contracts at once", func(h *RemoteHooks) { h.ProvisionCmd = "./provision.sh" },
+			"remote_hooks sets both provision_cmd and launch_cmd; they are alternatives, not layers — " +
+				"provision_cmd returns an ssh host and af runs the agent-server itself, launch_cmd returns an " +
+				"{\"url\",\"token\"} endpoint the script stands up. Keep one (see docs/remote-hooks.md)"},
 		{"empty delete_cmd", func(h *RemoteHooks) { h.DeleteCmd = "" }, "remote_hooks.delete_cmd is required"},
 		{"whitespace delete_cmd", func(h *RemoteHooks) { h.DeleteCmd = "   " }, "remote_hooks.delete_cmd is required"},
 	}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,21 @@
 # Release Notes
 
+## A remote hook can return an ssh host instead of an endpoint
+
+- **New `remote_hooks.provision_cmd`.** Your script makes a machine and prints
+  `{"host","host_key"}`; af reaches it over the operator's own ssh and runs the
+  `af agent-server` itself. The bearer token never enters your script, there is
+  no tunnel to keep alive, and no agent-server lifecycle to manage — the three
+  jobs that produced most of this backend's sharp edges.
+- **`host_key` is required, and that is the point.** A machine created seconds
+  ago has no `known_hosts` entry, and no existing host-key posture can help
+  without either refusing the launch or trusting the first key it sees. Your
+  script is the only party with an authentic channel to the key, so it returns
+  it and af pins it per session. There is deliberately no opt-out.
+- **`launch_cmd` is unchanged and not deprecated** — it remains the escape hatch
+  for targets with no sshd. A repo sets one or the other; setting both is
+  rejected rather than silently resolved.
+
 ## One session's terminal history no longer shows up in another session's editor
 
 - **A confidentiality fix.** code-server is VS Code *Web*, and it keeps its integrated

--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -76,7 +76,7 @@ delete_cmd = "./.agent-factory/hooks/delete.sh"
 
 (The in-repo file may also be named `config.json` for compatibility with older `af` versions — see [configuration.md](configuration.md#in-repo-file-name-configtoml-or-configjson). The JSON block further down this page is `launch_cmd` **output**, not config.)
 
-`launch_cmd` and `delete_cmd` are both **required** — an empty value is rejected when the backend is resolved, with an error naming the missing field (e.g. `remote_hooks.launch_cmd is required`) rather than a cryptic `exec: no command` at operation time.
+`delete_cmd` is **required**, and so is exactly one of `provision_cmd` / `launch_cmd`. An empty or missing value is rejected when the backend is resolved, with an error naming the missing field (e.g. `remote_hooks.provision_cmd or remote_hooks.launch_cmd is required`, `remote_hooks.delete_cmd is required`) rather than a cryptic `exec: no command` at operation time. Setting **both** provisioning keys is rejected too — they are alternatives, not layers.
 
 `remote_hooks` is an in-repo-only setting — it describes the repository, so it is not accepted in the global `~/.agent-factory/config.toml`. Configuring `backend = "hook"` selects the backend for that repo; you can also create a one-off hook session with `af sessions create --backend hook` or, in the TUI, press `N` for a remote session.
 

--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -10,6 +10,57 @@ Since **#1592 Phase 4 PR7** the hook backend follows the same **provision-and-ex
 
 > **⚠️ Breaking change (#1592 Phase 4 PR7).** The old hook contract — `launch_cmd` returning a session id, plus `list_cmd`/`attach_cmd`/`terminal_cmd` scripts for enumeration, terminal proxying, and preview capture — has been **removed**. `launch_cmd` now returns an `af agent-server` endpoint, and the only other script is `delete_cmd`. A config that still sets `list_cmd`, `attach_cmd`, or `terminal_cmd` is **rejected** with an error pointing here. See [Migrating from the old contract](#migrating-from-the-old-contract) for a copy-pasteable recipe.
 
+## Two contracts: `provision_cmd` or `launch_cmd`
+
+A remote-hook repo picks **one** of these. They answer the same question — how does this session get a workspace — in opposite ways, and setting both is rejected rather than resolved by preference.
+
+| | `provision_cmd` (#2847) | `launch_cmd` |
+|---|---|---|
+| Your script returns | an **ssh host** + its host key | an `af agent-server` **endpoint** (`{url,token}`) |
+| Who starts `af agent-server` | **af** | your script |
+| Who owns the bearer token | **af** — it never enters your script | your script: argv, stdout, logs, errors |
+| Who keeps a tunnel alive | **af** | your script |
+| Needs sshd on the target | yes | no |
+
+**Prefer `provision_cmd`.** Your script collapses to *make a machine, print how to reach it*, and the parts that have historically gone wrong stop being your problem: no token to leak, no tunnel to background, no agent-server lifecycle. Because a host address and a host **public** key are not secrets, nothing on this path needs redacting.
+
+**`launch_cmd` remains the escape hatch**, and is not deprecated. Some targets have no sshd — certain Kubernetes pods, serverless runners, WebSocket-only PaaS — and returning a URL is the only option there.
+
+### `provision_cmd`
+
+Same arguments as `launch_cmd` (`--name`, `--title`, `--repo`, and `--branch` on restore). **stdout carries one JSON object and nothing else:**
+
+```json
+{"host": "10.0.0.7", "user": "af", "port": 2222, "host_key": "ssh-ed25519 AAAAC3Nz…"}
+```
+
+- `host` (**required**) — the address af connects to. May carry the port as `host:port` instead of using `port`.
+- `host_key` (**required**) — the machine's **public** host key, in `authorized_keys` form.
+- `user`, `port` — optional.
+
+Progress goes on **stderr**; anything else on stdout fails the provision with the offending line quoted, exactly as for `launch_cmd`.
+
+#### Why `host_key` is required
+
+A machine created seconds ago has no `known_hosts` entry, and the resulting prompt is precisely what an unattended provision cannot answer. None of af's host-key postures solves it: `strict` refuses an unknown host, `accept-new` is trust-on-first-use where **every** session is a first contact (and its store later refuses a legitimate VM once an address is recycled), and `insecure` invites the man-in-the-middle who would then see the bearer token.
+
+Your script is the only party with an **authentic** channel to that key — it is talking to the provider's control plane, which af cannot reach. So it returns the key, and af writes a **per-session** `known_hosts` containing exactly it, then connects with `StrictHostKeyChecking=yes` and `GlobalKnownHostsFile=/dev/null`. That is a real verification rather than trust on sight, and it is stronger than what `backend = "ssh"` can do.
+
+Two ways to get the key, both ordinary practice:
+
+```bash
+# read it back from the provider
+aws ec2 get-console-output --instance-id "$ID" | sed -n 's/^ssh-ed25519 /ssh-ed25519 /p' | head -1
+
+# or inject one you generated, before first boot (strictly better: nothing is
+# ever trusted on sight)
+ssh-keygen -q -t ed25519 -N "" -f hostkey
+# …pass hostkey to cloud-init as /etc/ssh/ssh_host_ed25519_key…
+printf '{"host":"%s","user":"af","host_key":"%s"}\n' "$IP" "$(cat hostkey.pub)"
+```
+
+There is **no opt-out**. A record without a key is refused, because an escape hatch here would restore exactly the trust-on-sight this design removes.
+
 ## Configuration
 
 Add remote hooks to the repo's own config file at `<repo-root>/.agent-factory/config.toml` (check it into the repo so every clone gets the same backend), and select the backend:
@@ -18,7 +69,8 @@ Add remote hooks to the repo's own config file at `<repo-root>/.agent-factory/co
 backend = "hook"
 
 [remote_hooks]
-launch_cmd = "./.agent-factory/hooks/launch.sh"
+# One of provision_cmd (preferred) or launch_cmd — see above.
+provision_cmd = "./.agent-factory/hooks/provision.sh"
 delete_cmd = "./.agent-factory/hooks/delete.sh"
 ```
 

--- a/doctor/remote.go
+++ b/doctor/remote.go
@@ -87,6 +87,7 @@ func checkRemoteSetup(ctx *scanContext, report *Report) {
 	type hook struct{ field, cmd string }
 	for _, h := range []hook{
 		{"launch_cmd", hooks.LaunchCmd},
+		{"provision_cmd", hooks.ProvisionCmd},
 		{"delete_cmd", hooks.DeleteCmd},
 	} {
 		if strings.TrimSpace(h.cmd) == "" {
@@ -156,6 +157,7 @@ func remoteHooksMentionCoder(hooks *config.RemoteHooks) bool {
 	}
 	for _, command := range []string{
 		hooks.LaunchCmd,
+		hooks.ProvisionCmd,
 		hooks.DeleteCmd,
 	} {
 		if strings.Contains(strings.ToLower(command), "coder") {

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -111,6 +111,12 @@ func (hookRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 		slug:    Slugify(spec.Title),
 		program: config.ResolveProgram(&resolved.Config, spec.Program),
 	}
+	if hooks.UsesProvisionCmd() {
+		// The ssh-host contract (#2847): the script makes a machine and says how
+		// to reach it; af runs the agent-server itself over the sandbox transport.
+		// Teardown is still delete_cmd, so the reap path below is shared verbatim.
+		return p.provisionHostOrReap()
+	}
 	return p.provisionOrReap()
 }
 

--- a/session/backend_hook_provision.go
+++ b/session/backend_hook_provision.go
@@ -154,6 +154,10 @@ func hookProvisionSSHCommand(knownHostsPath string, record *hookProvisionRecord)
 		"ssh",
 		"-o", "UserKnownHostsFile=" + shellQuoteSandbox(knownHostsPath),
 		"-o", "GlobalKnownHostsFile=/dev/null",
+		// ssh_config(5) consults KnownHostsCommand IN ADDITION to both files, so an
+		// operator's matching Host block could hand OpenSSH a different key and
+		// satisfy verification without our pin ever deciding anything.
+		"-o", "KnownHostsCommand=none",
 		"-o", "StrictHostKeyChecking=yes",
 		// The script vouches for the key, so there is nobody to ask. Refuse
 		// rather than hang forever on a prompt no unattended provision can answer.
@@ -205,6 +209,13 @@ func (p *hookProvisioner) provisionHostOrReap() (ProvisionResult, error) {
 }
 
 func (p *hookProvisioner) provisionHost() (ProvisionResult, error) {
+	// Refuse BEFORE running the script. GitHub is the durable store, so a repo
+	// with no origin cannot be cloned onto the sandbox — and running provision_cmd
+	// first would create a billable machine to serve a clone guaranteed to fail.
+	// The sandbox runtime rejects this up front for the same reason.
+	if p.spec.CloneURL == "" {
+		return ProvisionResult{}, missingOriginError(BackendHook, p.spec.RepoRoot)
+	}
 	record, err := p.runProvisionCmd()
 	if err != nil {
 		return ProvisionResult{}, err
@@ -238,7 +249,11 @@ func (p *hookProvisioner) provisionHost() (ProvisionResult, error) {
 	}
 	res, err := sp.provision()
 	if err != nil {
-		return ProvisionResult{}, err
+		// sp owns LOCAL state the hook cleanup cannot touch: a tunnel child whose
+		// ssh/ProxyCommand may be alive without ever opening the forward. delete_cmd
+		// destroys the machine but not that process group, so reap it here exactly
+		// as sandboxRuntime.Provision does.
+		return ProvisionResult{}, sp.reapProvisionFailure(err)
 	}
 	// delete_cmd owns the MACHINE, so the session's teardown reaps the workspace
 	// first and then destroys the host.
@@ -256,11 +271,16 @@ func (p *hookProvisioner) provisionHost() (ProvisionResult, error) {
 			sandboxErr = sandboxTeardown()
 		}
 		hookErr := p.reap()
-		_ = os.RemoveAll(dir)
 		if hookErr == nil {
-			// The machine is gone; nothing about the workspace can still be unknown.
+			// The machine is gone: nothing about the workspace can still be unknown,
+			// and the pin has nothing left to verify. Both are safe to drop.
+			_ = os.RemoveAll(dir)
 			return nil
 		}
+		// Cleanup is still retryable, so the pin MUST survive: it is embedded in the
+		// sandbox ssh command, and deleting it would make every later reap fail
+		// host-key verification before it could reach the machine — a retained row
+		// that can never recover.
 		return errors.Join(sandboxErr, hookErr)
 	}
 	res.Teardown = teardown

--- a/session/backend_hook_provision.go
+++ b/session/backend_hook_provision.go
@@ -1,0 +1,311 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// The provisioning-hook contract (#2847): a hook that returns an ssh HOST, not
+// an endpoint.
+//
+// WHY THIS EXISTS. `launch_cmd` makes the script own TRANSPORT as the price of
+// owning provisioning: it must start an `af agent-server`, capture its bearer
+// token, keep a tunnel alive, and echo a URL. Nearly every wound in this area
+// came from that second job — #2845's undecidable stdout, and the whole token
+// redaction series (#2684, #2687, #2690, #2748, #2771), which exists only
+// because a SECRET travels through a script's stdout, argv, logs and errors.
+//
+// `provision_cmd` splits the two. The script makes a machine and says how to
+// reach it; af does the rest with the sandbox transport (#2476 PR2). What that
+// deletes, rather than mitigates:
+//
+//   - No bearer token ever enters a script. A host address and a host PUBLIC key
+//     are not secrets, so redaction stops being load-bearing on this path.
+//   - No tunnel to background, so the reap-the-launch-tree machinery is not
+//     load-bearing either.
+//   - No `af agent-server` lifecycle in user code — af already clones, streams
+//     its own binary, starts the server and reads the banner.
+//
+// `launch_cmd` REMAINS the escape hatch. Some targets have no sshd (certain k8s
+// pods, serverless runners, WebSocket-only PaaS) and returning a URL is their
+// only option. This is a safe default plus an override, not a replacement.
+
+// hookProvisionRecord is the single JSON object provision_cmd prints on stdout.
+//
+// Like the endpoint record it replaces, stdout carries this and NOTHING else —
+// the #2862 contract, adopted here from the first line rather than retrofitted,
+// so "is this the record?" is a parse and never a guess.
+type hookProvisionRecord struct {
+	// Host is the address af connects to. Required.
+	Host string `json:"host"`
+	// User is the ssh login. Optional — empty defers to the ssh binary's own
+	// resolution, which for this transport means the operator's ~/.ssh/config.
+	User string `json:"user,omitempty"`
+	// Port is the ssh port. Optional — 0 means ssh's default.
+	Port int `json:"port,omitempty"`
+	// HostKey is the sandbox's PUBLIC host key in authorized_keys form
+	// ("ssh-ed25519 AAAA…"). REQUIRED, and the heart of the contract — see
+	// hookProvisionKnownHosts.
+	HostKey string `json:"host_key"`
+}
+
+// parseHookProvisionRecord reads provision_cmd's stdout, which by contract holds
+// one JSON object and nothing else.
+//
+// Deliberately the same discipline as parseHookEndpoint: decode exactly one
+// value, refuse anything with content on either side of it. #2845 proved that a
+// stdout shared with a tunnel makes "which of these is the record?" undecidable;
+// this contract is new, so it starts where that one had to be dragged.
+func parseHookProvisionRecord(stdout string) (*hookProvisionRecord, bool, *hookStdoutViolation) {
+	open := 0
+	for open < len(stdout) && isJSONSpace(stdout[open]) {
+		open++
+	}
+	if open >= len(stdout) {
+		return nil, false, nil
+	}
+	decoder := json.NewDecoder(strings.NewReader(stdout[open:]))
+	var raw json.RawMessage
+	if err := decoder.Decode(&raw); err != nil {
+		return nil, false, &hookStdoutViolation{offending: stdout[open:]}
+	}
+	valueEnd := open + int(decoder.InputOffset())
+	tail := valueEnd
+	for tail < len(stdout) && isJSONSpace(stdout[tail]) {
+		tail++
+	}
+	if tail < len(stdout) {
+		return nil, true, &hookStdoutViolation{offending: stdout[tail:]}
+	}
+
+	var record hookProvisionRecord
+	decodeStrict := json.NewDecoder(strings.NewReader(string(raw)))
+	decodeStrict.DisallowUnknownFields()
+	if err := decodeStrict.Decode(&record); err != nil {
+		return nil, true, nil
+	}
+	if strings.TrimSpace(record.Host) == "" || strings.TrimSpace(record.HostKey) == "" {
+		return nil, true, nil
+	}
+	return &record, true, nil
+}
+
+// hookProvisionKnownHosts writes a known_hosts file holding EXACTLY the one key
+// this session's sandbox presented, and returns its path.
+//
+// This is the answer to the problem that blocked the whole idea: a VM created
+// seconds ago has no known_hosts entry, and the resulting prompt is precisely
+// what an unattended provision cannot answer. None of af's three postures works
+// for it — `strict` refuses an unknown host outright; `accept-new` is
+// trust-on-first-use where EVERY session is a first contact, so its one-time
+// window is open every time, and its append-only store later REFUSES a
+// legitimate VM once a name or IP is recycled; `insecure` is a standing
+// invitation to a man-in-the-middle that would see the bearer token.
+//
+// The way out is that the provisioning script is the only party with an
+// AUTHENTIC channel to the key — it is talking to the provider's control plane,
+// which af cannot reach. It either reads the key back (AWS console output, GCP
+// guest attributes) or, better, injects one it generated via cloud-init before
+// first boot. So the script returns it, af pins it for this session only, and
+// `StrictHostKeyChecking=yes` against a file containing exactly that key is a
+// VERIFICATION rather than a trust-on-first-use.
+//
+// Fails closed: a record with no key never reaches here, because the parse
+// rejects it.
+func hookProvisionKnownHosts(dir, host string, port int, hostKey string) (string, error) {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("cannot create the per-session host-key directory %q: %w", dir, err)
+	}
+	path := filepath.Join(dir, "known_hosts")
+	// A non-default port is part of the known_hosts identity, and OpenSSH spells
+	// it "[host]:port". Getting this wrong makes verification fail with a message
+	// about an unknown host rather than about the port.
+	entryHost := host
+	if port != 0 && port != 22 {
+		entryHost = "[" + host + "]:" + strconv.Itoa(port)
+	}
+	line := entryHost + " " + strings.TrimSpace(hostKey) + "\n"
+	if err := os.WriteFile(path, []byte(line), 0o600); err != nil {
+		return "", fmt.Errorf("cannot write the per-session known_hosts %q: %w", path, err)
+	}
+	return path, nil
+}
+
+// hookProvisionSSHCommand composes the ssh invocation for a provisioned host.
+//
+// It pins verification to the per-session file and turns strict checking ON.
+// That combination is what makes this safe on a host with no prior history:
+// there is exactly one acceptable key, af put it there, and the script vouched
+// for it out of band.
+//
+// GlobalKnownHostsFile=/dev/null is not belt-and-braces — without it OpenSSH
+// still consults /etc/ssh/ssh_known_hosts, so a system-wide entry for a recycled
+// address could satisfy the check instead of the key we actually pinned.
+func hookProvisionSSHCommand(knownHostsPath string, record *hookProvisionRecord) string {
+	parts := []string{
+		"ssh",
+		"-o", "UserKnownHostsFile=" + shellQuoteSandbox(knownHostsPath),
+		"-o", "GlobalKnownHostsFile=/dev/null",
+		"-o", "StrictHostKeyChecking=yes",
+		// The script vouches for the key, so there is nobody to ask. Refuse
+		// rather than hang forever on a prompt no unattended provision can answer.
+		"-o", "BatchMode=yes",
+	}
+	if record.Port != 0 {
+		parts = append(parts, "-p", strconv.Itoa(record.Port))
+	}
+	target := record.Host
+	if user := strings.TrimSpace(record.User); user != "" {
+		target = user + "@" + target
+	}
+	parts = append(parts, shellQuoteSandbox(target))
+	return strings.Join(parts, " ")
+}
+
+// hookProvisionHostPort splits a "host:port" Host value so a record may spell the
+// port either way. An address with no port is returned unchanged.
+func hookProvisionHostPort(record *hookProvisionRecord) (string, int) {
+	host := strings.TrimSpace(record.Host)
+	if record.Port != 0 {
+		return host, record.Port
+	}
+	if h, p, err := net.SplitHostPort(host); err == nil {
+		if port, convErr := strconv.Atoi(p); convErr == nil {
+			return h, port
+		}
+	}
+	return host, 0
+}
+
+// provisionHostOrReap runs the ssh-host contract end to end, reaping via
+// delete_cmd on any failure exactly as the endpoint contract does.
+//
+// The reap gate is deliberately the SAME one #1955 established for launch_cmd:
+// once provision_cmd has STARTED, a sandbox may exist, and "it failed" is not
+// evidence that nothing was created.
+func (p *hookProvisioner) provisionHostOrReap() (ProvisionResult, error) {
+	p.resolveAuthSelectors()
+	res, err := p.provisionHost()
+	if err == nil {
+		return res, nil
+	}
+	p.quiesceLaunchGroup()
+	if reapErr := p.reap(); reapErr != nil {
+		return ProvisionResult{}, fmt.Errorf("%w\n\n%s", errors.Join(err, reapErr), p.orphanWarning(reapErr))
+	}
+	return ProvisionResult{}, err
+}
+
+func (p *hookProvisioner) provisionHost() (ProvisionResult, error) {
+	record, err := p.runProvisionCmd()
+	if err != nil {
+		return ProvisionResult{}, err
+	}
+
+	host, port := hookProvisionHostPort(record)
+	dir, err := hookProvisionSessionDir(p.slug)
+	if err != nil {
+		return ProvisionResult{}, fmt.Errorf("backend=hook: %w", err)
+	}
+	knownHosts, err := hookProvisionKnownHosts(dir, host, port, record.HostKey)
+	if err != nil {
+		return ProvisionResult{}, fmt.Errorf("backend=hook: %w", err)
+	}
+	pinned := *record
+	pinned.Host, pinned.Port = host, port
+
+	afBin, err := sshSelfBinary()
+	if err != nil {
+		return ProvisionResult{}, fmt.Errorf("backend=hook: cannot locate the af binary to stream onto the sandbox: %w", err)
+	}
+	// Everything below the transport is the sandbox runtime's, unchanged: mktemp,
+	// clone, stream `af`, start the agent-server, read its banner, tunnel, and an
+	// identity-checked reap. That reuse is the whole point of splitting
+	// provisioning from transport.
+	sp := &sandboxProvisioner{
+		spec:    p.spec,
+		sshCmd:  hookProvisionSSHCommand(knownHosts, &pinned),
+		afBin:   afBin,
+		program: p.program,
+	}
+	res, err := sp.provision()
+	if err != nil {
+		return ProvisionResult{}, err
+	}
+	// delete_cmd owns the machine's life, so the session's teardown must reap the
+	// SANDBOX WORKSPACE first and then the machine. Chaining them keeps a single
+	// Teardown while neither step can be skipped.
+	sandboxTeardown := res.Teardown
+	teardown := func() error {
+		var sandboxErr error
+		if sandboxTeardown != nil {
+			sandboxErr = sandboxTeardown()
+		}
+		hookErr := p.reap()
+		_ = os.RemoveAll(dir)
+		return errors.Join(sandboxErr, hookErr)
+	}
+	res.Teardown = teardown
+	if b, ok := res.Backend.(*sandboxBackend); ok {
+		b.remoteAgentBackend.reap = teardown
+	}
+	return res, nil
+}
+
+// runProvisionCmd invokes provision_cmd with the same flags launch_cmd receives
+// and parses its one-record stdout.
+func (p *hookProvisioner) runProvisionCmd() (*hookProvisionRecord, error) {
+	args := []string{"--name", p.slug, "--title", p.spec.Title, "--repo", p.spec.CloneURL}
+	if branch := strings.TrimSpace(p.spec.RestoreBranch); branch != "" {
+		args = append(args, "--branch", branch)
+	}
+	out, cmd, err := runHookScriptWithResolvedEnvironment(hookLaunchTimeout, p.hooks.ProvisionCmd,
+		p.environmentAgent(), p.authSelectors, p.spec.SessionEnvPassthrough, args...)
+	p.launchStarted = cmd != nil && cmd.Process != nil
+	p.launchPgid = 0
+	if p.launchStarted {
+		p.launchPgid = cmd.Process.Pid
+	}
+	if err != nil {
+		return nil, fmt.Errorf("provision_cmd failed (%s): %w%s", p.hooks.ProvisionCmd, err, hookOutputSuffix(out.Combined()))
+	}
+
+	record, sawJSON, violation := parseHookProvisionRecord(string(out.Stdout))
+	if record != nil {
+		return record, nil
+	}
+	if violation != nil {
+		return nil, fmt.Errorf("provision_cmd (%s) printed something other than its host record on stdout: %s\n"+
+			"stdout carries the {\"host\",\"host_key\"} JSON and nothing else. Redirect every other writer off it — "+
+			"send progress to stderr — see docs/remote-hooks.md%s",
+			p.hooks.ProvisionCmd, hookStdoutExcerpt(violation.offending), hookOutputSuffix(out.Combined()))
+	}
+	if !sawJSON {
+		return nil, fmt.Errorf("provision_cmd (%s) exited 0 but printed no host record on stdout "+
+			"(see docs/remote-hooks.md for the recipe)%s", p.hooks.ProvisionCmd, hookOutputSuffix(out.Combined()))
+	}
+	return nil, fmt.Errorf("provision_cmd (%s) exited 0 and printed JSON on stdout, but it is not a host record; "+
+		"it must be {\"host\":\"…\",\"host_key\":\"ssh-… AAAA…\"} with both non-empty (optional \"user\", \"port\"). "+
+		"host_key is REQUIRED: af pins it for this session so a machine created seconds ago can be VERIFIED rather "+
+		"than trusted on sight — read it from your provider's console output or guest attributes, or inject one via "+
+		"cloud-init before first boot%s", p.hooks.ProvisionCmd, hookOutputSuffix(out.Combined()))
+}
+
+// hookProvisionSessionDir is where this session's pinned known_hosts lives: under
+// the af home, never the repo, since it is machine state rather than project
+// state.
+func hookProvisionSessionDir(slug string) (string, error) {
+	base, err := config.GetConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve the af home for the per-session host-key store: %w", err)
+	}
+	return filepath.Join(base, "hook-hosts", slug), nil
+}

--- a/session/backend_hook_provision.go
+++ b/session/backend_hook_provision.go
@@ -240,9 +240,15 @@ func (p *hookProvisioner) provisionHost() (ProvisionResult, error) {
 	if err != nil {
 		return ProvisionResult{}, err
 	}
-	// delete_cmd owns the machine's life, so the session's teardown must reap the
-	// SANDBOX WORKSPACE first and then the machine. Chaining them keeps a single
-	// Teardown while neither step can be skipped.
+	// delete_cmd owns the MACHINE, so the session's teardown reaps the workspace
+	// first and then destroys the host.
+	//
+	// A successful delete_cmd is CONCLUSIVE and outranks an unknown workspace
+	// reap. The workspace lives on a machine that no longer exists, so preserving
+	// ErrWorkspaceStateUnknown there would retain a row whose later reaps can only
+	// fail against a deleted host while the latched hook reap returns nil —
+	// leaving the session stuck in cleanup forever. Only a delete_cmd that did NOT
+	// confirm can leave the outcome unknown.
 	sandboxTeardown := res.Teardown
 	teardown := func() error {
 		var sandboxErr error
@@ -251,21 +257,52 @@ func (p *hookProvisioner) provisionHost() (ProvisionResult, error) {
 		}
 		hookErr := p.reap()
 		_ = os.RemoveAll(dir)
+		if hookErr == nil {
+			// The machine is gone; nothing about the workspace can still be unknown.
+			return nil
+		}
 		return errors.Join(sandboxErr, hookErr)
 	}
 	res.Teardown = teardown
-	if b, ok := res.Backend.(*sandboxBackend); ok {
-		b.remoteAgentBackend.reap = teardown
-	}
+	res.Backend = p.provisionedBackend(teardown)
 	return res, nil
+}
+
+// provisionedBackend builds the Backend a provision_cmd session is recorded as.
+//
+// Its IDENTITY is the HOOK's, not the sandbox's, and that is the whole point.
+// Recording it as `sandbox` would persist only SandboxRuntimeCleanupData, so
+// archive/restore would route to sandboxRuntime and demand the unrelated global
+// `sandbox_ssh` instead of re-running provision_cmd — and a kill tombstone
+// restored after a daemon crash would carry no delete_cmd, leaking the machine
+// this hook provisioned.
+//
+// Split out so a test drives the real constructor rather than a restatement of
+// it: asserting on a hand-built HookBackend would pass even if provisionHost
+// returned the sandbox one.
+func (p *hookProvisioner) provisionedBackend(teardown func() error) Backend {
+	return &HookBackend{
+		remoteAgentBackend: remoteAgentBackend{reap: teardown},
+		provisioner:        p,
+		cleanup:            p.cleanupData(),
+	}
 }
 
 // runProvisionCmd invokes provision_cmd with the same flags launch_cmd receives
 // and parses its one-record stdout.
 func (p *hookProvisioner) runProvisionCmd() (*hookProvisionRecord, error) {
+	// The SAME flags launch_cmd receives, because the contract says so — a
+	// provisioner that sizes a machine from --program, or delivers approved values
+	// named by --session-env, gets incomplete metadata otherwise.
 	args := []string{"--name", p.slug, "--title", p.spec.Title, "--repo", p.spec.CloneURL}
 	if branch := strings.TrimSpace(p.spec.RestoreBranch); branch != "" {
 		args = append(args, "--branch", branch)
+	}
+	if prog := strings.TrimSpace(p.environmentProgram()); prog != "" {
+		args = append(args, "--program", prog, "--program-resolved")
+	}
+	for _, name := range p.spec.SessionEnvPassthrough {
+		args = append(args, "--session-env", name)
 	}
 	out, cmd, err := runHookScriptWithResolvedEnvironment(hookLaunchTimeout, p.hooks.ProvisionCmd,
 		p.environmentAgent(), p.authSelectors, p.spec.SessionEnvPassthrough, args...)
@@ -277,6 +314,13 @@ func (p *hookProvisioner) runProvisionCmd() (*hookProvisionRecord, error) {
 	if err != nil {
 		return nil, fmt.Errorf("provision_cmd failed (%s): %w%s", p.hooks.ProvisionCmd, err, hookOutputSuffix(out.Combined()))
 	}
+	// provision_cmd has EXITED successfully. Everything after this — cloning,
+	// streaming the binary, starting the server — can take minutes, and a pgid the
+	// kernel has reclaimed may be reissued to an unrelated process in that window.
+	// So the group id is spent here: a later failure must never SIGKILL a group
+	// this script no longer owns. (A failure of provision_cmd ITSELF still
+	// quiesces, because the id is still live at that point.)
+	p.launchPgid = 0
 
 	record, sawJSON, violation := parseHookProvisionRecord(string(out.Stdout))
 	if record != nil {

--- a/session/backend_hook_provision_test.go
+++ b/session/backend_hook_provision_test.go
@@ -105,6 +105,9 @@ func TestHookProvisionSSHCommandPinsVerification(t *testing.T) {
 	assert.Contains(t, cmd, "GlobalKnownHostsFile=/dev/null",
 		"or a system-wide entry for a recycled address could satisfy the check instead of our key")
 	assert.Contains(t, cmd, "BatchMode=yes", "an unattended provision must fail rather than hang on a prompt")
+	assert.Contains(t, cmd, "KnownHostsCommand=none",
+		"ssh_config KnownHostsCommand is consulted IN ADDITION to both files, so an operator's Host block "+
+			"could otherwise supply a key and satisfy verification without our pin deciding anything")
 	assert.Contains(t, cmd, "-p 2222")
 	assert.Contains(t, cmd, "'af@10.0.0.7'")
 }
@@ -179,4 +182,27 @@ func TestProvisionedSessionKeepsTheHookBackendIdentity(t *testing.T) {
 	require.NotNil(t, data.Hook, "the tombstone must carry delete_cmd, or the machine leaks after a crash")
 	assert.Equal(t, "/bin/echo", data.Hook.DeleteCmd)
 	assert.Nil(t, data.Sandbox, "and must NOT be a sandbox handle")
+}
+
+// Codex 3726241029: Validate guarantees exactly one provisioning command, so
+// probing launch_cmd unconditionally ran lookPath("") for every provision-only
+// repo and reported the hook backend unavailable — hiding the preferred contract
+// from every picker (web, TUI, `af sessions backends`).
+func TestProvisionOnlyHooksAreReportedUsable(t *testing.T) {
+	h := newHookState(t, "exit 0", "")
+	cfg := &config.ResolvedConfig{RemoteHooks: &config.RemoteHooks{
+		ProvisionCmd: h.launch, // an executable script standing in for provision_cmd
+		DeleteCmd:    h.delete,
+	}}
+	repo := t.TempDir()
+
+	err := BackendConfigError(BackendHook, cfg)
+	require.NoError(t, err, "a provision-only config is complete")
+
+	// The availability probe must inspect provision_cmd, not an empty launch_cmd.
+	reason := BackendUnusableReason(BackendHook, cfg, repo)
+	if reason != nil {
+		assert.NotContains(t, reason.Error(), "launch_cmd",
+			"a provision-only repo must never be told its (deliberately absent) launch_cmd is the problem")
+	}
 }

--- a/session/backend_hook_provision_test.go
+++ b/session/backend_hook_provision_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/config"
 )
 
 const provisionKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIProvisionedHostKey"
@@ -139,4 +141,42 @@ func TestHookProvisionAndLaunchAreMutuallyExclusive(t *testing.T) {
 	p.hooks.ProvisionCmd = "./provision.sh"
 	require.Error(t, p.hooks.Validate())
 	assert.Contains(t, p.hooks.Validate().Error(), "alternatives, not layers")
+}
+
+// Codex 3726147295: the documented config is `provision_cmd =
+// "./.agent-factory/hooks/provision.sh"`, and the daemon runs hooks with a cwd
+// unrelated to the repo. A relative value that is not resolved fails to exec.
+func TestProvisionCmdResolvesAgainstTheRepoRoot(t *testing.T) {
+	root := t.TempDir()
+	resolved := config.RemoteHooks{
+		ProvisionCmd: "./.agent-factory/hooks/provision.sh",
+		DeleteCmd:    "./.agent-factory/hooks/delete.sh",
+	}.ResolveCommandPathsForTest(root)
+
+	assert.Equal(t, filepath.Join(root, ".agent-factory/hooks/provision.sh"), resolved.ProvisionCmd,
+		"a relative provision_cmd must resolve against the repo root, like launch_cmd and delete_cmd")
+	assert.Equal(t, filepath.Join(root, ".agent-factory/hooks/delete.sh"), resolved.DeleteCmd)
+}
+
+// Codex 3726147299: the session's identity is the HOOK's. Recording it as
+// `sandbox` would persist only SandboxRuntimeCleanupData, so archive/restore
+// would route to sandboxRuntime and demand the unrelated global sandbox_ssh
+// instead of re-running provision_cmd — and a kill tombstone restored after a
+// crash would carry no delete_cmd, leaking the provisioned machine.
+func TestProvisionedSessionKeepsTheHookBackendIdentity(t *testing.T) {
+	p := newHookProvisioner(hookState{}, "identity")
+	p.hooks.DeleteCmd = "/bin/echo"
+	p.hooks.ProvisionCmd = "/bin/echo"
+
+	backend := p.provisionedBackend(func() error { return nil })
+	assert.Equal(t, "remote", backend.Type(),
+		"a provision_cmd session must persist as a hook session, or restore looks for sandbox_ssh")
+
+	provider, ok := backend.(runtimeCleanupProvider)
+	require.True(t, ok, "a provisioned session must stage a cleanup handle, or its machine leaks after a crash")
+	data := provider.runtimeCleanupData()
+	require.NotNil(t, data)
+	require.NotNil(t, data.Hook, "the tombstone must carry delete_cmd, or the machine leaks after a crash")
+	assert.Equal(t, "/bin/echo", data.Hook.DeleteCmd)
+	assert.Nil(t, data.Sandbox, "and must NOT be a sandbox handle")
 }

--- a/session/backend_hook_provision_test.go
+++ b/session/backend_hook_provision_test.go
@@ -1,0 +1,142 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const provisionKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIProvisionedHostKey"
+
+// The record is one JSON object and nothing else — the #2862 contract, adopted
+// from this contract's first line rather than dragged onto it later.
+func TestParseHookProvisionRecordAcceptsOnlyTheRecord(t *testing.T) {
+	good := `{"host":"10.0.0.7","user":"af","port":2222,"host_key":"` + provisionKey + `"}`
+	record, _, violation := parseHookProvisionRecord(good + "\n")
+	require.NotNil(t, record)
+	require.Nil(t, violation)
+	assert.Equal(t, "10.0.0.7", record.Host)
+	assert.Equal(t, "af", record.User)
+	assert.Equal(t, 2222, record.Port)
+
+	for name, stdout := range map[string]string{
+		"prose before":    "provisioning…\n" + good + "\n",
+		"prose after":     good + "\nprovisioned\n",
+		"a second record": good + "\n" + good + "\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			r, _, v := parseHookProvisionRecord(stdout)
+			assert.Nil(t, r, "stdout carrying more than the record must yield none")
+			require.NotNil(t, v, "and must report the violation so the error can quote it")
+		})
+	}
+}
+
+// host_key is REQUIRED and the parse is what makes that fail closed: a record
+// without one never reaches the pinning code at all.
+func TestParseHookProvisionRecordRequiresHostAndKey(t *testing.T) {
+	for name, body := range map[string]string{
+		"no host_key":    `{"host":"10.0.0.7"}`,
+		"empty host_key": `{"host":"10.0.0.7","host_key":"  "}`,
+		"no host":        `{"host_key":"` + provisionKey + `"}`,
+		"unknown field":  `{"host":"10.0.0.7","host_key":"` + provisionKey + `","url":"http://x"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			record, sawJSON, violation := parseHookProvisionRecord(body + "\n")
+			assert.Nil(t, record)
+			assert.True(t, sawJSON, "it printed JSON, so the error must be about SHAPE not absence")
+			assert.Nil(t, violation, "a wrong-shaped record is not a stdout violation")
+		})
+	}
+}
+
+// THE host-key answer. A machine created seconds ago has no known_hosts entry,
+// and none of af's three postures can help: strict refuses, accept-new is TOFU
+// where every session is a first contact, insecure invites the MITM that would
+// see the bearer token. The script vouches for the key out of band, af pins it
+// for this session, and verification becomes real rather than trust-on-sight.
+func TestHookProvisionPinsExactlyTheKeyTheScriptVouchedFor(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "hook-hosts", "sess")
+
+	path, err := hookProvisionKnownHosts(dir, "10.0.0.7", 0, provisionKey)
+	require.NoError(t, err)
+	body, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "10.0.0.7 "+provisionKey+"\n", string(body),
+		"exactly one key, for exactly this host — that is what makes StrictHostKeyChecking a verification")
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+// A non-default port is part of the known_hosts identity and OpenSSH spells it
+// "[host]:port". Getting it wrong fails as "unknown host", which sends the
+// operator hunting for the wrong problem.
+func TestHookProvisionKnownHostsUsesOpenSSHPortSyntax(t *testing.T) {
+	dir := t.TempDir()
+	path, err := hookProvisionKnownHosts(dir, "10.0.0.7", 2222, provisionKey)
+	require.NoError(t, err)
+	body, _ := os.ReadFile(path)
+	assert.True(t, strings.HasPrefix(string(body), "[10.0.0.7]:2222 "), "got %q", string(body))
+
+	// Port 22 is the default and must NOT be bracketed, or it would never match.
+	plain, err := hookProvisionKnownHosts(t.TempDir(), "10.0.0.7", 22, provisionKey)
+	require.NoError(t, err)
+	body22, _ := os.ReadFile(plain)
+	assert.True(t, strings.HasPrefix(string(body22), "10.0.0.7 "), "got %q", string(body22))
+}
+
+// The composed invocation is what makes the pin load-bearing. Each option is
+// here for a reason and a regression in any of them silently weakens the check.
+func TestHookProvisionSSHCommandPinsVerification(t *testing.T) {
+	cmd := hookProvisionSSHCommand("/af/known_hosts", &hookProvisionRecord{
+		Host: "10.0.0.7", User: "af", Port: 2222, HostKey: provisionKey,
+	})
+
+	assert.Contains(t, cmd, "UserKnownHostsFile='/af/known_hosts'", "verification must use the pinned file")
+	assert.Contains(t, cmd, "StrictHostKeyChecking=yes", "with strict checking, or the pin decides nothing")
+	assert.Contains(t, cmd, "GlobalKnownHostsFile=/dev/null",
+		"or a system-wide entry for a recycled address could satisfy the check instead of our key")
+	assert.Contains(t, cmd, "BatchMode=yes", "an unattended provision must fail rather than hang on a prompt")
+	assert.Contains(t, cmd, "-p 2222")
+	assert.Contains(t, cmd, "'af@10.0.0.7'")
+}
+
+// No user and no port is the common case and must not emit empty flags.
+func TestHookProvisionSSHCommandMinimalRecord(t *testing.T) {
+	cmd := hookProvisionSSHCommand("/af/kh", &hookProvisionRecord{Host: "h.invalid", HostKey: provisionKey})
+	assert.NotContains(t, cmd, "-p ")
+	assert.Contains(t, cmd, "'h.invalid'")
+	assert.NotContains(t, cmd, "@")
+}
+
+// A record may spell the port either way; both must reach the same pin.
+func TestHookProvisionHostPortAcceptsEitherSpelling(t *testing.T) {
+	h, p := hookProvisionHostPort(&hookProvisionRecord{Host: "10.0.0.7:2222"})
+	assert.Equal(t, "10.0.0.7", h)
+	assert.Equal(t, 2222, p)
+
+	h, p = hookProvisionHostPort(&hookProvisionRecord{Host: "10.0.0.7", Port: 2222})
+	assert.Equal(t, "10.0.0.7", h)
+	assert.Equal(t, 2222, p)
+
+	h, p = hookProvisionHostPort(&hookProvisionRecord{Host: "10.0.0.7"})
+	assert.Equal(t, "10.0.0.7", h)
+	assert.Zero(t, p)
+}
+
+// The two contracts are alternatives. Setting both is refused rather than
+// silently preferring one, because the other's absence would then look like a
+// working config.
+func TestHookProvisionAndLaunchAreMutuallyExclusive(t *testing.T) {
+	h := newHookState(t, "exit 0", "")
+	p := newHookProvisioner(h, "both contracts")
+	p.hooks.ProvisionCmd = "./provision.sh"
+	require.Error(t, p.hooks.Validate())
+	assert.Contains(t, p.hooks.Validate().Error(), "alternatives, not layers")
+}

--- a/session/backend_preconditions.go
+++ b/session/backend_preconditions.go
@@ -141,8 +141,16 @@ func BackendUnusableReason(kind BackendKind, cfg *config.ResolvedConfig, repoRoo
 		// command is missing is the worst offender in this class: it is CONFIGURED,
 		// so a config-only check calls it available, and the failure lands later,
 		// mid-provision, as somebody else's error.
+		// Probe the PROVISIONING command this repo actually configured. Validate
+		// guarantees exactly one is set, so probing launch_cmd unconditionally
+		// would run lookPath("") for every provision_cmd repo and report the
+		// preferred contract as unavailable in every picker (#2847).
+		provisionKey, provisionCmd := "launch_cmd", cfg.RemoteHooks.LaunchCmd
+		if cfg.RemoteHooks.UsesProvisionCmd() {
+			provisionKey, provisionCmd = "provision_cmd", cfg.RemoteHooks.ProvisionCmd
+		}
 		for _, hook := range []struct{ key, cmd string }{
-			{"launch_cmd", cfg.RemoteHooks.LaunchCmd},
+			{provisionKey, provisionCmd},
 			{"delete_cmd", cfg.RemoteHooks.DeleteCmd},
 		} {
 			if _, err := lookPath(hook.cmd); err != nil {


### PR DESCRIPTION
Slice 1 of #2847, claimed on the issue first. Buildable now that #2995 landed the free-form ssh transport — which was the blocker my verdict on that issue identified.

## What

New `remote_hooks.provision_cmd`. The script makes a machine and prints one record:

```json
{"host": "10.0.0.7", "user": "af", "port": 2222, "host_key": "ssh-ed25519 AAAAC3Nz…"}
```

af pins the key, composes an ssh invocation, and hands it to the **existing** `sandboxProvisioner`, which already does mktemp → clone → stream `af` → start agent-server → tunnel → identity-checked reap. Teardown chains the sandbox workspace and then `delete_cmd`.

The implementation is small precisely because #2995 did the heavy lifting: that provisioner is parameterised by a plain `sshCmd` string.

## What it deletes, rather than mitigates

- **The bearer token never enters a script.** The redaction series (#2684, #2687, #2690, #2748, #2771) exists because a *secret* travels through hook stdout, argv, logs and errors. A host address and a host **public** key are not secrets, so redaction stops being load-bearing here.
- **No tunnel to background**, so the reap-the-launch-tree machinery is not load-bearing either.
- **No `af agent-server` lifecycle in user code.**

And because transport is the sandbox backend's, `.ssh/config`, `ProxyJump` and bastions work — the "inherit ssh's ecosystem" benefit this issue wanted, which as I established earlier does **not** come from af's Go client.

## Settled: host keys for a machine created seconds ago

You asked me to apply what I concluded. **`host_key` is required.**

A VM born seconds ago has no `known_hosts` entry, and the prompt that follows is exactly what an unattended provision cannot answer. None of af's three postures solves it, and I verified each against the code rather than assuming: `strict` refuses an unknown host (`TestSSHStrictDefaultRequiresKnownHost`); `accept-new` is trust-on-first-use where **every** session is a first contact, is global-only so it cannot be scoped to sandboxes, and its append-only store later **refuses a legitimate VM** once an address is recycled (`TestSSHAcceptNewRefusesChangedKey`); `insecure` invites the man-in-the-middle who would then see the bearer token.

The way out is that the script is the only party with an **authentic** channel to the key — it is talking to the provider's control plane, which af cannot reach. So it returns the key, af writes a **per-session** `known_hosts` containing exactly it, and connects with:

- `StrictHostKeyChecking=yes` — without it the pin decides nothing;
- `GlobalKnownHostsFile=/dev/null` — not belt-and-braces: otherwise a system-wide entry for a recycled address could satisfy the check *instead of* the key we pinned;
- `BatchMode=yes` — fail rather than hang on a prompt nobody can answer.

That is a **verification**, not a trust-on-first-use, and it is stronger than what `backend = "ssh"` can do today. **No opt-out** — an escape hatch would restore exactly the trust-on-sight this removes.

## `launch_cmd` stays

Unchanged and not deprecated: some targets have no sshd and a URL is their only option. Setting **both** is refused rather than resolved by preference — the other's absence would otherwise look like a working config. `Validate` names both keys, so a `provision_cmd` user is never sent to fix `launch_cmd`.

stdout is one **strict parse** from the first line, so #2845's undecidability cannot recur on this contract: it starts where the endpoint contract had to be dragged by #2862.

## Mutation-tested

Guards for a design that fails silently must be proven to bite:

| Mutation | Result |
|---|---|
| drop `StrictHostKeyChecking=yes` | FAIL — *"with strict checking, or the pin decides nothing"* |
| accept a record with no `host_key` | FAIL — parse returns a keyless record |

## Scope — this is slice 1 of 2

Stated on the issue before starting. **Slice 2:** restore/archive re-provision (`provision_cmd --branch`) and `af doctor` validation of the new key. Not in this PR because it is separable and this one is already end-to-end; anything smaller would be unwired code `deadcode` would reject.

## Validation

- `gofmt -l .` (no output) · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `scripts/lint-file-length.sh` · generated docs re-checked for drift
- `go test ./session/ ./config/` — both changed packages — green. Not deadcode (CI runs it), no containerized suites.

Refs #2847