### PR TITLE
fix(session): archive asks the backend whether it is a sandbox, not a pointer

### DIFF
--- a/session/archive_sandbox.go
+++ b/session/archive_sandbox.go
@@ -47,11 +47,28 @@ func (i *Instance) pushBranchForArchive() (string, error) {
 // directly, like Start/Kill). It is a no-op-and-error for a session with no
 // remote runtime — a local session archives by relocating its worktree, not here.
 func (i *Instance) ArchiveSandbox() (string, error) {
+	// Ask the BACKEND whether this is a sandbox session, not the client pointer.
+	// daemon/archive.go routes here on the declared capability
+	// (Capabilities().Workspace == WorkspaceRemote); re-deriving the same fact
+	// from `remoteClient != nil` lets the two disagree, and they disagree in the
+	// states that matter: a sandbox session loaded inert from disk, or one left
+	// Lost by a failed recovery, has a remote backend and a nil client (the cases
+	// AgentServer() enumerates when it installs deadRemoteAgentServer). The old
+	// check called those "not a sandbox session", which is false — it is a
+	// sandbox session whose wiring is torn down — and sent the reader looking for
+	// a backend-detection bug (#3000, the #2924 class).
 	i.mu.RLock()
-	isRemote := i.remoteClient != nil
+	isSandbox := i.capabilitiesLocked().Workspace == WorkspaceRemote
+	hasClient := i.remoteClient != nil
 	i.mu.RUnlock()
-	if !isRemote {
+	if !isSandbox {
 		return "", fmt.Errorf("session %q is not a sandbox session; cannot archive via push/teardown", i.Title)
+	}
+	if !hasClient {
+		// Distinct from the above on purpose: same refusal, different cause, and
+		// the caller can act on this one (recover the session, then archive).
+		return "", fmt.Errorf("session %q is a sandbox session whose runtime wiring is torn down, "+
+			"so there is no live client to push its branch through; recover it before archiving", i.Title)
 	}
 
 	as := i.AgentServer()

--- a/session/archive_sandbox_test.go
+++ b/session/archive_sandbox_test.go
@@ -469,3 +469,37 @@ func TestResetRemoteRuntime(t *testing.T) {
 	assert.Nil(t, i.agentSrv)
 	assert.Equal(t, "docker", i.backend.Type(), "backend is kept for restore classification")
 }
+
+// TestArchiveSandbox_AsksTheBackendNotTheClientPointer is the #2924 class applied
+// to archive (#3000): daemon/archive.go routes here on the DECLARED capability
+// (Capabilities().Workspace == WorkspaceRemote), so this method must answer the
+// same question the same way. Deriving it from `remoteClient != nil` instead let
+// the two disagree exactly where it matters — a sandbox session whose runtime
+// wiring is torn down has a remote backend and a nil client, and the old check
+// called it "not a sandbox session", which is false.
+func TestArchiveSandbox_AsksTheBackendNotTheClientPointer(t *testing.T) {
+	// A sandbox session loaded inert from disk: remote backend, no live client.
+	// This is the shape AgentServer() installs deadRemoteAgentServer for.
+	i := &Instance{Title: "s", backend: newInertSandboxBackend("docker")}
+
+	_, err := i.ArchiveSandbox()
+
+	require.Error(t, err, "there is no client to push through, so the archive must still refuse")
+	assert.NotContains(t, err.Error(), "is not a sandbox session",
+		"it IS a sandbox session — saying otherwise sends the reader after a backend-detection bug")
+	assert.Contains(t, err.Error(), "runtime wiring is torn down", "the error must name the real cause")
+	assert.Contains(t, err.Error(), "recover it before archiving", "and what to do about it")
+}
+
+// TestArchiveSandbox_StillRefusesALocalSession keeps the other half: a session
+// whose backend declares a local worktree is genuinely not archivable this way,
+// and must keep saying so.
+func TestArchiveSandbox_StillRefusesALocalSession(t *testing.T) {
+	i := &Instance{Title: "s", backend: &LocalBackend{}}
+
+	_, err := i.ArchiveSandbox()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not a sandbox session",
+		"a local-worktree session archives by relocating its worktree, not through this path")
+}


### PR DESCRIPTION
Chose the **#2924 structural lever** over a single gap, because it prevents the class rather than one instance — and my own table on #3000 identified this predicate as the one producing wrong cells.

## The defect

`daemon/archive.go:223` routes a session to the remote archive on the **declared** capability (`Capabilities().Workspace == WorkspaceRemote`). `ArchiveSandbox` then re-derived the same fact from `remoteClient != nil`. Two predicates for one question — and they disagree exactly where it matters.

A sandbox session whose runtime wiring is torn down has a remote backend and a nil client: an inert record loaded from disk, or one left Lost by a failed recovery — the same states `AgentServer()` enumerates when it installs `deadRemoteAgentServer`. The daemon routes those here, and this method answered:

> `session "s" is not a sandbox session; cannot archive via push/teardown`

which is false. It *is* a sandbox session; its wiring is gone. The message sends the reader after a backend-detection bug that does not exist.

## The fix

Ask `capabilitiesLocked().Workspace` — the same predicate the daemon used — and give the missing-client case its own error naming the real cause and the action (recover, then archive).

## Watched it fail first

The new test against master produces `session "s" is not a sandbox session` for a session that is one.

`TestBackendFieldIsOnlyReadUnderLock` (#2096) then caught my first attempt reading `i.backend` directly and named both sanctioned options. I took the already-locked accessor rather than an allowlist entry, because it also matches the daemon's predicate exactly — the guard improved the fix.

## Correction to my table on #3000

I listed `agentserver_local.go:88` as a re-derivation. **It is not.** `case i.remoteClient != nil:` asks "do I have a live client to build a remote server with?", and the next case uses the declared capability for the off-box question. That dispatch was already right; only `archive_sandbox.go` was wrong.

## Test plan

- [x] `gofmt -l .`, `go build ./...`, `golangci-lint --fast`, `scripts/lint-file-length.sh` — clean
- [x] `go test ./session/` — full package green (57s)
- [x] No deadcode, no containers, no ./daemon/ or ./app/ tests

Refs #3000 — one cell of the table, not the whole issue, so no `Closes`.