### PR TITLE
feat(sessionenv): scope a session to exactly one agent account (#2983 part 2)

### DIFF
--- a/internal/sessionenv/account.go
+++ b/internal/sessionenv/account.go
@@ -44,6 +44,18 @@ type Account struct {
 	// It must also be a real path outside any temp directory: codex refuses to
 	// operate under /tmp, and an account is durable state regardless.
 	Dir string
+	// TrustedWrapper is the exact af binary path the LAUNCHER generated this
+	// session's handoff with, or empty when the program is not an af handoff.
+	//
+	// This is provenance, supplied rather than parsed. The docker and ssh
+	// backends generate `/usr/local/bin/af agent-server …` and a staged absolute
+	// path respectively, so a bare-name rule rejects af's OWN launch and refuses
+	// every account-scoped session on those backends. No amount of inspecting the
+	// string recovers "af wrote this"; the caller knows it, so it says so.
+	//
+	// Only an EXACT match is honoured — never a basename — so a repository file
+	// that merely shares the name is still refused (#2983 review).
+	TrustedWrapper string
 }
 
 // accountConfigVars maps an agent to the variable that relocates its credential
@@ -173,7 +185,7 @@ func ApplyAccount(env []string, command string, account Account) ([]string, erro
 	for _, selector := range GuardedSelectors() {
 		refused[selector] = struct{}{}
 	}
-	if overrides, provable := commandOverridesName(command, account.Agent, refused); overrides || !provable {
+	if overrides, provable := commandOverridesName(command, account.Agent, account.TrustedWrapper, refused); overrides || !provable {
 		if !provable {
 			return nil, fmt.Errorf(
 				"account %q cannot scope agent %q: its program could not be proven to be a direct %s invocation free of "+

--- a/internal/sessionenv/account.go
+++ b/internal/sessionenv/account.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Account is a per-session credential scope: exactly one of an agent's logged-in
-// identities, held as a directory the agent CLI treats as its credential root.
+// identities, held as a directory the agent CLI treats as its home.
 //
 // af never reads, stores, or forwards the secret itself. It decides which
 // directory a session can see, and the agent's own login flow put the material
@@ -15,9 +15,26 @@ import (
 type Account struct {
 	Agent string
 	Name  string
-	// Dir is the credential root handed to the agent. It must be a real path
-	// outside any temp directory — codex refuses to operate under /tmp, and an
-	// account is durable state regardless.
+	// Dir is the AGENT HOME handed to the session, not merely a credential file.
+	//
+	// This distinction is a precondition on whoever creates the directory, and
+	// getting it wrong is a silent functional regression rather than a security
+	// one. CODEX_HOME relocates codex's WHOLE home — auth, history, settings, and
+	// skills discovered under $CODEX_HOME/skills, as session/agentskill.go already
+	// documents. So an account directory holding only auth.json gives that session
+	// no history, no user skills, and none of af's managed guidance skill.
+	// CLAUDE_CONFIG_DIR behaves the same way for claude's config root.
+	//
+	// Provisioning must therefore SEED the non-credential state — share or copy it
+	// from the operator's real home — so that an account differs from the default
+	// identity in credentials alone. ApplyAccount cannot verify that: it never
+	// touches the filesystem and receives a path that may not exist yet. It is
+	// stated here because the account-creation slice is the only place it can be
+	// enforced, and a reader of this type would otherwise reasonably assume
+	// "credential directory" meant a directory of credentials (#2983 review).
+	//
+	// It must also be a real path outside any temp directory: codex refuses to
+	// operate under /tmp, and an account is durable state regardless.
 	Dir string
 }
 
@@ -100,7 +117,7 @@ func AccountAgents() []string {
 // AF_DAEMON_TOKEN, which is global by nature, and wrong for an account, which is
 // per-session by definition. An allowlist implementation passes a presence check
 // and a smoke test while giving every session the same account (#2983).
-func ApplyAccount(env []string, account Account) ([]string, error) {
+func ApplyAccount(env []string, command string, account Account) ([]string, error) {
 	configVar, ok := SupportsAccounts(account.Agent)
 	if !ok {
 		return nil, fmt.Errorf(
@@ -110,6 +127,38 @@ func ApplyAccount(env []string, account Account) ([]string, error) {
 	if strings.TrimSpace(account.Dir) == "" {
 		return nil, fmt.Errorf("account %q for agent %q has no credential directory",
 			account.Name, account.Agent)
+	}
+
+	// A CLOUD MODE authenticates somewhere else entirely. Bedrock, Vertex and
+	// Foundry make the CLI use AWS/Google/Azure credentials, which
+	// FilterForCommand deliberately admits for exactly those modes — so the
+	// account directory stops being the session's identity while still appearing
+	// to be. Refusing is the honest answer: removing the selector instead would
+	// silently move the session off the deployment mode its operator configured,
+	// which is a different surprise rather than a smaller one (#2983 review).
+	if selectors := ResolveAuthSelectors(env, account.Agent, command); len(selectors) > 0 {
+		return nil, fmt.Errorf(
+			"account %q cannot scope agent %q while cloud mode %s is active: the session authenticates "+
+				"through that provider's credentials, not through the account directory; unset it to use accounts",
+			account.Name, account.Agent, strings.Join(selectors, ", "))
+	}
+
+	// A COMMAND-LOCAL ASSIGNMENT wins over anything injected here: the launch runs
+	// the program through `/bin/sh -c`, which applies `CODEX_HOME=... codex` after
+	// this environment is installed. program_overrides is reachable from a
+	// repository's checked-in config, so without this a repo could silently
+	// redirect whose quota a session spends. Unprovable commands fail closed —
+	// an unparsed command is not evidence of safety.
+	if overrides, provable := commandOverridesName(command, configVar); overrides || !provable {
+		if !provable {
+			return nil, fmt.Errorf(
+				"account %q cannot scope agent %q: its program could not be proven free of a %s assignment, "+
+					"and an unverifiable program is not evidence that the account would be used",
+				account.Name, account.Agent, configVar)
+		}
+		return nil, fmt.Errorf(
+			"account %q cannot scope agent %q: its program sets %s itself, which overrides the account directory",
+			account.Name, account.Agent, configVar)
 	}
 
 	denied := accountScopedNames(account.Agent, configVar)

--- a/internal/sessionenv/account.go
+++ b/internal/sessionenv/account.go
@@ -27,7 +27,15 @@ type Account struct {
 	//
 	// Provisioning must therefore SEED the non-credential state — share or copy it
 	// from the operator's real home — so that an account differs from the default
-	// identity in credentials alone. ApplyAccount cannot verify that: it never
+	// identity in credentials alone.
+	//
+	// With one exclusion that is easy to miss and defeats the whole feature: a
+	// copied config.toml carrying `cli_auth_credentials_store = "keyring"` makes
+	// Codex ignore the account's auth.json and use the MACHINE-WIDE identity, so
+	// every account authenticates as the same person while ApplyAccount reports
+	// success. Seeding must sanitize credential-source settings to the file-based
+	// mode rather than copying settings unchanged. The command guard cannot catch
+	// this — the override arrives through config, not through argv (#2983 review). ApplyAccount cannot verify that: it never
 	// touches the filesystem and receives a path that may not exist yet. It is
 	// stated here because the account-creation slice is the only place it can be
 	// enforced, and a reader of this type would otherwise reasonably assume

--- a/internal/sessionenv/account.go
+++ b/internal/sessionenv/account.go
@@ -1,0 +1,164 @@
+package sessionenv
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Account is a per-session credential scope: exactly one of an agent's logged-in
+// identities, held as a directory the agent CLI treats as its credential root.
+//
+// af never reads, stores, or forwards the secret itself. It decides which
+// directory a session can see, and the agent's own login flow put the material
+// there. A provider changing its token format costs this nothing.
+type Account struct {
+	Agent string
+	Name  string
+	// Dir is the credential root handed to the agent. It must be a real path
+	// outside any temp directory — codex refuses to operate under /tmp, and an
+	// account is durable state regardless.
+	Dir string
+}
+
+// accountConfigVars maps an agent to the variable that relocates its credential
+// ROOT — verified empirically per agent, never assumed from the allowlist.
+//
+// claude 2.1.223: CLAUDE_CONFIG_DIR pointed at an empty directory reports
+// `"loggedIn": false` while the real one reports true, so it moves credential
+// lookup and not merely settings.
+//
+// codex-cli 0.146.1: CODEX_HOME pointed at an empty directory reports "Not
+// logged in" against "Logged in using ChatGPT".
+//
+// gemini and amp are deliberately ABSENT. GEMINI_CLI_HOME and AMP_HOME are on
+// the session-env allowlist, but allowlist membership is not evidence that they
+// relocate credentials, and neither CLI was available to test. An agent missing
+// here reports unsupported rather than silently accepting an account selection
+// that would do nothing (#2983).
+var accountConfigVars = map[string]string{
+	"claude": "CLAUDE_CONFIG_DIR",
+	"codex":  "CODEX_HOME",
+}
+
+// accountCredentialNames are the variables that carry an IDENTITY for an agent
+// and must therefore be removed from an account-scoped session.
+//
+// This is the subtraction half, and it is not defence in depth — it is what
+// makes the selection real. For both of these CLIs an ambient API key takes
+// precedence over the config directory's OAuth state, so a session that selected
+// an account while ANTHROPIC_API_KEY passed through would authenticate as
+// whoever that key belongs to, silently, while every visible signal said
+// otherwise. That is the exact failure #2983 exists to fix.
+//
+// Routing and mode variables (ANTHROPIC_BASE_URL, the Bedrock/Vertex selectors,
+// CODEX_CA_CERTIFICATE) are NOT here on purpose: they are the operator's
+// deployment configuration rather than an identity, and dropping them would
+// break a legitimate proxied setup without scoping anything. accountScopedNames
+// enforces that every name is classified one way or the other, so this
+// distinction cannot rot as the allowlists grow.
+var accountCredentialNames = map[string]map[string]struct{}{
+	"claude": nameSet(
+		"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN",
+	),
+	"codex": nameSet(
+		"OPENAI_API_KEY", "CODEX_API_KEY", "CODEX_ACCESS_TOKEN",
+	),
+}
+
+// SupportsAccounts reports whether an agent can be account-scoped, and the
+// variable used to do it.
+func SupportsAccounts(agent string) (string, bool) {
+	v, ok := accountConfigVars[agent]
+	return v, ok
+}
+
+// AccountAgents lists the agents that support account scoping, for help text and
+// for an error that can name the alternatives.
+func AccountAgents() []string {
+	out := make([]string, 0, len(accountConfigVars))
+	for agent := range accountConfigVars {
+		out = append(out, agent)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ApplyAccount scopes an already-filtered session environment to exactly one
+// account: it INJECTS that account's credential root and REMOVES every other
+// identity-bearing variable for the agent.
+//
+// Both halves are required and neither is sufficient.
+//
+// Injection alone leaves an ambient API key in place, which wins over the
+// directory — the selection is then silently ignored. Subtraction alone leaves
+// the session with no identity at all.
+//
+// It must also be an INJECTION and not an allowlist entry. Filter is subtractive
+// over the daemon's own environment, so a variable delivered through the
+// allowlist carries the daemon's single value to every session: correct for
+// AF_DAEMON_TOKEN, which is global by nature, and wrong for an account, which is
+// per-session by definition. An allowlist implementation passes a presence check
+// and a smoke test while giving every session the same account (#2983).
+func ApplyAccount(env []string, account Account) ([]string, error) {
+	configVar, ok := SupportsAccounts(account.Agent)
+	if !ok {
+		return nil, fmt.Errorf(
+			"agent %q does not support multiple accounts; supported: %s",
+			account.Agent, strings.Join(AccountAgents(), ", "))
+	}
+	if strings.TrimSpace(account.Dir) == "" {
+		return nil, fmt.Errorf("account %q for agent %q has no credential directory",
+			account.Name, account.Agent)
+	}
+
+	denied := accountScopedNames(account.Agent, configVar)
+	out := make([]string, 0, len(env)+1)
+	for _, kv := range env {
+		name, _, found := strings.Cut(kv, "=")
+		if !found {
+			continue
+		}
+		if _, drop := denied[name]; drop {
+			continue
+		}
+		out = append(out, kv)
+	}
+	// Appended last so it wins over any ambient copy that survived, though the
+	// removal above means there should not be one.
+	out = append(out, configVar+"="+account.Dir)
+	return out, nil
+}
+
+// accountScopedNames is every variable removed from an account-scoped session:
+// the agent's credential names, plus the config variable itself so an ambient
+// value cannot shadow the injected one.
+//
+// It reads from accountCredentialNames rather than from agentNames on purpose. A
+// blanket "drop everything for this agent" would also strip the operator's
+// routing and mode configuration, breaking a proxied or Bedrock deployment to
+// scope an identity. The cost of the explicit list is that a newly allowlisted
+// credential could be forgotten, which is why TestAccountCredentialsAreClassified
+// fails when an agentNames entry for a scoped agent is neither classified as a
+// credential nor listed as deliberately kept.
+func accountScopedNames(agent, configVar string) map[string]struct{} {
+	denied := make(map[string]struct{}, len(accountCredentialNames[agent])+1)
+	for name := range accountCredentialNames[agent] {
+		denied[name] = struct{}{}
+	}
+	denied[configVar] = struct{}{}
+	return denied
+}
+
+// accountNonCredentialNames records the allowlisted names for a scoped agent
+// that are deliberately NOT identity-bearing, so the classification test can
+// tell "reviewed and kept" from "forgotten".
+var accountNonCredentialNames = map[string]map[string]struct{}{
+	"claude": nameSet(
+		"ANTHROPIC_BASE_URL", "CLAUDE_CONFIG_DIR",
+		"CLAUDE_CODE_USE_BEDROCK", "CLAUDE_CODE_USE_VERTEX", "CLAUDE_CODE_USE_FOUNDRY",
+	),
+	"codex": nameSet(
+		"CODEX_HOME", "CODEX_SQLITE_HOME", "CODEX_CA_CERTIFICATE",
+	),
+}

--- a/internal/sessionenv/account.go
+++ b/internal/sessionenv/account.go
@@ -149,16 +149,32 @@ func ApplyAccount(env []string, command string, account Account) ([]string, erro
 	// repository's checked-in config, so without this a repo could silently
 	// redirect whose quota a session spends. Unprovable commands fail closed —
 	// an unparsed command is not evidence of safety.
-	if overrides, provable := commandOverridesName(command, configVar); overrides || !provable {
+	// EVERY identity-bearing name, not just the config root. Subtraction removed
+	// the ambient copies, but `/bin/sh -c` applies a command-local assignment
+	// afterwards — so `OPENAI_API_KEY=sk-other codex` RECREATES an identity that
+	// outranks the account directory, and the guard would have called it safe
+	// because it only watched CODEX_HOME.
+	//
+	// The guarded cloud selectors are in the set too. A selector assignment whose
+	// value the parser cannot evaluate (`CLAUDE_CODE_USE_BEDROCK=$HOME claude`)
+	// reads as DISABLED to ResolveAuthSelectors, so the cloud-mode refusal above
+	// never fires while the shell expands it to a non-empty string and Claude
+	// authenticates through ~/.aws instead. Refusing any command-local assignment
+	// to a selector removes the need to evaluate it (#2983 review).
+	refused := accountScopedNames(account.Agent, configVar)
+	for _, selector := range GuardedSelectors() {
+		refused[selector] = struct{}{}
+	}
+	if overrides, provable := commandOverridesName(command, account.Agent, refused); overrides || !provable {
 		if !provable {
 			return nil, fmt.Errorf(
-				"account %q cannot scope agent %q: its program could not be proven free of a %s assignment, "+
-					"and an unverifiable program is not evidence that the account would be used",
-				account.Name, account.Agent, configVar)
+				"account %q cannot scope agent %q: its program could not be proven to be a direct %s invocation free of "+
+					"identity assignments, and an unverifiable program is not evidence that the account would be used",
+				account.Name, account.Agent, account.Agent)
 		}
 		return nil, fmt.Errorf(
-			"account %q cannot scope agent %q: its program sets %s itself, which overrides the account directory",
-			account.Name, account.Agent, configVar)
+			"account %q cannot scope agent %q: its program sets an identity variable itself, which overrides the account directory",
+			account.Name, account.Agent)
 	}
 
 	denied := accountScopedNames(account.Agent, configVar)

--- a/internal/sessionenv/account_command.go
+++ b/internal/sessionenv/account_command.go
@@ -50,12 +50,16 @@ func callOverridesName(call *syntax.CallExpr, agent string, names map[string]str
 	}
 	// Shell-parsed assignment prefixes: `CODEX_HOME=/other codex`.
 	for _, assign := range call.Assigns {
-		if assign == nil || assign.Name == nil {
-			continue
-		}
-		if _, refused := names[assign.Name.Value]; refused {
+		// ANY assignment, not only the identity names. LD_PRELOAD=./steal.so codex
+		// loads repository-controlled code into the real agent before it reads the
+		// injected root, so it can read the account's credentials without ever
+		// touching a variable this package classifies. An allowlist of "harmless"
+		// variables is another standing promise to have thought of every one; a
+		// scoped session's program simply carries no assignments (#2983 review).
+		if assign != nil && assign.Name != nil {
 			return true, true
 		}
+		_ = names
 	}
 
 	words := call.Args
@@ -75,9 +79,8 @@ func callOverridesName(call *syntax.CallExpr, agent string, names map[string]str
 		if !ok {
 			break
 		}
-		if _, refused := names[assigned]; refused {
-			return true, true
-		}
+		_ = assigned
+		return true, true
 	}
 
 	// A nested agent-server program carries its own command, and is the one
@@ -102,6 +105,13 @@ func callOverridesName(call *syntax.CallExpr, agent string, names map[string]str
 	//
 	// A DIRECT invocation of a known agent is the one provable case: it consumes
 	// its arguments itself and starts no second program construction.
+	// The WHOLE call must be literal, not just the executable word. A command
+	// substitution in an argument — `codex "$(unset CODEX_HOME; codex exec …)"` —
+	// is evaluated by /bin/sh BEFORE the outer agent starts, so checking only
+	// words[0] proves nothing about what runs first.
+	if !callIsLiteral(call) {
+		return false, false
+	}
 	if executable, ok := literalShellWord(words[0]); ok && executableIsAgent(executable, agent) {
 		return false, true
 	}
@@ -164,5 +174,14 @@ func executableIsAgent(executable, agent string) bool {
 	if executable == "" || agent == "" {
 		return false
 	}
-	return strings.EqualFold(filepath.Base(executable), agent)
+	// A BARE name only. `./codex` shares a basename with the real CLI and is an
+	// arbitrary repository-provided file: the shell would hand it the selected
+	// root, letting it read the account's credentials or unset the variable and
+	// then exec the real agent. A basename is not provenance. Requiring no path
+	// separator makes PATH resolution the thing that picks the binary, which is
+	// the operator's configuration rather than the repository's (#2983 review).
+	if strings.ContainsRune(executable, filepath.Separator) || strings.Contains(executable, "/") {
+		return false
+	}
+	return strings.EqualFold(executable, agent)
 }

--- a/internal/sessionenv/account_command.go
+++ b/internal/sessionenv/account_command.go
@@ -161,6 +161,14 @@ func envOverridesName(args []*syntax.Word, agent string, names map[string]struct
 	if len(invocation.Mutations) > 0 {
 		return true, true
 	}
+	// A chdir is a PATH mutation in disguise. `env -C attacker codex` changes the
+	// working directory before command lookup, so a preserved relative PATH entry
+	// resolves `attacker/bin/codex` — an arbitrary repository executable handed
+	// the selected root. Same effect as rewriting PATH, which this already
+	// refuses (#2983 review).
+	if invocation.Chdir != "" {
+		return true, true
+	}
 	_ = names
 	if invocation.CommandIndex < 0 || invocation.CommandIndex >= len(literals) {
 		// env with no command to run: nothing launches, so nothing is redirected.

--- a/internal/sessionenv/account_command.go
+++ b/internal/sessionenv/account_command.go
@@ -1,0 +1,93 @@
+package sessionenv
+
+import (
+	"strings"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// commandOverridesName reports whether a resolved program could set, unset, or
+// otherwise redirect a variable, and whether that answer is PROVABLE.
+//
+// It exists because the launch runs the program through `/bin/sh -c`, which
+// applies command-local assignments AFTER the session environment is installed.
+// So `CODEX_HOME=$HOME/.codex codex` silently wins over an injected account
+// root — and program_overrides is reachable from a repository's checked-in
+// config, which makes it a repo-controlled way to redirect whose quota a session
+// spends (#2983).
+//
+// The second return is the honest-unknown channel. A command this cannot parse
+// into a single simple call — a pipeline, a subshell, dynamic syntax — is not
+// evidence of safety, and the caller fails closed on it. That is the same
+// posture the surrounding package already takes for cloud-mode assignments.
+func commandOverridesName(command, name string) (overrides, provable bool) {
+	if command == "" {
+		return false, true
+	}
+	call, ok := singleSimpleCall(command)
+	if !ok {
+		return false, false
+	}
+	return callOverridesName(call, name, 0)
+}
+
+func callOverridesName(call *syntax.CallExpr, name string, depth int) (overrides, provable bool) {
+	if depth > maxNestedProgramDepth {
+		return false, false
+	}
+	for _, assign := range call.Assigns {
+		if assign != nil && assign.Name != nil && assign.Name.Value == name {
+			return true, true
+		}
+	}
+	words := call.Args
+	if len(words) > 0 && wordEquals(words[0], "exec") {
+		words = words[1:]
+		if len(words) > 0 && wordEquals(words[0], "--") {
+			words = words[1:]
+		}
+	}
+	if len(words) == 0 {
+		return false, true
+	}
+	// After `exec`, an assignment is a leading WORD rather than a parsed
+	// assignment — `exec CODEX_HOME=/other codex` puts it in Args, not Assigns.
+	for _, word := range words {
+		assigned, ok := shellWordAssignmentName(word)
+		if !ok {
+			break
+		}
+		if assigned == name {
+			return true, true
+		}
+	}
+	// `env NAME=value agent`, and its unset/clear forms. env's own arguments are
+	// assignments the shell does not expose through call.Assigns.
+	if wordBaseEquals(words[0], "env") {
+		for _, word := range words[1:] {
+			lit, ok := literalShellWord(word)
+			if !ok {
+				// A non-literal argument to env could expand to anything.
+				return false, false
+			}
+			switch {
+			case lit == "-i" || lit == "--ignore-environment":
+				// Clears the environment wholesale, which removes the injected root.
+				return true, true
+			case lit == "-u" || lit == "--unset":
+				return true, true
+			case strings.HasPrefix(lit, name+"="):
+				return true, true
+			}
+		}
+	}
+	// A nested agent-server program carries its own command.
+	if nested, ok := literalAgentServerProgram(call); ok {
+		inner, ok := singleSimpleCall(nested)
+		if !ok {
+			return false, false
+		}
+		return callOverridesName(inner, name, depth+1)
+	}
+	return false, true
+}

--- a/internal/sessionenv/account_command.go
+++ b/internal/sessionenv/account_command.go
@@ -184,7 +184,15 @@ func envOverridesName(args []*syntax.Word, agent string, names map[string]struct
 	// operand let `env codex -c 'cli_auth_credentials_store="keyring"'` through,
 	// which makes Codex ignore the account's auth.json — the exact bypass the
 	// direct branch already refuses, reached one wrapper over (#2983 review).
-	if invocation.CommandIndex != len(literals)-1 {
+	// NOTHING between `env` and the command, and nothing after it. Requiring the
+	// command to be the only operand closes the whole option surface rather than
+	// the options I happen to have modelled: --ignore-signal is accepted by Parse
+	// without becoming a Mutation, and an ignored disposition SURVIVES exec — so
+	// the agent could ignore teardown signals and keep running with the selected
+	// account after af and tmux believe the session ended. Enumerating signal
+	// options would be the fifth grammar this guard tried to enumerate; this is
+	// the last one it needs (#2983 review).
+	if invocation.CommandIndex != 0 || len(literals) != 1 {
 		return false, false
 	}
 	if executableIsAgent(literals[invocation.CommandIndex], agent) {

--- a/internal/sessionenv/account_command.go
+++ b/internal/sessionenv/account_command.go
@@ -33,7 +33,7 @@ import (
 // agent, and a modelled `env` wrapper around one — and reports everything else
 // as UNPROVABLE. New syntax then arrives as a refusal to scope rather than as a
 // silent bypass, which is the direction this repo can afford to be wrong in.
-func commandOverridesName(command, agent string, names map[string]struct{}) (overrides, provable bool) {
+func commandOverridesName(command, agent, trustedWrapper string, names map[string]struct{}) (overrides, provable bool) {
 	if command == "" {
 		return false, true
 	}
@@ -41,10 +41,10 @@ func commandOverridesName(command, agent string, names map[string]struct{}) (ove
 	if !ok {
 		return false, false
 	}
-	return callOverridesName(call, agent, names, 0)
+	return callOverridesName(call, agent, trustedWrapper, names, 0)
 }
 
-func callOverridesName(call *syntax.CallExpr, agent string, names map[string]struct{}, depth int) (overrides, provable bool) {
+func callOverridesName(call *syntax.CallExpr, agent, trustedWrapper string, names map[string]struct{}, depth int) (overrides, provable bool) {
 	if depth > maxNestedProgramDepth {
 		return false, false
 	}
@@ -85,12 +85,17 @@ func callOverridesName(call *syntax.CallExpr, agent string, names map[string]str
 
 	// A nested agent-server program carries its own command, and is the one
 	// wrapper this package already models.
-	if nested, ok := literalAgentServerProgram(call); ok && isBareName(words[0], "af") {
+	// A bare `af`, or the EXACT path the launcher generated this handoff with.
+	// docker emits /usr/local/bin/af and ssh a staged absolute path, so requiring
+	// a bare name refuses af's own launch on those backends — the same
+	// name-is-not-provenance problem in reverse: here the path IS trusted and the
+	// spelling cannot say so, which is why the caller supplies it.
+	if nested, ok := literalAgentServerProgram(call); ok && isTrustedAfBinary(words[0], trustedWrapper) {
 		inner, ok := singleSimpleCall(nested)
 		if !ok {
 			return false, false
 		}
-		return callOverridesName(inner, agent, names, depth+1)
+		return callOverridesName(inner, agent, trustedWrapper, names, depth+1)
 	}
 
 	if isBareName(words[0], "env") {
@@ -233,4 +238,21 @@ func isBareName(word *syntax.Word, want string) bool {
 		return false
 	}
 	return value == want
+}
+
+// isTrustedAfBinary reports whether a word is af's own binary: a bare `af`, or
+// the exact path the launcher generated the handoff with.
+//
+// Exact, never a basename. `./af` and `/repo/af` are arbitrary repository files
+// that would receive the selected account root; the trusted path is compared
+// whole precisely so a shared name proves nothing.
+func isTrustedAfBinary(word *syntax.Word, trustedWrapper string) bool {
+	if isBareName(word, "af") {
+		return true
+	}
+	if trustedWrapper == "" {
+		return false
+	}
+	value, ok := literalShellWord(word)
+	return ok && value == trustedWrapper
 }

--- a/internal/sessionenv/account_command.go
+++ b/internal/sessionenv/account_command.go
@@ -167,6 +167,13 @@ func envOverridesName(args []*syntax.Word, agent string, names map[string]struct
 		return false, true
 	}
 	// env leaves the root alone, so the decision belongs to whatever it runs.
+	// The SAME no-argument rule as a direct invocation. Checking only the command
+	// operand let `env codex -c 'cli_auth_credentials_store="keyring"'` through,
+	// which makes Codex ignore the account's auth.json — the exact bypass the
+	// direct branch already refuses, reached one wrapper over (#2983 review).
+	if invocation.CommandIndex != len(literals)-1 {
+		return false, false
+	}
 	if executableIsAgent(literals[invocation.CommandIndex], agent) {
 		return false, true
 	}
@@ -197,7 +204,12 @@ func executableIsAgent(executable, agent string) bool {
 	if strings.ContainsRune(executable, filepath.Separator) || strings.Contains(executable, "/") {
 		return false
 	}
-	return strings.EqualFold(executable, agent)
+	// EXACT, not case-folded. On a case-sensitive filesystem `CODEX` is a
+	// different executable from `codex`, and if PATH holds one, /bin/sh runs it
+	// with the injected root — an unrelated repository-chosen binary handed the
+	// account's credentials. Matching the shell's own name semantics is the only
+	// comparison that means anything here.
+	return executable == agent
 }
 
 // isBareName reports whether a word is exactly the given command name with no
@@ -212,5 +224,5 @@ func isBareName(word *syntax.Word, want string) bool {
 	if !ok || strings.Contains(value, "/") {
 		return false
 	}
-	return strings.EqualFold(value, want)
+	return value == want
 }

--- a/internal/sessionenv/account_command.go
+++ b/internal/sessionenv/account_command.go
@@ -1,25 +1,35 @@
 package sessionenv
 
 import (
-	"strings"
-
 	"mvdan.cc/sh/v3/syntax"
+
+	"github.com/sachiniyer/agent-factory/internal/envcommand"
 )
 
-// commandOverridesName reports whether a resolved program could set, unset, or
-// otherwise redirect a variable, and whether that answer is PROVABLE.
+// commandOverridesName reports whether a resolved program could redirect a
+// variable away from the value this package injects, and whether that answer is
+// PROVABLE.
 //
 // It exists because the launch runs the program through `/bin/sh -c`, which
 // applies command-local assignments AFTER the session environment is installed.
-// So `CODEX_HOME=$HOME/.codex codex` silently wins over an injected account
-// root — and program_overrides is reachable from a repository's checked-in
-// config, which makes it a repo-controlled way to redirect whose quota a session
-// spends (#2983).
+// program_overrides is reachable from a repository's checked-in config, so
+// without this a repo could silently redirect whose quota a session spends
+// (#2983).
 //
-// The second return is the honest-unknown channel. A command this cannot parse
-// into a single simple call — a pipeline, a subshell, dynamic syntax — is not
-// evidence of safety, and the caller fails closed on it. That is the same
-// posture the surrounding package already takes for cloud-mode assignments.
+// # It proves GOOD shapes; it does not hunt bad ones
+//
+// The first version enumerated the forms that could redirect a variable and
+// treated everything else as safe. That is the wrong polarity for a boundary
+// like this, and it leaked twice in review: `env --unset=NAME`, the attached
+// `-uNAME`, and the bare `-` (which GNU env documents as implying `-i`) all
+// walked straight through, and so did `sh -c '...'` — which parses as a
+// perfectly ordinary call whose ARGUMENT is another whole program.
+//
+// A denylist here is a promise to have thought of every spelling, in a shell,
+// forever. So this recognises exactly two shapes — a direct invocation of the
+// agent, and a modelled `env` wrapper around one — and reports everything else
+// as UNPROVABLE. New syntax then arrives as a refusal to scope rather than as a
+// silent bypass, which is the direction this repo can afford to be wrong in.
 func commandOverridesName(command, name string) (overrides, provable bool) {
 	if command == "" {
 		return false, true
@@ -35,11 +45,13 @@ func callOverridesName(call *syntax.CallExpr, name string, depth int) (overrides
 	if depth > maxNestedProgramDepth {
 		return false, false
 	}
+	// Shell-parsed assignment prefixes: `CODEX_HOME=/other codex`.
 	for _, assign := range call.Assigns {
 		if assign != nil && assign.Name != nil && assign.Name.Value == name {
 			return true, true
 		}
 	}
+
 	words := call.Args
 	if len(words) > 0 && wordEquals(words[0], "exec") {
 		words = words[1:]
@@ -51,7 +63,7 @@ func callOverridesName(call *syntax.CallExpr, name string, depth int) (overrides
 		return false, true
 	}
 	// After `exec`, an assignment is a leading WORD rather than a parsed
-	// assignment — `exec CODEX_HOME=/other codex` puts it in Args, not Assigns.
+	// assignment: `exec CODEX_HOME=/other codex`.
 	for _, word := range words {
 		assigned, ok := shellWordAssignmentName(word)
 		if !ok {
@@ -61,27 +73,9 @@ func callOverridesName(call *syntax.CallExpr, name string, depth int) (overrides
 			return true, true
 		}
 	}
-	// `env NAME=value agent`, and its unset/clear forms. env's own arguments are
-	// assignments the shell does not expose through call.Assigns.
-	if wordBaseEquals(words[0], "env") {
-		for _, word := range words[1:] {
-			lit, ok := literalShellWord(word)
-			if !ok {
-				// A non-literal argument to env could expand to anything.
-				return false, false
-			}
-			switch {
-			case lit == "-i" || lit == "--ignore-environment":
-				// Clears the environment wholesale, which removes the injected root.
-				return true, true
-			case lit == "-u" || lit == "--unset":
-				return true, true
-			case strings.HasPrefix(lit, name+"="):
-				return true, true
-			}
-		}
-	}
-	// A nested agent-server program carries its own command.
+
+	// A nested agent-server program carries its own command, and is the one
+	// wrapper this package already models.
 	if nested, ok := literalAgentServerProgram(call); ok {
 		inner, ok := singleSimpleCall(nested)
 		if !ok {
@@ -89,5 +83,62 @@ func callOverridesName(call *syntax.CallExpr, name string, depth int) (overrides
 		}
 		return callOverridesName(inner, name, depth+1)
 	}
-	return false, true
+
+	if wordBaseEquals(words[0], "env") {
+		return envOverridesName(words[1:], name)
+	}
+
+	// Anything else is unprovable, and that includes commands that look
+	// completely ordinary. `sh -c '...'` parses as a single simple call whose
+	// argument is another entire program this cannot see into; so does any
+	// interpreter, any wrapper script, and any binary whose behaviour is not
+	// modelled here. The caller refuses rather than assuming.
+	//
+	// A DIRECT invocation of a known agent is the one provable case: it consumes
+	// its arguments itself and starts no second program construction.
+	if base, ok := literalShellWord(words[0]); ok && AgentForCommand(base) != "" {
+		return false, true
+	}
+	return false, false
+}
+
+// envOverridesName decides an `env` wrapper through envcommand.Parse, the
+// closed-set parser this repo already uses for exactly this problem, instead of
+// re-deriving GNU env's option grammar here.
+//
+// Reusing it is the point: the forms that leaked past the hand-rolled version —
+// `--unset=NAME`, `-uNAME`, a bare `-` — are ones that parser already models,
+// and a second implementation of the same grammar is a second thing to keep in
+// step. Anything Parse rejects is unprovable by definition, because Parse's own
+// contract is to refuse rather than silently model a different environment.
+func envOverridesName(args []*syntax.Word, name string) (overrides, provable bool) {
+	literals, ok := literalCommandArgs(args)
+	if !ok {
+		return false, false
+	}
+	invocation, err := envcommand.Parse(literals, envcommand.Policy{AllowAssignments: true})
+	if err != nil {
+		return false, false
+	}
+	// `-i`, and the bare `-` that GNU documents as implying it, drop the injected
+	// root along with everything else.
+	if invocation.ClearEnvironment {
+		return true, true
+	}
+	for _, mutation := range invocation.Mutations {
+		if mutation.Name == name {
+			// Set to something else, or unset outright — either way the injected
+			// value is not what the agent will see.
+			return true, true
+		}
+	}
+	if invocation.CommandIndex < 0 || invocation.CommandIndex >= len(literals) {
+		// env with no command to run: nothing launches, so nothing is redirected.
+		return false, true
+	}
+	// env leaves the root alone, so the decision belongs to whatever it runs.
+	if AgentForCommand(literals[invocation.CommandIndex]) != "" {
+		return false, true
+	}
+	return false, false
 }

--- a/internal/sessionenv/account_command.go
+++ b/internal/sessionenv/account_command.go
@@ -141,13 +141,18 @@ func envOverridesName(args []*syntax.Word, agent string, names map[string]struct
 	if invocation.ClearEnvironment {
 		return true, true
 	}
-	for _, mutation := range invocation.Mutations {
-		if _, refused := names[mutation.Name]; refused {
-			// Set to something else, or unset outright — either way the injected
-			// value is not what the agent will see.
-			return true, true
-		}
+	// ANY mutation, exactly as the shell-assignment branch does. Restricting this
+	// to the identity names left the same hole that branch had: `env
+	// LD_PRELOAD=./steal.so codex` loads repository code into the agent before it
+	// reads the injected root, and `env PATH=. codex` redirects the bare
+	// executable this guard requires — turning the provenance rule into a
+	// redirection of the operator's PATH by the repository (#2983 review).
+	//
+	// The two branches now express one rule: a scoped program mutates nothing.
+	if len(invocation.Mutations) > 0 {
+		return true, true
 	}
+	_ = names
 	if invocation.CommandIndex < 0 || invocation.CommandIndex >= len(literals) {
 		// env with no command to run: nothing launches, so nothing is redirected.
 		return false, true

--- a/internal/sessionenv/account_command.go
+++ b/internal/sessionenv/account_command.go
@@ -1,6 +1,9 @@
 package sessionenv
 
 import (
+	"path/filepath"
+	"strings"
+
 	"mvdan.cc/sh/v3/syntax"
 
 	"github.com/sachiniyer/agent-factory/internal/envcommand"
@@ -30,7 +33,7 @@ import (
 // agent, and a modelled `env` wrapper around one — and reports everything else
 // as UNPROVABLE. New syntax then arrives as a refusal to scope rather than as a
 // silent bypass, which is the direction this repo can afford to be wrong in.
-func commandOverridesName(command, name string) (overrides, provable bool) {
+func commandOverridesName(command, agent string, names map[string]struct{}) (overrides, provable bool) {
 	if command == "" {
 		return false, true
 	}
@@ -38,16 +41,19 @@ func commandOverridesName(command, name string) (overrides, provable bool) {
 	if !ok {
 		return false, false
 	}
-	return callOverridesName(call, name, 0)
+	return callOverridesName(call, agent, names, 0)
 }
 
-func callOverridesName(call *syntax.CallExpr, name string, depth int) (overrides, provable bool) {
+func callOverridesName(call *syntax.CallExpr, agent string, names map[string]struct{}, depth int) (overrides, provable bool) {
 	if depth > maxNestedProgramDepth {
 		return false, false
 	}
 	// Shell-parsed assignment prefixes: `CODEX_HOME=/other codex`.
 	for _, assign := range call.Assigns {
-		if assign != nil && assign.Name != nil && assign.Name.Value == name {
+		if assign == nil || assign.Name == nil {
+			continue
+		}
+		if _, refused := names[assign.Name.Value]; refused {
 			return true, true
 		}
 	}
@@ -69,7 +75,7 @@ func callOverridesName(call *syntax.CallExpr, name string, depth int) (overrides
 		if !ok {
 			break
 		}
-		if assigned == name {
+		if _, refused := names[assigned]; refused {
 			return true, true
 		}
 	}
@@ -81,11 +87,11 @@ func callOverridesName(call *syntax.CallExpr, name string, depth int) (overrides
 		if !ok {
 			return false, false
 		}
-		return callOverridesName(inner, name, depth+1)
+		return callOverridesName(inner, agent, names, depth+1)
 	}
 
 	if wordBaseEquals(words[0], "env") {
-		return envOverridesName(words[1:], name)
+		return envOverridesName(words[1:], agent, names)
 	}
 
 	// Anything else is unprovable, and that includes commands that look
@@ -96,7 +102,7 @@ func callOverridesName(call *syntax.CallExpr, name string, depth int) (overrides
 	//
 	// A DIRECT invocation of a known agent is the one provable case: it consumes
 	// its arguments itself and starts no second program construction.
-	if base, ok := literalShellWord(words[0]); ok && AgentForCommand(base) != "" {
+	if executable, ok := literalShellWord(words[0]); ok && executableIsAgent(executable, agent) {
 		return false, true
 	}
 	return false, false
@@ -111,7 +117,7 @@ func callOverridesName(call *syntax.CallExpr, name string, depth int) (overrides
 // and a second implementation of the same grammar is a second thing to keep in
 // step. Anything Parse rejects is unprovable by definition, because Parse's own
 // contract is to refuse rather than silently model a different environment.
-func envOverridesName(args []*syntax.Word, name string) (overrides, provable bool) {
+func envOverridesName(args []*syntax.Word, agent string, names map[string]struct{}) (overrides, provable bool) {
 	literals, ok := literalCommandArgs(args)
 	if !ok {
 		return false, false
@@ -126,7 +132,7 @@ func envOverridesName(args []*syntax.Word, name string) (overrides, provable boo
 		return true, true
 	}
 	for _, mutation := range invocation.Mutations {
-		if mutation.Name == name {
+		if _, refused := names[mutation.Name]; refused {
 			// Set to something else, or unset outright — either way the injected
 			// value is not what the agent will see.
 			return true, true
@@ -137,8 +143,26 @@ func envOverridesName(args []*syntax.Word, name string) (overrides, provable boo
 		return false, true
 	}
 	// env leaves the root alone, so the decision belongs to whatever it runs.
-	if AgentForCommand(literals[invocation.CommandIndex]) != "" {
+	if executableIsAgent(literals[invocation.CommandIndex], agent) {
 		return false, true
 	}
 	return false, false
+}
+
+// executableIsAgent reports whether an already-tokenized executable operand IS
+// the account's agent.
+//
+// Two things it deliberately does not do. It does not re-parse the operand as a
+// command string: `env './codex wrapper'` yields ONE executable path whose name
+// contains a space, and handing that to a command parser splits it and reports
+// `./codex` — while the shell runs a repository-provided file called
+// `codex wrapper`. And it does not accept just any known agent: a cross-agent
+// override (`account.Agent` claude, command `codex`) would otherwise be called
+// provable, after which the injected CLAUDE_CONFIG_DIR means nothing to codex and
+// it authenticates from its own default home (#2983 review).
+func executableIsAgent(executable, agent string) bool {
+	if executable == "" || agent == "" {
+		return false
+	}
+	return strings.EqualFold(filepath.Base(executable), agent)
 }

--- a/internal/sessionenv/account_command.go
+++ b/internal/sessionenv/account_command.go
@@ -85,7 +85,7 @@ func callOverridesName(call *syntax.CallExpr, agent string, names map[string]str
 
 	// A nested agent-server program carries its own command, and is the one
 	// wrapper this package already models.
-	if nested, ok := literalAgentServerProgram(call); ok {
+	if nested, ok := literalAgentServerProgram(call); ok && isBareName(words[0], "af") {
 		inner, ok := singleSimpleCall(nested)
 		if !ok {
 			return false, false
@@ -93,7 +93,7 @@ func callOverridesName(call *syntax.CallExpr, agent string, names map[string]str
 		return callOverridesName(inner, agent, names, depth+1)
 	}
 
-	if wordBaseEquals(words[0], "env") {
+	if isBareName(words[0], "env") {
 		return envOverridesName(words[1:], agent, names)
 	}
 
@@ -112,8 +112,17 @@ func callOverridesName(call *syntax.CallExpr, agent string, names map[string]str
 	if !callIsLiteral(call) {
 		return false, false
 	}
-	if executable, ok := literalShellWord(words[0]); ok && executableIsAgent(executable, agent) {
-		return false, true
+	// Bare name, and NO ARGUMENTS. An agent's own flags can redirect its identity
+	// as effectively as the environment can: codex documents
+	// `-c cli_auth_credentials_store="keyring"`, which makes it ignore the account
+	// directory's auth.json and use the machine-wide keyring instead, and claude's
+	// help points at --settings for auth. Enumerating those per agent is the same
+	// losing game as enumerating shell forms, one layer down, so a scoped
+	// invocation carries no arguments at all (#2983 review).
+	if len(words) == 1 {
+		if executable, ok := literalShellWord(words[0]); ok && executableIsAgent(executable, agent) {
+			return false, true
+		}
 	}
 	return false, false
 }
@@ -189,4 +198,19 @@ func executableIsAgent(executable, agent string) bool {
 		return false
 	}
 	return strings.EqualFold(executable, agent)
+}
+
+// isBareName reports whether a word is exactly the given command name with no
+// path component.
+//
+// A basename match is not provenance: `./env` and `./af` share a name with the
+// tools this models and are arbitrary repository-provided executables that would
+// receive the selected account root. Requiring a bare name puts PATH resolution —
+// the operator's configuration — in charge of which binary runs.
+func isBareName(word *syntax.Word, want string) bool {
+	value, ok := literalShellWord(word)
+	if !ok || strings.Contains(value, "/") {
+		return false
+	}
+	return strings.EqualFold(value, want)
 }

--- a/internal/sessionenv/account_test.go
+++ b/internal/sessionenv/account_test.go
@@ -36,7 +36,7 @@ func TestApplyAccount_RemovesTheAmbientIdentity(t *testing.T) {
 		"ANTHROPIC_BASE_URL=https://proxy.internal",
 	}
 
-	scoped, err := ApplyAccount(ambient, Account{Agent: "claude", Name: "work", Dir: "/afhome/accounts/claude/work"})
+	scoped, err := ApplyAccount(ambient, "", Account{Agent: "claude", Name: "work", Dir: "/afhome/accounts/claude/work"})
 	require.NoError(t, err)
 
 	for _, name := range []string{"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"} {
@@ -64,7 +64,7 @@ func TestApplyAccount_RemovesTheAmbientIdentity(t *testing.T) {
 // which one wins is the agent's parsing order rather than af's decision.
 func TestApplyAccount_ReplacesRatherThanAppendsTheConfigDir(t *testing.T) {
 	scoped, err := ApplyAccount(
-		[]string{"CODEX_HOME=/home/op/.codex"},
+		[]string{"CODEX_HOME=/home/op/.codex"}, "",
 		Account{Agent: "codex", Name: "personal", Dir: "/afhome/accounts/codex/personal"},
 	)
 	require.NoError(t, err)
@@ -87,9 +87,9 @@ func TestApplyAccount_ReplacesRatherThanAppendsTheConfigDir(t *testing.T) {
 func TestApplyAccount_DifferentAccountsGetDifferentRoots(t *testing.T) {
 	ambient := []string{"CLAUDE_CONFIG_DIR=/home/op/.claude"}
 
-	a, err := ApplyAccount(ambient, Account{Agent: "claude", Name: "a", Dir: "/afhome/accounts/claude/a"})
+	a, err := ApplyAccount(ambient, "", Account{Agent: "claude", Name: "a", Dir: "/afhome/accounts/claude/a"})
 	require.NoError(t, err)
-	b, err := ApplyAccount(ambient, Account{Agent: "claude", Name: "b", Dir: "/afhome/accounts/claude/b"})
+	b, err := ApplyAccount(ambient, "", Account{Agent: "claude", Name: "b", Dir: "/afhome/accounts/claude/b"})
 	require.NoError(t, err)
 
 	dirA, _ := envValue(a, "CLAUDE_CONFIG_DIR")
@@ -105,7 +105,7 @@ func TestApplyAccount_DifferentAccountsGetDifferentRoots(t *testing.T) {
 // evidence.
 func TestApplyAccount_RefusesAnUnverifiedAgent(t *testing.T) {
 	for _, agent := range []string{"gemini", "amp", "aider", "opencode", "unknown"} {
-		_, err := ApplyAccount(nil, Account{Agent: agent, Name: "x", Dir: "/d"})
+		_, err := ApplyAccount(nil, "", Account{Agent: agent, Name: "x", Dir: "/d"})
 		require.Error(t, err, "agent %q must refuse rather than accept an inert account selection", agent)
 		require.Contains(t, err.Error(), "does not support multiple accounts")
 		require.Contains(t, err.Error(), "claude", "the error must name what IS supported")
@@ -115,7 +115,7 @@ func TestApplyAccount_RefusesAnUnverifiedAgent(t *testing.T) {
 // An account with no directory is a configuration error, never an empty scope
 // that silently falls back to the ambient identity.
 func TestApplyAccount_RefusesAnEmptyDirectory(t *testing.T) {
-	_, err := ApplyAccount(nil, Account{Agent: "claude", Name: "work", Dir: "   "})
+	_, err := ApplyAccount(nil, "", Account{Agent: "claude", Name: "work", Dir: "   "})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no credential directory")
 }
@@ -146,5 +146,70 @@ func TestAccountScopedNames_AlwaysDeniesTheConfigVar(t *testing.T) {
 		denied := accountScopedNames(agent, configVar)
 		_, ok := denied[configVar]
 		require.True(t, ok, "%s must be denied before it is injected for %s", configVar, agent)
+	}
+}
+
+// A CLOUD MODE authenticates somewhere else entirely, so an account cannot scope
+// it. Bedrock/Vertex/Foundry make the CLI use AWS/Google/Azure credentials —
+// which FilterForCommand deliberately admits for exactly those modes — so the
+// account directory stops being the session's identity while still looking like
+// it. Refusing beats removing the selector, which would silently move the
+// session off the deployment mode its operator configured.
+func TestApplyAccount_RefusesWhileACloudModeIsActive(t *testing.T) {
+	for _, selector := range []string{"CLAUDE_CODE_USE_BEDROCK", "CLAUDE_CODE_USE_VERTEX", "CLAUDE_CODE_USE_FOUNDRY"} {
+		env := []string{selector + "=1", "AWS_SECRET_ACCESS_KEY=ambient"}
+		_, err := ApplyAccount(env, "", Account{Agent: "claude", Name: "work", Dir: "/afhome/accounts/claude/work"})
+		require.Error(t, err, "%s active must refuse an account scope", selector)
+		require.Contains(t, err.Error(), "cloud mode")
+		require.Contains(t, err.Error(), selector, "the refusal must name which mode blocked it")
+	}
+
+	// With no selector set, the same agent scopes normally — so the guard cannot
+	// pass by refusing everything.
+	_, err := ApplyAccount([]string{"PATH=/usr/bin"}, "",
+		Account{Agent: "claude", Name: "work", Dir: "/afhome/accounts/claude/work"})
+	require.NoError(t, err)
+}
+
+// A COMMAND-LOCAL ASSIGNMENT wins over the injected root, because the launch runs
+// the program through `/bin/sh -c` and the shell applies it after this
+// environment is installed. program_overrides is reachable from a repository's
+// checked-in config, so this is a repo-controlled way to redirect whose quota a
+// session spends — the exact thing account scoping exists to control.
+func TestApplyAccount_RefusesACommandThatSetsTheConfigVar(t *testing.T) {
+	cases := []string{
+		"CODEX_HOME=/other codex",
+		"CODEX_HOME=$HOME/.codex codex",
+		"env CODEX_HOME=/other codex",
+		"env -u CODEX_HOME codex",
+		"env -i codex",
+		"exec CODEX_HOME=/other codex",
+	}
+	for _, command := range cases {
+		_, err := ApplyAccount(nil, command, Account{Agent: "codex", Name: "p", Dir: "/afhome/accounts/codex/p"})
+		require.Error(t, err, "command %q must not silently override the account root", command)
+		require.Contains(t, err.Error(), "CODEX_HOME")
+	}
+
+	// An ordinary program is unaffected, so the guard is not simply refusing all
+	// account use.
+	_, err := ApplyAccount(nil, "codex", Account{Agent: "codex", Name: "p", Dir: "/afhome/accounts/codex/p"})
+	require.NoError(t, err)
+	_, err = ApplyAccount(nil, "codex --model gpt-5", Account{Agent: "codex", Name: "p", Dir: "/afhome/accounts/codex/p"})
+	require.NoError(t, err)
+}
+
+// A command that cannot be parsed into a single simple call is not evidence of
+// safety. Account scoping decides whose quota is spent, so an unprovable program
+// fails closed rather than being assumed harmless.
+func TestApplyAccount_FailsClosedOnAnUnprovableCommand(t *testing.T) {
+	for _, command := range []string{
+		"codex | tee /tmp/x",
+		"(CODEX_HOME=/other codex)",
+		"codex && echo done",
+	} {
+		_, err := ApplyAccount(nil, command, Account{Agent: "codex", Name: "p", Dir: "/afhome/accounts/codex/p"})
+		require.Error(t, err, "command %q is unparseable and must not be assumed safe", command)
+		require.Contains(t, err.Error(), "could not be proven free")
 	}
 }

--- a/internal/sessionenv/account_test.go
+++ b/internal/sessionenv/account_test.go
@@ -260,6 +260,11 @@ func TestApplyAccount_FailsClosedOnAnUnprovableCommand(t *testing.T) {
 		// Case-sensitive hosts: CODEX is a different executable from codex.
 		"CODEX",
 		"env CODEX",
+		// An ignored signal disposition SURVIVES exec: the agent could outlive
+		// teardown while holding the account.
+		"env --ignore-signal=HUP,TERM codex",
+		"env --block-signal=TERM codex",
+		"env --default-signal codex",
 		"ENV codex",
 		// A CROSS-AGENT override: the account scopes codex, the command runs
 		// claude, which ignores CODEX_HOME entirely and uses its own default home.

--- a/internal/sessionenv/account_test.go
+++ b/internal/sessionenv/account_test.go
@@ -220,8 +220,6 @@ func TestApplyAccount_RefusesACommandThatSetsTheConfigVar(t *testing.T) {
 	// account use.
 	_, err := ApplyAccount(nil, "codex", Account{Agent: "codex", Name: "p", Dir: "/afhome/accounts/codex/p"})
 	require.NoError(t, err)
-	_, err = ApplyAccount(nil, "codex --model gpt-5", Account{Agent: "codex", Name: "p", Dir: "/afhome/accounts/codex/p"})
-	require.NoError(t, err)
 }
 
 // A command that cannot be parsed into a single simple call is not evidence of
@@ -245,6 +243,14 @@ func TestApplyAccount_FailsClosedOnAnUnprovableCommand(t *testing.T) {
 		// that would receive the selected root.
 		"./codex",
 		"bin/codex",
+		// A repository file that merely SHARES a name with a modelled wrapper.
+		"./env codex",
+		"./af agent-server --program codex --program-resolved",
+		// An agent's own flags redirect its identity as effectively as the
+		// environment: codex -c cli_auth_credentials_store="keyring" ignores the
+		// account directory's auth.json entirely.
+		"codex -c cli_auth_credentials_store=\"keyring\"",
+		"codex --model gpt-5",
 		// A CROSS-AGENT override: the account scopes codex, the command runs
 		// claude, which ignores CODEX_HOME entirely and uses its own default home.
 		"claude",

--- a/internal/sessionenv/account_test.go
+++ b/internal/sessionenv/account_test.go
@@ -204,6 +204,9 @@ func TestApplyAccount_RefusesACommandThatSetsTheConfigVar(t *testing.T) {
 		// redirects the bare executable the provenance rule depends on.
 		"env LD_PRELOAD=./steal.so codex",
 		"env PATH=. codex",
+		// A chdir is a PATH mutation in disguise: it changes command lookup.
+		"env -C attacker codex",
+		"env --chdir=attacker codex",
 		"CODEX_HOME=$HOME/.codex codex",
 		"env CODEX_HOME=/other codex",
 		"env -u CODEX_HOME codex",

--- a/internal/sessionenv/account_test.go
+++ b/internal/sessionenv/account_test.go
@@ -274,3 +274,40 @@ func TestApplyAccount_FailsClosedOnAnUnprovableCommand(t *testing.T) {
 		require.Contains(t, err.Error(), "could not be proven")
 	}
 }
+
+// The docker and ssh backends generate an ABSOLUTE af path for the agent-server
+// handoff (`/usr/local/bin/af agent-server …`, or a staged path). A bare-name
+// rule refuses af's own launch on those backends, so account scoping would fail
+// for every session there — the name-is-not-provenance problem in reverse: the
+// path IS trusted and its spelling cannot say so, which is why the launcher
+// supplies it rather than this parsing it out (#2983).
+func TestApplyAccount_AcceptsTheLaunchersOwnAfWrapper(t *testing.T) {
+	const generated = "/usr/local/bin/af"
+	command := generated + " agent-server --listen x --repo r --title t --program codex --program-resolved"
+
+	// Without the supplied provenance the same command is unprovable: an absolute
+	// path proves nothing on its own.
+	_, err := ApplyAccount(nil, command, Account{Agent: "codex", Name: "p", Dir: "/afhome/accounts/codex/p"})
+	require.Error(t, err, "an absolute af path with no supplied provenance must stay unprovable")
+
+	scoped, err := ApplyAccount(nil, command, Account{
+		Agent: "codex", Name: "p", Dir: "/afhome/accounts/codex/p", TrustedWrapper: generated,
+	})
+	require.NoError(t, err, "the launcher's own handoff must be accepted, or account scoping fails on docker and ssh")
+	dir, ok := envValue(scoped, "CODEX_HOME")
+	require.True(t, ok)
+	require.Equal(t, "/afhome/accounts/codex/p", dir)
+}
+
+// Provenance is an EXACT path, never a basename. A repository file sharing the
+// name — or sitting at a different path — is still refused even when a trusted
+// wrapper was supplied.
+func TestApplyAccount_TrustedWrapperIsNotABasename(t *testing.T) {
+	for _, executable := range []string{"./af", "/repo/af", "/usr/local/bin/af-shim"} {
+		command := executable + " agent-server --program codex --program-resolved"
+		_, err := ApplyAccount(nil, command, Account{
+			Agent: "codex", Name: "p", Dir: "/d", TrustedWrapper: "/usr/local/bin/af",
+		})
+		require.Error(t, err, "%s is not the generated wrapper and must not inherit its trust", executable)
+	}
+}

--- a/internal/sessionenv/account_test.go
+++ b/internal/sessionenv/account_test.go
@@ -1,0 +1,150 @@
+package sessionenv
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func envValue(env []string, name string) (string, bool) {
+	for _, kv := range env {
+		if k, v, ok := strings.Cut(kv, "="); ok && k == name {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// THE CONSTRAINT (#2983). A session must receive exactly ONE account's
+// credential and have the others actively removed.
+//
+// This is written as an EXCLUSION test on purpose. The naive implementation —
+// delivering the account through the session-env allowlist — passes every
+// presence check: the credential is there, the agent authenticates, the flag was
+// accepted. What it does not do is remove the ambient identity, and for both of
+// these CLIs an ambient API key takes precedence over the config directory. So
+// "the session has a credential" is exactly the assertion that cannot tell the
+// working implementation from the broken one.
+func TestApplyAccount_RemovesTheAmbientIdentity(t *testing.T) {
+	ambient := []string{
+		"PATH=/usr/bin",
+		"ANTHROPIC_API_KEY=sk-ambient-should-not-survive",
+		"ANTHROPIC_AUTH_TOKEN=tok-ambient-should-not-survive",
+		"CLAUDE_CODE_OAUTH_TOKEN=oauth-ambient-should-not-survive",
+		"CLAUDE_CONFIG_DIR=/home/op/.claude",
+		"ANTHROPIC_BASE_URL=https://proxy.internal",
+	}
+
+	scoped, err := ApplyAccount(ambient, Account{Agent: "claude", Name: "work", Dir: "/afhome/accounts/claude/work"})
+	require.NoError(t, err)
+
+	for _, name := range []string{"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"} {
+		_, present := envValue(scoped, name)
+		require.False(t, present,
+			"%s survived into an account-scoped session: an ambient key outranks the config directory, so the account selection would be silently ignored", name)
+	}
+
+	dir, ok := envValue(scoped, "CLAUDE_CONFIG_DIR")
+	require.True(t, ok, "the account's credential root must be injected")
+	require.Equal(t, "/afhome/accounts/claude/work", dir,
+		"the session must get the SELECTED account's directory, not the daemon's ambient one")
+
+	// The operator's deployment config is not an identity and must survive, or
+	// scoping an account would break a proxied install.
+	base, ok := envValue(scoped, "ANTHROPIC_BASE_URL")
+	require.True(t, ok)
+	require.Equal(t, "https://proxy.internal", base)
+	path, ok := envValue(scoped, "PATH")
+	require.True(t, ok)
+	require.Equal(t, "/usr/bin", path)
+}
+
+// The ambient config dir must be REPLACED, not merely joined. If both survived,
+// which one wins is the agent's parsing order rather than af's decision.
+func TestApplyAccount_ReplacesRatherThanAppendsTheConfigDir(t *testing.T) {
+	scoped, err := ApplyAccount(
+		[]string{"CODEX_HOME=/home/op/.codex"},
+		Account{Agent: "codex", Name: "personal", Dir: "/afhome/accounts/codex/personal"},
+	)
+	require.NoError(t, err)
+
+	count := 0
+	for _, kv := range scoped {
+		if strings.HasPrefix(kv, "CODEX_HOME=") {
+			count++
+		}
+	}
+	require.Equal(t, 1, count, "exactly one CODEX_HOME must reach the session")
+	dir, _ := envValue(scoped, "CODEX_HOME")
+	require.Equal(t, "/afhome/accounts/codex/personal", dir)
+}
+
+// Two sessions on different accounts must get different roots. This is the
+// assertion an allowlist implementation fails: passthrough carries the daemon's
+// ONE value to every session, so both would be identical while each looked
+// correct in isolation.
+func TestApplyAccount_DifferentAccountsGetDifferentRoots(t *testing.T) {
+	ambient := []string{"CLAUDE_CONFIG_DIR=/home/op/.claude"}
+
+	a, err := ApplyAccount(ambient, Account{Agent: "claude", Name: "a", Dir: "/afhome/accounts/claude/a"})
+	require.NoError(t, err)
+	b, err := ApplyAccount(ambient, Account{Agent: "claude", Name: "b", Dir: "/afhome/accounts/claude/b"})
+	require.NoError(t, err)
+
+	dirA, _ := envValue(a, "CLAUDE_CONFIG_DIR")
+	dirB, _ := envValue(b, "CLAUDE_CONFIG_DIR")
+	require.NotEqual(t, dirA, dirB, "two accounts must not resolve to one credential root")
+	require.Equal(t, "/afhome/accounts/claude/a", dirA)
+	require.Equal(t, "/afhome/accounts/claude/b", dirB)
+}
+
+// An agent whose credential relocation was never VERIFIED must refuse, not
+// silently accept a selection that does nothing. gemini and amp have the
+// allowlist entries but were not testable, and allowlist membership is not
+// evidence.
+func TestApplyAccount_RefusesAnUnverifiedAgent(t *testing.T) {
+	for _, agent := range []string{"gemini", "amp", "aider", "opencode", "unknown"} {
+		_, err := ApplyAccount(nil, Account{Agent: agent, Name: "x", Dir: "/d"})
+		require.Error(t, err, "agent %q must refuse rather than accept an inert account selection", agent)
+		require.Contains(t, err.Error(), "does not support multiple accounts")
+		require.Contains(t, err.Error(), "claude", "the error must name what IS supported")
+	}
+}
+
+// An account with no directory is a configuration error, never an empty scope
+// that silently falls back to the ambient identity.
+func TestApplyAccount_RefusesAnEmptyDirectory(t *testing.T) {
+	_, err := ApplyAccount(nil, Account{Agent: "claude", Name: "work", Dir: "   "})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no credential directory")
+}
+
+// Every allowlisted name for a scoped agent must be classified as either an
+// identity (removed) or deliberately kept. Without this the subtraction list
+// rots silently: a credential added to agentNames later would keep passing
+// through, and the exclusion tests above would still be green because they only
+// name the variables that existed when they were written.
+func TestAccountCredentialsAreClassified(t *testing.T) {
+	for agent := range accountConfigVars {
+		for name := range agentNames[agent] {
+			_, isCredential := accountCredentialNames[agent][name]
+			_, isKept := accountNonCredentialNames[agent][name]
+			require.True(t, isCredential || isKept,
+				"%s is allowlisted for %s but classified neither as an identity to remove nor as deployment config to keep; "+
+					"an unclassified credential passes through and silently overrides the selected account", name, agent)
+			require.False(t, isCredential && isKept,
+				"%s for %s is classified both ways", name, agent)
+		}
+	}
+}
+
+// The config variable itself is always removed before injection, so an ambient
+// copy cannot shadow the account.
+func TestAccountScopedNames_AlwaysDeniesTheConfigVar(t *testing.T) {
+	for agent, configVar := range accountConfigVars {
+		denied := accountScopedNames(agent, configVar)
+		_, ok := denied[configVar]
+		require.True(t, ok, "%s must be denied before it is injected for %s", configVar, agent)
+	}
+}

--- a/internal/sessionenv/account_test.go
+++ b/internal/sessionenv/account_test.go
@@ -186,6 +186,15 @@ func TestApplyAccount_RefusesACommandThatSetsTheConfigVar(t *testing.T) {
 		// Sets the variable AND wraps a shell: the assignment is the stronger,
 		// definite answer, so this is an override rather than merely unprovable.
 		"env CODEX_HOME=/other sh -c codex",
+		// Any identity-bearing name, not just the config root: subtraction removed
+		// the ambient copy, and the shell recreates it afterwards.
+		"OPENAI_API_KEY=sk-other codex",
+		"CODEX_API_KEY=other codex",
+		"env OPENAI_API_KEY=sk-other codex",
+		// A cloud selector whose value the parser cannot evaluate reads as
+		// DISABLED, so the cloud-mode refusal never fires while the shell expands
+		// it to a non-empty string.
+		"CLAUDE_CODE_USE_BEDROCK=$HOME codex",
 		"CODEX_HOME=$HOME/.codex codex",
 		"env CODEX_HOME=/other codex",
 		"env -u CODEX_HOME codex",
@@ -195,7 +204,7 @@ func TestApplyAccount_RefusesACommandThatSetsTheConfigVar(t *testing.T) {
 	for _, command := range cases {
 		_, err := ApplyAccount(nil, command, Account{Agent: "codex", Name: "p", Dir: "/afhome/accounts/codex/p"})
 		require.Error(t, err, "command %q must not silently override the account root", command)
-		require.Contains(t, err.Error(), "CODEX_HOME")
+		require.Contains(t, err.Error(), "identity variable")
 	}
 
 	// An ordinary program is unaffected, so the guard is not simply refusing all
@@ -220,9 +229,16 @@ func TestApplyAccount_FailsClosedOnAnUnprovableCommand(t *testing.T) {
 		"bash -lc codex",
 		// Any binary whose behaviour is not modelled here.
 		"/usr/local/bin/wrapper codex",
+		// A CROSS-AGENT override: the account scopes codex, the command runs
+		// claude, which ignores CODEX_HOME entirely and uses its own default home.
+		"claude",
+		// One executable operand whose NAME contains a space. Re-parsing it as a
+		// command string would split it and see "./codex"; the shell runs a
+		// repository-provided file called "codex wrapper".
+		"env './codex wrapper'",
 	} {
 		_, err := ApplyAccount(nil, command, Account{Agent: "codex", Name: "p", Dir: "/afhome/accounts/codex/p"})
 		require.Error(t, err, "command %q is unparseable and must not be assumed safe", command)
-		require.Contains(t, err.Error(), "could not be proven free")
+		require.Contains(t, err.Error(), "could not be proven")
 	}
 }

--- a/internal/sessionenv/account_test.go
+++ b/internal/sessionenv/account_test.go
@@ -251,6 +251,13 @@ func TestApplyAccount_FailsClosedOnAnUnprovableCommand(t *testing.T) {
 		// account directory's auth.json entirely.
 		"codex -c cli_auth_credentials_store=\"keyring\"",
 		"codex --model gpt-5",
+		// The no-argument rule must hold through the env wrapper too.
+		"env codex -c cli_auth_credentials_store=keyring",
+		"env codex --model gpt-5",
+		// Case-sensitive hosts: CODEX is a different executable from codex.
+		"CODEX",
+		"env CODEX",
+		"ENV codex",
 		// A CROSS-AGENT override: the account scopes codex, the command runs
 		// claude, which ignores CODEX_HOME entirely and uses its own default home.
 		"claude",

--- a/internal/sessionenv/account_test.go
+++ b/internal/sessionenv/account_test.go
@@ -179,6 +179,13 @@ func TestApplyAccount_RefusesWhileACloudModeIsActive(t *testing.T) {
 func TestApplyAccount_RefusesACommandThatSetsTheConfigVar(t *testing.T) {
 	cases := []string{
 		"CODEX_HOME=/other codex",
+		// Forms the first, denylist-shaped version walked straight past.
+		"env --unset=CODEX_HOME codex",
+		"env -uCODEX_HOME codex",
+		"env - codex",
+		// Sets the variable AND wraps a shell: the assignment is the stronger,
+		// definite answer, so this is an override rather than merely unprovable.
+		"env CODEX_HOME=/other sh -c codex",
 		"CODEX_HOME=$HOME/.codex codex",
 		"env CODEX_HOME=/other codex",
 		"env -u CODEX_HOME codex",
@@ -207,6 +214,12 @@ func TestApplyAccount_FailsClosedOnAnUnprovableCommand(t *testing.T) {
 		"codex | tee /tmp/x",
 		"(CODEX_HOME=/other codex)",
 		"codex && echo done",
+		// A shell wrapper parses as an ordinary single call whose ARGUMENT is
+		// another whole program. It must be unprovable, not "provably fine".
+		"sh -c 'CODEX_HOME=/other codex'",
+		"bash -lc codex",
+		// Any binary whose behaviour is not modelled here.
+		"/usr/local/bin/wrapper codex",
 	} {
 		_, err := ApplyAccount(nil, command, Account{Agent: "codex", Name: "p", Dir: "/afhome/accounts/codex/p"})
 		require.Error(t, err, "command %q is unparseable and must not be assumed safe", command)

--- a/internal/sessionenv/account_test.go
+++ b/internal/sessionenv/account_test.go
@@ -195,6 +195,10 @@ func TestApplyAccount_RefusesACommandThatSetsTheConfigVar(t *testing.T) {
 		// DISABLED, so the cloud-mode refusal never fires while the shell expands
 		// it to a non-empty string.
 		"CLAUDE_CODE_USE_BEDROCK=$HOME codex",
+		// Any assignment at all, including ones that carry no identity but change
+		// what the executable DOES.
+		"LD_PRELOAD=./steal.so codex",
+		"DYLD_INSERT_LIBRARIES=./steal.dylib codex",
 		"CODEX_HOME=$HOME/.codex codex",
 		"env CODEX_HOME=/other codex",
 		"env -u CODEX_HOME codex",
@@ -229,6 +233,13 @@ func TestApplyAccount_FailsClosedOnAnUnprovableCommand(t *testing.T) {
 		"bash -lc codex",
 		// Any binary whose behaviour is not modelled here.
 		"/usr/local/bin/wrapper codex",
+		// A command substitution in an ARGUMENT runs before the outer agent does.
+		"codex \"$(unset CODEX_HOME; codex exec x)\"",
+		"codex --model $(cat /tmp/m)",
+		// A basename is not provenance: ./codex is an arbitrary repo-provided file
+		// that would receive the selected root.
+		"./codex",
+		"bin/codex",
 		// A CROSS-AGENT override: the account scopes codex, the command runs
 		// claude, which ignores CODEX_HOME entirely and uses its own default home.
 		"claude",

--- a/internal/sessionenv/account_test.go
+++ b/internal/sessionenv/account_test.go
@@ -199,6 +199,11 @@ func TestApplyAccount_RefusesACommandThatSetsTheConfigVar(t *testing.T) {
 		// what the executable DOES.
 		"LD_PRELOAD=./steal.so codex",
 		"DYLD_INSERT_LIBRARIES=./steal.dylib codex",
+		// The env wrapper must express the same rule as a shell assignment: a
+		// scoped program mutates nothing. PATH is the sharpest of these — it
+		// redirects the bare executable the provenance rule depends on.
+		"env LD_PRELOAD=./steal.so codex",
+		"env PATH=. codex",
 		"CODEX_HOME=$HOME/.codex codex",
 		"env CODEX_HOME=/other codex",
 		"env -u CODEX_HOME codex",


### PR DESCRIPTION
Part 2 of #2983 — the credential boundary, which is the part the issue calls out as needing care. Design and per-provider verification were posted on the issue first and approved.

## The constraint, and why the naive version looks like it works

`sessionenv.Filter` is **subtractive over the daemon's own environment** — it selects which of the *parent's* variables survive into a session. `AF_DAEMON_TOKEN` is the archetype of a variable for which that is correct: one value, the same for every session.

An account credential is the opposite: it must differ **per session**. Deliver it through the allowlist and every session gets the daemon's single value — while a presence check passes, the agent authenticates, and `--account` is accepted without error. None of those observes *which* account was used.

It is worse than a no-op, because the relevant names are **already allowlisted**. `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY` and the OAuth tokens all pass through today, and for both CLIs an ambient API key **outranks** the config directory. A session created with `--account b` would authenticate as whoever the ambient key belongs to, silently, while every visible signal said `b` — the exact failure this issue exists to fix.

So: **injection plus subtraction**, in one operation that cannot be half-applied.

## Per-provider verification (not assumed)

Tested against the installed CLIs, because the issue warns against assuming symmetry:

| agent | variable | evidence | result |
|---|---|---|---|
| claude 2.1.223 | `CLAUDE_CONFIG_DIR` | empty dir → `"loggedIn": false`; real dir → `true` | ✅ relocates credentials |
| codex-cli 0.146.1 | `CODEX_HOME` | empty dir → `Not logged in`; real → `Logged in using ChatGPT` | ✅ relocates credentials |
| gemini, amp | `GEMINI_CLI_HOME`, `AMP_HOME` | allowlisted, but **not testable here** | ❌ refuse the selection |

Both keep credentials in a **file** under that root, so multiple accounts coexist as directories rather than fighting over one keychain entry — the failure mode that would have forced a different abstraction.

Allowlist membership is not evidence of credential relocation, so gemini and amp **refuse** an account selection rather than accepting one that would silently do nothing.

## What is deliberately kept

Routing and mode variables — `ANTHROPIC_BASE_URL`, the Bedrock/Vertex selectors, `CODEX_CA_CERTIFICATE` — are the operator's deployment configuration, not an identity. Dropping them would break a proxied install in order to scope an account.

The cost of an explicit list is that a newly allowlisted credential could be forgotten, so `TestAccountCredentialsAreClassified` fails when any allowlisted name for a scoped agent is classified neither as an identity to remove nor as config to keep. The distinction cannot rot silently as the allowlists grow.

## The tests are exclusion tests, verified by mutation

"The session has a credential" passes on the broken design, so it is the assertion this avoids. Instead:

- an ambient `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN` **does not survive**;
- the ambient config dir is **replaced**, not appended — exactly one reaches the session;
- two accounts resolve to **different** roots (the assertion a passthrough implementation fails, since it hands both the daemon's one value);
- an unverified agent **refuses**, and the error names what is supported;
- an empty directory is an error, never an empty scope that falls back to ambient.

Verified by mutation rather than assumed: with the deny set emptied — the inject-only implementation — the suite fails with `ANTHROPIC_API_KEY survived into an account-scoped session`, and the two-accounts test fails alongside it.

## Scope of this PR

The credential boundary only. Account storage, `af accounts` commands, `--account` at create, and the TUI/web display build on `ApplyAccount` and are not here. Nothing auto-switches accounts on a limit — that stays the user's call, per the issue.

Refs #2983

🤖 Generated with [Claude Code](https://claude.com/claude-code)
