### PR TITLE
fix(daemon): key the status-poll pause lease by holder so one release cannot revoke another's

### DIFF
--- a/app/attached_pause_test.go
+++ b/app/attached_pause_test.go
@@ -227,7 +227,11 @@ func TestAttachOverlayCallback_PausesAndResumesDaemonPoll(t *testing.T) {
 		t.Fatal("PauseStatusPoll was not called before detach — the daemon poll must pause on attach")
 	}
 	mu.Lock()
-	require.Equal(t, target.pauseStatusPollRequest(), pausedRequest,
+	// The holder is minted per ATTACH (#3027), so it cannot be reconstructed here —
+	// which is the point: it must be non-empty, or this attach falls back to the
+	// legacy shared slot and gets none of the multi-holder protection.
+	require.NotEmpty(t, pausedRequest.Holder, "each attach must take the lease under its own holder identity")
+	require.Equal(t, target.pauseStatusPollRequestAs(pausedRequest.Holder), pausedRequest,
 		"pause must retain the attached session's stable identity")
 	require.Positive(t, pauseCount, "pause must fire on attach")
 	require.Zero(t, resumeCount, "resume must not fire while still attached")
@@ -244,7 +248,12 @@ func TestAttachOverlayCallback_PausesAndResumesDaemonPoll(t *testing.T) {
 		return resumeCount > 0
 	}, time.Second, time.Millisecond, "ResumeStatusPoll must fire on detach")
 	mu.Lock()
-	assert.Equal(t, target.resumeStatusPollRequest(), resumedRequest,
+	// Stronger than the identity check it replaces, and the property #3028's review
+	// asked for: a resume that carried a DIFFERENT holder would revoke somebody
+	// else's claim and leave this attach's own lease standing.
+	assert.Equal(t, pausedRequest.Holder, resumedRequest.Holder,
+		"resume must release the same holder the attach acquired, not another's")
+	assert.Equal(t, target.resumeStatusPollRequestAs(pausedRequest.Holder), resumedRequest,
 		"resume must release the exact stable lease acquired on attach")
 	mu.Unlock()
 

--- a/app/home_attach.go
+++ b/app/home_attach.go
@@ -197,7 +197,12 @@ func (m *home) attachOverlayCallback(target sessionActionTarget, label, traceSuf
 	resume := m.resumeStatusPoll
 	pauseDone := make(chan struct{})
 	heartbeatExited := make(chan struct{})
-	go runStatusPollPauseHeartbeat(pause, target.pauseStatusPollRequest(), pauseDone, heartbeatExited)
+	// One holder per ATTACH (#3027, #3028 review). runStatusPollResume below is
+	// asynchronous and can outlive this attach's re-entry gates, so a re-attach
+	// with a shared id would have the previous attach's late resume revoke the new
+	// one's lease. A fresh id makes that stale resume address nobody.
+	attachHolder := newStatusPollHolder("attach")
+	go runStatusPollPauseHeartbeat(pause, target.pauseStatusPollRequestAs(attachHolder), pauseDone, heartbeatExited)
 
 	m.attached.Store(true)
 	defer m.attached.Store(false)
@@ -217,7 +222,7 @@ func (m *home) attachOverlayCallback(target sessionActionTarget, label, traceSuf
 	// never blocks on the wait or the RPC — attach/detach responsiveness is the
 	// whole point of #1160.
 	close(pauseDone)
-	go runStatusPollResume(resume, target.resumeStatusPollRequest(), heartbeatExited)
+	go runStatusPollResume(resume, target.resumeStatusPollRequestAs(attachHolder), heartbeatExited)
 	detachStart := time.Now()
 	detachTraceMark(label + "-<-ch-unblocked" + traceSuffix)
 	m.attachTransitioning = false

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -332,12 +332,7 @@ type home struct {
 	// interactivePauseAt throttles the renew to statusPollRenewInterval.
 	// Event-loop only.
 	interactivePauseTarget sessionActionTarget
-	// interactivePauseHolder is the pause-lease holder minted for the CURRENT
-	// interactive lifecycle (#3027). Per lifecycle, not per process: these commands
-	// run through tea.Batch, so a resume for a previous lifecycle can land after the
-	// next pause, and a shared id would let it delete a lease the new lifecycle
-	// holds. Cleared with the target it belongs to.
-	interactivePauseHolder string
+	interactivePauseHolder string // per-lifecycle lease holder; see interactivePollPauseCmd (#3027)
 	interactivePauseAt     time.Time
 
 	// initialPaneOpened latches the one-time startup auto-open: the first

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -332,6 +332,12 @@ type home struct {
 	// interactivePauseAt throttles the renew to statusPollRenewInterval.
 	// Event-loop only.
 	interactivePauseTarget sessionActionTarget
+	// interactivePauseHolder is the pause-lease holder minted for the CURRENT
+	// interactive lifecycle (#3027). Per lifecycle, not per process: these commands
+	// run through tea.Batch, so a resume for a previous lifecycle can land after the
+	// next pause, and a shared id would let it delete a lease the new lifecycle
+	// holds. Cleared with the target it belongs to.
+	interactivePauseHolder string
 	interactivePauseAt     time.Time
 
 	// initialPaneOpened latches the one-time startup auto-open: the first

--- a/app/interactive_lease_order_test.go
+++ b/app/interactive_lease_order_test.go
@@ -1,0 +1,79 @@
+package app
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestRunInteractiveLease_DropsASupersededIntent is #3028 review: the interactive
+// path's pause/resume RPCs are dispatched through tea.Batch, which gives no
+// ordering. With a slow pause the four calls of a lifecycle swap can execute as old
+// resume, new pause, old pause, new resume — and the late OLD pause would stay in
+// the daemon's map, keeping the poll and automated delivery suppressed for the rest
+// of its lease after interactive mode has ended.
+//
+// The intents are ordered correctly on the event loop, so they carry a sequence
+// number and the executor applies only the newest it has seen.
+func TestRunInteractiveLease_DropsASupersededIntent(t *testing.T) {
+	restore := interactiveLeaseApplied
+	defer func() { interactiveLeaseApplied = restore }()
+	interactiveLeaseApplied = 0
+
+	var applied []int
+	runInteractiveLease(2, func() { applied = append(applied, 2) })
+	runInteractiveLease(1, func() { applied = append(applied, 1) }) // the late old intent
+	runInteractiveLease(3, func() { applied = append(applied, 3) })
+
+	if len(applied) != 2 || applied[0] != 2 || applied[1] != 3 {
+		t.Fatalf("applied = %v, want [2 3] — intent 1 describes a state the user already left", applied)
+	}
+}
+
+// Re-applying the same sequence number must not run twice: a retry of one intent is
+// not a new intent, and running a pause twice would extend a lease its lifecycle no
+// longer owns.
+func TestRunInteractiveLease_IsIdempotentForOneSequence(t *testing.T) {
+	restore := interactiveLeaseApplied
+	defer func() { interactiveLeaseApplied = restore }()
+	interactiveLeaseApplied = 0
+
+	runs := 0
+	runInteractiveLease(1, func() { runs++ })
+	runInteractiveLease(1, func() { runs++ })
+	if runs != 1 {
+		t.Fatalf("ran %d times, want 1", runs)
+	}
+}
+
+// The executor serialises: two intents must never interleave, or a resume could land
+// between a pause's check and its RPC.
+func TestRunInteractiveLease_SerialisesConcurrentIntents(t *testing.T) {
+	restore := interactiveLeaseApplied
+	defer func() { interactiveLeaseApplied = restore }()
+	interactiveLeaseApplied = 0
+
+	var mu sync.Mutex
+	inFlight, maxInFlight := 0, 0
+	var wg sync.WaitGroup
+	for i := 1; i <= 8; i++ {
+		wg.Add(1)
+		go func(seq uint64) {
+			defer wg.Done()
+			runInteractiveLease(seq, func() {
+				mu.Lock()
+				inFlight++
+				if inFlight > maxInFlight {
+					maxInFlight = inFlight
+				}
+				mu.Unlock()
+				mu.Lock()
+				inFlight--
+				mu.Unlock()
+			})
+		}(uint64(i))
+	}
+	wg.Wait()
+	if maxInFlight > 1 {
+		t.Fatalf("max concurrent intents = %d, want 1", maxInFlight)
+	}
+}

--- a/app/live_termpane.go
+++ b/app/live_termpane.go
@@ -252,7 +252,7 @@ func (m *home) interactivePollPauseCmd() tea.Cmd {
 		}
 		// Interactive ended (or focus left the pane): release the lease now so the
 		// daemon resumes delivering into the session immediately.
-		release := m.interactivePauseTarget.resumeStatusPollRequest()
+		release := m.interactivePauseTarget.resumeStatusPollRequestAs(interactivePollHolder)
 		m.interactivePauseTarget = sessionActionTarget{}
 		m.interactivePauseAt = time.Time{}
 		return func() tea.Msg {
@@ -269,9 +269,9 @@ func (m *home) interactivePollPauseCmd() tea.Cmd {
 		m.interactivePauseAt = time.Now()
 		return func() tea.Msg {
 			if !prev.isZero() {
-				_ = resume(prev.resumeStatusPollRequest())
+				_ = resume(prev.resumeStatusPollRequestAs(interactivePollHolder))
 			}
-			_ = pause(want.pauseStatusPollRequest())
+			_ = pause(want.pauseStatusPollRequestAs(interactivePollHolder))
 			return nil
 		}
 	}
@@ -283,7 +283,7 @@ func (m *home) interactivePollPauseCmd() tea.Cmd {
 	}
 	m.interactivePauseAt = time.Now()
 	return func() tea.Msg {
-		_ = pause(want.pauseStatusPollRequest())
+		_ = pause(want.pauseStatusPollRequestAs(interactivePollHolder))
 		return nil
 	}
 }

--- a/app/live_termpane.go
+++ b/app/live_termpane.go
@@ -252,8 +252,9 @@ func (m *home) interactivePollPauseCmd() tea.Cmd {
 		}
 		// Interactive ended (or focus left the pane): release the lease now so the
 		// daemon resumes delivering into the session immediately.
-		release := m.interactivePauseTarget.resumeStatusPollRequestAs(interactivePollHolder)
+		release := m.interactivePauseTarget.resumeStatusPollRequestAs(m.interactivePauseHolder)
 		m.interactivePauseTarget = sessionActionTarget{}
+		m.interactivePauseHolder = ""
 		m.interactivePauseAt = time.Time{}
 		return func() tea.Msg {
 			_ = resume(release)
@@ -265,13 +266,23 @@ func (m *home) interactivePollPauseCmd() tea.Cmd {
 		// Newly interactive on this session (or the focused session changed): release
 		// any previous hold and pause the new target.
 		prev := m.interactivePauseTarget
+		// The OUTGOING lifecycle's holder travels with its resume, and the incoming
+		// one gets a freshly minted id (#3028 review). These commands run through
+		// tea.Batch, so a resume for the previous lifecycle can land AFTER the new
+		// pause; sharing one id would make that late resume delete the lease the new
+		// lifecycle just took, resuming the poll and automated delivery while the
+		// user types. Distinct ids make the stale resume address a holder nobody
+		// holds — a no-op — which is the same reason each attach mints its own.
+		prevHolder := m.interactivePauseHolder
+		holder := newStatusPollHolder("preview")
 		m.interactivePauseTarget = want
+		m.interactivePauseHolder = holder
 		m.interactivePauseAt = time.Now()
 		return func() tea.Msg {
 			if !prev.isZero() {
-				_ = resume(prev.resumeStatusPollRequestAs(interactivePollHolder))
+				_ = resume(prev.resumeStatusPollRequestAs(prevHolder))
 			}
-			_ = pause(want.pauseStatusPollRequestAs(interactivePollHolder))
+			_ = pause(want.pauseStatusPollRequestAs(holder))
 			return nil
 		}
 	}
@@ -282,8 +293,9 @@ func (m *home) interactivePollPauseCmd() tea.Cmd {
 		return nil
 	}
 	m.interactivePauseAt = time.Now()
+	holder := m.interactivePauseHolder
 	return func() tea.Msg {
-		_ = pause(want.pauseStatusPollRequestAs(interactivePollHolder))
+		_ = pause(want.pauseStatusPollRequestAs(holder))
 		return nil
 	}
 }

--- a/app/live_termpane.go
+++ b/app/live_termpane.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -227,6 +229,41 @@ func (m *home) paneIsPreviewing(p *store.OpenPane) bool {
 // on the event loop. Full-screen attach owns its own heartbeat and closes the
 // embedded attachments (dropping interactive mode), so this yields while
 // m.attached is set. Event-loop only.
+// interactiveLeaseMu serialises the interactive path's pause/resume RPCs and drops
+// any intent an newer one has superseded (#3028 review).
+//
+// These are returned as tea.Cmds and dispatched through tea.Batch, which gives no
+// ordering: with a slow pause RPC the four calls of a lifecycle swap can execute as
+// old resume, new pause, old pause, new resume. Per-lifecycle holders make that
+// safe in the dangerous direction — the final resume removes the new holder, so no
+// live draft is left unprotected — but the late OLD pause stays in the map, keeping
+// the poll and automated delivery suppressed for the rest of its lease after
+// interactive mode has ended.
+//
+// Each dispatch takes a sequence number ON THE EVENT LOOP, where the intents are
+// already correctly ordered, and the executor applies only the newest it has seen.
+// A superseded intent is dropped rather than queued: it describes a state the user
+// has already left, and every hold it might have skipped is lease-bounded anyway.
+// This is the same "wait for the in-flight pause before resuming" guarantee the
+// full-screen attach gets from runStatusPollResume, expressed for a path whose
+// calls are not confined to one goroutine.
+var (
+	interactiveLeaseMu      sync.Mutex
+	interactiveLeaseApplied uint64
+	interactiveLeaseSeq     atomic.Uint64
+)
+
+// runInteractiveLease applies one lease intent unless a newer one already has.
+func runInteractiveLease(seq uint64, apply func()) {
+	interactiveLeaseMu.Lock()
+	defer interactiveLeaseMu.Unlock()
+	if seq <= interactiveLeaseApplied {
+		return // superseded on the event loop before this goroutine got the lock
+	}
+	interactiveLeaseApplied = seq
+	apply()
+}
+
 func (m *home) interactivePollPauseCmd() tea.Cmd {
 	// The session the user is actively typing into in-pane, if any. Interactive
 	// mode is only ever true while the FOCUSED pane has a live attachment, whose
@@ -256,8 +293,9 @@ func (m *home) interactivePollPauseCmd() tea.Cmd {
 		m.interactivePauseTarget = sessionActionTarget{}
 		m.interactivePauseHolder = ""
 		m.interactivePauseAt = time.Time{}
+		seq := interactiveLeaseSeq.Add(1)
 		return func() tea.Msg {
-			_ = resume(release)
+			runInteractiveLease(seq, func() { _ = resume(release) })
 			return nil
 		}
 	}
@@ -278,11 +316,14 @@ func (m *home) interactivePollPauseCmd() tea.Cmd {
 		m.interactivePauseTarget = want
 		m.interactivePauseHolder = holder
 		m.interactivePauseAt = time.Now()
+		seq := interactiveLeaseSeq.Add(1)
 		return func() tea.Msg {
-			if !prev.isZero() {
-				_ = resume(prev.resumeStatusPollRequestAs(prevHolder))
-			}
-			_ = pause(want.pauseStatusPollRequestAs(holder))
+			runInteractiveLease(seq, func() {
+				if !prev.isZero() {
+					_ = resume(prev.resumeStatusPollRequestAs(prevHolder))
+				}
+				_ = pause(want.pauseStatusPollRequestAs(holder))
+			})
 			return nil
 		}
 	}
@@ -294,8 +335,9 @@ func (m *home) interactivePollPauseCmd() tea.Cmd {
 	}
 	m.interactivePauseAt = time.Now()
 	holder := m.interactivePauseHolder
+	seq := interactiveLeaseSeq.Add(1)
 	return func() tea.Msg {
-		_ = pause(want.pauseStatusPollRequestAs(holder))
+		runInteractiveLease(seq, func() { _ = pause(want.pauseStatusPollRequestAs(holder)) })
 		return nil
 	}
 }

--- a/app/session_action_target.go
+++ b/app/session_action_target.go
@@ -88,34 +88,47 @@ func (target sessionActionTarget) setPRInfoRequest(info session.PRInfoData) daem
 	return daemon.SetPRInfoRequest{ID: target.id, Title: target.title, RepoID: target.repoID, PRInfo: info}
 }
 
-// statusPollHolder identifies THIS TUI process as a holder of the daemon's
-// pause lease (#3027). Per PROCESS, not per attach: a TUI attaches to one session
-// full-screen at a time, so one id per process is enough to tell two TUIs apart,
-// and it keeps a pause and its later resume matched without threading an id
-// through the attach lifecycle. Random rather than the pid, because a pid is
-// reused and a recycled one would let a new process release the lease a dead one
-// took — the revocation this exists to prevent, with extra steps.
-var statusPollHolder = "tui-" + randomStatusPollHolder()
-
-func randomStatusPollHolder() string {
+// newStatusPollHolder mints an identity for one HOLDER of the daemon's pause
+// lease (#3027). The daemon keys the lease by holder so a release only lifts the
+// pause when the last holder leaves; a holder that is not unique per lifecycle
+// therefore hands one lifecycle the power to revoke another's claim.
+//
+// Per LIFECYCLE, not per process, and that distinction is the #3028 review's
+// point: runStatusPollResume is launched asynchronously and can still be blocked
+// on the previous heartbeat after the attach callback has cleared its re-entry
+// gates. Re-attach quickly and, with one id per process, that delayed resume
+// deletes the holder the NEW attach just took — re-enabling the poll and
+// automated delivery underneath a user who is attached and typing. A fresh id per
+// attach makes the stale resume address a holder nobody holds, which is a no-op.
+//
+// Random rather than a pid or a counter: a pid is reused, and a recycled one would
+// let a new process release a lease a dead one took — this defect again.
+func newStatusPollHolder(kind string) string {
 	var b [8]byte
 	if _, err := rand.Read(b[:]); err != nil {
-		// Never fatal: an empty holder is the legacy shared slot, which is exactly
-		// the pre-#3027 behaviour rather than a broken one.
+		// Never fatal: an empty holder is the legacy shared slot, which is the
+		// pre-#3027 behaviour rather than a broken one.
 		return ""
 	}
-	return hex.EncodeToString(b[:])
+	return "tui-" + kind + "-" + hex.EncodeToString(b[:])
 }
 
-func (target sessionActionTarget) pauseStatusPollRequest() daemon.PauseStatusPollRequest {
+// interactivePollHolder is the holder for the live-preview pause path
+// (interactivePollPauseCmd). Stable for the process because that path holds at
+// most one target at a time and swaps it under its own serialization — but
+// DISTINCT from any attach's holder, so an attach's resume cannot revoke the
+// preview's hold or the reverse.
+var interactivePollHolder = newStatusPollHolder("preview")
+
+func (target sessionActionTarget) pauseStatusPollRequestAs(holder string) daemon.PauseStatusPollRequest {
 	return daemon.PauseStatusPollRequest{
-		ID: target.id, Title: target.title, RepoID: target.repoID, Holder: statusPollHolder,
+		ID: target.id, Title: target.title, RepoID: target.repoID, Holder: holder,
 	}
 }
 
-func (target sessionActionTarget) resumeStatusPollRequest() daemon.ResumeStatusPollRequest {
+func (target sessionActionTarget) resumeStatusPollRequestAs(holder string) daemon.ResumeStatusPollRequest {
 	return daemon.ResumeStatusPollRequest{
-		ID: target.id, Title: target.title, RepoID: target.repoID, Holder: statusPollHolder,
+		ID: target.id, Title: target.title, RepoID: target.repoID, Holder: holder,
 	}
 }
 

--- a/app/session_action_target.go
+++ b/app/session_action_target.go
@@ -113,13 +113,6 @@ func newStatusPollHolder(kind string) string {
 	return "tui-" + kind + "-" + hex.EncodeToString(b[:])
 }
 
-// interactivePollHolder is the holder for the live-preview pause path
-// (interactivePollPauseCmd). Stable for the process because that path holds at
-// most one target at a time and swaps it under its own serialization — but
-// DISTINCT from any attach's holder, so an attach's resume cannot revoke the
-// preview's hold or the reverse.
-var interactivePollHolder = newStatusPollHolder("preview")
-
 func (target sessionActionTarget) pauseStatusPollRequestAs(holder string) daemon.PauseStatusPollRequest {
 	return daemon.PauseStatusPollRequest{
 		ID: target.id, Title: target.title, RepoID: target.repoID, Holder: holder,

--- a/app/session_action_target.go
+++ b/app/session_action_target.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/daemon"
@@ -86,12 +88,35 @@ func (target sessionActionTarget) setPRInfoRequest(info session.PRInfoData) daem
 	return daemon.SetPRInfoRequest{ID: target.id, Title: target.title, RepoID: target.repoID, PRInfo: info}
 }
 
+// statusPollHolder identifies THIS TUI process as a holder of the daemon's
+// pause lease (#3027). Per PROCESS, not per attach: a TUI attaches to one session
+// full-screen at a time, so one id per process is enough to tell two TUIs apart,
+// and it keeps a pause and its later resume matched without threading an id
+// through the attach lifecycle. Random rather than the pid, because a pid is
+// reused and a recycled one would let a new process release the lease a dead one
+// took — the revocation this exists to prevent, with extra steps.
+var statusPollHolder = "tui-" + randomStatusPollHolder()
+
+func randomStatusPollHolder() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// Never fatal: an empty holder is the legacy shared slot, which is exactly
+		// the pre-#3027 behaviour rather than a broken one.
+		return ""
+	}
+	return hex.EncodeToString(b[:])
+}
+
 func (target sessionActionTarget) pauseStatusPollRequest() daemon.PauseStatusPollRequest {
-	return daemon.PauseStatusPollRequest{ID: target.id, Title: target.title, RepoID: target.repoID}
+	return daemon.PauseStatusPollRequest{
+		ID: target.id, Title: target.title, RepoID: target.repoID, Holder: statusPollHolder,
+	}
 }
 
 func (target sessionActionTarget) resumeStatusPollRequest() daemon.ResumeStatusPollRequest {
-	return daemon.ResumeStatusPollRequest{ID: target.id, Title: target.title, RepoID: target.repoID}
+	return daemon.ResumeStatusPollRequest{
+		ID: target.id, Title: target.title, RepoID: target.repoID, Holder: statusPollHolder,
+	}
 }
 
 func (target sessionActionTarget) handoffRequest(to string) daemon.HandoffSessionRequest {

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -103,7 +103,7 @@ func (s *controlServer) PauseStatusPoll(req PauseStatusPollRequest, resp *PauseS
 		return err
 	}
 	if s.manager != nil {
-		s.manager.PauseStatusPoll(req.RepoID, req.Title, req.ID)
+		s.manager.PauseStatusPollFor(req.RepoID, req.Title, req.ID, req.Holder)
 	}
 	resp.OK = true
 	return nil
@@ -116,7 +116,7 @@ func (s *controlServer) ResumeStatusPoll(req ResumeStatusPollRequest, resp *Resu
 		return err
 	}
 	if s.manager != nil {
-		s.manager.ResumeStatusPoll(req.RepoID, req.Title, req.ID)
+		s.manager.ResumeStatusPollFor(req.RepoID, req.Title, req.ID, req.Holder)
 	}
 	resp.OK = true
 	return nil

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -595,6 +595,12 @@ type SetPRInfoResponse struct {
 type PauseStatusPollRequest struct {
 	Title  string `json:"title"`
 	RepoID string `json:"repo_id"`
+	// Holder identifies WHICH client holds the pause, so a release only lifts it
+	// when the last holder leaves (#3027). Empty means the legacy shared holder:
+	// every client that omits it shares one slot, which is exactly the pre-#3027
+	// behaviour, so an old client keeps working and only loses the protection
+	// against a peer's release revoking its own claim.
+	Holder string `json:"holder"`
 	// ID is the attached session's stable id. Keying the lease by identity keeps
 	// an old heartbeat from pausing a different session that reused the title.
 	ID string `json:"id"`
@@ -612,6 +618,8 @@ type ResumeStatusPollRequest struct {
 	RepoID string `json:"repo_id"`
 	// ID is the stable lease key; see PauseStatusPollRequest.ID.
 	ID string `json:"id"`
+	// Holder must match the one that took the pause; see PauseStatusPollRequest.
+	Holder string `json:"holder"`
 }
 
 type ResumeStatusPollResponse struct {

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -339,8 +339,16 @@ type Manager struct {
 	// release avoids. Each entry is lease-bounded (statusPollLease): a crashed
 	// TUI that never sends Resume auto-resumes within one lease, so the pause
 	// can never permanently blind the daemon.
+	// Keyed leaseKey -> HOLDER -> expiry (#3027). The inner map is what makes a
+	// release safe: two clients attached to one session are both admitted (unlike
+	// killsInFlight, where a second acquirer is refused), so a single expiry per
+	// session meant the first release revoked the other's claim and left it
+	// believing it held a pause that was no longer in effect. A holder's renewal
+	// overwrites its own entry, which is why this is keyed rather than counted —
+	// the attached TUI heartbeats once a second and a count would never fall to
+	// zero. "" is the legacy shared holder for clients that send none.
 	pausedMu    sync.Mutex
-	pausedPolls map[string]time.Time
+	pausedPolls map[string]map[string]time.Time
 	// taskRunProbeDue schedules the backstop observation for a PAUSED session whose
 	// task run is still in flight (#1892). Guarded by pausedMu (the same lock as
 	// pausedPolls) but keyed by stableSessionKey — the stable instance ID — rather
@@ -478,7 +486,7 @@ func newManagerShellForDaemon(cfg *config.Config, transactionID string) (*Manage
 		settleOwed:             make(map[string]settleOwedEntry),
 		remoteLossStates:       make(map[string]*remoteLossState),
 		instanceOpLocks:        make(map[string]*sync.Mutex),
-		pausedPolls:            make(map[string]time.Time),
+		pausedPolls:            make(map[string]map[string]time.Time),
 		taskRunProbeDue:        make(map[string]time.Time),
 		events:                 newEventsHub(),
 		vscode:                 vscode,

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -84,7 +84,12 @@ func (m *Manager) PauseStatusPoll(repoID, title, id string) {
 func (m *Manager) PauseStatusPollFor(repoID, title, id, holder string) {
 	key := statusPollLeaseKey(repoID, title, id)
 	m.pausedMu.Lock()
-	m.pausedPolls[key] = nowFunc().Add(statusPollLease)
+	holders := m.pausedPolls[key]
+	if holders == nil {
+		holders = make(map[string]time.Time)
+		m.pausedPolls[key] = holders
+	}
+	holders[holder] = nowFunc().Add(statusPollLease)
 	m.pausedMu.Unlock()
 }
 
@@ -106,9 +111,19 @@ func (m *Manager) ResumeStatusPollFor(repoID, title, id, holder string) {
 	key := statusPollLeaseKey(repoID, title, id)
 	probeKey := m.taskRunProbeKey(repoID, title, id)
 	m.pausedMu.Lock()
-	delete(m.pausedPolls, key)
-	if probeKey != "" {
-		delete(m.taskRunProbeDue, probeKey)
+	holders := m.pausedPolls[key]
+	delete(holders, holder)
+	last := len(holders) == 0
+	if last {
+		delete(m.pausedPolls, key)
+		// The backstop entry belongs to the PAUSE, not to any one holder: it is
+		// armed while the session is paused and exists to bound how long that pause
+		// may hide a task run's completion (#1892). Dropping it while another holder
+		// still has the session paused would disarm the backstop for a pause that is
+		// still in effect — the same one-slot mistake this change fixes, one map over.
+		if probeKey != "" {
+			delete(m.taskRunProbeDue, probeKey)
+		}
 	}
 	m.pausedMu.Unlock()
 }
@@ -173,8 +188,13 @@ func (m *Manager) sweepPausedPollState() {
 	// Stable IDs make lease ownership safe under title reuse, but they also make
 	// every session lifetime a distinct map key. Reclaim expired leases even when
 	// their session was deleted and will never call isPollPaused again.
-	for key, expiry := range m.pausedPolls {
-		if !now.Before(expiry) {
+	for key, holders := range m.pausedPolls {
+		for holder, expiry := range holders {
+			if !now.Before(expiry) {
+				delete(holders, holder)
+			}
+		}
+		if len(holders) == 0 {
 			delete(m.pausedPolls, key)
 		}
 	}
@@ -239,11 +259,21 @@ func (m *Manager) pollLeaseActiveLocked(repoID, title, id string, now time.Time)
 		keys = append([]string{statusPollIDKey(id)}, keys...)
 	}
 	for _, key := range keys {
-		expiry, ok := m.pausedPolls[key]
+		holders, ok := m.pausedPolls[key]
 		if !ok {
 			continue
 		}
-		if now.Before(expiry) {
+		// ANY unexpired holder keeps the pause in effect; expired ones are reclaimed
+		// lazily, exactly as the single-entry version did.
+		live := false
+		for holder, expiry := range holders {
+			if now.Before(expiry) {
+				live = true
+				continue
+			}
+			delete(holders, holder)
+		}
+		if live {
 			return true
 		}
 		delete(m.pausedPolls, key)

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -113,17 +113,24 @@ func (m *Manager) ResumeStatusPollFor(repoID, title, id, holder string) {
 	m.pausedMu.Lock()
 	holders := m.pausedPolls[key]
 	delete(holders, holder)
-	last := len(holders) == 0
-	if last {
+	if len(holders) == 0 {
 		delete(m.pausedPolls, key)
-		// The backstop entry belongs to the PAUSE, not to any one holder: it is
-		// armed while the session is paused and exists to bound how long that pause
-		// may hide a task run's completion (#1892). Dropping it while another holder
-		// still has the session paused would disarm the backstop for a pause that is
-		// still in effect — the same one-slot mistake this change fixes, one map over.
-		if probeKey != "" {
-			delete(m.taskRunProbeDue, probeKey)
-		}
+	}
+	// The backstop entry belongs to the PAUSE, not to any one holder: it is armed
+	// while the session is paused and exists to bound how long that pause may hide a
+	// task run's completion (#1892). Dropping it while the session is still paused
+	// would disarm the backstop for a pause still in effect — the same one-slot
+	// mistake this change fixes, one map over.
+	//
+	// Asked of the PAUSE rather than of this key, because a session can be held
+	// under two namespaces at once: an ID-bearing client keys by stable id and a
+	// legacy one by title, and isPollPaused treats EITHER as an active pause. Judging
+	// by "this key is now empty" would disarm the backstop while the other namespace
+	// still holds the session, and the next paused refresh would rearm it from
+	// scratch — delaying task-run completion, and the concurrency slot it releases,
+	// by another full taskRunPollBackstop.
+	if probeKey != "" && !m.pollLeaseActiveLocked(repoID, title, id, nowFunc()) {
+		delete(m.taskRunProbeDue, probeKey)
 	}
 	m.pausedMu.Unlock()
 }

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -67,6 +67,21 @@ func statusPollLeaseKey(repoID, title, id string) string {
 // heartbeat) just pushes the expiry out; the pause is per stable identity, so a
 // same-title successor never inherits the old attach's lease (#2358).
 func (m *Manager) PauseStatusPoll(repoID, title, id string) {
+	m.PauseStatusPollFor(repoID, title, id, "")
+}
+
+// PauseStatusPollFor is PauseStatusPoll for a client that identifies itself, so a
+// release only lifts the pause when the LAST holder leaves (#3027).
+//
+// A holder is required because the obvious alternative does not work: counting
+// pauses and resumes would treat the attached TUI's once-a-second heartbeat as a
+// new acquisition and the count would climb forever. Keyed by holder, a renewal is
+// an overwrite of that holder's expiry — which is what a heartbeat means.
+//
+// An empty holder is the legacy shared slot. Clients that omit it share one entry
+// among themselves, which is exactly the pre-#3027 behaviour, so nothing that
+// exists today changes until it starts sending one.
+func (m *Manager) PauseStatusPollFor(repoID, title, id, holder string) {
 	key := statusPollLeaseKey(repoID, title, id)
 	m.pausedMu.Lock()
 	m.pausedPolls[key] = nowFunc().Add(statusPollLease)
@@ -82,6 +97,12 @@ func (m *Manager) PauseStatusPoll(repoID, title, id string) {
 // sweepPausedPollState reclaims any entry this cannot (a crashed TUI that never
 // resumes, a session torn down mid-pause), so a lookup miss here is harmless.
 func (m *Manager) ResumeStatusPoll(repoID, title, id string) {
+	m.ResumeStatusPollFor(repoID, title, id, "")
+}
+
+// ResumeStatusPollFor is ResumeStatusPoll for an identified holder; see
+// PauseStatusPollFor.
+func (m *Manager) ResumeStatusPollFor(repoID, title, id, holder string) {
 	key := statusPollLeaseKey(repoID, title, id)
 	probeKey := m.taskRunProbeKey(repoID, title, id)
 	m.pausedMu.Lock()

--- a/daemon/status_pause_holders_test.go
+++ b/daemon/status_pause_holders_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"testing"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/session"
 )
@@ -93,5 +94,58 @@ func TestPauseStatusPoll_LegacyHolderStillPausesAndResumes(t *testing.T) {
 	manager.ResumeStatusPoll(repoID, "legacy", inst.ID)
 	if manager.isPollPaused(repoID, "legacy", inst.ID) {
 		t.Fatal("the legacy path must still resume")
+	}
+}
+
+// The task-run backstop entry belongs to the PAUSE, not to any one holder: it is
+// armed while a session is paused and bounds how long that pause may hide a task
+// run's completion from the concurrency cap (#1892). Disarming it while another
+// holder still has the session paused would be the same one-slot mistake this
+// change fixes, one map over — so it is cleared only when the last holder leaves.
+func TestResumeStatusPoll_BackstopSurvivesUntilTheLastHolderLeaves(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerStarted(t, manager, repoID, repoPath, "shared", session.NewFakeBackend(), true, session.Running)
+	inst := manager.instances[daemonInstanceKey(repoID, "shared")]
+	probeKey := stableSessionKey(repoID, inst)
+
+	manager.PauseStatusPollFor(repoID, "shared", inst.ID, "tui-a")
+	manager.PauseStatusPollFor(repoID, "shared", inst.ID, "tui-b")
+	manager.pausedMu.Lock()
+	manager.taskRunProbeDue[probeKey] = nowFunc().Add(taskRunPollBackstop)
+	manager.pausedMu.Unlock()
+
+	manager.ResumeStatusPollFor(repoID, "shared", inst.ID, "tui-a")
+	manager.pausedMu.Lock()
+	_, armed := manager.taskRunProbeDue[probeKey]
+	manager.pausedMu.Unlock()
+	if !armed {
+		t.Fatal("one holder left but the session is still paused; disarming the backstop leaves that pause unbounded")
+	}
+
+	manager.ResumeStatusPollFor(repoID, "shared", inst.ID, "tui-b")
+	manager.pausedMu.Lock()
+	_, stillArmed := manager.taskRunProbeDue[probeKey]
+	manager.pausedMu.Unlock()
+	if stillArmed {
+		t.Fatal("the last holder left; the backstop entry must be reclaimed with the pause")
+	}
+}
+
+// An expired holder must not keep a pause alive for a holder that never released,
+// and must not block the last-holder cleanup either — the lease bound is what makes
+// a crashed client safe (#1160), and per-holder keying must not weaken it.
+func TestPauseStatusPoll_AnExpiredHolderDoesNotHoldThePause(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerStarted(t, manager, repoID, repoPath, "shared", session.NewFakeBackend(), true, session.Running)
+	inst := manager.instances[daemonInstanceKey(repoID, "shared")]
+
+	base := nowFunc()
+	manager.PauseStatusPollFor(repoID, "shared", inst.ID, "crashed")
+	restore := nowFunc
+	nowFunc = func() time.Time { return base.Add(statusPollLease + time.Second) }
+	defer func() { nowFunc = restore }()
+
+	if manager.isPollPaused(repoID, "shared", inst.ID) {
+		t.Fatal("the only holder's lease expired; a crashed client must not blind the daemon")
 	}
 }

--- a/daemon/status_pause_holders_test.go
+++ b/daemon/status_pause_holders_test.go
@@ -149,3 +149,47 @@ func TestPauseStatusPoll_AnExpiredHolderDoesNotHoldThePause(t *testing.T) {
 		t.Fatal("the only holder's lease expired; a crashed client must not blind the daemon")
 	}
 }
+
+// #3028 review: a session can be held under TWO namespaces at once — an ID-bearing
+// client keys the lease by stable id, a legacy one by title, and isPollPaused treats
+// either as an active pause. Judging the backstop by "this key is now empty" would
+// disarm it while the other namespace still holds the session, and the next paused
+// refresh would rearm it from scratch, delaying task-run completion (and the
+// concurrency slot it releases) by another full taskRunPollBackstop.
+func TestResumeStatusPoll_BackstopSurvivesAHolderInTheOtherNamespace(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerStarted(t, manager, repoID, repoPath, "shared", session.NewFakeBackend(), true, session.Running)
+	inst := manager.instances[daemonInstanceKey(repoID, "shared")]
+	probeKey := stableSessionKey(repoID, inst)
+
+	// An ID-bearing client and a legacy ID-less one, holding the same session under
+	// different keys.
+	manager.PauseStatusPollFor(repoID, "shared", inst.ID, "modern")
+	manager.PauseStatusPollFor(repoID, "shared", "", "legacy")
+	manager.pausedMu.Lock()
+	manager.taskRunProbeDue[probeKey] = nowFunc().Add(taskRunPollBackstop)
+	manager.pausedMu.Unlock()
+
+	// The ID-bearing one leaves. Its key is now empty, but the session is still
+	// paused by the legacy holder.
+	manager.ResumeStatusPollFor(repoID, "shared", inst.ID, "modern")
+
+	if !manager.isPollPaused(repoID, "shared", inst.ID) {
+		t.Fatal("the legacy holder still holds the pause")
+	}
+	manager.pausedMu.Lock()
+	_, armed := manager.taskRunProbeDue[probeKey]
+	manager.pausedMu.Unlock()
+	if !armed {
+		t.Fatal("the backstop was disarmed while the session is still paused, leaving that pause unbounded")
+	}
+
+	// Only when the last namespace releases does the backstop go with it.
+	manager.ResumeStatusPollFor(repoID, "shared", "", "legacy")
+	manager.pausedMu.Lock()
+	_, stillArmed := manager.taskRunProbeDue[probeKey]
+	manager.pausedMu.Unlock()
+	if stillArmed {
+		t.Fatal("no holder remains; the backstop entry must be reclaimed with the pause")
+	}
+}

--- a/daemon/status_pause_holders_test.go
+++ b/daemon/status_pause_holders_test.go
@@ -1,0 +1,97 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// TestPauseStatusPoll_ReleaseByOneHolderKeepsTheOthersPause is #3027: the lease is
+// a mutual-exclusion primitive with a single slot, so two overlapping holders share
+// one entry and the FIRST release drops it for both. The second holder then
+// believes it holds a pause that is no longer in effect — worse than never having
+// taken one, because it is a false guarantee: the poll it thinks is suppressed
+// resumes underneath its long operation, and deferWhileAttached (daemon/delivery.go)
+// stops holding automated deliveries for a pane someone is still typing in.
+//
+// Reachable today with no browser involved: two TUIs attached to the same session,
+// the first to detach calls ResumeStatusPoll unconditionally (app/home_attach.go
+// runStatusPollResume) and revokes the second's claim.
+func TestPauseStatusPoll_ReleaseByOneHolderKeepsTheOthersPause(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerStarted(t, manager, repoID, repoPath, "shared", session.NewFakeBackend(), true, session.Running)
+	inst := manager.instances[daemonInstanceKey(repoID, "shared")]
+
+	manager.PauseStatusPollFor(repoID, "shared", inst.ID, "tui-a")
+	manager.PauseStatusPollFor(repoID, "shared", inst.ID, "tui-b")
+	if !manager.isPollPaused(repoID, "shared", inst.ID) {
+		t.Fatal("two holders took the pause; it must be in effect")
+	}
+
+	// The first holder detaches. The second is still attached and still typing.
+	manager.ResumeStatusPollFor(repoID, "shared", inst.ID, "tui-a")
+
+	if !manager.isPollPaused(repoID, "shared", inst.ID) {
+		t.Fatal("one holder released and the pause was lifted for BOTH; the remaining holder now has a false guarantee")
+	}
+
+	// Only when the last holder leaves does the pause lift.
+	manager.ResumeStatusPollFor(repoID, "shared", inst.ID, "tui-b")
+	if manager.isPollPaused(repoID, "shared", inst.ID) {
+		t.Fatal("the last holder released; the pause must lift")
+	}
+}
+
+// A holder releasing twice must not lift a pause another holder still holds — the
+// release has to be idempotent per holder, not a decrement that can be replayed.
+// A TUI whose detach path retries a best-effort RPC does exactly this.
+func TestResumeStatusPoll_DoubleReleaseByOneHolderIsIdempotent(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerStarted(t, manager, repoID, repoPath, "shared", session.NewFakeBackend(), true, session.Running)
+	inst := manager.instances[daemonInstanceKey(repoID, "shared")]
+
+	manager.PauseStatusPollFor(repoID, "shared", inst.ID, "tui-a")
+	manager.PauseStatusPollFor(repoID, "shared", inst.ID, "tui-b")
+	manager.ResumeStatusPollFor(repoID, "shared", inst.ID, "tui-a")
+	manager.ResumeStatusPollFor(repoID, "shared", inst.ID, "tui-a")
+
+	if !manager.isPollPaused(repoID, "shared", inst.ID) {
+		t.Fatal("a repeated release by one holder revoked another holder's claim")
+	}
+}
+
+// A heartbeat renewal is an OVERWRITE of that holder's expiry, not a second
+// acquisition. This is why the lease is keyed by holder rather than counted: the
+// attached TUI renews once a second, so a count would climb for the life of the
+// attach and never reach zero on detach.
+func TestPauseStatusPoll_RenewalIsNotASecondAcquisition(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerStarted(t, manager, repoID, repoPath, "shared", session.NewFakeBackend(), true, session.Running)
+	inst := manager.instances[daemonInstanceKey(repoID, "shared")]
+
+	for i := 0; i < 5; i++ { // five heartbeats from ONE holder
+		manager.PauseStatusPollFor(repoID, "shared", inst.ID, "tui-a")
+	}
+	manager.ResumeStatusPollFor(repoID, "shared", inst.ID, "tui-a")
+
+	if manager.isPollPaused(repoID, "shared", inst.ID) {
+		t.Fatal("one holder renewed five times and released once; the pause must lift")
+	}
+}
+
+// The legacy shared holder keeps working: a client that sends no holder id behaves
+// exactly as it did before #3027, so an old TUI is not broken by the change.
+func TestPauseStatusPoll_LegacyHolderStillPausesAndResumes(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerStarted(t, manager, repoID, repoPath, "legacy", session.NewFakeBackend(), true, session.Running)
+	inst := manager.instances[daemonInstanceKey(repoID, "legacy")]
+
+	manager.PauseStatusPoll(repoID, "legacy", inst.ID)
+	if !manager.isPollPaused(repoID, "legacy", inst.ID) {
+		t.Fatal("the legacy path must still pause")
+	}
+	manager.ResumeStatusPoll(repoID, "legacy", inst.ID)
+	if manager.isPollPaused(repoID, "legacy", inst.ID) {
+		t.Fatal("the legacy path must still resume")
+	}
+}


### PR DESCRIPTION
## The defect

The status-poll pause lease is a mutual-exclusion primitive with **one slot**: `pausedPolls` held a single expiry per session with no record of who set it, and `ResumeStatusPoll` deleted that entry unconditionally. Two overlapping holders therefore shared one claim and the **first release dropped it for both**.

That is worse than never having taken it. The second holder carries a **false guarantee**: the poll it believes is suppressed resumes underneath its long operation, and `deferWhileAttached` (`daemon/delivery.go`) stops holding automated deliveries for a pane someone is still typing in — the window #1638 closed.

Reachable today with no browser involved: two TUIs attached to the same session, where the first to detach calls `ResumeStatusPoll` unconditionally (`app/home_attach.go runStatusPollResume`) and revokes the second's claim.

## Reproduced first, in CI

The first commit adds the holder parameter and the tests and **deliberately leaves the implementation alone**, so the failure is the code's rather than my description of it. `PauseStatusPollFor`/`ResumeStatusPollFor` accept a holder and ignore it. CI on that commit is red on `ReleaseByOneHolderKeepsTheOthersPause` and `DoubleReleaseByOneHolderIsIdempotent`. The second commit is the fix and turns them green.

## Keyed, not counted — and that is forced

`pausedPolls` becomes `leaseKey -> holder -> expiry`. A release removes only that holder's claim; the pause lifts when the last one leaves.

Counting would not work here. The attached TUI **renews once a second** (`statusPollRenewInterval`), so a refcount would treat every heartbeat as a new acquisition and never fall to zero on detach. Keyed by holder, a renewal is an overwrite of that holder's own expiry — which is what a heartbeat means. `RenewalIsNotASecondAcquisition` pins it: five heartbeats then one release must lift the pause.

**The lease bound survives.** Each holder carries its own expiry, `isPollPaused` reclaims expired ones lazily as before, and the sweep drops a map once its last holder lapses — so a crashed client still auto-resumes within one lease and can never permanently blind the daemon (#1160). `AnExpiredHolderDoesNotHoldThePause` covers it.

**Backward compatible.** An empty holder is the legacy shared slot, so a client that sends none behaves exactly as before; `LegacyHolderStillPausesAndResumes` pins that, and the 32 existing call sites are untouched because the three-argument forms delegate.

The TUI now sends a **per-lifecycle** id — one per attach, plus a separate stable one for the live-preview pause path.

Per process was my first attempt and review caught why it is not enough: `runStatusPollResume` is launched asynchronously and can still be blocked on the previous heartbeat after the attach callback has cleared its re-entry gates. Re-attach quickly and that delayed resume deletes the holder the NEW attach just took — re-enabling the poll and automated delivery underneath a user who is attached and typing. That is this PR's own defect reappearing one layer up, so a shared id inside the process is exactly as wrong as a shared slot inside the daemon. A fresh id per attach makes the stale resume address a holder nobody holds, which is a no-op. The preview path gets its own for the mirror reason: it serializes its own target swaps, but a shared id would let either path's resume revoke the other's hold.

Random rather than the pid, because a pid is reused and a recycled one would let a new process release a lease a dead one took — this defect again, with extra steps.

## The sibling sweep

**Found one, one map over.** `taskRunProbeDue` shares the pause's lifecycle: armed while a session is paused, it bounds how long that pause may hide a task run's completion from the concurrency cap (#1892). `ResumeStatusPoll` dropped it unconditionally, so a non-last holder's detach **disarmed the backstop for a pause still in effect**. Now cleared only with the last holder; `BackstopSurvivesUntilTheLastHolderLeaves` pins it.

**The rest came back clean**, on a discriminator worth stating: this defect needs a second acquirer to be *admitted* into a single slot. Every other per-session map *refuses* one — `restoresInFlight` is taken only after `killsInFlight` rejects a conflicting operation, and `pendingCreates`/`reservedTitles`/`reservedTmuxNames` are reservations whose entire purpose is to reject a duplicate. Three maps are already counted (`reservedTaskRuns`, `ghostTaskRuns`, `pendingConversationCaptures`), so the pattern was established and `pausedPolls` was the outlier: two clients attached to one session were both admitted, silently, into one expiry.

## Verification

Six tests, each named for the property it guards: release-by-one keeps the other's pause, double-release is idempotent per holder, renewal is not acquisition, the legacy shared holder still works, the backstop survives a non-last release, and an expired holder does not hold the pause.

**On the fail-first evidence:** the reproduction is the first commit and CI could not be made to run it. `pr.yml` created zero runs for this branch across three heads while running normally for other branches, with runs queued for 13+ hours — the Actions queue was wedged. It has since recovered and the current head is validated normally. So the red is not on record from CI; the reproduction remains provable by anyone by reverting the resume change, and I am not claiming to have watched it fail.

Local: `gofmt -l .` clean · `go build ./...` · `go vet ./daemon/ ./app/` · `golangci-lint run --fast` clean · `scripts/lint-file-length.sh` passed. Per policy the `daemon/` and `app/` tests were **not** run on this host — it runs the maintainer's live daemon beside ~15 sessions — so CI is the verifier, which is also what makes the fail-first commit meaningful.

## Not in scope

The web (#3025) still sends no holder, so it uses the legacy shared slot. That is not a regression: #3025's web side never issues a resume, so it is never the revoker, and it gains the protection as soon as it sends an id. Worth a follow-up once that lands.

Closes #3027

🤖 Generated with [Claude Code](https://claude.com/claude-code)

