### PR TITLE
fix(daemon): give per-session observations the session record's lifetime

### DIFF
--- a/daemon/lostrestore_confirm_test.go
+++ b/daemon/lostrestore_confirm_test.go
@@ -22,7 +22,7 @@ import (
 // probe got an ANSWER out of the runtime. Tests drive it explicitly because that,
 // not elapsed time, is what confirms a restore (#1917 round 6).
 func observeAlive(m *Manager, repoID string, inst *session.Instance) {
-	m.noteAliveObservation(stableSessionKey(repoID, inst))
+	m.noteAliveObservation(repoID, inst)
 }
 
 // diesOnSpawnBackend models the reported agent: its Recover SUCCEEDS — the spawn

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -228,6 +228,9 @@ func (m *Manager) KillSession(req KillSessionRequest) (session.InstanceData, err
 	m.mu.Lock()
 	if current := m.instances[key]; current == nil || current == instance || stableIDMatchesForDaemon(current.ID, targetID) {
 		delete(m.instances, key)
+		// Same critical section as the record's removal, so the runtime state
+		// cannot outlive the session it describes (#3031).
+		m.forgetSessionRuntimeStateLocked(repoID, instance)
 	}
 	if session.IsReservedTitle(req.Title) {
 		// An explicit kill is honored only briefly: the ensure loop suppresses

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -573,7 +573,7 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		}
 	}
 	if observedAlive {
-		m.noteAliveObservation(key)
+		m.noteAliveObservation(repoID, instance)
 	}
 
 	// Persist a liveness OR usage-limit reset-time change (#1146); see limit.go.

--- a/daemon/remoteloss.go
+++ b/daemon/remoteloss.go
@@ -434,8 +434,23 @@ func aliveWithin(as session.AgentServer, timeout time.Duration) livenessProbe {
 // remoteLostGracePeriod means an unanswerable remote stays non-Lost long past any
 // short window. Counting answers is immune to both, and scales with whatever the
 // poll interval and grace actually are.
-func (m *Manager) noteAliveObservation(key string) {
+func (m *Manager) noteAliveObservation(repoID string, instance *session.Instance) {
+	// Gated on the instance still being the tracked one, in the SAME critical
+	// section as the increment. RefreshStatuses snapshots instances and releases
+	// m.mu for the slow probe, so a probe that began before a kill can land after
+	// forgetSessionRuntimeStateLocked deleted this entry — and an ungated
+	// increment recreates it, leaking exactly the entry #3031 exists to remove.
+	//
+	// The check is pointer identity against m.instances, NOT presence of the
+	// observation key: the two maps do not share a key space. m.instances is keyed
+	// by daemonInstanceKey (repoID\x00title) while aliveObservations is keyed by
+	// stableSessionKey, which is the stable instance ID whenever one is set — so
+	// `m.instances[key]` would miss on every ID-bearing session and silently stop
+	// recording the observations the restore-confirmation depends on.
 	m.mu.Lock()
-	m.aliveObservations[key]++
-	m.mu.Unlock()
+	defer m.mu.Unlock()
+	if m.instances[daemonInstanceKey(repoID, instance.Title)] != instance {
+		return
+	}
+	m.aliveObservations[stableSessionKey(repoID, instance)]++
 }

--- a/daemon/rootagent.go
+++ b/daemon/rootagent.go
@@ -682,6 +682,7 @@ func (m *Manager) reapDeadRoot(repoID string, inst *session.Instance) (reapedRoo
 	m.mu.Lock()
 	if m.instances[key] == inst {
 		delete(m.instances, key)
+		m.forgetSessionRuntimeStateLocked(repoID, inst)
 	}
 	m.mu.Unlock()
 	return carried, true, nil

--- a/daemon/rootkill.go
+++ b/daemon/rootkill.go
@@ -243,6 +243,7 @@ func (m *Manager) finishUserKill(repoID string, instance *session.Instance) {
 	m.mu.Lock()
 	if m.instances[key] == instance {
 		delete(m.instances, key)
+		m.forgetSessionRuntimeStateLocked(repoID, instance)
 		removed = true
 	}
 	if session.IsReservedTitle(instance.Title) {

--- a/daemon/session_state_forget.go
+++ b/daemon/session_state_forget.go
@@ -1,0 +1,45 @@
+package daemon
+
+import "github.com/sachiniyer/agent-factory/session"
+
+// forgetSessionRuntimeStateLocked drops the per-session runtime state whose
+// lifetime is the SESSION RECORD's, at the moment that record stops existing.
+//
+// The caller MUST hold m.mu, and MUST call this in the same critical section
+// that removes the instance — the point of the exercise is that the entry and
+// the record it describes disappear together, so no window exists in which one
+// outlives the other.
+//
+// # Why here and not a sweep
+//
+// A sweep is a second structure that decides what exists, and it can disagree
+// with the first. This daemon has already been bitten by exactly that: m.instances
+// is not the universe (#2549), so a sweep keyed off it drops entries for sessions
+// that are merely mid-provision, or keeps entries for sessions it cannot see.
+// Deleting where the record is deleted has no such gap by construction — there is
+// only one decision about whether the session exists, and both structures follow
+// it (#3031).
+//
+// # Why not a cap or an LRU
+//
+// Evicting a LIVE session's observation to stay under a bound would make
+// liveness reporting wrong for that session: aliveObservations is what the
+// Lost-restore loop reads to decide whether a session was ever seen alive after
+// spawn, so a missing entry reads as "never observed" and suppresses a legitimate
+// restore. That trades a slow leak for a fabricated answer, which is worse.
+func (m *Manager) forgetSessionRuntimeStateLocked(repoID string, instance *session.Instance) {
+	if instance == nil {
+		return
+	}
+	key := stableSessionKey(repoID, instance)
+	// The reported leak: the only stableSessionKey-keyed map in the manager with
+	// neither a delete nor a sweep, so an entry survived every session it ever
+	// described (#3031).
+	delete(m.aliveObservations, key)
+	// The sibling with the same shape, found by the audit the issue asked for.
+	// handoffRetryDue IS cleared — but only by ResumePendingHandoffs, which walks
+	// m.instances. A session removed from that map is never walked again, so its
+	// entry orphans exactly like aliveObservations. Clearing on settlement is the
+	// common path; this is the one it cannot reach.
+	delete(m.handoffRetryDue, key)
+}

--- a/daemon/session_state_forget_test.go
+++ b/daemon/session_state_forget_test.go
@@ -1,0 +1,90 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// #3031: aliveObservations grew for every session ever created and was never
+// pruned, so a daemon that "runs forever" accumulated one entry per session for
+// its whole lifetime.
+//
+// Asserted by COUNT, not by a memory reading. Resident set on the maintainer's
+// box was 47 MB after 448 sessions — far too noisy to pin this — while the map
+// length is exact and states the property directly: after N sessions are created
+// and killed, the map is back where it started.
+func TestForgetSessionRuntimeState_ReturnsToBaseline(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	baselineAlive := len(manager.aliveObservations)
+	baselineHandoff := len(manager.handoffRetryDue)
+
+	const sessions = 50
+	instances := make([]*session.Instance, 0, sessions)
+	for i := 0; i < sessions; i++ {
+		inst, _ := registerArchivable(t, manager, repoID, repoPath, sessionTitleForIndex(i))
+		instances = append(instances, inst)
+
+		// Exactly what the poll does when it gets an answer out of a runtime, and
+		// what ResumePendingHandoffs does when it defers a retry.
+		manager.mu.Lock()
+		key := stableSessionKey(repoID, inst)
+		manager.aliveObservations[key]++
+		manager.handoffRetryDue[key] = nowFunc()
+		manager.mu.Unlock()
+	}
+
+	manager.mu.Lock()
+	grewAlive := len(manager.aliveObservations)
+	manager.mu.Unlock()
+	require.Equal(t, baselineAlive+sessions, grewAlive,
+		"precondition: the observations must actually accumulate, or this test would pass without the leak existing")
+
+	for i, inst := range instances {
+		manager.mu.Lock()
+		key := daemonInstanceKey(repoID, sessionTitleForIndex(i))
+		delete(manager.instances, key)
+		manager.forgetSessionRuntimeStateLocked(repoID, inst)
+		manager.mu.Unlock()
+	}
+
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	require.Equal(t, baselineAlive, len(manager.aliveObservations),
+		"aliveObservations must return to its starting size once every session is gone; a surviving entry is the leak")
+	require.Equal(t, baselineHandoff, len(manager.handoffRetryDue),
+		"handoffRetryDue orphans the same way: its only clear runs from a loop over m.instances, which never walks a removed session")
+}
+
+// The other half of a correct lifetime. A cap or an LRU would also keep the map
+// small, and would be wrong: aliveObservations is what the Lost-restore loop
+// reads to decide whether a session was ever seen alive after spawn, so evicting
+// a LIVE session's entry reads as "never observed" and suppresses a legitimate
+// restore. Deleting only on record removal cannot do that.
+func TestForgetSessionRuntimeState_KeepsLiveSessions(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	keep, _ := registerArchivable(t, manager, repoID, repoPath, "keep-me")
+	drop, _ := registerArchivable(t, manager, repoID, repoPath, "drop-me")
+
+	manager.mu.Lock()
+	keepKey := stableSessionKey(repoID, keep)
+	dropKey := stableSessionKey(repoID, drop)
+	manager.aliveObservations[keepKey] = 7
+	manager.aliveObservations[dropKey] = 3
+	manager.forgetSessionRuntimeStateLocked(repoID, drop)
+	observedKeep, keptPresent := manager.aliveObservations[keepKey]
+	_, droppedPresent := manager.aliveObservations[dropKey]
+	manager.mu.Unlock()
+
+	require.True(t, keptPresent, "a live session's observation must survive another session's removal")
+	require.Equal(t, uint64(7), observedKeep, "the surviving count must be unchanged, not reset")
+	require.False(t, droppedPresent, "the removed session's observation must be gone")
+}
+
+func sessionTitleForIndex(i int) string {
+	return "leak-" + string(rune('a'+i%26)) + "-" + string(rune('0'+i/26))
+}


### PR DESCRIPTION
Fixes #3031 — `aliveObservations` grew for every session ever created and was never pruned.

## The fix is a lifetime, not a bound

Deleted **where the record is deleted, in the same critical section**, so the entry and the session it describes disappear together and no window exists in which one outlives the other.

**Not a periodic sweep.** A sweep is a second thing that decides what exists and can disagree with the first, and this daemon has already been bitten by exactly that: `m.instances` is not the universe (#2549), so a sweep keyed off it drops entries for sessions that are merely mid-provision and keeps entries for sessions it cannot see. Deleting at the point of removal has no such gap by construction — there is one decision about whether the session exists and both structures follow it.

**Not a cap or an LRU.** `aliveObservations` is what the Lost-restore loop reads to decide whether a session was ever seen alive after spawn. Evicting a **live** session's entry reads as "never observed" and suppresses a legitimate restore — a fabricated answer in place of a slow leak, which is strictly worse.

## The sibling audit found one

Of the session-keyed maps on `Manager`, `aliveObservations` was the only one with **zero deletes and zero sweeps**:

| map | deletes | sweeps |
|---|---|---|
| `aliveObservations` | **0** | **0** |
| `lostRestoreStates` | 4 | 1 |
| `limitResumeStates` | 2 | 1 |
| `remoteLossStates` | 2 | 1 |
| `settleOwed` | 3 | 1 |
| `taskRunProbeDue` | 2 | 1 |
| `pausedPolls` | 3 | 1 |
| `handoffRetryDue` | 1 | 0 |

`handoffRetryDue` is the one that looks covered and is not. Its single clear runs from `ResumePendingHandoffs`, which walks `m.instances` — so a session removed from that map is **never walked again** and its entry orphans exactly like `aliveObservations`, through a path the common case never reaches. Both are dropped by the same helper so the two cannot drift apart later.

## Reproduced by count

A memory reading is too noisy to pin this — 47 MB RSS after 448 sessions — while the map length is exact and states the property directly.

- `TestForgetSessionRuntimeState_ReturnsToBaseline` creates and kills 50 sessions and asserts both maps return to their starting size. It **asserts they actually grew first**, so it cannot pass against unfixed code by measuring nothing.
- `TestForgetSessionRuntimeState_KeepsLiveSessions` pins the other half: a live session's observation survives another session's removal *with its count unchanged*. That is the assertion a cap or an LRU would fail, and it is why the fix is a lifetime.

## Call sites

Every path that removes the record: `KillSession`, the root-agent kill, and the root-agent carry. Archive is deliberately **not** included — it marks the record `LiveArchived` and leaves it in `m.instances`, so nothing is orphaned; the entry is still owned by a record that exists.

## Verification

`gofmt -l .`, `go build ./...`, `go vet ./daemon/`, `golangci-lint run --fast`, `scripts/lint-file-length.sh` all clean. Per the standing rule no `./daemon/...` tests were run on the maintainer's box; CI runs them.

Closes #3031

🤖 Generated with [Claude Code](https://claude.com/claude-code)
