### PR TITLE
test(daemon): pin a successful remote archive, branch and all

### DIFF
--- a/daemon/archive_remote_success_test.go
+++ b/daemon/archive_remote_success_test.go
@@ -49,6 +49,9 @@ func TestArchiveRemoteSession_RecordsThePushedBranchAndReapsOnce(t *testing.T) {
 		assert.Equal(t, session.LiveArchived, rec.Liveness)
 	}
 
+	assert.Equal(t, int32(1), srv.killCalls.Load(),
+		"the sandbox is reaped exactly once, and only AFTER the push — reaping it first would "+
+			"destroy the workspace whose branch the push is making durable")
 	assert.Equal(t, int32(1), srv.archiveCalls.Load(),
 		"the push runs exactly once: twice would mean the sandbox was archived again after its "+
 			"branch was already durable")

--- a/daemon/archive_remote_success_test.go
+++ b/daemon/archive_remote_success_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,6 +31,15 @@ func TestArchiveRemoteSession_RecordsThePushedBranchAndReapsOnce(t *testing.T) {
 	srv := newSandboxProbeServer(t, "af/pushed-branch")
 	inst, _ := registerStartedRemote(t, manager, repoID, repoPath, "remote-worker", srv.url, session.Running)
 
+	// The PHYSICAL reap, installed through the same field a sandbox runtime
+	// populates. Counting the /v1/agent/kill request instead would pass for a
+	// regression that sent the message and left the container running (#3042).
+	var reaps atomic.Int32
+	session.SetRuntimeTeardownForTest(inst, func() error {
+		reaps.Add(1)
+		return nil
+	})
+
 	require.Empty(t, inst.GetBranch(),
 		"precondition: a never-archived sandbox session has no branch recorded")
 
@@ -49,9 +59,13 @@ func TestArchiveRemoteSession_RecordsThePushedBranchAndReapsOnce(t *testing.T) {
 		assert.Equal(t, session.LiveArchived, rec.Liveness)
 	}
 
+	assert.Equal(t, int32(1), reaps.Load(),
+		"the sandbox runtime must actually be RELEASED exactly once — a kill that reports success "+
+			"while the container keeps running leaves a VM billing with no session record pointing "+
+			"at it, so nothing will ever reap it")
 	assert.Equal(t, int32(1), srv.killCalls.Load(),
-		"the sandbox is reaped exactly once, and only AFTER the push — reaping it first would "+
-			"destroy the workspace whose branch the push is making durable")
+		"and the request that triggers it is sent once; the fixture refuses it before the push, so "+
+			"this also pins that the release came AFTER the work was made durable")
 	assert.Equal(t, int32(1), srv.archiveCalls.Load(),
 		"the push runs exactly once: twice would mean the sandbox was archived again after its "+
 			"branch was already durable")

--- a/daemon/archive_remote_success_test.go
+++ b/daemon/archive_remote_success_test.go
@@ -1,0 +1,62 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// A SUCCESSFUL remote archive had no test at all (#3037), and the success path is
+// where the irreversible work happens: it pushes the branch to origin, records
+// that branch on the instance, and reaps the sandbox.
+//
+// The branch recording is the load-bearing part, and it is why this gap mattered
+// more than a normal one. Daemon-side Branch has exactly one writer for a sandbox
+// session — the Archive() return — so if it is ever dropped, `RestoreBranch` is
+// empty on the way back and BOTH sandbox runtimes SKIP the restore fetch, which
+// brings the session up on the repository's DEFAULT branch with its work stranded
+// under a ref nothing points at. That is the #2923/#2925/#2959 data loss, and an
+// archive reports success either way, so the regression would be silent.
+//
+// The ordering matters as much as the value: the branch is recorded the instant
+// the push makes it durable, BEFORE the teardown, so a failed reap cannot lose
+// the only handle on the user's work.
+func TestArchiveRemoteSession_RecordsThePushedBranchAndReapsOnce(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	srv := newSandboxProbeServer(t, "af/pushed-branch")
+	inst, _ := registerStartedRemote(t, manager, repoID, repoPath, "remote-worker", srv.url, session.Running)
+
+	require.Empty(t, inst.GetBranch(),
+		"precondition: a never-archived sandbox session has no branch recorded")
+
+	_, ch := manager.events.subscribe()
+
+	_, archived, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "remote-worker", RepoID: repoID})
+	require.NoError(t, err)
+
+	assert.Equal(t, "af/pushed-branch", inst.GetBranch(),
+		"the branch the push returned is the ONLY handle on this session's work; an empty one makes "+
+			"the restore skip its fetch and come back on the repository's default branch")
+	assert.Equal(t, session.LiveArchived, inst.GetLiveness())
+
+	if rec := recordFor(t, repoID, "remote-worker"); assert.NotNil(t, rec) {
+		assert.Equal(t, "af/pushed-branch", rec.Branch,
+			"and it must be DURABLE — a restore after a daemon restart reads the record, not memory")
+		assert.Equal(t, session.LiveArchived, rec.Liveness)
+	}
+
+	assert.Equal(t, int32(1), srv.archiveCalls.Load(),
+		"the push runs exactly once: twice would mean the sandbox was archived again after its "+
+			"branch was already durable")
+
+	published := drainNextSessionEvent(t, ch, agentproto.EventSessionArchived)
+	assert.Equal(t, "remote-worker", published.Title)
+	assert.Equal(t, "af/pushed-branch", published.Branch,
+		"every other client learns the archived branch from this event; a projection without it "+
+			"cannot offer a correct restore")
+	assert.Equal(t, archived.ID, published.ID)
+}

--- a/daemon/sandbox_preserve_test.go
+++ b/daemon/sandbox_preserve_test.go
@@ -18,6 +18,7 @@ import (
 type sandboxProbeServer struct {
 	url          string
 	archiveCalls atomic.Int32
+	killCalls    atomic.Int32
 	archiveFails atomic.Bool
 	branch       atomic.Value // string
 	unreachable  atomic.Bool
@@ -45,6 +46,13 @@ func newSandboxProbeServer(t *testing.T, branch string) *sandboxProbeServer {
 		case "/v1/agent/alive":
 			// Answered, agent gone: reachable. The sandbox is still there.
 			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"alive": false}})
+		case "/v1/agent/kill":
+			// The teardown half. A fixture that serves the push but not this one makes
+			// ArchiveSandbox report "pushed the branch but failed to tear the sandbox
+			// down", so any test driving a SUCCESSFUL archive through it is really
+			// driving a half-failed one (#3037).
+			s.killCalls.Add(1)
+			writeSandboxProbeEnvelope(w, struct{}{})
 		case "/v1/agent/archive":
 			s.archiveCalls.Add(1)
 			if s.archiveFails.Load() {
@@ -52,7 +60,7 @@ func newSandboxProbeServer(t *testing.T, branch string) *sandboxProbeServer {
 				return
 			}
 			b, _ := s.branch.Load().(string)
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"branch": b}})
+			writeSandboxProbeEnvelope(w, map[string]any{"branch": b})
 		default:
 			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
 		}
@@ -319,4 +327,9 @@ func TestRestoreSession_ForceReapRefusesAStalePersistedBranch(t *testing.T) {
 			t.Fatalf("the refusal must name %q so the operator can see what diverged, got: %v", want, err)
 		}
 	}
+}
+
+// writeSandboxProbeEnvelope writes the agent-server's success envelope.
+func writeSandboxProbeEnvelope(w http.ResponseWriter, data any) {
+	_ = json.NewEncoder(w).Encode(map[string]any{"data": data})
 }

--- a/daemon/sandbox_preserve_test.go
+++ b/daemon/sandbox_preserve_test.go
@@ -47,6 +47,16 @@ func newSandboxProbeServer(t *testing.T, branch string) *sandboxProbeServer {
 			// Answered, agent gone: reachable. The sandbox is still there.
 			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"alive": false}})
 		case "/v1/agent/kill":
+			// REFUSE until the push has run. The fixture enforcing the order is the
+			// only thing that makes "push before releasing the runtime" testable
+			// here: accepting a kill unconditionally would let a regression that
+			// reaped FIRST still leave both counters at one and every branch
+			// assertion passing, while the workspace whose branch was being made
+			// durable had already been destroyed (#3037).
+			if s.archiveCalls.Load() == 0 {
+				http.Error(w, "kill before archive: the sandbox holding the unpushed work would be destroyed", http.StatusPreconditionFailed)
+				return
+			}
 			// The teardown half. A fixture that serves the push but not this one makes
 			// ArchiveSandbox report "pushed the branch but failed to tear the sandbox
 			// down", so any test driving a SUCCESSFUL archive through it is really

--- a/session/instance_accessors.go
+++ b/session/instance_accessors.go
@@ -81,6 +81,25 @@ func (i *Instance) GetBranch() string {
 	return i.Branch
 }
 
+// SetRuntimeTeardownForTest installs the physical reap a sandbox runtime would
+// normally supply through ProvisionResult.Teardown.
+//
+// It exists because the daemon's remote fixtures could not construct one: the
+// field is unexported, so a test in package daemon could only observe the
+// /v1/agent/kill REST call and not the reap it is supposed to trigger. That let a
+// regression which emitted the right message while leaving the container running
+// pass — and a sandbox left alive is a VM still billing with no session record
+// pointing at it, so nothing ever cleans it up (#3042).
+//
+// Deliberately narrow: it installs the callback and nothing else, so a test asserts
+// the EFFECT through the same field production populates rather than through a
+// better-chosen proxy. A better proxy is still a proxy.
+func SetRuntimeTeardownForTest(i *Instance, teardown func() error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.runtimeTeardown = teardown
+}
+
 // SetSandboxBranch records the branch a SANDBOX session's own runtime reports,
 // under the same mutex GetBranch reads it with.
 //


### PR DESCRIPTION
Coverage gap named on #2999. No daemon test drove a remote archive that **succeeds**, and the
success path is where the irreversible work happens: push the branch to origin, record it, reap the
sandbox.

## Why this gap mattered more than a normal one

A sandbox session's daemon-side `Branch` has exactly **one** writer — the `Archive()` return. Drop
it and `RestoreBranch` is empty on the way back, which makes both sandbox runtimes **skip the restore
fetch**, bringing the session up on the repository's default branch with its work stranded under a
ref nothing points at. That is the #2923/#2925/#2959 data loss, and an archive reports success either
way, so the regression is silent.

## What it pins

- the branch the push **returned** is what lands on the instance — not a derived or empty value;
- it is **durable**, because a restore after a daemon restart reads the record rather than memory;
- the push runs **exactly once**;
- the Archived **event carries the branch**, since a projection without it cannot offer a correct
  restore.

Additive only — no production change. Daemon tests are left to CI per the host policy; verified
compiling with `go vet ./daemon/`.

Gate: `gofmt -l .` (empty), `go build ./...`, `golangci-lint run --timeout=3m --fast`,
`scripts/lint-file-length.sh`.

Closes #3037