### PR TITLE
fix(config): stop reporting a failed listener rebind as applied

### DIFF
--- a/daemon/config_apply.go
+++ b/daemon/config_apply.go
@@ -103,6 +103,28 @@ var keyDiff = map[string]func(a, b *config.Config) bool{
 //
 // NOTE: the config was already written to disk by the caller (a save surface).
 // ApplyConfig only makes the running daemon reflect it.
+// withoutKeys returns keys minus drop, preserving order. Small n (at most the two
+// listener keys), so a linear scan beats building a set.
+func withoutKeys(keys, drop []string) []string {
+	if len(drop) == 0 {
+		return keys
+	}
+	kept := keys[:0]
+	for _, k := range keys {
+		remove := false
+		for _, d := range drop {
+			if k == d {
+				remove = true
+				break
+			}
+		}
+		if !remove {
+			kept = append(kept, k)
+		}
+	}
+	return kept
+}
+
 func (m *Manager) ApplyConfig() (ApplyConfigResult, error) {
 	newCfg, err := config.LoadConfig()
 	if err != nil {
@@ -167,6 +189,18 @@ func (m *Manager) ApplyConfig() (ApplyConfigResult, error) {
 		if failed, rerr := m.webListeners.reconcile(newCfg); rerr != nil {
 			result.Warnings = append(result.Warnings, rerr.Error())
 			result.FailedListenerKeys = append(result.FailedListenerKeys, failed...)
+			// And take them OUT of Applied (#3030). Applied is populated by effect
+			// CLASS, before the rebind is attempted, so a key that failed to bind was
+			// still being reported as live — the one field an operator reads to answer
+			// "did my change take effect" saying yes while the daemon serves the old
+			// address.
+			//
+			// Reporting it in Warnings and FailedListenerKeys is not a substitute:
+			// a consumer that renders Applied is rendering a claim, and a claim that
+			// contradicts the two fields beside it is worse than one that is merely
+			// incomplete. Three outcomes, not two — applied, deferred to the next
+			// start, and attempted-but-not-in-effect, which is what these keys are.
+			result.Applied = withoutKeys(result.Applied, failed)
 		}
 	}
 	// The tokenless-network exposure notice, surfaced at SAVE time so a user who

--- a/daemon/config_apply_failed_listener_test.go
+++ b/daemon/config_apply_failed_listener_test.go
@@ -1,0 +1,31 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A listener key that failed to rebind must not be reported as applied (#3030).
+//
+// Applied is populated by effect CLASS, before the rebind is attempted, so a key
+// whose bind failed was still listed as live — the one field an operator reads to
+// answer "did my change take effect" answering yes while the daemon serves the
+// old address. Warnings and FailedListenerKeys carried the truth beside it, which
+// makes it worse rather than better: a consumer rendering Applied renders a claim
+// that contradicts the two fields next to it.
+func TestWithoutKeys_DropsFailedListenerKeysFromApplied(t *testing.T) {
+	applied := []string{"cors_allowed_origins", "listen_addr", "require_loopback_token"}
+
+	kept := withoutKeys(applied, []string{"listen_addr"})
+
+	assert.Equal(t, []string{"cors_allowed_origins", "require_loopback_token"}, kept,
+		"a key that did not bind is not applied; the keys that took effect independently of the "+
+			"rebind must survive, because a security tightening lands whether or not a socket moved")
+}
+
+func TestWithoutKeys_NoFailuresLeavesAppliedIntact(t *testing.T) {
+	applied := []string{"listen_addr", "preview_listen_addr"}
+	assert.Equal(t, applied, withoutKeys(applied, nil),
+		"a successful reconcile must not disturb the applied set")
+}


### PR DESCRIPTION
`ApplyConfig` fills `result.Applied` by effect **class**, before the rebind is attempted, so a
`listen_addr` / `preview_listen_addr` change whose bind failed was still listed as live. `Applied` is
the one field an operator reads to answer *"did my change take effect"*, and it was answering yes
while the daemon served the old address.

Reporting the failure in `Warnings` and `FailedListenerKeys` is not a substitute — it is what makes
it worse. A consumer that renders `Applied` renders a claim, and a claim contradicting the two fields
beside it is worse than one that is merely incomplete.

Failed keys are now removed from `Applied`, leaving three distinguishable outcomes rather than two:
**applied live**, **deferred to the next daemon start**, and **attempted but not in effect**.

## One correction to the framing

The report and triage suggest a security-posture change could be reported as applied while the
daemon still accepts unauthenticated callers. Checking the code, that specific case does **not**
happen, and the reason is worth recording so nobody re-derives it: `require_loopback_token` and
`cors_allowed_origins` take effect on the next request and are DECOUPLED from any rebind — the
comment above `reconcile` says so explicitly, and it is accurate. A tightening lands whether or not
a socket moved, and it applies to whichever listener is actually serving.

So the false claim is scoped to the two listener-address keys. That is still a real defect worth
fixing — an operator who moved the daemon to a new address and was told it applied will look for it
there — but it is not a silent auth bypass, and saying otherwise would misrepresent the posture.

## On the third outcome

`reconcile` is bind-new-before-close and its failure path keeps the OLD listener serving, so a
failed rebind is the **rolled-back** case, never an unknown one — the daemon is never left without a
listener. That is why removing the key from `Applied` is the whole fix: there is no indeterminate
socket state left to report. If that ever changes, `FailedListenerKeys` is where the distinction
would belong.

Two unit tests cover the helper directly, including that keys which took effect independently of the
rebind survive. Daemon tests are left to CI per the host policy.

Gate: `gofmt -l .` (empty), `go build ./...`, `go vet ./daemon/`,
`golangci-lint run --timeout=3m --fast`, `scripts/lint-file-length.sh`.

Closes #3030