### PR TITLE
feat(sessions): watch the whole fleet for state transitions, not one title for a level (#3009)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -648,6 +648,8 @@ func init() {
 
 	sessionsWatchCmd.Flags().DurationVar(&watchTimeoutFlag, "timeout", 30*time.Minute, "Give up and exit non-zero if the session is not idle within this window (0 = wait forever)")
 	sessionsWatchCmd.Flags().DurationVar(&watchIntervalFlag, "interval", 2*time.Second, "How often to poll the session's status")
+	sessionsWatchCmd.Flags().BoolVar(&watchAllFlag, "all", false, "Watch every session in scope and return when the first one changes state (the default when no title is given)")
+	sessionsWatchCmd.Flags().BoolVar(&watchIncludeCurrentFlag, "include-current", false, "Fleet form: also report sessions that are already stopped at the first poll, instead of only transitions")
 
 	// The tab-* verbs and their tabs {create,delete,rename,reorder} aliases
 	// (#1192) share the same flag globals via these binders, so the two spellings

--- a/api/sessions_watch.go
+++ b/api/sessions_watch.go
@@ -188,8 +188,8 @@ func getSessionByTitleInScope(repoID, title string) (*session.InstanceData, erro
 }
 
 var sessionsWatchCmd = &cobra.Command{
-	Use:   "watch <title>",
-	Short: "Block until a session goes idle (ready for review)",
+	Use:   "watch [title]",
+	Short: "Block until a session goes idle, or until any session in the fleet changes state",
 	Long: `Watch a session and return when its agent finishes working: exit 0 the moment
 the session goes IDLE (the agent stopped working and is awaiting input), so an
 operator or root agent can dispatch a session and be notified on completion
@@ -203,17 +203,41 @@ usage-limit block that auto-resumes, or a create/archive/restore in progress all
 keep the watch waiting.
 
 By default prints a concise line on transition; with --json emits the final
-session record. Honors --repo to scope the title lookup to one repository.`,
-	Args: cobra.ExactArgs(1),
+session record. Honors --repo to scope the title lookup to one repository.
+
+With NO title (or --all) it watches every session in scope and returns when the
+first one CHANGES STATE, printing which and why. That form is edge-triggered: the
+first poll establishes a baseline and reports nothing, so a session that was
+already idle before you called does not fire. Pass --include-current to report
+those too, for a driver that wants a starting snapshot; that snapshot omits
+archived sessions, which are inert by construction and cannot change on their own
+(a session archived WHILE you watch is still reported).
+
+Each reported session carries a reason a driver can act on: idle, usage-limited
+(af resumes it automatically — do not prompt it), lost, dead, archived, killed,
+gone, or unknown. "idle" covers both "finished its work" and "waiting on input":
+af records both as the same state and does not distinguish them, so neither does
+this. A session af cannot classify reports "unknown" and is never reported as
+idle, because an idle report tells a driver to act.`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)
 		defer log.Close()
 
-		title := args[0]
-
 		if err := validateWatchFlags(watchIntervalFlag, watchTimeoutFlag); err != nil {
 			return jsonError(err)
 		}
+		if len(args) == 0 || watchAllFlag {
+			if len(args) == 1 && watchAllFlag {
+				return jsonError(fmt.Errorf("--all watches every session, so it cannot be combined with the title %q", args[0]))
+			}
+			return runFleetWatch()
+		}
+		if watchIncludeCurrentFlag {
+			return jsonError(fmt.Errorf("--include-current applies to the fleet form; a single-title watch already reports the session's current state"))
+		}
+
+		title := args[0]
 
 		// Snapshot-based read (getSessionByTitleInScope -> snapshotRead): it
 		// follows --daemon-url to the remote, so the client's cwd must not scope it.

--- a/api/sessions_watch_fleet.go
+++ b/api/sessions_watch_fleet.go
@@ -99,22 +99,29 @@ type watchEvent struct {
 // a record is not trustworthy — a failed create can carry a stale OpCreating, and
 // a committed kill can carry whatever the row held when the kill landed.
 func classifyWatchStop(d session.InstanceData) (watchStopReason, string) {
-	// Asked first: a record whose startup could not be confirmed has a liveness
-	// value that describes nothing. Reading it would produce exactly the
-	// fabricated-idle this command must not emit.
+	// Kill intent outranks startup uncertainty. MarkUserKilled writes the durable
+	// tombstone WITHOUT clearing StartupStateUnknown, so both are legitimately true
+	// while teardown runs — and the useful thing to tell a driver there is "this is
+	// killed", not "inspect it and remove it explicitly", which is advice to do what
+	// is already happening.
+	if d.UserKilled {
+		return watchStopKilled, "killed; its teardown may still be running"
+	}
+	// A record whose startup could not be confirmed has a liveness value that
+	// describes nothing, so it is asked before the liveness axis. Reading it would
+	// produce exactly the fabricated-idle this command must not emit.
 	if d.StartupStateUnknown {
 		return watchStopUnknown,
 			"af could not confirm which runtime owns this workspace; inspect it and remove it explicitly before retrying"
 	}
-	if d.UserKilled {
-		return watchStopKilled, "killed; its teardown may still be running"
-	}
-	// Mid-flight operations are not stops. A create/kill/archive/restore/handoff/
-	// respawn in progress is a session in motion, and reporting it would wake a
-	// driver for a state that is about to change on its own.
-	switch d.InFlightOp {
-	case session.OpCreating, session.OpKilling, session.OpArchiving,
-		session.OpRestoring, session.OpReplacing, session.OpRespawning:
+	// ANY operation in flight means the session is in motion, including one this
+	// binary does not recognise. That last part is the point: a newer daemon can
+	// send an InFlightOp value this build has no name for, JSON decoding accepts it
+	// happily, and matching only the known ops would fall through to a liveness
+	// field that is stale precisely because an operation is running — reporting
+	// `idle` for a session mid-transition, which is the fail-closed guarantee
+	// inverted. Anything non-zero is therefore in motion, known or not.
+	if d.InFlightOp != session.OpNone {
 		return watchWorking, ""
 	}
 	if d.PendingHandoffMission != "" {
@@ -136,16 +143,25 @@ func classifyWatchStop(d session.InstanceData) (watchStopReason, string) {
 		return watchStopArchived, "archived and inert; restore it before sending work"
 	}
 
-	// LivenessUnset, or a value this binary does not know.
+	// LivenessUnset: a pre-#1195 record read off disk when no daemon is reachable,
+	// or one from an older daemon. Its real state is on the legacy Status axis, and
+	// the NON-ZERO values there are unambiguous — Ready, Loading and Deleting each
+	// mean one thing and cannot have been left unset.
 	//
-	// The single-title path falls back to the legacy Status axis here. This one
-	// deliberately does not, and the reason is sharper than "be conservative":
-	// `Running` is Status's ZERO VALUE (session/instance.go: `Running Status =
-	// iota`), so a record that never had a status set is indistinguishable from one
-	// explicitly marked running. Reading it would not be a legacy fallback, it would
-	// be inventing an answer out of an unset field — the exact shape this reason
-	// exists to refuse. An empty record is something af cannot classify, and that is
-	// what it says.
+	// `Running` is the exception, and it is why this does not simply defer to the
+	// legacy axis wholesale: it is Status's ZERO VALUE (session/instance.go:
+	// `Running Status = iota`), so a record that never had a status set is
+	// byte-identical to one explicitly marked running. Reading that as "working"
+	// would not be a legacy fallback, it would be inventing an answer out of an
+	// unset field — the exact shape this reason exists to refuse.
+	switch d.Status {
+	case session.Ready:
+		return watchStopIdle, "the agent stopped and is awaiting input (from this record's legacy status)"
+	case session.Loading:
+		return watchWorking, ""
+	case session.Deleting:
+		return watchStopKilled, "being deleted (from this record's legacy status)"
+	}
 	return watchStopUnknown, "af cannot determine this session's state from its record"
 }
 
@@ -174,9 +190,12 @@ func watchKeyOf(d session.InstanceData) string {
 // will not be tested for all of them.
 type fleetWatcher struct {
 	phase map[string]watchStopReason
-	// titles remembers the last title seen for a key, so a session that vanishes
-	// can still be named in its event.
-	titles map[string]string
+	// identity remembers the last identifying fields seen for a key, so a session
+	// that vanishes can still be NAMED in its event. Title alone is not enough: in
+	// the kill-and-recreate case the poll emits a `gone` and an arrival under the
+	// same title, and without the id a driver cannot tell which of the two records
+	// disappeared.
+	identity map[string]watchEvent
 	// primed is false until the first snapshot has been absorbed. It is what makes
 	// this edge-triggered rather than level-triggered.
 	primed bool
@@ -188,7 +207,7 @@ type fleetWatcher struct {
 func newFleetWatcher(includeCurrent bool) *fleetWatcher {
 	return &fleetWatcher{
 		phase:          map[string]watchStopReason{},
-		titles:         map[string]string{},
+		identity:       map[string]watchEvent{},
 		includeCurrent: includeCurrent,
 	}
 }
@@ -209,7 +228,7 @@ func (w *fleetWatcher) observe(snapshot []session.InstanceData) []watchEvent {
 		reason, detail := classifyWatchStop(data)
 		previous, known := w.phase[key]
 		w.phase[key] = reason
-		w.titles[key] = data.Title
+		w.identity[key] = watchEvent{Title: data.Title, ID: data.ID, Path: data.Path}
 
 		switch {
 		case !known && !w.primed:
@@ -252,14 +271,13 @@ func (w *fleetWatcher) observe(snapshot []session.InstanceData) []watchEvent {
 				continue
 			}
 			if previous != watchStopGone {
-				events = append(events, watchEvent{
-					Title:  w.titles[key],
-					Reason: watchStopGone,
-					Detail: "the session's record disappeared while watching (killed or removed)",
-				})
+				gone := w.identity[key]
+				gone.Reason = watchStopGone
+				gone.Detail = "the session's record disappeared while watching (killed or removed)"
+				events = append(events, gone)
 			}
 			delete(w.phase, key)
-			delete(w.titles, key)
+			delete(w.identity, key)
 		}
 	}
 
@@ -280,12 +298,24 @@ func newWatchEvent(d session.InstanceData, reason watchStopReason, detail string
 	}
 }
 
-// describeWatchEvent renders one event as a human line.
-func describeWatchEvent(e watchEvent) string {
-	if e.Detail == "" {
-		return fmt.Sprintf("%s\t%s", e.Title, e.Reason)
+// describeWatchEvent renders one event as a tab-separated human line.
+//
+// qualify appends the worktree path. Session titles are unique within a PROJECT,
+// not globally, so an unscoped fleet — run outside a repository, or against a
+// remote without --repo — can hold two sessions called `worker`, and both would
+// render as the same line with no way to tell which one changed. The path is
+// added exactly when the scope permits that collision rather than always, so the
+// common single-project output stays short. --json always carries id and path.
+func describeWatchEvent(e watchEvent, qualify bool) string {
+	line := e.Title
+	if qualify && e.Path != "" {
+		line += "\t" + e.Path
 	}
-	return fmt.Sprintf("%s\t%s\t%s", e.Title, e.Reason, e.Detail)
+	line += "\t" + string(e.Reason)
+	if e.Detail != "" {
+		line += "\t" + e.Detail
+	}
+	return line
 }
 
 // fleetWatchDeps are the injectable dependencies of the fleet loop, so its
@@ -321,7 +351,17 @@ func watchFleet(d fleetWatchDeps, includeCurrent bool) ([]watchEvent, error) {
 			return nil, fmt.Errorf("timed out after %s waiting for any session to change state (%d watched)",
 				d.timeout, len(snapshot))
 		}
-		d.sleep(d.interval)
+		// Never sleep past the deadline. --interval and --timeout are validated
+		// independently, so `--timeout 5s --interval 1h` is accepted — and an
+		// unconditional sleep would poll once, block for an hour, and then report a
+		// five-second timeout, making the advertised bound a fiction.
+		wait := d.interval
+		if d.timeout > 0 {
+			if remaining := start.Add(d.timeout).Sub(d.now()); remaining < wait {
+				wait = remaining
+			}
+		}
+		d.sleep(wait)
 	}
 }
 
@@ -354,8 +394,11 @@ func runFleetWatch() error {
 	if envelopeOutput {
 		return jsonOut(map[string]any{"events": events})
 	}
+	// An empty repoID means every project is in scope, which is exactly when titles
+	// can collide.
+	qualify := repoID == ""
 	for _, event := range events {
-		fmt.Println(describeWatchEvent(event))
+		fmt.Println(describeWatchEvent(event, qualify))
 	}
 	return nil
 }

--- a/api/sessions_watch_fleet.go
+++ b/api/sessions_watch_fleet.go
@@ -143,6 +143,18 @@ func classifyWatchStop(d session.InstanceData) (watchStopReason, string) {
 		return watchStopArchived, "archived and inert; restore it before sending work"
 	}
 
+	// Anything else on the liveness axis is a value this build has no name for —
+	// a newer daemon's. It fails closed HERE rather than falling through, because
+	// the legacy fallback below is only valid for a record that has no liveness
+	// axis at all. A record that HAS one this client cannot read is not a legacy
+	// record, and consulting its compatibility Status could emit `idle` for a state
+	// the client does not understand — the fail-closed guarantee inverted, on the
+	// one path where an automated driver acts immediately.
+	if d.Liveness != session.LivenessUnset {
+		return watchStopUnknown,
+			"this session reports a state a newer daemon understands and this af build does not; upgrade af to act on it"
+	}
+
 	// LivenessUnset: a pre-#1195 record read off disk when no daemon is reachable,
 	// or one from an older daemon. Its real state is on the legacy Status axis, and
 	// the NON-ZERO values there are unambiguous — Ready, Loading and Deleting each
@@ -157,10 +169,22 @@ func classifyWatchStop(d session.InstanceData) (watchStopReason, string) {
 	switch d.Status {
 	case session.Ready:
 		return watchStopIdle, "the agent stopped and is awaiting input (from this record's legacy status)"
-	case session.Loading:
+	case session.Loading, session.Deleting:
+		// In motion, matching classifyActivityByStatus. A delete in progress resolves
+		// into a `gone` event when the record leaves the snapshot, which is the
+		// outcome a driver acts on — reporting it as a stop first would wake one for
+		// a session that is on its way out anyway.
 		return watchWorking, ""
-	case session.Deleting:
-		return watchStopKilled, "being deleted (from this record's legacy status)"
+	case session.Lost:
+		return watchStopLost, "its backing tmux/worktree vanished; recover it with 'af sessions restore' (from this record's legacy status)"
+	case session.Dead:
+		// Rolled forward to `lost`, not reported as its own reason. Status: Dead is
+		// legacy — deaths have recorded as Lost since #1108 — and `lost` is the
+		// reason that carries the recovery instruction, so a driver reading an old
+		// record gets the same actionable answer as one reading a current one.
+		return watchStopLost, "its backing runtime is gone; recover it with 'af sessions restore' (from this record's legacy status)"
+	case session.Archived:
+		return watchStopArchived, "archived and inert; restore it before sending work (from this record's legacy status)"
 	}
 	return watchStopUnknown, "af cannot determine this session's state from its record"
 }
@@ -282,7 +306,20 @@ func (w *fleetWatcher) observe(snapshot []session.InstanceData) []watchEvent {
 	}
 
 	w.primed = true
-	sort.SliceStable(events, func(i, j int) bool { return events[i].Title < events[j].Title })
+	// Title, then identity. The `gone` events above are appended while ranging a
+	// MAP, so their relative order is randomised — and same-titled sessions from
+	// different projects compare equal on title alone, leaving SliceStable to
+	// preserve that randomness. A driver reading the first line would then get a
+	// different answer run to run for an output documented as deterministic.
+	sort.Slice(events, func(i, j int) bool {
+		if events[i].Title != events[j].Title {
+			return events[i].Title < events[j].Title
+		}
+		if events[i].ID != events[j].ID {
+			return events[i].ID < events[j].ID
+		}
+		return events[i].Path < events[j].Path
+	})
 	return events
 }
 
@@ -321,7 +358,10 @@ func describeWatchEvent(e watchEvent, qualify bool) string {
 // fleetWatchDeps are the injectable dependencies of the fleet loop, so its
 // timeout and polling behaviour are testable without a daemon or a wall clock.
 type fleetWatchDeps struct {
-	list     func() ([]session.InstanceData, error)
+	// list returns a snapshot AND the source it came from. The source is part of
+	// the contract because comparing two sources is worse than not polling at all
+	// — see watchFleet.
+	list     func() ([]session.InstanceData, watchSource, error)
 	interval time.Duration
 	timeout  time.Duration
 	now      func() time.Time
@@ -339,10 +379,31 @@ type fleetWatchDeps struct {
 func watchFleet(d fleetWatchDeps, includeCurrent bool) ([]watchEvent, error) {
 	watcher := newFleetWatcher(includeCurrent)
 	start := d.now()
+	baseline := watchSourceNone
 	for {
-		snapshot, err := d.list()
+		snapshot, source, err := d.list()
 		if err != nil {
 			return nil, err
+		}
+		// The baseline pins the SOURCE, not just the state. listSessionsInScope falls
+		// back to a disk scan when the daemon read fails, and the two projections are
+		// legitimately different views of the same fleet — a pending create exists in
+		// the daemon's memory and not yet on disk. Feeding both into one watcher
+		// compares them as consecutive states of one fleet, so a transient daemon
+		// failure would manufacture `gone` events for every in-memory-only session
+		// and `idle`/arrival events when it came back. Those are fabricated
+		// transitions, and a driver acts on them immediately.
+		//
+		// So a switch ends the watch with an error instead. The caller re-runs and
+		// gets a fresh, coherent baseline; reporting nothing is recoverable, while
+		// reporting a session as gone when it is mid-create is not.
+		if baseline == watchSourceNone {
+			baseline = source
+		} else if source != baseline {
+			return nil, fmt.Errorf(
+				"stopped watching: the session snapshot switched from the %s to the %s mid-watch, "+
+					"and comparing the two would report transitions that did not happen — re-run to start a fresh baseline",
+				baseline, source)
 		}
 		if events := watcher.observe(snapshot); len(events) > 0 {
 			return events, nil
@@ -365,6 +426,16 @@ func watchFleet(d fleetWatchDeps, includeCurrent bool) ([]watchEvent, error) {
 	}
 }
 
+// watchSource names which projection a snapshot came from. Two sources cannot be
+// compared as consecutive states of one fleet — see watchFleet.
+type watchSource string
+
+const (
+	watchSourceNone   watchSource = ""
+	watchSourceDaemon watchSource = "daemon snapshot"
+	watchSourceDisk   watchSource = "on-disk session records"
+)
+
 var (
 	watchAllFlag            bool
 	watchIncludeCurrentFlag bool
@@ -381,7 +452,7 @@ func runFleetWatch() error {
 	}
 
 	events, err := watchFleet(fleetWatchDeps{
-		list:     func() ([]session.InstanceData, error) { return listSessionsInScope(repoID) },
+		list:     func() ([]session.InstanceData, watchSource, error) { return listSessionsInScope(repoID) },
 		interval: watchIntervalFlag,
 		timeout:  watchTimeoutFlag,
 		now:      time.Now,
@@ -407,16 +478,20 @@ func runFleetWatch() error {
 // scoped disk scan when no daemon is reachable — the same read path and the same
 // fallback rule the single-title form uses, so the two cannot disagree about what
 // "in scope" means.
-func listSessionsInScope(repoID string) ([]session.InstanceData, error) {
+func listSessionsInScope(repoID string) ([]session.InstanceData, watchSource, error) {
 	data, fallBack, err := snapshotRead(daemon.SnapshotRequest{RepoID: repoID})
 	if err != nil {
 		// A remote target has no local disk to fall back to; surfacing the daemon's
 		// error beats masking it as an empty fleet, which would look like "nothing
 		// is happening" and park a driver until its timeout (#1679).
 		if !fallBack {
-			return nil, err
+			return nil, watchSourceNone, err
 		}
-		return diskListSessions(repoID)
+		data, err = diskListSessions(repoID)
+		if err != nil {
+			return nil, watchSourceNone, err
+		}
+		return data, watchSourceDisk, nil
 	}
-	return data, nil
+	return data, watchSourceDaemon, nil
 }

--- a/api/sessions_watch_fleet.go
+++ b/api/sessions_watch_fleet.go
@@ -1,0 +1,379 @@
+package api
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// Watching a whole fleet for state TRANSITIONS (#3009).
+//
+// `af sessions watch <title>` answers "is this session idle?" — a LEVEL. That
+// makes "block until something finishes" and "tell me what is finished now" the
+// same call: arming watchers over seven already-idle sessions returned all seven
+// instantly. A driver cannot tell a session that just completed from one that has
+// been idle for an hour, so it re-triggers on the same session forever unless it
+// keeps its own prior-state map — which is the bookkeeping the command exists to
+// remove.
+//
+// So this half reports EDGES. The first poll establishes a baseline and reports
+// nothing; afterwards a session is reported when it CHANGES into a stopped state.
+// --include-current opts into the starting snapshot for a driver that wants one.
+//
+// Two properties are load-bearing rather than incidental:
+//
+//   - It says WHY a session stopped. A driver responds differently to "idle",
+//     "usage-limited" (auto-resumes; do not interrupt) and "lost" (needs restore,
+//     not a prompt). Without it a driver must preview the pane and read terminal
+//     text to guess, which is what the issue was filed about.
+//   - UNKNOWN is a reason of its own and never collapses into idle. An idle report
+//     tells a driver to act; a fabricated one makes it interrupt a working session.
+
+// watchStopReason is why a session is no longer working. It is a string rather
+// than an int because it crosses the CLI boundary as JSON that a driver switches
+// on — a renumbered iota would silently change every consumer's meaning.
+type watchStopReason string
+
+const (
+	// watchStopIdle: the agent stopped and is awaiting input.
+	//
+	// This deliberately covers BOTH "finished its work" and "waiting on input for
+	// something it needs", because af cannot tell them apart: both are LiveReady,
+	// and no field on InstanceData separates them. Reporting a "finished" would be
+	// a guess, and the expensive direction of that guess is a driver moving on from
+	// a session that is actually blocked on it (#3009).
+	watchStopIdle watchStopReason = "idle"
+	// watchStopUsageLimited: blocked on a provider usage limit. The daemon
+	// auto-resumes it (#1146), so a driver should NOT send it a prompt — it is
+	// reported so the driver can leave it alone knowingly rather than by omission.
+	watchStopUsageLimited watchStopReason = "usage-limited"
+	// watchStopLost: the backing tmux/worktree vanished under a live record. Needs
+	// `af sessions restore`, not a prompt.
+	watchStopLost watchStopReason = "lost"
+	// watchStopDead: observed death of the backing runtime.
+	watchStopDead watchStopReason = "dead"
+	// watchStopArchived: deliberately shelved and inert until restored.
+	watchStopArchived watchStopReason = "archived"
+	// watchStopKilled: a committed kill whose teardown may still be running. The
+	// session will not come back.
+	watchStopKilled watchStopReason = "killed"
+	// watchStopGone: the session was present on an earlier poll and is absent now.
+	// Distinct from `killed`, which is a state the record still reports; this is the
+	// record itself disappearing.
+	watchStopGone watchStopReason = "gone"
+	// watchStopUnknown: af cannot determine the state.
+	//
+	// Never silently mapped to idle, and that is the whole point of having it. An
+	// idle report is an instruction to act, so a fabricated one makes an automated
+	// driver interrupt a session that is working — this repo's recurring failure
+	// shape (#2870, #2874, #2885, #2962), and worse here because the consumer acts
+	// immediately and without a human.
+	watchStopUnknown watchStopReason = "unknown"
+	// watchWorking is the sentinel for "not stopped at all". It never appears in an
+	// event; it exists so the phase map has one total function over every session.
+	watchWorking watchStopReason = "working"
+)
+
+// stopped reports whether this phase is one a driver should be told about.
+func (r watchStopReason) stopped() bool { return r != watchWorking }
+
+// watchEvent is one reported transition.
+type watchEvent struct {
+	Title  string          `json:"title"`
+	ID     string          `json:"id,omitempty"`
+	Path   string          `json:"path,omitempty"`
+	Reason watchStopReason `json:"reason"`
+	Detail string          `json:"detail,omitempty"`
+	// Session is the full record so a driver can act without a second call. Absent
+	// for `gone`, where there is no longer a record to send.
+	Session *session.InstanceData `json:"session,omitempty"`
+}
+
+// classifyWatchStop maps one snapshot onto a stop reason.
+//
+// The order is the argument. Every check that means "af does not know" or "this
+// is over" is asked BEFORE the liveness axis, because the liveness value on such
+// a record is not trustworthy — a failed create can carry a stale OpCreating, and
+// a committed kill can carry whatever the row held when the kill landed.
+func classifyWatchStop(d session.InstanceData) (watchStopReason, string) {
+	// Asked first: a record whose startup could not be confirmed has a liveness
+	// value that describes nothing. Reading it would produce exactly the
+	// fabricated-idle this command must not emit.
+	if d.StartupStateUnknown {
+		return watchStopUnknown,
+			"af could not confirm which runtime owns this workspace; inspect it and remove it explicitly before retrying"
+	}
+	if d.UserKilled {
+		return watchStopKilled, "killed; its teardown may still be running"
+	}
+	// Mid-flight operations are not stops. A create/kill/archive/restore/handoff/
+	// respawn in progress is a session in motion, and reporting it would wake a
+	// driver for a state that is about to change on its own.
+	switch d.InFlightOp {
+	case session.OpCreating, session.OpKilling, session.OpArchiving,
+		session.OpRestoring, session.OpReplacing, session.OpRespawning:
+		return watchWorking, ""
+	}
+	if d.PendingHandoffMission != "" {
+		return watchWorking, ""
+	}
+
+	switch d.Liveness {
+	case session.LiveRunning:
+		return watchWorking, ""
+	case session.LiveReady:
+		return watchStopIdle, "the agent stopped and is awaiting input"
+	case session.LiveLimitReached:
+		return watchStopUsageLimited, "blocked on a provider usage limit; af resumes it automatically — do not send it a prompt"
+	case session.LiveLost:
+		return watchStopLost, "its backing tmux/worktree vanished; recover it with 'af sessions restore'"
+	case session.LiveDead:
+		return watchStopDead, "its backing runtime is gone"
+	case session.LiveArchived:
+		return watchStopArchived, "archived and inert; restore it before sending work"
+	}
+
+	// LivenessUnset, or a value this binary does not know.
+	//
+	// The single-title path falls back to the legacy Status axis here. This one
+	// deliberately does not, and the reason is sharper than "be conservative":
+	// `Running` is Status's ZERO VALUE (session/instance.go: `Running Status =
+	// iota`), so a record that never had a status set is indistinguishable from one
+	// explicitly marked running. Reading it would not be a legacy fallback, it would
+	// be inventing an answer out of an unset field — the exact shape this reason
+	// exists to refuse. An empty record is something af cannot classify, and that is
+	// what it says.
+	return watchStopUnknown, "af cannot determine this session's state from its record"
+}
+
+// watchKeyOf identifies a session across polls.
+//
+// The stable id wins over the title, and that is not a detail: titles are reused.
+// A session killed and re-created under the same name is a DIFFERENT session, and
+// keying by title would carry the dead one's phase onto the new one — so a fresh
+// session that started working would look like "no change" and never be reported,
+// or worse, inherit an `idle` baseline and be reported the moment it was created.
+// Falls back to repo+title only for pre-#1738 records that have no id.
+func watchKeyOf(d session.InstanceData) string {
+	if d.ID != "" {
+		return "id:" + d.ID
+	}
+	// The worktree path rather than the bare title: it is unique per session and
+	// distinguishes same-titled sessions in different repositories.
+	return "path:" + d.Path + "\x00" + d.Title
+}
+
+// fleetWatcher turns a sequence of whole-fleet snapshots into transition events.
+//
+// Pure and snapshot-driven: no clock, no daemon, no I/O. The interesting
+// behaviour here is entirely about ORDERINGS — first poll, change, change back,
+// vanish, reappear — and a state machine that needs a live fleet to reach those
+// will not be tested for all of them.
+type fleetWatcher struct {
+	phase map[string]watchStopReason
+	// titles remembers the last title seen for a key, so a session that vanishes
+	// can still be named in its event.
+	titles map[string]string
+	// primed is false until the first snapshot has been absorbed. It is what makes
+	// this edge-triggered rather than level-triggered.
+	primed bool
+	// includeCurrent reports the sessions that are ALREADY stopped at the first
+	// snapshot, for a driver that wants a starting picture.
+	includeCurrent bool
+}
+
+func newFleetWatcher(includeCurrent bool) *fleetWatcher {
+	return &fleetWatcher{
+		phase:          map[string]watchStopReason{},
+		titles:         map[string]string{},
+		includeCurrent: includeCurrent,
+	}
+}
+
+// observe absorbs one snapshot and returns the transitions it represents.
+//
+// Events are sorted by title so a poll that produces several is deterministic —
+// a driver reading the first line of output gets a stable answer rather than map
+// order.
+func (w *fleetWatcher) observe(snapshot []session.InstanceData) []watchEvent {
+	seen := make(map[string]struct{}, len(snapshot))
+	var events []watchEvent
+
+	for i := range snapshot {
+		data := snapshot[i]
+		key := watchKeyOf(data)
+		seen[key] = struct{}{}
+		reason, detail := classifyWatchStop(data)
+		previous, known := w.phase[key]
+		w.phase[key] = reason
+		w.titles[key] = data.Title
+
+		switch {
+		case !known && !w.primed:
+			// Baseline. Reported only when the caller asked for the starting
+			// snapshot; otherwise this is exactly the level-triggered behaviour that
+			// made the single-title command unusable as a trigger.
+			//
+			// Archived sessions are left out of that snapshot even so, and this is a
+			// measured decision rather than a taste one: on the box this was built
+			// against, --include-current reported 440 archived sessions and 6 idle
+			// ones. A starting picture is "what needs me now", and a deliberately
+			// shelved session never does — it is inert by construction and cannot
+			// change on its own. Burying six actionable lines under 440 is the
+			// "loop with extra steps" outcome this feature exists to avoid.
+			//
+			// A TRANSITION into archived is still reported below: something archiving
+			// a session out from under a driver is news, whereas a shelf that was
+			// already full is not.
+			if w.includeCurrent && reason.stopped() && reason != watchStopArchived {
+				events = append(events, newWatchEvent(data, reason, detail))
+			}
+		case !known:
+			// A session that appeared after priming. Report it only if it arrives
+			// already stopped — an appearing session that is working is not news, and
+			// its stop will be reported when it happens.
+			if reason.stopped() {
+				events = append(events, newWatchEvent(data, reason, detail))
+			}
+		case reason != previous && reason.stopped():
+			// The edge this command exists for.
+			events = append(events, newWatchEvent(data, reason, detail))
+		}
+	}
+
+	// A session that was present and is now absent. Only reported after priming:
+	// before that there is nothing it could have transitioned from.
+	if w.primed {
+		for key, previous := range w.phase {
+			if _, present := seen[key]; present {
+				continue
+			}
+			if previous != watchStopGone {
+				events = append(events, watchEvent{
+					Title:  w.titles[key],
+					Reason: watchStopGone,
+					Detail: "the session's record disappeared while watching (killed or removed)",
+				})
+			}
+			delete(w.phase, key)
+			delete(w.titles, key)
+		}
+	}
+
+	w.primed = true
+	sort.SliceStable(events, func(i, j int) bool { return events[i].Title < events[j].Title })
+	return events
+}
+
+func newWatchEvent(d session.InstanceData, reason watchStopReason, detail string) watchEvent {
+	record := d
+	return watchEvent{
+		Title:   d.Title,
+		ID:      d.ID,
+		Path:    d.Path,
+		Reason:  reason,
+		Detail:  detail,
+		Session: &record,
+	}
+}
+
+// describeWatchEvent renders one event as a human line.
+func describeWatchEvent(e watchEvent) string {
+	if e.Detail == "" {
+		return fmt.Sprintf("%s\t%s", e.Title, e.Reason)
+	}
+	return fmt.Sprintf("%s\t%s\t%s", e.Title, e.Reason, e.Detail)
+}
+
+// fleetWatchDeps are the injectable dependencies of the fleet loop, so its
+// timeout and polling behaviour are testable without a daemon or a wall clock.
+type fleetWatchDeps struct {
+	list     func() ([]session.InstanceData, error)
+	interval time.Duration
+	timeout  time.Duration
+	now      func() time.Time
+	sleep    func(time.Duration)
+}
+
+// watchFleet polls the whole fleet until at least one session transitions, and
+// returns the transitions from that poll.
+//
+// It returns EVERY event from the poll that produced the first one, not just the
+// single earliest. Several sessions finishing inside one interval is the normal
+// case for a fleet, and reporting one while discarding the rest would hand a
+// driver an incomplete picture that it cannot recover — the next call establishes
+// a new baseline, so the dropped events would never be reported at all.
+func watchFleet(d fleetWatchDeps, includeCurrent bool) ([]watchEvent, error) {
+	watcher := newFleetWatcher(includeCurrent)
+	start := d.now()
+	for {
+		snapshot, err := d.list()
+		if err != nil {
+			return nil, err
+		}
+		if events := watcher.observe(snapshot); len(events) > 0 {
+			return events, nil
+		}
+		if d.timeout > 0 && !d.now().Before(start.Add(d.timeout)) {
+			return nil, fmt.Errorf("timed out after %s waiting for any session to change state (%d watched)",
+				d.timeout, len(snapshot))
+		}
+		d.sleep(d.interval)
+	}
+}
+
+var (
+	watchAllFlag            bool
+	watchIncludeCurrentFlag bool
+)
+
+// runFleetWatch is the no-title / --all form: block until any session in scope
+// changes state, then report which and why.
+func runFleetWatch() error {
+	// Same scoping as the single-title form: --repo confines the fleet to one
+	// repository, and an empty repoID watches every session the daemon reports.
+	repoID, err := resolveRepoIDForLookup()
+	if err != nil {
+		return jsonError(err)
+	}
+
+	events, err := watchFleet(fleetWatchDeps{
+		list:     func() ([]session.InstanceData, error) { return listSessionsInScope(repoID) },
+		interval: watchIntervalFlag,
+		timeout:  watchTimeoutFlag,
+		now:      time.Now,
+		sleep:    time.Sleep,
+	}, watchIncludeCurrentFlag)
+	if err != nil {
+		return jsonError(err)
+	}
+
+	if envelopeOutput {
+		return jsonOut(map[string]any{"events": events})
+	}
+	for _, event := range events {
+		fmt.Println(describeWatchEvent(event))
+	}
+	return nil
+}
+
+// listSessionsInScope reads every session the daemon reports, falling back to a
+// scoped disk scan when no daemon is reachable — the same read path and the same
+// fallback rule the single-title form uses, so the two cannot disagree about what
+// "in scope" means.
+func listSessionsInScope(repoID string) ([]session.InstanceData, error) {
+	data, fallBack, err := snapshotRead(daemon.SnapshotRequest{RepoID: repoID})
+	if err != nil {
+		// A remote target has no local disk to fall back to; surfacing the daemon's
+		// error beats masking it as an empty fleet, which would look like "nothing
+		// is happening" and park a driver until its timeout (#1679).
+		if !fallBack {
+			return nil, err
+		}
+		return diskListSessions(repoID)
+	}
+	return data, nil
+}

--- a/api/sessions_watch_fleet_test.go
+++ b/api/sessions_watch_fleet_test.go
@@ -242,12 +242,12 @@ func TestFleetWatcher_MultipleTransitionsAreOrdered(t *testing.T) {
 func TestWatchFleet_BlocksUntilSomethingChanges(t *testing.T) {
 	polls := 0
 	deps := fleetWatchDeps{
-		list: func() ([]session.InstanceData, error) {
+		list: func() ([]session.InstanceData, watchSource, error) {
 			polls++
 			if polls < 4 {
-				return []session.InstanceData{fleetRunning("alpha"), withLiveness("bravo", session.LiveReady)}, nil
+				return []session.InstanceData{fleetRunning("alpha"), withLiveness("bravo", session.LiveReady)}, watchSourceDaemon, nil
 			}
-			return []session.InstanceData{withLiveness("alpha", session.LiveReady), withLiveness("bravo", session.LiveReady)}, nil
+			return []session.InstanceData{withLiveness("alpha", session.LiveReady), withLiveness("bravo", session.LiveReady)}, watchSourceDaemon, nil
 		},
 		interval: time.Second,
 		timeout:  time.Hour,
@@ -269,16 +269,16 @@ func TestWatchFleet_BlocksUntilSomethingChanges(t *testing.T) {
 func TestWatchFleet_ReturnsEveryEventFromThePollThatFired(t *testing.T) {
 	polls := 0
 	deps := fleetWatchDeps{
-		list: func() ([]session.InstanceData, error) {
+		list: func() ([]session.InstanceData, watchSource, error) {
 			polls++
 			if polls == 1 {
-				return []session.InstanceData{fleetRunning("alpha"), fleetRunning("bravo"), fleetRunning("charlie")}, nil
+				return []session.InstanceData{fleetRunning("alpha"), fleetRunning("bravo"), fleetRunning("charlie")}, watchSourceDaemon, nil
 			}
 			return []session.InstanceData{
 				withLiveness("alpha", session.LiveReady),
 				withLiveness("bravo", session.LiveLimitReached),
 				fleetRunning("charlie"),
-			}, nil
+			}, watchSourceDaemon, nil
 		},
 		interval: time.Second, timeout: time.Hour,
 		now:   func() time.Time { return time.Unix(0, 0) },
@@ -296,7 +296,9 @@ func TestWatchFleet_ReturnsEveryEventFromThePollThatFired(t *testing.T) {
 func TestWatchFleet_TimesOutRatherThanBlockingForever(t *testing.T) {
 	clock := time.Unix(0, 0)
 	deps := fleetWatchDeps{
-		list:     func() ([]session.InstanceData, error) { return []session.InstanceData{fleetRunning("alpha")}, nil },
+		list: func() ([]session.InstanceData, watchSource, error) {
+			return []session.InstanceData{fleetRunning("alpha")}, watchSourceDaemon, nil
+		},
 		interval: time.Second,
 		timeout:  10 * time.Second,
 		now:      func() time.Time { return clock },
@@ -312,7 +314,9 @@ func TestWatchFleet_TimesOutRatherThanBlockingForever(t *testing.T) {
 // like "nothing is happening" and parks a driver until its timeout.
 func TestWatchFleet_SurfacesAReadFailure(t *testing.T) {
 	deps := fleetWatchDeps{
-		list:     func() ([]session.InstanceData, error) { return nil, errors.New("daemon unreachable") },
+		list: func() ([]session.InstanceData, watchSource, error) {
+			return nil, watchSourceNone, errors.New("daemon unreachable")
+		},
 		interval: time.Second, timeout: time.Hour,
 		now:   func() time.Time { return time.Unix(0, 0) },
 		sleep: func(time.Duration) {},
@@ -411,7 +415,9 @@ func TestWatchFleet_NeverSleepsPastTheDeadline(t *testing.T) {
 	clock := time.Unix(0, 0)
 	var slept []time.Duration
 	deps := fleetWatchDeps{
-		list:     func() ([]session.InstanceData, error) { return []session.InstanceData{fleetRunning("alpha")}, nil },
+		list: func() ([]session.InstanceData, watchSource, error) {
+			return []session.InstanceData{fleetRunning("alpha")}, watchSourceDaemon, nil
+		},
 		interval: time.Hour,
 		timeout:  5 * time.Second,
 		now:      func() time.Time { return clock },
@@ -429,4 +435,89 @@ func TestDescribeWatchEvent_QualifiesOnlyWhenTitlesCanCollide(t *testing.T) {
 		"a single-project fleet has unique titles and stays short")
 	require.Equal(t, "worker\t/w/proj-a/worker\tidle\td", describeWatchEvent(e, true),
 		"an all-project fleet can hold two 'worker's, so the path says which")
+}
+
+// A newer daemon's Liveness value must fail closed, not fall through to the legacy
+// Status axis. That fallback is only valid for a record with NO liveness axis; a
+// record that HAS one this build cannot read is not a legacy record, and reading
+// its compatibility status could emit `idle` for a state the client does not
+// understand.
+func TestClassifyWatchStop_UnknownLivenessDoesNotUseTheLegacyFallback(t *testing.T) {
+	d := session.InstanceData{ID: "x", Title: "s", Path: "/w/s",
+		Liveness: session.Liveness(9999), // from a future daemon
+		Status:   session.Ready,          // compatibility value that would say "idle"
+	}
+	reason, detail := classifyWatchStop(d)
+	require.Equal(t, watchStopUnknown, reason,
+		"an unreadable liveness must not be rescued by a Status field that says idle")
+	require.Contains(t, detail, "upgrade af")
+}
+
+// A pre-#1195 record read off disk can carry its terminal state only on the legacy
+// axis. Reporting those as `unknown` loses an answer af actually has.
+func TestClassifyWatchStop_LegacyTerminalStatuses(t *testing.T) {
+	legacy := func(st session.Status) session.InstanceData {
+		return session.InstanceData{ID: "x", Title: "s", Path: "/w/s", Status: st}
+	}
+	lost, _ := classifyWatchStop(legacy(session.Lost))
+	require.Equal(t, watchStopLost, lost)
+
+	// Dead rolls forward to lost: deaths have recorded as Lost since #1108, and
+	// `lost` is the reason carrying the recovery instruction.
+	dead, detail := classifyWatchStop(legacy(session.Dead))
+	require.Equal(t, watchStopLost, dead)
+	require.Contains(t, detail, "restore")
+
+	archived, _ := classifyWatchStop(legacy(session.Archived))
+	require.Equal(t, watchStopArchived, archived)
+
+	// A delete in progress is motion, matching classifyActivityByStatus; its
+	// outcome arrives as a `gone` event.
+	deleting, _ := classifyWatchStop(legacy(session.Deleting))
+	require.Equal(t, watchWorking, deleting)
+}
+
+// Switching projections mid-watch would manufacture transitions: a pending create
+// lives in the daemon's memory and not on disk, so a daemon->disk fallback reads as
+// every such session vanishing, and the return trip as them arriving.
+func TestWatchFleet_RefusesToCompareTwoSnapshotSources(t *testing.T) {
+	polls := 0
+	deps := fleetWatchDeps{
+		list: func() ([]session.InstanceData, watchSource, error) {
+			polls++
+			if polls == 1 {
+				return []session.InstanceData{fleetRunning("alpha"), fleetRunning("mid-create")}, watchSourceDaemon, nil
+			}
+			// The daemon read failed and the disk projection does not know about the
+			// in-memory create.
+			return []session.InstanceData{fleetRunning("alpha")}, watchSourceDisk, nil
+		},
+		interval: time.Second, timeout: time.Hour,
+		now:   func() time.Time { return time.Unix(0, 0) },
+		sleep: func(time.Duration) {},
+	}
+
+	events, err := watchFleet(deps, false)
+	require.Error(t, err, "it must stop rather than report a create-in-flight as gone")
+	require.Empty(t, events)
+	require.Contains(t, err.Error(), "switched from")
+	require.Contains(t, err.Error(), "re-run")
+}
+
+// Same-titled sessions in different projects vanishing in one poll are appended
+// while ranging a MAP, so title alone leaves their order randomised.
+func TestFleetWatcher_OrderingBreaksTiesOnIdentity(t *testing.T) {
+	first := session.InstanceData{ID: "id-a", Title: "worker", Path: "/w/proj-a", Liveness: session.LiveRunning}
+	second := session.InstanceData{ID: "id-b", Title: "worker", Path: "/w/proj-b", Liveness: session.LiveRunning}
+
+	// Run it repeatedly: a title-only comparator passes this by luck roughly half
+	// the time, so one iteration would not catch the regression.
+	for attempt := 0; attempt < 50; attempt++ {
+		w := newFleetWatcher(false)
+		require.Empty(t, w.observe([]session.InstanceData{first, second}))
+		events := w.observe(nil)
+		require.Len(t, events, 2)
+		require.Equalf(t, []string{"id-a", "id-b"}, []string{events[0].ID, events[1].ID},
+			"attempt %d: same-titled sessions must order deterministically", attempt)
+	}
 }

--- a/api/sessions_watch_fleet_test.go
+++ b/api/sessions_watch_fleet_test.go
@@ -190,8 +190,9 @@ func TestFleetWatcher_KeysBySessionIdNotTitle(t *testing.T) {
 	}
 	require.Equal(t, watchStopIdle, byID["id-new"],
 		"the new session is reported on its own merits rather than inheriting the old one's phase")
-	require.Equal(t, watchStopGone, byID[""],
-		"and the session that vanished is reported as gone, not silently replaced")
+	require.Equal(t, watchStopGone, byID["id-old"],
+		"and the session that vanished is reported as gone, named by ITS id — a driver seeing only the "+
+			"shared title could not tell which of the two records disappeared")
 }
 
 func TestFleetWatcher_ReportsASessionThatDisappears(t *testing.T) {
@@ -345,4 +346,87 @@ func TestFleetWatcher_ReportsATransitionIntoArchived(t *testing.T) {
 
 	events := w.observe([]session.InstanceData{withLiveness("alpha", session.LiveArchived)})
 	require.Equal(t, map[string]watchStopReason{"alpha": watchStopArchived}, reasons(events))
+}
+
+// A `gone` event must still identify WHICH session went. In the kill-and-recreate
+// case the same poll emits a gone and an arrival under one title, so a driver that
+// only has the title cannot tell them apart.
+func TestFleetWatcher_GoneEventKeepsSessionIdentity(t *testing.T) {
+	w := newFleetWatcher(false)
+	require.Empty(t, w.observe([]session.InstanceData{fleetRunning("alpha")}))
+
+	events := w.observe(nil)
+	require.Len(t, events, 1)
+	require.Equal(t, watchStopGone, events[0].Reason)
+	require.Equal(t, "id-alpha", events[0].ID, "the vanished session is named by its stable id")
+	require.Equal(t, "/w/alpha", events[0].Path)
+}
+
+// Version skew: a newer daemon can send an InFlightOp this build has no name for.
+// Matching only the known ops would fall through to a liveness field that is stale
+// BECAUSE an operation is running, and report a mid-transition session as idle.
+func TestClassifyWatchStop_UnknownInFlightOpIsNotIdle(t *testing.T) {
+	d := withLiveness("s", session.LiveReady)
+	d.InFlightOp = session.InFlightOp(9999) // from a future daemon
+	reason, _ := classifyWatchStop(d)
+	require.Equal(t, watchWorking, reason,
+		"an operation this build cannot name is still an operation in flight")
+}
+
+// MarkUserKilled does not clear StartupStateUnknown, so both are legitimately true
+// during teardown. Telling a driver to "inspect it and remove it explicitly" there
+// is advice to do what is already happening.
+func TestClassifyWatchStop_KillIntentOutranksStartupUncertainty(t *testing.T) {
+	d := withLiveness("s", session.LiveReady)
+	d.StartupStateUnknown = true
+	d.UserKilled = true
+	reason, detail := classifyWatchStop(d)
+	require.Equal(t, watchStopKilled, reason)
+	require.Contains(t, detail, "teardown")
+}
+
+// A pre-#1195 record read off disk has no liveness axis, but its non-zero legacy
+// Status values are unambiguous and should be used rather than discarded.
+func TestClassifyWatchStop_LegacyStatusIsUsedWhereItIsUnambiguous(t *testing.T) {
+	legacy := func(st session.Status) session.InstanceData {
+		return session.InstanceData{ID: "x", Title: "s", Path: "/w/s", Status: st}
+	}
+	idle, _ := classifyWatchStop(legacy(session.Ready))
+	require.Equal(t, watchStopIdle, idle, "legacy Ready is unambiguous")
+
+	loading, _ := classifyWatchStop(legacy(session.Loading))
+	require.Equal(t, watchWorking, loading)
+
+	// Running is the ZERO value, so it cannot be told from a record that never had
+	// a status set — the one legacy value that must stay unknown.
+	ambiguous, _ := classifyWatchStop(legacy(session.Running))
+	require.Equal(t, watchStopUnknown, ambiguous,
+		"Running is Status's zero value and carries no information")
+}
+
+// --interval and --timeout are validated independently, so an interval longer than
+// the timeout is accepted. An unconditional sleep would make the advertised bound a
+// fiction: poll once, block for the interval, then report the short timeout.
+func TestWatchFleet_NeverSleepsPastTheDeadline(t *testing.T) {
+	clock := time.Unix(0, 0)
+	var slept []time.Duration
+	deps := fleetWatchDeps{
+		list:     func() ([]session.InstanceData, error) { return []session.InstanceData{fleetRunning("alpha")}, nil },
+		interval: time.Hour,
+		timeout:  5 * time.Second,
+		now:      func() time.Time { return clock },
+		sleep:    func(d time.Duration) { slept = append(slept, d); clock = clock.Add(d) },
+	}
+	_, err := watchFleet(deps, false)
+	require.ErrorContains(t, err, "timed out")
+	require.Equal(t, []time.Duration{5 * time.Second}, slept,
+		"the wait is clamped to the remaining timeout, not the full hour")
+}
+
+func TestDescribeWatchEvent_QualifiesOnlyWhenTitlesCanCollide(t *testing.T) {
+	e := watchEvent{Title: "worker", Path: "/w/proj-a/worker", Reason: watchStopIdle, Detail: "d"}
+	require.Equal(t, "worker\tidle\td", describeWatchEvent(e, false),
+		"a single-project fleet has unique titles and stays short")
+	require.Equal(t, "worker\t/w/proj-a/worker\tidle\td", describeWatchEvent(e, true),
+		"an all-project fleet can hold two 'worker's, so the path says which")
 }

--- a/api/sessions_watch_fleet_test.go
+++ b/api/sessions_watch_fleet_test.go
@@ -1,0 +1,348 @@
+package api
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+func fleetRunning(title string) session.InstanceData {
+	return session.InstanceData{ID: "id-" + title, Title: title, Path: "/w/" + title, Liveness: session.LiveRunning}
+}
+
+func withLiveness(title string, l session.Liveness) session.InstanceData {
+	d := fleetRunning(title)
+	d.Liveness = l
+	return d
+}
+
+func reasons(events []watchEvent) map[string]watchStopReason {
+	out := map[string]watchStopReason{}
+	for _, e := range events {
+		out[e.Title] = e.Reason
+	}
+	return out
+}
+
+// The defect the whole feature exists for. Arming watchers over already-idle
+// sessions returned all of them instantly, so "block until something finishes"
+// and "tell me what is finished now" were the same call and a driver re-triggered
+// on the same session forever (#3009).
+func TestFleetWatcher_FirstSnapshotIsABaselineNotAnAlert(t *testing.T) {
+	w := newFleetWatcher(false)
+
+	events := w.observe([]session.InstanceData{
+		withLiveness("alpha", session.LiveReady),
+		withLiveness("bravo", session.LiveReady),
+		withLiveness("charlie", session.LiveReady),
+	})
+	require.Empty(t, events,
+		"three sessions that were ALREADY idle are not three transitions — that is the level-triggered bug")
+
+	// Still nothing while they stay idle: a level would re-fire on every poll.
+	require.Empty(t, w.observe([]session.InstanceData{
+		withLiveness("alpha", session.LiveReady),
+		withLiveness("bravo", session.LiveReady),
+		withLiveness("charlie", session.LiveReady),
+	}))
+}
+
+func TestFleetWatcher_ReportsTheEdgeIntoIdle(t *testing.T) {
+	w := newFleetWatcher(false)
+	require.Empty(t, w.observe([]session.InstanceData{fleetRunning("alpha"), fleetRunning("bravo")}))
+
+	events := w.observe([]session.InstanceData{
+		withLiveness("alpha", session.LiveReady),
+		fleetRunning("bravo"),
+	})
+	require.Len(t, events, 1, "only the session that changed is reported")
+	require.Equal(t, "alpha", events[0].Title)
+	require.Equal(t, watchStopIdle, events[0].Reason)
+	require.NotNil(t, events[0].Session, "the record rides along so a driver acts without a second call")
+
+	// The same idle state on the next poll is not a new edge.
+	require.Empty(t, w.observe([]session.InstanceData{
+		withLiveness("alpha", session.LiveReady),
+		fleetRunning("bravo"),
+	}))
+
+	// Going back to work and finishing again IS a new edge.
+	require.Empty(t, w.observe([]session.InstanceData{fleetRunning("alpha"), fleetRunning("bravo")}))
+	again := w.observe([]session.InstanceData{withLiveness("alpha", session.LiveReady), fleetRunning("bravo")})
+	require.Len(t, again, 1)
+	require.Equal(t, watchStopIdle, again[0].Reason)
+}
+
+// --include-current is the level query, kept available for a driver that wants a
+// starting picture — but it must be asked for.
+func TestFleetWatcher_IncludeCurrentReportsTheStartingSnapshot(t *testing.T) {
+	w := newFleetWatcher(true)
+	events := w.observe([]session.InstanceData{
+		withLiveness("alpha", session.LiveReady),
+		fleetRunning("bravo"),
+		withLiveness("charlie", session.LiveLost),
+	})
+	require.Equal(t, map[string]watchStopReason{
+		"alpha":   watchStopIdle,
+		"charlie": watchStopLost,
+	}, reasons(events), "the working session is not a stop and is never reported")
+}
+
+// A driver responds differently to each of these; without them it must preview the
+// pane and read terminal text to guess, which is what #3009 was filed about.
+func TestClassifyWatchStop_SaysWhy(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		data   session.InstanceData
+		reason watchStopReason
+	}{
+		{"idle", withLiveness("s", session.LiveReady), watchStopIdle},
+		{"usage limit auto-resumes", withLiveness("s", session.LiveLimitReached), watchStopUsageLimited},
+		{"lost needs restore", withLiveness("s", session.LiveLost), watchStopLost},
+		{"dead", withLiveness("s", session.LiveDead), watchStopDead},
+		{"archived", withLiveness("s", session.LiveArchived), watchStopArchived},
+		{"working is not a stop", fleetRunning("s"), watchWorking},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reason, detail := classifyWatchStop(tc.data)
+			require.Equal(t, tc.reason, reason)
+			if tc.reason.stopped() {
+				require.NotEmpty(t, detail, "every stop must carry a reason a driver can act on")
+			}
+		})
+	}
+}
+
+// The rule that matters most: an idle report tells a driver to ACT, so a
+// fabricated one makes it interrupt a working session.
+func TestClassifyWatchStop_UnknownIsNeverIdle(t *testing.T) {
+	t.Run("unconfirmed startup", func(t *testing.T) {
+		d := withLiveness("s", session.LiveReady) // a liveness value that describes nothing
+		d.StartupStateUnknown = true
+		reason, detail := classifyWatchStop(d)
+		require.Equal(t, watchStopUnknown, reason,
+			"a record whose startup could not be confirmed must not be read as idle, whatever its liveness says")
+		require.NotEmpty(t, detail)
+	})
+
+	t.Run("no liveness axis at all", func(t *testing.T) {
+		d := session.InstanceData{ID: "x", Title: "s", Path: "/w/s"} // LivenessUnset, zero Status
+		reason, _ := classifyWatchStop(d)
+		require.Equal(t, watchStopUnknown, reason,
+			"a record af cannot classify reports unknown; the single-title path's legacy-status fallback is deliberately not used here")
+	})
+
+	t.Run("legacy Status cannot rescue it either", func(t *testing.T) {
+		// Running is Status's ZERO VALUE, so "Status == Running" is also true of a
+		// record that never had a status set. An earlier version of this code read it
+		// as "working"; that was inventing an answer from an unset field rather than
+		// falling back to a legacy one, and this case is what caught it.
+		explicit := session.InstanceData{ID: "x", Title: "s", Path: "/w/s", Status: session.Running}
+		empty := session.InstanceData{ID: "y", Title: "t", Path: "/w/t"}
+		require.Equal(t, explicit.Status, empty.Status,
+			"premise: an explicit Running is byte-identical to an unset status, so it carries no information")
+
+		reason, _ := classifyWatchStop(explicit)
+		require.Equal(t, watchStopUnknown, reason,
+			"af cannot tell these apart, so it must not claim to")
+	})
+}
+
+// A create/kill/archive/restore/handoff in flight is a session in motion. Waking a
+// driver for it would report a state that is about to change on its own.
+func TestClassifyWatchStop_InFlightOperationsAreNotStops(t *testing.T) {
+	for _, op := range []session.InFlightOp{
+		session.OpCreating, session.OpKilling, session.OpArchiving,
+		session.OpRestoring, session.OpReplacing, session.OpRespawning,
+	} {
+		d := withLiveness("s", session.LiveReady)
+		d.InFlightOp = op
+		reason, _ := classifyWatchStop(d)
+		require.Equalf(t, watchWorking, reason, "op %v is mid-transition, not a stop", op)
+	}
+}
+
+// Titles are reused. A kill-and-recreate under the same name is a DIFFERENT
+// session, and carrying the dead one's phase onto it would either suppress the new
+// session's first real transition or report it the instant it was created.
+func TestFleetWatcher_KeysBySessionIdNotTitle(t *testing.T) {
+	w := newFleetWatcher(false)
+	old := withLiveness("worker", session.LiveReady)
+	old.ID = "id-old"
+	require.Empty(t, w.observe([]session.InstanceData{old}))
+
+	// Same title, new session, already idle. It is not the session we baselined.
+	fresh := withLiveness("worker", session.LiveReady)
+	fresh.ID = "id-new"
+	events := w.observe([]session.InstanceData{fresh})
+
+	// TWO events, not one, and asserting on a title-keyed map would hide that: the
+	// old session is gone and a different session now holds the name. Keying by
+	// title anywhere — here or in the watcher — loses exactly this.
+	require.Len(t, events, 2, "a recycled title is two facts: one session ended, another arrived")
+	byID := map[string]watchStopReason{}
+	for _, e := range events {
+		byID[e.ID] = e.Reason
+	}
+	require.Equal(t, watchStopIdle, byID["id-new"],
+		"the new session is reported on its own merits rather than inheriting the old one's phase")
+	require.Equal(t, watchStopGone, byID[""],
+		"and the session that vanished is reported as gone, not silently replaced")
+}
+
+func TestFleetWatcher_ReportsASessionThatDisappears(t *testing.T) {
+	w := newFleetWatcher(false)
+	require.Empty(t, w.observe([]session.InstanceData{fleetRunning("alpha"), fleetRunning("bravo")}))
+
+	events := w.observe([]session.InstanceData{fleetRunning("bravo")})
+	require.Len(t, events, 1)
+	require.Equal(t, "alpha", events[0].Title)
+	require.Equal(t, watchStopGone, events[0].Reason)
+	require.Nil(t, events[0].Session, "there is no record left to hand a driver")
+
+	// And it is reported once, not on every later poll.
+	require.Empty(t, w.observe([]session.InstanceData{fleetRunning("bravo")}))
+}
+
+// A session created after priming is not news while it works; its stop is reported
+// when it happens.
+func TestFleetWatcher_SessionAppearingAfterPriming(t *testing.T) {
+	w := newFleetWatcher(false)
+	require.Empty(t, w.observe([]session.InstanceData{fleetRunning("alpha")}))
+	require.Empty(t, w.observe([]session.InstanceData{fleetRunning("alpha"), fleetRunning("bravo")}),
+		"a new session that is working is not a transition")
+
+	events := w.observe([]session.InstanceData{fleetRunning("alpha"), withLiveness("bravo", session.LiveReady)})
+	require.Equal(t, map[string]watchStopReason{"bravo": watchStopIdle}, reasons(events))
+}
+
+// Several transitions in one poll must come out in a stable order, or a driver
+// reading the first line gets whatever the map iteration happened to yield.
+func TestFleetWatcher_MultipleTransitionsAreOrdered(t *testing.T) {
+	w := newFleetWatcher(false)
+	require.Empty(t, w.observe([]session.InstanceData{fleetRunning("zulu"), fleetRunning("alpha"), fleetRunning("mike")}))
+
+	events := w.observe([]session.InstanceData{
+		withLiveness("zulu", session.LiveReady),
+		withLiveness("alpha", session.LiveLost),
+		withLiveness("mike", session.LiveReady),
+	})
+	require.Len(t, events, 3)
+	require.Equal(t, []string{"alpha", "mike", "zulu"},
+		[]string{events[0].Title, events[1].Title, events[2].Title})
+}
+
+// The loop blocks while nothing changes, then returns the transition. This is the
+// property the issue asked for in one sentence: "block until any session needs me".
+func TestWatchFleet_BlocksUntilSomethingChanges(t *testing.T) {
+	polls := 0
+	deps := fleetWatchDeps{
+		list: func() ([]session.InstanceData, error) {
+			polls++
+			if polls < 4 {
+				return []session.InstanceData{fleetRunning("alpha"), withLiveness("bravo", session.LiveReady)}, nil
+			}
+			return []session.InstanceData{withLiveness("alpha", session.LiveReady), withLiveness("bravo", session.LiveReady)}, nil
+		},
+		interval: time.Second,
+		timeout:  time.Hour,
+		now:      func() time.Time { return time.Unix(0, 0) },
+		sleep:    func(time.Duration) {},
+	}
+
+	events, err := watchFleet(deps, false)
+	require.NoError(t, err)
+	require.Len(t, events, 1, "bravo was already idle at the baseline and is not a transition")
+	require.Equal(t, "alpha", events[0].Title)
+	require.Equal(t, watchStopIdle, events[0].Reason)
+	require.Equal(t, 4, polls, "it kept polling while nothing changed")
+}
+
+// Several sessions finishing inside one interval is the normal case for a fleet.
+// Reporting one and dropping the rest would lose them permanently — the next call
+// re-baselines, so the dropped transitions are never reported at all.
+func TestWatchFleet_ReturnsEveryEventFromThePollThatFired(t *testing.T) {
+	polls := 0
+	deps := fleetWatchDeps{
+		list: func() ([]session.InstanceData, error) {
+			polls++
+			if polls == 1 {
+				return []session.InstanceData{fleetRunning("alpha"), fleetRunning("bravo"), fleetRunning("charlie")}, nil
+			}
+			return []session.InstanceData{
+				withLiveness("alpha", session.LiveReady),
+				withLiveness("bravo", session.LiveLimitReached),
+				fleetRunning("charlie"),
+			}, nil
+		},
+		interval: time.Second, timeout: time.Hour,
+		now:   func() time.Time { return time.Unix(0, 0) },
+		sleep: func(time.Duration) {},
+	}
+
+	events, err := watchFleet(deps, false)
+	require.NoError(t, err)
+	require.Equal(t, map[string]watchStopReason{
+		"alpha": watchStopIdle,
+		"bravo": watchStopUsageLimited,
+	}, reasons(events), "both transitions come back; charlie is still working and is not one")
+}
+
+func TestWatchFleet_TimesOutRatherThanBlockingForever(t *testing.T) {
+	clock := time.Unix(0, 0)
+	deps := fleetWatchDeps{
+		list:     func() ([]session.InstanceData, error) { return []session.InstanceData{fleetRunning("alpha")}, nil },
+		interval: time.Second,
+		timeout:  10 * time.Second,
+		now:      func() time.Time { return clock },
+		sleep:    func(d time.Duration) { clock = clock.Add(d) },
+	}
+	_, err := watchFleet(deps, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timed out")
+	require.Contains(t, err.Error(), "1 watched", "the message says how many sessions were being watched")
+}
+
+// A read failure must surface, not read as an empty fleet: an empty fleet looks
+// like "nothing is happening" and parks a driver until its timeout.
+func TestWatchFleet_SurfacesAReadFailure(t *testing.T) {
+	deps := fleetWatchDeps{
+		list:     func() ([]session.InstanceData, error) { return nil, errors.New("daemon unreachable") },
+		interval: time.Second, timeout: time.Hour,
+		now:   func() time.Time { return time.Unix(0, 0) },
+		sleep: func(time.Duration) {},
+	}
+	_, err := watchFleet(deps, false)
+	require.ErrorContains(t, err, "daemon unreachable")
+}
+
+// Measured on the box this was built against: --include-current reported 440
+// archived sessions and 6 idle ones. A starting picture is "what needs me now",
+// and an archived session is inert by construction — it cannot change on its own
+// and a driver cannot act on it. Burying the actionable lines is the "loop with
+// extra steps" outcome the feature exists to avoid.
+func TestFleetWatcher_IncludeCurrentOmitsTheArchivedShelf(t *testing.T) {
+	w := newFleetWatcher(true)
+	snapshot := []session.InstanceData{withLiveness("live-idle", session.LiveReady)}
+	for _, name := range []string{"shelf-a", "shelf-b", "shelf-c"} {
+		snapshot = append(snapshot, withLiveness(name, session.LiveArchived))
+	}
+
+	events := w.observe(snapshot)
+	require.Equal(t, map[string]watchStopReason{"live-idle": watchStopIdle}, reasons(events),
+		"the shelf is not a starting picture of what needs attention")
+}
+
+// But being archived WHILE a driver is watching is news — something shelved a
+// session out from under it.
+func TestFleetWatcher_ReportsATransitionIntoArchived(t *testing.T) {
+	w := newFleetWatcher(false)
+	require.Empty(t, w.observe([]session.InstanceData{fleetRunning("alpha")}))
+
+	events := w.observe([]session.InstanceData{withLiveness("alpha", session.LiveArchived)})
+	require.Equal(t, map[string]watchStopReason{"alpha": watchStopArchived}, reasons(events))
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -61,7 +61,7 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 - [`af sessions tabs delete`](#af-sessions-tabs-delete) — Delete a single tab from a session
 - [`af sessions tabs rename`](#af-sessions-tabs-rename) — Rename a tab of a session
 - [`af sessions tabs reorder`](#af-sessions-tabs-reorder) — Move a tab within a session's tab order
-- [`af sessions watch`](#af-sessions-watch) — Block until a session goes idle (ready for review)
+- [`af sessions watch`](#af-sessions-watch) — Block until a session goes idle, or until any session in the fleet changes state
 - [`af sessions whoami`](#af-sessions-whoami) — Identify the current Agent Factory session
 - [`af tasks`](#af-tasks) — Manage tasks
 - [`af tasks add`](#af-tasks-add) — Add a new task bound to the current project
@@ -1239,7 +1239,7 @@ af sessions
 - [`af sessions tab-rename`](#af-sessions-tab-rename) — Rename a tab of a session
 - [`af sessions tab-reorder`](#af-sessions-tab-reorder) — Move a tab within a session's tab order
 - [`af sessions tabs`](#af-sessions-tabs) — Manage a session's tabs (create/delete/rename/reorder)
-- [`af sessions watch`](#af-sessions-watch) — Block until a session goes idle (ready for review)
+- [`af sessions watch`](#af-sessions-watch) — Block until a session goes idle, or until any session in the fleet changes state
 - [`af sessions whoami`](#af-sessions-whoami) — Identify the current Agent Factory session
 
 **Flags**
@@ -2016,7 +2016,7 @@ af sessions tabs reorder <title> [flags]
 
 ## af sessions watch
 
-Block until a session goes idle (ready for review)
+Block until a session goes idle, or until any session in the fleet changes state
 
 Watch a session and return when its agent finishes working: exit 0 the moment
 the session goes IDLE (the agent stopped working and is awaiting input), so an
@@ -2033,14 +2033,31 @@ keep the watch waiting.
 By default prints a concise line on transition; with --json emits the final
 session record. Honors --repo to scope the title lookup to one repository.
 
+With NO title (or --all) it watches every session in scope and returns when the
+first one CHANGES STATE, printing which and why. That form is edge-triggered: the
+first poll establishes a baseline and reports nothing, so a session that was
+already idle before you called does not fire. Pass --include-current to report
+those too, for a driver that wants a starting snapshot; that snapshot omits
+archived sessions, which are inert by construction and cannot change on their own
+(a session archived WHILE you watch is still reported).
+
+Each reported session carries a reason a driver can act on: idle, usage-limited
+(af resumes it automatically — do not prompt it), lost, dead, archived, killed,
+gone, or unknown. "idle" covers both "finished its work" and "waiting on input":
+af records both as the same state and does not distinguish them, so neither does
+this. A session af cannot classify reports "unknown" and is never reported as
+idle, because an idle report tells a driver to act.
+
 ```
-af sessions watch <title> [flags]
+af sessions watch [title] [flags]
 ```
 
 **Flags**
 
 | Flag | Type | Description |
 |------|------|-------------|
+| `--all` |  | Watch every session in scope and return when the first one changes state (the default when no title is given) |
+| `--include-current` |  | Fleet form: also report sessions that are already stopped at the first poll, instead of only transitions |
 | `--interval` | `duration` | How often to poll the session's status (default `2s`) |
 | `--timeout` | `duration` | Give up and exit non-zero if the session is not idle within this window (0 = wait forever) (default `30m0s`) |
 

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -439,7 +439,7 @@
     },
     {
       "id": "session.watch",
-      "title": "Block until a session goes idle",
+      "title": "Block until a session goes idle, or until any session in the fleet changes state",
       "tui": {
         "status": "n/a",
         "pointer": ""
@@ -450,10 +450,10 @@
       },
       "cli": {
         "status": "yes",
-        "pointer": "api/sessions_watch.go:214 sessionsWatchCmd"
+        "pointer": "api/sessions_watch.go sessionsWatchCmd; api/sessions_watch_fleet.go fleetWatcher"
       },
       "verdict": "deliberate",
-      "notes": "A blocking scripting primitive for automation. Both UIs show liveness continuously, so 'block until idle' is meaningless there — you just look."
+      "notes": "A blocking scripting primitive for automation. Both UIs show liveness continuously, so 'block until idle' is meaningless there — you just look. The fleet form (#3009, no title or --all) is edge-triggered and exists for an automated driver rather than a person: it returns when any session TRANSITIONS, which is not something a UI can offer by rendering state, so it stays CLI-only for the same reason."
     },
     {
       "id": "session.whoami",
@@ -1712,7 +1712,9 @@
       "af sessions tabs reorder --help": "session.tab.reorder",
       "af sessions tabs reorder --index": "session.tab.reorder",
       "af sessions tabs reorder --name": "session.tab.reorder",
+      "af sessions watch --all": "session.watch",
       "af sessions watch --help": "meta.discovery",
+      "af sessions watch --include-current": "session.watch",
       "af sessions watch --interval": "session.watch",
       "af sessions watch --timeout": "session.watch",
       "af sessions whoami --help": "meta.discovery",


### PR DESCRIPTION
Closes #3009

Built to the shape agreed on the issue. Each of the four requirements, and what verifies it.

## 1. Edges, not levels

`watch <title>` answers "is this session idle?" — a level — so "block until something finishes" and "tell me what is finished now" were the same call. With no title (or `--all`), watch now takes the whole fleet and returns on a **transition**. The first poll establishes a baseline and reports nothing; `--include-current` opts into a starting snapshot.

**Verified against the live fleet**, not just in tests:

```
$ af sessions watch --all --include-current --timeout 10s
handoff-dupes              idle   the agent stopped and is awaiting input
hook-stdout-endpoint-only  idle   ...            (6 sessions, returns at once)

$ af sessions watch --all --timeout 12s          # transition-only
root  idle  the agent stopped and is awaiting input
--- elapsed=8s ---
```

The second run is the point: six sessions were **already** idle and none of them fired. It blocked, then returned when a seventh actually went idle. The old behaviour returned all six instantly at t=0.

## 2. It says WHY

`idle`, `usage-limited`, `lost`, `dead`, `archived`, `killed`, `gone`, `unknown` — each with a clause saying what to do (`usage-limited` says af resumes it automatically, do not prompt it; `lost` says restore it). Without this a driver must `preview` the pane and read terminal text to guess.

**One honest gap, flagged before I built it.** The agreed list separates *finished* from *waiting-on-input*. af cannot: both are `LiveReady`, and no field on `InstanceData` distinguishes them. They report as one reason, `idle`, and the help says so. Emitting a `finished` would be a guess whose expensive direction is a driver moving on from a session that is blocked on it. Separating them is a real feature for the liveness axis, where every surface would get it — not something to invent in this command's output.

## 3. Unknown is never idle

`StartupStateUnknown` is checked **before** the liveness axis, because a record whose startup was never confirmed carries a liveness value that describes nothing.

The legacy-`Status` fallback the single-title path uses is deliberately **absent** here, and the reason is sharper than caution: `Running` is `Status`'s **zero value** (`Running Status = iota`), so a record that never had a status set is byte-identical to one explicitly marked running. I originally kept that branch as "inferring *working* is safe" — a test I wrote caught that it fires on a completely empty record, which is inventing an answer from an unset field, not falling back to a legacy one. The test now asserts the two are indistinguishable and that af therefore says `unknown`.

## 4. Single-title watch is untouched

Same `watchForReady`, same `classifyWatch`, same output. The only edits to that path are the command's `Use`/`Args`/doc and one moved variable; its existing tests pass unchanged. `--include-current` on a single title is rejected with a message rather than silently ignored.

## Two decisions worth a reviewer's eye

**Keyed by stable session id, not title.** Titles are reused; carrying a dead session's phase onto its replacement would either suppress the new session's first transition or report it the instant it was created. A kill-and-recreate under one name produces two events — `gone` for the old id, its own reason for the new.

**`--include-current` omits archived sessions.** Measured here: it reported **440 archived and 6 idle**. A starting picture is "what needs me now", and an archived session is inert by construction. A transition *into* archived is still reported — being shelved while a driver watches is news.

## Testing

Fifteen tests over a pure, snapshot-driven state machine — no daemon, no clock — because the behaviour is entirely orderings: baseline, edge, edge-back, vanish, reappear, recycled title, multiple-in-one-poll. Plus the loop's blocking, multi-event return, timeout and read-failure paths. `go test ./api/` and `./session/` green; `gofmt`, `go build`, `golangci-lint --fast`, `scripts/lint-file-length.sh` clean; `docs/reference/cli.md` regenerated.