### PR TITLE
fix(daemon): give the control socket the outcome envelope HTTP already has

### DIFF
--- a/apiclient/client.go
+++ b/apiclient/client.go
@@ -274,6 +274,22 @@ func (c *Client) callCtx(ctx context.Context, method string, req any, resp any) 
 			return fmt.Errorf("apiclient: malformed response data: %w", err)
 		}
 	}
+	return committedFromResponse(resp)
+}
+
+// committedFromResponse reconstitutes a COMMITTED outcome from any response that
+// embeds daemon.MutationOutcome, keyed on the SAME apiproto code the error
+// envelope uses. Generic on purpose: a new mutating method inherits this by
+// embedding the outcome, with no per-method branch here to forget — which is the
+// property the deleted per-RPC classifier never had (#3036).
+func committedFromResponse(resp any) error {
+	carrier, ok := resp.(interface{ CommittedOutcome() (bool, string) })
+	if !ok {
+		return nil
+	}
+	if committed, warning := carrier.CommittedOutcome(); committed {
+		return &mutationCommittedError{detail: warning}
+	}
 	return nil
 }
 

--- a/apiclient/control.go
+++ b/apiclient/control.go
@@ -44,13 +44,13 @@ func (c *Client) KillSession(ctx context.Context, req daemon.KillSessionRequest)
 // relocated worktree's new path.
 func (c *Client) ArchiveSession(req daemon.ArchiveSessionRequest) (string, error) {
 	var resp daemon.ArchiveSessionResponse
-	if err := c.call("ArchiveSession", req, &resp); err != nil {
+	err := c.call("ArchiveSession", req, &resp)
+	// call() classifies a committed outcome generically; this only keeps the
+	// payload, which a committed archive still needs to report where it landed.
+	if err != nil && !IsMutationCommitted(err) {
 		return "", err
 	}
-	if resp.Warning != "" {
-		return resp.ArchivedPath, &mutationCommittedError{detail: resp.Warning}
-	}
-	return resp.ArchivedPath, nil
+	return resp.ArchivedPath, err
 }
 
 // RestoreSession asks the daemon to restore an archived, Lost, or Dead session.
@@ -67,13 +67,11 @@ func (c *Client) RestoreSession(req daemon.RestoreSessionRequest) (string, error
 // opt-in. Returns the daemon's response (archived/killed counts).
 func (c *Client) DeleteProject(req daemon.DeleteProjectRequest) (daemon.DeleteProjectResponse, error) {
 	var resp daemon.DeleteProjectResponse
-	if err := c.call("DeleteProject", req, &resp); err != nil {
+	err := c.call("DeleteProject", req, &resp)
+	if err != nil && !IsMutationCommitted(err) {
 		return daemon.DeleteProjectResponse{}, err
 	}
-	if resp.Warning != "" {
-		return resp, &mutationCommittedError{detail: resp.Warning}
-	}
-	return resp, nil
+	return resp, err
 }
 
 // ResumeFromLimit asks the daemon to resume a usage-limit-blocked session

--- a/apiclient/control_test.go
+++ b/apiclient/control_test.go
@@ -78,7 +78,13 @@ func TestControlRoundTrips(t *testing.T) {
 		c := routeServer(t, "ArchiveSession", func([]byte) apiproto.Envelope {
 			return apiproto.Success(daemon.ArchiveSessionResponse{
 				OK: true, ArchivedPath: "/arch/alpha",
-				Warning: "archive committed, but on-archive hook failed",
+				// The outcome is embedded now, and keyed on the SAME apiproto code
+				// the error envelope uses — so this literal states the contract the
+				// client actually reads, not a parallel warning field (#3036).
+				MutationOutcome: daemon.MutationOutcome{
+					Code:    apiproto.ErrorCodeMutationCommitted,
+					Warning: "archive committed, but on-archive hook failed",
+				},
 			})
 		})
 		path, err := c.ArchiveSession(daemon.ArchiveSessionRequest{Title: "alpha"})

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -532,13 +532,14 @@ func RestoreSession(req RestoreSessionRequest) (string, error) {
 // opt-in. Returns how many sessions were archived and how many were torn down.
 func DeleteProject(req DeleteProjectRequest) (DeleteProjectResponse, error) {
 	var resp DeleteProjectResponse
-	if err := callDaemon("DeleteProject", req, &resp); err != nil {
+	err := callDaemon("DeleteProject", req, &resp)
+	// Keep the payload on the committed path, as ArchiveSession does: the
+	// deletion IS durable, and api/projects.go prints the archived/killed counts
+	// and deregistration state from exactly this response.
+	if err != nil && !isMutationCommitted(err) {
 		return DeleteProjectResponse{}, err
 	}
-	if resp.Warning != "" {
-		return resp, &rpcMutationCommittedError{err: errors.New(resp.Warning)}
-	}
-	return resp, nil
+	return resp, err
 }
 
 // RegisterProject asks the daemon to register a git checkout as a durable,

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -296,34 +296,22 @@ func callDaemonNoEnsure(method string, req any, resp any) error {
 	}
 	client := rpc.NewClient(conn)
 	defer client.Close()
-	return classifyTaskMutationRPCError(method, client.Call(controlServiceName+"."+method, req, resp))
-}
-
-// classifyTaskMutationRPCError restores the one machine-readable outcome that
-// net/rpc drops: rpc.ServerError carries only Error(), not the concrete server
-// type. Classification is deliberately narrow — both the RPC method and the
-// exact server-owned prefix must match — so a transport failure or an arbitrary
-// application error remains unknown rather than being promoted to committed.
-func classifyTaskMutationRPCError(method string, err error) error {
-	if err == nil {
-		return nil
-	}
-	var prefix string
-	switch method {
-	case "AddTask":
-		prefix = taskAddCommittedErrorPrefix
-	case "UpdateTask":
-		prefix = taskUpdateCommittedErrorPrefix
-	case "RemoveTask":
-		prefix = taskRemoveCommittedErrorPrefix
-	default:
+	if err := client.Call(controlServiceName+"."+method, req, resp); err != nil {
 		return err
 	}
-	var serverErr rpc.ServerError
-	if !errors.As(err, &serverErr) || !strings.HasPrefix(serverErr.Error(), prefix+" ") {
-		return err
+	// A committed mutation answers OK and reports itself in the response
+	// envelope: net/rpc reduces a concrete error to rpc.ServerError and keeps
+	// only its string, so the marker cannot ride in the error. Read once,
+	// generically, for any response embedding MutationOutcome — which replaced
+	// reconstructing it from per-method message prefixes (#3036).
+	if carrier, ok := resp.(interface {
+		committedOutcome() (bool, string)
+	}); ok {
+		if committed, warning := carrier.committedOutcome(); committed {
+			return &rpcMutationCommittedError{err: errors.New(warning)}
+		}
 	}
-	return &rpcMutationCommittedError{err: err}
+	return nil
 }
 
 type rpcMutationCommittedError struct{ err error }

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -305,9 +305,9 @@ func callDaemonNoEnsure(method string, req any, resp any) error {
 	// generically, for any response embedding MutationOutcome — which replaced
 	// reconstructing it from per-method message prefixes (#3036).
 	if carrier, ok := resp.(interface {
-		committedOutcome() (bool, string)
+		CommittedOutcome() (bool, string)
 	}); ok {
-		if committed, warning := carrier.committedOutcome(); committed {
+		if committed, warning := carrier.CommittedOutcome(); committed {
 			return &rpcMutationCommittedError{err: errors.New(warning)}
 		}
 	}

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -297,6 +297,14 @@ func callDaemonNoEnsure(method string, req any, resp any) error {
 	client := rpc.NewClient(conn)
 	defer client.Close()
 	if err := client.Call(controlServiceName+"."+method, req, resp); err != nil {
+		// An erroring handler sends NO response body, so the envelope below
+		// never runs for handlers that answer with an error -- the task
+		// mutations do. Recognise an older daemon's committed marker here so a
+		// new CLI does not read "failed" and retry a durable task change into a
+		// duplicate. Skew-only; see committedFromLegacyRPCError.
+		if committed := committedFromLegacyRPCError(err); committed != nil {
+			return committed
+		}
 		return err
 	}
 	// A committed mutation answers OK and reports itself in the response
@@ -309,6 +317,35 @@ func callDaemonNoEnsure(method string, req any, resp any) error {
 	}); ok {
 		if committed, warning := carrier.CommittedOutcome(); committed {
 			return &rpcMutationCommittedError{err: errors.New(warning)}
+		}
+	}
+	return nil
+}
+
+// committedPrefixes are the wire strings a pre-#3036 daemon uses to mark a
+// durable-but-incomplete task mutation. This is NOT the deleted per-method
+// classifier: it is one shared, method-agnostic check over the SAME shared
+// vocabulary, reached only when no response body exists to carry the envelope.
+// Delete it once the oldest supported daemon reports through the envelope.
+var committedPrefixes = []string{
+	taskAddCommittedErrorPrefix,
+	taskUpdateCommittedErrorPrefix,
+	taskRemoveCommittedErrorPrefix,
+}
+
+// committedFromLegacyRPCError recognises an older daemon's committed outcome,
+// which arrives as a flattened rpc.ServerError with no structure left (#2512).
+func committedFromLegacyRPCError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var srv rpc.ServerError
+	if !errors.As(err, &srv) {
+		return nil
+	}
+	for _, prefix := range committedPrefixes {
+		if strings.HasPrefix(string(srv), prefix) {
+			return &rpcMutationCommittedError{err: err}
 		}
 	}
 	return nil
@@ -445,13 +482,14 @@ func KillSession(req KillSessionRequest) error {
 // relocated worktree's new path.
 func ArchiveSession(req ArchiveSessionRequest) (string, error) {
 	var resp ArchiveSessionResponse
-	if err := callDaemon("ArchiveSession", req, &resp); err != nil {
+	err := callDaemon("ArchiveSession", req, &resp)
+	// callDaemon classifies the committed outcome generically. Keep the payload
+	// on that path: the archive IS durable, and the CLI still has to report
+	// where it landed. Only a clean failure has no path to report.
+	if err != nil && !isMutationCommitted(err) {
 		return "", err
 	}
-	if resp.Warning != "" {
-		return resp.ArchivedPath, &rpcMutationCommittedError{err: errors.New(resp.Warning)}
-	}
-	return resp.ArchivedPath, nil
+	return resp.ArchivedPath, err
 }
 
 // ResumeFromLimit asks the daemon to retry a session parked at a usage-limit

--- a/daemon/control_committed.go
+++ b/daemon/control_committed.go
@@ -109,16 +109,10 @@ func (r *ArchiveSessionResponse) record(err error) bool {
 	return ok
 }
 
-// CommittedOutcome also consults the flat field, which is where an OLDER
-// daemon's warning lands once the outer name takes precedence.
+// CommittedOutcome reconciles the envelope with the flat legacy field; see
+// committedWithFlatWarning for why the text can land on either side.
 func (r ArchiveSessionResponse) CommittedOutcome() (committed bool, warning string) {
-	if committed, warning := r.MutationOutcome.CommittedOutcome(); committed {
-		return true, warning
-	}
-	if r.Warning != "" {
-		return true, r.Warning
-	}
-	return false, ""
+	return committedWithFlatWarning(r.MutationOutcome, r.Warning)
 }
 
 func (r *DeleteProjectResponse) record(err error) bool {
@@ -127,12 +121,25 @@ func (r *DeleteProjectResponse) record(err error) bool {
 	return ok
 }
 
+// CommittedOutcome reconciles the envelope with the flat legacy field; see
+// committedWithFlatWarning for why the text can land on either side.
 func (r DeleteProjectResponse) CommittedOutcome() (committed bool, warning string) {
-	if committed, warning := r.MutationOutcome.CommittedOutcome(); committed {
-		return true, warning
+	return committedWithFlatWarning(r.MutationOutcome, r.Warning)
+}
+
+// committedWithFlatWarning reconciles the envelope with the flat legacy field.
+// Both encoders resolve the OUTER `warning` name first, so a current daemon's
+// JSON puts the text in flat while `code` still decodes into the embedded
+// struct -- the envelope then reads committed with an EMPTY message, and the
+// TUI has no hook failure to show. Whichever side carries the text wins, and a
+// flat warning with no code is an older daemon reporting a committed outcome.
+func committedWithFlatWarning(outcome MutationOutcome, flat string) (committed bool, warning string) {
+	committed, warning = outcome.CommittedOutcome()
+	if warning == "" {
+		warning = flat
 	}
-	if r.Warning != "" {
-		return true, r.Warning
+	if !committed && flat != "" {
+		committed = true
 	}
-	return false, ""
+	return committed, warning
 }

--- a/daemon/control_committed.go
+++ b/daemon/control_committed.go
@@ -41,17 +41,10 @@ func (o *MutationOutcome) record(err error) (ok bool) {
 	case err == nil:
 		return true
 	case isMutationCommitted(err):
-		o.Committed = true
+		o.Code = apiproto.ErrorCodeMutationCommitted
 		o.Warning = err.Error()
 		return true
 	default:
 		return false
 	}
-}
-
-// committedOutcome exposes the envelope generically. Promoted to every response
-// embedding MutationOutcome, which is what lets the client read it without
-// knowing the concrete type.
-func (o MutationOutcome) committedOutcome() (committed bool, warning string) {
-	return o.Committed, o.Warning
 }

--- a/daemon/control_committed.go
+++ b/daemon/control_committed.go
@@ -48,3 +48,91 @@ func (o *MutationOutcome) record(err error) (ok bool) {
 		return false
 	}
 }
+
+// MutationOutcome is the control socket's answer to a question its transport
+// could not previously express: did the side effect land?
+//
+// A mutating operation has THREE outcomes — succeeded, failed with nothing
+// committed, and failed AFTER something irreversible landed — and only the third
+// is unsafe to retry. The HTTP API already carries that distinction structurally
+// (apiproto.ErrorCodeMutationCommitted, reconstituted in apiclient/skew.go), but
+// the control socket is net/rpc, which reduces any concrete error to
+// rpc.ServerError and keeps only its string. Rebuilding the marker from that
+// string is what classifyTaskMutationRPCError did, and why it could only ever
+// cover the three task RPCs whose message prefixes were fixed.
+//
+// Embedding it in the RESPONSE puts the answer somewhere the transport cannot
+// drop: gob encodes struct fields, so no prefix matching, no per-method casing,
+// and a new mutating RPC inherits the channel by embedding rather than by
+// remembering (#3036).
+//
+// VALUE TYPES ONLY — never pointers. gob elides zero values (see
+// control_expect_gob_test.go and #1700), so a *bool would arrive nil at false
+// and be indistinguishable from "never set", silently turning a committed
+// outcome back into a clean failure: exactly the bug this exists to prevent.
+type MutationOutcome struct {
+	// Code carries apiproto.ErrorCodeMutationCommitted when the mutation
+	// committed, and is empty otherwise. It SHARES the HTTP envelope's code
+	// rather than paralleling it with a second boolean: one vocabulary means a
+	// client asks both transports the same question, and a new signal would be
+	// one more thing that can disagree.
+	Code string `json:"code,omitempty"`
+	// Warning is why the follow-up failed, when Code says it committed.
+	Warning string `json:"warning,omitempty"`
+}
+
+// CommittedOutcome reports whether the mutation committed and why its follow-up
+// failed. Exported because BOTH clients read it — daemon's control client and
+// apiclient — generically, off the embedded struct, so a response type opts in
+// by embedding rather than by each client growing a per-method branch.
+func (o MutationOutcome) CommittedOutcome() (committed bool, warning string) {
+	if o.Code == apiproto.ErrorCodeMutationCommitted {
+		return true, o.Warning
+	}
+	// Version skew: a pre-#3036 daemon sends `warning` with no `code`, and that
+	// field lands here on both transports (gob matches the promoted name; the
+	// json tag flattens). `warning` only ever meant "durable, post-commit step
+	// failed", so a code-less warning IS a committed outcome. Delete this branch
+	// once the oldest supported daemon emits the code.
+	if o.Code == "" && o.Warning != "" {
+		return true, o.Warning
+	}
+	return false, ""
+}
+
+// record mirrors the envelope into the flat legacy field so BOTH client
+// generations see the committed outcome. It shadows the promoted method, so a
+// handler that writes the envelope gets the legacy wire for free.
+func (r *ArchiveSessionResponse) record(err error) bool {
+	ok := r.MutationOutcome.record(err)
+	r.Warning = r.MutationOutcome.Warning
+	return ok
+}
+
+// CommittedOutcome also consults the flat field, which is where an OLDER
+// daemon's warning lands once the outer name takes precedence.
+func (r ArchiveSessionResponse) CommittedOutcome() (committed bool, warning string) {
+	if committed, warning := r.MutationOutcome.CommittedOutcome(); committed {
+		return true, warning
+	}
+	if r.Warning != "" {
+		return true, r.Warning
+	}
+	return false, ""
+}
+
+func (r *DeleteProjectResponse) record(err error) bool {
+	ok := r.MutationOutcome.record(err)
+	r.Warning = r.MutationOutcome.Warning
+	return ok
+}
+
+func (r DeleteProjectResponse) CommittedOutcome() (committed bool, warning string) {
+	if committed, warning := r.MutationOutcome.CommittedOutcome(); committed {
+		return true, warning
+	}
+	if r.Warning != "" {
+		return true, r.Warning
+	}
+	return false, ""
+}

--- a/daemon/control_committed.go
+++ b/daemon/control_committed.go
@@ -1,0 +1,57 @@
+package daemon
+
+import (
+	"errors"
+
+	"github.com/sachiniyer/agent-factory/apiproto"
+)
+
+// Everything that makes a COMMITTED mutation distinguishable from a clean
+// failure lives here: the marker, its constructor, the API code, and the two
+// halves of the control-socket envelope. One home, so a new write path meets the
+// whole rule rather than a fragment of it (#3036).
+
+func isMutationCommitted(err error) bool {
+	type committed interface {
+		MutationCommitted() bool
+	}
+	var outcome committed
+	return errors.As(err, &outcome) && outcome.MutationCommitted()
+}
+func (e *mutationCommittedError) Error() string           { return e.err.Error() }
+func (e *mutationCommittedError) Unwrap() error           { return e.err }
+func (e *mutationCommittedError) MutationCommitted() bool { return true }
+func (e *mutationCommittedError) APIErrorCode() string {
+	return apiproto.ErrorCodeMutationCommitted
+}
+
+// mutationCommittedError preserves the otherwise-ambiguous outcome of a
+// durable mutation whose non-transactional follow-up failed. HTTP exposes its
+// code additively; net/rpc carries the server-owned prefix that the control
+// client narrowly restores to the same three-valued marker.
+type mutationCommittedError struct {
+	err error
+}
+
+// record classifies a mutation's error for a control-socket handler and fills
+// the response envelope, returning false for a genuine failure the handler must
+// return unchanged. The ONLY place a handler decides what committed means.
+func (o *MutationOutcome) record(err error) (ok bool) {
+	switch {
+	case err == nil:
+		return true
+	case isMutationCommitted(err):
+		o.Committed = true
+		o.Warning = err.Error()
+		return true
+	default:
+		return false
+	}
+}
+
+// committedOutcome exposes the envelope generically. Promoted to every response
+// embedding MutationOutcome, which is what lets the client read it without
+// knowing the concrete type.
+func (o MutationOutcome) committedOutcome() (committed bool, warning string) {
+	return o.Committed, o.Warning
+}

--- a/daemon/control_committed_gob_test.go
+++ b/daemon/control_committed_gob_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/gob"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/apiproto"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,7 +20,7 @@ import (
 func TestMutationOutcomeSurvivesGobRoundTrip(t *testing.T) {
 	t.Run("committed outcome arrives intact", func(t *testing.T) {
 		sent := KillSessionResponse{OK: true}
-		sent.Committed = true
+		sent.Code = apiproto.ErrorCodeMutationCommitted
 		sent.Warning = "kill committed, but teardown failed"
 
 		var got KillSessionResponse
@@ -27,7 +28,8 @@ func TestMutationOutcomeSurvivesGobRoundTrip(t *testing.T) {
 		require.NoError(t, gob.NewEncoder(&buf).Encode(sent))
 		require.NoError(t, gob.NewDecoder(&buf).Decode(&got))
 
-		require.True(t, got.Committed,
+		committed, _ := got.CommittedOutcome()
+		require.True(t, committed,
 			"a committed kill that decodes as not-committed tells the caller to retry an applied change")
 		require.Equal(t, "kill committed, but teardown failed", got.Warning)
 	})
@@ -41,7 +43,8 @@ func TestMutationOutcomeSurvivesGobRoundTrip(t *testing.T) {
 		require.NoError(t, gob.NewEncoder(&buf).Encode(KillSessionResponse{OK: true}))
 		require.NoError(t, gob.NewDecoder(&buf).Decode(&got))
 
-		require.False(t, got.Committed, "a clean kill must never read as committed")
+		committed, _ := got.CommittedOutcome()
+		require.False(t, committed, "a clean kill must never read as committed")
 		require.Empty(t, got.Warning)
 	})
 
@@ -57,8 +60,37 @@ func TestMutationOutcomeSurvivesGobRoundTrip(t *testing.T) {
 			"UpdateTask":      &UpdateTaskResponse{},
 			"RemoveTask":      &RemoveTaskResponse{},
 		} {
-			_, ok := resp.(interface{ committedOutcome() (bool, string) })
+			_, ok := resp.(interface{ CommittedOutcome() (bool, string) })
 			require.True(t, ok, "%s response must embed MutationOutcome, or the client cannot read its outcome", name)
 		}
 	})
+}
+
+// The GENERAL case, and the property the deleted per-RPC classifier never had:
+// a response type that no client, list, or switch has ever heard of still
+// round-trips a committed outcome, purely by embedding MutationOutcome. If this
+// ever needs a per-method branch to pass, the mechanism has regressed to what
+// #3032 was closed for.
+type unlistedMutationResponse struct {
+	OK bool
+	MutationOutcome
+}
+
+func TestUnlistedResponseTypeStillRoundTripsCommitted(t *testing.T) {
+	sent := unlistedMutationResponse{OK: true}
+	sent.Code = apiproto.ErrorCodeMutationCommitted
+	sent.Warning = "committed, follow-up failed"
+
+	var got unlistedMutationResponse
+	var buf bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&buf).Encode(sent))
+	require.NoError(t, gob.NewDecoder(&buf).Decode(&got))
+
+	// Read exactly as the control client reads it: through the exported accessor
+	// on the embedded struct, with no knowledge of this type.
+	carrier, ok := any(&got).(interface{ CommittedOutcome() (bool, string) })
+	require.True(t, ok, "embedding MutationOutcome must be all a response needs to opt in")
+	committed, warning := carrier.CommittedOutcome()
+	require.True(t, committed, "an unlisted response type must still report its committed outcome")
+	require.Equal(t, "committed, follow-up failed", warning)
 }

--- a/daemon/control_committed_gob_test.go
+++ b/daemon/control_committed_gob_test.go
@@ -179,3 +179,94 @@ func TestDeleteProjectCarriesCommittedOutcome(t *testing.T) {
 		t.Errorf("legacy `warning` json key disappeared, breaking old clients: %s", encoded)
 	}
 }
+
+// TestCommittedWarningSurvivesEveryDecodePath is the matrix the earlier tests
+// left a hole in: they covered new->old and old->new but never a CURRENT daemon
+// decoded by a CURRENT client. Both encoders resolve the outer `warning` name
+// first, so that case lands the text in the flat field while `code` lands in the
+// embedded struct -- and an envelope read that stopped at the embedded pair
+// reported committed with an EMPTY message, leaving the TUI nothing to show.
+func TestCommittedWarningSurvivesEveryDecodePath(t *testing.T) {
+	current := ArchiveSessionResponse{OK: true, ArchivedPath: "/archived/here"}
+	current.record(&mutationCommittedError{err: errors.New("on-archive hook failed")})
+
+	type legacyWire struct {
+		OK           bool
+		ArchivedPath string
+		Warning      string
+	}
+	legacy := legacyWire{OK: true, ArchivedPath: "/archived/here", Warning: "legacy hook failed"}
+
+	for _, tc := range []struct {
+		name    string
+		decode  func(*testing.T) ArchiveSessionResponse
+		wantMsg string
+	}{
+		{"json, current daemon and client", func(t *testing.T) ArchiveSessionResponse {
+			raw, err := json.Marshal(current)
+			require.NoError(t, err)
+			var got ArchiveSessionResponse
+			require.NoError(t, json.Unmarshal(raw, &got))
+			return got
+		}, "on-archive hook failed"},
+		{"gob, current daemon and client", func(t *testing.T) ArchiveSessionResponse {
+			var buf bytes.Buffer
+			require.NoError(t, gob.NewEncoder(&buf).Encode(current))
+			var got ArchiveSessionResponse
+			require.NoError(t, gob.NewDecoder(&buf).Decode(&got))
+			return got
+		}, "on-archive hook failed"},
+		{"json, older daemon", func(t *testing.T) ArchiveSessionResponse {
+			raw, err := json.Marshal(legacy)
+			require.NoError(t, err)
+			var got ArchiveSessionResponse
+			require.NoError(t, json.Unmarshal(raw, &got))
+			return got
+		}, "legacy hook failed"},
+		{"gob, older daemon", func(t *testing.T) ArchiveSessionResponse {
+			var buf bytes.Buffer
+			require.NoError(t, gob.NewEncoder(&buf).Encode(legacy))
+			var got ArchiveSessionResponse
+			require.NoError(t, gob.NewDecoder(&buf).Decode(&got))
+			return got
+		}, "legacy hook failed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.decode(t)
+			committed, warning := got.CommittedOutcome()
+			require.True(t, committed, "committed outcome lost across this decode path")
+			require.Equal(t, tc.wantMsg, warning,
+				"committed but with no message to show the user -- the hook failure is invisible")
+			require.Equal(t, "/archived/here", got.ArchivedPath, "payload lost")
+		})
+	}
+
+	// Negative control: a clean success must not be promoted by either field.
+	var clean ArchiveSessionResponse
+	raw, err := json.Marshal(ArchiveSessionResponse{OK: true, ArchivedPath: "/p"})
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(raw, &clean))
+	committed, _ := clean.CommittedOutcome()
+	require.False(t, committed, "a clean success was promoted to committed")
+}
+
+// TestNewDaemonWarningReachesOlderClient pins the direction the flat field
+// exists for: gob encodes the embedded envelope as a NESTED field an older
+// client has no slot for, so without the flat mirror the hook failure vanishes
+// and the older client reports clean success.
+func TestNewDaemonWarningReachesOlderClient(t *testing.T) {
+	current := ArchiveSessionResponse{OK: true, ArchivedPath: "/archived/here"}
+	current.record(&mutationCommittedError{err: errors.New("on-archive hook failed")})
+
+	type olderClientWire struct {
+		OK           bool
+		ArchivedPath string
+		Warning      string
+	}
+	var buf bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&buf).Encode(current))
+	var older olderClientWire
+	require.NoError(t, gob.NewDecoder(&buf).Decode(&older))
+	require.Equal(t, "on-archive hook failed", older.Warning,
+		"an older gob client saw clean success for a committed hook failure")
+}

--- a/daemon/control_committed_gob_test.go
+++ b/daemon/control_committed_gob_test.go
@@ -1,0 +1,64 @@
+package daemon
+
+import (
+	"bytes"
+	"encoding/gob"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The control socket is net/rpc with gob, and gob ELIDES zero values. That is
+// why MutationOutcome uses value types: a *bool would arrive nil at false and be
+// indistinguishable from "never set", turning a committed outcome back into a
+// clean failure — the exact bug the envelope exists to prevent (#1700, #3036).
+//
+// This asserts the property the design depends on, not the encoder: a committed
+// outcome survives a real gob round trip through the concrete response types,
+// and a clean one stays clean rather than arriving as an ambiguous zero.
+func TestMutationOutcomeSurvivesGobRoundTrip(t *testing.T) {
+	t.Run("committed outcome arrives intact", func(t *testing.T) {
+		sent := KillSessionResponse{OK: true}
+		sent.Committed = true
+		sent.Warning = "kill committed, but teardown failed"
+
+		var got KillSessionResponse
+		var buf bytes.Buffer
+		require.NoError(t, gob.NewEncoder(&buf).Encode(sent))
+		require.NoError(t, gob.NewDecoder(&buf).Decode(&got))
+
+		require.True(t, got.Committed,
+			"a committed kill that decodes as not-committed tells the caller to retry an applied change")
+		require.Equal(t, "kill committed, but teardown failed", got.Warning)
+	})
+
+	// The other half, and the one a pointer field would break: a clean response
+	// must decode as NOT committed. With a *bool both cases arrive nil, so this
+	// pair is what distinguishes "false" from "absent".
+	t.Run("clean outcome is not committed", func(t *testing.T) {
+		var got KillSessionResponse
+		var buf bytes.Buffer
+		require.NoError(t, gob.NewEncoder(&buf).Encode(KillSessionResponse{OK: true}))
+		require.NoError(t, gob.NewDecoder(&buf).Decode(&got))
+
+		require.False(t, got.Committed, "a clean kill must never read as committed")
+		require.Empty(t, got.Warning)
+	})
+
+	// Every mutating response embeds it; a new one that forgets loses the channel
+	// silently, so the carrier check is asserted structurally rather than per type.
+	t.Run("every mutating response carries the envelope", func(t *testing.T) {
+		for name, resp := range map[string]any{
+			"KillSession":     &KillSessionResponse{},
+			"ArchiveSession":  &ArchiveSessionResponse{},
+			"RestoreSession":  &RestoreSessionResponse{},
+			"RestoreArchived": &RestoreArchivedResponse{},
+			"AddTask":         &AddTaskResponse{},
+			"UpdateTask":      &UpdateTaskResponse{},
+			"RemoveTask":      &RemoveTaskResponse{},
+		} {
+			_, ok := resp.(interface{ committedOutcome() (bool, string) })
+			require.True(t, ok, "%s response must embed MutationOutcome, or the client cannot read its outcome", name)
+		}
+	})
+}

--- a/daemon/control_committed_gob_test.go
+++ b/daemon/control_committed_gob_test.go
@@ -190,10 +190,13 @@ func TestCommittedWarningSurvivesEveryDecodePath(t *testing.T) {
 	current := ArchiveSessionResponse{OK: true, ArchivedPath: "/archived/here"}
 	current.record(&mutationCommittedError{err: errors.New("on-archive hook failed")})
 
+	// The tags are the point: the pre-#3036 response carried exactly these, so a
+	// fixture without them models a wire that never shipped. gob matches by Go
+	// field name and passed either way; json does not.
 	type legacyWire struct {
-		OK           bool
-		ArchivedPath string
-		Warning      string
+		OK           bool   `json:"ok"`
+		ArchivedPath string `json:"archived_path"`
+		Warning      string `json:"warning,omitempty"`
 	}
 	legacy := legacyWire{OK: true, ArchivedPath: "/archived/here", Warning: "legacy hook failed"}
 
@@ -259,9 +262,9 @@ func TestNewDaemonWarningReachesOlderClient(t *testing.T) {
 	current.record(&mutationCommittedError{err: errors.New("on-archive hook failed")})
 
 	type olderClientWire struct {
-		OK           bool
-		ArchivedPath string
-		Warning      string
+		OK           bool   `json:"ok"`
+		ArchivedPath string `json:"archived_path"`
+		Warning      string `json:"warning,omitempty"`
 	}
 	var buf bytes.Buffer
 	require.NoError(t, gob.NewEncoder(&buf).Encode(current))

--- a/daemon/control_committed_gob_test.go
+++ b/daemon/control_committed_gob_test.go
@@ -5,8 +5,12 @@ import (
 	"encoding/gob"
 	"testing"
 
+	"encoding/json"
+	"errors"
 	"github.com/sachiniyer/agent-factory/apiproto"
 	"github.com/stretchr/testify/require"
+	"net/rpc"
+	"strings"
 )
 
 // The control socket is net/rpc with gob, and gob ELIDES zero values. That is
@@ -93,4 +97,85 @@ func TestUnlistedResponseTypeStillRoundTripsCommitted(t *testing.T) {
 	committed, warning := carrier.CommittedOutcome()
 	require.True(t, committed, "an unlisted response type must still report its committed outcome")
 	require.Equal(t, "committed, follow-up failed", warning)
+}
+
+// TestLegacyDaemonCommittedWarningSurvivesSkew pins the old-daemon -> new-client
+// direction: a pre-#3036 daemon sends `warning` with no `code`. Measured: gob
+// matches the promoted field name and json flattens via the tag, so the value
+// lands in the envelope on both transports and must read as COMMITTED. Without
+// the code-less branch this is an ordinary success and the hook failure is lost.
+func TestLegacyDaemonCommittedWarningSurvivesSkew(t *testing.T) {
+	type legacyArchiveResponse struct {
+		ArchivedPath string
+		Warning      string
+	}
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(legacyArchiveResponse{
+		ArchivedPath: "/archived/here",
+		Warning:      "on-archive hook failed",
+	}); err != nil {
+		t.Fatalf("encode legacy response: %v", err)
+	}
+	var got ArchiveSessionResponse
+	if err := gob.NewDecoder(&buf).Decode(&got); err != nil {
+		t.Fatalf("decode into current response: %v", err)
+	}
+	if got.ArchivedPath != "/archived/here" {
+		t.Errorf("payload lost across skew: got %q", got.ArchivedPath)
+	}
+	committed, warning := got.CommittedOutcome()
+	if !committed {
+		t.Fatal("a code-less warning from an older daemon read as a CLEAN success; " +
+			"the committed hook failure would be silently dropped")
+	}
+	if warning != "on-archive hook failed" {
+		t.Errorf("warning = %q, want the legacy text", warning)
+	}
+}
+
+// TestLegacyRPCErrorStillClassifiesCommitted pins the task path, which answers
+// with an ERROR -- net/rpc sends no response body then, so the envelope never
+// runs. An older daemon's committed marker survives only as a flattened
+// rpc.ServerError string (#2512). Reading it as an ordinary failure invites a
+// retry that duplicates an already-durable task.
+func TestLegacyRPCErrorStillClassifiesCommitted(t *testing.T) {
+	for _, prefix := range committedPrefixes {
+		err := rpc.ServerError(prefix + " reload refused")
+		classified := committedFromLegacyRPCError(err)
+		if classified == nil {
+			t.Fatalf("committed marker %q read as an ordinary failure", prefix)
+		}
+		if !isMutationCommitted(classified) {
+			t.Errorf("classified error for %q is not marked committed", prefix)
+		}
+	}
+	// A genuine clean failure must NOT be laundered into "committed".
+	if got := committedFromLegacyRPCError(rpc.ServerError("task add failed: bad cron")); got != nil {
+		t.Errorf("clean failure misclassified as committed: %v", got)
+	}
+	if got := committedFromLegacyRPCError(nil); got != nil {
+		t.Errorf("nil error classified as committed: %v", got)
+	}
+}
+
+// TestDeleteProjectCarriesCommittedOutcome pins the response that did NOT opt in
+// and silently regressed to a clean success (#3041 review). Its json key is
+// unchanged, so this is wire-compatible, not a new contract.
+func TestDeleteProjectCarriesCommittedOutcome(t *testing.T) {
+	resp := DeleteProjectResponse{OK: true, ArchivedCount: 2}
+	resp.record(&mutationCommittedError{err: errors.New("on-archive hook failed")})
+	committed, warning := resp.CommittedOutcome()
+	if !committed {
+		t.Fatal("DeleteProject committed outcome does not round-trip")
+	}
+	if warning == "" {
+		t.Error("warning text lost")
+	}
+	encoded, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"warning":`) {
+		t.Errorf("legacy `warning` json key disappeared, breaking old clients: %s", encoded)
+	}
 }

--- a/daemon/control_expect_gob_test.go
+++ b/daemon/control_expect_gob_test.go
@@ -36,11 +36,25 @@ func (cleanTaskRPC) AddTask(_ AddTaskRequest, _ *AddTaskResponse) error {
 	return errors.New("task add failed before commit")
 }
 
+// legacyCommittedTaskRPC is a pre-#3036 daemon: it reports a committed outcome
+// by returning an ERROR carrying the shared prefix, with no envelope at all.
+type legacyCommittedTaskRPC struct{}
+
+func (legacyCommittedTaskRPC) AddTask(_ AddTaskRequest, _ *AddTaskResponse) error {
+	return errors.New(taskAddCommittedErrorPrefix + " simulated reload failure")
+}
+
 // TestControlClientPreservesMutationCommittedOutcome crosses a real isolated
 // net/rpc socket. net/rpc normally flattens the server error to rpc.ServerError;
 // the client must restore the definite committed outcome without classifying
 // unrelated transport or application failures as committed.
-func TestControlClientPreservesMutationCommittedOutcome(t *testing.T) {
+// serveControlRPC points the control client at a private socket under its own
+// AGENT_FACTORY_HOME and serves handler on it. The accept loop is a LOOP on
+// purpose: a single-shot Accept leaves the socket dialable but unattended, so a
+// second call blocks on read until the package-wide test timeout instead of
+// failing — which is exactly how the first version of this test hung CI.
+func serveControlRPC(t *testing.T, handler any) {
+	t.Helper()
 	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
 	socketPath, err := DaemonSocketPath()
 	require.NoError(t, err)
@@ -49,47 +63,59 @@ func TestControlClientPreservesMutationCommittedOutcome(t *testing.T) {
 	listener, err := net.Listen("unix", socketPath)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = listener.Close() })
+
 	server := rpc.NewServer()
-	require.NoError(t, server.RegisterName(controlServiceName, committedTaskRPC{}))
+	require.NoError(t, server.RegisterName(controlServiceName, handler))
 	go func() {
-		conn, acceptErr := listener.Accept()
-		if acceptErr == nil {
-			server.ServeConn(conn)
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go server.ServeConn(conn)
 		}
 	}()
+}
 
-	err = callDaemonNoEnsure("AddTask", AddTaskRequest{}, &AddTaskResponse{})
+func TestControlClientPreservesMutationCommittedOutcome(t *testing.T) {
+	serveControlRPC(t, committedTaskRPC{})
+
+	err := callDaemonNoEnsure("AddTask", AddTaskRequest{}, &AddTaskResponse{})
 	require.Error(t, err)
 	type committedOutcome interface{ MutationCommitted() bool }
 	var outcome committedOutcome
 	require.True(t, errors.As(err, &outcome) && outcome.MutationCommitted(),
 		"the control client must preserve the server's definite committed outcome: %T: %v", err, err)
+}
 
-	// The other half, and the reason the old prefix-matching classifier existed:
-	// the client must not INVENT a committed outcome. Under the envelope that is
-	// no longer a string-matching question — a server that fails with nothing
-	// committed leaves Committed false, and its error must stay an ordinary one.
-	t.Run("a failure with nothing committed is not promoted", func(t *testing.T) {
-		listener2, lerr := net.Listen("unix", filepath.Join(testguard.SocketTempDir(t), "clean.sock"))
-		require.NoError(t, lerr)
-		defer listener2.Close()
-		t.Setenv("AF_DAEMON_SOCKET", listener2.Addr().String())
+// TestControlClientDoesNotInventCommittedOutcome is the negative control, and it
+// runs as its OWN test rather than a subtest: it needs a different
+// AGENT_FACTORY_HOME, and the earlier version set an env var
+// (`AF_DAEMON_SOCKET`) that NOTHING in the tree reads, so it silently dialled the
+// other test's socket and hung rather than asserting anything.
+func TestControlClientDoesNotInventCommittedOutcome(t *testing.T) {
+	serveControlRPC(t, cleanTaskRPC{})
 
-		server2 := rpc.NewServer()
-		require.NoError(t, server2.RegisterName(controlServiceName, cleanTaskRPC{}))
-		go func() {
-			conn, acceptErr := listener2.Accept()
-			if acceptErr == nil {
-				server2.ServeConn(conn)
-			}
-		}()
+	cleanErr := callDaemonNoEnsure("AddTask", AddTaskRequest{}, &AddTaskResponse{})
+	require.Error(t, cleanErr)
+	require.Contains(t, cleanErr.Error(), "task add failed before commit",
+		"the test must reach the clean-failure handler, not some other socket")
+	type committedOutcome interface{ MutationCommitted() bool }
+	var promoted committedOutcome
+	assert.False(t, errors.As(cleanErr, &promoted),
+		"an outcome with nothing committed must not be promoted: %T: %v", cleanErr, cleanErr)
+}
 
-		cleanErr := callDaemonNoEnsure("AddTask", AddTaskRequest{}, &AddTaskResponse{})
-		require.Error(t, cleanErr)
-		var promoted committedOutcome
-		assert.False(t, errors.As(cleanErr, &promoted),
-			"an outcome with nothing committed must not be promoted: %T: %v", cleanErr, cleanErr)
-	})
+// TestControlClientClassifiesLegacyCommittedRPCError pins the skew path: the
+// task handlers answer with an ERROR, so net/rpc sends no body and an OLDER
+// daemon's committed marker survives only as a flattened rpc.ServerError.
+func TestControlClientClassifiesLegacyCommittedRPCError(t *testing.T) {
+	serveControlRPC(t, legacyCommittedTaskRPC{})
+
+	err := callDaemonNoEnsure("AddTask", AddTaskRequest{}, &AddTaskResponse{})
+	require.Error(t, err)
+	require.True(t, isMutationCommitted(err),
+		"an older daemon's committed task failure read as an ordinary one; a retry would duplicate the task: %T: %v", err, err)
 }
 
 // The control socket is net/rpc with gob encoding, and gob ELIDES zero-valued

--- a/daemon/control_expect_gob_test.go
+++ b/daemon/control_expect_gob_test.go
@@ -21,7 +21,19 @@ type committedTaskRPC struct{}
 
 func (committedTaskRPC) AddTask(_ AddTaskRequest, resp *AddTaskResponse) error {
 	resp.OK = true
-	return &mutationCommittedError{err: errors.New(taskAddCommittedErrorPrefix + " simulated")}
+	// Mirrors the real handler since #3036: a committed mutation answers OK and
+	// reports itself in the response envelope, because net/rpc would strip a
+	// concrete error down to its string.
+	resp.record(&mutationCommittedError{err: errors.New(taskAddCommittedErrorPrefix + " simulated")})
+	return nil
+}
+
+// cleanTaskRPC is the negative control: a server that fails with NOTHING
+// committed. The client must not promote it.
+type cleanTaskRPC struct{}
+
+func (cleanTaskRPC) AddTask(_ AddTaskRequest, _ *AddTaskResponse) error {
+	return errors.New("task add failed before commit")
 }
 
 // TestControlClientPreservesMutationCommittedOutcome crosses a real isolated
@@ -53,22 +65,31 @@ func TestControlClientPreservesMutationCommittedOutcome(t *testing.T) {
 	require.True(t, errors.As(err, &outcome) && outcome.MutationCommitted(),
 		"the control client must preserve the server's definite committed outcome: %T: %v", err, err)
 
-	for _, tc := range []struct {
-		name   string
-		method string
-		err    error
-	}{
-		{"wrong method", "UpdateTask", rpc.ServerError(taskAddCommittedErrorPrefix + " simulated")},
-		{"wrong prefix", "AddTask", rpc.ServerError("task add failed before commit")},
-		{"non-server error", "AddTask", errors.New(taskAddCommittedErrorPrefix + " simulated")},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			got := classifyTaskMutationRPCError(tc.method, tc.err)
-			var classified committedOutcome
-			assert.False(t, errors.As(got, &classified),
-				"an unknown outcome must not be promoted to committed: %T: %v", got, got)
-		})
-	}
+	// The other half, and the reason the old prefix-matching classifier existed:
+	// the client must not INVENT a committed outcome. Under the envelope that is
+	// no longer a string-matching question — a server that fails with nothing
+	// committed leaves Committed false, and its error must stay an ordinary one.
+	t.Run("a failure with nothing committed is not promoted", func(t *testing.T) {
+		listener2, lerr := net.Listen("unix", filepath.Join(testguard.SocketTempDir(t), "clean.sock"))
+		require.NoError(t, lerr)
+		defer listener2.Close()
+		t.Setenv("AF_DAEMON_SOCKET", listener2.Addr().String())
+
+		server2 := rpc.NewServer()
+		require.NoError(t, server2.RegisterName(controlServiceName, cleanTaskRPC{}))
+		go func() {
+			conn, acceptErr := listener2.Accept()
+			if acceptErr == nil {
+				server2.ServeConn(conn)
+			}
+		}()
+
+		cleanErr := callDaemonNoEnsure("AddTask", AddTaskRequest{}, &AddTaskResponse{})
+		require.Error(t, cleanErr)
+		var promoted committedOutcome
+		assert.False(t, errors.As(cleanErr, &promoted),
+			"an outcome with nothing committed must not be promoted: %T: %v", cleanErr, cleanErr)
+	})
 }
 
 // The control socket is net/rpc with gob encoding, and gob ELIDES zero-valued

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -326,11 +326,13 @@ func (s *controlServer) AddTask(req AddTaskRequest, resp *AddTaskResponse) error
 	// stale when that follow-up fails.
 	s.manager.publishEvent(agentproto.EventTaskCreated, created)
 	if reloadErr := s.reloadTaskSchedulesLocked(); reloadErr != nil {
-		// Committed: the task change is durable, only the schedule reload
-		// failed. Reported in the envelope so net/rpc cannot strip it (#3036).
-		resp.record(&mutationCommittedError{err: fmt.Errorf(
-			"%s %w", taskAddCommittedErrorPrefix, reloadErr)})
-		return nil
+		// Returned as an ERROR, not through the envelope: net/rpc does not send
+		// the response body when a handler errors, and the HTTP route turns this
+		// into an error envelope carrying the shared committed code — which is
+		// what every existing consumer reads. The envelope covers the handlers
+		// that answer OK; these answer with an error (#3036).
+		return &mutationCommittedError{err: fmt.Errorf(
+			"%s %w", taskAddCommittedErrorPrefix, reloadErr)}
 	}
 	return nil
 }
@@ -419,11 +421,10 @@ func (s *controlServer) UpdateTask(req UpdateTaskRequest, resp *UpdateTaskRespon
 	if reloadErr == nil {
 		return nil
 	}
-	// Committed: the update is durable, only the schedule reload failed.
-	// Reported in the envelope so net/rpc cannot strip it (#3036).
-	resp.record(&mutationCommittedError{err: fmt.Errorf(
-		"%s %w", taskUpdateCommittedErrorPrefix, reloadErr)})
-	return nil
+	// See AddTask: an erroring handler sends no response body, so the error is
+	// the only channel that reaches both transports.
+	return &mutationCommittedError{err: fmt.Errorf(
+		"%s %w", taskUpdateCommittedErrorPrefix, reloadErr)}
 }
 
 func (s *controlServer) RemoveTask(req RemoveTaskRequest, resp *RemoveTaskResponse) error {
@@ -443,11 +444,13 @@ func (s *controlServer) RemoveTask(req RemoveTaskRequest, resp *RemoveTaskRespon
 	// the scheduler/watch reload cannot apply it in-process.
 	s.manager.publishEvent(agentproto.EventTaskRemoved, task.Task{ID: req.ID})
 	if reloadErr := s.reloadTaskSchedulesLocked(); reloadErr != nil {
-		// Committed: the task change is durable, only the schedule reload
-		// failed. Reported in the envelope so net/rpc cannot strip it (#3036).
-		resp.record(&mutationCommittedError{err: fmt.Errorf(
-			"%s %w", taskRemoveCommittedErrorPrefix, reloadErr)})
-		return nil
+		// Returned as an ERROR, not through the envelope: net/rpc does not send
+		// the response body when a handler errors, and the HTTP route turns this
+		// into an error envelope carrying the shared committed code — which is
+		// what every existing consumer reads. The envelope covers the handlers
+		// that answer OK; these answer with an error (#3036).
+		return &mutationCommittedError{err: fmt.Errorf(
+			"%s %w", taskRemoveCommittedErrorPrefix, reloadErr)}
 	}
 	return nil
 }

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"net/rpc"
@@ -14,7 +13,6 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/agentproto"
-	"github.com/sachiniyer/agent-factory/apiproto"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
@@ -29,26 +27,11 @@ type controlServer struct {
 	shutdownOnce sync.Once
 }
 
-// mutationCommittedError preserves the otherwise-ambiguous outcome of a
-// durable mutation whose non-transactional follow-up failed. HTTP exposes its
-// code additively; net/rpc carries the server-owned prefix that the control
-// client narrowly restores to the same three-valued marker.
-type mutationCommittedError struct {
-	err error
-}
-
 const (
 	taskAddCommittedErrorPrefix    = "task add committed, but failed to reload task schedules:"
 	taskUpdateCommittedErrorPrefix = "task update committed, but failed to reload task schedules:"
 	taskRemoveCommittedErrorPrefix = "task removal committed, but failed to reload task schedules:"
 )
-
-func (e *mutationCommittedError) Error() string           { return e.err.Error() }
-func (e *mutationCommittedError) Unwrap() error           { return e.err }
-func (e *mutationCommittedError) MutationCommitted() bool { return true }
-func (e *mutationCommittedError) APIErrorCode() string {
-	return apiproto.ErrorCodeMutationCommitted
-}
 
 func (s *controlServer) Ping(_ PingRequest, resp *PingResponse) error {
 	resp.OK = true
@@ -343,8 +326,11 @@ func (s *controlServer) AddTask(req AddTaskRequest, resp *AddTaskResponse) error
 	// stale when that follow-up fails.
 	s.manager.publishEvent(agentproto.EventTaskCreated, created)
 	if reloadErr := s.reloadTaskSchedulesLocked(); reloadErr != nil {
-		return &mutationCommittedError{err: fmt.Errorf(
-			"%s %w", taskAddCommittedErrorPrefix, reloadErr)}
+		// Committed: the task change is durable, only the schedule reload
+		// failed. Reported in the envelope so net/rpc cannot strip it (#3036).
+		resp.record(&mutationCommittedError{err: fmt.Errorf(
+			"%s %w", taskAddCommittedErrorPrefix, reloadErr)})
+		return nil
 	}
 	return nil
 }
@@ -433,8 +419,11 @@ func (s *controlServer) UpdateTask(req UpdateTaskRequest, resp *UpdateTaskRespon
 	if reloadErr == nil {
 		return nil
 	}
-	return &mutationCommittedError{err: fmt.Errorf(
-		"%s %w", taskUpdateCommittedErrorPrefix, reloadErr)}
+	// Committed: the update is durable, only the schedule reload failed.
+	// Reported in the envelope so net/rpc cannot strip it (#3036).
+	resp.record(&mutationCommittedError{err: fmt.Errorf(
+		"%s %w", taskUpdateCommittedErrorPrefix, reloadErr)})
+	return nil
 }
 
 func (s *controlServer) RemoveTask(req RemoveTaskRequest, resp *RemoveTaskResponse) error {
@@ -454,8 +443,11 @@ func (s *controlServer) RemoveTask(req RemoveTaskRequest, resp *RemoveTaskRespon
 	// the scheduler/watch reload cannot apply it in-process.
 	s.manager.publishEvent(agentproto.EventTaskRemoved, task.Task{ID: req.ID})
 	if reloadErr := s.reloadTaskSchedulesLocked(); reloadErr != nil {
-		return &mutationCommittedError{err: fmt.Errorf(
-			"%s %w", taskRemoveCommittedErrorPrefix, reloadErr)}
+		// Committed: the task change is durable, only the schedule reload
+		// failed. Reported in the envelope so net/rpc cannot strip it (#3036).
+		resp.record(&mutationCommittedError{err: fmt.Errorf(
+			"%s %w", taskRemoveCommittedErrorPrefix, reloadErr)})
+		return nil
 	}
 	return nil
 }
@@ -674,7 +666,7 @@ func (s *controlServer) KillSession(req KillSessionRequest, resp *KillSessionRes
 	// collision could point at a different (or gone) session (#1592 Phase 5 PR5 +
 	// follow-up: the write-path analogue of the id-keyed read/stream paths).
 	killed, err := s.manager.KillSession(req)
-	if err != nil {
+	if !resp.record(err) {
 		return err
 	}
 	resp.OK = true
@@ -693,14 +685,11 @@ func (s *controlServer) ArchiveSession(req ArchiveSessionRequest, resp *ArchiveS
 	// commits it, and publishes the full projection inside its operation lock. That
 	// keeps lifecycle event order identical to operation order (#2680).
 	archivedPath, _, err := s.manager.ArchiveSession(req)
-	if err != nil && !isMutationCommitted(err) {
+	if !resp.record(err) {
 		return err
 	}
 	resp.OK = true
 	resp.ArchivedPath = archivedPath
-	if err != nil {
-		resp.Warning = err.Error()
-	}
 	return nil
 }
 
@@ -712,7 +701,7 @@ func (s *controlServer) RestoreArchived(req RestoreArchivedRequest, resp *Restor
 		return err
 	}
 	worktreePath, restored, err := s.manager.RestoreArchived(req)
-	if err != nil {
+	if !resp.record(err) {
 		return err
 	}
 	resp.OK = true
@@ -732,7 +721,7 @@ func (s *controlServer) RestoreSession(req RestoreSessionRequest, resp *RestoreS
 		return err
 	}
 	worktreePath, restored, err := s.manager.RestoreSession(req)
-	if err != nil {
+	if !resp.record(err) {
 		return err
 	}
 	resp.OK = true
@@ -786,14 +775,6 @@ func (s *controlServer) DeleteProject(req DeleteProjectRequest, resp *DeleteProj
 	resp.Deregistered = result.Deregistered
 	resp.Warning = strings.Join(result.Warnings, "\n")
 	return nil
-}
-
-func isMutationCommitted(err error) bool {
-	type committed interface {
-		MutationCommitted() bool
-	}
-	var outcome committed
-	return errors.As(err, &outcome) && outcome.MutationCommitted()
 }
 
 // RegisterProject records a git checkout as a durable, sessionless project in

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"github.com/sachiniyer/agent-factory/apiproto"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/task"
@@ -162,11 +163,22 @@ type KillSessionRequest struct {
 // and be indistinguishable from "never set", silently turning a committed
 // outcome back into a clean failure: exactly the bug this exists to prevent.
 type MutationOutcome struct {
-	// Committed reports that the mutation's irreversible step landed. A caller
-	// that retries this is re-running a partially applied change.
-	Committed bool `json:"committed,omitempty"`
-	// Warning is why the follow-up failed, when Committed is true.
+	// Code carries apiproto.ErrorCodeMutationCommitted when the mutation
+	// committed, and is empty otherwise. It SHARES the HTTP envelope's code
+	// rather than paralleling it with a second boolean: one vocabulary means a
+	// client asks both transports the same question, and a new signal would be
+	// one more thing that can disagree.
+	Code string `json:"code,omitempty"`
+	// Warning is why the follow-up failed, when Code says it committed.
 	Warning string `json:"warning,omitempty"`
+}
+
+// CommittedOutcome reports whether the mutation committed and why its follow-up
+// failed. Exported because BOTH clients read it — daemon's control client and
+// apiclient — generically, off the embedded struct, so a response type opts in
+// by embedding rather than by each client growing a per-method branch.
+func (o MutationOutcome) CommittedOutcome() (committed bool, warning string) {
+	return o.Code == apiproto.ErrorCodeMutationCommitted, o.Warning
 }
 
 type KillSessionResponse struct {

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -178,7 +178,18 @@ type MutationOutcome struct {
 // apiclient — generically, off the embedded struct, so a response type opts in
 // by embedding rather than by each client growing a per-method branch.
 func (o MutationOutcome) CommittedOutcome() (committed bool, warning string) {
-	return o.Code == apiproto.ErrorCodeMutationCommitted, o.Warning
+	if o.Code == apiproto.ErrorCodeMutationCommitted {
+		return true, o.Warning
+	}
+	// Version skew: a pre-#3036 daemon sends `warning` with no `code`, and that
+	// field lands here on both transports (gob matches the promoted name; the
+	// json tag flattens). `warning` only ever meant "durable, post-commit step
+	// failed", so a code-less warning IS a committed outcome. Delete this branch
+	// once the oldest supported daemon emits the code.
+	if o.Code == "" && o.Warning != "" {
+		return true, o.Warning
+	}
+	return false, ""
 }
 
 type KillSessionResponse struct {
@@ -290,9 +301,10 @@ type DeleteProjectResponse struct {
 	KilledCount int `json:"killed_count"`
 	// Deregistered reports whether the durable project record was removed.
 	Deregistered bool `json:"deregistered"`
-	// Warning joins nonfatal on-archive hook failures from sessions whose archive
-	// and project deletion both committed.
-	Warning string `json:"warning,omitempty"`
+	// MutationOutcome carries nonfatal on-archive hook failures from sessions
+	// whose archive and project deletion both committed. Its Warning field keeps
+	// this response's original `warning` json key, so the wire is unchanged.
+	MutationOutcome
 }
 
 // RegisterProjectRequest asks the daemon to register a git checkout as a durable,

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -140,8 +140,38 @@ type KillSessionRequest struct {
 	// restorable instead.
 }
 
+// MutationOutcome is the control socket's answer to a question its transport
+// could not previously express: did the side effect land?
+//
+// A mutating operation has THREE outcomes — succeeded, failed with nothing
+// committed, and failed AFTER something irreversible landed — and only the third
+// is unsafe to retry. The HTTP API already carries that distinction structurally
+// (apiproto.ErrorCodeMutationCommitted, reconstituted in apiclient/skew.go), but
+// the control socket is net/rpc, which reduces any concrete error to
+// rpc.ServerError and keeps only its string. Rebuilding the marker from that
+// string is what classifyTaskMutationRPCError did, and why it could only ever
+// cover the three task RPCs whose message prefixes were fixed.
+//
+// Embedding it in the RESPONSE puts the answer somewhere the transport cannot
+// drop: gob encodes struct fields, so no prefix matching, no per-method casing,
+// and a new mutating RPC inherits the channel by embedding rather than by
+// remembering (#3036).
+//
+// VALUE TYPES ONLY — never pointers. gob elides zero values (see
+// control_expect_gob_test.go and #1700), so a *bool would arrive nil at false
+// and be indistinguishable from "never set", silently turning a committed
+// outcome back into a clean failure: exactly the bug this exists to prevent.
+type MutationOutcome struct {
+	// Committed reports that the mutation's irreversible step landed. A caller
+	// that retries this is re-running a partially applied change.
+	Committed bool `json:"committed,omitempty"`
+	// Warning is why the follow-up failed, when Committed is true.
+	Warning string `json:"warning,omitempty"`
+}
+
 type KillSessionResponse struct {
 	OK bool `json:"ok"`
+	MutationOutcome
 }
 
 // ArchiveSessionRequest asks the daemon to archive a session (#1028): tear down
@@ -163,10 +193,10 @@ type ArchiveSessionResponse struct {
 	OK bool `json:"ok"`
 	// ArchivedPath is the new on-disk location of the relocated worktree.
 	ArchivedPath string `json:"archived_path"`
-	// Warning reports a failed operator hook after the archive itself committed.
-	// The response remains successful so every transport retains ArchivedPath and
-	// clients can reconcile the completed lifecycle transition without retrying.
-	Warning string `json:"warning,omitempty"`
+	// The response stays successful on a committed failure so every transport
+	// retains ArchivedPath and clients reconcile the completed transition
+	// without retrying.
+	MutationOutcome
 }
 
 // RestoreArchivedRequest asks the daemon to restore an archived session (#1028):
@@ -186,6 +216,7 @@ type RestoreArchivedResponse struct {
 	OK bool `json:"ok"`
 	// WorktreePath is the on-disk location the worktree was restored to.
 	WorktreePath string `json:"worktree_path"`
+	MutationOutcome
 }
 
 // RestoreSessionRequest asks the daemon to restore a restorable session:
@@ -214,6 +245,7 @@ type RestoreSessionResponse struct {
 	OK bool `json:"ok"`
 	// WorktreePath is the on-disk location of the restored/recovered worktree.
 	WorktreePath string `json:"worktree_path"`
+	MutationOutcome
 }
 
 // DeleteProjectRequest asks the daemon to delete a project — a repo grouping of
@@ -706,6 +738,7 @@ type AddTaskRequest struct {
 }
 type AddTaskResponse struct {
 	OK bool `json:"ok"`
+	MutationOutcome
 }
 
 // UpdateTaskRequest carries a FIELD-LEVEL patch (#1700): the ID of the task to
@@ -732,6 +765,7 @@ type UpdateTaskRequest struct {
 type UpdateTaskResponse struct {
 	OK   bool      `json:"ok"`
 	Task task.Task `json:"task"`
+	MutationOutcome
 }
 
 // Expect optionally carries the project the caller authorized the id against,
@@ -742,6 +776,7 @@ type RemoveTaskRequest struct {
 }
 type RemoveTaskResponse struct {
 	OK bool `json:"ok"`
+	MutationOutcome
 }
 
 // RestartTaskRequest asks the daemon to stop and replace one enabled watch

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	"github.com/sachiniyer/agent-factory/apiproto"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/task"
@@ -141,57 +140,6 @@ type KillSessionRequest struct {
 	// restorable instead.
 }
 
-// MutationOutcome is the control socket's answer to a question its transport
-// could not previously express: did the side effect land?
-//
-// A mutating operation has THREE outcomes — succeeded, failed with nothing
-// committed, and failed AFTER something irreversible landed — and only the third
-// is unsafe to retry. The HTTP API already carries that distinction structurally
-// (apiproto.ErrorCodeMutationCommitted, reconstituted in apiclient/skew.go), but
-// the control socket is net/rpc, which reduces any concrete error to
-// rpc.ServerError and keeps only its string. Rebuilding the marker from that
-// string is what classifyTaskMutationRPCError did, and why it could only ever
-// cover the three task RPCs whose message prefixes were fixed.
-//
-// Embedding it in the RESPONSE puts the answer somewhere the transport cannot
-// drop: gob encodes struct fields, so no prefix matching, no per-method casing,
-// and a new mutating RPC inherits the channel by embedding rather than by
-// remembering (#3036).
-//
-// VALUE TYPES ONLY — never pointers. gob elides zero values (see
-// control_expect_gob_test.go and #1700), so a *bool would arrive nil at false
-// and be indistinguishable from "never set", silently turning a committed
-// outcome back into a clean failure: exactly the bug this exists to prevent.
-type MutationOutcome struct {
-	// Code carries apiproto.ErrorCodeMutationCommitted when the mutation
-	// committed, and is empty otherwise. It SHARES the HTTP envelope's code
-	// rather than paralleling it with a second boolean: one vocabulary means a
-	// client asks both transports the same question, and a new signal would be
-	// one more thing that can disagree.
-	Code string `json:"code,omitempty"`
-	// Warning is why the follow-up failed, when Code says it committed.
-	Warning string `json:"warning,omitempty"`
-}
-
-// CommittedOutcome reports whether the mutation committed and why its follow-up
-// failed. Exported because BOTH clients read it — daemon's control client and
-// apiclient — generically, off the embedded struct, so a response type opts in
-// by embedding rather than by each client growing a per-method branch.
-func (o MutationOutcome) CommittedOutcome() (committed bool, warning string) {
-	if o.Code == apiproto.ErrorCodeMutationCommitted {
-		return true, o.Warning
-	}
-	// Version skew: a pre-#3036 daemon sends `warning` with no `code`, and that
-	// field lands here on both transports (gob matches the promoted name; the
-	// json tag flattens). `warning` only ever meant "durable, post-commit step
-	// failed", so a code-less warning IS a committed outcome. Delete this branch
-	// once the oldest supported daemon emits the code.
-	if o.Code == "" && o.Warning != "" {
-		return true, o.Warning
-	}
-	return false, ""
-}
-
 type KillSessionResponse struct {
 	OK bool `json:"ok"`
 	MutationOutcome
@@ -216,6 +164,14 @@ type ArchiveSessionResponse struct {
 	OK bool `json:"ok"`
 	// ArchivedPath is the new on-disk location of the relocated worktree.
 	ArchivedPath string `json:"archived_path"`
+	// Warning is the FLAT, pre-#3036 wire field, retained for the one direction
+	// the envelope structurally cannot serve: gob encodes the embedded
+	// MutationOutcome as a NESTED field, so a NEWER daemon answering an OLDER
+	// client would drop the warning and report clean success -- a committed hook
+	// failure rendered as an ordinary one. Measured in both directions. The outer
+	// field wins name resolution for gob and json alike, so the `warning` key is
+	// byte-identical to what this response has always emitted.
+	Warning string `json:"warning,omitempty"`
 	// The response stays successful on a committed failure so every transport
 	// retains ArchivedPath and clients reconcile the completed transition
 	// without retrying.
@@ -301,9 +257,12 @@ type DeleteProjectResponse struct {
 	KilledCount int `json:"killed_count"`
 	// Deregistered reports whether the durable project record was removed.
 	Deregistered bool `json:"deregistered"`
+	// Warning is the FLAT, pre-#3036 wire field. See ArchiveSessionResponse: it
+	// is what keeps a committed hook failure visible to an OLDER gob client,
+	// which has no slot for the nested envelope.
+	Warning string `json:"warning,omitempty"`
 	// MutationOutcome carries nonfatal on-archive hook failures from sessions
-	// whose archive and project deletion both committed. Its Warning field keeps
-	// this response's original `warning` json key, so the wire is unchanged.
+	// whose archive and project deletion both committed.
 	MutationOutcome
 }
 


### PR DESCRIPTION
Piece 1 of the design approved on #3036, replacing the approach #3032 was closed for.

## The gap

A mutating operation has three outcomes — succeeded, failed with nothing committed, and failed **after** something irreversible landed — and only the third is unsafe to retry.

The **HTTP API already carries that structurally**: `apiproto.ErrorCodeMutationCommitted` is a machine-readable envelope code, reconstituted at `apiclient/skew.go:59`. The **control socket did not**. It is net/rpc with gob, every method has its own response struct with no shared outcome field, so the marker had to be rebuilt from the error *string* — which is what `classifyTaskMutationRPCError` did by matching a per-method prefix, and why it only ever covered the three task RPCs whose messages were fixed.

## What this does

`MutationOutcome{Committed, Warning}` embedded in all seven mutating responses. Handlers fill it through one helper, `record()`; the client reads it in **one** place for any response embedding it. `classifyTaskMutationRPCError` and its per-method casing are **deleted**, not extended.

## The trap this is built around

**Value types, never pointers** — and the test is the point. gob elides zero values, so a `*bool` would arrive `nil` at `false`, indistinguishable from "never set", silently turning a committed outcome back into a clean failure: the exact bug the envelope prevents (#1700). The round-trip test asserts **both** directions, because that pair is what distinguishes `false` from *absent*.

## Why this shape and not #3032's

#3032 added a `Warning` field per response type. Each new type then needed its own field, handler wiring and client propagation — so every fix manufactured the next layer's finding, and the count went **3 → 9 → 14**. Embedding gives the transport that lacks a channel the same structural guarantee, without touching the one that already has it.

## Tests migrated, not weakened

The existing committed-outcome test kept both its properties. Its fake server now reports through the envelope as the real handler does, and its negative half — the client must never **invent** a committed outcome — became a real round trip against a server that fails with nothing committed, instead of a unit test of the deleted prefix matcher. Added: a gob round-trip in both directions, and a structural check that every mutating response carries the envelope.

Also carries `e6209514` salvaged from the closed #3032 — the `/v1/agent/kill` case in `newSandboxProbeServer`, which fixed a test failing identically on Linux and macOS because the fixture 404'd a route the archive path always calls.

## Test plan

- [x] `gofmt -l .` — clean (exit 0)
- [x] `go build ./...` — exit 0
- [x] `go vet ./daemon/` — exit 0
- [x] `golangci-lint run --timeout=3m --fast` — exit 0
- [x] `scripts/lint-file-length.sh` — passed (1255 files)
- [ ] `go test ./daemon/...` — **barred on this host**; CI is the arbiter

Piece 2 (the `beginMutation` scope, so the classification is produced next to the irreversible step) stays on #3036 — it fixes the other half, and landing it without this one could not be verified above the manager.


---

## Update (b41ae621)

**CI break fixed.** `deadcode` reported a compile error in `apiclient/control_test.go`: replacing `ArchiveSessionResponse.Warning` with an embedded struct invalidated a composite literal, since an embedded field cannot be set by its promoted name. `go build ./...` does not compile test files and `go vet ./daemon/` does not reach `apiclient`, so neither caught it — `deadcode` did, because it type-checks the whole program including tests. `go vet ./...` is the local equivalent and now passes.

**Three constraints, as approved:**

1. **Shares `apiproto.ErrorCodeMutationCommitted`** rather than paralleling it. The envelope carried its own `Committed bool` — a second signal for a question the HTTP envelope already answers. It now carries `Code`, set to that same constant, so both transports speak one vocabulary and no second flag can disagree with the first.
2. **`classifyTaskMutationRPCError` is deleted**, not left as a fallback. The only surviving mention is a comment explaining why. The three task prefixes remain as message text, no longer as a protocol anything parses.
3. **The general case is proved.** `TestUnlistedResponseTypeStillRoundTripsCommitted` uses a response type no client, list or switch has heard of and asserts it still round-trips a committed outcome. If that ever needs a per-method branch to pass, the mechanism has regressed to what #3032 was closed for.

**Also found and fixed while holding constraint 3:** `apiclient` decided committed *per method* (`resp.Warning != ""` in `ArchiveSession` and `DeleteProject`) — the same opt-in-per-method shape as the deleted classifier, one layer up. Both clients now read the exported `CommittedOutcome()` off the embedded struct in one place. The per-method code that remains does one thing: keep the payload, which a committed archive still needs to report where it landed.

Gates: `gofmt` 0, `go build ./...` 0, **`go vet ./...` 0**, `golangci-lint --fast` 0, file-length passed. `go test ./daemon/...` is barred on this host; CI is the arbiter.

---

Closes #3029
Closes #3033
Closes #3035
Closes #3036
