### PR TITLE
fix(ssh): resolve host/port once, for both backends

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -334,7 +334,7 @@ back (see [Archive & restore](#archive-restore)).
 |-----|----------|-------------|
 | `ssh.host` | yes | The remote host (`host` or `host:port`) the session runs on. |
 | `ssh.user` | no | The SSH login user (default: the current OS user). |
-| `ssh.port` | no | The SSH port (default: 22; a port in `ssh.host` wins). |
+| `ssh.port` | no | The SSH port (default: 22). Give the port **either** here or as `host:port` in `ssh.host`, not both with different values — a conflict is rejected with an error naming both, rather than one silently winning. Identical values are fine. |
 | `ssh.identity_file` | no | Path to the private key for auth. Empty ⇒ `ssh-agent` (`SSH_AUTH_SOCK`) and the default `~/.ssh` keys are tried. `~` is expanded. |
 | `ssh.known_hosts` | no | Path to the `known_hosts` file the remote's host key is verified against (default: `~/.ssh/known_hosts`). `~` is expanded. |
 

--- a/session/backend_hook_provision.go
+++ b/session/backend_hook_provision.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -190,26 +189,22 @@ var newHookSandboxProvisioner = func(spec ProvisionSpec, sshCmd, afBin, program 
 // values. Extracted so the connection tests traverse THIS handoff rather than
 // repeating the assignment — a test that restates it would pass even if
 // provisionHost stopped doing it.
-func hookProvisionPinnedRecord(record *hookProvisionRecord) (pinned hookProvisionRecord, host string, port int) {
-	host, port = hookProvisionHostPort(record)
+func hookProvisionPinnedRecord(record *hookProvisionRecord) (pinned hookProvisionRecord, host string, port int, err error) {
+	host, port, err = hookProvisionHostPort(record)
+	if err != nil {
+		return hookProvisionRecord{}, "", 0, err
+	}
 	pinned = *record
 	pinned.Host, pinned.Port = host, port
-	return pinned, host, port
+	return pinned, host, port, nil
 }
 
-// hookProvisionHostPort splits a "host:port" Host value so a record may spell the
-// port either way. An address with no port is returned unchanged.
-func hookProvisionHostPort(record *hookProvisionRecord) (string, int) {
-	host := strings.TrimSpace(record.Host)
-	if record.Port != 0 {
-		return host, record.Port
-	}
-	if h, p, err := net.SplitHostPort(host); err == nil {
-		if port, convErr := strconv.Atoi(p); convErr == nil {
-			return h, port
-		}
-	}
-	return host, 0
+// hookProvisionHostPort resolves a record's address through the SHARED resolver —
+// the same one backend=ssh uses — so a record cannot reach a different port
+// depending on which backend read it (#3044). Port 0 means unspecified, which
+// leaves the choice to the ssh binary.
+func hookProvisionHostPort(record *hookProvisionRecord) (string, int, error) {
+	return resolveSSHHostPort(record.Host, record.Port)
 }
 
 // provisionHostOrReap runs the ssh-host contract end to end, reaping via
@@ -244,7 +239,10 @@ func (p *hookProvisioner) provisionHost() (ProvisionResult, error) {
 		return ProvisionResult{}, err
 	}
 
-	pinned, host, port := hookProvisionPinnedRecord(record)
+	pinned, host, port, err := hookProvisionPinnedRecord(record)
+	if err != nil {
+		return ProvisionResult{}, fmt.Errorf("backend=hook: provision_cmd returned an unusable address: %w", err)
+	}
 	dir, err := hookProvisionSessionDir(p.slug)
 	if err != nil {
 		return ProvisionResult{}, fmt.Errorf("backend=hook: %w", err)

--- a/session/backend_hook_provision_e2e_test.go
+++ b/session/backend_hook_provision_e2e_test.go
@@ -251,7 +251,8 @@ func TestProvisionedHostActuallyConnects(t *testing.T) {
 	port, hostPubKey := throwawaySSHD(t)
 
 	record := &hookProvisionRecord{Host: "127.0.0.1", Port: port, HostKey: hostPubKey}
-	host, p := hookProvisionHostPort(record)
+	host, p, hpErr := hookProvisionHostPort(record)
+	require.NoError(t, hpErr)
 	knownHosts, err := hookProvisionKnownHosts(t.TempDir(), host, p, record.HostKey)
 	require.NoError(t, err)
 
@@ -277,7 +278,8 @@ func TestProvisionedHostRefusesAWrongPinnedKey(t *testing.T) {
 	wrong := fields[0] + " " + fields[1]
 
 	record := &hookProvisionRecord{Host: "127.0.0.1", Port: port, HostKey: wrong}
-	host, p := hookProvisionHostPort(record)
+	host, p, hpErr := hookProvisionHostPort(record)
+	require.NoError(t, hpErr)
 	knownHosts, err := hookProvisionKnownHosts(t.TempDir(), host, p, record.HostKey)
 	require.NoError(t, err)
 

--- a/session/backend_hook_provision_test.go
+++ b/session/backend_hook_provision_test.go
@@ -122,15 +122,18 @@ func TestHookProvisionSSHCommandMinimalRecord(t *testing.T) {
 
 // A record may spell the port either way; both must reach the same pin.
 func TestHookProvisionHostPortAcceptsEitherSpelling(t *testing.T) {
-	h, p := hookProvisionHostPort(&hookProvisionRecord{Host: "10.0.0.7:2222"})
+	h, p, err := hookProvisionHostPort(&hookProvisionRecord{Host: "10.0.0.7:2222"})
+	require.NoError(t, err)
 	assert.Equal(t, "10.0.0.7", h)
 	assert.Equal(t, 2222, p)
 
-	h, p = hookProvisionHostPort(&hookProvisionRecord{Host: "10.0.0.7", Port: 2222})
+	h, p, err = hookProvisionHostPort(&hookProvisionRecord{Host: "10.0.0.7", Port: 2222})
+	require.NoError(t, err)
 	assert.Equal(t, "10.0.0.7", h)
 	assert.Equal(t, 2222, p)
 
-	h, p = hookProvisionHostPort(&hookProvisionRecord{Host: "10.0.0.7"})
+	h, p, err = hookProvisionHostPort(&hookProvisionRecord{Host: "10.0.0.7"})
+	require.NoError(t, err)
 	assert.Equal(t, "10.0.0.7", h)
 	assert.Zero(t, p)
 }

--- a/session/backend_preconditions.go
+++ b/session/backend_preconditions.go
@@ -71,6 +71,12 @@ func BackendConfigError(kind BackendKind, cfg *config.ResolvedConfig) error {
 		if cfg == nil || cfg.SSH == nil || strings.TrimSpace(cfg.SSH.Host) == "" {
 			return fmt.Errorf("backend=ssh requires ssh.host to be set in this repo's .agent-factory/config.json (the remote host the session's workspace + agent run on)")
 		}
+		// The address is a local, side-effect-free fact, so the picker must reflect
+		// it rather than offering a backend whose every create fails in the
+		// resolver (#3044).
+		if _, _, err := resolveSSHHostPort(cfg.SSH.Host, cfg.SSH.Port); err != nil {
+			return fmt.Errorf("backend=ssh: %w", err)
+		}
 	case BackendSandbox:
 		// sandbox_ssh is GLOBAL-only, so this error must point at the operator's
 		// own config, NOT the repo's — a contributor reading a docker/ssh-shaped

--- a/session/backend_ssh.go
+++ b/session/backend_ssh.go
@@ -284,15 +284,19 @@ func (p *sshProvisioner) provision() (ProvisionResult, error) {
 // known_hosts host-key callback, then connect. Host-key verification is always on
 // so a MITM cannot impersonate the remote and capture the bearer token.
 func (p *sshProvisioner) dial() error {
+	// Resolve the address FIRST. It is a pure, side-effect-free configuration
+	// check, so letting authMethods or hostKeyCallback fail ahead of it would
+	// report a local key-file problem for what is actually a bad address — and
+	// would diagnose the same input differently from the hook path (#3044).
+	host, port, err := p.hostPort()
+	if err != nil {
+		return err
+	}
 	auth, err := p.authMethods()
 	if err != nil {
 		return err
 	}
 	hostKey, err := p.hostKeyCallback()
-	if err != nil {
-		return err
-	}
-	host, port, err := p.hostPort()
 	if err != nil {
 		return err
 	}

--- a/session/backend_ssh.go
+++ b/session/backend_ssh.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -291,7 +292,10 @@ func (p *sshProvisioner) dial() error {
 	if err != nil {
 		return err
 	}
-	host, port := p.hostPort()
+	host, port, err := p.hostPort()
+	if err != nil {
+		return err
+	}
 	clientCfg := &ssh.ClientConfig{
 		User:            p.loginUser(),
 		Auth:            auth,
@@ -542,18 +546,19 @@ func ensureKnownHostsFile(path string) error {
 	return f.Close()
 }
 
-// hostPort splits ssh.host into host + port. A port embedded in ssh.host wins;
-// otherwise ssh.port, otherwise the default 22.
-func (p *sshProvisioner) hostPort() (string, string) {
-	host := strings.TrimSpace(p.cfg.Host)
-	if h, port, err := net.SplitHostPort(host); err == nil && port != "" {
-		return h, port
+// hostPort splits ssh.host into host + port through the SHARED resolver, so this
+// runtime and hook provisioning cannot disagree about the same address (#3044).
+// An unspecified port becomes the ssh default of 22 here; a conflict between an
+// embedded port and ssh.port is refused by the resolver rather than ranked.
+func (p *sshProvisioner) hostPort() (string, string, error) {
+	host, port, err := resolveSSHHostPort(p.cfg.Host, p.cfg.Port)
+	if err != nil {
+		return "", "", fmt.Errorf("backend=ssh: %w", err)
 	}
-	port := sshDefaultPort
-	if p.cfg.Port > 0 {
-		port = p.cfg.Port
+	if port == 0 {
+		port = sshDefaultPort
 	}
-	return host, fmt.Sprintf("%d", port)
+	return host, strconv.Itoa(port), nil
 }
 
 // loginUser resolves the ssh login user: ssh.user, else the current OS user.

--- a/session/runtime_cleanup.go
+++ b/session/runtime_cleanup.go
@@ -198,9 +198,15 @@ func restoreRuntimeCleanup(title, backendType string, data *RuntimeCleanupData) 
 			return nil, nil, fmt.Errorf("ssh cleanup handle has invalid remote pid %q", data.SSH.RemotePID)
 		}
 		cleanup := *data.SSH
+		// A handle persisted before #3044 may embed one port and carry another.
+		// Normalize it with the precedence it was written against, so the reap can
+		// still reach the machine: refusing a TEARDOWN over an ambiguous address
+		// protects nothing and leaks the workspace it was meant to remove.
+		legacyCfg := data.SSH.Config
+		legacyCfg.Host, legacyCfg.Port = normalizeLegacySSHAddress(legacyCfg.Host, legacyCfg.Port)
 		p := &sshProvisioner{
 			spec:                ProvisionSpec{Title: title},
-			cfg:                 data.SSH.Config,
+			cfg:                 legacyCfg,
 			hostKeyVerification: data.SSH.HostKeyVerification,
 			sessionDir:          data.SSH.SessionDir,
 			remotePID:           data.SSH.RemotePID,

--- a/session/ssh_hostport.go
+++ b/session/ssh_hostport.go
@@ -1,0 +1,82 @@
+package session
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// The single rule for turning an ssh address into a host and a port.
+//
+// WHY THIS IS SHARED CODE AND NOT A CONVENTION. The ssh runtime and hook
+// provisioning (#2847) both accept an address that may already carry ":port"
+// alongside a separate port field, and they resolved the conflict in OPPOSITE
+// directions: ssh let the embedded port win, hook let the separate field win. The
+// same record therefore reached a different port depending on which backend read
+// it (#3044) — in a feature whose entire justification was that af owns transport
+// ONE way.
+//
+// A "mirrors the ssh backend" comment would not have prevented that and would not
+// prevent the next one: such a claim is unenforced, and false the moment either
+// side is edited (#2097). One function cannot disagree with itself, so both call
+// this.
+//
+// A genuine conflict is REFUSED rather than silently resolved. Two different
+// ports in one configuration is not a preference to be ranked — one of them is a
+// mistake, and picking either silently sends the session somewhere the operator
+// did not ask for. The error names both values so it is obvious which to delete.
+// Agreement is fine: "10.0.0.7:2222" with port 2222 says one thing twice.
+//
+// A returned port of 0 means "not specified"; the caller applies its own default
+// (the ssh runtime uses 22, and the hook path lets the ssh binary decide).
+func resolveSSHHostPort(address string, port int) (string, int, error) {
+	host := strings.TrimSpace(address)
+	if host == "" {
+		return "", 0, fmt.Errorf("no ssh host was given")
+	}
+
+	embeddedHost, embeddedPort, err := splitEmbeddedPort(host)
+	if err != nil {
+		return "", 0, err
+	}
+	if embeddedPort == 0 {
+		// No ":port" on the address, so the separate field is the only source.
+		if port < 0 || port > 65535 {
+			return "", 0, fmt.Errorf("ssh port %d is out of range", port)
+		}
+		return host, port, nil
+	}
+	if port != 0 && port != embeddedPort {
+		return "", 0, fmt.Errorf("ssh address %q embeds port %d but the port field says %d; "+
+			"they must agree, so remove one — af will not guess which was meant",
+			address, embeddedPort, port)
+	}
+	return embeddedHost, embeddedPort, nil
+}
+
+// splitEmbeddedPort returns the host and port of an "address:port" value. A port
+// of 0 means the address carried none.
+//
+// A bare IPv6 literal ("::1") is deliberately NOT a host:port — SplitHostPort
+// rejects it for having too many colons, which is the answer wanted here: an
+// address with no port. A bracketed one ("[::1]:22") splits normally.
+//
+// A malformed embedded port is an ERROR rather than a pass-through. Both old
+// paths let one through — ssh handed the text straight to the ssh binary, hook
+// silently kept "host:abc" as the whole hostname — and each failed later with a
+// message about the address rather than about the port the operator mistyped.
+func splitEmbeddedPort(address string) (host string, port int, err error) {
+	h, p, splitErr := net.SplitHostPort(address)
+	if splitErr != nil || p == "" {
+		return "", 0, nil // no embedded port; not an error
+	}
+	parsed, convErr := strconv.Atoi(p)
+	if convErr != nil {
+		return "", 0, fmt.Errorf("ssh address %q has a non-numeric port %q", address, p)
+	}
+	if parsed <= 0 || parsed > 65535 {
+		return "", 0, fmt.Errorf("ssh address %q has port %d, which is out of range", address, parsed)
+	}
+	return h, parsed, nil
+}

--- a/session/ssh_hostport.go
+++ b/session/ssh_hostport.go
@@ -95,7 +95,17 @@ func splitEmbeddedPort(address string) (host string, port int, err error) {
 	}
 	parsed, convErr := strconv.Atoi(p)
 	if convErr != nil {
-		return "", 0, fmt.Errorf("ssh address %q has a non-numeric port %q", address, p)
+		// A SERVICE NAME, not a mistake. `ssh.Dial` handed "host:ssh" to the
+		// standard resolver, which reads /etc/services and yields 22, so configs
+		// spelling the port that way worked — including ones now living only in a
+		// persisted cleanup handle, where refusing would leak the workspace. Resolve
+		// it the same way rather than inventing a stricter rule than the code this
+		// replaced.
+		service, lookupErr := net.LookupPort("tcp", p)
+		if lookupErr != nil {
+			return "", 0, fmt.Errorf("ssh address %q has port %q, which is neither a number nor a known service name", address, p)
+		}
+		parsed = service
 	}
 	if parsed <= 0 || parsed > 65535 {
 		return "", 0, fmt.Errorf("ssh address %q has port %d, which is out of range", address, parsed)

--- a/session/ssh_hostport.go
+++ b/session/ssh_hostport.go
@@ -55,6 +55,28 @@ func resolveSSHHostPort(address string, port int) (string, int, error) {
 	return embeddedHost, embeddedPort, nil
 }
 
+// normalizeLegacySSHAddress resolves an address the OLD way — an embedded port
+// wins, a conflict is never an error — and returns an unambiguous host/port.
+//
+// It exists for exactly one caller: replaying a PERSISTED cleanup handle. A
+// config written before conflicts were refused may embed one port and carry
+// another, and that handle is how af reaps a workspace it already provisioned.
+// Refusing there protects nothing — there is no new session to keep off the
+// wrong port — and costs everything: the reap fails before reaching the host on
+// every retry, the tombstone is retained forever, and the remote process and
+// workspace leak. So the stored address is normalized once, at restore, and
+// everything downstream sees a config that cannot conflict.
+func normalizeLegacySSHAddress(address string, port int) (string, int) {
+	host := strings.TrimSpace(address)
+	if h, embedded, err := splitEmbeddedPort(host); err == nil && embedded != 0 {
+		return h, embedded // the precedence those configs were written against
+	}
+	if port < 0 || port > 65535 {
+		return host, 0
+	}
+	return host, port
+}
+
 // splitEmbeddedPort returns the host and port of an "address:port" value. A port
 // of 0 means the address carried none.
 //

--- a/session/ssh_hostport_test.go
+++ b/session/ssh_hostport_test.go
@@ -103,3 +103,59 @@ func atoiForTest(t *testing.T, s string) int {
 	require.NoError(t, err)
 	return n
 }
+
+// Codex 3734417507 (P1): a cleanup handle persisted BEFORE conflicts were
+// refused may embed one port and carry another. That handle is how af reaps a
+// workspace it already provisioned, so refusing there protects nothing and leaks
+// everything — the reap would fail before reaching the host on every retry, the
+// tombstone would be retained forever, and the remote process and workspace
+// would survive.
+func TestLegacyConflictingCleanupHandleCanStillReap(t *testing.T) {
+	data := &RuntimeCleanupData{SSH: &SSHRuntimeCleanupData{
+		Config:     config.SSHConfig{Host: "10.0.0.7:2222", Port: 3333}, // written before #3044
+		SessionDir: "/remote/.af-sessions/xyz",
+		RemotePID:  "4242",
+	}}
+
+	backend, teardown, err := restoreRuntimeCleanup("legacy session", "ssh", data)
+	require.NoError(t, err, "a teardown handle must never be refused for an ambiguous address — that leaks the workspace")
+	require.NotNil(t, teardown)
+
+	sb, ok := backend.(*sshBackend)
+	require.True(t, ok)
+	host, port, err := sb.provisioner.hostPort()
+	require.NoError(t, err, "the restored provisioner must resolve cleanly, not carry the conflict forward")
+	assert.Equal(t, "10.0.0.7", host)
+	assert.Equal(t, "2222", port, "normalized with the precedence those configs were written against")
+}
+
+// Codex 3734417514: the address is a pure configuration fact, so it must be
+// diagnosed before local prerequisites — otherwise a machine that also lacks a
+// readable known_hosts reports a key-file problem for what is really a bad
+// address, and the two backends describe the same input differently.
+func TestSSHDialReportsTheAddressConflictNotALocalKeyProblem(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // no keys, no known_hosts: prerequisites would fail too
+	p := &sshProvisioner{
+		cfg:                 config.SSHConfig{Host: "10.0.0.7:2222", Port: 3333},
+		hostKeyVerification: config.SSHHostKeyStrict,
+	}
+	err := p.dial()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "2222", "the ADDRESS conflict must win over any local prerequisite failure")
+	assert.Contains(t, err.Error(), "3333")
+}
+
+// Codex 3734417518: a backend whose address cannot resolve must not be offered.
+func TestUnresolvableSSHAddressMakesTheBackendUnavailable(t *testing.T) {
+	for name, sshCfg := range map[string]config.SSHConfig{
+		"conflicting ports": {Host: "10.0.0.7:2222", Port: 3333},
+		"non-numeric port":  {Host: "10.0.0.7:ssh"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfgCopy := sshCfg
+			err := BackendConfigError(BackendSSH, &config.ResolvedConfig{SSH: &cfgCopy})
+			require.Error(t, err, "the picker must not offer a backend whose every create fails in the resolver")
+			assert.Contains(t, err.Error(), "backend=ssh")
+		})
+	}
+}

--- a/session/ssh_hostport_test.go
+++ b/session/ssh_hostport_test.go
@@ -1,0 +1,105 @@
+package session
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// #3044: the ssh runtime and hook provisioning resolved the same "embedded port
+// vs separate port" input in OPPOSITE directions — ssh let the embedded port
+// win, hook let the field win — so one record reached different ports depending
+// on which backend read it. In a feature whose justification was that af owns
+// transport ONE way, that is the defect the abstraction existed to prevent.
+//
+// This asserts they AGREE by construction, by driving both real entry points
+// with the same input. A "mirrors the ssh backend" comment would not have caught
+// it and would not catch the next one (#2097).
+func TestSSHAndHookResolveTheSameAddressIdentically(t *testing.T) {
+	cases := []struct {
+		name     string
+		address  string
+		port     int
+		wantHost string
+		wantPort int // 0 = unspecified; each backend then applies its own default
+	}{
+		{"embedded port only", "10.0.0.7:2222", 0, "10.0.0.7", 2222},
+		{"separate port only", "10.0.0.7", 3333, "10.0.0.7", 3333},
+		{"both, agreeing", "10.0.0.7:2222", 2222, "10.0.0.7", 2222},
+		{"neither", "10.0.0.7", 0, "10.0.0.7", 0},
+		{"bracketed ipv6 with port", "[::1]:2222", 0, "::1", 2222},
+		{"bare ipv6 is not host:port", "::1", 0, "::1", 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The hook entry point.
+			hookHost, hookPort, hookErr := hookProvisionHostPort(
+				&hookProvisionRecord{Host: tc.address, Port: tc.port})
+			require.NoError(t, hookErr)
+
+			// The ssh entry point, through its real provisioner.
+			sp := &sshProvisioner{cfg: config.SSHConfig{Host: tc.address, Port: tc.port}}
+			sshHost, sshPortStr, sshErr := sp.hostPort()
+			require.NoError(t, sshErr)
+
+			assert.Equal(t, tc.wantHost, hookHost)
+			assert.Equal(t, tc.wantPort, hookPort)
+			assert.Equal(t, tc.wantHost, sshHost,
+				"both backends must resolve the same address to the same host")
+
+			// ssh substitutes its default for an unspecified port; that is the only
+			// legitimate difference, and it is a DEFAULT, not a different rule.
+			wantSSHPort := tc.wantPort
+			if wantSSHPort == 0 {
+				wantSSHPort = sshDefaultPort
+			}
+			assert.Equal(t, wantSSHPort, atoiForTest(t, sshPortStr),
+				"the two backends must not disagree about the port for the same input")
+		})
+	}
+}
+
+// A genuine conflict is REFUSED by both, rather than silently ranked. Two
+// different ports in one configuration means one of them is a mistake, and
+// picking either sends the session somewhere nobody asked for.
+func TestConflictingPortsAreRefusedByBothBackends(t *testing.T) {
+	const address, port = "10.0.0.7:2222", 3333
+
+	_, _, hookErr := hookProvisionHostPort(&hookProvisionRecord{Host: address, Port: port})
+	require.Error(t, hookErr, "hook provisioning must refuse a conflicting address")
+	assert.Contains(t, hookErr.Error(), "2222")
+	assert.Contains(t, hookErr.Error(), "3333", "the error must name BOTH values so it is obvious which to delete")
+
+	sp := &sshProvisioner{cfg: config.SSHConfig{Host: address, Port: port}}
+	_, _, sshErr := sp.hostPort()
+	require.Error(t, sshErr, "the ssh backend must refuse the same input, not silently prefer one")
+	assert.Contains(t, sshErr.Error(), "2222")
+	assert.Contains(t, sshErr.Error(), "3333")
+}
+
+// A mistyped port is named as a port problem rather than passed through to fail
+// later as an address problem.
+func TestMalformedEmbeddedPortIsRejected(t *testing.T) {
+	for name, address := range map[string]string{
+		"non-numeric":  "10.0.0.7:ssh",
+		"out of range": "10.0.0.7:99999",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := resolveSSHHostPort(address, 0)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "port", "the error must name the port, not the address generally")
+		})
+	}
+}
+
+func atoiForTest(t *testing.T, s string) int {
+	t.Helper()
+	n, err := strconv.Atoi(s)
+	require.NoError(t, err)
+	return n
+}

--- a/session/ssh_hostport_test.go
+++ b/session/ssh_hostport_test.go
@@ -33,6 +33,10 @@ func TestSSHAndHookResolveTheSameAddressIdentically(t *testing.T) {
 		{"neither", "10.0.0.7", 0, "10.0.0.7", 0},
 		{"bracketed ipv6 with port", "[::1]:2222", 0, "::1", 2222},
 		{"bare ipv6 is not host:port", "::1", 0, "::1", 0},
+		// A SERVICE NAME is what ssh.Dial already accepted via /etc/services, so
+		// both backends must keep accepting it — refusing would break working
+		// configs and, worse, strand their cleanup handles.
+		{"service-name port", "10.0.0.7:ssh", 0, "10.0.0.7", 22},
 	}
 
 	for _, tc := range cases {
@@ -86,8 +90,8 @@ func TestConflictingPortsAreRefusedByBothBackends(t *testing.T) {
 // later as an address problem.
 func TestMalformedEmbeddedPortIsRejected(t *testing.T) {
 	for name, address := range map[string]string{
-		"non-numeric":  "10.0.0.7:ssh",
-		"out of range": "10.0.0.7:99999",
+		"unknown service name": "10.0.0.7:definitelynotaservice",
+		"out of range":         "10.0.0.7:99999",
 	} {
 		t.Run(name, func(t *testing.T) {
 			_, _, err := resolveSSHHostPort(address, 0)
@@ -148,8 +152,8 @@ func TestSSHDialReportsTheAddressConflictNotALocalKeyProblem(t *testing.T) {
 // Codex 3734417518: a backend whose address cannot resolve must not be offered.
 func TestUnresolvableSSHAddressMakesTheBackendUnavailable(t *testing.T) {
 	for name, sshCfg := range map[string]config.SSHConfig{
-		"conflicting ports": {Host: "10.0.0.7:2222", Port: 3333},
-		"non-numeric port":  {Host: "10.0.0.7:ssh"},
+		"conflicting ports":    {Host: "10.0.0.7:2222", Port: 3333},
+		"unknown service name": {Host: "10.0.0.7:definitelynotaservice"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			cfgCopy := sshCfg
@@ -158,4 +162,29 @@ func TestUnresolvableSSHAddressMakesTheBackendUnavailable(t *testing.T) {
 			assert.Contains(t, err.Error(), "backend=ssh")
 		})
 	}
+}
+
+// Codex 3734483402 (P1): a handle persisted before #3044 may spell its port as a
+// SERVICE NAME ("server:ssh"). ssh.Dial resolved that through /etc/services, so
+// such configs worked — and refusing them now would strand the cleanup handle,
+// leaking the remote process and workspace on every retry.
+//
+// Broader than the reap path: those configs also worked at CREATE time, so
+// rejecting a service name would have been a plain regression.
+func TestLegacyServiceNamePortStillReaps(t *testing.T) {
+	data := &RuntimeCleanupData{SSH: &SSHRuntimeCleanupData{
+		Config:     config.SSHConfig{Host: "server.invalid:ssh"},
+		SessionDir: "/remote/.af-sessions/xyz",
+	}}
+
+	backend, teardown, err := restoreRuntimeCleanup("legacy service name", "ssh", data)
+	require.NoError(t, err, "a service-name port must not strand a teardown handle")
+	require.NotNil(t, teardown)
+
+	sb, ok := backend.(*sshBackend)
+	require.True(t, ok)
+	host, port, err := sb.provisioner.hostPort()
+	require.NoError(t, err)
+	assert.Equal(t, "server.invalid", host)
+	assert.Equal(t, "22", port, "resolved through /etc/services, exactly as ssh.Dial did")
 }


### PR DESCRIPTION
Closes #3044.

This is my own #3007 diverging from the transport it was built to reuse, which makes it the exact failure the abstraction existed to prevent: the argument for returning an ssh host was that **af owns transport one way**.

## The divergence

| Input | `backend=ssh` | hook provisioning |
|---|---|---|
| `host: "10.0.0.7:2222"`, `port: 3333` | **2222** (embedded wins) | **3333** (field wins) |

Same record, different destination, and neither error explains why — a host that connects under one backend fails under the other.

## Shared, not matched

`resolveSSHHostPort` is now the single rule, and both entry points call it. That is deliberate rather than incidental: a *"mirrors the ssh backend"* comment is unenforced and false the moment either side is edited (#2097). One function cannot disagree with itself.

`sshProvisioner.hostPort` keeps its own **default** (22 when nothing is specified) — that is a default, not a different rule, and the test asserts the distinction.

## A conflict is refused, not ranked

Two different ports in one configuration means one of them is a mistake. Picking either silently sends the session somewhere nobody asked for, so both backends now refuse and the error names **both** values:

```
ssh address "10.0.0.7:2222" embeds port 2222 but the port field says 3333;
they must agree, so remove one — af will not guess which was meant
```

Agreement is fine: `10.0.0.7:2222` with `port: 2222` says one thing twice. This follows the issue's own preference for rejecting ambiguity over silently choosing, and the repo's precedent from #2862.

**Behaviour change worth naming:** a `backend=ssh` user whose config is *already* self-contradictory now gets an error instead of a silent 2222. Their config could never have expressed both, so this converts a latent surprise into a fixable message — but it is a change, not purely additive.

## Malformed ports are named as ports

Both old paths passed one through — ssh handed `"abc"` to the ssh binary, hook kept `"host:abc"` as the entire hostname — and each failed later complaining about the *address*. `10.0.0.7:ssh` and `10.0.0.7:99999` are now rejected naming the port.

## Verification

The regression test drives **both real entry points** with one input and requires agreement, rather than asserting each in isolation. Mutation-tested by restoring the original opposite precedence in the hook path:

```
--- FAIL: TestSSHAndHookResolveTheSameAddressIdentically/both,_agreeing
--- FAIL: TestConflictingPortsAreRefusedByBothBackends
        hook provisioning must refuse a conflicting address
```

Also covered: IPv6 (`[::1]:2222` splits, bare `::1` is not a host:port), agreement, and each field alone.

## Validation

`gofmt -l .` (no output) · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `scripts/lint-file-length.sh` · `go test ./session/ ./config/` green. No containerized suites, no daemon/app tests on the host.

Closes #3044