### PR TITLE
ci: report dead code instead of blocking on it (#3014)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,16 +41,39 @@ jobs:
             exit 1
           fi
 
-      - name: Check for dead code
+      # REPORTS, does not block (#3014). The gate was right about the code and wrong
+      # about the workflow: requiring every merged symbol to be reachable means a
+      # feature cannot land its mechanism first and its call site second. That
+      # inverts the review order you want for exactly the code where you want it
+      # most — a security-sensitive core has to be reviewed small, then wired up,
+      # and this forced mechanism and call site into one larger diff. It also
+      # pushed toward shipping a token caller purely to satisfy a linter.
+      #
+      # So the finding survives and the veto does not: every unreachable symbol is
+      # still named, as an annotation and in the job summary. Unreachable code is
+      # still usually a defect — read this output before assuming it is a staged
+      # foundation. What it must never become is an allowlist of permanent
+      # exceptions, which is why nothing here suppresses individual symbols.
+      - name: Report dead code
         run: |
           # Pinned for reproducibility; v0.48.0 supports the Go 1.25 language version
           # (older x/tools cannot analyze go1.25 source).
           go install golang.org/x/tools/cmd/deadcode@v0.48.0
           out=$("$(go env GOPATH)/bin/deadcode" -test ./...)
           if [ -n "$out" ]; then
-            echo "::error::Dead code detected. Remove the following or refactor so it's reachable:"
+            echo "::warning::Dead code detected (reported, not blocking — see #3014):"
             echo "$out"
-            exit 1
+            {
+              echo "### Dead code — reported, not blocking"
+              echo
+              echo "These symbols are unreachable. That is usually a defect worth fixing; it is"
+              echo "not a merge blocker, because a feature may legitimately land its mechanism"
+              echo "before its call site (#3014). Read the list before assuming it is staged."
+              echo
+              echo '```'
+              echo "$out"
+              echo '```'
+            } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
           fi
 
       - name: Check file lengths

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,7 +61,17 @@ jobs:
           go install golang.org/x/tools/cmd/deadcode@v0.48.0
           out=$("$(go env GOPATH)/bin/deadcode" -test ./...)
           if [ -n "$out" ]; then
-            echo "::warning::Dead code detected (reported, not blocking — see #3014):"
+            # A workflow command is ONE line: a bare `echo "$out"` after it is an
+            # ordinary log record, not part of the annotation, so the annotation
+            # would read "Dead code detected" and name nothing. Newlines must be
+            # %0A-escaped into the command itself. Escape % FIRST or the escapes
+            # inserted below get double-escaped.
+            encoded=$(printf '%s' "$out" \
+              | sed -e 's/%/%25/g' -e 's/\r/%0D/g' \
+              | awk 'BEGIN{ORS=""} {print (NR>1 ? "%0A" : "") $0}')
+            echo "::warning::Dead code detected (reported, not blocking — see #3014):%0A${encoded}"
+            # Kept as plain log output too: the annotation is for the reviewer, this
+            # is what stays greppable in the raw log.
             echo "$out"
             {
               echo "### Dead code — reported, not blocking"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -76,7 +76,17 @@ jobs:
           go install golang.org/x/tools/cmd/deadcode@v0.48.0
           out=$("$(go env GOPATH)/bin/deadcode" -test ./...)
           if [ -n "$out" ]; then
-            echo "::warning::Dead code detected (reported, not blocking — see #3014):"
+            # A workflow command is ONE line: a bare `echo "$out"` after it is an
+            # ordinary log record, not part of the annotation, so the annotation
+            # would read "Dead code detected" and name nothing. Newlines must be
+            # %0A-escaped into the command itself. Escape % FIRST or the escapes
+            # inserted below get double-escaped.
+            encoded=$(printf '%s' "$out" \
+              | sed -e 's/%/%25/g' -e 's/\r/%0D/g' \
+              | awk 'BEGIN{ORS=""} {print (NR>1 ? "%0A" : "") $0}')
+            echo "::warning::Dead code detected (reported, not blocking — see #3014):%0A${encoded}"
+            # Kept as plain log output too: the annotation is for the reviewer, this
+            # is what stays greppable in the raw log.
             echo "$out"
             {
               echo "### Dead code — reported, not blocking"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -56,16 +56,39 @@ jobs:
             exit 1
           fi
 
-      - name: Check for dead code
+      # REPORTS, does not block (#3014). The gate was right about the code and wrong
+      # about the workflow: requiring every merged symbol to be reachable means a
+      # feature cannot land its mechanism first and its call site second. That
+      # inverts the review order you want for exactly the code where you want it
+      # most — a security-sensitive core has to be reviewed small, then wired up,
+      # and this forced mechanism and call site into one larger diff. It also
+      # pushed toward shipping a token caller purely to satisfy a linter.
+      #
+      # So the finding survives and the veto does not: every unreachable symbol is
+      # still named, as an annotation and in the job summary. Unreachable code is
+      # still usually a defect — read this output before assuming it is a staged
+      # foundation. What it must never become is an allowlist of permanent
+      # exceptions, which is why nothing here suppresses individual symbols.
+      - name: Report dead code
         run: |
           # Pinned for reproducibility; v0.48.0 supports the Go 1.25 language version
           # (older x/tools cannot analyze go1.25 source).
           go install golang.org/x/tools/cmd/deadcode@v0.48.0
           out=$("$(go env GOPATH)/bin/deadcode" -test ./...)
           if [ -n "$out" ]; then
-            echo "::error::Dead code detected. Remove the following or refactor so it's reachable:"
+            echo "::warning::Dead code detected (reported, not blocking — see #3014):"
             echo "$out"
-            exit 1
+            {
+              echo "### Dead code — reported, not blocking"
+              echo
+              echo "These symbols are unreachable. That is usually a defect worth fixing; it is"
+              echo "not a merge blocker, because a feature may legitimately land its mechanism"
+              echo "before its call site (#3014). Read the list before assuming it is staged."
+              echo
+              echo '```'
+              echo "$out"
+              echo '```'
+            } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
           fi
 
       - name: Check file lengths

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,12 +64,16 @@ Working style:
   `scripts/lint-file-length.sh` — plus `go test` on **only the non-daemon,
   non-app package you changed**. Then push and let CI run the rest, and fix what
   CI reports on your PR head.
-- **`deadcode` is not a local check.** It is whole-program reachability
-  analysis, not a lint: it builds and walks the entire call graph, and ~15
-  sessions running it at once was the largest CPU consumer on this box — ~375%
-  of a core each, load 36 on 16 cores. The Lint job runs it on every push, on a
-  runner, once per PR instead of once per session. Run it locally only to
-  reproduce a CI `deadcode` failure you cannot read from the log.
+- **`deadcode` is not a local check, and no longer blocks.** It is whole-program
+  reachability analysis, not a lint: it builds and walks the entire call graph,
+  and ~15 sessions running it at once was the largest CPU consumer on this box —
+  ~375% of a core each, load 36 on 16 cores. CI runs it on every push, on a
+  runner, once per PR instead of once per session, and **reports** rather than
+  fails (#3014): it named every unreachable symbol *and* made a foundation-only
+  slice unmergeable, so a feature could not land its mechanism first and its call
+  site second — inverting the review order you want for security-sensitive code.
+  Read its annotation and job-summary section anyway. Unreachable code is usually
+  a defect; "it is a staged foundation" is a claim to check, not a default.
 - **Do not run containerized suites as a routine pre-PR gate.** Not
   `make test-container`, not `make remote-roundtrip-container`, not
   `make playtest-container`. Each spins a container that rebuilds the whole Go
@@ -135,12 +139,13 @@ gofmt -l .   # should produce no output
 scripts/lint-file-length.sh   # or: make lint-file-length
 
 # NOT a routine local check — whole-program analysis, and the fleet running it
-# concurrently buries the box. CI's Lint job runs it on every push. Reach for it
-# only to reproduce a CI deadcode failure.
-deadcode -test ./...   # should produce no output
+# concurrently buries the box. CI runs it on every push and REPORTS rather than
+# fails (#3014), so it will not block a merge. Reach for it locally only to
+# investigate what CI reported.
+deadcode -test ./...   # empty output = nothing unreachable
 ```
 
-Install the `deadcode` binary once with `go install golang.org/x/tools/cmd/deadcode@v0.48.0`; CI pins the same version. This project's Go floor is 1.25 (raised from 1.24 in #1592 Phase 4 PR5 to pull in the CVE-patched `golang.org/x/crypto` ≥ v0.52.0, which requires Go 1.25); deadcode must be ≥ v0.45.0 to analyze go1.25 source (older x/tools cannot).
+Install the `deadcode` binary once with `go install golang.org/x/tools/cmd/deadcode@v0.48.0`; CI pins the same version. Its findings are advisory (#3014) — an unreachable symbol is worth fixing or explaining in the PR, but it does not hold the merge, and it must never be silenced with a per-symbol allowlist. This project's Go floor is 1.25 (raised from 1.24 in #1592 Phase 4 PR5 to pull in the CVE-patched `golang.org/x/crypto` ≥ v0.52.0, which requires Go 1.25); deadcode must be ≥ v0.45.0 to analyze go1.25 source (older x/tools cannot).
 
 **File-length lint (#1145):** `scripts/lint-file-length.sh` fails if any Go
 file exceeds its line limit — 1000 lines for production code, 1500 for


### PR DESCRIPTION
Closes #3014

The deadcode gate was right about the code and wrong about the workflow, so this keeps the finding and drops the veto.

## What changes

Both workflows still install the same pinned `deadcode`, still run `-test ./...` on every push, and still name every unreachable symbol. It now lands as a **warning annotation plus a job-summary section** instead of `::error::` + `exit 1`.

## Why

Requiring every merged symbol to be reachable means a feature cannot land its **mechanism first and its call site second**. That inverts the review order you want for exactly the code where you want it most: a security-sensitive core should be reviewed small and then wired up, and this forced mechanism and call site into one larger diff. It also pushed toward the worse workaround — shipping a token caller purely to satisfy a linter.

## What this deliberately is not

**Not a per-symbol allowlist.** #3014 is explicit that unreachable auth code is precisely the kind that rots without anyone noticing, and an allowlist makes exceptions permanent and invisible. A visible advisory finding somebody has to read and justify in review is the weaker veto but the stronger signal. Nothing here can suppress an individual symbol.

## One correction to the issue's premise, from master rather than from its thread

#3014 cites three blocked PRs. Checking them:

- **#3011 has since merged** — it grew its reader, so it stopped being foundation-only.
- **#3012 is closed** — and not by this gate. Nine review rounds established that its route scope must be empty, which is a design result, not a lint problem.
- **#2476's banked WIP** remains.

So the gate's live cost is lower than the issue claims. It is still worth removing as a blocker, for the reason in its own "Why it matters" section rather than for the body count.

## Docs

`CLAUDE.md` said `deadcode -test ./...` "should produce no output" and described a check that must pass before a PR. It now says CI reports rather than fails, that a merge is not held, and — the part worth keeping sharp — that the output is still *usually a defect*: "it is a staged foundation" is a claim to check, not a default.

## Verification

Both workflows re-parse as valid YAML with the step present (`Report dead code`), and the `exit 1` is gone from that step in both. The deadcode step in this PR's own Lint run exercises the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
