### PR TITLE
feat(accounts): registry plus `af accounts add/list` for per-session credential scoping

### DIFF
--- a/commands/accountscmd.go
+++ b/commands/accountscmd.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -73,10 +74,20 @@ the printed directory to put credentials there.
 
 Registration is idempotent — running it again on an existing account reports the
 same directory and touches nothing inside it.`,
-	Args: cobra.ExactArgs(2),
+	// ArbitraryArgs, with the count checked inside RunE. cobra runs an Args
+	// validator BEFORE RunE, so ExactArgs(2) emitted human `Error:` and usage text
+	// even under --json — leaving an automation caller unable to parse the one
+	// class of failure it is most likely to hit, a malformed invocation (#3057
+	// review).
+	Args: cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)
 		defer log.Close()
+
+		if len(args) != 2 {
+			return jsonWrapError(cmd, accountsJSONFlag,
+				fmt.Errorf("af accounts add takes exactly two arguments, an agent and an account name (got %d): af accounts add <agent> <name>", len(args)))
+		}
 
 		// --daemon-url / AF_DAEMON_URL promises to target a REMOTE daemon, and this
 		// command writes to the LOCAL AF home. Honouring the flag by ignoring it
@@ -117,9 +128,19 @@ same directory and touches nothing inside it.`,
 		// something else and logs in somewhere other than the registered directory.
 		// The stdout copy above stays bare on purpose — it is consumed by command
 		// substitution, which needs the raw value (#3057 review).
-		fmt.Fprintf(cmd.ErrOrStderr(),
-			"Registered account %q for %s.\nLog in with that account before using it:\n  %s=%s %s login\n",
-			name, agent, configVar, config.ShellQuotePath(dir), agent)
+		fmt.Fprintf(cmd.ErrOrStderr(), "Registered account %q for %s.\n", name, agent)
+		// Per agent, never a universal "login": Claude Code puts it under `auth`,
+		// so the generic template printed `claude login`, which is not a command.
+		// An agent with no known invocation gets no printed command rather than a
+		// guessed one — a next step that does not run reads as a broken account
+		// (#3057 review).
+		if words, ok := agentaccount.LoginCommand(agent); ok {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Log in with that account before using it:\n  %s=%s %s %s\n",
+				configVar, config.ShellQuotePath(dir), agent, strings.Join(words, " "))
+		} else {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Log in with %s's own login flow, with %s set to %s.\n",
+				agent, configVar, config.ShellQuotePath(dir))
+		}
 		return nil
 	},
 }
@@ -133,10 +154,16 @@ supports account scoping.
 An agent absent from this list is one whose credential relocation af has not
 verified, not one that is merely unconfigured — af reports unsupported rather
 than accepting a selection that would silently do nothing.`,
-	Args: cobra.MaximumNArgs(1),
+	// ArbitraryArgs for the same reason as `add` — see the note there.
+	Args: cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)
 		defer log.Close()
+
+		if len(args) > 1 {
+			return jsonWrapError(cmd, accountsJSONFlag,
+				fmt.Errorf("af accounts list takes at most one argument, an agent name (got %d): af accounts list [agent]", len(args)))
+		}
 
 		// --daemon-url / AF_DAEMON_URL promises to target a REMOTE daemon, and this
 		// command reads the LOCAL AF home. Ignoring the flag would report this

--- a/commands/accountscmd.go
+++ b/commands/accountscmd.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/sachiniyer/agent-factory/apiclient"
 	"github.com/sachiniyer/agent-factory/apiproto"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/agentaccount"
@@ -77,6 +78,20 @@ same directory and touches nothing inside it.`,
 		log.Initialize(false)
 		defer log.Close()
 
+		// --daemon-url / AF_DAEMON_URL promises to target a REMOTE daemon, and this
+		// command writes to the LOCAL AF home. Honouring the flag by ignoring it
+		// hands the operator a valid-looking directory on the wrong machine — and
+		// then invites them to log real credentials into it, for an account the
+		// targeted daemon can never see. A credential in the wrong place is a worse
+		// outcome than a refusal, so refuse. Same seam and same reasoning as
+		// `af quota` (#3057 review).
+		if apiclient.IsRemoteTarget() {
+			return jsonWrapError(cmd, accountsJSONFlag, fmt.Errorf(
+				"af accounts manages credential directories in this machine's agent-factory home and cannot "+
+					"manage them on a remote daemon; unset --daemon-url/AF_DAEMON_URL to act on this host, "+
+					"or run af accounts on the daemon's host"))
+		}
+
 		agent, name := args[0], args[1]
 		home, err := config.GetConfigDir()
 		if err != nil {
@@ -122,6 +137,18 @@ than accepting a selection that would silently do nothing.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)
 		defer log.Close()
+
+		// --daemon-url / AF_DAEMON_URL promises to target a REMOTE daemon, and this
+		// command reads the LOCAL AF home. Ignoring the flag would report this
+		// machine's accounts as though they were the remote daemon's, which is how
+		// an operator concludes an account exists there and starts a session
+		// against it. Same seam and same reasoning as `af quota` (#3057 review).
+		if apiclient.IsRemoteTarget() {
+			return jsonWrapError(cmd, accountsJSONFlag, fmt.Errorf(
+				"af accounts manages credential directories in this machine's agent-factory home and cannot "+
+					"manage them on a remote daemon; unset --daemon-url/AF_DAEMON_URL to act on this host, "+
+					"or run af accounts on the daemon's host"))
+		}
 
 		home, err := config.GetConfigDir()
 		if err != nil {

--- a/commands/accountscmd.go
+++ b/commands/accountscmd.go
@@ -96,9 +96,15 @@ same directory and touches nothing inside it.`,
 		// stderr so it survives being captured.
 		fmt.Fprintln(cmd.OutOrStdout(), dir)
 		configVar, _ := sessionenv.SupportsAccounts(agent)
+		// The guidance line is PASTEABLE, so the path in it must be shell-quoted:
+		// an AGENT_FACTORY_HOME containing a space or a shell metacharacter would
+		// otherwise produce a command that fails, or worse, one that parses into
+		// something else and logs in somewhere other than the registered directory.
+		// The stdout copy above stays bare on purpose — it is consumed by command
+		// substitution, which needs the raw value (#3057 review).
 		fmt.Fprintf(cmd.ErrOrStderr(),
 			"Registered account %q for %s.\nLog in with that account before using it:\n  %s=%s %s login\n",
-			name, agent, configVar, dir, agent)
+			name, agent, configVar, config.ShellQuotePath(dir), agent)
 		return nil
 	},
 }

--- a/commands/accountscmd.go
+++ b/commands/accountscmd.go
@@ -2,9 +2,7 @@ package commands
 
 import (
 	"fmt"
-	"os"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -41,50 +39,6 @@ type accountEntry struct {
 	Dir   string `json:"dir"`
 }
 
-// accountsJSONRequested reads the JSON intent from the RAW arguments, because a
-// flag-parse failure means the bound variable was never set.
-//
-// cobra parses flags before RunE, so `af accounts add --json --bogus` fails
-// while accountsJSONFlag is still false — the caller asked for JSON and the
-// bound flag cannot say so. Scanning argv is the only source of that intent at
-// this point. `--` ends flag parsing, so anything after it is an operand and
-// must not be read as a request.
-//
-// The VALUE goes through strconv.ParseBool rather than a list of spellings,
-// because that is the function pflag's own boolean setter calls. Matching only
-// `--json=true` missed `--json=1`, `--json=t`, `--json=T`, `--json=TRUE` and
-// `--json=True`, every one of which pflag accepts — so automation using a legal
-// spelling got human error text. Enumerating the accepted forms is a promise to
-// have thought of all of them; deferring to the same parser is not (#3057
-// review).
-//
-// A value pflag would REJECT still counts as a request. `--json=zzz` is an
-// invalid invocation, and the caller's intent to receive JSON is unambiguous, so
-// reporting that failure as JSON is the answer they can act on.
-func accountsJSONRequested(args []string) bool {
-	// The LAST occurrence wins, not the first. pflag calls Value.Set for every
-	// occurrence in order, so `--json=false --json=true` is true by the time it
-	// reaches a later bad flag. Returning on the first match read that as false
-	// and emitted human text to a caller that had asked for JSON — the same
-	// mistake as matching one spelling, one level up: I modelled a single
-	// occurrence of a flag that pflag lets repeat (#3057 review).
-	requested := false
-	for _, arg := range args {
-		if arg == "--" {
-			break
-		}
-		if arg == "--json" {
-			requested = true
-			continue
-		}
-		if value, ok := strings.CutPrefix(arg, "--json="); ok {
-			parsed, err := strconv.ParseBool(value)
-			requested = err != nil || parsed
-		}
-	}
-	return requested
-}
-
 // accountsFlagError routes a flag-parse failure through the same {data,error}
 // envelope as every other failure in this group.
 //
@@ -93,33 +47,53 @@ func accountsJSONRequested(args []string) bool {
 // returns before RunE and prints human `Error:` plus usage. ArbitraryArgs moved
 // argument-COUNT validation into RunE but cannot reach flag parsing, which
 // happens earlier still.
+//
+// It reads the BOUND variable, which is already authoritative here. Three
+// revisions of this function scanned os.Args instead, on the premise that a
+// parse failure leaves the bound variable unset — and that premise is false.
+// pflag calls Value.Set as it walks argv, so every occurrence BEFORE the failure
+// has already landed by the time cobra calls this: all spellings, repeats with
+// last-one-wins, and the `--` terminator, handled by the parser itself. The only
+// thing a scanner could add is a `--json` occurring AFTER the failure point,
+// which pflag never accepted and which therefore must not count.
+//
+// Each revision fixed one way the scan diverged from pflag — first occurrence,
+// then boolean spellings, then repeats — and each was a closer simulation of a
+// parser we can simply ask. That is the defect class, not the individual bugs
+// (#3057 review).
 func accountsFlagError(cmd *cobra.Command, err error) error {
-	return jsonWrapError(cmd, accountsJSONRequested(os.Args), err)
+	return jsonWrapError(cmd, accountsJSONFlag, err)
 }
 
 var accountsCmd = &cobra.Command{
 	Use:   "accounts",
 	Short: "Manage per-session agent credential directories",
-	Long: `Manage the credential directories a session can be scoped to.
+	Long: `Prepare the credential directories a session can later be scoped to.
 
 An account is one of an agent's logged-in identities, held as a directory the
 agent CLI treats as its home. af never reads, stores, or forwards the credential
 itself — it decides which directory a session sees, and the agent's own login
 flow puts the material there.
 
+add creates that directory and prints its path · list shows what is registered.
 Register an account, then log in with the agent pointed at that directory:
 
   af accounts add codex work
   CODEX_HOME=$(af accounts add codex work) codex login
 
-Selecting an account for a session both INJECTS that directory and REMOVES every
-other identity-bearing variable for the agent. The removal is what makes the
-selection real: an ambient ANTHROPIC_API_KEY or OPENAI_API_KEY outranks the
-config directory, so without it the session would authenticate as whoever that
-key belongs to while every visible signal reported the selected account.
+Selecting an account for a session is not available yet — see issue #3051. These
+two subcommands prepare the directories and nothing reads them at session start,
+so a session started today still runs on whatever credentials it inherits from
+the environment.
 
-af never switches accounts on its own — not on a rate limit, not on a failure.
-A session runs as the account it was started with.`,
+When selection arrives it will both inject that directory and remove every other
+identity-bearing variable for the agent. The removal is what will make the
+selection real: an ambient ANTHROPIC_API_KEY or OPENAI_API_KEY outranks the
+config directory, so without it a session would authenticate as whoever that key
+belongs to while every visible signal reported the selected account.
+
+af will never switch accounts on its own — not on a rate limit, not on a
+failure. A session will run as the account it was started with.`,
 }
 
 var accountsAddCmd = &cobra.Command{

--- a/commands/accountscmd.go
+++ b/commands/accountscmd.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -47,14 +48,30 @@ type accountEntry struct {
 // while accountsJSONFlag is still false — the caller asked for JSON and the
 // bound flag cannot say so. Scanning argv is the only source of that intent at
 // this point. `--` ends flag parsing, so anything after it is an operand and
-// must not be read as a request (#3057 review).
+// must not be read as a request.
+//
+// The VALUE goes through strconv.ParseBool rather than a list of spellings,
+// because that is the function pflag's own boolean setter calls. Matching only
+// `--json=true` missed `--json=1`, `--json=t`, `--json=T`, `--json=TRUE` and
+// `--json=True`, every one of which pflag accepts — so automation using a legal
+// spelling got human error text. Enumerating the accepted forms is a promise to
+// have thought of all of them; deferring to the same parser is not (#3057
+// review).
+//
+// A value pflag would REJECT still counts as a request. `--json=zzz` is an
+// invalid invocation, and the caller's intent to receive JSON is unambiguous, so
+// reporting that failure as JSON is the answer they can act on.
 func accountsJSONRequested(args []string) bool {
 	for _, arg := range args {
 		if arg == "--" {
 			return false
 		}
-		if arg == "--json" || arg == "--json=true" {
+		if arg == "--json" {
 			return true
+		}
+		if value, ok := strings.CutPrefix(arg, "--json="); ok {
+			parsed, err := strconv.ParseBool(value)
+			return err != nil || parsed
 		}
 	}
 	return false

--- a/commands/accountscmd.go
+++ b/commands/accountscmd.go
@@ -1,0 +1,186 @@
+package commands
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sachiniyer/agent-factory/apiproto"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/agentaccount"
+	"github.com/sachiniyer/agent-factory/internal/sessionenv"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// `af accounts` manages the credential DIRECTORIES a session can be scoped to
+// (#2983/#3051).
+//
+// The thing to understand before reading further: af never handles the secret.
+// An account is a directory that the agent CLI treats as its home, and the
+// agent's own `login` flow is what puts credential material there. af decides
+// only which directory a session sees. That is why `add` creates an empty
+// directory and tells you to log in, rather than asking for a token — a provider
+// rotating its token format costs this code nothing, and af never becomes a
+// place where credentials are stored or could leak from.
+
+// accountsJSONFlag switches the subcommands to the shared {data,error} envelope,
+// matching `af config` and `af token`.
+var accountsJSONFlag bool
+
+// accountEntry is one registered account. The directory is included because it
+// is the thing the operator has to point the agent's login flow at, so omitting
+// it would make the JSON strictly less useful than the human output.
+type accountEntry struct {
+	Agent string `json:"agent"`
+	Name  string `json:"name"`
+	Dir   string `json:"dir"`
+}
+
+var accountsCmd = &cobra.Command{
+	Use:   "accounts",
+	Short: "Manage per-session agent credential directories",
+	Long: `Manage the credential directories a session can be scoped to.
+
+An account is one of an agent's logged-in identities, held as a directory the
+agent CLI treats as its home. af never reads, stores, or forwards the credential
+itself — it decides which directory a session sees, and the agent's own login
+flow puts the material there.
+
+Register an account, then log in with the agent pointed at that directory:
+
+  af accounts add codex work
+  CODEX_HOME=$(af accounts add codex work) codex login
+
+Selecting an account for a session both INJECTS that directory and REMOVES every
+other identity-bearing variable for the agent. The removal is what makes the
+selection real: an ambient ANTHROPIC_API_KEY or OPENAI_API_KEY outranks the
+config directory, so without it the session would authenticate as whoever that
+key belongs to while every visible signal reported the selected account.
+
+af never switches accounts on its own — not on a rate limit, not on a failure.
+A session runs as the account it was started with.`,
+}
+
+var accountsAddCmd = &cobra.Command{
+	Use:   "add <agent> <name>",
+	Short: "Register a credential directory for an agent account",
+	Long: `Create the credential directory for an account and print its path.
+
+This makes a place; it does not log in. Run the agent's own login flow against
+the printed directory to put credentials there.
+
+Registration is idempotent — running it again on an existing account reports the
+same directory and touches nothing inside it.`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		agent, name := args[0], args[1]
+		home, err := config.GetConfigDir()
+		if err != nil {
+			return jsonWrapError(cmd, accountsJSONFlag, err)
+		}
+		dir, err := agentaccount.Register(home, agent, name)
+		if err != nil {
+			return jsonWrapError(cmd, accountsJSONFlag, err)
+		}
+
+		entry := accountEntry{Agent: agent, Name: name, Dir: dir}
+		if accountsJSONFlag {
+			return apiproto.WriteEnvelope(cmd.OutOrStdout(), apiproto.Success(entry))
+		}
+		// The bare path on stdout is deliberate: it makes the command substitutable
+		// into the login invocation above without any parsing. Guidance goes to
+		// stderr so it survives being captured.
+		fmt.Fprintln(cmd.OutOrStdout(), dir)
+		configVar, _ := sessionenv.SupportsAccounts(agent)
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"Registered account %q for %s.\nLog in with that account before using it:\n  %s=%s %s login\n",
+			name, agent, configVar, dir, agent)
+		return nil
+	},
+}
+
+var accountsListCmd = &cobra.Command{
+	Use:   "list [agent]",
+	Short: "List registered agent accounts",
+	Long: `List the registered accounts, for one agent or for every agent that
+supports account scoping.
+
+An agent absent from this list is one whose credential relocation af has not
+verified, not one that is merely unconfigured — af reports unsupported rather
+than accepting a selection that would silently do nothing.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		home, err := config.GetConfigDir()
+		if err != nil {
+			return jsonWrapError(cmd, accountsJSONFlag, err)
+		}
+
+		agents := sessionenv.AccountAgents()
+		if len(args) == 1 {
+			if _, ok := sessionenv.SupportsAccounts(args[0]); !ok {
+				return jsonWrapError(cmd, accountsJSONFlag, fmt.Errorf("%w: %s (supported: %s)",
+					agentaccount.ErrUnsupportedAgent, args[0], joinAgents(agents)))
+			}
+			agents = []string{args[0]}
+		}
+
+		entries := []accountEntry{}
+		for _, agent := range agents {
+			names, err := agentaccount.List(home, agent)
+			if err != nil {
+				return jsonWrapError(cmd, accountsJSONFlag, err)
+			}
+			for _, name := range names {
+				dir, err := agentaccount.Dir(home, agent, name)
+				if err != nil {
+					return jsonWrapError(cmd, accountsJSONFlag, err)
+				}
+				entries = append(entries, accountEntry{Agent: agent, Name: name, Dir: dir})
+			}
+		}
+		sort.Slice(entries, func(i, j int) bool {
+			if entries[i].Agent != entries[j].Agent {
+				return entries[i].Agent < entries[j].Agent
+			}
+			return entries[i].Name < entries[j].Name
+		})
+
+		if accountsJSONFlag {
+			return apiproto.WriteEnvelope(cmd.OutOrStdout(), apiproto.Success(entries))
+		}
+		if len(entries) == 0 {
+			fmt.Fprintf(cmd.OutOrStdout(),
+				"No accounts registered · add one with `af accounts add %s <name>`\n", agents[0])
+			return nil
+		}
+		for _, entry := range entries {
+			fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\n", entry.Agent, entry.Name, entry.Dir)
+		}
+		return nil
+	},
+}
+
+func joinAgents(agents []string) string {
+	out := ""
+	for idx, agent := range agents {
+		if idx > 0 {
+			out += ", "
+		}
+		out += agent
+	}
+	return out
+}
+
+func init() {
+	accountsAddCmd.Flags().BoolVar(&accountsJSONFlag, "json", false, "Output the {data,error} JSON envelope")
+	accountsListCmd.Flags().BoolVar(&accountsJSONFlag, "json", false, "Output the {data,error} JSON envelope")
+	accountsCmd.AddCommand(accountsAddCmd)
+	accountsCmd.AddCommand(accountsListCmd)
+}

--- a/commands/accountscmd.go
+++ b/commands/accountscmd.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -37,6 +38,38 @@ type accountEntry struct {
 	Agent string `json:"agent"`
 	Name  string `json:"name"`
 	Dir   string `json:"dir"`
+}
+
+// accountsJSONRequested reads the JSON intent from the RAW arguments, because a
+// flag-parse failure means the bound variable was never set.
+//
+// cobra parses flags before RunE, so `af accounts add --json --bogus` fails
+// while accountsJSONFlag is still false — the caller asked for JSON and the
+// bound flag cannot say so. Scanning argv is the only source of that intent at
+// this point. `--` ends flag parsing, so anything after it is an operand and
+// must not be read as a request (#3057 review).
+func accountsJSONRequested(args []string) bool {
+	for _, arg := range args {
+		if arg == "--" {
+			return false
+		}
+		if arg == "--json" || arg == "--json=true" {
+			return true
+		}
+	}
+	return false
+}
+
+// accountsFlagError routes a flag-parse failure through the same {data,error}
+// envelope as every other failure in this group.
+//
+// Without it, the one input class an automation caller is most likely to get
+// wrong — a mistyped flag — was the one class it could not parse, because cobra
+// returns before RunE and prints human `Error:` plus usage. ArbitraryArgs moved
+// argument-COUNT validation into RunE but cannot reach flag parsing, which
+// happens earlier still.
+func accountsFlagError(cmd *cobra.Command, err error) error {
+	return jsonWrapError(cmd, accountsJSONRequested(os.Args), err)
 }
 
 var accountsCmd = &cobra.Command{
@@ -241,6 +274,9 @@ func joinAgents(agents []string) string {
 func init() {
 	accountsAddCmd.Flags().BoolVar(&accountsJSONFlag, "json", false, "Output the {data,error} JSON envelope")
 	accountsListCmd.Flags().BoolVar(&accountsJSONFlag, "json", false, "Output the {data,error} JSON envelope")
+	accountsAddCmd.SetFlagErrorFunc(accountsFlagError)
+	accountsListCmd.SetFlagErrorFunc(accountsFlagError)
+	accountsCmd.SetFlagErrorFunc(accountsFlagError)
 	accountsCmd.AddCommand(accountsAddCmd)
 	accountsCmd.AddCommand(accountsListCmd)
 }

--- a/commands/accountscmd.go
+++ b/commands/accountscmd.go
@@ -62,19 +62,27 @@ type accountEntry struct {
 // invalid invocation, and the caller's intent to receive JSON is unambiguous, so
 // reporting that failure as JSON is the answer they can act on.
 func accountsJSONRequested(args []string) bool {
+	// The LAST occurrence wins, not the first. pflag calls Value.Set for every
+	// occurrence in order, so `--json=false --json=true` is true by the time it
+	// reaches a later bad flag. Returning on the first match read that as false
+	// and emitted human text to a caller that had asked for JSON — the same
+	// mistake as matching one spelling, one level up: I modelled a single
+	// occurrence of a flag that pflag lets repeat (#3057 review).
+	requested := false
 	for _, arg := range args {
 		if arg == "--" {
-			return false
+			break
 		}
 		if arg == "--json" {
-			return true
+			requested = true
+			continue
 		}
 		if value, ok := strings.CutPrefix(arg, "--json="); ok {
 			parsed, err := strconv.ParseBool(value)
-			return err != nil || parsed
+			requested = err != nil || parsed
 		}
 	}
-	return false
+	return requested
 }
 
 // accountsFlagError routes a flag-parse failure through the same {data,error}

--- a/commands/accountscmd_test.go
+++ b/commands/accountscmd_test.go
@@ -162,6 +162,10 @@ func TestAccountsJSONNotRequestedWhenPflagNeverAcceptedIt(t *testing.T) {
 		{"json after the failure", []string{"add", "codex", "work", "--bogus", "--json"}},
 		// pflag REJECTS the value, so --json is not on either.
 		{"value pflag rejects", []string{"add", "codex", "work", "--json=zzz"}},
+		// The `accounts` group binds no --json at all, so the parse fails ON it.
+		// Human text is also the more useful answer here: the usage block lists
+		// the subcommands, which is what the caller actually needed.
+		{"group command binds no json flag", []string{"--json"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, stderr, err := runAccounts(t, tc.args...)

--- a/commands/accountscmd_test.go
+++ b/commands/accountscmd_test.go
@@ -1,0 +1,237 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/apiclient"
+)
+
+// `af accounts` had no test file at all while its --json failure path was
+// rewritten three times by review (#3057). Each rewrite hand-modelled a piece of
+// pflag's behaviour — first-occurrence, then boolean spellings, then repeats —
+// and each was wrong in a way no test could catch, because there were none. These
+// drive the real cobra command so the envelope contract is pinned to observable
+// output rather than to a helper's internal logic.
+
+// accountsEnvelope is the shared {data,error} envelope, decoded loosely: these
+// tests care whether the output IS the envelope, not about the payload's shape.
+type accountsEnvelope struct {
+	Data  json.RawMessage `json:"data"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// runAccounts drives `af accounts …` through the real root command and returns
+// what the caller would see on each stream.
+//
+// It resets the shared flag state rather than constructing a fresh command,
+// because the thing under test is the package-level wiring: accountsJSONFlag is
+// bound by BOTH subcommands, and jsonWrapError latches SilenceUsage/SilenceErrors
+// onto the command and its root. A hermetic copy of the command would not
+// reproduce either.
+func runAccounts(t *testing.T, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	tempAFHome(t)
+	// --daemon-url / AF_DAEMON_URL makes both subcommands refuse (they write the
+	// LOCAL home), so an ambient value on the developer's box would turn every
+	// case below into the remote-target refusal.
+	t.Setenv("AF_DAEMON_URL", "")
+	prevFlagURL := apiclient.FlagDaemonURL
+	apiclient.FlagDaemonURL = ""
+
+	prevJSON := accountsJSONFlag
+	accountsJSONFlag = false
+	resetAccountsJSONFlags()
+
+	// os.Args is set to the argv a real shell would hand `af`, because the
+	// behaviour these cases pin used to be decided by scanning it. Leaving it as
+	// the `go test` binary's own argv would make every case pass for the wrong
+	// reason — the scanner would simply find no --json to read. It is set here so
+	// the same test is faithful on both sides of the change; that the answers no
+	// longer depend on it is the point.
+	prevArgs := os.Args
+	os.Args = append([]string{"af", "accounts"}, args...)
+
+	var out, errBuf bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&errBuf)
+	rootCmd.SetArgs(append([]string{"accounts"}, args...))
+	t.Cleanup(func() {
+		accountsJSONFlag = prevJSON
+		apiclient.FlagDaemonURL = prevFlagURL
+		os.Args = prevArgs
+		resetAccountsJSONFlags()
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(os.Stdout)
+		rootCmd.SetErr(os.Stderr)
+		resetCobraSilence(rootCmd)
+	})
+
+	err = rootCmd.Execute()
+	return out.String(), errBuf.String(), err
+}
+
+// resetAccountsJSONFlags puts the bound --json flag back to its default on both
+// subcommands. cobra keeps flag values and Changed across Execute calls, so
+// without this a case that passes --json would leak into the next one.
+func resetAccountsJSONFlags() {
+	for _, cmd := range accountsCmd.Commands() {
+		if flag := cmd.Flags().Lookup("json"); flag != nil {
+			_ = flag.Value.Set("false")
+			flag.Changed = false
+		}
+	}
+}
+
+// requireEnvelope asserts the stream is exactly the shared envelope — no cobra
+// `Error:` line, no usage block — which is the whole point of --json for an
+// automation caller.
+func requireEnvelope(t *testing.T, stream, label string) accountsEnvelope {
+	t.Helper()
+	var env accountsEnvelope
+	if err := json.Unmarshal([]byte(stream), &env); err != nil {
+		t.Fatalf("%s is not a parseable {data,error} envelope: %v\ngot: %q", label, err, stream)
+	}
+	return env
+}
+
+// requireHumanText asserts the opposite: the caller did NOT get an envelope.
+func requireHumanText(t *testing.T, stream, label string) {
+	t.Helper()
+	var env accountsEnvelope
+	if err := json.Unmarshal([]byte(stream), &env); err == nil && env.Error != nil {
+		t.Fatalf("%s is a JSON envelope, want human text: %q", label, stream)
+	}
+	if !strings.Contains(stream, "Error:") {
+		t.Fatalf("%s carries neither an envelope nor cobra's human error: %q", label, stream)
+	}
+}
+
+// TestAccountsJSONEnvelopeOnFlagParseFailure is the motivating case for the
+// whole --json failure path: an automation caller asks for JSON and mistypes a
+// DIFFERENT flag. The failure it is most likely to hit must still be parseable.
+func TestAccountsJSONEnvelopeOnFlagParseFailure(t *testing.T) {
+	stdout, stderr, err := runAccounts(t, "add", "codex", "work", "--json", "--bogus")
+	if err == nil {
+		t.Fatal("expected an error for the unknown flag")
+	}
+	if stdout != "" {
+		t.Fatalf("failure path wrote stdout: %q", stdout)
+	}
+	env := requireEnvelope(t, stderr, "stderr")
+	if env.Error == nil || !strings.Contains(env.Error.Message, "--bogus") {
+		t.Fatalf("envelope does not name the offending flag: %q", stderr)
+	}
+}
+
+// TestAccountsJSONEnvelopeSurvivesAJSONFalseAfterTheFailure is the #3057 review
+// repro, and it FAILS against the hand-rolled argv scanner this change deletes.
+//
+// pflag stops at `--bogus`, so it never reads the `--json=false` that follows —
+// but the scanner walked the WHOLE of os.Args and let that unreached occurrence
+// win, reporting human text to a caller whose --json pflag had already accepted.
+// The bound variable does not have this bug because it only records what pflag
+// actually parsed.
+func TestAccountsJSONEnvelopeSurvivesAJSONFalseAfterTheFailure(t *testing.T) {
+	_, stderr, err := runAccounts(t, "add", "codex", "work", "--json", "--bogus", "--json=false")
+	if err == nil {
+		t.Fatal("expected an error for the unknown flag")
+	}
+	env := requireEnvelope(t, stderr, "stderr")
+	if env.Error == nil || !strings.Contains(env.Error.Message, "--bogus") {
+		t.Fatalf("envelope does not name the offending flag: %q", stderr)
+	}
+}
+
+// TestAccountsJSONNotRequestedWhenPflagNeverAcceptedIt pins the two deliberate
+// narrowings that fall out of trusting the bound variable. In both, pflag never
+// accepted the --json, so the command was never in JSON mode and human text is
+// the honest answer.
+func TestAccountsJSONNotRequestedWhenPflagNeverAcceptedIt(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		// The parse fails BEFORE reaching --json, so pflag never set it.
+		{"json after the failure", []string{"add", "codex", "work", "--bogus", "--json"}},
+		// pflag REJECTS the value, so --json is not on either.
+		{"value pflag rejects", []string{"add", "codex", "work", "--json=zzz"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, stderr, err := runAccounts(t, tc.args...)
+			if err == nil {
+				t.Fatal("expected a flag-parse error")
+			}
+			requireHumanText(t, stderr, "stderr")
+		})
+	}
+}
+
+// TestAccountsDashTerminatorIsNotAJSONRequest guards the operand case: after
+// `--`, a bare `--json` is an ARGUMENT, and pflag treats it as one. It must not
+// flip the command into JSON mode.
+func TestAccountsDashTerminatorIsNotAJSONRequest(t *testing.T) {
+	_, stderr, err := runAccounts(t, "add", "a", "b", "--", "--json")
+	if err == nil {
+		t.Fatal("expected the argument-count error: `--json` after `--` is a third operand")
+	}
+	requireHumanText(t, stderr, "stderr")
+	if !strings.Contains(stderr, "exactly two arguments") {
+		t.Fatalf("stderr is not the argument-count error: %q", stderr)
+	}
+}
+
+// TestAccountsArgCountErrorIsEnveloped covers the other half of why `add` uses
+// ArbitraryArgs: a cobra Args validator runs before RunE and would emit usage
+// text, unparseable to the --json caller.
+func TestAccountsArgCountErrorIsEnveloped(t *testing.T) {
+	stdout, stderr, err := runAccounts(t, "add", "codex", "--json")
+	if err == nil {
+		t.Fatal("expected the argument-count error")
+	}
+	if stdout != "" {
+		t.Fatalf("failure path wrote stdout: %q", stdout)
+	}
+	env := requireEnvelope(t, stderr, "stderr")
+	if env.Error == nil || !strings.Contains(env.Error.Message, "exactly two arguments") {
+		t.Fatalf("envelope is not the argument-count error: %q", stderr)
+	}
+}
+
+// TestAccountsListFlagParseFailureIsEnveloped confirms the routing is on the
+// list subcommand too, not just on add.
+func TestAccountsListFlagParseFailureIsEnveloped(t *testing.T) {
+	_, stderr, err := runAccounts(t, "list", "--json", "--bogus")
+	if err == nil {
+		t.Fatal("expected an error for the unknown flag")
+	}
+	env := requireEnvelope(t, stderr, "stderr")
+	if env.Error == nil || !strings.Contains(env.Error.Message, "--bogus") {
+		t.Fatalf("envelope does not name the offending flag: %q", stderr)
+	}
+}
+
+// TestAccountsAddJSONSuccessEnvelope is the success side, so the failure cases
+// above are not the only thing holding the --json contract.
+func TestAccountsAddJSONSuccessEnvelope(t *testing.T) {
+	stdout, _, err := runAccounts(t, "add", "codex", "work", "--json")
+	if err != nil {
+		t.Fatalf("add failed: %v", err)
+	}
+	env := requireEnvelope(t, stdout, "stdout")
+	if env.Error != nil {
+		t.Fatalf("success envelope carries an error: %q", stdout)
+	}
+	var entry accountEntry
+	if err := json.Unmarshal(env.Data, &entry); err != nil {
+		t.Fatalf("envelope data is not an accountEntry: %v (%q)", err, stdout)
+	}
+	if entry.Agent != "codex" || entry.Name != "work" || entry.Dir == "" {
+		t.Fatalf("unexpected entry: %+v", entry)
+	}
+}

--- a/commands/accountscmd_test.go
+++ b/commands/accountscmd_test.go
@@ -11,11 +11,12 @@ import (
 )
 
 // `af accounts` had no test file at all while its --json failure path was
-// rewritten three times by review (#3057). Each rewrite hand-modelled a piece of
-// pflag's behaviour — first-occurrence, then boolean spellings, then repeats —
-// and each was wrong in a way no test could catch, because there were none. These
-// drive the real cobra command so the envelope contract is pinned to observable
-// output rather than to a helper's internal logic.
+// rewritten three times by review (#3057). Each rewrite hand-modelled one more
+// piece of pflag's behaviour — first occurrence, then boolean spellings, then
+// repeats — and each shipped on a manual check against the built binary, because
+// the logic read os.Args and so could not be reached from an in-process test at
+// all. These drive the real cobra command instead, pinning the envelope contract
+// to what a caller observes on stdout and stderr.
 
 // accountsEnvelope is the shared {data,error} envelope, decoded loosely: these
 // tests care whether the output IS the envelope, not about the payload's shape.

--- a/commands/reset.go
+++ b/commands/reset.go
@@ -50,6 +50,15 @@ const worktreesResidueDir = "worktrees"
 //     is user configuration, not session state.
 //   - daemon-token, daemon-tls.* — daemon runtime IDENTITY; wiping it would
 //     needlessly break already-configured remote clients.
+//   - accounts/ — agent credential directories (#3051). af creates the
+//     directory but never writes what is inside it: the agent's own login flow
+//     does, and af never reads the material. Wiping them would destroy
+//     credentials af did not create and force a re-login to every account, which
+//     is not what a reset of AF's session state should cost. Same reasoning as
+//     daemon-token — it is identity, not session state. printResetPlan and
+//     printResetSummary name it EXPLICITLY, because "removes all AF state" would
+//     otherwise let someone reset expecting their logins to be gone (#3057
+//     review).
 //
 // The daemon SOCKETS are not listed here but are still removed — in runReset,
 // not this list. They are ORDERED, not unordered: they may only be unlinked
@@ -958,6 +967,7 @@ func printResetPlan(out io.Writer, plan *resetPlan) {
 	fmt.Fprintln(out, "WILL KEEP:")
 	fmt.Fprintln(out, "  • your git repositories (working tree, .git, and your own branches)")
 	fmt.Fprintln(out, "  • daemon config: config.toml (listen_addr, defaults, root_agents, update_channel) and per-repo config")
+	fmt.Fprintln(out, "  • registered agent accounts and their credentials (accounts/) — log out with the agent's own CLI to remove those")
 }
 
 func printResetSummary(out io.Writer, s *resetSummary) {
@@ -979,6 +989,6 @@ func printResetSummary(out io.Writer, s *resetSummary) {
 			"they are locked. Each was left in place, along with its branch and its session record. "+
 			"Run the recovery command shown with each one below, then re-run `af reset` to finish.\n", s.blocked)
 	}
-	fmt.Fprintln(out, "Preserved: your git repositories and daemon config (config.toml).")
+	fmt.Fprintln(out, "Preserved: your git repositories, daemon config (config.toml), and registered agent accounts (accounts/).")
 	fmt.Fprintln(out, "The supervised daemon will restart with empty session/task/project-registration state and the same config.")
 }

--- a/commands/root.go
+++ b/commands/root.go
@@ -317,6 +317,7 @@ func init() {
 	rootCmd.AddCommand(agentServerCmd)
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(tokenCmd)
+	rootCmd.AddCommand(accountsCmd)
 	rootCmd.AddCommand(quotaCmd)
 	rootCmd.AddCommand(api.SessionsCmd)
 	rootCmd.AddCommand(api.TasksCmd)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -130,26 +130,32 @@ af [flags]
 
 Manage per-session agent credential directories
 
-Manage the credential directories a session can be scoped to.
+Prepare the credential directories a session can later be scoped to.
 
 An account is one of an agent's logged-in identities, held as a directory the
 agent CLI treats as its home. af never reads, stores, or forwards the credential
 itself — it decides which directory a session sees, and the agent's own login
 flow puts the material there.
 
+add creates that directory and prints its path · list shows what is registered.
 Register an account, then log in with the agent pointed at that directory:
 
   af accounts add codex work
   CODEX_HOME=$(af accounts add codex work) codex login
 
-Selecting an account for a session both INJECTS that directory and REMOVES every
-other identity-bearing variable for the agent. The removal is what makes the
-selection real: an ambient ANTHROPIC_API_KEY or OPENAI_API_KEY outranks the
-config directory, so without it the session would authenticate as whoever that
-key belongs to while every visible signal reported the selected account.
+Selecting an account for a session is not available yet — see issue #3051. These
+two subcommands prepare the directories and nothing reads them at session start,
+so a session started today still runs on whatever credentials it inherits from
+the environment.
 
-af never switches accounts on its own — not on a rate limit, not on a failure.
-A session runs as the account it was started with.
+When selection arrives it will both inject that directory and remove every other
+identity-bearing variable for the agent. The removal is what will make the
+selection real: an ambient ANTHROPIC_API_KEY or OPENAI_API_KEY outranks the
+config directory, so without it a session would authenticate as whoever that key
+belongs to while every visible signal reported the selected account.
+
+af will never switch accounts on its own — not on a rate limit, not on a
+failure. A session will run as the account it was started with.
 
 ```
 af accounts

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -9,6 +9,9 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 ## Commands
 
 - [`af`](#af) — Agent Factory - Manage multiple AI agents like Claude Code, Aider, Codex, Gemini, and Amp.
+- [`af accounts`](#af-accounts) — Manage per-session agent credential directories
+- [`af accounts add`](#af-accounts-add) — Register a credential directory for an agent account
+- [`af accounts list`](#af-accounts-list) — List registered agent accounts
 - [`af agent-server`](#af-agent-server) — Run a headless single-workspace backend (not the web UI — that is 'af daemon')
 - [`af api`](#af-api) — Show the daemon-hosted HTTP/JSON API catalog
 - [`af bug-report`](#af-bug-report) — Bundle logs, versions, tasks, and redacted state for a bug report
@@ -96,6 +99,7 @@ af [flags]
 
 **Subcommands**
 
+- [`af accounts`](#af-accounts) — Manage per-session agent credential directories
 - [`af agent-server`](#af-agent-server) — Run a headless single-workspace backend (not the web UI — that is 'af daemon')
 - [`af api`](#af-api) — Show the daemon-hosted HTTP/JSON API catalog
 - [`af bug-report`](#af-bug-report) — Bundle logs, versions, tasks, and redacted state for a bug report
@@ -120,6 +124,104 @@ af [flags]
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this http:// or ws:// URL instead of the local unix socket (env: AF_DAEMON_URL). The daemon is HTTP-only; terminate TLS at your own proxy if needed. |
 | `-p`, `--program` | `string` | Program to run in new sessions (one of: claude, codex, aider, gemini, amp, opencode, devin) |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
+
+## af accounts
+
+Manage per-session agent credential directories
+
+Manage the credential directories a session can be scoped to.
+
+An account is one of an agent's logged-in identities, held as a directory the
+agent CLI treats as its home. af never reads, stores, or forwards the credential
+itself — it decides which directory a session sees, and the agent's own login
+flow puts the material there.
+
+Register an account, then log in with the agent pointed at that directory:
+
+  af accounts add codex work
+  CODEX_HOME=$(af accounts add codex work) codex login
+
+Selecting an account for a session both INJECTS that directory and REMOVES every
+other identity-bearing variable for the agent. The removal is what makes the
+selection real: an ambient ANTHROPIC_API_KEY or OPENAI_API_KEY outranks the
+config directory, so without it the session would authenticate as whoever that
+key belongs to while every visible signal reported the selected account.
+
+af never switches accounts on its own — not on a rate limit, not on a failure.
+A session runs as the account it was started with.
+
+```
+af accounts
+```
+
+**Subcommands**
+
+- [`af accounts add`](#af-accounts-add) — Register a credential directory for an agent account
+- [`af accounts list`](#af-accounts-list) — List registered agent accounts
+
+**Global flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--daemon-url` | `string` | Target a REMOTE daemon at this http:// or ws:// URL instead of the local unix socket (env: AF_DAEMON_URL). The daemon is HTTP-only; terminate TLS at your own proxy if needed. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
+
+## af accounts add
+
+Register a credential directory for an agent account
+
+Create the credential directory for an account and print its path.
+
+This makes a place; it does not log in. Run the agent's own login flow against
+the printed directory to put credentials there.
+
+Registration is idempotent — running it again on an existing account reports the
+same directory and touches nothing inside it.
+
+```
+af accounts add <agent> <name> [flags]
+```
+
+**Flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--json` |  | Output the {data,error} JSON envelope |
+
+**Global flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--daemon-url` | `string` | Target a REMOTE daemon at this http:// or ws:// URL instead of the local unix socket (env: AF_DAEMON_URL). The daemon is HTTP-only; terminate TLS at your own proxy if needed. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
+
+## af accounts list
+
+List registered agent accounts
+
+List the registered accounts, for one agent or for every agent that
+supports account scoping.
+
+An agent absent from this list is one whose credential relocation af has not
+verified, not one that is merely unconfigured — af reports unsupported rather
+than accepting a selection that would silently do nothing.
+
+```
+af accounts list [agent] [flags]
+```
+
+**Flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--json` |  | Output the {data,error} JSON envelope |
+
+**Global flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--daemon-url` | `string` | Target a REMOTE daemon at this http:// or ws:// URL instead of the local unix socket (env: AF_DAEMON_URL). The daemon is HTTP-only; terminate TLS at your own proxy if needed. |
 | `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af agent-server

--- a/internal/agentaccount/agentaccount.go
+++ b/internal/agentaccount/agentaccount.go
@@ -81,8 +81,19 @@ func Register(home, agent, name string) (string, error) {
 	if err := refuseCaseCollision(home, agent, name); err != nil {
 		return "", err
 	}
+	// BEFORE MkdirAll, which follows an ancestor symlink silently and would create
+	// the account inside its target before any check below could object.
+	if err := refuseSymlinkedAncestor(home, dir); err != nil {
+		return "", err
+	}
 	if err := os.MkdirAll(dir, dirMode); err != nil {
 		return "", fmt.Errorf("create account directory %s: %w", dir, err)
+	}
+	// And AFTER, because the pre-check can only inspect components that already
+	// existed. This pass covers everything MkdirAll just created, plus anything
+	// swapped in between the two.
+	if err := refuseSymlinkedAncestor(home, dir); err != nil {
+		return "", err
 	}
 	// Lstat AFTER MkdirAll, which succeeds on an existing symlink-to-directory
 	// without reporting that it followed one. Chmod would then follow it too and
@@ -136,6 +147,51 @@ func Register(home, agent, name string) (string, error) {
 // Refusing rather than lowercasing is deliberate too: silently folding `Work`
 // into `work` would hand back an EXISTING account's directory from a command the
 // operator issued to create a new one.
+// refuseSymlinkedAncestor rejects a symlink anywhere between the AF home and the
+// account directory, exclusive of the home itself.
+//
+// Checking only the final component was not enough, and the gap is the whole
+// point of the guard: if `accounts/codex` is a symlink, MkdirAll follows it and
+// creates `work` inside the target, where `work` is a perfectly ordinary
+// directory. A final-component Lstat sees nothing wrong and the registration is
+// accepted, so the boundary is bypassed one level up — af then chmods and
+// authenticates through a location chosen by whoever made the link, and both
+// List and Selected report it as a valid account (#3057 review).
+//
+// The AF home itself is deliberately NOT checked. An operator symlinking their
+// own ~/.agent-factory somewhere is an ordinary, deliberate arrangement, and
+// af's other state trees already live behind it; refusing that would reject a
+// working install for a property this package has no business policing. What is
+// policed is everything af creates BELOW it.
+//
+// A component that does not exist yet is fine — it is about to be created as a
+// real directory. Only what is actually there is inspected.
+func refuseSymlinkedAncestor(home, dir string) error {
+	relative, err := filepath.Rel(home, dir)
+	if err != nil {
+		return fmt.Errorf("locate account directory %s under %s: %w", dir, home, err)
+	}
+	current := home
+	for _, component := range strings.Split(relative, string(filepath.Separator)) {
+		current = filepath.Join(current, component)
+		info, err := os.Lstat(current)
+		if os.IsNotExist(err) {
+			// Not created yet; MkdirAll will make a real directory here.
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("inspect account path %s: %w", current, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf(
+				"account path component %s is a symlink; accounts must live in real directories under the "+
+					"agent-factory home so af never re-permissions or authenticates through a path chosen elsewhere",
+				current)
+		}
+	}
+	return nil
+}
+
 func refuseCaseCollision(home, agent, name string) error {
 	existing, err := List(home, agent)
 	if err != nil {

--- a/internal/agentaccount/agentaccount.go
+++ b/internal/agentaccount/agentaccount.go
@@ -29,6 +29,34 @@ const dirMode = 0o700
 // those is a bug waiting to happen rather than a convenience.
 var nameRule = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$`)
 
+// loginCommands is the agent's OWN login invocation, verified against the
+// installed CLIs rather than assumed from the binary name.
+//
+// They do not share a shape, which is the whole reason this is a table. Appending
+// "login" universally printed `claude login`, which is not a command at all —
+// Claude Code puts it under an `auth` subcommand. A registration flow whose
+// printed next step does not run is worse than no guidance: the operator
+// concludes the account is broken, when the only thing wrong was af's sentence.
+//
+// Verified 2026-08-07:
+//   - `claude auth --help` lists `login  Sign in to your Anthropic account`,
+//     and `login` is absent from `claude --help`'s command list.
+//   - `codex --help` lists `login  Manage login` at the top level.
+//
+// An agent added to accountConfigVars without an entry here gets no printed
+// command rather than a guessed one (#3057 review).
+var loginCommands = map[string][]string{
+	"claude": {"auth", "login"},
+	"codex":  {"login"},
+}
+
+// LoginCommand returns the agent's login invocation words, and whether one is
+// known. A false result means "say nothing", never "guess".
+func LoginCommand(agent string) ([]string, bool) {
+	words, ok := loginCommands[agent]
+	return words, ok
+}
+
 // ErrUnsupportedAgent reports an agent whose credential relocation was never
 // verified. It is a distinct error because the answer for the operator is
 // "this agent cannot do accounts", not "you typed the name wrong".
@@ -218,7 +246,14 @@ func List(home, agent string) ([]string, error) {
 	if _, ok := sessionenv.SupportsAccounts(agent); !ok {
 		return nil, fmt.Errorf("%w: %s", ErrUnsupportedAgent, agent)
 	}
-	entries, err := os.ReadDir(filepath.Join(home, DirName, agent))
+	root := filepath.Join(home, DirName, agent)
+	// Same reason as Selected: ReadDir follows a symlinked ancestor, so a swapped
+	// component would have `af accounts list` enumerate an arbitrary directory as
+	// though those were registered accounts.
+	if err := refuseSymlinkedAncestor(home, root); err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(root)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -265,6 +300,15 @@ func Selected(home, agent, name, trustedWrapper string) (sessionenv.Account, err
 	}
 	dir, err := Dir(home, agent, name)
 	if err != nil {
+		return sessionenv.Account{}, err
+	}
+	// Ancestors, not just the leaf — and on every SELECTION, not only at
+	// registration. Register's check cannot protect an account registered last
+	// week whose `accounts/<agent>` component was replaced with a symlink since:
+	// the leaf is still a real directory, so a leaf-only check accepts it and the
+	// session authenticates through a path outside the registry. The guard has to
+	// run where the decision is made (#3057 review).
+	if err := refuseSymlinkedAncestor(home, dir); err != nil {
 		return sessionenv.Account{}, err
 	}
 	// Lstat, matching Register and List. os.Stat follows a symlink, so a launch

--- a/internal/agentaccount/agentaccount.go
+++ b/internal/agentaccount/agentaccount.go
@@ -78,8 +78,34 @@ func Register(home, agent, name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if err := refuseCaseCollision(home, agent, name); err != nil {
+		return "", err
+	}
 	if err := os.MkdirAll(dir, dirMode); err != nil {
 		return "", fmt.Errorf("create account directory %s: %w", dir, err)
+	}
+	// Lstat AFTER MkdirAll, which succeeds on an existing symlink-to-directory
+	// without reporting that it followed one. Chmod would then follow it too and
+	// re-permission whatever it points at — an arbitrary path, chosen by whoever
+	// made the link, silently set to 0700 by a registration command.
+	//
+	// Refusing also keeps the readers agreeing with each other. List skips a
+	// symlink (DirEntry.IsDir is false for one) while Selected accepts it
+	// (os.Stat follows), so a symlinked account is invisible to `af accounts
+	// list` and usable by a launch — an account that does not appear to exist and
+	// works anyway is the kind of state nobody debugs successfully (#3057 review).
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return "", fmt.Errorf("inspect account directory %s: %w", dir, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf(
+			"account path %s is a symlink; accounts must be real directories so af never re-permissions or "+
+				"authenticates through a path chosen elsewhere — remove the link, or point AGENT_FACTORY_HOME at the real location",
+			dir)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("account path %s exists and is not a directory", dir)
 	}
 	// MkdirAll honours the umask, so a 077 umask would have produced 0700 anyway
 	// and a 022 one would not. Set it explicitly rather than inherit whatever the
@@ -88,6 +114,43 @@ func Register(home, agent, name string) (string, error) {
 		return "", fmt.Errorf("secure account directory %s: %w", dir, err)
 	}
 	return dir, nil
+}
+
+// refuseCaseCollision rejects a name that differs from an existing account only
+// by case.
+//
+// macOS and Windows default to case-INSENSITIVE filesystems, where `work` and
+// `Work` are one directory. The registry would treat them as two accounts, so a
+// second `codex login` would overwrite the first account's credentials and both
+// selections would then authenticate as the same person — while the UI reported
+// two distinct accounts. That is the exact silent-wrong-identity outcome this
+// feature exists to prevent, arrived at from the filesystem instead of from the
+// environment (#3057 review).
+//
+// It refuses on EVERY platform rather than probing the filesystem's behaviour.
+// An account name is portable configuration — a project config can name one, and
+// that config is shared across machines — so a name that means two accounts on
+// Linux and one on a colleague's Mac is a footgun wherever it is written. The
+// uniform rule costs a user one rename and behaves identically everywhere.
+//
+// Refusing rather than lowercasing is deliberate too: silently folding `Work`
+// into `work` would hand back an EXISTING account's directory from a command the
+// operator issued to create a new one.
+func refuseCaseCollision(home, agent, name string) error {
+	existing, err := List(home, agent)
+	if err != nil {
+		return err
+	}
+	for _, other := range existing {
+		if other != name && strings.EqualFold(other, name) {
+			return fmt.Errorf(
+				"account %q collides with existing account %q for %s: account names must differ by more than case, "+
+					"because macOS and Windows filesystems treat them as one directory and both accounts would share "+
+					"a single identity",
+				name, other, agent)
+		}
+	}
+	return nil
 }
 
 // List returns the registered account names for an agent, sorted.
@@ -148,7 +211,11 @@ func Selected(home, agent, name, trustedWrapper string) (sessionenv.Account, err
 	if err != nil {
 		return sessionenv.Account{}, err
 	}
-	info, err := os.Stat(dir)
+	// Lstat, matching Register and List. os.Stat follows a symlink, so a launch
+	// would authenticate through a path the registry never created and that `af
+	// accounts list` does not show. All three readers must answer the same
+	// question or an account exists for some of them and not others.
+	info, err := os.Lstat(dir)
 	if err != nil || !info.IsDir() {
 		return sessionenv.Account{}, fmt.Errorf(
 			"account %q is not registered for %s; run `af accounts add %s %s` and log in with that account first",

--- a/internal/agentaccount/agentaccount.go
+++ b/internal/agentaccount/agentaccount.go
@@ -1,0 +1,160 @@
+// Package agentaccount owns where an agent account's credentials live and how a
+// session's account is chosen. It never reads, writes, or transports the
+// credential itself (#3051).
+package agentaccount
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/internal/sessionenv"
+)
+
+// DirName is the account root under the AF home.
+const DirName = "accounts"
+
+// dirMode is owner-only. These directories hold agent credentials — af does not
+// read them, but it does decide where they sit, and a world-readable credential
+// store would be af's fault regardless of who wrote the bytes.
+const dirMode = 0o700
+
+// nameRule keeps an account name usable as a single path component. It is
+// deliberately stricter than "not a path traversal": a name reaches a shell
+// message, a config value and a directory, and one that needs quoting in any of
+// those is a bug waiting to happen rather than a convenience.
+var nameRule = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$`)
+
+// ErrUnsupportedAgent reports an agent whose credential relocation was never
+// verified. It is a distinct error because the answer for the operator is
+// "this agent cannot do accounts", not "you typed the name wrong".
+var ErrUnsupportedAgent = errors.New("agent does not support multiple accounts")
+
+// ValidateName rejects a name that cannot be one path component.
+//
+// Traversal is the obvious case and not the only one: "." and ".." resolve to
+// the account ROOT and to the AF home, so a create there would scatter an
+// agent's config over af's own state directory.
+func ValidateName(name string) error {
+	if !nameRule.MatchString(name) {
+		return fmt.Errorf("account name %q must be 1-64 characters of letters, digits, dot, dash or underscore, starting with a letter or digit", name)
+	}
+	if name == "." || name == ".." || strings.ContainsRune(name, filepath.Separator) {
+		return fmt.Errorf("account name %q must be a single path component", name)
+	}
+	return nil
+}
+
+// Dir is where one account's credentials live. Deriving it in exactly one place
+// is what keeps the writer (registration) and the reader (session launch) from
+// disagreeing about the path — the class of bug where a feature works until two
+// call sites drift.
+func Dir(home, agent, name string) (string, error) {
+	if _, ok := sessionenv.SupportsAccounts(agent); !ok {
+		return "", fmt.Errorf("%w: %s (supported: %s)",
+			ErrUnsupportedAgent, agent, strings.Join(sessionenv.AccountAgents(), ", "))
+	}
+	if err := ValidateName(name); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(home) == "" {
+		return "", errors.New("cannot locate an agent account without an agent-factory home")
+	}
+	return filepath.Join(home, DirName, agent, name), nil
+}
+
+// Register creates an account's credential directory and returns it, so the
+// operator can run the agent's own login flow against it.
+//
+// af does not perform the login and never sees the secret: that is the whole
+// point of an account being a DIRECTORY. Registration is therefore idempotent —
+// it makes a place, and the agent fills it.
+func Register(home, agent, name string) (string, error) {
+	dir, err := Dir(home, agent, name)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, dirMode); err != nil {
+		return "", fmt.Errorf("create account directory %s: %w", dir, err)
+	}
+	// MkdirAll honours the umask, so a 077 umask would have produced 0700 anyway
+	// and a 022 one would not. Set it explicitly rather than inherit whatever the
+	// operator's shell had.
+	if err := os.Chmod(dir, dirMode); err != nil {
+		return "", fmt.Errorf("secure account directory %s: %w", dir, err)
+	}
+	return dir, nil
+}
+
+// List returns the registered account names for an agent, sorted.
+//
+// A missing directory is an empty list, not an error: "no accounts registered"
+// is an ordinary state, and reporting it as a failure would make `af accounts
+// list` fail on a fresh install.
+func List(home, agent string) ([]string, error) {
+	if _, ok := sessionenv.SupportsAccounts(agent); !ok {
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedAgent, agent)
+	}
+	entries, err := os.ReadDir(filepath.Join(home, DirName, agent))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var names []string
+	for _, entry := range entries {
+		if entry.IsDir() && ValidateName(entry.Name()) == nil {
+			names = append(names, entry.Name())
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// Resolve picks the account for a session: an explicit --account, else the
+// project default, else the global one. Same precedence as every other key, so
+// there is nothing new for an operator to learn.
+//
+// An empty result means "no account selected", which must leave the session on
+// the ambient identity exactly as before this feature existed — never a silent
+// fallback to some arbitrary registered account.
+func Resolve(explicit, project, global string) string {
+	for _, candidate := range []string{explicit, project, global} {
+		if trimmed := strings.TrimSpace(candidate); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+// Selected builds the scope a launch applies, or the zero value when no account
+// was selected.
+//
+// It REFUSES a name that was never registered rather than creating the directory
+// on demand. An unregistered account has no credentials in it, so launching
+// against it would start an unauthenticated agent while the UI reported the
+// selected account — the silent-wrong-identity outcome this whole feature exists
+// to prevent.
+func Selected(home, agent, name, trustedWrapper string) (sessionenv.Account, error) {
+	if strings.TrimSpace(name) == "" {
+		return sessionenv.Account{}, nil
+	}
+	dir, err := Dir(home, agent, name)
+	if err != nil {
+		return sessionenv.Account{}, err
+	}
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return sessionenv.Account{}, fmt.Errorf(
+			"account %q is not registered for %s; run `af accounts add %s %s` and log in with that account first",
+			name, agent, agent, name)
+	}
+	return sessionenv.Account{
+		Agent: agent, Name: name, Dir: dir, TrustedWrapper: trustedWrapper,
+	}, nil
+}

--- a/internal/agentaccount/agentaccount.go
+++ b/internal/agentaccount/agentaccount.go
@@ -266,8 +266,19 @@ func reserveName(home, agent, name string) (string, error) {
 
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 	if err == nil {
-		defer func() { _ = file.Close() }()
 		if _, err := file.WriteString(name); err != nil {
+			// Remove the file THIS call created. Left behind, it poisons the name
+			// permanently: a partial write reads as a different owner and reports a
+			// case collision forever, and an empty one reports an ownerless
+			// reservation forever. Either way the account is unusable until someone
+			// finds and deletes a dot-directory entry they were never told about —
+			// a failed registration must not cost the name (#3057 review).
+			_ = file.Close()
+			_ = os.Remove(path)
+			return "", fmt.Errorf("record account reservation %s: %w", path, err)
+		}
+		if err := file.Close(); err != nil {
+			_ = os.Remove(path)
 			return "", fmt.Errorf("record account reservation %s: %w", path, err)
 		}
 		return name, nil

--- a/internal/agentaccount/agentaccount.go
+++ b/internal/agentaccount/agentaccount.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/internal/sessionenv"
 )
@@ -131,17 +132,26 @@ func Register(home, agent, name string) (string, error) {
 	if err := os.MkdirAll(filepath.Dir(dir), dirMode); err != nil {
 		return "", fmt.Errorf("create account directory %s: %w", dir, err)
 	}
-	if err := os.Mkdir(dir, dirMode); err != nil {
-		if !os.IsExist(err) {
-			return "", fmt.Errorf("create account directory %s: %w", dir, err)
-		}
-		// EEXIST is ambiguous: re-registering this exact account (idempotent, the
-		// ordinary case) or colliding with a case-variant that now exists on disk.
-		// The collision check distinguishes them, and this time it reads state that
-		// is already committed.
-		if err := refuseCaseCollision(home, agent, name); err != nil {
-			return "", err
-		}
+	// The RESERVATION is the serialization point, not the account directory.
+	//
+	// os.Mkdir on the account directory only serializes where the filesystem folds
+	// case, so on Linux both `work` and `Work` succeeded and the uniform rule this
+	// package documents was not actually uniform. The reservation is named for the
+	// CASE-FOLDED account, so the same O_EXCL create collides on every filesystem
+	// (#3057 review).
+	owner, err := reserveName(home, agent, name)
+	if err != nil {
+		return "", err
+	}
+	if owner != name {
+		return "", fmt.Errorf(
+			"account %q collides with existing account %q for %s: account names must differ by more than case, "+
+				"because macOS and Windows filesystems treat them as one directory and both accounts would share "+
+				"a single identity",
+			name, owner, agent)
+	}
+	if err := os.Mkdir(dir, dirMode); err != nil && !os.IsExist(err) {
+		return "", fmt.Errorf("create account directory %s: %w", dir, err)
 	}
 	// And AFTER, because the pre-check can only inspect components that already
 	// existed. This pass covers everything MkdirAll just created, plus anything
@@ -220,6 +230,63 @@ func Register(home, agent, name string) (string, error) {
 //
 // A component that does not exist yet is fine — it is about to be created as a
 // real directory. Only what is actually there is inspected.
+// reservationDir holds one file per case-folded account name, recording the
+// spelling that owns it. It is a dot-directory so ValidateName rejects it and
+// List therefore skips it without needing a special case.
+const reservationDir = ".names"
+
+// reserveName claims an account name's CASE-FOLDED form and returns the spelling
+// that owns it — this call's own name when the claim succeeded, or the existing
+// owner's when it did not.
+//
+// This is what makes the rule uniform. Creating the account directory only
+// collides where the filesystem folds case; creating a file named for the folded
+// form collides everywhere, so `work` and `Work` contend for one O_EXCL create
+// on Linux exactly as they do on macOS.
+//
+// The reservation is never removed. It is the record of which spelling owns the
+// name, and deleting it on unregister would let a differently-cased account take
+// the same directory later — the collision the reservation exists to prevent,
+// merely deferred.
+func reserveName(home, agent, name string) (string, error) {
+	dir := filepath.Join(home, DirName, agent, reservationDir)
+	if err := os.MkdirAll(dir, dirMode); err != nil {
+		return "", fmt.Errorf("create account reservation directory %s: %w", dir, err)
+	}
+	path := filepath.Join(dir, strings.ToLower(name))
+
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err == nil {
+		defer func() { _ = file.Close() }()
+		if _, err := file.WriteString(name); err != nil {
+			return "", fmt.Errorf("record account reservation %s: %w", path, err)
+		}
+		return name, nil
+	}
+	if !os.IsExist(err) {
+		return "", fmt.Errorf("reserve account name %s: %w", path, err)
+	}
+
+	// Someone else holds it. Read the owning spelling — retrying briefly, because
+	// the winner creates the file before writing to it, so a loser arriving inside
+	// that window sees an empty file rather than the owner's name. Treating empty
+	// as "no owner" would let both registrations through, which is the race this
+	// whole mechanism exists to close.
+	for attempt := 0; attempt < 50; attempt++ {
+		recorded, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("read account reservation %s: %w", path, err)
+		}
+		if owner := strings.TrimSpace(string(recorded)); owner != "" {
+			return owner, nil
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	return "", fmt.Errorf(
+		"account reservation %s was created but never recorded an owner; remove it if no account of that name exists",
+		path)
+}
+
 func refuseSymlinkedAncestor(home, dir string) error {
 	relative, err := filepath.Rel(home, dir)
 	if err != nil {

--- a/internal/agentaccount/agentaccount.go
+++ b/internal/agentaccount/agentaccount.go
@@ -114,8 +114,34 @@ func Register(home, agent, name string) (string, error) {
 	if err := refuseSymlinkedAncestor(home, dir); err != nil {
 		return "", err
 	}
-	if err := os.MkdirAll(dir, dirMode); err != nil {
+	// Parents with MkdirAll, the LEAF with a bare Mkdir — because the leaf's
+	// creation is what serializes two concurrent registrations.
+	//
+	// refuseCaseCollision above is check-then-act: two processes registering
+	// `work` and `Work` can both pass it before either creates anything, and both
+	// then succeed. On a case-insensitive filesystem that is the P1 outcome
+	// arriving through a race — one directory, two names, a shared identity.
+	//
+	// os.Mkdir is atomic and, on exactly the filesystems where the harm exists,
+	// fails with EEXIST for a case-variant of an existing directory. So the
+	// re-check below runs against COMMITTED state rather than a snapshot, and the
+	// loser of the race is refused rather than silently joined to the winner's
+	// credentials. MkdirAll cannot do this: it treats an existing directory as
+	// success and reports nothing (#3057 review).
+	if err := os.MkdirAll(filepath.Dir(dir), dirMode); err != nil {
 		return "", fmt.Errorf("create account directory %s: %w", dir, err)
+	}
+	if err := os.Mkdir(dir, dirMode); err != nil {
+		if !os.IsExist(err) {
+			return "", fmt.Errorf("create account directory %s: %w", dir, err)
+		}
+		// EEXIST is ambiguous: re-registering this exact account (idempotent, the
+		// ordinary case) or colliding with a case-variant that now exists on disk.
+		// The collision check distinguishes them, and this time it reads state that
+		// is already committed.
+		if err := refuseCaseCollision(home, agent, name); err != nil {
+			return "", err
+		}
 	}
 	// And AFTER, because the pre-check can only inspect components that already
 	// existed. This pass covers everything MkdirAll just created, plus anything

--- a/internal/agentaccount/agentaccount.go
+++ b/internal/agentaccount/agentaccount.go
@@ -253,6 +253,15 @@ func reserveName(home, agent, name string) (string, error) {
 	if err := os.MkdirAll(dir, dirMode); err != nil {
 		return "", fmt.Errorf("create account reservation directory %s: %w", dir, err)
 	}
+	// The reservation path gets the SAME ancestor check as the account directory.
+	// It was added after that guard existed and was not routed through it, so a
+	// symlinked `.names` had MkdirAll follow it and the reservation land outside
+	// the AF home — the identity record for every account of this agent, written
+	// somewhere chosen by whoever made the link, while registration reported
+	// success. A guard is only worth what it covers (#3057 review).
+	if err := refuseSymlinkedAncestor(home, dir); err != nil {
+		return "", err
+	}
 	path := filepath.Join(dir, strings.ToLower(name))
 
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)

--- a/internal/agentaccount/agentaccount_test.go
+++ b/internal/agentaccount/agentaccount_test.go
@@ -419,3 +419,29 @@ func TestRegister_ConcurrentCaseVariantsNeverShareADirectory(t *testing.T) {
 		seen[key] = name
 	}
 }
+
+// The RESERVATION directory needs the same ancestor guard as the account
+// directory. It was added after that guard existed and was not routed through
+// it, so a symlinked `.names` had MkdirAll follow it and the reservation — the
+// record of which spelling owns each account — land outside the AF home, while
+// registration reported success (#3057 review).
+func TestRegister_RefusesASymlinkedReservationDirectory(t *testing.T) {
+	home := t.TempDir()
+	elsewhere := t.TempDir()
+
+	names := filepath.Join(home, DirName, "codex", reservationDir)
+	if err := os.MkdirAll(filepath.Dir(names), 0o700); err != nil {
+		t.Fatalf("mkdir agent dir: %v", err)
+	}
+	if err := os.Symlink(elsewhere, names); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	if _, err := Register(home, "codex", "work"); err == nil {
+		t.Fatal("a symlinked reservation directory must be refused: the reservation " +
+			"would be written outside the AF home while registration reported success")
+	}
+	if _, err := os.Stat(filepath.Join(elsewhere, "work")); err == nil {
+		t.Fatal("the refused registration wrote a reservation into the symlink target")
+	}
+}

--- a/internal/agentaccount/agentaccount_test.go
+++ b/internal/agentaccount/agentaccount_test.go
@@ -401,42 +401,21 @@ func TestRegister_ConcurrentCaseVariantsNeverShareADirectory(t *testing.T) {
 		t.Fatalf("registry holds %d accounts but %d registrations were accepted", len(names), accepted)
 	}
 
-	// The stronger assertion — no case-variant PAIR survives — is only true where
-	// the harm exists. On a case-insensitive filesystem the two names address one
-	// directory, so accepting both is the shared-identity bug and os.Mkdir's
-	// EEXIST is what prevents it. On a case-sensitive one they are two distinct
-	// directories holding distinct credentials, and accepting both is merely a
-	// portability-hygiene miss under a rare race, not a safety failure.
+	// No case-variant PAIR survives — asserted UNCONDITIONALLY now.
 	//
-	// Asserting it unconditionally would be asserting the CLAIM rather than the
-	// behaviour: it fails on Linux for a reason that is not a defect. CI runs this
-	// on macOS too, which is where the real check happens.
-	if !filesystemIsCaseInsensitive(t, home) {
-		t.Logf("case-sensitive filesystem: %d accounts, shared-directory invariant held", len(names))
-		return
-	}
+	// This used to be gated on the filesystem folding case, because os.Mkdir only
+	// serializes where it does, so on Linux both variants landed. That gate was
+	// the test agreeing with a weaker implementation instead of holding it to the
+	// rule refuseCaseCollision documents. The case-folded reservation collides on
+	// every filesystem, so the rule is now genuinely uniform and the test says so
+	// on every platform rather than only on macOS (#3057 review).
 	seen := map[string]string{}
 	for _, name := range names {
 		key := strings.ToLower(name)
 		if other, dup := seen[key]; dup {
-			t.Fatalf("case-insensitive filesystem accepted case-variant accounts %q and %q: "+
-				"they address one directory and authenticate as one identity", other, name)
+			t.Fatalf("accepted case-variant accounts %q and %q for one agent: the rule is "+
+				"documented as uniform across platforms and must hold under concurrency too", other, name)
 		}
 		seen[key] = name
 	}
-}
-
-// filesystemIsCaseInsensitive reports what the filesystem under dir actually
-// does, rather than guessing from runtime.GOOS — macOS can be formatted
-// case-sensitively and Linux can mount a case-insensitive filesystem, and the
-// assertion above depends on the real behaviour, not the usual one.
-func filesystemIsCaseInsensitive(t *testing.T, dir string) bool {
-	t.Helper()
-	probe := filepath.Join(dir, "CaseProbe")
-	if err := os.Mkdir(probe, 0o700); err != nil {
-		t.Fatalf("case probe: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(probe) }()
-	_, err := os.Stat(filepath.Join(dir, "caseprobe"))
-	return err == nil
 }

--- a/internal/agentaccount/agentaccount_test.go
+++ b/internal/agentaccount/agentaccount_test.go
@@ -155,3 +155,87 @@ func envValue(t *testing.T, env []string, name string) string {
 	t.Fatalf("%s not present in the scoped environment", name)
 	return ""
 }
+
+// A case-only variant must be refused. On the default macOS/Windows filesystem
+// `work` and `Work` are ONE directory, so registering both would give two named
+// accounts a single credential store: the second login overwrites the first, and
+// both selections then authenticate as the same person while the UI reports two
+// accounts. That is the silent-wrong-identity failure #2983 exists to prevent,
+// reached through the filesystem rather than through the environment.
+//
+// Asserted on every platform, because the rule is uniform on every platform: an
+// account name travels in shared project config, so one that means two accounts
+// on Linux and one on a colleague's Mac is broken wherever it is written.
+func TestRegister_RefusesANameThatDiffersOnlyByCase(t *testing.T) {
+	home := t.TempDir()
+	if _, err := Register(home, "codex", "work"); err != nil {
+		t.Fatalf("register work: %v", err)
+	}
+
+	_, err := Register(home, "codex", "Work")
+	if err == nil {
+		t.Fatal("registering a case-only variant must be refused: on a case-insensitive " +
+			"filesystem both names address one directory and share one identity")
+	}
+	if !strings.Contains(err.Error(), "collides with existing account") {
+		t.Fatalf("the refusal must name the collision, got: %v", err)
+	}
+	// And it must not have been created under either spelling.
+	names, err := List(home, "codex")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(names) != 1 || names[0] != "work" {
+		t.Fatalf("the refused registration must leave the registry untouched, got %v", names)
+	}
+
+	// The exact same name is still idempotent — the collision rule must not break
+	// re-registration, which is the ordinary case.
+	if _, err := Register(home, "codex", "work"); err != nil {
+		t.Fatalf("re-registering the same name must stay idempotent: %v", err)
+	}
+}
+
+// A symlinked account path must be refused rather than followed.
+//
+// Two distinct harms, both silent. MkdirAll succeeds on an existing
+// symlink-to-directory without saying it followed one, so the Chmod behind it
+// would re-permission an arbitrary target to 0700. And the readers disagree
+// about whether such an account exists at all: List skips it (DirEntry.IsDir is
+// false for a symlink) while a Stat-based Selected would accept it, giving an
+// account that `af accounts list` does not show and a launch happily uses.
+func TestRegister_RefusesASymlinkedAccountPath(t *testing.T) {
+	home := t.TempDir()
+	elsewhere := t.TempDir()
+	if err := os.Chmod(elsewhere, 0o755); err != nil {
+		t.Fatalf("chmod target: %v", err)
+	}
+
+	linkPath := filepath.Join(home, DirName, "codex", "linked")
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0o700); err != nil {
+		t.Fatalf("mkdir parent: %v", err)
+	}
+	if err := os.Symlink(elsewhere, linkPath); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	if _, err := Register(home, "codex", "linked"); err == nil {
+		t.Fatal("a symlinked account path must be refused, not followed")
+	}
+
+	// The link target's permissions must be untouched — the whole point.
+	info, err := os.Stat(elsewhere)
+	if err != nil {
+		t.Fatalf("stat target: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o755 {
+		t.Fatalf("the refused registration re-permissioned the symlink target to %#o; "+
+			"chmod followed the link", perm)
+	}
+
+	// And Selected must agree with List that it is not an account, rather than
+	// authenticating through a path the registry never created.
+	if _, err := Selected(home, "codex", "linked", ""); err == nil {
+		t.Fatal("Selected must refuse a symlinked account, matching List which cannot see it")
+	}
+}

--- a/internal/agentaccount/agentaccount_test.go
+++ b/internal/agentaccount/agentaccount_test.go
@@ -1,0 +1,157 @@
+package agentaccount
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/internal/sessionenv"
+)
+
+// EXCLUSIVITY, not presence. Two accounts must genuinely resolve to different
+// credential directories and a session must receive exactly one — the assertion
+// a passthrough implementation fails, since it would hand every session the
+// daemon's single ambient value while each looked correct in isolation (#3051).
+func TestSelected_TwoAccountsSeeDifferentDirectories(t *testing.T) {
+	home := t.TempDir()
+	dirA, err := Register(home, "codex", "work")
+	require.NoError(t, err)
+	dirB, err := Register(home, "codex", "personal")
+	require.NoError(t, err)
+	require.NotEqual(t, dirA, dirB)
+
+	ambient := []string{
+		"CODEX_HOME=/home/op/.codex",
+		"OPENAI_API_KEY=sk-ambient",
+		"PATH=/usr/bin",
+	}
+
+	accountA, err := Selected(home, "codex", "work", "")
+	require.NoError(t, err)
+	scopedA, err := sessionenv.ApplyAccount(ambient, "codex", accountA)
+	require.NoError(t, err)
+
+	accountB, err := Selected(home, "codex", "personal", "")
+	require.NoError(t, err)
+	scopedB, err := sessionenv.ApplyAccount(ambient, "codex", accountB)
+	require.NoError(t, err)
+
+	homeA := envValue(t, scopedA, "CODEX_HOME")
+	homeB := envValue(t, scopedB, "CODEX_HOME")
+	require.NotEqual(t, homeA, homeB,
+		"two concurrent sessions on different accounts must see different credential roots")
+	require.Equal(t, dirA, homeA)
+	require.Equal(t, dirB, homeB)
+
+	// SUBTRACTION, the load-bearing half: an ambient key outranks the config
+	// directory, so if it survived, the selection would be silently ignored while
+	// every visible signal said it worked.
+	for _, scoped := range [][]string{scopedA, scopedB} {
+		require.NotContains(t, strings.Join(scoped, "\n"), "OPENAI_API_KEY=",
+			"an ambient credential must not reach a session that selected an account")
+	}
+
+	// A session on one account cannot reach the other's directory: they are
+	// separate paths, and only one is ever named.
+	require.NotContains(t, strings.Join(scopedA, "\n"), dirB)
+	require.NotContains(t, strings.Join(scopedB, "\n"), dirA)
+}
+
+// No account selected must leave the session exactly as it was before this
+// feature existed — never a silent fallback onto some registered account.
+func TestSelected_NoSelectionIsNotAnAccount(t *testing.T) {
+	home := t.TempDir()
+	_, err := Register(home, "codex", "work")
+	require.NoError(t, err)
+
+	account, err := Selected(home, "codex", "", "")
+	require.NoError(t, err)
+	require.Equal(t, sessionenv.Account{}, account,
+		"an unselected session must carry no account, not the first registered one")
+}
+
+// An unregistered name REFUSES rather than being created on demand. An empty
+// directory has no credentials in it, so launching against it would start an
+// unauthenticated agent while the UI reported the selected account.
+func TestSelected_RefusesAnUnregisteredAccount(t *testing.T) {
+	home := t.TempDir()
+	_, err := Selected(home, "codex", "never-registered", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not registered")
+	require.Contains(t, err.Error(), "af accounts add", "the error must say how to fix it")
+}
+
+// Agents whose credential relocation was never verified refuse, rather than
+// accepting a selection that would do nothing.
+func TestDir_RefusesAnUnverifiedAgent(t *testing.T) {
+	for _, agent := range []string{"gemini", "amp", "aider", "unknown"} {
+		_, err := Dir(t.TempDir(), agent, "work")
+		require.ErrorIs(t, err, ErrUnsupportedAgent, "agent %q", agent)
+	}
+}
+
+// A name must be one path component. "." and ".." resolve to the account root
+// and the AF home, so a create there would scatter agent config over af's state.
+func TestValidateName_RejectsTraversalAndSeparators(t *testing.T) {
+	for _, name := range []string{"", ".", "..", "a/b", "../escape", "/abs", "-leading", strings.Repeat("x", 65)} {
+		require.Error(t, ValidateName(name), "name %q must be refused", name)
+	}
+	for _, name := range []string{"work", "personal-2", "team.eu", "a_b", "A1"} {
+		require.NoError(t, ValidateName(name), "name %q is ordinary and must be accepted", name)
+	}
+}
+
+// The credential directory is owner-only whatever the operator's umask. af does
+// not read these bytes, but it chose where they sit.
+func TestRegister_CreatesAnOwnerOnlyDirectory(t *testing.T) {
+	home := t.TempDir()
+	dir, err := Register(home, "claude", "work")
+	require.NoError(t, err)
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o700), info.Mode().Perm())
+	require.Equal(t, filepath.Join(home, DirName, "claude", "work"), dir)
+
+	// Idempotent: registering again is not an error, because af only makes the
+	// place and the agent's own login fills it.
+	again, err := Register(home, "claude", "work")
+	require.NoError(t, err)
+	require.Equal(t, dir, again)
+}
+
+func TestList_EmptyOnAFreshHomeAndSortedAfterRegistration(t *testing.T) {
+	home := t.TempDir()
+	names, err := List(home, "codex")
+	require.NoError(t, err, "no accounts registered is an ordinary state, not a failure")
+	require.Empty(t, names)
+
+	for _, name := range []string{"zulu", "alpha"} {
+		_, err := Register(home, "codex", name)
+		require.NoError(t, err)
+	}
+	names, err = List(home, "codex")
+	require.NoError(t, err)
+	require.Equal(t, []string{"alpha", "zulu"}, names)
+}
+
+// Same precedence as every other key, and an empty result means "none".
+func TestResolve_PrefersExplicitThenProjectThenGlobal(t *testing.T) {
+	require.Equal(t, "flag", Resolve("flag", "project", "global"))
+	require.Equal(t, "project", Resolve("", "project", "global"))
+	require.Equal(t, "global", Resolve("", "  ", "global"))
+	require.Equal(t, "", Resolve("", "", ""))
+}
+
+func envValue(t *testing.T, env []string, name string) string {
+	t.Helper()
+	for _, kv := range env {
+		if k, v, ok := strings.Cut(kv, "="); ok && k == name {
+			return v
+		}
+	}
+	t.Fatalf("%s not present in the scoped environment", name)
+	return ""
+}

--- a/internal/agentaccount/agentaccount_test.go
+++ b/internal/agentaccount/agentaccount_test.go
@@ -1,9 +1,11 @@
 package agentaccount
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -324,4 +326,117 @@ func TestLoginCommand_IsPerAgentAndNotGuessed(t *testing.T) {
 	// An unknown agent yields nothing rather than a guess.
 	_, ok = LoginCommand("gemini")
 	require.False(t, ok, "an agent with no verified login command must report none, not a guess")
+}
+
+// Concurrent registration of case-variant names must not produce two accounts.
+//
+// refuseCaseCollision is check-then-act, so two processes registering `work` and
+// `Work` could both pass it before either created anything. On a
+// case-insensitive filesystem that is the P1 outcome reached through a race: one
+// directory, two names, a shared identity. The fix makes the LEAF's creation the
+// serialization point — os.Mkdir is atomic and returns EEXIST for a case-variant
+// there — so the loser re-checks against committed state (#3057 review).
+//
+// On a case-SENSITIVE filesystem the two names are genuinely distinct
+// directories with distinct credentials, so there is no shared identity to
+// prevent and both may legitimately succeed. This asserts the invariant that
+// holds on BOTH: every accepted registration owns a directory no other accepted
+// registration shares.
+func TestRegister_ConcurrentCaseVariantsNeverShareADirectory(t *testing.T) {
+	home := t.TempDir()
+
+	const pairs = 64
+	type result struct {
+		dir string
+		err error
+	}
+	results := make(chan result, pairs*2)
+	var start sync.WaitGroup
+	start.Add(1)
+	var done sync.WaitGroup
+
+	for i := 0; i < pairs; i++ {
+		for _, name := range []string{fmt.Sprintf("acct%d", i), fmt.Sprintf("ACCT%d", i)} {
+			done.Add(1)
+			go func(name string) {
+				defer done.Done()
+				start.Wait()
+				dir, err := Register(home, "codex", name)
+				results <- result{dir: dir, err: err}
+			}(name)
+		}
+	}
+	start.Done()
+	done.Wait()
+	close(results)
+
+	// The invariant: no two ACCEPTED registrations resolved to the same directory.
+	// A shared directory is precisely the shared-credential outcome.
+	owners := map[string]int{}
+	accepted := 0
+	for r := range results {
+		if r.err != nil {
+			continue
+		}
+		accepted++
+		owners[r.dir]++
+	}
+	if accepted == 0 {
+		t.Fatal("every concurrent registration failed; the test proves nothing")
+	}
+	for dir, n := range owners {
+		if n > 1 {
+			t.Fatalf("%d accepted registrations share the credential directory %s: "+
+				"those accounts authenticate as the same identity", n, dir)
+		}
+	}
+
+	// And the registry must agree: one entry per real directory, never a
+	// case-variant pair addressing one.
+	names, err := List(home, "codex")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(names) != accepted {
+		t.Fatalf("registry holds %d accounts but %d registrations were accepted", len(names), accepted)
+	}
+
+	// The stronger assertion — no case-variant PAIR survives — is only true where
+	// the harm exists. On a case-insensitive filesystem the two names address one
+	// directory, so accepting both is the shared-identity bug and os.Mkdir's
+	// EEXIST is what prevents it. On a case-sensitive one they are two distinct
+	// directories holding distinct credentials, and accepting both is merely a
+	// portability-hygiene miss under a rare race, not a safety failure.
+	//
+	// Asserting it unconditionally would be asserting the CLAIM rather than the
+	// behaviour: it fails on Linux for a reason that is not a defect. CI runs this
+	// on macOS too, which is where the real check happens.
+	if !filesystemIsCaseInsensitive(t, home) {
+		t.Logf("case-sensitive filesystem: %d accounts, shared-directory invariant held", len(names))
+		return
+	}
+	seen := map[string]string{}
+	for _, name := range names {
+		key := strings.ToLower(name)
+		if other, dup := seen[key]; dup {
+			t.Fatalf("case-insensitive filesystem accepted case-variant accounts %q and %q: "+
+				"they address one directory and authenticate as one identity", other, name)
+		}
+		seen[key] = name
+	}
+}
+
+// filesystemIsCaseInsensitive reports what the filesystem under dir actually
+// does, rather than guessing from runtime.GOOS — macOS can be formatted
+// case-sensitively and Linux can mount a case-insensitive filesystem, and the
+// assertion above depends on the real behaviour, not the usual one.
+func filesystemIsCaseInsensitive(t *testing.T, dir string) bool {
+	t.Helper()
+	probe := filepath.Join(dir, "CaseProbe")
+	if err := os.Mkdir(probe, 0o700); err != nil {
+		t.Fatalf("case probe: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(probe) }()
+	_, err := os.Stat(filepath.Join(dir, "caseprobe"))
+	return err == nil
 }

--- a/internal/agentaccount/agentaccount_test.go
+++ b/internal/agentaccount/agentaccount_test.go
@@ -239,3 +239,33 @@ func TestRegister_RefusesASymlinkedAccountPath(t *testing.T) {
 		t.Fatal("Selected must refuse a symlinked account, matching List which cannot see it")
 	}
 }
+
+// A symlink ANYWHERE below the AF home must be refused, not just the final
+// component. Checking only the leaf left the boundary bypassable one level up:
+// with `accounts/codex` a symlink, MkdirAll follows it and creates `work` inside
+// the target as a perfectly ordinary directory, so a leaf-only Lstat sees
+// nothing wrong and accepts the registration (#3057 review).
+func TestRegister_RefusesASymlinkedAncestor(t *testing.T) {
+	home := t.TempDir()
+	elsewhere := t.TempDir()
+
+	// accounts/codex is a symlink; the account name below it would be real.
+	agentLink := filepath.Join(home, DirName, "codex")
+	if err := os.MkdirAll(filepath.Dir(agentLink), 0o700); err != nil {
+		t.Fatalf("mkdir accounts: %v", err)
+	}
+	if err := os.Symlink(elsewhere, agentLink); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	if _, err := Register(home, "codex", "work"); err == nil {
+		t.Fatal("a symlinked ANCESTOR must be refused: MkdirAll follows it and the " +
+			"account lands in the link target while the leaf looks like a real directory")
+	}
+
+	// Nothing may have been created inside the link target — the refusal has to
+	// happen before MkdirAll, not merely be reported after it.
+	if _, err := os.Stat(filepath.Join(elsewhere, "work")); err == nil {
+		t.Fatal("the refused registration created the account inside the symlink target")
+	}
+}

--- a/internal/agentaccount/agentaccount_test.go
+++ b/internal/agentaccount/agentaccount_test.go
@@ -269,3 +269,59 @@ func TestRegister_RefusesASymlinkedAncestor(t *testing.T) {
 		t.Fatal("the refused registration created the account inside the symlink target")
 	}
 }
+
+// The ancestor guard must run where the DECISION is made, not only where the
+// account was created. Register's check cannot protect an account registered
+// earlier whose `accounts/<agent>` component was replaced with a symlink since:
+// the leaf stays a real directory, so a leaf-only check accepts it and the
+// session authenticates through a path outside the registry (#3057 review).
+func TestSelectedAndList_RefuseAnAncestorSwappedAfterRegistration(t *testing.T) {
+	home := t.TempDir()
+	if _, err := Register(home, "codex", "work"); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if _, err := Selected(home, "codex", "work", ""); err != nil {
+		t.Fatalf("precondition: a freshly registered account must select cleanly: %v", err)
+	}
+
+	// Swap accounts/codex for a symlink to a directory that DOES contain a
+	// real "work" directory — so the leaf check alone would still pass.
+	agentDir := filepath.Join(home, DirName, "codex")
+	elsewhere := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(elsewhere, "work"), 0o700); err != nil {
+		t.Fatalf("mkdir decoy: %v", err)
+	}
+	if err := os.RemoveAll(agentDir); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if err := os.Symlink(elsewhere, agentDir); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	if _, err := Selected(home, "codex", "work", ""); err == nil {
+		t.Fatal("Selected accepted an account whose ancestor is now a symlink: the " +
+			"session would authenticate through a path outside the registry")
+	}
+	if _, err := List(home, "codex"); err == nil {
+		t.Fatal("List enumerated through a symlinked ancestor, reporting an arbitrary " +
+			"directory's contents as registered accounts")
+	}
+}
+
+// The login guidance must be the agent's REAL invocation. Appending "login"
+// universally printed `claude login`, which Claude Code does not have — it lives
+// under `auth`. Verified against the installed CLIs on 2026-08-07.
+func TestLoginCommand_IsPerAgentAndNotGuessed(t *testing.T) {
+	claude, ok := LoginCommand("claude")
+	require.True(t, ok)
+	require.Equal(t, []string{"auth", "login"}, claude,
+		"claude puts login under `auth`; `claude login` is not a command")
+
+	codex, ok := LoginCommand("codex")
+	require.True(t, ok)
+	require.Equal(t, []string{"login"}, codex)
+
+	// An unknown agent yields nothing rather than a guess.
+	_, ok = LoginCommand("gemini")
+	require.False(t, ok, "an agent with no verified login command must report none, not a guess")
+}

--- a/internal/agentaccount/agentaccount_test.go
+++ b/internal/agentaccount/agentaccount_test.go
@@ -445,3 +445,35 @@ func TestRegister_RefusesASymlinkedReservationDirectory(t *testing.T) {
 		t.Fatal("the refused registration wrote a reservation into the symlink target")
 	}
 }
+
+// A reservation whose owner write fails must not poison the name.
+//
+// The O_EXCL create already happened, so a file left behind is permanent: a
+// partial write reads as a different owner and reports a case collision forever,
+// an empty one reports an ownerless reservation forever. Either way the account
+// is unusable until someone finds and deletes a dot-directory entry they were
+// never told about (#3057 review).
+func TestReserveName_DoesNotPoisonTheNameWhenTheOwnerWriteFails(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, DirName, "codex", reservationDir)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+
+	// Simulate the failed-write outcome exactly: the exclusive file exists and
+	// carries no owner, which is the state a crashed or short write leaves.
+	path := filepath.Join(dir, "work")
+	require.NoError(t, os.WriteFile(path, nil, 0o600))
+
+	_, err := Register(home, "codex", "work")
+	require.Error(t, err, "an ownerless reservation must be reported, not silently adopted")
+
+	// Now the rollback path: remove it as the fixed code does, and the name must
+	// be reclaimable rather than permanently lost.
+	require.NoError(t, os.Remove(path))
+	dirPath, err := Register(home, "codex", "work")
+	require.NoError(t, err, "once the poisoned reservation is gone the name must be usable again")
+	require.DirExists(t, dirPath)
+
+	owner, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "work", string(owner), "a successful registration must record its owner")
+}

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -543,7 +543,7 @@
       },
       "cli": {
         "status": "partial",
-        "pointer": "commands/accountscmd.go:66,109"
+        "pointer": "commands/accountscmd.go:67 accountsAddCmd, :148 accountsListCmd; internal/agentaccount/agentaccount.go Register/List/Selected"
       },
       "verdict": "real-gap",
       "issue": "#3051",

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -543,7 +543,7 @@
       },
       "cli": {
         "status": "partial",
-        "pointer": "commands/accountscmd.go:67 accountsAddCmd, :148 accountsListCmd; internal/agentaccount/agentaccount.go Register/List/Selected"
+        "pointer": "commands/accountscmd.go accountsAddCmd/accountsListCmd; internal/agentaccount/agentaccount.go Register/List/Selected"
       },
       "verdict": "real-gap",
       "issue": "#3051",

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -18,155 +18,26 @@
   ],
   "capabilities": [
     {
-      "id": "session.create",
-      "title": "Create a session",
+      "id": "backend.list",
+      "title": "Discover which backends are available for a repo (with availability + reason)",
       "tui": {
         "status": "yes",
-        "pointer": "keys/keys.go:145 (n) -> app/handle_input.go:181"
+        "pointer": "app/backend_picker.go openBackendPicker -> apiclient/control.go ListBackends -> the naming form's backend field renders label + status + reason"
       },
       "web": {
         "status": "yes",
-        "pointer": "web/src/api.ts:251 createSession"
+        "pointer": "web/src/api.ts:260 ListBackends -> web/src/backends.ts renders the picker"
       },
       "cli": {
         "status": "yes",
-        "pointer": "api/sessions.go:245 sessionsCreateCmd"
+        "pointer": "api/sessions_backends.go:19 sessionsBackendsCmd -> daemon/control_client.go:332 ListBackends"
       },
       "verdict": "parity",
-      "notes": "The verb is at parity; the OPTIONS are not. See the session.create.opt.* rows — no surface is a superset of another."
+      "notes": "POST /v1/ListBackends (#1968) serves config.SupportedBackends per-repo with a tri-state answer (available / unavailable+reason / unknown+reason). CLI half CLOSED by #2584: `af sessions backends` prints that catalog verbatim, reaching the SAME controlServer.ListBackends the web's picker calls over /v1/ListBackends (daemon/httproutes.go wires the route to that method; the gob control socket exposes it), so the surfaces cannot describe a repo's backends differently and a backend added server-side reaches all of them with no client change (pinned by TestSessionsBackends_PassesThroughAnUnknownBackendName). It resolves the project through the same resolveRepo `sessions create` uses, so it describes the create it predicts, and the --backend flag help names it. TUI half CLOSED by #1933's create-form backend field, which is exactly the flip #2584's note anticipated ('this cell flips to yes with that picker, not before'): the TUI reaches the same catalog over apiclient.ListBackends and renders the daemon's labels/statuses/reasons rather than deriving availability locally — which would answer about the CLIENT's host, since apiclient.NewTargeted may point at a REMOTE daemon. Note what 'yes' means uniformly here: on both UIs this capability IS the create-time picker rendering availability, not a standalone catalog view — a catalog with no way to act on it would be a dead-end read. The CLI's standalone verb is the shape that fits a scripting surface. Three surfaces, one catalog, one implementation: parity."
     },
     {
-      "id": "session.create.opt.title",
-      "title": "Set the new session's title",
-      "tui": {
-        "status": "yes",
-        "pointer": "app/handle_input.go:135-158 (typed during stateNew)"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/modals.ts:148 titleInput"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/api.go:584 --name (required)"
-      },
-      "verdict": "parity",
-      "notes": "TUI/web send title_base so the daemon auto-suffixes collisions; the CLI sends title and errors on collision instead."
-    },
-    {
-      "id": "session.create.opt.program",
-      "title": "Choose the agent program at create time",
-      "tui": {
-        "status": "yes",
-        "pointer": "app/handle_input.go:119-134 (Tab -> stateSelectProgram)"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/modals.ts:170-175 programSelect"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/api.go:586 --program"
-      },
-      "verdict": "parity",
-      "notes": ""
-    },
-    {
-      "id": "session.create.opt.prompt",
-      "title": "Send an initial prompt with the new session",
-      "tui": {
-        "status": "yes",
-        "pointer": "shift+tab during naming -> app/handle_overlay.go handleStateInitialPrompt -> app/handle_input.go sessionStartRequest.Prompt"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/modals.ts:177 promptArea -> web/src/api.ts:258"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/api.go:585 --prompt"
-      },
-      "verdict": "parity",
-      "issue": "#1936",
-      "notes": "Closed by #1936: the naming form grew an initial-prompt field on shift+tab (a textarea overlay, so multi-line prompts and pastes survive), populating the sessionStartRequest.Prompt that was already plumbed to the daemon. Was an inverted gap — the TUI was the short surface, with the field dead at its only construction site."
-    },
-    {
-      "id": "session.create.opt.backend",
-      "title": "Choose the session's backend (local/docker/ssh/hook) per session",
-      "tui": {
-        "status": "yes",
-        "pointer": "keys/keys.go KeySetBackend (ctrl+r) -> app/backend_picker.go openBackendPicker + handleStateSelectBackend -> app/session_control.go sessionStartRequest.Backend"
-      },
-      "web": {
-        "status": "partial",
-        "pointer": "web/src/api.ts:265 createSession sends `backend` when picked (via ListBackends), built as a body variable"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/sessions.go:242,328 --backend local|docker|ssh|hook"
-      },
-      "verdict": "real-gap",
-      "issue": "#1933",
-      "notes": "The TUI half is CLOSED: the naming form has a backend field (ctrl+r) whose list is the daemon's ListBackends catalog — the same RPC the web picker reads, reached through apiclient.ListBackends — and the choice rides sessionStartRequest.Backend to CreateSessionRequest.Backend, the field `af sessions create --backend` fills. It is a control and not merely a reachable field: the picker offers exactly the backends the daemon named (no enum in app/), refuses an `unavailable`/`unknown` row with the daemon's own reason rather than promising it, and its 'repo default' row sends NO backend so the repo config still decides. The hint sheds below ~93 columns (ui/menu.go hintDropOrder); the help overlay names the field at every width. web stays `partial`, NOT `yes`: what is proven is that the web SENDS the field and the daemon offers an honest picker; what is NOT proven is that a user can create a WORKING remote session from the browser — #1968 observed provisioning (launch_cmd ran, an agent-server came up) but the session timed out waiting for its program, cause unresolved. That unproven end-to-end remote create is now the whole of what keeps this row off 'parity'. See docs/surface-parity.md 'reachable != user-settable'."
-    },
-    {
-      "id": "session.create.opt.remote",
-      "title": "Force a session onto the remote hook backend",
-      "tui": {
-        "status": "yes",
-        "pointer": "keys/keys.go:153 (N) -> app/handle_input.go ForceRemote; PLUS the naming form's backend field (ctrl+r) reaching backend='hook' — app/backend_picker.go"
-      },
-      "web": {
-        "status": "partial",
-        "pointer": "web/src/api.ts createSession sends backend='hook' via the #1968 ListBackends picker — the SAME BackendHook force_remote selects (session/instance_factory.go resolveBackendKind)"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/api.go:589 --backend hook"
-      },
-      "verdict": "real-gap",
-      "issue": "#1933",
-      "notes": "TUI is now 'yes': `N` still resolves to the hook backend ONLY (session/instance_factory.go resolveBackendKind), but the naming form's backend field reaches backend='hook' explicitly, by the same STRONGER path described below for the web — and the TUI additionally sends the dedicated force_remote field, so it is a superset of both other surfaces here. The web is 'partial', not 'no': the hook backend is reachable from the browser via the #1968 backend picker (backend='hook'), which resolveBackendKind routes to the same BackendHook by a STRONGER path than force_remote — an explicit backend wins over ForceRemote, and both override the repo's backend config, so the picker's 'hook' is strictly more capable than the legacy selector. The dedicated force_remote FIELD is deliberately NOT sent by the web (it stays a field_coverage gap): it adds no capability over the picker, and an ungated 'remote hooks' checkbox reintroduces the 'offered then fails at provision' trap the picker's backendSelectable gate closes (#2406 was closed in favor of this ledger correction). Same unproven-provisioning caveat as session.create.opt.backend: reachable != proven to create a WORKING remote session from the browser (#1968)."
-    },
-    {
-      "id": "session.create.opt.inplace",
-      "title": "Attach a session to the repo's existing working tree (--here)",
-      "tui": {
-        "status": "no",
-        "pointer": "no InPlace assignment anywhere in app/ (grep-verified)"
-      },
-      "web": {
-        "status": "no",
-        "pointer": "web/src/api.ts:251-264 never sends in_place"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/api.go:587-588 --here / --in-place"
-      },
-      "verdict": "unclear",
-      "notes": "CLI-only. Plausibly deliberate: --here is a scripting affordance for 'run an agent right here in my checkout', and the TUI/web are worktree-oriented session managers. Needs an owner call before filing."
-    },
-    {
-      "id": "session.list",
-      "title": "List sessions",
-      "tui": {
-        "status": "yes",
-        "pointer": "app/sidebar rail (always rendered)"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/api.ts:179 fetchSnapshot"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/sessions.go:186 sessionsListCmd"
-      },
-      "verdict": "parity",
-      "notes": ""
-    },
-    {
-      "id": "session.get",
-      "title": "Get one session's record",
+      "id": "cli.argshape.session-title",
+      "title": "Name a session the same way across the sessions verbs",
       "tui": {
         "status": "n/a",
         "pointer": ""
@@ -177,269 +48,33 @@
       },
       "cli": {
         "status": "yes",
-        "pointer": "api/sessions.go:204 sessionsGetCmd"
+        "pointer": "api/sessions.go sessionsCreateCmd accepts create [title] and the existing --name alias"
+      },
+      "verdict": "parity",
+      "issue": "#1972",
+      "notes": "Closed additively: `af sessions create <title>` now shares the positional title shape and vocabulary of its ten sibling verbs, while `--name <title>` remains an alias so existing scripts do not break. Both forms resolve once, before dispatch, into the same CreateSessionRequest.Title path. tui/web are n/a: this is about CLI argument shape, and neither UI has arguments."
+    },
+    {
+      "id": "cli.json-envelope",
+      "title": "Machine-readable {data,error} envelope output",
+      "tui": {
+        "status": "n/a",
+        "pointer": ""
+      },
+      "web": {
+        "status": "n/a",
+        "pointer": ""
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/api.go:580-581 --json (persistent on sessions/tasks/projects); per-command on config/token/daemon/api/bug-report"
       },
       "verdict": "deliberate",
-      "notes": "A scripting read-verb. The TUI and web render the whole projection continuously, so 'get one record' has no UI analogue — the row is already on screen."
+      "notes": "An output FORMAT for scripts consuming stdout, not a product capability. The UIs render the same data as pixels; there is nothing for --json to mean there."
     },
     {
-      "id": "session.send-prompt",
-      "title": "Send a prompt to an existing session",
-      "tui": {
-        "status": "yes",
-        "pointer": "interactive mode types straight into the pane (app/interactive.go:147)"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/terminal.ts:225 onData + :233 attachCustomKeyEventHandler"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/sessions.go:346 sendPromptCmd"
-      },
-      "verdict": "parity",
-      "notes": "The TUI and web reach this by typing into the live terminal rather than via the SendPrompt RPC; same user capability, different transport. In the agent tab, the web maps bare Shift+Enter to LF/Ctrl+J for a multiline composer while plain Enter remains the submitting CR; shell/process tabs retain xterm's native Enter handling."
-    },
-    {
-      "id": "session.send-prompt.broadcast",
-      "title": "Broadcast one prompt to many sessions (--all/--all-repos)",
-      "tui": {
-        "status": "no",
-        "pointer": ""
-      },
-      "web": {
-        "status": "no",
-        "pointer": ""
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/api.go:594-596 --all/--all-repos/--include-root"
-      },
-      "verdict": "deliberate",
-      "notes": "A fan-out scripting verb with no interactive analogue: broadcasting to every live session is a batch operation, and both UIs are single-selection by construction."
-    },
-    {
-      "id": "session.kill",
-      "title": "Permanently destroy a session",
-      "tui": {
-        "status": "yes",
-        "pointer": "keys/keys.go:146 (D) -> app/handle_actions.go:149"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/api.ts:281 killSession"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/sessions.go:703 sessionsKillCmd"
-      },
-      "verdict": "parity",
-      "notes": ""
-    },
-    {
-      "id": "session.archive",
-      "title": "Archive a session (restorable)",
-      "tui": {
-        "status": "yes",
-        "pointer": "keys/keys.go:147 (a) -> app/handle_actions.go:305"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/api.ts:287 archiveSession"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/sessions.go:741 sessionsArchiveCmd"
-      },
-      "verdict": "parity",
-      "notes": "Reachable everywhere. Restorable everywhere too as of #1932 — see session.restore, which closed the web's archive-only one-way door."
-    },
-    {
-      "id": "session.restore",
-      "title": "Restore an archived, Lost, or Dead session",
-      "tui": {
-        "status": "yes",
-        "pointer": "keys/keys.go:148 (r) -> app/session_control.go:172"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/api.ts restoreSession -> RestoreSession; the selected rail row's Archive slot becomes Restore on an archived row (web/src/ui.ts selectedRowActions/patchMainHead)"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/sessions.go:823 sessionsRestoreCmd"
-      },
-      "verdict": "parity",
-      "notes": "Reachable everywhere as of #1932, which closed the archive-only one-way door. The retained TUI and web actions send RestoreSession's stable id so a confirmation/background command cannot retarget a same-title replacement; the one-shot CLI deliberately keeps its repo-scoped title contract. RestoreSession also recovers Lost/Dead rows, giving every surface the same recovery off-ramp."
-    },
-    {
-      "id": "session.limit-retry",
-      "title": "Resume a session blocked at a usage-limit wall",
-      "tui": {
-        "status": "yes",
-        "pointer": "keys/keys.go:169 (c) -> app/handle_actions.go:482 handleLimitRetry -> app/session_control.go:197"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/ui.ts Retry action -> web/src/api.ts resumeFromLimit (shown only on a LimitReached selection)"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/sessions_limit_retry.go (af sessions retry-limit <title>)"
-      },
-      "verdict": "parity",
-      "issue": "#1934",
-      "notes": "Closed across all three surfaces. #1934 promoted ResumeFromLimit into the public catalog and added the web Retry action; `af sessions retry-limit <title>` closes the remaining CLI half using the same daemon controlServer and Manager.resumeFromLimit action. The CLI follows the established repo-scoped title contract and leaves stable-id addressing to the all-project web client (wire.id-addressing). Every surface therefore shares the daemon-owned respawn, pending-prompt delivery, and durable liveness transition instead of implementing recovery client-side."
-    },
-    {
-      "id": "session.handoff",
-      "title": "Continue a session under a different agent, in place",
-      "tui": {
-        "status": "yes",
-        "pointer": "keys/keys.go (F, handoff) -> app/handle_handoff.go -> app/session_control.go handoffSessionThroughDaemon"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/api.ts handoffSession -> HandoffSession; web/src/ui.ts Handoff action (shown on a handoff-capable selection via canHandoff); picker web/src/modals.ts handoffModal"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/sessions_handoff.go (af sessions handoff <title> --to <agent>)"
-      },
-      "verdict": "parity",
-      "issue": "#2013",
-      "notes": "Closed across all three surfaces. Shipped TUI+CLI in the #2013 prompted-handoff PR; the web action was the deferred follow-up, and #2084 is why it stayed a real gap not a deliberate one — #2084 gave the web a way OUT of a limit-blocked session (closing #1934), so the web surfaced the exact state that motivates a handoff while offering only one of the two answers to it (wait, but not switch). The web now calls the existing HandoffSession public route through the same daemon path the TUI/CLI use — no parallel recovery logic — and renders the served ListPrograms enum (enum.agent-programs) in a picker, so a new agent is a handoff target with no web change. The gate is not re-derived client-side: the daemon projects InstanceData.CanHandoff from the SAME Capabilities().Handoff + ValidateRuntimeAction(RuntimeActionHandoff) predicates the TUI's handleHandoff reads, and CurrentAgent from the SAME session.CurrentAgentName the daemon's same-agent guard resolves through, so the picker's exclude-current and the button's show/hide cannot drift from the daemon. `brief` is deliberately not sent (see field_coverage HandoffSession.brief)."
-    },
-    {
-      "id": "session.attach",
-      "title": "Attach to a session's terminal",
-      "tui": {
-        "status": "yes",
-        "pointer": "keys/keys.go:143 (o) -> app/handle_actions.go:712"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/terminal.ts:205-223 (WS /v1/sessions/{id}/stream)"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/sessions.go:854 sessionsAttachCmd"
-      },
-      "verdict": "parity",
-      "notes": ""
-    },
-    {
-      "id": "session.preview",
-      "title": "Read a session's terminal content without attaching",
-      "tui": {
-        "status": "yes",
-        "pointer": "the rail renders live pane previews continuously"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/terminal.ts (xterm renders the live stream)"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/sessions.go:640 sessionsPreviewCmd"
-      },
-      "verdict": "parity",
-      "notes": "The CLI uses the internal Preview RPC; the UIs get the same content off the live stream."
-    },
-    {
-      "id": "session.preview-tab",
-      "title": "Preview a specific tab (by ordinal or stable id)",
-      "tui": {
-        "status": "yes",
-        "pointer": "app/live_stream.go:35 sends Tab + TabID"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/terminal.ts:205-223 streams any tab via tab_id"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/sessions.go sessionsPreviewCmd --tab/--tab-name/--tab-id"
-      },
-      "verdict": "parity",
-      "notes": "Closed by #1948. PreviewRequest always carried Tab and TabID and the CLI sent neither, so `af sessions preview` could only ever see tab 0 — it could CREATE a tab and then had no way to read it. The CLI now sends all three selectors and gained --tab-name, the handle a person actually has; the id/name/ordinal precedence is session.ResolveTabIndex, shared with every other tab verb rather than restated per surface."
-    },
-    {
-      "id": "session.preview-full",
-      "title": "Preview a tab's full scrollback rather than the visible screen",
-      "tui": {
-        "status": "yes",
-        "pointer": "app/live_stream.go:35 sends Full"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/terminal.ts (xterm holds its own scrollback)"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/sessions.go sessionsPreviewCmd --full"
-      },
-      "verdict": "parity",
-      "notes": "Closed by #1948. --full selects PreviewFullHistory over the visible capture, so the CLI can read scrollback instead of only the visible screen."
-    },
-    {
-      "id": "session.tab.create.options",
-      "title": "Choose a new tab's command, name, or kind at create time",
-      "tui": {
-        "status": "partial",
-        "pointer": "app/handle_tabs.go showNewTabPicker chooses Terminal/VS Code; app/session_control.go sends Shell or Kind"
-      },
-      "web": {
-        "status": "partial",
-        "pointer": "web/src/api.ts:339,355 sets shell/kind but never command/name"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/sessions_tabs.go:112 sends Command, Name, Kind, URL, Port"
-      },
-      "verdict": "unclear",
-      "notes": "#2077 added the no-input kind choice (Terminal / VS Code) to `t`. The TUI still cannot name a tab or supply a process command; those input-bearing options remain CLI/API surface. Distinct from session.tab.create.web, which is a deliberate omission."
-    },
-    {
-      "id": "session.tab.create.shell",
-      "title": "Spawn a bare $SHELL tab with no command",
-      "tui": {
-        "status": "yes",
-        "pointer": "app/session_action_target.go:111 Shell:true"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/api.ts:563 shell:true"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/sessions_tabs.go:148 normalizes --kind shell to Shell:true"
-      },
-      "verdict": "parity",
-      "notes": "Closed by #2619: `shell` is the canonical explicit kind, and the CLI normalizes `--kind shell` to the same Shell:true request the TUI/web send. That reaches Manager.CreateTab's single AddShellTab path, so it is a real bare $SHELL tab (TabKindShell), not the different `--command $SHELL` process-tab workaround. `Terminal` remains the presentation-only UI label, consistent with the tab identifier rule."
-    },
-    {
-      "id": "wire.id-addressing",
-      "title": "Address a session by its stable id rather than by title",
-      "tui": {
-        "status": "partial",
-        "pointer": "app/session_action_target.go captures stable identity and constructs kill/archive/restore/limit/handoff/tab requests; retained handlers resolve completions by that identity"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/api.ts:281 et al send id"
-      },
-      "cli": {
-        "status": "no",
-        "pointer": "api/sessions.go:733 et al send {Title, RepoID}"
-      },
-      "verdict": "real-gap",
-      "issue": "#2358",
-      "notes": "#2322 disproved the old blanket 'repo-scoped title is enough' rationale for an action that survives a modal or async command: a killed/recreated row can reuse the title while the user's intent still names the prior stable session. Handoff, kill, archive, restore, usage-limit retry, and tab create/close now carry captured identity through retained boundaries and daemon dispatch; close also sends the stable tab ID when the projection has adopted one. Requests whose wire type still lacks a session ID remain for action-by-action audit; the CLI remains deliberately repo+title scoped because each invocation resolves and dispatches one command without retained UI intent."
-    },
-    {
-      "id": "session.watch",
-      "title": "Block until a session goes idle, or until any session in the fleet changes state",
+      "id": "cli.shell-completion",
+      "title": "Generate a shell completion script",
       "tui": {
         "status": "n/a",
         "pointer": ""
@@ -450,125 +85,17 @@
       },
       "cli": {
         "status": "yes",
-        "pointer": "api/sessions_watch.go sessionsWatchCmd; api/sessions_watch_fleet.go fleetWatcher"
+        "pointer": "cobra's InitDefaultCompletionCmd (af completion bash|zsh|fish|powershell)"
       },
       "verdict": "deliberate",
-      "notes": "A blocking scripting primitive for automation. Both UIs show liveness continuously, so 'block until idle' is meaningless there — you just look. The fleet form (#3009, no title or --all) is edge-triggered and exists for an automated driver rather than a person: it returns when any session TRANSITIONS, which is not something a UI can offer by rendering state, so it stays CLI-only for the same reason."
+      "notes": "A shell integration emitted for the user's shell rc. There is nothing to complete in a TUI or a browser, so the other surfaces have no analogue. Added by cobra lazily at Execute() time, which is why the derivation must init cobra's defaults before walking the tree — otherwise this surface exists and the inventory cannot see it."
     },
     {
-      "id": "session.whoami",
-      "title": "Identify the current session from inside it",
-      "tui": {
-        "status": "n/a",
-        "pointer": ""
-      },
-      "web": {
-        "status": "n/a",
-        "pointer": ""
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/sessions.go:911 sessionsWhoamiCmd"
-      },
-      "verdict": "deliberate",
-      "notes": "Only meaningful to an agent running INSIDE a session's shell. Neither UI runs inside a session."
-    },
-    {
-      "id": "session.tab.create",
-      "title": "Spawn a shell/process tab in a session",
+      "id": "config-agent",
+      "title": "Open the config agent (the default agent, briefed to help configure af)",
       "tui": {
         "status": "yes",
-        "pointer": "keys/keys.go KeyNewTab -> app/handle_tabs.go showNewTabPicker"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/api.ts:339 createTab (shell)"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/sessions_tabs.go:39 tab-create"
-      },
-      "verdict": "parity",
-      "notes": "All three gate off-box backends. The web keeps a visible explanation where the create control would be, while its close controls stay withdrawn; the TUI refuses before opening the picker. Both mirror the daemon's Capabilities().TabManagement."
-    },
-    {
-      "id": "session.tab.create.vscode",
-      "title": "Spawn a VS Code tab",
-      "tui": {
-        "status": "yes",
-        "pointer": "app/handle_tabs.go showNewTabPicker -> createNewTab(TabKindVSCode)"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/api.ts:355 createVSCodeTab"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/sessions_tabs.go:27 --kind vscode"
-      },
-      "verdict": "parity",
-      "notes": "Closed by #2077. The TUI creates Kind:vscode through the same daemon CreateTab RPC as `af sessions tab-create --kind vscode`; its pane shows the existing web-UI placeholder because a terminal cannot render the editor. The web exposes the choice from a labelled New tab menu."
-    },
-    {
-      "id": "session.tab.create.web",
-      "title": "Spawn a web tab (URL/port iframe)",
-      "tui": {
-        "status": "no",
-        "pointer": ""
-      },
-      "web": {
-        "status": "no",
-        "pointer": "web/src/ui.ts:41-43 NewTabKind deliberately excludes 'web'"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/sessions_tabs.go:27-29 --kind web --url/--port"
-      },
-      "verdict": "deliberate",
-      "notes": "Documented in code: 'A web tab is deliberately absent: its target comes from whatever an agent is running, so it stays CLI/API-created' (web/src/ui.ts:41-43, docs/web.md). Both UIs RENDER existing web tabs; only creation is CLI/API-scoped."
-    },
-    {
-      "id": "session.tab.close",
-      "title": "Close a tab",
-      "tui": {
-        "status": "yes",
-        "pointer": "keys/keys.go:157 (w) -> app/handle_actions.go:869"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/api.ts:368 closeTab"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/sessions_tabs.go:129 tab-delete"
-      },
-      "verdict": "parity",
-      "notes": "The agent tab (index 0) is refused on every surface."
-    },
-    {
-      "id": "session.pr.set",
-      "title": "Record a session's GitHub PR info",
-      "tui": {
-        "status": "yes",
-        "pointer": "app/session_control.go:308 (auto-fetched on sync, not a user verb)"
-      },
-      "web": {
-        "status": "no",
-        "pointer": "no SetPRInfo call in web/src"
-      },
-      "cli": {
-        "status": "no",
-        "pointer": "no PR verb in the cobra tree (derived)"
-      },
-      "verdict": "unclear",
-      "notes": "Public route, but the TUI's use is background sync (it fetches PR info from git and records it) rather than a user action. Whether the web should also sync PR info — or whether this should be daemon-side for every client — is an owner call, not a filed gap."
-    },
-    {
-      "id": "session.pr.open",
-      "title": "Open / copy a session's PR URL",
-      "tui": {
-        "status": "yes",
-        "pointer": "keys/keys.go:169-170 (p, y)"
+        "pointer": "keys/keys.go:186 (C) -> app/config_agent.go:87 handleConfigAgent"
       },
       "web": {
         "status": "no",
@@ -579,86 +106,11 @@
         "pointer": ""
       },
       "verdict": "unclear",
-      "notes": "Depends on session.pr.set: no other surface records PR info, so there is nothing for them to open. Triage together."
+      "notes": "A TUI affordance (C) that spawns the user's default agent to help set up config. TUI-only today. Whether a config-helper agent belongs on the web/CLI, or is inherently an interactive TUI flow, is an owner call. Its lifecycle reap is the internal ReapConfigAgent RPC (not a public route). Not filed."
     },
     {
-      "id": "project.list",
-      "title": "See the list of durable projects",
-      "tui": {
-        "status": "yes",
-        "pointer": "app/switch_project.go buildProjectListFrom unions config.ListProjects() (registry) with derived sessions + root_agents"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/api.ts listProjects → project.ts projectSummaries/pickerProjects ∪ registeredProjects; web/src/ui.ts project switcher"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/projects.go projectsListCmd (config.ListProjects)"
-      },
-      "verdict": "parity",
-      "issue": "#2478",
-      "notes": "The CLI, TUI, and web all now surface the durable registry (#2216 identity slice, read via config.ListProjects / the daemon's ListProjects RPC). #2456 added the read half (ListProjects RPC, POST /v1/ListProjects) and unioned it into both switchers: derived (live sessions + tasks) ∪ registry ∪ root_agents, so a registered-but-sessionless project appears everywhere and is creatable-into. This closes the #2478 gap (the TUI/web switchers previously derived only from sessions + legacy root_agents). The web reads over HTTP; the two Go surfaces read config.ListProjects() in-process (a read of on-disk config the daemon writes needs no round trip)."
-    },
-    {
-      "id": "project.delete",
-      "title": "Delete a project (archive its sessions, drop the grouping)",
-      "tui": {
-        "status": "yes",
-        "pointer": "keys/keys.go:162 (D on projects focus) -> app/switch_project.go:223"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/api.ts:304 deleteProject"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/projects.go:25 projectsDeleteCmd"
-      },
-      "verdict": "parity",
-      "notes": ""
-    },
-    {
-      "id": "project.add",
-      "title": "Register a new project",
-      "tui": {
-        "status": "yes",
-        "pointer": "app/switch_project.go handleAddProject → registerProjectThroughDaemon (apiclient RegisterProject RPC)"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/ui.ts renderProjectSwitch '+ Add project' → web/src/modals.ts addProjectModal → api.ts registerProject (RegisterProject RPC)"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/projects.go newProjectsAddCmd (af projects add, register alias) → daemon RegisterProject RPC"
-      },
-      "verdict": "parity",
-      "issue": "#2456",
-      "notes": "#2456 adds the daemon RegisterProject RPC (POST /v1/RegisterProject); all three surfaces route through it — `af projects add` (register is a deprecated alias) over the gob control socket, the TUI's picker '+ Add project' via apiclient (registerProjectThroughDaemon), and the web switcher's '+ Add project' via af() — so the checkout is resolved on the daemon's filesystem and the single writer (#960) owns the registry. The web add is the coherent zero-projects empty state (the switcher is always openable and hosts the action). Parity now that the TUI add writes the durable registry instead of the legacy in-process root_agents entry, and all three switchers union the registry into their project lists (project.list)."
-    },
-    {
-      "id": "project.browse",
-      "title": "Browse the daemon host's directories to find a repo to add",
-      "tui": {
-        "status": "n/a",
-        "pointer": ""
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/dirpicker.ts directoryPicker → web/src/modals.ts addProjectModal; web/src/api.ts listDirectory (ListDirectory RPC)"
-      },
-      "cli": {
-        "status": "n/a",
-        "pointer": ""
-      },
-      "verdict": "deliberate",
-      "issue": "#2788",
-      "notes": "#2788 adds the daemon ListDirectory RPC (POST /v1/ListDirectory) and the web Add-project picker that reads it. It is deliberately web-only, and the reason is the same for both other surfaces: they already run WHERE the filesystem is, next to a shell. `af projects add` is typed at a prompt that has $PWD, tab-completion and `ls`, so a browser inside the CLI would reimplement the shell badly; the TUI's '+ Add project…' overlay sits in a terminal on that same host, one keystroke from the same shell. The web is the only surface with no such access — a phone, or any browser away from the daemon host, cannot see the paths it is being asked to type — which is why the affordance exists there and nowhere else. All three keep the free-text path as the input the submit actually reads (project.add), so nothing the picker can reach is reachable ONLY through it. Re-open this only if the TUI overlay grows the same complaint; the RPC is surface-agnostic and would serve it unchanged."
-    },
-    {
-      "id": "project.rebind",
-      "title": "Rebind a stable project identity to a replacement checkout",
+      "id": "config.explain",
+      "title": "Explain which config layers supplied an effective value",
       "tui": {
         "status": "no",
         "pointer": ""
@@ -669,173 +121,11 @@
       },
       "cli": {
         "status": "yes",
-        "pointer": "api/projects.go projectsRebindCmd"
+        "pointer": "commands/configexplain.go:53-127; commands/configcmd.go:181-190,233-241 --explain"
       },
       "verdict": "real-gap",
       "issue": "#2216",
-      "notes": "The CLI exposes the explicit repair required after a reclone. TUI/web status and repair actions remain part of the later #2216 project-identity integration."
-    },
-    {
-      "id": "project.switch",
-      "title": "Scope the view to one project",
-      "tui": {
-        "status": "yes",
-        "pointer": "keys/keys.go:172 (ctrl+p)"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/ui.ts:1047 switchProject"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/api.go:572 --repo (per-invocation scoping)"
-      },
-      "verdict": "parity",
-      "notes": "The CLI expresses this as per-command --repo scoping rather than sticky state."
-    },
-    {
-      "id": "task.list",
-      "title": "List tasks",
-      "tui": {
-        "status": "yes",
-        "pointer": "keys/keys.go:159 (m) -> app/handle_overlay.go:221"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/api.ts:391 listTasks"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/tasks.go:75 tasksListCmd"
-      },
-      "verdict": "parity",
-      "notes": ""
-    },
-    {
-      "id": "task.add",
-      "title": "Add a task",
-      "tui": {
-        "status": "yes",
-        "pointer": "ui/task_pane.go:370 (n inside the tasks overlay)"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/tasks.ts:286-319 -> api.ts:409 addTask"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/tasks.go:121 tasksAddCmd"
-      },
-      "verdict": "parity",
-      "notes": ""
-    },
-    {
-      "id": "task.edit",
-      "title": "Edit an existing task's name/prompt/trigger/target/program",
-      "tui": {
-        "status": "yes",
-        "pointer": "ui/task_pane.go:362 (enter) -> ui/task_pane_edit.go form"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/tasks.ts editTaskModal (seeded from the task) -> web/src/index.ts openEditTask sends a field-level TaskUpdate patch via api.ts updateTask"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/tasks.go:270 tasksUpdateCmd (7 fields)"
-      },
-      "verdict": "parity",
-      "notes": "Closed by #1935: the Edit action opens the add-task form seeded from the task and submits the changed fields to UpdateTask. project_path is now in the web TS TaskUpdate (web/src/types.ts) and sent by the edit call site, so every field the create form collects is editable."
-    },
-    {
-      "id": "task.toggle",
-      "title": "Enable / disable a task",
-      "tui": {
-        "status": "yes",
-        "pointer": "ui/task_pane.go:356 (x)"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/index.ts:854-865 toggleTask"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/api.go:649 --enabled"
-      },
-      "verdict": "parity",
-      "notes": ""
-    },
-    {
-      "id": "task.remove",
-      "title": "Remove a task",
-      "tui": {
-        "status": "yes",
-        "pointer": "ui/task_pane.go:359 (D)"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/api.ts:436 removeTask"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/tasks.go:196 tasksRemoveCmd"
-      },
-      "verdict": "parity",
-      "notes": ""
-    },
-    {
-      "id": "task.restart",
-      "title": "Restart an enabled watch task after editing its script",
-      "tui": {
-        "status": "no",
-        "pointer": ""
-      },
-      "web": {
-        "status": "no",
-        "pointer": ""
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/tasks.go:368 tasksRestartCmd"
-      },
-      "verdict": "deliberate",
-      "notes": "This is an operator workflow after editing an external script file, which neither UI owns. Both task UIs already expose the enabled toggle; its daemon update is synchronous and therefore remains a safe manual cycle. The dedicated one-command restart belongs in the scripting CLI."
-    },
-    {
-      "id": "task.trigger",
-      "title": "Trigger a task now",
-      "tui": {
-        "status": "yes",
-        "pointer": "ui/task_pane.go:367-369 (r)"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/api.ts:429 triggerTask"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/tasks.go:237 tasksRunCmd"
-      },
-      "verdict": "parity",
-      "notes": "All three refuse watch-backed tasks; the web additionally hides the button (web/src/tasks.ts:92-94)."
-    },
-    {
-      "id": "task.get",
-      "title": "Get one task's record",
-      "tui": {
-        "status": "n/a",
-        "pointer": ""
-      },
-      "web": {
-        "status": "n/a",
-        "pointer": ""
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/tasks.go:216 tasksGetCmd"
-      },
-      "verdict": "deliberate",
-      "notes": "Scripting read-verb; both UIs render the task list continuously."
+      "notes": "The CLI now exposes complete on-disk source candidates, per-leaf origins, and whether the running daemon was checked. TUI/web/config-agent introspection remains #2216 stage 7 so those surfaces consume the same resolver rather than growing a second precedence implementation."
     },
     {
       "id": "config.read",
@@ -873,25 +163,6 @@
       "verdict": "real-gap",
       "issue": "#2216",
       "notes": "Stage 2 of #2216 added read-only CLI selection of an existing repository path; it neither registers a project nor writes identity state. #2607 aligned that read path with the shared project-context contract: get/list default to the cwd's repository, --repo selects another path, and the old --project spelling remains a compatibility alias. TUI/web exposure is tracked by #2216."
-    },
-    {
-      "id": "config.explain",
-      "title": "Explain which config layers supplied an effective value",
-      "tui": {
-        "status": "no",
-        "pointer": ""
-      },
-      "web": {
-        "status": "no",
-        "pointer": ""
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "commands/configexplain.go:53-127; commands/configcmd.go:181-190,233-241 --explain"
-      },
-      "verdict": "real-gap",
-      "issue": "#2216",
-      "notes": "The CLI now exposes complete on-disk source candidates, per-leaf origins, and whether the running daemon was checked. TUI/web/config-agent introspection remains #2216 stage 7 so those surfaces consume the same resolver rather than growing a second precedence implementation."
     },
     {
       "id": "config.validate",
@@ -949,24 +220,6 @@
       "notes": "Stage 5 of #2216 adds CLI per-project writes: `af config set <key> --project <id-or-path>` and `af config unset <key> --project`. The value lands in the project's machine-local ~/.agent-factory/.agent-factory-projects/<id>/config.toml, above the checked-in in-repo layer, and only for the preference keys the manifest admits per project. TUI/web target selection, source badge, and Clear-override are intentionally scheduled for #2216 stage 7 after the durable project model and personal layers exist."
     },
     {
-      "id": "worktree.hooks.edit",
-      "title": "Edit a repo's post-worktree hooks",
-      "tui": {
-        "status": "yes",
-        "pointer": "keys/keys.go:171 (e) -> app/handle_overlay.go:291"
-      },
-      "web": {
-        "status": "no",
-        "pointer": ""
-      },
-      "cli": {
-        "status": "no",
-        "pointer": ""
-      },
-      "verdict": "unclear",
-      "notes": "TUI-only editor over in-repo config. Same question as config.write: is editing repo config a UI concern at all?"
-    },
-    {
       "id": "daemon.lifecycle",
       "title": "Install / uninstall / restart / status / adopt the daemon",
       "tui": {
@@ -983,6 +236,24 @@
       },
       "verdict": "deliberate",
       "notes": "Both UIs are clients OF the daemon: the web is served BY it (a web button to stop the daemon would kill the page), and the TUI needs it running to render. Host-lifecycle control belongs to the CLI."
+    },
+    {
+      "id": "daemon.remote-access",
+      "title": "Point a client at a remote daemon (URL + bearer token)",
+      "tui": {
+        "status": "yes",
+        "pointer": "commands/root.go:267,274 persistent --daemon-url/--token (inherited by the TUI launch)"
+      },
+      "web": {
+        "status": "n/a",
+        "pointer": ""
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "commands/root.go:267,274 --daemon-url/--token"
+      },
+      "verdict": "deliberate",
+      "notes": "The web is SERVED BY the daemon it talks to, so it has no 'point me elsewhere' knob by construction — it is already at the only daemon it can reach. The TUI and CLI are separate processes that must be told where the daemon is, so the flags are persistent on root for both."
     },
     {
       "id": "daemon.token",
@@ -1003,6 +274,42 @@
       "notes": "A credential-bootstrap verb: the web must already HAVE the token to talk to the daemon, so it cannot be where you go to get it. Rotating from the web would sever the rotating client."
     },
     {
+      "id": "enum.agent-programs",
+      "title": "Offer the full set of agent programs af supports",
+      "tui": {
+        "status": "yes",
+        "pointer": "app/handle_input.go:121-123 reads tmux.SupportedPrograms"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/programs.ts renders the served ListPrograms catalog (modals.ts + tasks.ts pickers)"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "commands/root.go:246 + api/api.go:586 advertise tmux.SupportedProgramsString()"
+      },
+      "verdict": "parity",
+      "notes": "RESOLVED by #1970. A third drift dimension under verbs and fields: the VALUES a surface offers for a field. The TUI and CLI read tmux.SupportedPrograms (session/tmux/session.go); the web kept its own copy in two pickers, so adding an agent server-side would have left the web silently offering the old set with every field-level check green. The fix is structural rather than a re-sync: the daemon SERVES the enum (POST /v1/ListPrograms, daemon/programs.go) and the web renders the response (web/src/programs.ts), so a seventh agent reaches the web with no edit under web/src — the acceptance criterion, pinned by TestListPrograms_NewProgramReachesClientsWithNoClientChange and its web twin. TestWebProgramEnumMatchesWire (the interim 'is the copy current?' guard) is replaced by TestWebHardcodesNoAgentEnum, which asserts the stronger property that NO copy exists. The reported default comes from the same decision function the create path uses (defaultProgramFor), so the picker's 'repo default' label cannot disagree with the program a real create picks."
+    },
+    {
+      "id": "install.bug-report",
+      "title": "Bundle a bug report",
+      "tui": {
+        "status": "n/a",
+        "pointer": ""
+      },
+      "web": {
+        "status": "n/a",
+        "pointer": ""
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "commands/bugreportcmd.go:35"
+      },
+      "verdict": "deliberate",
+      "notes": "Collects host-side logs and redacted state; must work when af is too broken to render a UI."
+    },
+    {
       "id": "install.doctor",
       "title": "Diagnose setup and leaked resources",
       "tui": {
@@ -1019,24 +326,6 @@
       },
       "verdict": "deliberate",
       "notes": "Diagnoses the host install, including the case where the daemon is down — exactly when neither UI can run."
-    },
-    {
-      "id": "install.upgrade",
-      "title": "Upgrade af",
-      "tui": {
-        "status": "n/a",
-        "pointer": ""
-      },
-      "web": {
-        "status": "n/a",
-        "pointer": ""
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "commands/upgrade.go:105"
-      },
-      "verdict": "deliberate",
-      "notes": "Replaces the running binary; cannot be driven from a client the binary is serving."
     },
     {
       "id": "install.reset",
@@ -1057,8 +346,8 @@
       "notes": "Destroys the state both UIs are rendering, daemon included. Owner-locked as a typed-confirmation CLI op (#1736)."
     },
     {
-      "id": "install.bug-report",
-      "title": "Bundle a bug report",
+      "id": "install.upgrade",
+      "title": "Upgrade af",
       "tui": {
         "status": "n/a",
         "pointer": ""
@@ -1069,10 +358,10 @@
       },
       "cli": {
         "status": "yes",
-        "pointer": "commands/bugreportcmd.go:35"
+        "pointer": "commands/upgrade.go:105"
       },
       "verdict": "deliberate",
-      "notes": "Collects host-side logs and redacted state; must work when af is too broken to render a UI."
+      "notes": "Replaces the running binary; cannot be driven from a client the binary is serving."
     },
     {
       "id": "meta.discovery",
@@ -1111,98 +400,323 @@
       "notes": "af gen-docs is Hidden:true (CI docs generation). af agent-server is daemon-consumed plumbing — its own Long says it 'exists to be consumed by a daemon rather than opened by a person' — and af --daemon is a hidden flag. af hook-guard-tmux is also hidden: #2608 retains the removed command name only as an exit-0 compatibility tombstone for already-running pre-#2563 Codex hooks; it performs no guard or user operation. None are user capabilities. af gen-docs --plugin-root (#2172) regenerates the committed per-agent plugin artifacts from the canonical af usage text; like the rest of gen-docs it is build tooling, run by scripts/gen-docs.sh and the CI drift gate. The TUI and web will deliberately never expose these internals — regenerating a repo's committed build artifacts and legacy hook compatibility are not things either surface should offer — so this is a recorded decision, not a parity gap to re-report."
     },
     {
-      "id": "tui.navigation",
-      "title": "Move around the TUI (cursor, focus, sections, scroll, search, help, quit)",
+      "id": "project.add",
+      "title": "Register a new project",
       "tui": {
         "status": "yes",
-        "pointer": "keys/keys.go:136-176 (up/down/collapse/expand/focus/sections/scroll/search/help/quit)"
+        "pointer": "app/switch_project.go handleAddProject → registerProjectThroughDaemon (apiclient RegisterProject RPC)"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/ui.ts renderProjectSwitch '+ Add project' → web/src/modals.ts addProjectModal → api.ts registerProject (RegisterProject RPC)"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/projects.go newProjectsAddCmd (af projects add, register alias) → daemon RegisterProject RPC"
+      },
+      "verdict": "parity",
+      "issue": "#2456",
+      "notes": "#2456 adds the daemon RegisterProject RPC (POST /v1/RegisterProject); all three surfaces route through it — `af projects add` (register is a deprecated alias) over the gob control socket, the TUI's picker '+ Add project' via apiclient (registerProjectThroughDaemon), and the web switcher's '+ Add project' via af() — so the checkout is resolved on the daemon's filesystem and the single writer (#960) owns the registry. The web add is the coherent zero-projects empty state (the switcher is always openable and hosts the action). Parity now that the TUI add writes the durable registry instead of the legacy in-process root_agents entry, and all three switchers union the registry into their project lists (project.list)."
+    },
+    {
+      "id": "project.browse",
+      "title": "Browse the daemon host's directories to find a repo to add",
+      "tui": {
+        "status": "n/a",
+        "pointer": ""
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/dirpicker.ts directoryPicker → web/src/modals.ts addProjectModal; web/src/api.ts listDirectory (ListDirectory RPC)"
+      },
+      "cli": {
+        "status": "n/a",
+        "pointer": ""
+      },
+      "verdict": "deliberate",
+      "issue": "#2788",
+      "notes": "#2788 adds the daemon ListDirectory RPC (POST /v1/ListDirectory) and the web Add-project picker that reads it. It is deliberately web-only, and the reason is the same for both other surfaces: they already run WHERE the filesystem is, next to a shell. `af projects add` is typed at a prompt that has $PWD, tab-completion and `ls`, so a browser inside the CLI would reimplement the shell badly; the TUI's '+ Add project…' overlay sits in a terminal on that same host, one keystroke from the same shell. The web is the only surface with no such access — a phone, or any browser away from the daemon host, cannot see the paths it is being asked to type — which is why the affordance exists there and nowhere else. All three keep the free-text path as the input the submit actually reads (project.add), so nothing the picker can reach is reachable ONLY through it. Re-open this only if the TUI overlay grows the same complaint; the RPC is surface-agnostic and would serve it unchanged."
+    },
+    {
+      "id": "project.delete",
+      "title": "Delete a project (archive its sessions, drop the grouping)",
+      "tui": {
+        "status": "yes",
+        "pointer": "keys/keys.go:162 (D on projects focus) -> app/switch_project.go:223"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/api.ts:304 deleteProject"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/projects.go:25 projectsDeleteCmd"
+      },
+      "verdict": "parity",
+      "notes": ""
+    },
+    {
+      "id": "project.list",
+      "title": "See the list of durable projects",
+      "tui": {
+        "status": "yes",
+        "pointer": "app/switch_project.go buildProjectListFrom unions config.ListProjects() (registry) with derived sessions + root_agents"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/api.ts listProjects → project.ts projectSummaries/pickerProjects ∪ registeredProjects; web/src/ui.ts project switcher"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/projects.go projectsListCmd (config.ListProjects)"
+      },
+      "verdict": "parity",
+      "issue": "#2478",
+      "notes": "The CLI, TUI, and web all now surface the durable registry (#2216 identity slice, read via config.ListProjects / the daemon's ListProjects RPC). #2456 added the read half (ListProjects RPC, POST /v1/ListProjects) and unioned it into both switchers: derived (live sessions + tasks) ∪ registry ∪ root_agents, so a registered-but-sessionless project appears everywhere and is creatable-into. This closes the #2478 gap (the TUI/web switchers previously derived only from sessions + legacy root_agents). The web reads over HTTP; the two Go surfaces read config.ListProjects() in-process (a read of on-disk config the daemon writes needs no round trip)."
+    },
+    {
+      "id": "project.rebind",
+      "title": "Rebind a stable project identity to a replacement checkout",
+      "tui": {
+        "status": "no",
+        "pointer": ""
+      },
+      "web": {
+        "status": "no",
+        "pointer": ""
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/projects.go projectsRebindCmd"
+      },
+      "verdict": "real-gap",
+      "issue": "#2216",
+      "notes": "The CLI exposes the explicit repair required after a reclone. TUI/web status and repair actions remain part of the later #2216 project-identity integration."
+    },
+    {
+      "id": "project.switch",
+      "title": "Scope the view to one project",
+      "tui": {
+        "status": "yes",
+        "pointer": "keys/keys.go:172 (ctrl+p)"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/ui.ts:1047 switchProject"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/api.go:572 --repo (per-invocation scoping)"
+      },
+      "verdict": "parity",
+      "notes": "The CLI expresses this as per-command --repo scoping rather than sticky state."
+    },
+    {
+      "id": "quota.usage-report",
+      "title": "Report usage-limit status per agent CLI",
+      "tui": {
+        "status": "no",
+        "pointer": ""
+      },
+      "web": {
+        "status": "no",
+        "pointer": ""
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "commands/quotacmd.go:29"
+      },
+      "verdict": "real-gap",
+      "issue": "#2983",
+      "notes": "#2983 Part 1 ships the CLI only; the issue also asks for a TUI/web panel, so tui and web are a real GAP rather than n/a and are recorded as such. The report keeps provider ENTITLEMENT (always \"not reported\" — no supported agent exposes a quota surface af can read) apart from af's own OBSERVATION of sessions parked at a usage wall, so a surface that renders it must preserve that separation: a blank or zero quota cell reads as exhausted, which is the failure the command exists to avoid."
+    },
+    {
+      "id": "session.accounts",
+      "title": "Register and select per-session agent credential accounts",
+      "tui": {
+        "status": "no",
+        "pointer": ""
+      },
+      "web": {
+        "status": "no",
+        "pointer": ""
+      },
+      "cli": {
+        "status": "partial",
+        "pointer": "commands/accountscmd.go:66,109"
+      },
+      "verdict": "real-gap",
+      "issue": "#3051",
+      "notes": "Registration and listing are CLI-only so far (#3051). An account is a credential DIRECTORY the agent CLI treats as its home; af never reads or stores the secret, so `add` makes a place and the agent's own login flow fills it. Selecting an account for a session, and showing the selected account in the TUI and web, are the remaining slices — which is why cli is partial and the UIs are no rather than n/a."
+    },
+    {
+      "id": "session.archive",
+      "title": "Archive a session (restorable)",
+      "tui": {
+        "status": "yes",
+        "pointer": "keys/keys.go:147 (a) -> app/handle_actions.go:305"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/api.ts:287 archiveSession"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/sessions.go:741 sessionsArchiveCmd"
+      },
+      "verdict": "parity",
+      "notes": "Reachable everywhere. Restorable everywhere too as of #1932 — see session.restore, which closed the web's archive-only one-way door."
+    },
+    {
+      "id": "session.attach",
+      "title": "Attach to a session's terminal",
+      "tui": {
+        "status": "yes",
+        "pointer": "keys/keys.go:143 (o) -> app/handle_actions.go:712"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/terminal.ts:205-223 (WS /v1/sessions/{id}/stream)"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/sessions.go:854 sessionsAttachCmd"
+      },
+      "verdict": "parity",
+      "notes": ""
+    },
+    {
+      "id": "session.create",
+      "title": "Create a session",
+      "tui": {
+        "status": "yes",
+        "pointer": "keys/keys.go:145 (n) -> app/handle_input.go:181"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/api.ts:251 createSession"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/sessions.go:245 sessionsCreateCmd"
+      },
+      "verdict": "parity",
+      "notes": "The verb is at parity; the OPTIONS are not. See the session.create.opt.* rows — no surface is a superset of another."
+    },
+    {
+      "id": "session.create.opt.backend",
+      "title": "Choose the session's backend (local/docker/ssh/hook) per session",
+      "tui": {
+        "status": "yes",
+        "pointer": "keys/keys.go KeySetBackend (ctrl+r) -> app/backend_picker.go openBackendPicker + handleStateSelectBackend -> app/session_control.go sessionStartRequest.Backend"
       },
       "web": {
         "status": "partial",
-        "pointer": "web/src/nav.ts:109-200 (its own j/k, [/], 1-9, Enter, Esc, Alt+j/k/w)"
+        "pointer": "web/src/api.ts:265 createSession sends `backend` when picked (via ListBackends), built as a body variable"
       },
       "cli": {
-        "status": "n/a",
-        "pointer": ""
+        "status": "yes",
+        "pointer": "api/sessions.go:242,328 --backend local|docker|ssh|hook"
       },
-      "verdict": "deliberate",
-      "notes": "Navigation is per-surface chrome, not a product capability: each UI navigates its own layout idiomatically and a CLI has nothing to navigate. Deliberately NOT held to key-for-key parity — see docs/surface-parity.md."
+      "verdict": "real-gap",
+      "issue": "#1933",
+      "notes": "The TUI half is CLOSED: the naming form has a backend field (ctrl+r) whose list is the daemon's ListBackends catalog — the same RPC the web picker reads, reached through apiclient.ListBackends — and the choice rides sessionStartRequest.Backend to CreateSessionRequest.Backend, the field `af sessions create --backend` fills. It is a control and not merely a reachable field: the picker offers exactly the backends the daemon named (no enum in app/), refuses an `unavailable`/`unknown` row with the daemon's own reason rather than promising it, and its 'repo default' row sends NO backend so the repo config still decides. The hint sheds below ~93 columns (ui/menu.go hintDropOrder); the help overlay names the field at every width. web stays `partial`, NOT `yes`: what is proven is that the web SENDS the field and the daemon offers an honest picker; what is NOT proven is that a user can create a WORKING remote session from the browser — #1968 observed provisioning (launch_cmd ran, an agent-server came up) but the session timed out waiting for its program, cause unresolved. That unproven end-to-end remote create is now the whole of what keeps this row off 'parity'. See docs/surface-parity.md 'reachable != user-settable'."
     },
     {
-      "id": "tui.panes",
-      "title": "Open / split / hide / focus workspace panes",
+      "id": "session.create.opt.inplace",
+      "title": "Attach a session to the repo's existing working tree (--here)",
+      "tui": {
+        "status": "no",
+        "pointer": "no InPlace assignment anywhere in app/ (grep-verified)"
+      },
+      "web": {
+        "status": "no",
+        "pointer": "web/src/api.ts:251-264 never sends in_place"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/api.go:587-588 --here / --in-place"
+      },
+      "verdict": "unclear",
+      "notes": "CLI-only. Plausibly deliberate: --here is a scripting affordance for 'run an agent right here in my checkout', and the TUI/web are worktree-oriented session managers. Needs an owner call before filing."
+    },
+    {
+      "id": "session.create.opt.program",
+      "title": "Choose the agent program at create time",
       "tui": {
         "status": "yes",
-        "pointer": "keys/keys.go:163-167 (s, S, x, left/right)"
+        "pointer": "app/handle_input.go:119-134 (Tab -> stateSelectProgram)"
       },
       "web": {
         "status": "yes",
-        "pointer": "web/src/split.ts (drag-to-split, divider resize, Alt+j/k/w)"
-      },
-      "cli": {
-        "status": "n/a",
-        "pointer": ""
-      },
-      "verdict": "deliberate",
-      "notes": "Both UIs have a pane workspace with surface-idiomatic gestures (the web adds mouse drag-and-drop the TUI cannot express; the TUI has keyboard splits the web reaches via Alt-chords). Layout is client-local and never hits the daemon."
-    },
-    {
-      "id": "daemon.remote-access",
-      "title": "Point a client at a remote daemon (URL + bearer token)",
-      "tui": {
-        "status": "yes",
-        "pointer": "commands/root.go:267,274 persistent --daemon-url/--token (inherited by the TUI launch)"
-      },
-      "web": {
-        "status": "n/a",
-        "pointer": ""
+        "pointer": "web/src/modals.ts:170-175 programSelect"
       },
       "cli": {
         "status": "yes",
-        "pointer": "commands/root.go:267,274 --daemon-url/--token"
-      },
-      "verdict": "deliberate",
-      "notes": "The web is SERVED BY the daemon it talks to, so it has no 'point me elsewhere' knob by construction — it is already at the only daemon it can reach. The TUI and CLI are separate processes that must be told where the daemon is, so the flags are persistent on root for both."
-    },
-    {
-      "id": "cli.json-envelope",
-      "title": "Machine-readable {data,error} envelope output",
-      "tui": {
-        "status": "n/a",
-        "pointer": ""
-      },
-      "web": {
-        "status": "n/a",
-        "pointer": ""
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/api.go:580-581 --json (persistent on sessions/tasks/projects); per-command on config/token/daemon/api/bug-report"
-      },
-      "verdict": "deliberate",
-      "notes": "An output FORMAT for scripts consuming stdout, not a product capability. The UIs render the same data as pixels; there is nothing for --json to mean there."
-    },
-    {
-      "id": "task.edit.project-path",
-      "title": "Change which project a task belongs to",
-      "tui": {
-        "status": "yes",
-        "pointer": "ui/task_pane_edit.go:135 edits ProjectPath; the patch is task.DiffTask over the edited task.Task (ui/task_pane_state.go:91)"
-      },
-      "web": {
-        "status": "yes",
-        "pointer": "web/src/tasks.ts editTaskModal project picker (seeded, editable) -> web/src/index.ts openEditTask sends update.project_path"
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/api.go:722 --project-path -> api/tasks.go:576 patch.ProjectPath = strPtr(absPath) -> daemonUpdateTask"
+        "pointer": "api/api.go:586 --program"
       },
       "verdict": "parity",
-      "notes": "The web half was subsumed by #1935: its seeded project picker sends update.project_path. The CLI now sends the same TaskUpdate.ProjectPath patch with `af tasks update --project-path`; `--repo` remains the authorization scope for the task's current project, so `--repo old --project-path new` is unambiguous. This also supplies a repair path for the wrong-project automation incident in #1891 without duplicating the daemon's rebind and RepoID logic."
+      "notes": ""
     },
     {
-      "id": "cli.shell-completion",
-      "title": "Generate a shell completion script",
+      "id": "session.create.opt.prompt",
+      "title": "Send an initial prompt with the new session",
+      "tui": {
+        "status": "yes",
+        "pointer": "shift+tab during naming -> app/handle_overlay.go handleStateInitialPrompt -> app/handle_input.go sessionStartRequest.Prompt"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/modals.ts:177 promptArea -> web/src/api.ts:258"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/api.go:585 --prompt"
+      },
+      "verdict": "parity",
+      "issue": "#1936",
+      "notes": "Closed by #1936: the naming form grew an initial-prompt field on shift+tab (a textarea overlay, so multi-line prompts and pastes survive), populating the sessionStartRequest.Prompt that was already plumbed to the daemon. Was an inverted gap — the TUI was the short surface, with the field dead at its only construction site."
+    },
+    {
+      "id": "session.create.opt.remote",
+      "title": "Force a session onto the remote hook backend",
+      "tui": {
+        "status": "yes",
+        "pointer": "keys/keys.go:153 (N) -> app/handle_input.go ForceRemote; PLUS the naming form's backend field (ctrl+r) reaching backend='hook' — app/backend_picker.go"
+      },
+      "web": {
+        "status": "partial",
+        "pointer": "web/src/api.ts createSession sends backend='hook' via the #1968 ListBackends picker — the SAME BackendHook force_remote selects (session/instance_factory.go resolveBackendKind)"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/api.go:589 --backend hook"
+      },
+      "verdict": "real-gap",
+      "issue": "#1933",
+      "notes": "TUI is now 'yes': `N` still resolves to the hook backend ONLY (session/instance_factory.go resolveBackendKind), but the naming form's backend field reaches backend='hook' explicitly, by the same STRONGER path described below for the web — and the TUI additionally sends the dedicated force_remote field, so it is a superset of both other surfaces here. The web is 'partial', not 'no': the hook backend is reachable from the browser via the #1968 backend picker (backend='hook'), which resolveBackendKind routes to the same BackendHook by a STRONGER path than force_remote — an explicit backend wins over ForceRemote, and both override the repo's backend config, so the picker's 'hook' is strictly more capable than the legacy selector. The dedicated force_remote FIELD is deliberately NOT sent by the web (it stays a field_coverage gap): it adds no capability over the picker, and an ungated 'remote hooks' checkbox reintroduces the 'offered then fails at provision' trap the picker's backendSelectable gate closes (#2406 was closed in favor of this ledger correction). Same unproven-provisioning caveat as session.create.opt.backend: reachable != proven to create a WORKING remote session from the browser (#1968)."
+    },
+    {
+      "id": "session.create.opt.title",
+      "title": "Set the new session's title",
+      "tui": {
+        "status": "yes",
+        "pointer": "app/handle_input.go:135-158 (typed during stateNew)"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/modals.ts:148 titleInput"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/api.go:584 --name (required)"
+      },
+      "verdict": "parity",
+      "notes": "TUI/web send title_base so the daemon auto-suffixes collisions; the CLI sends title and errors on collision instead."
+    },
+    {
+      "id": "session.get",
+      "title": "Get one session's record",
       "tui": {
         "status": "n/a",
         "pointer": ""
@@ -1213,72 +727,91 @@
       },
       "cli": {
         "status": "yes",
-        "pointer": "cobra's InitDefaultCompletionCmd (af completion bash|zsh|fish|powershell)"
+        "pointer": "api/sessions.go:204 sessionsGetCmd"
       },
       "verdict": "deliberate",
-      "notes": "A shell integration emitted for the user's shell rc. There is nothing to complete in a TUI or a browser, so the other surfaces have no analogue. Added by cobra lazily at Execute() time, which is why the derivation must init cobra's defaults before walking the tree — otherwise this surface exists and the inventory cannot see it."
+      "notes": "A scripting read-verb. The TUI and web render the whole projection continuously, so 'get one record' has no UI analogue — the row is already on screen."
     },
     {
-      "id": "enum.agent-programs",
-      "title": "Offer the full set of agent programs af supports",
+      "id": "session.handoff",
+      "title": "Continue a session under a different agent, in place",
       "tui": {
         "status": "yes",
-        "pointer": "app/handle_input.go:121-123 reads tmux.SupportedPrograms"
+        "pointer": "keys/keys.go (F, handoff) -> app/handle_handoff.go -> app/session_control.go handoffSessionThroughDaemon"
       },
       "web": {
         "status": "yes",
-        "pointer": "web/src/programs.ts renders the served ListPrograms catalog (modals.ts + tasks.ts pickers)"
+        "pointer": "web/src/api.ts handoffSession -> HandoffSession; web/src/ui.ts Handoff action (shown on a handoff-capable selection via canHandoff); picker web/src/modals.ts handoffModal"
       },
       "cli": {
         "status": "yes",
-        "pointer": "commands/root.go:246 + api/api.go:586 advertise tmux.SupportedProgramsString()"
+        "pointer": "api/sessions_handoff.go (af sessions handoff <title> --to <agent>)"
       },
       "verdict": "parity",
-      "notes": "RESOLVED by #1970. A third drift dimension under verbs and fields: the VALUES a surface offers for a field. The TUI and CLI read tmux.SupportedPrograms (session/tmux/session.go); the web kept its own copy in two pickers, so adding an agent server-side would have left the web silently offering the old set with every field-level check green. The fix is structural rather than a re-sync: the daemon SERVES the enum (POST /v1/ListPrograms, daemon/programs.go) and the web renders the response (web/src/programs.ts), so a seventh agent reaches the web with no edit under web/src — the acceptance criterion, pinned by TestListPrograms_NewProgramReachesClientsWithNoClientChange and its web twin. TestWebProgramEnumMatchesWire (the interim 'is the copy current?' guard) is replaced by TestWebHardcodesNoAgentEnum, which asserts the stronger property that NO copy exists. The reported default comes from the same decision function the create path uses (defaultProgramFor), so the picker's 'repo default' label cannot disagree with the program a real create picks."
+      "issue": "#2013",
+      "notes": "Closed across all three surfaces. Shipped TUI+CLI in the #2013 prompted-handoff PR; the web action was the deferred follow-up, and #2084 is why it stayed a real gap not a deliberate one — #2084 gave the web a way OUT of a limit-blocked session (closing #1934), so the web surfaced the exact state that motivates a handoff while offering only one of the two answers to it (wait, but not switch). The web now calls the existing HandoffSession public route through the same daemon path the TUI/CLI use — no parallel recovery logic — and renders the served ListPrograms enum (enum.agent-programs) in a picker, so a new agent is a handoff target with no web change. The gate is not re-derived client-side: the daemon projects InstanceData.CanHandoff from the SAME Capabilities().Handoff + ValidateRuntimeAction(RuntimeActionHandoff) predicates the TUI's handleHandoff reads, and CurrentAgent from the SAME session.CurrentAgentName the daemon's same-agent guard resolves through, so the picker's exclude-current and the button's show/hide cannot drift from the daemon. `brief` is deliberately not sent (see field_coverage HandoffSession.brief)."
     },
     {
-      "id": "cli.argshape.session-title",
-      "title": "Name a session the same way across the sessions verbs",
-      "tui": {
-        "status": "n/a",
-        "pointer": ""
-      },
-      "web": {
-        "status": "n/a",
-        "pointer": ""
-      },
-      "cli": {
-        "status": "yes",
-        "pointer": "api/sessions.go sessionsCreateCmd accepts create [title] and the existing --name alias"
-      },
-      "verdict": "parity",
-      "issue": "#1972",
-      "notes": "Closed additively: `af sessions create <title>` now shares the positional title shape and vocabulary of its ten sibling verbs, while `--name <title>` remains an alias so existing scripts do not break. Both forms resolve once, before dispatch, into the same CreateSessionRequest.Title path. tui/web are n/a: this is about CLI argument shape, and neither UI has arguments."
-    },
-    {
-      "id": "backend.list",
-      "title": "Discover which backends are available for a repo (with availability + reason)",
+      "id": "session.kill",
+      "title": "Permanently destroy a session",
       "tui": {
         "status": "yes",
-        "pointer": "app/backend_picker.go openBackendPicker -> apiclient/control.go ListBackends -> the naming form's backend field renders label + status + reason"
+        "pointer": "keys/keys.go:146 (D) -> app/handle_actions.go:149"
       },
       "web": {
         "status": "yes",
-        "pointer": "web/src/api.ts:260 ListBackends -> web/src/backends.ts renders the picker"
+        "pointer": "web/src/api.ts:281 killSession"
       },
       "cli": {
         "status": "yes",
-        "pointer": "api/sessions_backends.go:19 sessionsBackendsCmd -> daemon/control_client.go:332 ListBackends"
+        "pointer": "api/sessions.go:703 sessionsKillCmd"
       },
       "verdict": "parity",
-      "notes": "POST /v1/ListBackends (#1968) serves config.SupportedBackends per-repo with a tri-state answer (available / unavailable+reason / unknown+reason). CLI half CLOSED by #2584: `af sessions backends` prints that catalog verbatim, reaching the SAME controlServer.ListBackends the web's picker calls over /v1/ListBackends (daemon/httproutes.go wires the route to that method; the gob control socket exposes it), so the surfaces cannot describe a repo's backends differently and a backend added server-side reaches all of them with no client change (pinned by TestSessionsBackends_PassesThroughAnUnknownBackendName). It resolves the project through the same resolveRepo `sessions create` uses, so it describes the create it predicts, and the --backend flag help names it. TUI half CLOSED by #1933's create-form backend field, which is exactly the flip #2584's note anticipated ('this cell flips to yes with that picker, not before'): the TUI reaches the same catalog over apiclient.ListBackends and renders the daemon's labels/statuses/reasons rather than deriving availability locally — which would answer about the CLIENT's host, since apiclient.NewTargeted may point at a REMOTE daemon. Note what 'yes' means uniformly here: on both UIs this capability IS the create-time picker rendering availability, not a standalone catalog view — a catalog with no way to act on it would be a dead-end read. The CLI's standalone verb is the shape that fits a scripting surface. Three surfaces, one catalog, one implementation: parity."
+      "notes": ""
     },
     {
-      "id": "config-agent",
-      "title": "Open the config agent (the default agent, briefed to help configure af)",
+      "id": "session.limit-retry",
+      "title": "Resume a session blocked at a usage-limit wall",
       "tui": {
         "status": "yes",
-        "pointer": "keys/keys.go:186 (C) -> app/config_agent.go:87 handleConfigAgent"
+        "pointer": "keys/keys.go:169 (c) -> app/handle_actions.go:482 handleLimitRetry -> app/session_control.go:197"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/ui.ts Retry action -> web/src/api.ts resumeFromLimit (shown only on a LimitReached selection)"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/sessions_limit_retry.go (af sessions retry-limit <title>)"
+      },
+      "verdict": "parity",
+      "issue": "#1934",
+      "notes": "Closed across all three surfaces. #1934 promoted ResumeFromLimit into the public catalog and added the web Retry action; `af sessions retry-limit <title>` closes the remaining CLI half using the same daemon controlServer and Manager.resumeFromLimit action. The CLI follows the established repo-scoped title contract and leaves stable-id addressing to the all-project web client (wire.id-addressing). Every surface therefore shares the daemon-owned respawn, pending-prompt delivery, and durable liveness transition instead of implementing recovery client-side."
+    },
+    {
+      "id": "session.list",
+      "title": "List sessions",
+      "tui": {
+        "status": "yes",
+        "pointer": "app/sidebar rail (always rendered)"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/api.ts:179 fetchSnapshot"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/sessions.go:186 sessionsListCmd"
+      },
+      "verdict": "parity",
+      "notes": ""
+    },
+    {
+      "id": "session.pr.open",
+      "title": "Open / copy a session's PR URL",
+      "tui": {
+        "status": "yes",
+        "pointer": "keys/keys.go:169-170 (p, y)"
       },
       "web": {
         "status": "no",
@@ -1289,11 +822,119 @@
         "pointer": ""
       },
       "verdict": "unclear",
-      "notes": "A TUI affordance (C) that spawns the user's default agent to help set up config. TUI-only today. Whether a config-helper agent belongs on the web/CLI, or is inherently an interactive TUI flow, is an owner call. Its lifecycle reap is the internal ReapConfigAgent RPC (not a public route). Not filed."
+      "notes": "Depends on session.pr.set: no other surface records PR info, so there is nothing for them to open. Triage together."
     },
     {
-      "id": "task.max-concurrent-runs",
-      "title": "Cap a watch task's in-flight session count",
+      "id": "session.pr.set",
+      "title": "Record a session's GitHub PR info",
+      "tui": {
+        "status": "yes",
+        "pointer": "app/session_control.go:308 (auto-fetched on sync, not a user verb)"
+      },
+      "web": {
+        "status": "no",
+        "pointer": "no SetPRInfo call in web/src"
+      },
+      "cli": {
+        "status": "no",
+        "pointer": "no PR verb in the cobra tree (derived)"
+      },
+      "verdict": "unclear",
+      "notes": "Public route, but the TUI's use is background sync (it fetches PR info from git and records it) rather than a user action. Whether the web should also sync PR info — or whether this should be daemon-side for every client — is an owner call, not a filed gap."
+    },
+    {
+      "id": "session.preview",
+      "title": "Read a session's terminal content without attaching",
+      "tui": {
+        "status": "yes",
+        "pointer": "the rail renders live pane previews continuously"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/terminal.ts (xterm renders the live stream)"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/sessions.go:640 sessionsPreviewCmd"
+      },
+      "verdict": "parity",
+      "notes": "The CLI uses the internal Preview RPC; the UIs get the same content off the live stream."
+    },
+    {
+      "id": "session.preview-full",
+      "title": "Preview a tab's full scrollback rather than the visible screen",
+      "tui": {
+        "status": "yes",
+        "pointer": "app/live_stream.go:35 sends Full"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/terminal.ts (xterm holds its own scrollback)"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/sessions.go sessionsPreviewCmd --full"
+      },
+      "verdict": "parity",
+      "notes": "Closed by #1948. --full selects PreviewFullHistory over the visible capture, so the CLI can read scrollback instead of only the visible screen."
+    },
+    {
+      "id": "session.preview-tab",
+      "title": "Preview a specific tab (by ordinal or stable id)",
+      "tui": {
+        "status": "yes",
+        "pointer": "app/live_stream.go:35 sends Tab + TabID"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/terminal.ts:205-223 streams any tab via tab_id"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/sessions.go sessionsPreviewCmd --tab/--tab-name/--tab-id"
+      },
+      "verdict": "parity",
+      "notes": "Closed by #1948. PreviewRequest always carried Tab and TabID and the CLI sent neither, so `af sessions preview` could only ever see tab 0 — it could CREATE a tab and then had no way to read it. The CLI now sends all three selectors and gained --tab-name, the handle a person actually has; the id/name/ordinal precedence is session.ResolveTabIndex, shared with every other tab verb rather than restated per surface."
+    },
+    {
+      "id": "session.restore",
+      "title": "Restore an archived, Lost, or Dead session",
+      "tui": {
+        "status": "yes",
+        "pointer": "keys/keys.go:148 (r) -> app/session_control.go:172"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/api.ts restoreSession -> RestoreSession; the selected rail row's Archive slot becomes Restore on an archived row (web/src/ui.ts selectedRowActions/patchMainHead)"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/sessions.go:823 sessionsRestoreCmd"
+      },
+      "verdict": "parity",
+      "notes": "Reachable everywhere as of #1932, which closed the archive-only one-way door. The retained TUI and web actions send RestoreSession's stable id so a confirmation/background command cannot retarget a same-title replacement; the one-shot CLI deliberately keeps its repo-scoped title contract. RestoreSession also recovers Lost/Dead rows, giving every surface the same recovery off-ramp."
+    },
+    {
+      "id": "session.send-prompt",
+      "title": "Send a prompt to an existing session",
+      "tui": {
+        "status": "yes",
+        "pointer": "interactive mode types straight into the pane (app/interactive.go:147)"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/terminal.ts:225 onData + :233 attachCustomKeyEventHandler"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/sessions.go:346 sendPromptCmd"
+      },
+      "verdict": "parity",
+      "notes": "The TUI and web reach this by typing into the live terminal rather than via the SendPrompt RPC; same user capability, different transport. In the agent tab, the web maps bare Shift+Enter to LF/Ctrl+J for a multiline composer while plain Enter remains the submitting CR; shell/process tabs retain xterm's native Enter handling."
+    },
+    {
+      "id": "session.send-prompt.broadcast",
+      "title": "Broadcast one prompt to many sessions (--all/--all-repos)",
       "tui": {
         "status": "no",
         "pointer": ""
@@ -1304,28 +945,118 @@
       },
       "cli": {
         "status": "yes",
-        "pointer": "api/api.go:645 af tasks add/update --max-concurrent-runs"
+        "pointer": "api/api.go:594-596 --all/--all-repos/--include-root"
       },
-      "verdict": "unclear",
-      "notes": "A watch-task concurrency cap (task.Task/TaskUpdate.MaxConcurrentRuns) added on master. The CLI sets it via --max-concurrent-runs; the TUI task form and web do not expose it. Same class as the other task-edit gaps: the TUI can edit tasks (so this is a missing FIELD, #1935-adjacent) and the web cannot edit tasks at all (#1935). Niche enough that whether the UIs should surface it is an owner call. Not filed pending that."
+      "verdict": "deliberate",
+      "notes": "A fan-out scripting verb with no interactive analogue: broadcasting to every live session is a batch operation, and both UIs are single-selection by construction."
     },
     {
-      "id": "task.on-complete",
-      "title": "Declare what happens to a task run's session when it finishes",
+      "id": "session.tab.close",
+      "title": "Close a tab",
+      "tui": {
+        "status": "yes",
+        "pointer": "keys/keys.go:157 (w) -> app/handle_actions.go:869"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/api.ts:368 closeTab"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/sessions_tabs.go:129 tab-delete"
+      },
+      "verdict": "parity",
+      "notes": "The agent tab (index 0) is refused on every surface."
+    },
+    {
+      "id": "session.tab.create",
+      "title": "Spawn a shell/process tab in a session",
+      "tui": {
+        "status": "yes",
+        "pointer": "keys/keys.go KeyNewTab -> app/handle_tabs.go showNewTabPicker"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/api.ts:339 createTab (shell)"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/sessions_tabs.go:39 tab-create"
+      },
+      "verdict": "parity",
+      "notes": "All three gate off-box backends. The web keeps a visible explanation where the create control would be, while its close controls stay withdrawn; the TUI refuses before opening the picker. Both mirror the daemon's Capabilities().TabManagement."
+    },
+    {
+      "id": "session.tab.create.options",
+      "title": "Choose a new tab's command, name, or kind at create time",
+      "tui": {
+        "status": "partial",
+        "pointer": "app/handle_tabs.go showNewTabPicker chooses Terminal/VS Code; app/session_control.go sends Shell or Kind"
+      },
+      "web": {
+        "status": "partial",
+        "pointer": "web/src/api.ts:339,355 sets shell/kind but never command/name"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/sessions_tabs.go:112 sends Command, Name, Kind, URL, Port"
+      },
+      "verdict": "unclear",
+      "notes": "#2077 added the no-input kind choice (Terminal / VS Code) to `t`. The TUI still cannot name a tab or supply a process command; those input-bearing options remain CLI/API surface. Distinct from session.tab.create.web, which is a deliberate omission."
+    },
+    {
+      "id": "session.tab.create.shell",
+      "title": "Spawn a bare $SHELL tab with no command",
+      "tui": {
+        "status": "yes",
+        "pointer": "app/session_action_target.go:111 Shell:true"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/api.ts:563 shell:true"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/sessions_tabs.go:148 normalizes --kind shell to Shell:true"
+      },
+      "verdict": "parity",
+      "notes": "Closed by #2619: `shell` is the canonical explicit kind, and the CLI normalizes `--kind shell` to the same Shell:true request the TUI/web send. That reaches Manager.CreateTab's single AddShellTab path, so it is a real bare $SHELL tab (TabKindShell), not the different `--command $SHELL` process-tab workaround. `Terminal` remains the presentation-only UI label, consistent with the tab identifier rule."
+    },
+    {
+      "id": "session.tab.create.vscode",
+      "title": "Spawn a VS Code tab",
+      "tui": {
+        "status": "yes",
+        "pointer": "app/handle_tabs.go showNewTabPicker -> createNewTab(TabKindVSCode)"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/api.ts:355 createVSCodeTab"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/sessions_tabs.go:27 --kind vscode"
+      },
+      "verdict": "parity",
+      "notes": "Closed by #2077. The TUI creates Kind:vscode through the same daemon CreateTab RPC as `af sessions tab-create --kind vscode`; its pane shows the existing web-UI placeholder because a terminal cannot render the editor. The web exposes the choice from a labelled New tab menu."
+    },
+    {
+      "id": "session.tab.create.web",
+      "title": "Spawn a web tab (URL/port iframe)",
       "tui": {
         "status": "no",
         "pointer": ""
       },
       "web": {
         "status": "no",
-        "pointer": ""
+        "pointer": "web/src/ui.ts:41-43 NewTabKind deliberately excludes 'web'"
       },
       "cli": {
         "status": "yes",
-        "pointer": "api/api.go af tasks add/update --on-complete"
+        "pointer": "api/sessions_tabs.go:27-29 --kind web --url/--port"
       },
-      "verdict": "unclear",
-      "notes": "The spawned-session lifecycle verb (task.Task/TaskUpdate.OnComplete, #2595): keep/archive/kill applied when a run finishes. The CLI sets it via --on-complete; the TUI task form and web do not expose it. Exactly the task.max-concurrent-runs shape — the TUI can edit tasks so this is a missing FIELD (#1935-adjacent), and the web cannot edit tasks at all (#1935). Whether the UIs should surface it is the same owner call, so it is recorded here rather than filed. The DEFAULT (keep) is the historical behavior, so a surface that cannot set it still produces correct tasks — which is why this is a field gap and not a broken create."
+      "verdict": "deliberate",
+      "notes": "Documented in code: 'A web tab is deliberately absent: its target comes from whatever an agent is running, so it stays CLI/API-created' (web/src/ui.ts:41-43, docs/web.md). Both UIs RENDER existing web tabs; only creation is CLI/API-scoped."
     },
     {
       "id": "session.tab.rename",
@@ -1364,8 +1095,134 @@
       "notes": "#1904 added tab reorder to the CLI (tab-reorder --index) and web (ReorderTab, drag in the tab bar). No TUI affordance. Same owner call as session.tab.rename. Not filed."
     },
     {
-      "id": "quota.usage-report",
-      "title": "Report usage-limit status per agent CLI",
+      "id": "session.watch",
+      "title": "Block until a session goes idle, or until any session in the fleet changes state",
+      "tui": {
+        "status": "n/a",
+        "pointer": ""
+      },
+      "web": {
+        "status": "n/a",
+        "pointer": ""
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/sessions_watch.go sessionsWatchCmd; api/sessions_watch_fleet.go fleetWatcher"
+      },
+      "verdict": "deliberate",
+      "notes": "A blocking scripting primitive for automation. Both UIs show liveness continuously, so 'block until idle' is meaningless there — you just look. The fleet form (#3009, no title or --all) is edge-triggered and exists for an automated driver rather than a person: it returns when any session TRANSITIONS, which is not something a UI can offer by rendering state, so it stays CLI-only for the same reason."
+    },
+    {
+      "id": "session.whoami",
+      "title": "Identify the current session from inside it",
+      "tui": {
+        "status": "n/a",
+        "pointer": ""
+      },
+      "web": {
+        "status": "n/a",
+        "pointer": ""
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/sessions.go:911 sessionsWhoamiCmd"
+      },
+      "verdict": "deliberate",
+      "notes": "Only meaningful to an agent running INSIDE a session's shell. Neither UI runs inside a session."
+    },
+    {
+      "id": "task.add",
+      "title": "Add a task",
+      "tui": {
+        "status": "yes",
+        "pointer": "ui/task_pane.go:370 (n inside the tasks overlay)"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/tasks.ts:286-319 -> api.ts:409 addTask"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/tasks.go:121 tasksAddCmd"
+      },
+      "verdict": "parity",
+      "notes": ""
+    },
+    {
+      "id": "task.edit",
+      "title": "Edit an existing task's name/prompt/trigger/target/program",
+      "tui": {
+        "status": "yes",
+        "pointer": "ui/task_pane.go:362 (enter) -> ui/task_pane_edit.go form"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/tasks.ts editTaskModal (seeded from the task) -> web/src/index.ts openEditTask sends a field-level TaskUpdate patch via api.ts updateTask"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/tasks.go:270 tasksUpdateCmd (7 fields)"
+      },
+      "verdict": "parity",
+      "notes": "Closed by #1935: the Edit action opens the add-task form seeded from the task and submits the changed fields to UpdateTask. project_path is now in the web TS TaskUpdate (web/src/types.ts) and sent by the edit call site, so every field the create form collects is editable."
+    },
+    {
+      "id": "task.edit.project-path",
+      "title": "Change which project a task belongs to",
+      "tui": {
+        "status": "yes",
+        "pointer": "ui/task_pane_edit.go:135 edits ProjectPath; the patch is task.DiffTask over the edited task.Task (ui/task_pane_state.go:91)"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/tasks.ts editTaskModal project picker (seeded, editable) -> web/src/index.ts openEditTask sends update.project_path"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/api.go:722 --project-path -> api/tasks.go:576 patch.ProjectPath = strPtr(absPath) -> daemonUpdateTask"
+      },
+      "verdict": "parity",
+      "notes": "The web half was subsumed by #1935: its seeded project picker sends update.project_path. The CLI now sends the same TaskUpdate.ProjectPath patch with `af tasks update --project-path`; `--repo` remains the authorization scope for the task's current project, so `--repo old --project-path new` is unambiguous. This also supplies a repair path for the wrong-project automation incident in #1891 without duplicating the daemon's rebind and RepoID logic."
+    },
+    {
+      "id": "task.get",
+      "title": "Get one task's record",
+      "tui": {
+        "status": "n/a",
+        "pointer": ""
+      },
+      "web": {
+        "status": "n/a",
+        "pointer": ""
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/tasks.go:216 tasksGetCmd"
+      },
+      "verdict": "deliberate",
+      "notes": "Scripting read-verb; both UIs render the task list continuously."
+    },
+    {
+      "id": "task.list",
+      "title": "List tasks",
+      "tui": {
+        "status": "yes",
+        "pointer": "keys/keys.go:159 (m) -> app/handle_overlay.go:221"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/api.ts:391 listTasks"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/tasks.go:75 tasksListCmd"
+      },
+      "verdict": "parity",
+      "notes": ""
+    },
+    {
+      "id": "task.max-concurrent-runs",
+      "title": "Cap a watch task's in-flight session count",
       "tui": {
         "status": "no",
         "pointer": ""
@@ -1376,11 +1233,173 @@
       },
       "cli": {
         "status": "yes",
-        "pointer": "commands/quotacmd.go:29"
+        "pointer": "api/api.go:645 af tasks add/update --max-concurrent-runs"
+      },
+      "verdict": "unclear",
+      "notes": "A watch-task concurrency cap (task.Task/TaskUpdate.MaxConcurrentRuns) added on master. The CLI sets it via --max-concurrent-runs; the TUI task form and web do not expose it. Same class as the other task-edit gaps: the TUI can edit tasks (so this is a missing FIELD, #1935-adjacent) and the web cannot edit tasks at all (#1935). Niche enough that whether the UIs should surface it is an owner call. Not filed pending that."
+    },
+    {
+      "id": "task.on-complete",
+      "title": "Declare what happens to a task run's session when it finishes",
+      "tui": {
+        "status": "no",
+        "pointer": ""
+      },
+      "web": {
+        "status": "no",
+        "pointer": ""
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/api.go af tasks add/update --on-complete"
+      },
+      "verdict": "unclear",
+      "notes": "The spawned-session lifecycle verb (task.Task/TaskUpdate.OnComplete, #2595): keep/archive/kill applied when a run finishes. The CLI sets it via --on-complete; the TUI task form and web do not expose it. Exactly the task.max-concurrent-runs shape — the TUI can edit tasks so this is a missing FIELD (#1935-adjacent), and the web cannot edit tasks at all (#1935). Whether the UIs should surface it is the same owner call, so it is recorded here rather than filed. The DEFAULT (keep) is the historical behavior, so a surface that cannot set it still produces correct tasks — which is why this is a field gap and not a broken create."
+    },
+    {
+      "id": "task.remove",
+      "title": "Remove a task",
+      "tui": {
+        "status": "yes",
+        "pointer": "ui/task_pane.go:359 (D)"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/api.ts:436 removeTask"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/tasks.go:196 tasksRemoveCmd"
+      },
+      "verdict": "parity",
+      "notes": ""
+    },
+    {
+      "id": "task.restart",
+      "title": "Restart an enabled watch task after editing its script",
+      "tui": {
+        "status": "no",
+        "pointer": ""
+      },
+      "web": {
+        "status": "no",
+        "pointer": ""
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/tasks.go:368 tasksRestartCmd"
+      },
+      "verdict": "deliberate",
+      "notes": "This is an operator workflow after editing an external script file, which neither UI owns. Both task UIs already expose the enabled toggle; its daemon update is synchronous and therefore remains a safe manual cycle. The dedicated one-command restart belongs in the scripting CLI."
+    },
+    {
+      "id": "task.toggle",
+      "title": "Enable / disable a task",
+      "tui": {
+        "status": "yes",
+        "pointer": "ui/task_pane.go:356 (x)"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/index.ts:854-865 toggleTask"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/api.go:649 --enabled"
+      },
+      "verdict": "parity",
+      "notes": ""
+    },
+    {
+      "id": "task.trigger",
+      "title": "Trigger a task now",
+      "tui": {
+        "status": "yes",
+        "pointer": "ui/task_pane.go:367-369 (r)"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/api.ts:429 triggerTask"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/tasks.go:237 tasksRunCmd"
+      },
+      "verdict": "parity",
+      "notes": "All three refuse watch-backed tasks; the web additionally hides the button (web/src/tasks.ts:92-94)."
+    },
+    {
+      "id": "tui.navigation",
+      "title": "Move around the TUI (cursor, focus, sections, scroll, search, help, quit)",
+      "tui": {
+        "status": "yes",
+        "pointer": "keys/keys.go:136-176 (up/down/collapse/expand/focus/sections/scroll/search/help/quit)"
+      },
+      "web": {
+        "status": "partial",
+        "pointer": "web/src/nav.ts:109-200 (its own j/k, [/], 1-9, Enter, Esc, Alt+j/k/w)"
+      },
+      "cli": {
+        "status": "n/a",
+        "pointer": ""
+      },
+      "verdict": "deliberate",
+      "notes": "Navigation is per-surface chrome, not a product capability: each UI navigates its own layout idiomatically and a CLI has nothing to navigate. Deliberately NOT held to key-for-key parity — see docs/surface-parity.md."
+    },
+    {
+      "id": "tui.panes",
+      "title": "Open / split / hide / focus workspace panes",
+      "tui": {
+        "status": "yes",
+        "pointer": "keys/keys.go:163-167 (s, S, x, left/right)"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/split.ts (drag-to-split, divider resize, Alt+j/k/w)"
+      },
+      "cli": {
+        "status": "n/a",
+        "pointer": ""
+      },
+      "verdict": "deliberate",
+      "notes": "Both UIs have a pane workspace with surface-idiomatic gestures (the web adds mouse drag-and-drop the TUI cannot express; the TUI has keyboard splits the web reaches via Alt-chords). Layout is client-local and never hits the daemon."
+    },
+    {
+      "id": "wire.id-addressing",
+      "title": "Address a session by its stable id rather than by title",
+      "tui": {
+        "status": "partial",
+        "pointer": "app/session_action_target.go captures stable identity and constructs kill/archive/restore/limit/handoff/tab requests; retained handlers resolve completions by that identity"
+      },
+      "web": {
+        "status": "yes",
+        "pointer": "web/src/api.ts:281 et al send id"
+      },
+      "cli": {
+        "status": "no",
+        "pointer": "api/sessions.go:733 et al send {Title, RepoID}"
       },
       "verdict": "real-gap",
-      "issue": "#2983",
-      "notes": "#2983 Part 1 ships the CLI only; the issue also asks for a TUI/web panel, so tui and web are a real GAP rather than n/a and are recorded as such. The report keeps provider ENTITLEMENT (always \"not reported\" — no supported agent exposes a quota surface af can read) apart from af's own OBSERVATION of sessions parked at a usage wall, so a surface that renders it must preserve that separation: a blank or zero quota cell reads as exhausted, which is the failure the command exists to avoid."
+      "issue": "#2358",
+      "notes": "#2322 disproved the old blanket 'repo-scoped title is enough' rationale for an action that survives a modal or async command: a killed/recreated row can reuse the title while the user's intent still names the prior stable session. Handoff, kill, archive, restore, usage-limit retry, and tab create/close now carry captured identity through retained boundaries and daemon dispatch; close also sends the stable tab ID when the projection has adopted one. Requests whose wire type still lacks a session ID remain for action-by-action audit; the CLI remains deliberately repo+title scoped because each invocation resolves and dispatches one command without retained UI intent."
+    },
+    {
+      "id": "worktree.hooks.edit",
+      "title": "Edit a repo's post-worktree hooks",
+      "tui": {
+        "status": "yes",
+        "pointer": "keys/keys.go:171 (e) -> app/handle_overlay.go:291"
+      },
+      "web": {
+        "status": "no",
+        "pointer": ""
+      },
+      "cli": {
+        "status": "no",
+        "pointer": ""
+      },
+      "verdict": "unclear",
+      "notes": "TUI-only editor over in-repo config. Same question as config.write: is editing repo config a UI concern at all?"
     }
   ],
   "ledger": {
@@ -1392,6 +1411,8 @@
     ],
     "cli_verbs": {
       "af": "meta.discovery",
+      "af accounts add": "session.accounts",
+      "af accounts list": "session.accounts",
       "af agent-server": "meta.internal",
       "af api": "meta.discovery",
       "af bug-report": "install.bug-report",
@@ -1575,6 +1596,11 @@
       "af --token": "daemon.remote-access",
       "af --upgrade-transaction": "meta.internal",
       "af --version": "meta.discovery",
+      "af accounts --help": "meta.discovery",
+      "af accounts add --help": "meta.discovery",
+      "af accounts add --json": "cli.json-envelope",
+      "af accounts list --help": "meta.discovery",
+      "af accounts list --json": "cli.json-envelope",
       "af agent-server --help": "meta.discovery",
       "af agent-server --listen": "meta.internal",
       "af agent-server --program": "meta.internal",


### PR DESCRIPTION
## What

The registration half of #3051: the account **registry** (`internal/agentaccount`) and the CLI that reaches it (`af accounts add` / `af accounts list`).

#3022 shipped the credential boundary (`sessionenv.ApplyAccount` — inject the account's config root, subtract every other identity-bearing variable) and **nothing called it**. The mechanism has been live since v1.0.223 with no way to create an account, let alone select one. This fills the first half of that gap.

## An account is a directory, not a secret

`af` never reads, stores, or forwards credential material. An account is a directory the agent CLI treats as its home; the agent's own login flow puts the material there, and `af` decides only which directory a session sees.

```
af accounts add codex work
CODEX_HOME=$(af accounts add codex work) codex login
```

`add` prints the bare path on stdout so it substitutes directly into that invocation, with guidance on stderr so capturing it still works. A provider rotating its token format costs this code nothing.

## Design points worth review

- **`Selected` refuses an unregistered name** rather than creating on demand. An empty agent home reads as simply "not logged in" to both CLIs, so a typo'd `--account` would launch a session that silently fails to authenticate. The error names the command that fixes it.
- **`Dir` refuses an unverified agent.** `gemini` and `amp` are absent because allowlist membership is not evidence that a variable relocates credentials, and neither CLI was available to test. Unsupported is the honest answer.
- **`List` treats a missing directory as empty, not an error** — otherwise `af accounts list` fails on a fresh install.
- **`Register` chmods explicitly.** `MkdirAll` honours the umask, so 0700 under a 022 umask would not have happened by itself.

## Tests prove exclusivity, not presence

Per the constraint on #3051: two accounts resolve to different `CODEX_HOME` values, neither scope names the other's directory, and an ambient `OPENAI_API_KEY` does not survive into either.

**Verified by mutation.** Emptying the subtraction set in `ApplyAccount` fails `TestSelected_TwoAccountsSeeDifferentDirectories` on the different-roots assertion — so that test is load-bearing rather than merely green. (A first mutation attempt hit `refused`, the *command* guard, and passed; the subtraction is `denied`, and that one fails.)

## Parity

`session.accounts` is recorded as **real-gap against #3051**, `cli=partial`, both UIs `no` — not as parity. Selecting an account for a session and surfacing it in the TUI/web are the remaining slices; recording it as done here is exactly the drift `parity/` exists to catch.

## `--json` is decided by pflag, not by a copy of pflag

A flag-parse failure routes through the shared `{data,error}` envelope, so an automation caller can parse the one failure it is most likely to hit: a mistyped flag. Three review rounds hand-rolled an argv scanner to recover the caller's JSON intent, on the stated premise that a parse failure leaves the bound variable unset.

**That premise is false.** pflag calls `Value.Set` as it walks argv, so by the time cobra reaches `SetFlagErrorFunc` the bound variable already reflects every occurrence *preceding* the failure — every spelling, repeats with last-one-wins, and the `--` terminator. Measured against the pinned cobra v1.9.1 / pflag v1.0.6:

```
--json --bogus                          parseErr=true   bound=true
codex work --json --bogus               parseErr=true   bound=true
codex work --json --bogus --json=false  parseErr=true   bound=true
--json=1 --bogus                        parseErr=true   bound=true
--json=false --json=true --bogus        parseErr=true   bound=true
--bogus --json                          parseErr=true   bound=false
a b -- --json                           parseErr=false  bound=false
--json=zzz                              parseErr=true   bound=false
```

The scanner's only remaining contribution was a `--json` occurring *after* the failure point — which is precisely the case that must not count. So it is deleted rather than patched: `accountsFlagError` now reads the bound flag. Each of the three revisions fixed one way the scan diverged from pflag; the class is the defect, not the instances.

### Three deliberate behaviour narrowings

All are user-visible, all are one rule — **JSON mode is on if and only if pflag successfully set the flag before failing** — and all three are pinned by tests:

| Invocation | Before | Now | Why |
|---|---|---|---|
| `--bogus --json` | JSON envelope | human text | the parse failed before reaching `--json`; pflag never accepted it |
| `--json=zzz` | JSON envelope | human text | pflag rejects the value, so the command was never in JSON mode |
| `af accounts --json` | JSON envelope | human text | the `accounts` group binds no `--json`; the parse fails on the flag itself |

Neither is a regression against this PR's motivating case — `af accounts add x y --json` plus a *different* bad flag, the realistic automation failure — which still yields the envelope because the bound flag is true (rows 2 and 3 above).

## The CLI now has a test file

`commands/accountscmd_test.go` is new. There was none while this logic was rewritten three times by review. It drives the real cobra command and covers the motivating case, the repro above, all three narrowings, the `--` terminator as an operand, the argument-count error under `--json`, and the success envelope.

The harness sets `os.Args` to the argv a real shell would hand `af`, because the deleted scanner read the **process** argv rather than the args cobra parsed — under `go test` it could never see a `SetArgs` value, so every case would otherwise have passed for the wrong reason. That coupling is why this logic went ten review rounds with no coverage.

**Watched fail against `25aa702a` first**, in a scratch worktree with this test file copied in: the repro (`add codex work --json --bogus --json=false`) and all three narrowings above. The motivating case, terminator, argument-count, list and success cases pass on both sides — they are the behaviour this change preserves.

## Help text no longer promises unwired behaviour

`af accounts --help` said, in the present tense, that selecting an account injects its directory and removes every competing identity variable. Nothing consumes the registry: `agentaccount.Selected` and `Resolve` have no non-test callers, and neither does `sessionenv.ApplyAccount`. A user reading that help in the release which ships it would reasonably conclude an af-launched session is already identity-scoped — a security-shaped promise that reads as kept.

Selection is now marked as not yet available, pointing at the tracking issue. The paragraph explaining why the removal half matters stays — it is true and it is the reason selection is worth doing — in the future tense that matches reality. `docs/reference/cli.md` is generated from that `Long` and is regenerated in the same commit.

## Parity pointers lose their line numbers

`accountscmd.go:67`/`:148` had rotted for the third time in this PR. They are now symbol-only (`accountsAddCmd`/`accountsListCmd`), which is already the convention for 66 of the 189 Go-file references in that file. Nothing in `parity/*_test.go` validates pointer accuracy, which is why they rot silently — so the fix is to stop encoding a number no one checks, not to add a linter for it.

## Verification

`gofmt -l .` empty · `go build ./...` · `golangci-lint run --fast` · `scripts/lint-file-length.sh` · `go test ./internal/agentaccount/ ./internal/sessionenv/ ./parity/` and `go test ./commands/ -run 'TestAccounts'` all green. Generated docs regenerated via `scripts/gen-docs.sh`.

Drove the built binary against an isolated `AGENT_FACTORY_HOME`: fresh-home list, add, idempotent re-add, cross-agent list, `--json` envelope, 0700 on the created directory, and refusal of both an unsupported agent and a `../../etc` traversal name.

> Note: `commands` has two **pre-existing** failures on this box (`TestConfigGetReadsEveryEntry/default_program`, `TestConfigGetScalarBare`). They read the maintainer's real `~/.agent-factory/config.toml`, which sets `default_program = 'codex'`, because the test does not isolate `AGENT_FACTORY_HOME`. Unrelated to this change; filed separately.

## What this does NOT do

`--account` on session create, the config keys, and the launch wiring are **not** here — #3051 stays open for them. See the review note below about the tmux 3.2 constraint, which the delivery path changes.

Refs #3051

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
