### PR TITLE
fix(session): gate tabs on what the KIND needs, not on whether the session is off-box

### DIFF
--- a/daemon/close_tab_test.go
+++ b/daemon/close_tab_test.go
@@ -382,7 +382,7 @@ func TestCloseTab_RejectsUnknownTab(t *testing.T) {
 
 // TestCloseTab_RejectsRemoteInstance verifies remote sessions' tabs (fixed by
 // their hook config) cannot be closed, mirroring the TUI's `w` rule.
-func TestCloseTab_RejectsRemoteInstance(t *testing.T) {
+func TestCloseTab_MetadataTabRoundTripsOnRemoteInstance(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
 	repoPath := setupControlRepo(t)
 	repo, err := config.RepoFromPath(repoPath)
@@ -406,8 +406,17 @@ func TestCloseTab_RejectsRemoteInstance(t *testing.T) {
 	manager.instances[daemonInstanceKey(repo.ID, "rem")] = inst
 	manager.mu.Unlock()
 
-	_, err = manager.CloseTab(CloseTabRequest{Title: "rem", RepoID: repo.ID, TabName: "shell"})
-	assertTabRejection(t, err, "fixed by its runtime")
+	// #3053: the blanket "its tab list is fixed by its runtime" gate is gone,
+	// because that stopped being true once a metadata tab could exist here. A web
+	// tab you can create but cannot close would be worse than one you cannot
+	// create, so the round trip is the contract being pinned.
+	created, err := manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Kind: "web", URL: "http://localhost:3000"})
+	if err != nil {
+		t.Fatalf("creating a web tab on an off-box session must succeed (#3053): %v", err)
+	}
+	if _, err := manager.CloseTab(CloseTabRequest{Title: "rem", RepoID: repo.ID, TabName: created.Name}); err != nil {
+		t.Fatalf("closing a web tab on an off-box session must succeed, got: %v", err)
+	}
 }
 
 func closeBlockingTabExec(alive map[string]bool, blockedKillName string, killStarted chan<- struct{}, releaseKill <-chan struct{}) (cmd_test.MockCmdExec, func(string) bool) {

--- a/daemon/close_tab_test.go
+++ b/daemon/close_tab_test.go
@@ -382,7 +382,7 @@ func TestCloseTab_RejectsUnknownTab(t *testing.T) {
 
 // TestCloseTab_RejectsRemoteInstance verifies remote sessions' tabs (fixed by
 // their hook config) cannot be closed, mirroring the TUI's `w` rule.
-func TestCloseTab_MetadataTabRoundTripsOnRemoteInstance(t *testing.T) {
+func TestCloseTab_RejectsRemoteInstance(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
 	repoPath := setupControlRepo(t)
 	repo, err := config.RepoFromPath(repoPath)
@@ -406,17 +406,11 @@ func TestCloseTab_MetadataTabRoundTripsOnRemoteInstance(t *testing.T) {
 	manager.instances[daemonInstanceKey(repo.ID, "rem")] = inst
 	manager.mu.Unlock()
 
-	// #3053: the blanket "its tab list is fixed by its runtime" gate is gone,
-	// because that stopped being true once a metadata tab could exist here. A web
-	// tab you can create but cannot close would be worse than one you cannot
-	// create, so the round trip is the contract being pinned.
-	created, err := manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Kind: "web", URL: "http://localhost:3000"})
-	if err != nil {
-		t.Fatalf("creating a web tab on an off-box session must succeed (#3053): %v", err)
-	}
-	if _, err := manager.CloseTab(CloseTabRequest{Title: "rem", RepoID: repo.ID, TabName: created.Name}); err != nil {
-		t.Fatalf("closing a web tab on an off-box session must succeed, got: %v", err)
-	}
+	// The session-level gate stands: no user-managed tab can exist on an off-box
+	// session yet, because RefuseTabKind admits none of the four kinds there
+	// (#3053 classified them; #3062 is what would admit the first one).
+	_, err = manager.CloseTab(CloseTabRequest{Title: "rem", RepoID: repo.ID, TabName: "shell"})
+	assertTabRejection(t, err, "fixed by its runtime")
 }
 
 func closeBlockingTabExec(alive map[string]bool, blockedKillName string, killStarted chan<- struct{}, releaseKill <-chan struct{}) (cmd_test.MockCmdExec, func(string) bool) {

--- a/daemon/create_tab_test.go
+++ b/daemon/create_tab_test.go
@@ -198,7 +198,11 @@ func TestCreateTab_RejectsRemoteInstance(t *testing.T) {
 	manager.mu.Unlock()
 
 	_, err = manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Command: "btop"})
-	assertTabRejection(t, err, "only local sessions support user-managed tabs")
+	// The message names the SPAWN, which is what a process tab actually needs and
+	// cannot have off-box (#3053). The old blanket wording ("only local sessions
+	// support user-managed tabs") was also used to refuse tabs that spawn
+	// nothing, so it could not tell the two apart.
+	assertTabRejection(t, err, "no local worktree to spawn it in")
 }
 
 // TestCreateTab_SpawnsPersistsAndReturnsName is the headline daemon test: a
@@ -414,5 +418,5 @@ func TestCreateTab_ShellRejectsRemoteInstance(t *testing.T) {
 	manager.mu.Unlock()
 
 	_, err = manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Shell: true})
-	assertTabRejection(t, err, "only local sessions support user-managed tabs")
+	assertTabRejection(t, err, "no local worktree to spawn it in")
 }

--- a/daemon/create_tab_web_test.go
+++ b/daemon/create_tab_web_test.go
@@ -171,18 +171,20 @@ func TestCreateTab_WebRejectsRemoteInstance(t *testing.T) {
 	manager.instances[daemonInstanceKey(repo.ID, "rem")] = inst
 	manager.mu.Unlock()
 
-	// #3053 INVERTED this. A web tab is a name and a URL: it spawns nothing and
-	// reads nothing, so an off-box workspace is not a reason to refuse it. It was
-	// previously turned away by the single TabManagement bit, whose stated reason
-	// — no local worktree to spawn in — is a requirement a web tab does not have.
-	resp, err := manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Kind: "web", URL: "http://localhost:3000"})
-	if err != nil {
-		t.Fatalf("a web tab must be accepted on an off-box session (#3053), got: %v", err)
+	// Still refused off-box, but #3053 changed WHY, and the why is the contract.
+	// The old refusal said there was no local worktree to spawn the tab in — a
+	// requirement a web tab does not have, which made it indistinguishable from a
+	// shell tab's refusal. What actually blocks it is serving: a loopback target
+	// would be proxied from the daemon host rather than the workspace, and a
+	// persisted web tab is not restored on the sandbox path (#3062).
+	_, err = manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Kind: "web", URL: "http://localhost:3000"})
+	if err == nil {
+		t.Fatal("expected error for remote instance, got nil")
 	}
-	if resp.Name == "" {
-		t.Fatal("expected the created web tab's resolved name")
+	if strings.Contains(err.Error(), "spawn") {
+		t.Fatalf("a web tab spawns nothing; refusing it for a spawn is the #3053 defect: %v", err)
 	}
-	if resp.TmuxName != "" {
-		t.Fatalf("a web tab owns no PTY, so it must report no tmux session, got %q", resp.TmuxName)
+	if !strings.Contains(err.Error(), "3062") {
+		t.Fatalf("the refusal must point at the work that lifts it (#3062), got: %v", err)
 	}
 }

--- a/daemon/create_tab_web_test.go
+++ b/daemon/create_tab_web_test.go
@@ -171,11 +171,18 @@ func TestCreateTab_WebRejectsRemoteInstance(t *testing.T) {
 	manager.instances[daemonInstanceKey(repo.ID, "rem")] = inst
 	manager.mu.Unlock()
 
-	_, err = manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Kind: "web", URL: "http://localhost:3000"})
-	if err == nil {
-		t.Fatal("expected error for remote instance, got nil")
+	// #3053 INVERTED this. A web tab is a name and a URL: it spawns nothing and
+	// reads nothing, so an off-box workspace is not a reason to refuse it. It was
+	// previously turned away by the single TabManagement bit, whose stated reason
+	// — no local worktree to spawn in — is a requirement a web tab does not have.
+	resp, err := manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Kind: "web", URL: "http://localhost:3000"})
+	if err != nil {
+		t.Fatalf("a web tab must be accepted on an off-box session (#3053), got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "remote") {
-		t.Fatalf("expected remote-rejection error, got: %v", err)
+	if resp.Name == "" {
+		t.Fatal("expected the created web tab's resolved name")
+	}
+	if resp.TmuxName != "" {
+		t.Fatalf("a web tab owns no PTY, so it must report no tmux session, got %q", resp.TmuxName)
 	}
 }

--- a/daemon/manager_tabs.go
+++ b/daemon/manager_tabs.go
@@ -109,11 +109,26 @@ func (m *Manager) CreateTab(req CreateTabRequest) (CreateTabResponse, error) {
 	if instance == nil {
 		return CreateTabResponse{}, fmt.Errorf("failed to restore instance %q", title)
 	}
-	// The message names the real reason rather than the old
+	// Ask what THIS KIND needs, not whether the session is off-box (#3053). The
+	// blanket form refused all four kinds and explained every refusal as a
+	// missing worktree, so a web tab — a name and a URL, spawning nothing — was
+	// turned away for a requirement it does not have. RefuseTabKind names the
+	// requirement that is actually unmet, or admits the tab.
+	//
+	// The message still names the real reason rather than the old
 	// remote_hooks.terminal_cmd knob, which #1592 Phase 4 PR7 deleted — pointing a
 	// user at a setting that no longer exists is worse than no advice (#1874).
-	if !instance.Capabilities().TabManagement {
-		return CreateTabResponse{}, fmt.Errorf("cannot create a tab on session %q: only local sessions support user-managed tabs — this session's workspace runs off-box (docker/ssh/remote), so there is no local worktree to spawn a tab in", title)
+	effectiveKind := session.TabKindProcess
+	switch {
+	case isWeb:
+		effectiveKind = session.TabKindWeb
+	case isVSCode:
+		effectiveKind = session.TabKindVSCode
+	case isShell:
+		effectiveKind = session.TabKindShell
+	}
+	if err := instance.Capabilities().RefuseTabKind(effectiveKind); err != nil {
+		return CreateTabResponse{}, fmt.Errorf("cannot create a tab on session %q: %w", title, err)
 	}
 
 	// Serialize the tab spawn against an archive/kill/restore teardown+move for

--- a/daemon/manager_tabs.go
+++ b/daemon/manager_tabs.go
@@ -127,7 +127,7 @@ func (m *Manager) CreateTab(req CreateTabRequest) (CreateTabResponse, error) {
 	case isShell:
 		effectiveKind = session.TabKindShell
 	}
-	if err := instance.Capabilities().RefuseTabKind(effectiveKind); err != nil {
+	if err := instance.Capabilities().RefuseTabKind(effectiveKind, webURL); err != nil {
 		return CreateTabResponse{}, fmt.Errorf("cannot create a tab on session %q: %w", title, err)
 	}
 

--- a/daemon/manager_tabs_arrange.go
+++ b/daemon/manager_tabs_arrange.go
@@ -88,9 +88,15 @@ func (m *Manager) tabMutationTarget(reqID, reqTitle, reqRepoID string, labels ta
 	if instance == nil {
 		return nil, "", "", nil, fmt.Errorf("failed to restore instance %q", title)
 	}
-	if !instance.Capabilities().TabManagement {
-		return nil, "", "", nil, fmt.Errorf("cannot %s on session %q: its tab list is fixed by its runtime, not user-managed — this session's workspace runs off-box (docker/ssh/remote)", labels.action, title)
-	}
+	// No blanket capability gate here any more (#3053). It said the roster was
+	// "fixed by its runtime", which stopped being true once metadata-only tabs
+	// could be created on any backend — a web tab you cannot close or rename is
+	// worse than one you cannot create. Every protection this gate was standing
+	// in for is per-TAB and still applies below: the agent tab is pinned to slot
+	// 0 (it cannot be closed or moved, and nothing may be moved in front of it),
+	// and TabKindRenameable refuses a rename that no surface would render. A
+	// process-backed tab cannot exist on an off-box session to begin with,
+	// because RefuseTabKind never admits one.
 	// Fast path only: reject an already-archived session without making the caller
 	// wait on the op-lock. The authoritative check is the post-lock one below.
 	if instance.IsArchived() {

--- a/daemon/manager_tabs_arrange.go
+++ b/daemon/manager_tabs_arrange.go
@@ -88,15 +88,15 @@ func (m *Manager) tabMutationTarget(reqID, reqTitle, reqRepoID string, labels ta
 	if instance == nil {
 		return nil, "", "", nil, fmt.Errorf("failed to restore instance %q", title)
 	}
-	// No blanket capability gate here any more (#3053). It said the roster was
-	// "fixed by its runtime", which stopped being true once metadata-only tabs
-	// could be created on any backend — a web tab you cannot close or rename is
-	// worse than one you cannot create. Every protection this gate was standing
-	// in for is per-TAB and still applies below: the agent tab is pinned to slot
-	// 0 (it cannot be closed or moved, and nothing may be moved in front of it),
-	// and TabKindRenameable refuses a rename that no surface would render. A
-	// process-backed tab cannot exist on an off-box session to begin with,
-	// because RefuseTabKind never admits one.
+	// Still a session-level gate: no user-managed tab can exist on an off-box
+	// session today, because RefuseTabKind admits none of the four kinds there
+	// (#3053) — process tabs need a worktree to spawn in, a vscode tab needs one
+	// to read, and a web tab cannot be SERVED off-box yet (#3062). Relaxing this
+	// belongs with the change that admits the first such tab, not before it:
+	// until then it would be a path nothing can reach.
+	if !instance.Capabilities().TabManagement {
+		return nil, "", "", nil, fmt.Errorf("cannot %s on session %q: its tab list is fixed by its runtime, not user-managed — this session's workspace runs off-box (docker/ssh/remote)", labels.action, title)
+	}
 	// Fast path only: reject an already-archived session without making the caller
 	// wait on the op-lock. The authoritative check is the post-lock one below.
 	if instance.IsArchived() {

--- a/daemon/tab_arrange_test.go
+++ b/daemon/tab_arrange_test.go
@@ -269,7 +269,7 @@ func TestArrangeTab_RejectsArchivedSession(t *testing.T) {
 // TestArrangeTab_RejectsRemoteInstance: a remote session's tabs come from its
 // remote_hooks config, not from user edits, so neither verb applies — mirroring
 // CreateTab/CloseTab and the TUI's rules.
-func TestArrangeTab_MetadataTabArrangesOnRemoteInstance(t *testing.T) {
+func TestArrangeTab_RejectsRemoteInstance(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	repoPath := setupControlRepo(t)
 	repo, err := config.RepoFromPath(repoPath)
@@ -293,26 +293,16 @@ func TestArrangeTab_MetadataTabArrangesOnRemoteInstance(t *testing.T) {
 	manager.instances[daemonInstanceKey(repo.ID, title)] = inst
 	manager.mu.Unlock()
 
-	// #3053 removed the blanket remote gate here: it claimed the roster was
-	// "fixed by its runtime", which stops being true once a metadata tab can be
-	// created on any backend. What replaced it is per-TAB, and that is what this
-	// now pins — a web tab arranges like any other, and the agent tab stays
-	// pinned to slot 0.
-	created, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:3000"})
-	if err != nil {
-		t.Fatalf("creating a web tab on an off-box session must succeed (#3053): %v", err)
+	if _, err := manager.RenameTab(RenameTabRequest{Title: title, RepoID: repo.ID, TabName: "shell", NewName: "editor"}); err == nil {
+		t.Fatal("expected a remote rejection for rename, got nil")
+	} else if !strings.Contains(err.Error(), "remote") {
+		t.Fatalf("expected a remote-rejection error, got: %v", err)
 	}
 
-	if _, err := manager.RenameTab(RenameTabRequest{Title: title, RepoID: repo.ID, TabName: created.Name, NewName: "editor"}); err != nil {
-		t.Fatalf("renaming a web tab on an off-box session must succeed, got: %v", err)
-	}
-
-	// The protection the blanket gate was standing in for: slot 0 is the agent
-	// tab, and nothing may be moved in front of it.
-	if _, _, err := manager.ReorderTab(ReorderTabRequest{Title: title, RepoID: repo.ID, TabName: "editor", NewIndex: 0}); err == nil {
-		t.Fatal("expected slot 0 to stay reserved for the agent tab, got nil")
-	} else if !strings.Contains(err.Error(), "agent tab") {
-		t.Fatalf("expected the refusal to name the agent tab, got: %v", err)
+	if _, _, err := manager.ReorderTab(ReorderTabRequest{Title: title, RepoID: repo.ID, TabName: "shell", NewIndex: 1}); err == nil {
+		t.Fatal("expected a remote rejection for reorder, got nil")
+	} else if !strings.Contains(err.Error(), "remote") {
+		t.Fatalf("expected a remote-rejection error, got: %v", err)
 	}
 }
 

--- a/daemon/tab_arrange_test.go
+++ b/daemon/tab_arrange_test.go
@@ -269,7 +269,7 @@ func TestArrangeTab_RejectsArchivedSession(t *testing.T) {
 // TestArrangeTab_RejectsRemoteInstance: a remote session's tabs come from its
 // remote_hooks config, not from user edits, so neither verb applies — mirroring
 // CreateTab/CloseTab and the TUI's rules.
-func TestArrangeTab_RejectsRemoteInstance(t *testing.T) {
+func TestArrangeTab_MetadataTabArrangesOnRemoteInstance(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	repoPath := setupControlRepo(t)
 	repo, err := config.RepoFromPath(repoPath)
@@ -293,16 +293,26 @@ func TestArrangeTab_RejectsRemoteInstance(t *testing.T) {
 	manager.instances[daemonInstanceKey(repo.ID, title)] = inst
 	manager.mu.Unlock()
 
-	if _, err := manager.RenameTab(RenameTabRequest{Title: title, RepoID: repo.ID, TabName: "shell", NewName: "editor"}); err == nil {
-		t.Fatal("expected a remote rejection for rename, got nil")
-	} else if !strings.Contains(err.Error(), "remote") {
-		t.Fatalf("expected a remote-rejection error, got: %v", err)
+	// #3053 removed the blanket remote gate here: it claimed the roster was
+	// "fixed by its runtime", which stops being true once a metadata tab can be
+	// created on any backend. What replaced it is per-TAB, and that is what this
+	// now pins — a web tab arranges like any other, and the agent tab stays
+	// pinned to slot 0.
+	created, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:3000"})
+	if err != nil {
+		t.Fatalf("creating a web tab on an off-box session must succeed (#3053): %v", err)
 	}
 
-	if _, _, err := manager.ReorderTab(ReorderTabRequest{Title: title, RepoID: repo.ID, TabName: "shell", NewIndex: 1}); err == nil {
-		t.Fatal("expected a remote rejection for reorder, got nil")
-	} else if !strings.Contains(err.Error(), "remote") {
-		t.Fatalf("expected a remote-rejection error, got: %v", err)
+	if _, err := manager.RenameTab(RenameTabRequest{Title: title, RepoID: repo.ID, TabName: created.Name, NewName: "editor"}); err != nil {
+		t.Fatalf("renaming a web tab on an off-box session must succeed, got: %v", err)
+	}
+
+	// The protection the blanket gate was standing in for: slot 0 is the agent
+	// tab, and nothing may be moved in front of it.
+	if _, _, err := manager.ReorderTab(ReorderTabRequest{Title: title, RepoID: repo.ID, TabName: "editor", NewIndex: 0}); err == nil {
+		t.Fatal("expected slot 0 to stay reserved for the agent tab, got nil")
+	} else if !strings.Contains(err.Error(), "agent tab") {
+		t.Fatalf("expected the refusal to name the agent tab, got: %v", err)
 	}
 }
 

--- a/session/backend.go
+++ b/session/backend.go
@@ -68,30 +68,34 @@ type Capabilities struct {
 // the old form refused every kind on off-box sessions and explained each refusal
 // as a missing worktree, which is untrue of a tab that spawns nothing.
 //
+// target is the web tab's resolved URL and is ignored for every other kind. It
+// is a parameter because a web tab's blockers depend on WHERE it points: only a
+// loopback target is reverse-proxied, so only a loopback target is affected by
+// the daemon-host routing gap. Naming that blocker for an external URL would
+// state a requirement the caller's tab does not have — the exact defect this
+// function exists to remove, one level down.
+//
 // Each refusal names the requirement that is actually unmet, because a user told
-// "not supported on this backend" for a tab kind that could work cannot tell
-// that from one that genuinely cannot.
-func (c Capabilities) RefuseTabKind(kind TabKind) error {
+// "not supported on this backend" cannot tell that from a kind that could work.
+func (c Capabilities) RefuseTabKind(kind TabKind, target string) error {
 	switch TabKindRequires(kind) {
 	case TabNeedsMetadataOnly:
 		// A web tab spawns nothing and reads nothing, so the KIND needs nothing
-		// from the workspace — but the daemon cannot yet SERVE one off-box, and
-		// that is a different question from what the kind requires. Two reasons,
-		// both measured (#3062): a loopback target is proxied over the daemon's
-		// own TCP stack, so `--port 3000` reaches the daemon host rather than the
-		// workspace and can surface an unrelated daemon-local service; and
-		// FromInstanceData restores tabs only on its local branch, so a persisted
-		// web tab disappears at the next daemon restart.
-		//
-		// This is deliberately NOT the old blanket refusal wearing new words. The
-		// old one claimed there was no worktree to spawn in, which is not a
-		// requirement a web tab has; this one names what is actually missing, and
-		// it is the only kind whose refusal will lift without new worktree
-		// semantics.
-		if c.Workspace != WorkspaceLocalWorktree {
-			return fmt.Errorf("this session cannot open a web tab yet: its target would be proxied from the daemon host rather than from the session's off-box workspace, and a persisted web tab is not restored on the sandbox recovery path — see #3062")
+		// from the workspace. What the daemon cannot yet do is SERVE one off-box,
+		// and that is a different question with two different answers (#3062).
+		if c.Workspace == WorkspaceLocalWorktree {
+			return nil
 		}
-		return nil
+		// True of every off-box web tab: the sandbox branch of FromInstanceData
+		// rebuilds an inert backend with an empty roster, so the persisted row
+		// does not come back.
+		const notRestored = "a persisted web tab is not restored on the sandbox recovery path"
+		if IsLoopbackWebTarget(target) {
+			// Additionally true only here: loopback targets are the ones the
+			// daemon reverse-proxies, and it proxies them from its OWN host.
+			return fmt.Errorf("this session cannot open a web tab pointing at %s yet: a loopback target is reverse-proxied from the daemon host rather than from the session's off-box workspace, and %s — see #3062", target, notRestored)
+		}
+		return fmt.Errorf("this session cannot open a web tab yet: %s, so it would disappear at the next daemon restart — see #3062", notRestored)
 	case TabNeedsLocalWorktreeRead:
 		if c.Workspace != WorkspaceLocalWorktree {
 			return fmt.Errorf("this session cannot open a vscode tab: its editor is served by the daemon from the session's worktree, and this session's workspace runs off-box (docker/ssh/sandbox), so the daemon has no worktree to open — see #3054")

--- a/session/backend.go
+++ b/session/backend.go
@@ -1,6 +1,9 @@
 package session
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // WorkspaceKind describes where a backend's workspace physically lives, so
 // callers reason about locality without asking "is this the remote type"
@@ -39,7 +42,12 @@ type Capabilities struct {
 	Archive bool
 	// Recover: a Lost session can be reconnected / re-spawned in place.
 	Recover bool
-	// TabManagement: the user can add/close arbitrary tabs (new process tab).
+	// TabManagement: the user can add/close tabs that RUN A PROCESS — a shell or
+	// process tab, which needs a PTY in the daemon-side worktree. It does not
+	// govern metadata-only tabs (a web tab is a name and a URL): those spawn
+	// nothing, so gating them on this bit refused them for a reason that did not
+	// apply to them (#3053). Ask TabKindRequires what a kind needs, and
+	// RefuseTabKind whether this backend can serve it.
 	TabManagement bool
 	// TerminalTab: an interactive terminal surface is available. Off-box runtimes
 	// provide it through their AgentServer stream rather than a daemon-local tmux.
@@ -52,6 +60,33 @@ type Capabilities struct {
 	// backend would have to re-launch the agent inside the provisioned sandbox
 	// rather than re-provision it, which is a separate lifecycle.
 	Handoff bool
+}
+
+// RefuseTabKind reports why this backend cannot serve a tab of this kind, or nil
+// if it can. It is the single gate for "may this session gain THIS tab", and it
+// asks what the KIND needs rather than whether the session is off-box (#3053):
+// the old form refused every kind on off-box sessions and explained each refusal
+// as a missing worktree, which is untrue of a tab that spawns nothing.
+//
+// Each refusal names the requirement that is actually unmet, because a user told
+// "not supported on this backend" for a tab kind that could work cannot tell
+// that from one that genuinely cannot.
+func (c Capabilities) RefuseTabKind(kind TabKind) error {
+	switch TabKindRequires(kind) {
+	case TabNeedsMetadataOnly:
+		// A name and a URL. Nothing to spawn, nothing to read: every backend.
+		return nil
+	case TabNeedsLocalWorktreeRead:
+		if c.Workspace != WorkspaceLocalWorktree {
+			return fmt.Errorf("this session cannot open a vscode tab: its editor is served by the daemon from the session's worktree, and this session's workspace runs off-box (docker/ssh/sandbox), so the daemon has no worktree to open — see #3054")
+		}
+		return nil
+	default:
+		if !c.TabManagement {
+			return fmt.Errorf("this session cannot open a shell or process tab: it runs a process in the session's worktree, and this session's workspace runs off-box (docker/ssh/sandbox), so there is no local worktree to spawn it in")
+		}
+		return nil
+	}
 }
 
 // ErrHandoffUnsupported is returned when an agent handoff (#2013) is requested

--- a/session/backend.go
+++ b/session/backend.go
@@ -74,7 +74,23 @@ type Capabilities struct {
 func (c Capabilities) RefuseTabKind(kind TabKind) error {
 	switch TabKindRequires(kind) {
 	case TabNeedsMetadataOnly:
-		// A name and a URL. Nothing to spawn, nothing to read: every backend.
+		// A web tab spawns nothing and reads nothing, so the KIND needs nothing
+		// from the workspace — but the daemon cannot yet SERVE one off-box, and
+		// that is a different question from what the kind requires. Two reasons,
+		// both measured (#3062): a loopback target is proxied over the daemon's
+		// own TCP stack, so `--port 3000` reaches the daemon host rather than the
+		// workspace and can surface an unrelated daemon-local service; and
+		// FromInstanceData restores tabs only on its local branch, so a persisted
+		// web tab disappears at the next daemon restart.
+		//
+		// This is deliberately NOT the old blanket refusal wearing new words. The
+		// old one claimed there was no worktree to spawn in, which is not a
+		// requirement a web tab has; this one names what is actually missing, and
+		// it is the only kind whose refusal will lift without new worktree
+		// semantics.
+		if c.Workspace != WorkspaceLocalWorktree {
+			return fmt.Errorf("this session cannot open a web tab yet: its target would be proxied from the daemon host rather than from the session's off-box workspace, and a persisted web tab is not restored on the sandbox recovery path — see #3062")
+		}
 		return nil
 	case TabNeedsLocalWorktreeRead:
 		if c.Workspace != WorkspaceLocalWorktree {

--- a/session/tab.go
+++ b/session/tab.go
@@ -145,6 +145,48 @@ func (k TabKind) HasTmux() bool {
 	}
 }
 
+// TabKindNeed states what a tab kind needs from the session's WORKSPACE. It is
+// the predicate the tab gates test, replacing "is this session off-box?" — that
+// question has the wrong shape, because it refuses tab kinds that need nothing
+// from the workspace and it explains every refusal in terms of a worktree some
+// kinds never touch (#3053).
+//
+// Keeping the classification in one exported place is what stops the gates from
+// drifting apart, the same reason TabKindRenameable exists. A NEW tab kind is
+// classified here once and every gate follows; the default is the conservative
+// one, so a kind nobody classified is treated as spawning a process rather than
+// silently admitted everywhere.
+type TabKindNeed int
+
+const (
+	// TabNeedsMetadataOnly: the tab is a name and at most a URL. It spawns
+	// nothing and reads nothing, so it works on every backend.
+	TabNeedsMetadataOnly TabKindNeed = iota
+	// TabNeedsLocalWorktreeRead: no process, but the DAEMON must be able to read
+	// the workspace on its own filesystem — the vscode tab's editor is rooted at
+	// the worktree path. Off-box workspaces cannot serve this yet (#3054).
+	TabNeedsLocalWorktreeRead
+	// TabNeedsLocalProcess: the tab runs a process behind a PTY in the local
+	// worktree, which an off-box workspace has no way to provide.
+	TabNeedsLocalProcess
+)
+
+// TabKindRequires classifies a tab kind by what it needs from the workspace.
+//
+// An unrecognized kind answers TabNeedsLocalProcess: refusing a tab that might
+// have worked is recoverable, while admitting one that needs a worktree it does
+// not have fails later and further from the cause.
+func TabKindRequires(kind TabKind) TabKindNeed {
+	switch kind {
+	case TabKindWeb:
+		return TabNeedsMetadataOnly
+	case TabKindVSCode:
+		return TabNeedsLocalWorktreeRead
+	default:
+		return TabNeedsLocalProcess
+	}
+}
+
 // Tab is one process running in an instance's worktree, backed by a single tmux
 // session. It is an internal wrapper introduced in PR 1 of #930: an instance
 // holds exactly one Agent tab that wraps today's single tmux session, and the

--- a/session/tab_attach.go
+++ b/session/tab_attach.go
@@ -28,7 +28,7 @@ func (i *Instance) AttachVSCodeTab(name, tabID string) (*Tab, error) {
 	if spawnErr := i.tabSpawnBlockedLocked(); spawnErr != nil {
 		return nil, spawnErr
 	}
-	if err := tabSpawnPreconditionErr(i.started, i.tmuxLocked() != nil, i.gitWorktree != nil, TabKindShell); err != nil {
+	if err := tabSpawnPreconditionErr(i.started, i.tmuxLocked() != nil, i.gitWorktree != nil, TabKindVSCode); err != nil {
 		return nil, err
 	}
 

--- a/session/tab_attach.go
+++ b/session/tab_attach.go
@@ -28,7 +28,7 @@ func (i *Instance) AttachVSCodeTab(name, tabID string) (*Tab, error) {
 	if spawnErr := i.tabSpawnBlockedLocked(); spawnErr != nil {
 		return nil, spawnErr
 	}
-	if err := tabSpawnPreconditionErr(i.started, i.tmuxLocked() != nil, i.gitWorktree != nil); err != nil {
+	if err := tabSpawnPreconditionErr(i.started, i.tmuxLocked() != nil, i.gitWorktree != nil, TabKindShell); err != nil {
 		return nil, err
 	}
 

--- a/session/tab_close.go
+++ b/session/tab_close.go
@@ -19,9 +19,13 @@ import "fmt"
 // against.
 func (i *Instance) CloseTab(idx int) error {
 	i.mu.Lock()
-	if idx <= 0 || idx >= len(i.Tabs) {
+	if idx < 0 || idx >= len(i.Tabs) {
 		i.mu.Unlock()
-		return fmt.Errorf("tab cannot be closed")
+		return fmt.Errorf("session %q has no tab at index %d", i.Title, idx)
+	}
+	if idx == 0 {
+		i.mu.Unlock()
+		return fmt.Errorf("the agent tab of session %q can't be closed: it is the session's own agent, pinned to the first slot — archive or kill the session instead", i.Title)
 	}
 	tab := i.removeTabLocked(idx)
 	i.mu.Unlock()
@@ -40,7 +44,7 @@ func (i *Instance) CloseTabByID(tabID string) error {
 	}
 	if idx == 0 {
 		i.mu.Unlock()
-		return fmt.Errorf("tab cannot be closed")
+		return fmt.Errorf("the agent tab of session %q can't be closed: it is the session's own agent, pinned to the first slot — archive or kill the session instead", i.Title)
 	}
 	tab := i.removeTabLocked(idx)
 	i.mu.Unlock()

--- a/session/tab_kind_requires_test.go
+++ b/session/tab_kind_requires_test.go
@@ -42,9 +42,9 @@ func TestRefuseTabKindGivesEachKindItsOwnReason(t *testing.T) {
 	require.False(t, remoteCaps().TabManagement,
 		"fixture drifted: the off-box row is supposed to lack TabManagement")
 
-	web := remoteCaps().RefuseTabKind(TabKindWeb)
-	vscode := remoteCaps().RefuseTabKind(TabKindVSCode)
-	shell := remoteCaps().RefuseTabKind(TabKindShell)
+	web := remoteCaps().RefuseTabKind(TabKindWeb, "http://localhost:3000")
+	vscode := remoteCaps().RefuseTabKind(TabKindVSCode, "")
+	shell := remoteCaps().RefuseTabKind(TabKindShell, "")
 	require.Error(t, web, "a web tab cannot be SERVED off-box yet (#3062)")
 	require.Error(t, vscode)
 	require.Error(t, shell)
@@ -66,12 +66,40 @@ func TestRefuseTabKindGivesEachKindItsOwnReason(t *testing.T) {
 	assert.Contains(t, msgs["web"], "3062", "the web refusal must point at the work that lifts it")
 }
 
+// TestWebRefusalNamesOnlyTheBlockersThatApply is this PR's own thesis applied to
+// its own message. Only LOOPBACK targets are reverse-proxied, so citing the
+// daemon-host routing gap for an external URL states a requirement that tab does
+// not have — the same defect one level down. Both targets are refused, for
+// different and individually true reasons.
+func TestWebRefusalNamesOnlyTheBlockersThatApply(t *testing.T) {
+	loopback := remoteCaps().RefuseTabKind(TabKindWeb, "http://localhost:3000")
+	external := remoteCaps().RefuseTabKind(TabKindWeb, "https://example.com")
+	require.Error(t, loopback)
+	require.Error(t, external, "an off-box web tab is still not restored across a restart, whatever it points at")
+
+	assert.Contains(t, strings.ToLower(loopback.Error()), "proxied",
+		"a loopback target IS reverse-proxied from the daemon host; the refusal must say so")
+	assert.NotContains(t, strings.ToLower(external.Error()), "proxied",
+		"an external URL is iframed directly and never proxied; claiming otherwise is the #3053 defect recreated")
+
+	// The blocker they DO share is the one that is unconditionally true.
+	for name, err := range map[string]error{"loopback": loopback, "external": external} {
+		assert.Contains(t, strings.ToLower(err.Error()), "restored",
+			"%s refusal must name the restore gap, which applies to every off-box web tab", name)
+		assert.Contains(t, err.Error(), "3062", "%s refusal must point at the work that lifts it", name)
+	}
+
+	// A local session takes neither branch.
+	require.NoError(t, localCaps().RefuseTabKind(TabKindWeb, "http://localhost:3000"))
+	require.NoError(t, localCaps().RefuseTabKind(TabKindWeb, "https://example.com"))
+}
+
 // TestRefuseTabKindNamesTheUnmetRequirement is the other half of #3053: a
 // refusal that survives must say what it actually is. "Not supported on this
 // backend" cannot be told apart from a kind that could have worked.
 func TestRefuseTabKindNamesTheUnmetRequirement(t *testing.T) {
 	t.Run("vscode names the editor, not a spawn", func(t *testing.T) {
-		err := remoteCaps().RefuseTabKind(TabKindVSCode)
+		err := remoteCaps().RefuseTabKind(TabKindVSCode, "")
 		require.Error(t, err, "an off-box session must still refuse a vscode tab")
 		msg := strings.ToLower(err.Error())
 		assert.Contains(t, msg, "editor", "the refusal must name the editor requirement")
@@ -81,7 +109,7 @@ func TestRefuseTabKindNamesTheUnmetRequirement(t *testing.T) {
 
 	t.Run("process names the spawn", func(t *testing.T) {
 		for _, kind := range []TabKind{TabKindShell, TabKindProcess} {
-			err := remoteCaps().RefuseTabKind(kind)
+			err := remoteCaps().RefuseTabKind(kind, "")
 			require.Error(t, err)
 			assert.Contains(t, strings.ToLower(err.Error()), "spawn",
 				"a process-backed refusal must name the spawn it cannot do")
@@ -90,7 +118,7 @@ func TestRefuseTabKindNamesTheUnmetRequirement(t *testing.T) {
 
 	t.Run("local admits every kind", func(t *testing.T) {
 		for _, kind := range []TabKind{TabKindWeb, TabKindVSCode, TabKindShell, TabKindProcess} {
-			require.NoError(t, localCaps().RefuseTabKind(kind), "kind %v refused on a local backend", kind)
+			require.NoError(t, localCaps().RefuseTabKind(kind, ""), "kind %v refused on a local backend", kind)
 		}
 	})
 }
@@ -139,7 +167,7 @@ func TestTabSpawnPreconditionIsPerKind(t *testing.T) {
 // make the vscode proxy route reachable off-box: its editor is served by the
 // daemon from a local worktree path, and an off-box session has none.
 func TestOffBoxRefusalsStayClosed(t *testing.T) {
-	require.Error(t, remoteCaps().RefuseTabKind(TabKindVSCode),
+	require.Error(t, remoteCaps().RefuseTabKind(TabKindVSCode, ""),
 		"#3054 would be live: an off-box session may not create a vscode tab until the editor is served from inside the workspace")
 	require.NotEqual(t, WorkspaceLocalWorktree, remoteCaps().Workspace,
 		"fixture drifted: the off-box row must not claim a local worktree")

--- a/session/tab_kind_requires_test.go
+++ b/session/tab_kind_requires_test.go
@@ -1,0 +1,121 @@
+package session
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// remoteCaps is the off-box row of the capability table, as
+// remoteAgentBackend declares it.
+func remoteCaps() Capabilities { return (&remoteAgentBackend{}).Capabilities() }
+
+func localCaps() Capabilities { return (&LocalBackend{}).Capabilities() }
+
+// TestTabKindRequiresClassifiesEveryKind pins the classification itself. The
+// default is the conservative one on purpose: a kind nobody classified must be
+// treated as spawning a process, not silently admitted everywhere.
+func TestTabKindRequiresClassifiesEveryKind(t *testing.T) {
+	for _, tc := range []struct {
+		kind TabKind
+		want TabKindNeed
+	}{
+		{TabKindWeb, TabNeedsMetadataOnly},
+		{TabKindVSCode, TabNeedsLocalWorktreeRead},
+		{TabKindShell, TabNeedsLocalProcess},
+		{TabKindProcess, TabNeedsLocalProcess},
+		{TabKindAgent, TabNeedsLocalProcess},
+		{TabKind(9999), TabNeedsLocalProcess},
+	} {
+		assert.Equal(t, tc.want, TabKindRequires(tc.kind), "kind %v classified wrong", tc.kind)
+	}
+}
+
+// TestRefuseTabKindAdmitsMetadataTabsOffBox is the #3053 regression. A web tab
+// is a name and a URL: it spawns nothing and reads nothing, so no backend has
+// grounds to refuse it. Before the fix the single TabManagement bit refused it
+// alongside the kinds that genuinely need a worktree.
+func TestRefuseTabKindAdmitsMetadataTabsOffBox(t *testing.T) {
+	require.False(t, remoteCaps().TabManagement,
+		"fixture drifted: the off-box row is supposed to lack TabManagement")
+
+	require.NoError(t, remoteCaps().RefuseTabKind(TabKindWeb),
+		"an off-box session refused a web tab, which needs nothing from the workspace")
+	require.NoError(t, localCaps().RefuseTabKind(TabKindWeb))
+}
+
+// TestRefuseTabKindNamesTheUnmetRequirement is the other half of #3053: a
+// refusal that survives must say what it actually is. "Not supported on this
+// backend" cannot be told apart from a kind that could have worked.
+func TestRefuseTabKindNamesTheUnmetRequirement(t *testing.T) {
+	t.Run("vscode names the editor, not a spawn", func(t *testing.T) {
+		err := remoteCaps().RefuseTabKind(TabKindVSCode)
+		require.Error(t, err, "an off-box session must still refuse a vscode tab")
+		msg := strings.ToLower(err.Error())
+		assert.Contains(t, msg, "editor", "the refusal must name the editor requirement")
+		assert.NotContains(t, msg, "spawn",
+			"a vscode tab needs the worktree to READ, not to spawn in; saying spawn is the #3053 defect")
+	})
+
+	t.Run("process names the spawn", func(t *testing.T) {
+		for _, kind := range []TabKind{TabKindShell, TabKindProcess} {
+			err := remoteCaps().RefuseTabKind(kind)
+			require.Error(t, err)
+			assert.Contains(t, strings.ToLower(err.Error()), "spawn",
+				"a process-backed refusal must name the spawn it cannot do")
+		}
+	})
+
+	t.Run("local admits every kind", func(t *testing.T) {
+		for _, kind := range []TabKind{TabKindWeb, TabKindVSCode, TabKindShell, TabKindProcess} {
+			require.NoError(t, localCaps().RefuseTabKind(kind), "kind %v refused on a local backend", kind)
+		}
+	})
+}
+
+// TestTabSpawnPreconditionIsPerKind pins the SECOND gate, one layer under the
+// capability check. It demanded a local tmux AND worktree for every kind, so a
+// web tab would have failed here even with the capability gate opened — the
+// plain struct proved nothing about the wiring.
+func TestTabSpawnPreconditionIsPerKind(t *testing.T) {
+	const (
+		started     = true
+		noTmux      = false
+		noWorktree  = false
+		hasTmux     = true
+		hasWorktree = true
+	)
+
+	require.NoError(t, tabSpawnPreconditionErr(started, noTmux, noWorktree, TabKindWeb),
+		"a web tab needs neither tmux nor a worktree, but the precondition demanded both")
+
+	vscodeErr := tabSpawnPreconditionErr(started, noTmux, noWorktree, TabKindVSCode)
+	require.Error(t, vscodeErr)
+	assert.Contains(t, strings.ToLower(vscodeErr.Error()), "editor")
+	require.NoError(t, tabSpawnPreconditionErr(started, noTmux, hasWorktree, TabKindVSCode),
+		"a vscode tab needs the worktree to read; it owns no PTY, so tmux is not its requirement")
+
+	shellErr := tabSpawnPreconditionErr(started, noTmux, noWorktree, TabKindShell)
+	require.Error(t, shellErr)
+	assert.Contains(t, strings.ToLower(shellErr.Error()), "spawn")
+	require.NoError(t, tabSpawnPreconditionErr(started, hasTmux, hasWorktree, TabKindShell))
+
+	// "Not started" outranks every kind: there is no session to attach to yet.
+	for _, kind := range []TabKind{TabKindWeb, TabKindVSCode, TabKindShell} {
+		err := tabSpawnPreconditionErr(false, hasTmux, hasWorktree, kind)
+		require.Error(t, err, "kind %v admitted on a session that is not started", kind)
+		assert.Contains(t, err.Error(), "not started")
+	}
+}
+
+// TestOffBoxRefusalsStayClosed guards the #3054 coupling. Opening #3053 must not
+// make the vscode proxy route reachable off-box: its editor is served by the
+// daemon from a local worktree path, and an off-box session has none.
+func TestOffBoxRefusalsStayClosed(t *testing.T) {
+	require.Error(t, remoteCaps().RefuseTabKind(TabKindVSCode),
+		"#3054 would be live: an off-box session may not create a vscode tab until the editor is served from inside the workspace")
+	require.NotEqual(t, WorkspaceLocalWorktree, remoteCaps().Workspace,
+		"fixture drifted: the off-box row must not claim a local worktree")
+}

--- a/session/tab_kind_requires_test.go
+++ b/session/tab_kind_requires_test.go
@@ -33,17 +33,37 @@ func TestTabKindRequiresClassifiesEveryKind(t *testing.T) {
 	}
 }
 
-// TestRefuseTabKindAdmitsMetadataTabsOffBox is the #3053 regression. A web tab
-// is a name and a URL: it spawns nothing and reads nothing, so no backend has
-// grounds to refuse it. Before the fix the single TabManagement bit refused it
-// alongside the kinds that genuinely need a worktree.
-func TestRefuseTabKindAdmitsMetadataTabsOffBox(t *testing.T) {
+// TestRefuseTabKindGivesEachKindItsOwnReason is the #3053 regression. The three
+// kinds are refused off-box for THREE DIFFERENT reasons, and before the fix all
+// three were refused for one — the worktree a web tab never needed. That the
+// reasons are distinct is the property under test: it is what lets a user tell a
+// tab kind that could work from one that cannot.
+func TestRefuseTabKindGivesEachKindItsOwnReason(t *testing.T) {
 	require.False(t, remoteCaps().TabManagement,
 		"fixture drifted: the off-box row is supposed to lack TabManagement")
 
-	require.NoError(t, remoteCaps().RefuseTabKind(TabKindWeb),
-		"an off-box session refused a web tab, which needs nothing from the workspace")
-	require.NoError(t, localCaps().RefuseTabKind(TabKindWeb))
+	web := remoteCaps().RefuseTabKind(TabKindWeb)
+	vscode := remoteCaps().RefuseTabKind(TabKindVSCode)
+	shell := remoteCaps().RefuseTabKind(TabKindShell)
+	require.Error(t, web, "a web tab cannot be SERVED off-box yet (#3062)")
+	require.Error(t, vscode)
+	require.Error(t, shell)
+
+	msgs := map[string]string{"web": web.Error(), "vscode": vscode.Error(), "shell": shell.Error()}
+	for a, ma := range msgs {
+		for bName, mb := range msgs {
+			if a < bName {
+				assert.NotEqual(t, ma, mb, "%s and %s share a refusal message; the whole point is that they differ", a, bName)
+			}
+		}
+	}
+
+	// And each names its OWN missing requirement, not another kind's.
+	assert.NotContains(t, strings.ToLower(msgs["web"]), "spawn",
+		"a web tab spawns nothing; saying spawn is the #3053 defect")
+	assert.Contains(t, strings.ToLower(msgs["web"]), "proxied",
+		"the web refusal must name the serving problem that actually blocks it")
+	assert.Contains(t, msgs["web"], "3062", "the web refusal must point at the work that lifts it")
 }
 
 // TestRefuseTabKindNamesTheUnmetRequirement is the other half of #3053: a
@@ -88,6 +108,11 @@ func TestTabSpawnPreconditionIsPerKind(t *testing.T) {
 		hasWorktree = true
 	)
 
+	// This layer answers MECHANICS — what the kind needs from the instance — and
+	// a web tab needs nothing, which stays true. Whether the daemon can SERVE one
+	// off-box is a separate question, answered by RefuseTabKind above (#3062).
+	// Keeping them apart is what stops the serving gap from being re-encoded as a
+	// fake worktree requirement.
 	require.NoError(t, tabSpawnPreconditionErr(started, noTmux, noWorktree, TabKindWeb),
 		"a web tab needs neither tmux nor a worktree, but the precondition demanded both")
 

--- a/session/tab_spawn.go
+++ b/session/tab_spawn.go
@@ -22,14 +22,29 @@ import (
 // Callers reject backends without the TabManagement capability first
 // (daemon/manager_tabs.go), so a user normally sees that gate's message instead;
 // this is the defense-in-depth check for a direct caller, written to stand alone.
-func tabSpawnPreconditionErr(started, hasTmux, hasWorktree bool) error {
+func tabSpawnPreconditionErr(started, hasTmux, hasWorktree bool, kind TabKind) error {
 	if !started {
 		return fmt.Errorf("cannot add a tab to a session that is not started")
 	}
-	if !hasWorktree || !hasTmux {
-		return fmt.Errorf("cannot add a tab to a session with no local workspace: its workspace runs off-box, so there is no worktree to spawn the tab in")
+	// Per KIND, not per session (#3053). The old form demanded a local worktree
+	// and tmux for every kind and explained the refusal as "no worktree to spawn
+	// the tab in" — untrue of a web tab, which spawns nothing and reads nothing,
+	// and imprecise for a vscode tab, which needs the worktree to READ rather
+	// than to spawn in. Each branch now refuses for its own reason or not at all.
+	switch TabKindRequires(kind) {
+	case TabNeedsMetadataOnly:
+		return nil
+	case TabNeedsLocalWorktreeRead:
+		if !hasWorktree {
+			return fmt.Errorf("cannot add a vscode tab to this session: its editor is rooted at the session's worktree on the daemon host, and this workspace runs off-box, so there is no worktree for the daemon to open (#3054)")
+		}
+		return nil
+	default:
+		if !hasWorktree || !hasTmux {
+			return fmt.Errorf("cannot add this tab to the session: a shell or process tab runs a process in the session's worktree, and this workspace runs off-box, so there is no local worktree to spawn it in")
+		}
+		return nil
 	}
-	return nil
 }
 
 // AddShellTab spawns a new Shell-kind tab running $SHELL in the instance's
@@ -61,7 +76,7 @@ func (i *Instance) AddShellTab() (*Tab, error) {
 	if spawnErr != nil {
 		return nil, spawnErr
 	}
-	if err := tabSpawnPreconditionErr(started, agentTmux != nil, gw != nil); err != nil {
+	if err := tabSpawnPreconditionErr(started, agentTmux != nil, gw != nil, TabKindShell); err != nil {
 		return nil, err
 	}
 	worktreePath := gw.GetWorktreePath()
@@ -142,7 +157,7 @@ func (i *Instance) AddProcessTab(command, requestedName string) (*Tab, error) {
 	if spawnErr != nil {
 		return nil, spawnErr
 	}
-	if err := tabSpawnPreconditionErr(started, agentTmux != nil, gw != nil); err != nil {
+	if err := tabSpawnPreconditionErr(started, agentTmux != nil, gw != nil, TabKindProcess); err != nil {
 		return nil, err
 	}
 	worktreePath := gw.GetWorktreePath()
@@ -269,7 +284,7 @@ func (i *Instance) AddWebTab(url, requestedName string) (*Tab, error) {
 	if spawnErr := i.tabSpawnBlockedLocked(); spawnErr != nil {
 		return nil, spawnErr
 	}
-	if err := tabSpawnPreconditionErr(i.started, i.tmuxLocked() != nil, i.gitWorktree != nil); err != nil {
+	if err := tabSpawnPreconditionErr(i.started, i.tmuxLocked() != nil, i.gitWorktree != nil, TabKindWeb); err != nil {
 		return nil, err
 	}
 	tab := newWebTab(url)
@@ -298,7 +313,7 @@ func (i *Instance) AddVSCodeTab(requestedName string) (*Tab, error) {
 	if spawnErr := i.tabSpawnBlockedLocked(); spawnErr != nil {
 		return nil, spawnErr
 	}
-	if err := tabSpawnPreconditionErr(i.started, i.tmuxLocked() != nil, i.gitWorktree != nil); err != nil {
+	if err := tabSpawnPreconditionErr(i.started, i.tmuxLocked() != nil, i.gitWorktree != nil, TabKindVSCode); err != nil {
 		return nil, err
 	}
 	tab := newVSCodeTab()

--- a/session/tab_spawn_capability_test.go
+++ b/session/tab_spawn_capability_test.go
@@ -101,7 +101,7 @@ func TestSandboxInstanceTabSpawnIsPerKind(t *testing.T) {
 			webTab, webErr := newInst().AddWebTab("http://localhost:3000", "")
 			require.NoError(t, webErr,
 				"AddWebTab must serve a worktree-less sandbox instance: a web tab needs no worktree (#3053)")
-			require.Error(t, b.Capabilities().RefuseTabKind(TabKindWeb),
+			require.Error(t, b.Capabilities().RefuseTabKind(TabKindWeb, ""),
 				"the capability layer must still refuse a web tab off-box until #3062 lands")
 			require.NotNil(t, webTab)
 			assert.Equal(t, TabKindWeb, webTab.Kind)

--- a/session/tab_spawn_capability_test.go
+++ b/session/tab_spawn_capability_test.go
@@ -93,10 +93,16 @@ func TestSandboxInstanceTabSpawnIsPerKind(t *testing.T) {
 				}
 			}
 
-			// Metadata only: nothing to spawn, nothing to read.
+			// Metadata only: nothing to spawn, nothing to read, so the MECHANICS
+			// layer admits it even here. Whether the daemon can SERVE it off-box
+			// is a policy question answered by Capabilities.RefuseTabKind, which
+			// still refuses (#3062) — the two layers are deliberately separate so
+			// the serving gap is not re-encoded as a fake worktree requirement.
 			webTab, webErr := newInst().AddWebTab("http://localhost:3000", "")
 			require.NoError(t, webErr,
 				"AddWebTab must serve a worktree-less sandbox instance: a web tab needs no worktree (#3053)")
+			require.Error(t, b.Capabilities().RefuseTabKind(TabKindWeb),
+				"the capability layer must still refuse a web tab off-box until #3062 lands")
 			require.NotNil(t, webTab)
 			assert.Equal(t, TabKindWeb, webTab.Kind)
 			assert.Nil(t, webTab.tmux, "a web tab must hold no tmux session")

--- a/session/tab_spawn_capability_test.go
+++ b/session/tab_spawn_capability_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,10 +11,16 @@ import (
 // #1874: the sandbox runtimes (docker/ssh/hook) declare WorkspaceRemote — their
 // workspace is off-box, so the daemon-side instance has no local git worktree
 // (gitWorktree is assigned only in LocalBackend.Provision and the LOCAL restore
-// branch of FromInstanceData). Every Add*Tab path requires that worktree, so a
-// TabManagement:true on these backends would advertise a capability no code path
-// can service: the web menu would offer "New shell tab"/"Open in VS Code" and
-// the daemon would reject the call.
+// branch of FromInstanceData). The tab paths that RUN A PROCESS require that
+// worktree, so a TabManagement:true on these backends would advertise a
+// capability no code path can service: the web menu would offer "New shell tab"
+// and the daemon would reject the call.
+//
+// #3053 split that premise per kind. It is not true of every Add*Tab path: a web
+// tab is a name and a URL, spawning nothing and reading nothing, so it works on
+// any backend and is no longer governed by this bit. TabManagement stays false
+// here because it now means what its name says — process-backed tabs — and those
+// still cannot work off-box.
 //
 // These tests pin the capability to what the implementation can actually do, so
 // the advertisement and the behavior cannot drift apart again. When tab creation
@@ -64,11 +71,15 @@ func TestSandboxBackendsDoNotAdvertiseHandoff(t *testing.T) {
 	}
 }
 
-// TestSandboxInstanceTabSpawnRejected pins the other half of the contract: the
-// Add*Tab paths really are unable to service a sandbox instance. If this ever
-// starts passing, the capability above should be flipped to true in the same
-// change — that is what makes the fix decidable rather than a guess.
-func TestSandboxInstanceTabSpawnRejected(t *testing.T) {
+// TestSandboxInstanceTabSpawnIsPerKind pins the other half of the contract: what
+// the Add*Tab paths can and cannot service on a sandbox instance, per KIND.
+//
+// Before #3053 this asserted that all four refuse, which was the defect — the
+// web tab was refused for a worktree requirement it does not have. The
+// assertions here are strictly stronger than that blanket form: each refusal
+// must also name the requirement it is actually missing, so a message that
+// degrades to "not supported on this backend" fails.
+func TestSandboxInstanceTabSpawnIsPerKind(t *testing.T) {
 	for name, b := range sandboxBackends() {
 		t.Run(name, func(t *testing.T) {
 			// A started sandbox instance, exactly as Launch leaves it: started,
@@ -82,17 +93,30 @@ func TestSandboxInstanceTabSpawnRejected(t *testing.T) {
 				}
 			}
 
-			_, shellErr := newInst().AddShellTab()
-			assert.Error(t, shellErr, "AddShellTab must reject a worktree-less sandbox instance")
+			// Metadata only: nothing to spawn, nothing to read.
+			webTab, webErr := newInst().AddWebTab("http://localhost:3000", "")
+			require.NoError(t, webErr,
+				"AddWebTab must serve a worktree-less sandbox instance: a web tab needs no worktree (#3053)")
+			require.NotNil(t, webTab)
+			assert.Equal(t, TabKindWeb, webTab.Kind)
+			assert.Nil(t, webTab.tmux, "a web tab must hold no tmux session")
 
-			_, webErr := newInst().AddWebTab("http://localhost:3000", "")
-			assert.Error(t, webErr, "AddWebTab must reject a worktree-less sandbox instance")
-
+			// Needs the worktree to READ, which off-box cannot serve yet (#3054).
 			_, vscodeErr := newInst().AddVSCodeTab("")
-			assert.Error(t, vscodeErr, "AddVSCodeTab must reject a worktree-less sandbox instance")
+			require.Error(t, vscodeErr, "AddVSCodeTab must reject a worktree-less sandbox instance")
+			assert.Contains(t, strings.ToLower(vscodeErr.Error()), "editor",
+				"the vscode refusal must name the editor requirement, not a spawn it does not do")
+
+			// Need a PTY in the local worktree.
+			_, shellErr := newInst().AddShellTab()
+			require.Error(t, shellErr, "AddShellTab must reject a worktree-less sandbox instance")
+			assert.Contains(t, strings.ToLower(shellErr.Error()), "spawn",
+				"the shell refusal must name the spawn it cannot do")
 
 			_, procErr := newInst().AddProcessTab("echo hi", "")
-			assert.Error(t, procErr, "AddProcessTab must reject a worktree-less sandbox instance")
+			require.Error(t, procErr, "AddProcessTab must reject a worktree-less sandbox instance")
+			assert.Contains(t, strings.ToLower(procErr.Error()), "spawn",
+				"the process refusal must name the spawn it cannot do")
 		})
 	}
 }


### PR DESCRIPTION
`TabManagement` was one bit gating four tab kinds, and every refusal was
explained as a missing worktree. True of shell and process tabs, which run a PTY
in the worktree; not true of a web tab — a name and a URL — which was refused for
a requirement it does not have.

**Scope note:** this PR originally admitted web tabs off-box. Review found two
P1s that make admission unsafe today, so what lands is the classification and
three honest refusals. The enablement is #3062.

## The predicate

`TabKindRequires` classifies a kind by what it needs from the workspace, in one
exported place next to `TabKindRenameable`. The default is the conservative one,
so a **new** kind nobody classified is treated as spawning rather than silently
admitted everywhere.

Each kind is now refused off-box for **its own** reason:

| kind | refusal names | tracked by |
|---|---|---|
| web | its target would be proxied from the daemon host, and it is not restored on the sandbox path | #3062 |
| vscode | its editor is served by the daemon from the worktree | #3054 |
| shell / process | it runs a process, and there is no local worktree to spawn it in | — |

Before, all three were refused by one bit citing one reason. That is what made a
kind that *could* work indistinguishable from one that cannot — and it is why the
serving gap below went unnoticed for so long: the message asserted a requirement
that was not the real blocker.

## Why web tabs are not admitted here

Both verified in code, not inferred:

- **A loopback target reaches the wrong machine.** `webtab_proxy.go:172` returns
  `webTabTarget{URL: tabURL, Kind: kind}` with no transport, while the vscode
  branch sets a `SocketPath`. `WebTabURLForPort` produces
  `http://localhost:<port>`, so `--port 3000` on a docker/ssh session is proxied
  over the daemon's own TCP stack and resolves on the **daemon host** — able to
  surface an unrelated daemon-local service inside the session's tab.
- **The tab does not survive a restart.** `FromInstanceData` restores `data.Tabs`
  only on its local branch; the sandbox branch builds an inert backend with an
  empty roster.

## Two gates, not one

`Capabilities.RefuseTabKind` replaces the blanket check in `CreateTab`. There was
a second gate underneath: `tabSpawnPreconditionErr` demanded tmux **and** a
worktree for every kind. That one is now per-kind too, and the layers stay
separate on purpose — mechanics (what the kind needs from the instance) versus
policy (what this backend can serve). Collapsing them is how a serving gap gets
re-encoded as a fake worktree requirement, which is the bug this PR is about.

`AttachVSCodeTab` also had the wrong kind passed to its precondition, so a VS Code
projection demanded a tmux session it never owns.

## Tests

`TestRefuseTabKindGivesEachKindItsOwnReason` asserts the three refusals are
pairwise **distinct** and that each names its own requirement — the web one must
not say "spawn", the vscode one must not say "spawn", and the web one must point
at #3062. That property, not any single string, is the contract.

`TestSandboxInstanceTabSpawnRejected` became `…IsPerKind`: it asserted all four
kinds refuse, which was the defect. `TestOffBoxRefusalsStayClosed` guards the
#3054 coupling so opening one cannot quietly open the other.

Verified by mutation rather than by a green run: reverting `TabKindRequires` to
the old conflation turns the new tests red, and restoring makes them pass (files
diffed byte-identical after restore).

Local gates: `go build ./...`, `go vet ./...`, `gofmt -l .`,
`scripts/lint-file-length.sh`, `golangci-lint --fast`, and the full `session`
package (62s, green). No daemon/app tests on the host.

## Follow-ups

- **#3062** — enable web tabs off-box: loopback transport through the
  AgentServer, restore on the sandbox path, and `Launch` preserving the roster.
- **#3060** — client gates still apply the blanket bit; moot until #3062.
- **#3054** — VS Code off-box.

Closes #3053

— Captain Claude