### PR TITLE
feat(daemon): bind the sandbox callback credential to its owning session (#3056)

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -341,6 +341,29 @@ func (m *Manager) archiveSession(req ArchiveSessionRequest, taskTargets map[stri
 	// persist-error cause this issue reports is fully closed.)
 	_ = instance.Transition(session.CommitArchive())
 	archivedPath := instance.GetWorktreePath()
+	// Revocation of this session's sandbox callback credential (#2999) follows the
+	// COMMITTED STATE, not any one exit path (#3012 review).
+	//
+	// Armed here, at the commit, and disarmed only where a rollback genuinely
+	// succeeded and left the session Lost — a Lost session is still drivable, so it
+	// keeps its credential. Every other return below leaves the archive committed
+	// and the runtime reaped, including the two that could not move the worktree
+	// home and persist the committed archive best-effort; those returned above the
+	// revocation when it was a single statement, so a token copied out of the
+	// sandbox kept authenticating for an inert session until the daemon restarted.
+	//
+	// Deliberately a defer rather than a third call site. This is the third place in
+	// this PR where revocation had to be anchored to a commit point, and the first
+	// two were fixed by moving a statement — which is exactly the shape that breaks
+	// again the next time someone adds an exit. Armed-and-disarmed fails CLOSED for
+	// any return added later, matching how the create path already handles a mint
+	// that is abandoned.
+	archiveCommitted := true
+	defer func() {
+		if archiveCommitted {
+			m.sandboxTokens.revoke(instance.ID)
+		}
+	}()
 	if stopErr := m.stopVSCodeForInstance(vscodeKey, instance.ID); stopErr != nil {
 		log.ErrorLog.Printf("archive of session %q: final VS Code editor teardown was not confirmed (%v); rolling back the moved worktree", req.Title, stopErr)
 		if rbErr := m.undoCommittedArchive(repoID, instance, origPath); rbErr != nil {
@@ -350,6 +373,8 @@ func (m *Manager) archiveSession(req ArchiveSessionRequest, taskTargets map[stri
 			m.persistInstance(repoID, instance)
 			return "", session.InstanceData{}, fmt.Errorf("archived session %q to %s but could not confirm its final VS Code editor teardown (%v) and could not roll the worktree back (%v); it may need manual recovery", req.Title, archivedPath, stopErr, rbErr)
 		}
+		// Rolled back: the session is Lost, still drivable, so it keeps its credential.
+		archiveCommitted = false
 		return "", session.InstanceData{}, fmt.Errorf("could not confirm final VS Code editor teardown for session %q; rolled the archive back and left it Lost for retry: %w", req.Title, stopErr)
 	}
 	if perr := archivePersist(m, repoID, instance); perr != nil {
@@ -361,6 +386,8 @@ func (m *Manager) archiveSession(req ArchiveSessionRequest, taskTargets map[stri
 			m.persistInstance(repoID, instance)
 			return "", session.InstanceData{}, fmt.Errorf("archived session %q to %s but failed to record it durably (%v) and could not roll it back (%v); it may need manual recovery", req.Title, archivedPath, perr, rbErr)
 		}
+		// Rolled back: the session is Lost, still drivable, so it keeps its credential.
+		archiveCommitted = false
 		return "", session.InstanceData{}, fmt.Errorf("failed to durably archive session %q; rolled it back and left it Lost to be restored in place: %w", req.Title, perr)
 	}
 	log.InfoLog.Printf("archived session %q (repo %s): tmux torn down, worktree moved to %s", req.Title, repoID, archivedPath)
@@ -508,6 +535,21 @@ func (m *Manager) archiveRemoteSession(repoID string, instance *session.Instance
 	// Success: branch is durable on origin, sandbox reaped. Commit the inert
 	// Archived state (started=false, op cleared) and persist it durably.
 	_ = instance.Transition(session.CommitArchive())
+	// THIS is the archive path that matters for the sandbox callback credential
+	// (#2999), and the one the first fix missed. BackendKind.InjectsSandboxCallback
+	// is ssh and sandbox only, and both are WorkspaceRemote — so every session that
+	// can hold a credential archives through HERE, while the revocation added for
+	// the earlier review round sat in the local-worktree body, past a branch that
+	// returns at the call site above. It never fired for a single credential-holding
+	// session.
+	//
+	// Armed at the commit, with no disarm: unlike the local body there is nothing to
+	// roll back here — the sandbox is already reaped and the branch is already on
+	// origin — so every return below this line leaves the session committed and
+	// inert, including the durability failure. The rollback that keeps a credential
+	// is the ArchiveSandbox failure above, which aborts to Lost before this point
+	// and so never arms.
+	defer m.sandboxTokens.revoke(instance.ID)
 	if perr := archivePersist(m, repoID, instance); perr != nil {
 		// The sandbox is already reaped and the branch is on origin, so there is
 		// nothing to undo — the Archived record is recoverable from origin either

--- a/daemon/archive_test.go
+++ b/daemon/archive_test.go
@@ -690,3 +690,43 @@ func TestArchiveSession_RejectsRemote(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "remote")
 }
+
+// A remote archive that FAILS must leave the session's sandbox callback
+// credential alone (#2999, #3012 review).
+//
+// This is the half of the revocation rule that pins WHERE the defer is armed. The
+// remote body commits only after ArchiveSandbox succeeds; a failure aborts the
+// fence back to Lost, and a Lost sandbox session is still recoverable and still
+// drivable, so severing its callback would break a session the operator was told
+// to retry. Arming revocation any earlier than the commit — at entry, or at the
+// fence — passes every "successful archive revokes" test and breaks exactly here.
+//
+// The success half is NOT covered: no daemon test drives a successful remote
+// archive, because that needs a live agent-server endpoint to push a branch
+// through. That gap is real and is recorded on #2999 rather than papered over — it
+// is the reason the missing revocation on this path survived a review round.
+func TestArchiveRemoteSession_FailedArchiveKeepsTheCallbackCredential(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, err := session.NewInstance(session.InstanceOptions{Title: "faraway", Path: repoPath, Program: "claude"})
+	require.NoError(t, err)
+	inst.SetBackend(fakeRemoteBackend{session.NewFakeBackend()})
+	inst.SetStartedForTest(true)
+	inst.SetStatusForTest(session.Ready)
+	seedDiskInstance(t, repoID, "faraway", repoPath)
+	manager.mu.Lock()
+	manager.instances[daemonInstanceKey(repoID, "faraway")] = inst
+	manager.mu.Unlock()
+
+	callback, err := manager.sandboxTokens.mint(inst.ID)
+	require.NoError(t, err)
+
+	// No remote client is wired, so ArchiveSandbox refuses before anything is
+	// pushed or reaped — the archive never commits.
+	_, aerr := manager.archiveRemoteSession(repoID, inst, "faraway")
+	require.Error(t, aerr, "an archive with no live client must fail rather than commit")
+
+	owner, ok := manager.sandboxTokens.sessionFor(callback)
+	assert.True(t, ok, "a FAILED remote archive revoked the session's callback credential: "+
+		"the session is Lost, still recoverable and still drivable, and its credential cannot be re-minted without re-provisioning")
+	assert.Equal(t, inst.ID, owner)
+}

--- a/daemon/config_apply.go
+++ b/daemon/config_apply.go
@@ -203,6 +203,34 @@ func (m *Manager) ApplyConfig() (ApplyConfigResult, error) {
 			result.Applied = withoutKeys(result.Applied, failed)
 		}
 	}
+	// Turning require_token OFF voids the premise every outstanding sandbox callback
+	// credential was issued under (#3012 review).
+	//
+	// mintSandboxCallback REFUSES to issue one while require_token is false, on the
+	// grounds that a scoped credential against a listener that authenticates nobody
+	// "manufactures the appearance of a boundary that nothing enforces". That check
+	// runs once, at provision time — and per the block above, an auth key applies
+	// live with no rebind, so this relaxation silently converts every already-issued
+	// credential into exactly the thing that refusal exists to prevent: authGate
+	// short-circuits on the tokenless posture before it ever consults the registry,
+	// so the scope stops being enforced for callers that had one.
+	//
+	// Revoked and WARNED rather than refused. Refusing would make an operator's own
+	// config unwritable because of sessions they may not remember provisioning, and
+	// this repo does not hold a config key hostage to runtime state. But af must
+	// also stop claiming a scope it is no longer enforcing, so the credentials go
+	// and the operator is told what they just widened.
+	//
+	// This does NOT restore the boundary, and the warning says so: with require_token
+	// false the control plane answers every caller anonymously, so a sandbox does not
+	// need a credential to reach it. Only re-enabling the key restores it.
+	if old.RequireToken && !newCfg.RequireToken {
+		if n := m.sandboxTokens.revokeAll(); n > 0 {
+			warning := fmt.Sprintf("require_token is now false: revoked %d sandbox callback credential(s), because a scoped credential enforces nothing against a listener that authenticates nobody. Those sessions lose callback. NOTE: this does not re-isolate them — the control plane now answers unauthenticated callers, provisioned sandboxes included; re-enable require_token to restore the boundary", n)
+			log.WarningLog.Printf("%s", warning)
+			result.Warnings = append(result.Warnings, warning)
+		}
+	}
 	// The tokenless-network exposure notice, surfaced at SAVE time so a user who
 	// makes the control API reachable without a token is told once — warned, never
 	// refused (#2168 Phase 0 / config/authposture.go).

--- a/daemon/config_apply_test.go
+++ b/daemon/config_apply_test.go
@@ -1,8 +1,10 @@
 package daemon
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/config"
@@ -110,4 +112,63 @@ func TestApplyBucketsAgreeWithEffectClasses(t *testing.T) {
 				key, config.KeyEffectClass(key))
 		}
 	}
+}
+
+// Turning require_token OFF must not leave sandbox callback credentials behind
+// (#2999, #3012 review).
+//
+// mintSandboxCallback refuses to ISSUE one while require_token is false, because a
+// scoped credential against a listener that authenticates nobody enforces nothing.
+// That check runs once, at provision time, and auth keys apply live with no rebind
+// — so without this, relaxing the key silently converts every already-issued
+// credential into exactly what the refusal exists to prevent.
+func TestApplyConfig_DisablingRequireTokenRevokesSandboxCredentials(t *testing.T) {
+	m := applyConfigTestManager(t)
+
+	_, err := config.SetGlobalConfigValue("require_token", "true")
+	require.NoError(t, err)
+	_, err = m.ApplyConfig()
+	require.NoError(t, err)
+	require.True(t, m.Config().RequireToken, "the premise of this test is that the key starts enabled")
+
+	secret, err := m.sandboxTokens.mint("sess-a")
+	require.NoError(t, err)
+	_, ok := m.sandboxTokens.sessionFor(secret)
+	require.True(t, ok, "anti-vacuous: the credential must be live before the flip, or the assertion below proves nothing")
+
+	_, err = config.SetGlobalConfigValue("require_token", "false")
+	require.NoError(t, err)
+	result, err := m.ApplyConfig()
+	require.NoError(t, err)
+
+	_, ok = m.sandboxTokens.sessionFor(secret)
+	assert.False(t, ok, "a credential issued under require_token=true must not outlive it: the gate short-circuits on the tokenless posture before consulting the registry, so its scope stops being enforced")
+
+	// And the operator must be TOLD, including that this does not re-isolate the
+	// sandboxes — revoking without saying so would read as a security action.
+	joined := strings.Join(result.Warnings, "\n")
+	assert.Contains(t, joined, "require_token is now false")
+	assert.Contains(t, joined, "does not re-isolate")
+}
+
+// The converse: an unrelated config change must leave credentials alone, or every
+// save would silently sever every sandbox's callback.
+func TestApplyConfig_UnrelatedChangeKeepsSandboxCredentials(t *testing.T) {
+	m := applyConfigTestManager(t)
+	_, err := config.SetGlobalConfigValue("require_token", "true")
+	require.NoError(t, err)
+	_, err = m.ApplyConfig()
+	require.NoError(t, err)
+
+	secret, err := m.sandboxTokens.mint("sess-a")
+	require.NoError(t, err)
+
+	_, err = config.SetGlobalConfigValue("default_program", "codex")
+	require.NoError(t, err)
+	_, err = m.ApplyConfig()
+	require.NoError(t, err)
+
+	owner, ok := m.sandboxTokens.sessionFor(secret)
+	assert.True(t, ok, "an unrelated save must not revoke callback credentials")
+	assert.Equal(t, "sess-a", owner)
 }

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -644,18 +644,6 @@ func (s *controlServer) SetPRInfo(req SetPRInfoRequest, resp *SetPRInfoResponse)
 	return nil
 }
 
-func (s *controlServer) Snapshot(req SnapshotRequest, resp *SnapshotResponse) error {
-	if err := s.requireManagerReady(); err != nil {
-		return err
-	}
-	if err := validateRPCRepoID(req.RepoID); err != nil {
-		return err
-	}
-	resp.Instances = s.manager.Snapshot(req.RepoID)
-	resp.DeliveryAlarms = s.deliveryAlarms(req.RepoID)
-	return nil
-}
-
 func (s *controlServer) KillSession(req KillSessionRequest, resp *KillSessionResponse) error {
 	if err := s.requireStateMutationAdmission(); err != nil {
 		return err

--- a/daemon/httpauth.go
+++ b/daemon/httpauth.go
@@ -70,6 +70,12 @@ type authGate struct {
 	// the daemon's web listener sets it true.
 	loopbackExempt bool
 
+	// sandboxTokens admits per-session sandbox callback credentials alongside the
+	// operator token (#2999). Nil ⇒ no sandbox credential is accepted on this
+	// listener, which is the correct default: only the daemon's own control-plane
+	// listener sets it, and the agent-server and preview gates leave it nil.
+	sandboxTokens *sandboxTokenRegistry
+
 	// presentedToken extracts the credential a request presents. Nil ⇒
 	// webTabAwareToken, the daemon/agent-server default (Authorization header, then
 	// the ?access_token= / webtab query+cookie fallbacks). The PREVIEW listener
@@ -99,19 +105,60 @@ func (g *authGate) authRequired(r *http.Request) bool {
 // bearer token. Token resolution failing, or an empty expected token (a daemon
 // with no token must never accept the empty credential), fails closed; the
 // compare is constant time to close the timing oracle.
-func (g *authGate) authorize(r *http.Request) bool {
+func (g *authGate) authorize(r *http.Request) (sandboxOwner string, ok bool) {
 	if !g.authRequired(r) {
-		return true
+		return "", true
 	}
 	want, err := g.wantToken(r)
 	if err != nil {
-		return false
+		return "", false
 	}
 	extract := g.presentedToken
 	if extract == nil {
 		extract = webTabAwareToken
 	}
-	return ConstantTimeEqual(extract(r), want)
+	presented := extract(r)
+	if ConstantTimeEqual(presented, want) {
+		return "", true
+	}
+	return g.authorizeSandbox(r, presented)
+}
+
+// authorizeSandbox admits a per-session sandbox callback credential (#2999).
+//
+// Checked only AFTER the operator token fails, so the ordinary path is unchanged
+// and costs nothing extra. A sandbox credential is accepted for the routes its
+// scope opts into and refused everywhere else, so a compromised sandbox cannot
+// reach DeliverPrompt — the verb that runs instructions through every agent on
+// the machine, and the reason the operator's own token is not what gets injected.
+//
+// Nil registry (the agent-server's gate, and every test gate) means no sandbox
+// credential exists, so this is a plain false rather than a special case.
+// It returns the OWNING SESSION alongside the decision (#3056). The registry has
+// always known it; discarding it after the bool is what left the scope unable to
+// express "the caller's own session", and therefore unable to admit any route at
+// all. servePosture puts it on the request context, and the route's own handler
+// enforces the constraint — see sandbox_owner.go, which states the rule and holds
+// the check that keeps the scope and the constraints in step.
+func (g *authGate) authorizeSandbox(r *http.Request, presented string) (string, bool) {
+	if g.sandboxTokens == nil || presented == "" {
+		return "", false
+	}
+	owner, ok := g.sandboxTokens.sessionFor(presented)
+	if !ok {
+		return "", false
+	}
+	if !sandboxAllowedPath(r.URL.Path) {
+		return "", false
+	}
+	// A credential with no owner must never authorize. The registry cannot mint one
+	// (mint refuses an empty session id), so this is unreachable today — but the
+	// whole binding downstream reads an empty owner as "the operator", so the one
+	// place that could introduce that confusion refuses instead of propagating it.
+	if owner == "" {
+		return "", false
+	}
+	return owner, true
 }
 
 // wantToken resolves the credential this request must present. A per-request
@@ -256,32 +303,42 @@ func servePosture(w http.ResponseWriter, r *http.Request, next http.Handler, p r
 			return
 		}
 	}
-	if p.gate != nil && !p.gate.authorize(r) {
-		if p.previewOrigin {
-			// A preview origin's denial is RENDERED IN A PANE, so it must not be the
-			// JSON envelope. WHICH page depends on whether the address can still become
-			// valid, and getting that backwards strands the frame either way.
-			//
-			// WARMING UP: the listener binds long before RestoreInstances (#829), so an
-			// editor iframe can navigate while the daemon still has no sessions to
-			// recognise its label by. That address becomes valid the moment restore
-			// finishes, so this must be the RETRYING notice — the expired page never
-			// re-requests, and the frame would sit on it until a manual reload even
-			// though the daemon recovered seconds later.
-			if p.previewWarmingUp != nil && p.previewWarmingUp() {
-				writeTabNoticePage(w, "Starting up",
-					"af is starting up — this tab will load as soon as the daemon has restored its sessions.", true)
+	if p.gate != nil {
+		owner, ok := p.gate.authorize(r)
+		if ok {
+			// Bind the request to the session whose credential admitted it (#3056),
+			// so the route's own handler can constrain to "the caller's own". Empty
+			// owner = the operator's authority, which stays unconstrained.
+			if owner != "" {
+				r = r.WithContext(withSandboxOwner(r.Context(), owner))
+			}
+		} else {
+			if p.previewOrigin {
+				// A preview origin's denial is RENDERED IN A PANE, so it must not be the
+				// JSON envelope. WHICH page depends on whether the address can still become
+				// valid, and getting that backwards strands the frame either way.
+				//
+				// WARMING UP: the listener binds long before RestoreInstances (#829), so an
+				// editor iframe can navigate while the daemon still has no sessions to
+				// recognise its label by. That address becomes valid the moment restore
+				// finishes, so this must be the RETRYING notice — the expired page never
+				// re-requests, and the frame would sit on it until a manual reload even
+				// though the daemon recovered seconds later.
+				if p.previewWarmingUp != nil && p.previewWarmingUp() {
+					writeTabNoticePage(w, "Starting up",
+						"af is starting up — this tab will load as soon as the daemon has restored its sessions.", true)
+					return
+				}
+				// Otherwise the address really is dead: a web tab's label does not survive
+				// the secret rotating, and an editor label the restored daemon cannot place
+				// names no session it holds. Deliberately NON-retrying — nothing will make
+				// it valid — and the web client mints a fresh origin when it rebuilds.
+				writePreviewExpiredPage(w)
 				return
 			}
-			// Otherwise the address really is dead: a web tab's label does not survive
-			// the secret rotating, and an editor label the restored daemon cannot place
-			// names no session it holds. Deliberately NON-retrying — nothing will make
-			// it valid — and the web client mints a fresh origin when it rebuilds.
-			writePreviewExpiredPage(w)
+			writeHTTPError(w, r, http.StatusUnauthorized, errUnauthorized)
 			return
 		}
-		writeHTTPError(w, r, http.StatusUnauthorized, errUnauthorized)
-		return
 	}
 	next.ServeHTTP(w, r)
 }

--- a/daemon/httproutes.go
+++ b/daemon/httproutes.go
@@ -39,6 +39,75 @@ type HTTPRoute struct {
 	// Unexported: net/json skips it (so it never leaks into the catalog) and
 	// importers cannot set it.
 	handler func(*controlServer) http.HandlerFunc
+	// sandboxAllowed opts this route into the SCOPED sandbox callback credential
+	// (#2999). Zero value false means DENIED, deliberately: a route added later is
+	// unreachable by a sandbox until someone consciously opts it in. A denylist
+	// would grant every future route by default, which is the wrong direction for
+	// a credential handed to a machine af provisioned but does not trust.
+	//
+	// THE RULE FOR ADDING ONE, and it took two review rounds to state correctly
+	// (#3012). A route may be opted in only if an attacker who has taken the
+	// sandbox cannot use it to gain authority over the HOST, or to learn the
+	// operator's private layout. What remains is capability DISCOVERY: what this
+	// daemon could offer, never what the operator has or what it will go do.
+	//
+	// The rule was first written as "it cannot name another session", which is a
+	// SYMPTOM of the real predicate and let CreateSession through — it names no
+	// session and still starts an agent on the host with an attacker's repo_path,
+	// program, and prompt, which is the host-side instruction authority denying
+	// DeliverPrompt exists to withhold. Naming is one route to that authority, not
+	// the definition of it. Test the authority, not the shape of the request.
+	//
+	// Denied by this rule, with the reason each is tempting:
+	//
+	//   - CreateSession — no session named; starts one on the host anyway.
+	//   - SendPrompt, CreateTab, AddTask (via Task.TargetSession) — reach an
+	//     existing agent, reproducing DeliverPrompt one at a time.
+	//   - Snapshot — the enumeration that makes the above aimable.
+	//   - ListProjects, ListDirectory — read-only, and still hand a compromised
+	//     sandbox the operator's absolute host paths and an arbitrary directory
+	//     walk of the daemon's filesystem. Reconnaissance is authority's
+	//     precursor, and a sandbox has no use for the HOST's tree: the picker
+	//     that consumes ListDirectory (#2788) is the operator's own client,
+	//     holding the operator's own token.
+	//   - ListBackends, ListPrograms — the same oracle in a quieter form, and the
+	//     reason this list is shorter than it looks like it should be. Both take a
+	//     caller-supplied repo_path and answer through config.RepoFromPath, which
+	//     wraps git's own stderr: a caller learns "No such file or directory" vs
+	//     "Permission denied" vs "not a git repository" for any path it guesses,
+	//     and on success learns where the enclosing git root is. Confirming a
+	//     guessed path is weaker than enumerating one, but it is the same class,
+	//     and a rule that admits it is a rule with an exception carved for
+	//     convenience.
+	//
+	//   - SuggestSessionName — the last one standing under the old scheme, and it
+	//     fell too. It takes no arguments and returns a random unused name, which
+	//     looks like the one harmless thing on the surface. But it avoids every live
+	//     title ACROSS ALL REPOS (its handler says so), the wordlist is finite, and
+	//     the sandbox holds that wordlist in the `af` binary af itself put there —
+	//     so sampling until the free combinations run out reveals which ones are
+	//     persistently missing, i.e. the operator's live session titles and their
+	//     activity. An oracle can be a route that returns nothing about its own
+	//     answer.
+	//
+	// THAT EMPTIED THE TABLE, which is what #3056 changed. Both halves of the
+	// surface had failed for opposite reasons: parameterised routes need "the
+	// caller's OWN repo/session", which a flag cannot express, and parameterless
+	// routes answer from global state because it is the only state they have.
+	//
+	// THE CONTRACT NOW, and it is two conditions, not one:
+	//
+	//  1. This flag admits a route to the SCOPE. It does not authorize a request.
+	//  2. The route's HANDLER must enforce its own owner constraint, reading
+	//     sandboxOwner(ctx) — the session the presented credential belongs to,
+	//     carried from the gate (see sandbox_owner.go).
+	//
+	// A route admitted under (1) without (2) is a boundary that reads as enforced
+	// and is not. That is not left to a reader: sandboxConstrainedRoutes names every
+	// route that has a constraint, and a test asserts it equals this table in both
+	// directions, so opting a route in without giving it one FAILS. The rule used to
+	// be prose here, and prose is exactly what the four rounds above drifted from.
+	sandboxAllowed bool
 	// requestType is the RPC request struct this route decodes, kept so a consumer
 	// that needs the FULL body shape can reflect it rather than re-deriving a
 	// second, driftable list. RequestFields above is computed FROM it (see
@@ -104,11 +173,14 @@ var httpRoutes = []HTTPRoute{
 		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.SuggestSessionName) },
 	},
 	{
-		Method:      http.MethodPost,
-		Path:        "/v1/Snapshot",
-		Description: "List sessions from the daemon's authoritative in-memory state (empty repo_id = all repos).",
-		requestType: reflect.TypeOf(SnapshotRequest{}),
-		handler:     func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.Snapshot) },
+		Method:         http.MethodPost,
+		Path:           "/v1/Snapshot",
+		sandboxAllowed: true,
+		Description:    "List sessions from the daemon's authoritative in-memory state (empty repo_id = all repos).",
+		requestType:    reflect.TypeOf(SnapshotRequest{}),
+		// rpcHandlerCtx, not rpcHandler: the handler needs the request context to
+		// see whether the caller is a sandbox and narrow to its own session (#3056).
+		handler: func(cs *controlServer) http.HandlerFunc { return rpcHandlerCtx(cs.snapshot) },
 	},
 	{
 		Method:      http.MethodPost,
@@ -351,6 +423,26 @@ var internalHTTPRoutes = []HTTPRoute{
 	},
 }
 
+// sandboxAllowedPath reports whether a sandbox callback credential may call the
+// given request path (#2999).
+//
+// Derived from the served table rather than a second list: a route's capability
+// is declared beside the route, so there is no separate inventory to fall out of
+// step with it. Anything not in the table — the WS stream planes, the
+// config-assistant, the webtab proxy, the catch-all — is denied by falling
+// through, which is the same default the table itself applies.
+func sandboxAllowedPath(path string) bool {
+	return sandboxAllowedPaths[path]
+}
+
+// sandboxAllowedPaths is the derived lookup, filled in init() rather than by a
+// var initializer. That is not style: httpRoutes' initializer transitively
+// references the auth gate, which references this, and Go rejects the resulting
+// package-variable initialization cycle. Filling it in init() — which runs after
+// variable initialization — keeps the capability declared beside its route while
+// leaving the lookup a plain map read.
+var sandboxAllowedPaths = map[string]bool{}
+
 // servedHTTPRoutes is every route newHTTPMux registers: the public catalog plus
 // the internal routes. The mux serves this union; HTTPRoutes() exposes only the
 // public half. Keeping them as one concatenation here means "what is served" has
@@ -375,6 +467,11 @@ func servedHTTPRoutes() []HTTPRoute {
 func init() {
 	fillRequestFields(httpRoutes)
 	fillRequestFields(internalHTTPRoutes)
+	for _, rt := range servedHTTPRoutes() {
+		if rt.sandboxAllowed {
+			sandboxAllowedPaths[rt.Path] = true
+		}
+	}
 }
 
 func fillRequestFields(routes []HTTPRoute) {

--- a/daemon/kill_wedge_test.go
+++ b/daemon/kill_wedge_test.go
@@ -87,7 +87,7 @@ func killGuardHeld(m *Manager, key string) bool {
 // is not that the error was wrong — there was no error at all.
 func TestKillSession_ContendedInstancesLock_IsBoundedAndRetryable(t *testing.T) {
 	backend := &raceBackend{}
-	manager, repoID, _ := installRaceBackend(t, backend, "wedged")
+	manager, repoID, inst := installRaceBackend(t, backend, "wedged")
 
 	// Short budgets: this test is about the bounds existing, not their production
 	// sizes. BOTH flock sites on the kill path are bounded and both are exercised
@@ -114,6 +114,16 @@ func TestKillSession_ContendedInstancesLock_IsBoundedAndRetryable(t *testing.T) 
 	defer release()
 
 	key := daemonInstanceKey(repoID, "wedged")
+
+	// A sandbox callback credential for this session (#2999), so the two kill
+	// outcomes below can be told apart by their effect on it (#3012 review). The
+	// pair is what makes each half non-vacuous: revocation is keyed on the
+	// resolved session id, so if that id were not inst.ID the second assertion
+	// fails rather than the first passing for the wrong reason.
+	callback, err := manager.sandboxTokens.mint(inst.ID)
+	if err != nil {
+		t.Fatalf("mint sandbox callback credential: %v", err)
+	}
 
 	killDone := make(chan error, 1)
 	go func() {
@@ -148,6 +158,16 @@ func TestKillSession_ContendedInstancesLock_IsBoundedAndRetryable(t *testing.T) 
 		t.Fatal("killsInFlight still held after a failed kill: the session is undeletable and a retry would be rejected")
 	}
 
+	// The kill aborted at the tombstone and told the caller nothing was changed, so
+	// the still-running session's callback credential must still work (#3012
+	// review). Revocation is NOT reversible — the registry mints only at provision
+	// time — so revoking on an aborted kill silently and permanently severs a live
+	// sandbox from the daemon, and the retry the error asks for cannot restore it.
+	if _, ok := manager.sandboxTokens.sessionFor(callback); !ok {
+		t.Fatal("a kill that aborted before its commit point revoked the session's sandbox callback credential anyway: " +
+			"the session is still running, the error says nothing was changed, and the credential cannot be re-minted without re-provisioning")
+	}
+
 	// And the retry must actually work once the contention clears.
 	release()
 	if _, err := manager.KillSession(KillSessionRequest{Title: "wedged", RepoID: repoID}); err != nil {
@@ -158,6 +178,13 @@ func TestKillSession_ContendedInstancesLock_IsBoundedAndRetryable(t *testing.T) 
 	manager.mu.Unlock()
 	if stillTracked {
 		t.Fatal("session still tracked after a successful retry")
+	}
+	// The other half of the pair: a kill that DID commit must take the credential
+	// with it, before the runtime is torn down. Without this assertion the check
+	// above would pass just as happily if revocation never ran at all.
+	if _, ok := manager.sandboxTokens.sessionFor(callback); ok {
+		t.Fatal("a committed kill left the session's sandbox callback credential live: " +
+			"a token copied out of the sandbox keeps authenticating until the daemon restarts")
 	}
 }
 

--- a/daemon/listener_reload.go
+++ b/daemon/listener_reload.go
@@ -127,12 +127,16 @@ func (wl *webListeners) bindWebLocked(addr string) error {
 		}
 		wl.webConfigAddr = ""
 		// Tearing the listener DOWN is a listener change like any other, and this
-		// early return used to skip both consequences of that (#3012 review): the
-		// generation did not advance, so mintSandboxCallback's revalidation compared
-		// equal and let a racing create finish against a listener that had just
-		// closed; and no sweep ran, so credentials outlived the listener entirely.
-		// The opt-out is the MOST complete form of "the endpoint is gone", so it
-		// cannot be the one path that reports nothing.
+		// early return used to skip both consequences of that (#3012 review): no
+		// sweep ran, so credentials outlived the listener entirely, and the
+		// generation did not advance. The opt-out is the MOST complete form of "the
+		// endpoint is gone", so it cannot be the one path that reports nothing.
+		//
+		// The generation bump no longer feeds a mint check — that fence moved onto
+		// the registry in #3065, because a listener counter could not see an
+		// auth-only invalidation. It stays because it still retires THIS generation:
+		// the done-watcher below clears listener state only while its own generation
+		// is current, and a torn-down listener must not have its state cleared twice.
 		wl.webGen++
 		if n := wl.manager.sandboxTokens.revokeAll(); n > 0 {
 			log.WarningLog.Printf("listen_addr is now empty: revoked %d sandbox callback credential(s) — the control listener is closed, so nothing can call back until it is re-enabled and those sessions are re-provisioned", n)
@@ -314,16 +318,6 @@ func (wl *webListeners) webConfigAddress() string {
 	wl.mu.Lock()
 	defer wl.mu.Unlock()
 	return wl.webConfigAddr
-}
-
-// bindGeneration is the control listener's binding counter, incremented on every
-// successful (re)bind. A caller that read the listener address without holding
-// wl.mu can compare it before and after to learn whether the listener moved in
-// between — see mintSandboxCallback, which cannot hold this lock across a mint.
-func (wl *webListeners) bindGeneration() uint64 {
-	wl.mu.Lock()
-	defer wl.mu.Unlock()
-	return wl.webGen
 }
 
 // close tears down both listeners (daemon shutdown). Errors are joined so one

--- a/daemon/listener_reload.go
+++ b/daemon/listener_reload.go
@@ -126,6 +126,17 @@ func (wl *webListeners) bindWebLocked(addr string) error {
 			}
 		}
 		wl.webConfigAddr = ""
+		// Tearing the listener DOWN is a listener change like any other, and this
+		// early return used to skip both consequences of that (#3012 review): the
+		// generation did not advance, so mintSandboxCallback's revalidation compared
+		// equal and let a racing create finish against a listener that had just
+		// closed; and no sweep ran, so credentials outlived the listener entirely.
+		// The opt-out is the MOST complete form of "the endpoint is gone", so it
+		// cannot be the one path that reports nothing.
+		wl.webGen++
+		if n := wl.manager.sandboxTokens.revokeAll(); n > 0 {
+			log.WarningLog.Printf("listen_addr is now empty: revoked %d sandbox callback credential(s) — the control listener is closed, so nothing can call back until it is re-enabled and those sessions are re-provisioned", n)
+		}
 		return nil
 	}
 	cfg := wl.manager.Config()
@@ -135,7 +146,11 @@ func (wl *webListeners) bindWebLocked(addr string) error {
 	policy := webListenerPolicy(cfg)
 	notice := config.ListenerExposureNotice(cfg)
 	closer, info, err := startTCPListenerWithListen(wl.webMux, addr, cfg, policy, withWebShell, nil,
-		&livePosture{snapshot: wl.manager.Config, policyFromConfig: true}, wl.listenTCP)
+		&livePosture{
+			snapshot:         wl.manager.Config,
+			policyFromConfig: true,
+			sandboxTokens:    &wl.manager.sandboxTokens,
+		}, wl.listenTCP)
 	if err != nil {
 		return fmt.Errorf("apply listen_addr %q: %w — daemon still serving on %s", addr, err, servingOn(wl.webConfigAddr))
 	}
@@ -152,6 +167,7 @@ func (wl *webListeners) bindWebLocked(addr string) error {
 	go func() {
 		<-info.done
 		wl.mu.Lock()
+		revoked := 0
 		if wl.webGen == gen {
 			if wl.manager.lifecycle != nil {
 				wl.manager.lifecycle.clearTCPBound()
@@ -160,11 +176,40 @@ func (wl *webListeners) bindWebLocked(addr string) error {
 				wl.webClose = nil
 			}
 			wl.webConfigAddr = ""
+			// The listener is gone whether or not anyone asked for it to be, so an
+			// UNEXPECTED death has to advance the same state a rebind or a teardown
+			// does (#3012 review). Without this, a listener that dies under
+			// http.Server left credentials registered against an endpoint that no
+			// longer accepts — contradicting the invariant this file states — and
+			// left webGen unchanged, so a create racing the failure passed its
+			// post-mint revalidation and shipped a URL nothing answers.
+			//
+			// This is the third path that had to learn the same rule. Rebind and
+			// teardown were the two I wrote by hand; the listener simply dying was
+			// the one I did not think of, which is the argument for the rule being
+			// stated on the state itself rather than remembered at each site.
+			wl.webGen++
+			revoked = wl.manager.sandboxTokens.revokeAll()
 		}
 		wl.mu.Unlock()
+		if revoked > 0 {
+			log.WarningLog.Printf("the control listener on %s is no longer accepting: revoked %d sandbox callback credential(s) issued against it; those sessions lose callback until the listener is restored and they are re-provisioned", addr, revoked)
+		}
 	}()
 	if old != nil {
 		_ = old()
+	}
+	// The listener moved, so every sandbox callback credential minted against the
+	// old one now points at a closed address (#3012 review). Each sandbox has the
+	// URL baked into the environment file written at provision time and nothing
+	// rewrites it, so those tokens can no longer be used by the sandboxes holding
+	// them. Revoke rather than leave live credentials aimed at nothing, and SAY so:
+	// otherwise the capability vanishes silently inside sandboxes nobody is
+	// watching. Same rule the registry already applies across a daemon restart —
+	// a credential does not outlive the listener it was issued against. Affected
+	// sessions regain callback when they are re-provisioned.
+	if n := wl.manager.sandboxTokens.revokeAll(); n > 0 {
+		log.WarningLog.Printf("listen_addr moved to %s: revoked %d sandbox callback credential(s) minted against the previous listener; those sessions lose callback until they are re-provisioned", addr, n)
 	}
 	// The enable banner + posture, logged once per bind (initial and rebind). The
 	// bearer-token line is the operator's only channel to a network listener's
@@ -258,6 +303,27 @@ func (wl *webListeners) previewConfigAddress() string {
 	wl.mu.Lock()
 	defer wl.mu.Unlock()
 	return wl.previewConfigAddr
+}
+
+// webConfigAddress is previewConfigAddress for the control-plane listener: the
+// CONFIG address that produced the listener currently accepting, not the one
+// config merely asks for. Same divergence, same cause — a live rebind that failed
+// leaves the old listener serving while ApplyConfig has already stored the new
+// address. "" when nothing is bound.
+func (wl *webListeners) webConfigAddress() string {
+	wl.mu.Lock()
+	defer wl.mu.Unlock()
+	return wl.webConfigAddr
+}
+
+// bindGeneration is the control listener's binding counter, incremented on every
+// successful (re)bind. A caller that read the listener address without holding
+// wl.mu can compare it before and after to learn whether the listener moved in
+// between — see mintSandboxCallback, which cannot hold this lock across a mint.
+func (wl *webListeners) bindGeneration() uint64 {
+	wl.mu.Lock()
+	defer wl.mu.Unlock()
+	return wl.webGen
 }
 
 // close tears down both listeners (daemon shutdown). Errors are joined so one

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -537,6 +537,7 @@ func (m *Manager) restoreInstances() error {
 	if err != nil {
 		return err
 	}
+	m.attachCredentialsToAll(instances)
 	m.mu.Lock()
 	m.instances = instances
 	m.ghostTaskRuns = ghosts
@@ -675,6 +676,7 @@ func (m *Manager) refreshLocked() error {
 	if err != nil {
 		return err
 	}
+	m.attachCredentialsToAll(refreshed)
 	m.instances = refreshed
 	// Replaced wholesale, never merged: the ghost set is a projection of what is on
 	// disk RIGHT NOW (#1892). A row that starts loading again must stop being a
@@ -723,4 +725,19 @@ func (m *Manager) opLockFor(key string) *sync.Mutex {
 		m.instanceOpLocks[key] = lock
 	}
 	return lock
+}
+
+// attachCredentialsToAll gives every instance the daemon holds its credential
+// minter (#3068).
+//
+// Applied at the two points where the daemon takes ownership of instances built
+// from DISK — the startup restore and every refresh — because that is the half a
+// per-call-site fix keeps missing: session.FromInstanceData cannot populate it,
+// so a session loaded after a daemon restart would provision its replacement
+// sandbox with no callback and no error. Idempotent and cheap; re-attaching to an
+// instance that already has one is a pointer write.
+func (m *Manager) attachCredentialsToAll(instances map[string]*session.Instance) {
+	for _, inst := range instances {
+		attachSandboxCredentials(m, inst)
+	}
 }

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -42,6 +42,12 @@ type Manager struct {
 	// NOT go through here — their handlers read live config per request.
 	webListeners *webListeners
 
+	// sandboxTokens holds the per-session callback credentials handed to
+	// provisioned sandboxes (#2999). In memory only and never persisted: a
+	// daemon restart invalidates every outstanding one, which is the correct
+	// side to fail on.
+	sandboxTokens sandboxTokenRegistry
+
 	// previewSecret is the HMAC key from which the web-tab PREVIEW listener derives
 	// a PER-TAB credential (#1856 step 3): the origin label for (sessionID, tabID) is
 	// previewTabHostLabel(previewSecret, sid, tid). It is minted once, in memory, at

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -124,9 +124,6 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 	// own config.LoadConfig() here, so a raw hand-edit of session_env_passthrough
 	// was picked up on the next create; now it applies on save/ApplyConfig like
 	// every other key — a deliberate, uniform change (see the #2480 release note).
-	// Captured by the SandboxCallback closure below, read after NewInstance returns.
-	var grant sandboxGrant
-	var granted bool
 	instance, err := session.NewInstance(session.InstanceOptions{
 		ID:                             pending.ID,
 		CreatedAt:                      pending.CreatedAt,
@@ -141,19 +138,15 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 		RestoreTabs:                    req.restoreTabs,
 		PendingRecreateNotice:          req.pendingRecreateNotice,
 		ProvisionSessionEnvPassthrough: append([]string(nil), cfg.SessionEnvPassthrough...),
-		// Invoked by the session runtime ONLY for a kind that provisions off-box
-		// (#2999), so a local create neither mints a credential nor inherits the
-		// require_token refusal that guards one. The grant is captured so the create
-		// can revalidate it AFTER provisioning (#3065 review) — minting can only
-		// fence its own window, and provisioning is the long one.
-		SandboxCallback: func() (string, string, error) {
-			g, err := m.mintSandboxCallback(cfg, pending.ID)
-			if err != nil {
-				return "", "", err
-			}
-			grant, granted = g, true
-			return g.URL, g.Token, nil
-		},
+		// Mints and revokes this session's credential, driven by the RUNTIME's
+		// lifetime rather than by this call site (#3068): the session runtime mints
+		// when it provisions a sandbox — original or replacement — and revokes when
+		// it reaps one. Invoked only for a kind that provisions off-box (#2999), so
+		// a local create neither mints nor inherits the require_token refusal.
+		//
+		// Post-provision revalidation lives with the mint, in session, so the create
+		// and replacement paths cannot differ on it.
+		SandboxCredentials: newSandboxCredentials(m, pending.ID),
 	})
 	// A create that does not finish must not leave a live credential behind
 	// (#3012 review). The mint happens INSIDE NewInstance, so a provisioning
@@ -177,26 +170,7 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 	// InPlace only changes WHICH worktree that is — the repo's own working tree,
 	// marked external — not the flow itself. finishCreateStart marks the instance
 	// live, PARKS it at a usage-limit wall (#1146 PR4), or returns a fatal error.
-	// Revalidate the callback grant now that provisioning is DONE (#3065 review).
-	// The mint fences its own window, but provisioning is the slow part — an ssh
-	// clone and a binary copy — and a listener rebind or a require_token=false
-	// landing inside it revokes the credential and closes its URL while the sandbox
-	// has already had the stale pair written into it. The create would otherwise
-	// commit a session whose callback silently never connects.
-	//
-	// Routed through startErr rather than handled here on purpose: the discard path
-	// below is #1917's, with its teardown-state classification and its
-	// keepFailedCreate fallback, and a second hand-written copy of that is how the
-	// two drift. Passing this as the start failure reuses all of it, and skips
-	// starting the agent at all — there is no point prompting a session that is
-	// about to be torn down.
-	var conversationCapture session.ConversationCaptureSnapshot
-	var startErr error
-	if granted && !grant.stillValid(&m.sandboxTokens) {
-		startErr = errSandboxCallbackInvalidated(grant.URL)
-	} else {
-		conversationCapture, startErr = task.StartAndSendPromptWithConversationCapture(ctx, instance, req.Prompt)
-	}
+	conversationCapture, startErr := task.StartAndSendPromptWithConversationCapture(ctx, instance, req.Prompt)
 	if serr := finishCreateStart(instance, req.Prompt, startErr); serr != nil {
 		// An unknown startup outcome is already a teardown boundary. Launch may have
 		// failed because the name it probed is not the name tmux stored; asking Kill

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -124,6 +124,9 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 	// own config.LoadConfig() here, so a raw hand-edit of session_env_passthrough
 	// was picked up on the next create; now it applies on save/ApplyConfig like
 	// every other key — a deliberate, uniform change (see the #2480 release note).
+	// Captured by the SandboxCallback closure below, read after NewInstance returns.
+	var grant sandboxGrant
+	var granted bool
 	instance, err := session.NewInstance(session.InstanceOptions{
 		ID:                             pending.ID,
 		CreatedAt:                      pending.CreatedAt,
@@ -140,9 +143,16 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 		ProvisionSessionEnvPassthrough: append([]string(nil), cfg.SessionEnvPassthrough...),
 		// Invoked by the session runtime ONLY for a kind that provisions off-box
 		// (#2999), so a local create neither mints a credential nor inherits the
-		// require_token refusal that guards one.
+		// require_token refusal that guards one. The grant is captured so the create
+		// can revalidate it AFTER provisioning (#3065 review) — minting can only
+		// fence its own window, and provisioning is the long one.
 		SandboxCallback: func() (string, string, error) {
-			return m.mintSandboxCallback(cfg, pending.ID)
+			g, err := m.mintSandboxCallback(cfg, pending.ID)
+			if err != nil {
+				return "", "", err
+			}
+			grant, granted = g, true
+			return g.URL, g.Token, nil
 		},
 	})
 	// A create that does not finish must not leave a live credential behind
@@ -167,7 +177,26 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 	// InPlace only changes WHICH worktree that is — the repo's own working tree,
 	// marked external — not the flow itself. finishCreateStart marks the instance
 	// live, PARKS it at a usage-limit wall (#1146 PR4), or returns a fatal error.
-	conversationCapture, startErr := task.StartAndSendPromptWithConversationCapture(ctx, instance, req.Prompt)
+	// Revalidate the callback grant now that provisioning is DONE (#3065 review).
+	// The mint fences its own window, but provisioning is the slow part — an ssh
+	// clone and a binary copy — and a listener rebind or a require_token=false
+	// landing inside it revokes the credential and closes its URL while the sandbox
+	// has already had the stale pair written into it. The create would otherwise
+	// commit a session whose callback silently never connects.
+	//
+	// Routed through startErr rather than handled here on purpose: the discard path
+	// below is #1917's, with its teardown-state classification and its
+	// keepFailedCreate fallback, and a second hand-written copy of that is how the
+	// two drift. Passing this as the start failure reuses all of it, and skips
+	// starting the agent at all — there is no point prompting a session that is
+	// about to be torn down.
+	var conversationCapture session.ConversationCaptureSnapshot
+	var startErr error
+	if granted && !grant.stillValid(&m.sandboxTokens) {
+		startErr = errSandboxCallbackInvalidated(grant.URL)
+	} else {
+		conversationCapture, startErr = task.StartAndSendPromptWithConversationCapture(ctx, instance, req.Prompt)
+	}
 	if serr := finishCreateStart(instance, req.Prompt, startErr); serr != nil {
 		// An unknown startup outcome is already a teardown boundary. Launch may have
 		// failed because the name it probed is not the name tmux stored; asking Kill

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -138,7 +138,27 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 		RestoreTabs:                    req.restoreTabs,
 		PendingRecreateNotice:          req.pendingRecreateNotice,
 		ProvisionSessionEnvPassthrough: append([]string(nil), cfg.SessionEnvPassthrough...),
+		// Invoked by the session runtime ONLY for a kind that provisions off-box
+		// (#2999), so a local create neither mints a credential nor inherits the
+		// require_token refusal that guards one.
+		SandboxCallback: func() (string, string, error) {
+			return m.mintSandboxCallback(cfg, pending.ID)
+		},
 	})
+	// A create that does not finish must not leave a live credential behind
+	// (#3012 review). The mint happens INSIDE NewInstance, so a provisioning
+	// failure after it — or any later abandonment on this path — would otherwise
+	// leave an orphaned sandbox authenticating indefinitely, with no session left
+	// for an operator to kill. Deferred and armed rather than repeated at each
+	// exit: the exits are many and one forgotten `return` is a credential that
+	// never dies. Disarmed only once the session is committed to the roster,
+	// where KillSession and archive take over revocation.
+	createCommitted := false
+	defer func() {
+		if !createCommitted {
+			m.sandboxTokens.revoke(pending.ID)
+		}
+	}()
 	if err != nil {
 		return session.InstanceData{}, err
 	}
@@ -162,6 +182,19 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 				return session.InstanceData{}, fmt.Errorf("failed to start instance %q, and its startup outcome could not be determined safely — its workspace may still be on disk at %s and could not be recorded, so it must be inspected and cleaned up by hand: %w",
 					title, instance.GetWorktreePath(), errors.Join(serr, keepErr))
 			}
+			// A COMMITTED outcome, not an abandonment (#3012 review). The whole point
+			// of this branch is that the runtime may still be alive — that is why no
+			// cleanup runs — so revoking its callback credential would sever a
+			// possibly-running agent from the daemon while deliberately keeping its
+			// session for inspection and later lifecycle operations. KillSession and
+			// archive own its revocation now, exactly as for a clean start.
+			//
+			// Deliberately NOT applied to the keepFailedCreate branch below: there
+			// cleanup has been attempted and the daemon keeps retrying it, so that
+			// session is on its way out and its credential should go with it. And not
+			// applied when keepUncertainCreate FAILS, because a credential with no
+			// durable record is one no operator surface could ever revoke.
+			createCommitted = true
 			settleRetainedCreate(instance)
 			return session.InstanceData{}, fmt.Errorf("failed to start instance %q, and its startup outcome could not be determined safely, so its workspace was left in place; the session is recorded for inspection and no automatic cleanup will run: %w",
 				title, serr)
@@ -243,6 +276,9 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 		return session.InstanceData{}, persistErr
 	}
 	creatingProjectionSettled = true
+	// The session is on the roster and persisted, so its credential is now owned
+	// by the ordinary lifecycle — KillSession and archive revoke it from here.
+	createCommitted = true
 	// Publish from the Manager, not only the control-server wrapper: task delivery
 	// and root-agent ensure call Manager.CreateSession directly. They announced the
 	// same pending row above and therefore must settle it on the same events plane.

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -123,6 +123,24 @@ func (m *Manager) KillSession(req KillSessionRequest) (session.InstanceData, err
 		return session.InstanceData{}, fmt.Errorf("kill of session %q was not started: its kill intent could not be recorded, and tearing the session down without that record risks it being restored later; nothing was changed — retry the kill: %w", req.Title, err)
 	}
 
+	// Revoke this session's sandbox callback credential (#2999), anchored to the
+	// commit point immediately above rather than to the top of the function
+	// (#3012 review). Still before teardown, so the credential dies with the
+	// session — but only once the kill is real.
+	//
+	// It used to sit above the op-lock wait, on the reasoning that intent alone
+	// should stop a credential. That reasoning is wrong here, because revocation
+	// is NOT reversible on this path: the registry mints only at provision time,
+	// so a kill that aborts early — the op-lock timeout, a failed tombstone, or
+	// the identity-changed skip, all of which return leaving the session
+	// bit-for-bit unchanged and ask the caller to retry — left a still-running
+	// sandbox permanently unable to call back. An operation that promises "nothing
+	// was changed" must not have changed anything.
+	//
+	// This is the same rule the archive path already follows; the two placements
+	// disagreed and the archive one was right.
+	m.sandboxTokens.revoke(resolvedID)
+
 	// Stop this session's VS Code editor before the worktree goes away: it is
 	// daemon-owned infrastructure rather than a tab, so no tab teardown covers it,
 	// and a killed session's editor would otherwise linger rooted at a directory

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -617,6 +617,11 @@ func (m *Manager) findSessionByStableID(stableID, title, repoID string) (*sessio
 	if restoreErr != nil {
 		return nil, rid, data, nil
 	}
+	// Give it the daemon-backed credential minter (#3068). A disk-loaded instance
+	// has none — FromInstanceData cannot know about the daemon — and without this
+	// a restore would provision its replacement sandbox with no callback at all,
+	// silently, which is the ordinary case after a daemon restart.
+	attachSandboxCredentials(m, instance)
 
 	// We built `instance` from disk with m.mu released, so a concurrent
 	// refresh (or another RPC) may have restored and registered the canonical

--- a/daemon/sandbox_credentials.go
+++ b/daemon/sandbox_credentials.go
@@ -1,0 +1,91 @@
+package daemon
+
+import "github.com/sachiniyer/agent-factory/session"
+
+// The daemon's implementation of session.SandboxCredentials (#3068).
+//
+// It is what lets the session runtime drive the credential from the runtime's
+// own lifetime — mint when a sandbox is provisioned, revoke when one is reaped —
+// without package session knowing anything about the registry, the listener, or
+// the auth posture.
+//
+// One instance of this per session, carrying only the session id. Everything
+// else is read LIVE at call time, which is the correction to the first attempt:
+// that one stored a closure capturing the config from create time, so a re-mint
+// hours later still saw the posture the session was born under. If the operator
+// had disabled require_token in between, ApplyConfig revoked every outstanding
+// credential and the stale snapshot still said "require_token is true" — so the
+// re-mint succeeded against a listener that by then authenticated nobody, and it
+// happened BEFORE the new mint sampled its fence, so the fence could not catch it
+// either. A fence protects a window; it cannot protect inputs that were already
+// wrong when the window opened (#3065 review).
+type sandboxCredentials struct {
+	manager   *Manager
+	sessionID string
+}
+
+// newSandboxCredentials binds a credential minter to one session.
+func newSandboxCredentials(m *Manager, sessionID string) *sandboxCredentials {
+	return &sandboxCredentials{manager: m, sessionID: sessionID}
+}
+
+// Mint issues a fresh credential, replacing (and so revoking) any the session
+// already held.
+//
+// m.Config() is read HERE, per call, never captured. The refusals inside
+// mintSandboxCallback then evaluate the posture that is live at the moment a
+// sandbox is actually being provisioned, which is the only posture that matters.
+func (c *sandboxCredentials) Mint() (session.SandboxCredential, error) {
+	if c == nil || c.manager == nil {
+		return session.SandboxCredential{}, nil
+	}
+	grant, err := c.manager.mintSandboxCallback(c.manager.Config(), c.sessionID)
+	if err != nil {
+		return session.SandboxCredential{}, err
+	}
+	registry := &c.manager.sandboxTokens
+	return session.SandboxCredential{
+		URL:   grant.URL,
+		Token: grant.Token,
+		// Carries the fence with it, so whoever provisions can re-check it after —
+		// the create path and the replacement path both do, through the same
+		// helper. The first version handed back only url+token, and the fence it
+		// had just introduced was dropped on the floor by the second call site.
+		Revalidate: func() error {
+			if grant.stillValid(registry) {
+				return nil
+			}
+			return errSandboxCallbackInvalidated(grant.URL)
+		},
+	}, nil
+}
+
+// Revoke drops this session's credential. Idempotent, and a no-op for a session
+// that never held one — every teardown path calls it and none should fail for it.
+func (c *sandboxCredentials) Revoke() {
+	if c == nil || c.manager == nil {
+		return
+	}
+	c.manager.sandboxTokens.revoke(c.sessionID)
+}
+
+// attachSandboxCredentials gives an instance the daemon-backed minter, so a
+// replacement sandbox provisioned for it can re-mint.
+//
+// Called for instances LOADED FROM DISK, which is the half the first attempt
+// missed entirely: session.FromInstanceData reconstructs an inert instance and
+// has no way to populate this, so every restore after a daemon restart — the
+// ordinary restore — silently skipped minting while looking like it worked
+// (#3065 review). A created instance gets it through InstanceOptions instead.
+//
+// Deliberately unconditional on backend kind. Whether a credential is issued is
+// decided at provision time by BackendKind.InjectsSandboxCallback, from the kind
+// the instance actually has THEN; deciding it here, from the kind it had when it
+// was loaded, would be a second and staler copy of that predicate.
+func attachSandboxCredentials(m *Manager, inst *session.Instance) *session.Instance {
+	if m == nil || inst == nil || inst.ID == "" {
+		return inst
+	}
+	inst.SetSandboxCredentials(newSandboxCredentials(m, inst.ID))
+	return inst
+}

--- a/daemon/sandbox_credentials.go
+++ b/daemon/sandbox_credentials.go
@@ -39,7 +39,13 @@ func (c *sandboxCredentials) Mint() (session.SandboxCredential, error) {
 	if c == nil || c.manager == nil {
 		return session.SandboxCredential{}, nil
 	}
-	grant, err := c.manager.mintSandboxCallback(c.manager.Config(), c.sessionID)
+	// Fence FIRST, then read config. An argument is evaluated before the call it is
+	// passed to, so `mint(m.Config(), …)` would read the posture outside the window
+	// and an invalidation landing in between would finish its sweep before the
+	// window opened — the fence comparing equal on both sides while the config it
+	// guards was already stale (#3065 review).
+	fence := c.manager.sandboxTokens.invalidationCount()
+	grant, err := c.manager.mintSandboxCallbackFenced(fence, c.manager.Config(), c.sessionID)
 	if err != nil {
 		return session.SandboxCredential{}, err
 	}

--- a/daemon/sandbox_credentials_test.go
+++ b/daemon/sandbox_credentials_test.go
@@ -1,0 +1,78 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The half the first attempt missed: an instance materialized from DISK has no
+// credential minter unless the daemon attaches one (#3065 review, #3068).
+//
+// session.FromInstanceData cannot populate it — package session knows nothing
+// about the daemon — so without this every session loaded after a daemon restart
+// provisions its replacement sandbox with no callback at all, silently. That is
+// the ordinary restore, not an edge case, which is why the first fix looked like
+// it worked and did nothing.
+func TestRefresh_AttachesCredentialsToDiskLoadedInstances(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	seedDiskInstance(t, repoID, "restored", repoPath)
+
+	manager.mu.Lock()
+	err := manager.refreshLocked()
+	manager.mu.Unlock()
+	require.NoError(t, err)
+
+	manager.mu.Lock()
+	inst := manager.instances[daemonInstanceKey(repoID, "restored")]
+	manager.mu.Unlock()
+	require.NotNil(t, inst, "the seeded row must materialize, or this test asserts nothing")
+
+	assert.True(t, inst.SandboxCredentialsAttached(),
+		"a disk-loaded instance reached the manager with no credential minter: a restore would provision its "+
+			"replacement sandbox with no callback and report success")
+}
+
+// The minter reads LIVE config, never a snapshot captured when it was built.
+//
+// A stored closure holding create-time config was the previous shape: if the
+// operator later disabled require_token, ApplyConfig revoked every outstanding
+// credential and a re-mint through that closure still saw RequireToken=true — so
+// it succeeded against a listener that by then authenticated nobody, and the
+// invalidation predated the new mint's fence, so the fence could not catch it.
+func TestSandboxCredentials_MintReadsTheLivePosture(t *testing.T) {
+	m := applyConfigTestManager(t)
+	creds := newSandboxCredentials(m, "sess-a")
+
+	// require_token defaults to false, so a mint must REFUSE: a scoped credential
+	// against a listener that demands none enforces nothing.
+	_, err := creds.Mint()
+	require.Error(t, err, "a credential against a tokenless listener enforces nothing")
+	assert.Contains(t, err.Error(), requireTokenFixHint)
+
+	// Flip the posture LIVE. The same minter, already built, must see it — that is
+	// the whole point: the previous shape captured config when it was constructed.
+	_, err = config.SetGlobalConfigValue("require_token", "true")
+	require.NoError(t, err)
+	_, err = config.SetGlobalConfigValue("listen_addr", "10.0.0.5:8443")
+	require.NoError(t, err)
+	_, err = m.ApplyConfig()
+	require.NoError(t, err)
+
+	cred, err := creds.Mint()
+	require.NoError(t, err, "the minter must read the posture live, not the one captured when it was built")
+	assert.Equal(t, "http://10.0.0.5:8443", cred.URL)
+	assert.NotEmpty(t, cred.Token)
+
+	// And it revokes through the same object, which is what the runtime lifecycle
+	// calls when it reaps a sandbox.
+	owner, ok := m.sandboxTokens.sessionFor(cred.Token)
+	require.True(t, ok)
+	assert.Equal(t, "sess-a", owner)
+	creds.Revoke()
+	_, ok = m.sandboxTokens.sessionFor(cred.Token)
+	assert.False(t, ok, "revoking through the credentials object must reach the registry")
+}

--- a/daemon/sandbox_credentials_test.go
+++ b/daemon/sandbox_credentials_test.go
@@ -1,12 +1,14 @@
 package daemon
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
 )
 
 // The half the first attempt missed: an instance materialized from DISK has no
@@ -18,42 +20,59 @@ import (
 // the ordinary restore, not an edge case, which is why the first fix looked like
 // it worked and did nothing.
 //
-// Driven through a REAL restart — persist, then a second Manager that loads from
-// disk — because that is the situation. Seeding a row and refreshing in place does
-// not reproduce it: my first version of this test did that, and the row never
-// materialized at all, so it asserted nothing.
-func TestRestoreInstances_AttachesCredentialsToDiskLoadedInstances(t *testing.T) {
-	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
-	installInstantBackend(t)
-	repoPath := setupControlRepo(t)
-	repo, err := config.RepoFromPath(repoPath)
-	require.NoError(t, err)
+// Driven through fromInstanceDataForRefresh, the seam that exists so a test can
+// "observe (or substitute) the call". Two earlier versions of this test tried to
+// get a real row to materialize — seeding disk and refreshing, then persisting and
+// restarting — and in both the row never loaded, so the test asserted nothing
+// while looking like coverage. Substituting the materializer removes the fixture
+// from the question entirely: what is under test is whether the manager attaches
+// credentials to whatever it loads, not whether a particular row is loadable.
+func TestRefresh_AttachesCredentialsToDiskLoadedInstances(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	seedDiskInstanceWithID(t, repoID, "sess-restored", "restored", repoPath)
 
-	manager, err := NewManager(config.DefaultConfig())
-	require.NoError(t, err)
-	data, err := createForTask(manager, repoPath, "task1", "restored", 1)
-	require.NoError(t, err)
+	restore := fromInstanceDataForRefresh
+	t.Cleanup(func() { fromInstanceDataForRefresh = restore })
+
+	// Stands in for a disk-materialized instance: built with no SandboxCredentials,
+	// exactly as FromInstanceData leaves one.
+	bornWithout := false
+	fromInstanceDataForRefresh = func(d session.InstanceData) (*session.Instance, error) {
+		inst, err := session.NewInstance(session.InstanceOptions{ID: d.ID, Title: d.Title, Path: d.Path, Program: "claude"})
+		if err != nil {
+			return nil, err
+		}
+		// Anti-vacuous: if it arrived already attached, the assertion below would
+		// pass without the manager having done anything.
+		bornWithout = !inst.SandboxCredentialsAttached()
+		return inst, nil
+	}
 
 	manager.mu.Lock()
-	inst := manager.instances[daemonInstanceKey(repo.ID, data.Title)]
+	err := manager.refreshLocked()
 	manager.mu.Unlock()
-	require.NotNil(t, inst)
-	require.True(t, inst.SandboxCredentialsAttached(), "a created instance gets its minter through InstanceOptions")
-	manager.persistInstance(repo.ID, inst)
-
-	// The restart. This manager has never seen the session; it builds it from disk.
-	restarted, err := NewManager(config.DefaultConfig())
 	require.NoError(t, err)
-	require.NoError(t, restarted.RestoreInstances())
+	require.True(t, bornWithout, "the substitute must produce an UNATTACHED instance, or this test proves nothing")
 
-	restarted.mu.Lock()
-	loaded := restarted.instances[daemonInstanceKey(repo.ID, data.Title)]
-	restarted.mu.Unlock()
-	require.NotNil(t, loaded, "the persisted row must load, or this test asserts nothing")
+	manager.mu.Lock()
+	inst := manager.instances[daemonInstanceKey(repoID, "restored")]
+	manager.mu.Unlock()
+	require.NotNil(t, inst, "the seeded row must materialize through the substitute")
 
-	assert.True(t, loaded.SandboxCredentialsAttached(),
+	assert.True(t, inst.SandboxCredentialsAttached(),
 		"a disk-loaded instance reached the manager with no credential minter: restoring it would provision a "+
 			"replacement sandbox with no callback and report success")
+}
+
+// seedDiskInstanceWithID is seedDiskInstance with a stable id, which the
+// credential attach keys on.
+func seedDiskInstanceWithID(t *testing.T, repoID, id, title, repoPath string) {
+	t.Helper()
+	seeded, err := json.Marshal([]session.InstanceData{
+		{ID: id, Title: title, Path: repoPath, Status: session.Running},
+	})
+	require.NoError(t, err)
+	require.NoError(t, config.LoadState().SaveInstances(repoID, seeded))
 }
 
 // The minter reads LIVE config, never a snapshot captured when it was built.

--- a/daemon/sandbox_credentials_test.go
+++ b/daemon/sandbox_credentials_test.go
@@ -3,10 +3,10 @@ package daemon
 import (
 	"testing"
 
-	"github.com/sachiniyer/agent-factory/config"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/config"
 )
 
 // The half the first attempt missed: an instance materialized from DISK has no
@@ -17,22 +17,42 @@ import (
 // provisions its replacement sandbox with no callback at all, silently. That is
 // the ordinary restore, not an edge case, which is why the first fix looked like
 // it worked and did nothing.
-func TestRefresh_AttachesCredentialsToDiskLoadedInstances(t *testing.T) {
-	manager, repoID, repoPath := newStatusTestManager(t)
-	seedDiskInstance(t, repoID, "restored", repoPath)
+//
+// Driven through a REAL restart — persist, then a second Manager that loads from
+// disk — because that is the situation. Seeding a row and refreshing in place does
+// not reproduce it: my first version of this test did that, and the row never
+// materialized at all, so it asserted nothing.
+func TestRestoreInstances_AttachesCredentialsToDiskLoadedInstances(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	installInstantBackend(t)
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	require.NoError(t, err)
 
-	manager.mu.Lock()
-	err := manager.refreshLocked()
-	manager.mu.Unlock()
+	manager, err := NewManager(config.DefaultConfig())
+	require.NoError(t, err)
+	data, err := createForTask(manager, repoPath, "task1", "restored", 1)
 	require.NoError(t, err)
 
 	manager.mu.Lock()
-	inst := manager.instances[daemonInstanceKey(repoID, "restored")]
+	inst := manager.instances[daemonInstanceKey(repo.ID, data.Title)]
 	manager.mu.Unlock()
-	require.NotNil(t, inst, "the seeded row must materialize, or this test asserts nothing")
+	require.NotNil(t, inst)
+	require.True(t, inst.SandboxCredentialsAttached(), "a created instance gets its minter through InstanceOptions")
+	manager.persistInstance(repo.ID, inst)
 
-	assert.True(t, inst.SandboxCredentialsAttached(),
-		"a disk-loaded instance reached the manager with no credential minter: a restore would provision its "+
+	// The restart. This manager has never seen the session; it builds it from disk.
+	restarted, err := NewManager(config.DefaultConfig())
+	require.NoError(t, err)
+	require.NoError(t, restarted.RestoreInstances())
+
+	restarted.mu.Lock()
+	loaded := restarted.instances[daemonInstanceKey(repo.ID, data.Title)]
+	restarted.mu.Unlock()
+	require.NotNil(t, loaded, "the persisted row must load, or this test asserts nothing")
+
+	assert.True(t, loaded.SandboxCredentialsAttached(),
+		"a disk-loaded instance reached the manager with no credential minter: restoring it would provision a "+
 			"replacement sandbox with no callback and report success")
 }
 
@@ -47,17 +67,25 @@ func TestSandboxCredentials_MintReadsTheLivePosture(t *testing.T) {
 	m := applyConfigTestManager(t)
 	creds := newSandboxCredentials(m, "sess-a")
 
-	// require_token defaults to false, so a mint must REFUSE: a scoped credential
+	// A dialable listen_addr first. DefaultConfig's is loopback, which is refused
+	// for a reason of its own — a sandbox dialling it reaches itself — and that
+	// refusal would mask the posture one this test is about. (My first version
+	// asserted the require_token hint here and got the loopback message, because
+	// dialability is checked first.)
+	_, err := config.SetGlobalConfigValue("listen_addr", "10.0.0.5:8443")
+	require.NoError(t, err)
+	_, err = m.ApplyConfig()
+	require.NoError(t, err)
+
+	// require_token is still false, so a mint must REFUSE: a scoped credential
 	// against a listener that demands none enforces nothing.
-	_, err := creds.Mint()
-	require.Error(t, err, "a credential against a tokenless listener enforces nothing")
+	_, err = creds.Mint()
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), requireTokenFixHint)
 
 	// Flip the posture LIVE. The same minter, already built, must see it — that is
-	// the whole point: the previous shape captured config when it was constructed.
+	// the whole point: the previous shape captured its config at construction.
 	_, err = config.SetGlobalConfigValue("require_token", "true")
-	require.NoError(t, err)
-	_, err = config.SetGlobalConfigValue("listen_addr", "10.0.0.5:8443")
 	require.NoError(t, err)
 	_, err = m.ApplyConfig()
 	require.NoError(t, err)
@@ -67,8 +95,8 @@ func TestSandboxCredentials_MintReadsTheLivePosture(t *testing.T) {
 	assert.Equal(t, "http://10.0.0.5:8443", cred.URL)
 	assert.NotEmpty(t, cred.Token)
 
-	// And it revokes through the same object, which is what the runtime lifecycle
-	// calls when it reaps a sandbox.
+	// And it revokes through the same object — what the runtime lifecycle calls
+	// when it reaps a sandbox.
 	owner, ok := m.sandboxTokens.sessionFor(cred.Token)
 	require.True(t, ok)
 	assert.Equal(t, "sess-a", owner)

--- a/daemon/sandbox_owner.go
+++ b/daemon/sandbox_owner.go
@@ -1,0 +1,83 @@
+package daemon
+
+import "context"
+
+// The sandbox callback credential's OWNER binding (#3056).
+//
+// #3012 spent nine review rounds establishing that a route-level allowlist
+// cannot carry this credential, and the reason generalises: every route worth
+// giving a sandbox is parameterised by a host path or a session id, so what the
+// scope needs to express is "the caller's OWN repo/session" — and a bool on a
+// route table cannot say that. The routes that take no parameter fail from the
+// other side: they answer from global state, because that is the only state they
+// have. The table ended EMPTY, which is what this file exists to change.
+//
+// The registry has always known the answer — sandboxTokenRegistry.sessionFor
+// returns the session that owns a presented credential — and the gate threw it
+// away after converting it to a bool. This carries it through to the handler.
+//
+// THE RULE, and every part of this file serves it:
+//
+//	The flag on the route table admits a route to the SCOPE. It does not
+//	authorize a request. A route in the scope must ALSO enforce its own owner
+//	constraint. A route admitted before its own constraint exists is a boundary
+//	that reads as enforced and is not.
+//
+// That rule was previously prose in a doc comment, which is how it got broken
+// repeatedly. sandboxConstrainedRoutes below makes it a test failure instead.
+
+// sandboxOwnerKey is the context key carrying the owning session id. An
+// unexported zero-size struct type, so no other package can collide with it or
+// forge a value into a context.
+type sandboxOwnerKey struct{}
+
+// withSandboxOwner marks ctx as a request that authenticated with the sandbox
+// callback credential belonging to sessionID.
+func withSandboxOwner(ctx context.Context, sessionID string) context.Context {
+	return context.WithValue(ctx, sandboxOwnerKey{}, sessionID)
+}
+
+// sandboxOwner returns the session owning the credential this request
+// authenticated with, and whether the request came from a sandbox at all.
+//
+// THE BOOL IS THE SAFETY-CRITICAL HALF, not the string. false means the request
+// carried the OPERATOR's authority — the trusted unix socket, or the operator's
+// own token — which is deliberately unconstrained. So a handler must branch on
+// the bool and narrow only when it is true; a handler that instead filtered by
+// "whatever id is in the context, empty means match nothing" would invert the
+// two and hand a sandbox everything.
+//
+// The residual risk is the mirror image: a sandbox request that lost its context
+// value would read as the operator. Nothing in the gate can lose it — servePosture
+// attaches it at the single point where authorize admits a credential — but
+// "structurally cannot happen" is what a test is for, so the binding is proved by
+// driving a real credentialed request through the real mux rather than by
+// inspecting this function.
+func sandboxOwner(ctx context.Context) (string, bool) {
+	id, ok := ctx.Value(sandboxOwnerKey{}).(string)
+	if !ok || id == "" {
+		return "", false
+	}
+	return id, true
+}
+
+// sandboxConstrainedRoutes names every route whose handler enforces an owner
+// constraint, and says what the constraint IS. It is the machine-checkable half
+// of the rule at the top of this file: a test asserts this set and the scope
+// table (HTTPRoute.sandboxAllowed) are EQUAL in both directions, so
+//
+//   - opting a route into the scope without giving it a constraint fails, and
+//   - deleting a constraint while leaving the route admitted fails.
+//
+// Prose in a comment could not do that. #3012's scope was governed by a written
+// rule and drifted from it in four separate rounds — CreateSession, the repo-path
+// oracles, the path enumerations, and finally the parameterless collision oracle
+// — each time because a route was judged against the rule by a reader rather than
+// by a check.
+//
+// The value is documentation for the reviewer, not something the code branches
+// on: the constraint itself lives in the handler, which is the only place that
+// knows what "the caller's own" means for that route.
+var sandboxConstrainedRoutes = map[string]string{
+	"/v1/Snapshot": "returns ONLY the caller's own session, and no delivery alarms",
+}

--- a/daemon/sandbox_owner_test.go
+++ b/daemon/sandbox_owner_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -167,4 +168,99 @@ func TestSnapshot_SandboxCredentialSeesOnlyItsOwnSession(t *testing.T) {
 	}
 	assert.Empty(t, own.DeliveryAlarms,
 		"delivery alarms name their target by TITLE, so they are withheld from a sandbox entirely rather than filtered by an id-to-title mapping")
+}
+
+// The owner's OWN row must still not describe the daemon host (#3065 review).
+//
+// Reflective rather than a list of field assertions, and that is the point: the
+// projection is default-deny by construction, so this walks every field of the
+// result and fails on any populated one that has not been consciously allowed.
+// A field ADDED to InstanceData later is caught the moment it starts arriving —
+// which a hand-written "assert Path is empty" would never do.
+func TestSandboxSafeInstanceData_WithholdsEverythingNotExplicitlyAllowed(t *testing.T) {
+	allowed := map[string]bool{
+		"ID": true, "TaskID": true, "Title": true, "Branch": true, "Status": true,
+		"Liveness": true, "InFlightOp": true, "LifecycleAction": true,
+		"CurrentAgent": true, "Program": true, "BackendType": true,
+		"TaskRunActive": true, "LimitResetAt": true, "CreatedAt": true, "UpdatedAt": true,
+	}
+
+	// Populate EVERY field with a non-zero value, so anything that survives the
+	// projection is visible. Strings and bools are enough to make the point; the
+	// struct/slice fields are set to non-nil so they too show up as populated.
+	full := session.InstanceData{
+		ID: "sess-a", TaskID: "task-1", Title: "mine", Branch: "af/mine",
+		Status: session.Ready, CurrentAgent: "claude", Program: "claude",
+		BackendType: "ssh", TaskRunActive: true, CanKill: true, CanHandoff: true,
+		IsRoot: true, UserKilled: true, StartupStateUnknown: true,
+		Height: 40, Width: 120,
+		Path:                  "/home/operator/private/repo",
+		TmuxName:              "af-mine",
+		Prompt:                "the operator's prompt text",
+		PendingHandoffMission: "mission",
+		Tabs:                  []session.TabData{{Name: "shell"}},
+	}
+	full.Worktree.RepoPath = "/home/operator/private/repo"
+	full.Worktree.WorktreePath = "/home/operator/private/repo/.af/worktrees/mine"
+
+	got := sandboxSafeInstanceData(full)
+
+	v := reflect.ValueOf(got)
+	typ := v.Type()
+	require.Greater(t, typ.NumField(), 20, "InstanceData shrank unexpectedly; this guard assumes the wide struct it is protecting")
+	var leaked []string
+	for i := 0; i < typ.NumField(); i++ {
+		name := typ.Field(i).Name
+		if allowed[name] {
+			continue
+		}
+		if !v.Field(i).IsZero() {
+			leaked = append(leaked, name)
+		}
+	}
+	assert.Emptyf(t, leaked,
+		"sandboxSafeInstanceData passed through %v, which is not in the allowed set. If a new field is genuinely safe "+
+			"for a sandbox to learn about its own session, add it to the projection AND to this test's allowed set — "+
+			"deliberately. Fields describing the daemon HOST (Path, Worktree, TmuxName) must never be added.", leaked)
+
+	// And the allowed ones actually survive, or the projection would "pass" by
+	// returning an empty struct.
+	assert.Equal(t, "sess-a", got.ID)
+	assert.Equal(t, "mine", got.Title)
+	assert.Equal(t, "af/mine", got.Branch)
+	assert.Equal(t, session.Ready, got.Status)
+	assert.Empty(t, got.Path, "the host's absolute repo root is the field this projection exists for")
+	assert.Empty(t, got.Worktree.WorktreePath, "the worktree carries host paths too, so the whole struct is withheld")
+}
+
+// An invalidation anywhere — listener OR auth posture — must fence a mint in
+// flight (#3065 review). The listener generation this replaced could not see an
+// auth-only change.
+func TestSandboxTokenRegistry_InvalidationCountFencesEveryGlobalRevoke(t *testing.T) {
+	var r sandboxTokenRegistry
+	start := r.invalidationCount()
+
+	// Advances even with an EMPTY registry: a sweep that finds nothing still means
+	// an invalidating event happened, and the mint racing it has not registered its
+	// token yet — exactly the case a count gated on "something was dropped" misses.
+	require.Equal(t, 0, r.revokeAll())
+	assert.Equal(t, start+1, r.invalidationCount(),
+		"an invalidation with nothing outstanding must still advance the fence, or a mint racing it survives")
+
+	_, err := r.mint("sess-a")
+	require.NoError(t, err)
+	afterMint := r.invalidationCount()
+	assert.Equal(t, start+1, afterMint, "minting is not an invalidation and must not move the fence")
+
+	require.Equal(t, 1, r.revokeAll())
+	assert.Equal(t, start+2, r.invalidationCount())
+
+	// A TARGETED revoke is not a global invalidation: one session ending must not
+	// fence every other session's in-flight create.
+	_, err = r.mint("sess-b")
+	require.NoError(t, err)
+	before := r.invalidationCount()
+	r.revoke("sess-b")
+	assert.Equal(t, before, r.invalidationCount(),
+		"revoking one session must not advance the global fence, or every teardown would fail unrelated creates")
 }

--- a/daemon/sandbox_owner_test.go
+++ b/daemon/sandbox_owner_test.go
@@ -1,0 +1,170 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The owner binding (#3056): a sandbox callback credential authorizes only what
+// belongs to the session that owns it.
+
+// THE STRUCTURAL GUARD. Every route in the sandbox scope must have a handler-side
+// owner constraint, and every registered constraint must name a route that is
+// actually in the scope.
+//
+// This is the check that replaces a rule written in prose. #3012's scope was
+// governed by exactly such a rule and drifted from it four separate times —
+// CreateSession, the repo-path oracles, the path enumerations, the parameterless
+// collision oracle — each time because a route was judged against the rule by a
+// reader rather than by a test.
+func TestEverySandboxRouteEnforcesAnOwnerConstraint(t *testing.T) {
+	require.NotEmpty(t, sandboxAllowedPaths,
+		"an empty scope makes this test vacuous; if the scope is deliberately empty again, delete the routes from sandboxConstrainedRoutes too and say so here")
+
+	for path := range sandboxAllowedPaths {
+		constraint, ok := sandboxConstrainedRoutes[path]
+		assert.Truef(t, ok,
+			"%s is admitted to the sandbox scope but no handler-side owner constraint is registered for it. "+
+				"Admission is not authorization: give the handler a constraint that narrows to sandboxOwner(ctx), "+
+				"then register it in sandboxConstrainedRoutes. A route admitted without one is a boundary that "+
+				"reads as enforced and is not.", path)
+		assert.NotEmptyf(t, constraint, "%s registers an empty constraint description", path)
+	}
+	for path := range sandboxConstrainedRoutes {
+		assert.Truef(t, sandboxAllowedPaths[path],
+			"%s registers an owner constraint but is not in the sandbox scope. Either the route was withdrawn and "+
+				"this entry is stale, or the opt-in was dropped by accident and the constraint is now dead code.", path)
+	}
+}
+
+func TestSandboxOwner_AbsentMeansOperatorNotEmptySandbox(t *testing.T) {
+	// A bare context is the operator (unix socket, or the operator's own token):
+	// unconstrained, and the bool is what says so.
+	_, isSandbox := sandboxOwner(context.Background())
+	assert.False(t, isSandbox, "a request with no sandbox owner carries operator authority and must not be narrowed")
+
+	owner, isSandbox := sandboxOwner(withSandboxOwner(context.Background(), "sess-a"))
+	assert.True(t, isSandbox)
+	assert.Equal(t, "sess-a", owner)
+
+	// An empty id must never read as a sandbox: the whole binding treats "no owner"
+	// as the operator, so an empty one would widen rather than narrow.
+	_, isSandbox = sandboxOwner(withSandboxOwner(context.Background(), ""))
+	assert.False(t, isSandbox, "an empty owner must not present as a constrained sandbox caller")
+}
+
+func TestAuthGate_BindsTheCredentialToItsOwningSession(t *testing.T) {
+	var registry sandboxTokenRegistry
+	secretA, err := registry.mint("sess-a")
+	require.NoError(t, err)
+	secretB, err := registry.mint("sess-b")
+	require.NoError(t, err)
+
+	gate := &authGate{
+		expectedToken: func() (string, error) { return "operator-token", nil },
+		sandboxTokens: &registry,
+	}
+	request := func(token string) *http.Request {
+		r := mustRequest(t, http.MethodPost, "/v1/Snapshot")
+		r.Header.Set("Authorization", "Bearer "+token)
+		return r
+	}
+
+	owner, ok := gate.authorize(request(secretA))
+	require.True(t, ok)
+	assert.Equal(t, "sess-a", owner, "the gate must report WHICH session's credential admitted the request")
+
+	owner, ok = gate.authorize(request(secretB))
+	require.True(t, ok)
+	assert.Equal(t, "sess-b", owner, "two sandboxes must not resolve to the same owner")
+
+	// The operator's token authorizes with NO owner — that absence is what keeps
+	// the operator unconstrained downstream.
+	owner, ok = gate.authorize(request("operator-token"))
+	require.True(t, ok)
+	assert.Empty(t, owner, "the operator's own token must carry no sandbox owner, or it would be narrowed like one")
+}
+
+// THE ACCEPTANCE TEST for #3056, driven through the real mux rather than by
+// calling the handler: a credential minted for session A must not be able to see
+// session B.
+//
+// It goes through newHTTPMux + the real gate on purpose. The binding is a chain —
+// registry to gate to request context to handler — and every link is somewhere a
+// regression would silently restore full visibility while every unit test still
+// passed. Calling s.snapshot with a hand-built context would prove the filter and
+// none of the wiring.
+func TestSnapshot_SandboxCredentialSeesOnlyItsOwnSession(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	mk := func(title string) *session.Instance {
+		inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: repoPath, Program: "claude"})
+		require.NoError(t, err)
+		inst.SetStartedForTest(true)
+		inst.SetStatusForTest(session.Ready)
+		seedDiskInstance(t, repoID, title, repoPath)
+		manager.mu.Lock()
+		manager.instances[daemonInstanceKey(repoID, title)] = inst
+		manager.mu.Unlock()
+		return inst
+	}
+	mine := mk("mine")
+	theirs := mk("theirs")
+	require.NotEqual(t, mine.ID, theirs.ID)
+
+	secret, err := manager.sandboxTokens.mint(mine.ID)
+	require.NoError(t, err)
+
+	mux := newHTTPMux(&controlServer{manager: manager})
+	gated := withAuth(mux, &authGate{
+		expectedToken: func() (string, error) { return "operator-token", nil },
+		sandboxTokens: &manager.sandboxTokens,
+	}, nil)
+
+	snapshotAs := func(token string) SnapshotResponse {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/v1/Snapshot", strings.NewReader(`{}`))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		gated.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+		var env struct {
+			Data SnapshotResponse `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &env), "body: %s", rec.Body.String())
+		return env.Data
+	}
+
+	// The operator sees everything. Asserted FIRST and not as a courtesy: it is what
+	// proves the filter below narrowed something, rather than the fixture being
+	// empty or the mux answering an error the assertion would not notice.
+	all := snapshotAs("operator-token")
+	titles := map[string]bool{}
+	for _, d := range all.Instances {
+		titles[d.Title] = true
+	}
+	require.True(t, titles["mine"] && titles["theirs"],
+		"the operator must see both sessions, or this test cannot show the sandbox saw fewer; got %v", titles)
+
+	// The sandbox sees exactly its own.
+	own := snapshotAs(secret)
+	require.Len(t, own.Instances, 1,
+		"a sandbox credential must see ONLY its own session; it saw %d", len(own.Instances))
+	assert.Equal(t, mine.ID, own.Instances[0].ID)
+	assert.Equal(t, "mine", own.Instances[0].Title)
+	for _, d := range own.Instances {
+		assert.NotEqual(t, theirs.ID, d.ID, "session B leaked into session A's snapshot")
+	}
+	assert.Empty(t, own.DeliveryAlarms,
+		"delivery alarms name their target by TITLE, so they are withheld from a sandbox entirely rather than filtered by an id-to-title mapping")
+}

--- a/daemon/sandbox_token.go
+++ b/daemon/sandbox_token.go
@@ -1,0 +1,347 @@
+package daemon
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// The sandbox callback credential (#2999).
+//
+// A provisioned sandbox can be driven BY the daemon but could not call back INTO
+// it at all. Giving it the operator's own token would have been the easy answer
+// and the wrong one: that token grants the whole control plane including
+// DeliverPrompt, which runs instructions through every agent on the machine — so
+// one compromised sandbox would own the host.
+//
+// What a sandbox gets instead is a token that is:
+//
+//   - PER SESSION, so it can be revoked with that session and names who used it;
+//   - SCOPED, and at present to a single route — SuggestSessionName — with every
+//     other route denied unless it opts in (see HTTPRoute.sandboxAllowed, which
+//     carries the rule and the reasoning for each denial). Notably NOT creating a
+//     session: that names no session and still starts an agent on the host with a
+//     caller-supplied repo_path, program and prompt (#3012 review). The scope is
+//     this small because every route worth giving a sandbox is parameterised by a
+//     host path or a session id, which route-level allowlisting cannot constrain
+//     to the caller's own; that waits on binding the credential to its session;
+//   - IN MEMORY ONLY, so a daemon restart invalidates every outstanding sandbox
+//     credential. A long-running sandbox loses callback until it is
+//     re-provisioned, which is the right side to fail on: a restart is exactly
+//     when a credential minted by the previous process should stop working.
+//
+// It is deliberately NOT written to disk beside the operator token. There is no
+// `af sandbox-token show`, and nothing renders one: the only copy outside this
+// registry is the one injected into the sandbox that owns it.
+
+// sandboxTokenRegistry maps live sandbox credentials to the session that owns
+// them. Zero value is usable.
+type sandboxTokenRegistry struct {
+	mu sync.RWMutex
+	// bySecret is the authorization lookup: presented credential -> session id.
+	bySecret map[string]string
+	// bySession is the revocation index, so ending a session drops its
+	// credential without scanning. A session holds at most one at a time; a
+	// re-provision replaces it, which implicitly revokes the old one.
+	bySession map[string]string
+}
+
+// mint issues a fresh credential for sessionID, replacing and thereby revoking
+// any credential that session already held.
+func (r *sandboxTokenRegistry) mint(sessionID string) (string, error) {
+	if strings.TrimSpace(sessionID) == "" {
+		return "", fmt.Errorf("cannot mint a sandbox callback token without a session id")
+	}
+	secret, err := generateToken()
+	if err != nil {
+		return "", fmt.Errorf("cannot mint a sandbox callback token: %w", err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.bySecret == nil {
+		r.bySecret, r.bySession = map[string]string{}, map[string]string{}
+	}
+	if previous, ok := r.bySession[sessionID]; ok {
+		delete(r.bySecret, previous)
+	}
+	r.bySecret[secret] = sessionID
+	r.bySession[sessionID] = secret
+	return secret, nil
+}
+
+// sessionFor returns the session a presented credential belongs to.
+//
+// The lookup is by map key rather than a constant-time compare against every
+// entry. That is not a timing regression over the operator token: a map hit
+// leaks only whether a secret exists, and the secret is 256 bits of CSPRNG
+// output, so an attacker cannot walk the space with timing. Comparing linearly
+// in constant time would leak the registry SIZE through latency instead.
+func (r *sandboxTokenRegistry) sessionFor(secret string) (string, bool) {
+	if secret == "" {
+		return "", false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	sessionID, ok := r.bySecret[secret]
+	return sessionID, ok
+}
+
+// revoke drops the credential a session holds. Idempotent: a session that never
+// had one, or whose credential was already replaced, is a no-op success, because
+// every teardown path calls this and none of them should fail for it.
+func (r *sandboxTokenRegistry) revoke(sessionID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	secret, ok := r.bySession[sessionID]
+	if !ok {
+		return
+	}
+	delete(r.bySecret, secret)
+	delete(r.bySession, sessionID)
+}
+
+// revokeAll drops every outstanding sandbox credential and reports how many it
+// dropped, for the caller's log line.
+//
+// The control listener rebinding is the one event that calls this (#3012 review).
+// A callback credential is inseparable from the endpoint it was minted for: the
+// URL is baked into the sandbox's environment file at provision time and nothing
+// rewrites it, so when bindWebLocked moves the listener and closes the old one,
+// every already-running sandbox is left calling an address that no longer answers
+// while its token stays valid. Leaving it valid buys nothing — the sandbox cannot
+// reach the daemon to use it — and costs the ability to say what happened.
+//
+// This is the same rule the registry already documents for a daemon restart:
+// credentials do not survive the listener they were issued against. Revoking makes
+// the capability's disappearance explicit and logged, instead of a silent
+// connection failure inside a sandbox nobody is watching. It is a MITIGATION, not
+// the fix — the fix is a stable advertised callback endpoint that a rebind does not
+// move, which is recorded on #2999.
+func (r *sandboxTokenRegistry) revokeAll() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n := len(r.bySession)
+	r.bySecret, r.bySession = nil, nil
+	return n
+}
+
+// requireTokenFixHint is the one-line fix named by the refusal below. Kept beside
+// the refusal so the message and the key cannot drift.
+const requireTokenFixHint = "af config set require_token true"
+
+// errSandboxCallbackNeedsRequireToken refuses to hand a sandbox a credential for
+// a listener that does not ask for one (#2999).
+//
+// This is the load-bearing refusal, so the reasoning is here rather than at the
+// call site. require_token defaults to FALSE, and #2168 Phase 0 reversed #2090's
+// refusal to bind a tokenless network listener — af now binds it and warns once.
+// So the moment an operator points listen_addr somewhere a sandbox can reach, the
+// whole control plane answers every caller with no credential at all.
+//
+// Injecting a token into that would be worse than doing nothing: it manufactures
+// the appearance of a boundary that nothing enforces, and the next reader — human
+// or agent — would reasonably believe the sandbox is limited to its scope when it
+// is limited by nothing.
+//
+// Silently skipping the injection would be worse still. The sandbox would reach
+// an UNAUTHENTICATED daemon and simply not know it, so the failure would surface
+// as a mysterious capability rather than a refusal. Failing closed, naming the
+// single config key that fixes it, is the only honest option.
+func errSandboxCallbackNeedsRequireToken() error {
+	return fmt.Errorf(
+		"refusing to give this sandbox a callback credential: require_token is false, so the daemon's "+
+			"listener accepts requests with no token and a scoped credential would enforce nothing. "+
+			"Enable it first: %s",
+		requireTokenFixHint,
+	)
+}
+
+// mintSandboxCallback returns the credential and daemon URL to inject into a
+// sandbox, or refuses.
+//
+// Order matters twice over. The posture is checked BEFORE a secret is generated,
+// so a refused provision never leaves an unusable credential in the registry. And
+// every address decision reads the listener that is ACTUALLY ACCEPTING rather than
+// cfg.ListenAddr (#3012 review): the two diverge exactly when a live rebind failed,
+// because ApplyConfig stores the new address while bindWebLocked deliberately
+// leaves the old listener serving rather than making the daemon unreachable
+// through the very API an operator would use to fix it. Reading config there would
+// hand every sandbox a URL for an address nothing is bound to — a callback that
+// silently never connects — and would judge the loopback posture against a
+// listener that does not exist. #1856 hit the same divergence for the preview
+// origin; activeWebConfigAddr is the same answer for this one.
+func (m *Manager) mintSandboxCallback(cfg *config.Config, sessionID string) (url, token string, err error) {
+	if cfg == nil {
+		return "", "", errSandboxCallbackNeedsRequireToken()
+	}
+	// The generation is sampled BEFORE the address is read, not just before the mint
+	// (#3012 review). Sampling it after left the address read itself outside the
+	// window: a rebind landing in between would close the old listener, complete its
+	// revokeAll, and then be recorded as the "starting" generation — so the final
+	// comparison matched and the create finished with a live token paired to a
+	// closed URL. Everything the credential depends on must be read inside the
+	// window, and the address is the first of those reads.
+	gen := m.webBindGeneration()
+	active := m.activeWebConfigAddr(cfg.ListenAddr)
+	if strings.TrimSpace(active) == "" && strings.TrimSpace(cfg.ListenAddr) != "" {
+		return "", "", fmt.Errorf("refusing to give this sandbox a callback credential: listen_addr is %q but no control-plane listener is accepting on it, so a callback would have nothing to reach. Check the daemon log for the bind failure and fix listen_addr", cfg.ListenAddr)
+	}
+	// Dialability first, posture second. Both refuse before any secret exists, but
+	// the ORDER decides which message an operator reads, and a loopback listen_addr
+	// used to answer "enable require_loopback_token" — advice that would have led
+	// them to a well-enforced credential their sandbox still could not use.
+	url, err = sandboxCallbackURL(active)
+	if err != nil {
+		return "", "", err
+	}
+	if err := sandboxCallbackPostureOK(cfg); err != nil {
+		return "", "", err
+	}
+	// Snapshot the listener generation BEFORE minting and revalidate after, because
+	// nothing holds webListeners.mu across the mint (#3012 review). A listen_addr
+	// change racing this create would otherwise complete its rebind — including the
+	// revokeAll sweep — in the window between reading the address and registering
+	// the token, leaving a credential that survived the sweep while carrying the
+	// URL of the listener the sweep just closed.
+	//
+	// Revalidate-and-refuse rather than lock, deliberately. Holding the listener
+	// lock across a mint inverts the order bindWebLocked already uses (listener lock
+	// -> revokeAll -> registry lock) and is a deadlock waiting to happen. Refusing
+	// costs a create that the operator can retry against the new listener; the retry
+	// is honest, and the alternative is a session that looks provisioned and has a
+	// callback that never connects.
+	token, err = m.sandboxTokens.mint(sessionID)
+	if err != nil {
+		return "", "", err
+	}
+	if m.webBindGeneration() != gen {
+		m.sandboxTokens.revoke(sessionID)
+		return "", "", fmt.Errorf("refusing to give this sandbox a callback credential: the control listener rebound while this session was being provisioned, so the callback address %q is already closed. Retry the create", url)
+	}
+	return url, token, nil
+}
+
+// webBindGeneration counts control-listener bindings, so a caller can tell whether
+// the listener moved underneath it. 0 when there is no listener owner (a bare
+// Manager, as tests construct), where nothing can rebind.
+func (m *Manager) webBindGeneration() uint64 {
+	if m.webListeners == nil {
+		return 0
+	}
+	return m.webListeners.bindGeneration()
+}
+
+// activeWebConfigAddr is the config address behind the control-plane listener that
+// is actually serving. It falls back to requested — the caller's own config value —
+// only when there is no listener owner at all (a bare Manager, as tests construct),
+// where the two cannot disagree because nothing has bound.
+func (m *Manager) activeWebConfigAddr(requested string) string {
+	if m.webListeners == nil {
+		return requested
+	}
+	return m.webListeners.webConfigAddress()
+}
+
+// sandboxCallbackURL renders listen_addr as a URL a sandbox can dial, or refuses.
+//
+// It never rewrites an address into something routable: guessing an
+// externally-reachable one would invent a fact about the operator's network, and a
+// wrong guess points the agent at whatever answers there — far worse to debug than
+// a named refusal. So every address that is not dialable FROM A SANDBOX is refused,
+// and the three ways an address can fail that test are one rule, not three special
+// cases: the address must name the daemon when resolved on the sandbox's side of
+// the network, and must name a fixed port.
+func sandboxCallbackURL(listenAddr string) (string, error) {
+	addr := strings.TrimSpace(listenAddr)
+	if addr == "" {
+		return "", fmt.Errorf("refusing to give this sandbox a callback credential: listen_addr is empty, so the daemon serves no HTTP listener for it to call back to. Set listen_addr to an address the sandbox can reach")
+	}
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", fmt.Errorf("refusing to give this sandbox a callback credential: listen_addr %q is not host:port, so no callback URL can be derived from it", addr)
+	}
+	// A BIND address is not automatically a DIALABLE one, and the difference is not
+	// cosmetic: a wildcard or empty host means "every interface HERE", which from
+	// inside a sandbox names the SANDBOX, so the agent would quietly call itself.
+	// Port 0 means "whatever the kernel picked", which this config value cannot know.
+	//
+	// Refused rather than guessed. Rewriting a wildcard into some interface address
+	// would invent a fact about the operator's network, and a wrong guess points the
+	// agent at whatever answers there — far worse to debug than a named refusal.
+	// ONE predicate for the host, because the previous three rounds of this review
+	// each found another spelling the last one missed: a wildcard, then the expanded
+	// and v4-mapped unspecified forms, then loopback, then loopback ALIASES like
+	// ip6-localhost, then zone-scoped addresses. Enumerating spellings loses.
+	//
+	// The host must be a LITERAL IP. That is not a convenience — it is the only form
+	// whose meaning does not depend on who resolves it, and the resolver that matters
+	// here is the SANDBOX'S, not this daemon's. "ip6-localhost" was the visible case
+	// of a general fact: af cannot know what a name denotes on the other side of the
+	// network, so it must not put one in a callback URL. Requiring a literal also
+	// rejects zone-scoped addresses (net.ParseIP refuses "fe80::1234%eth0") — which
+	// is right twice over, since a zone names an interface on the DAEMON'S host and
+	// would additionally emit a raw "%" that Go's URL parser reads as a bad escape.
+	//
+	// With the host guaranteed to be an IP, the two undialable classes are semantic
+	// questions with exact answers, rather than string comparisons:
+	//   - IsUnspecified — binds every interface, so it names the SANDBOX.
+	//   - IsLoopback — names the sandbox ITSELF, and nothing forwards a callback back
+	//     (the ssh runtime tunnels daemon→sandbox only).
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return "", fmt.Errorf("refusing to give this sandbox a callback credential: listen_addr %q does not name a literal IP address, and a hostname is resolved by the SANDBOX rather than by this daemon — af cannot know what it points at over there. Set listen_addr to a literal IP the sandbox can reach", addr)
+	}
+	if ip.IsUnspecified() {
+		return "", fmt.Errorf("refusing to give this sandbox a callback credential: listen_addr %q binds every interface, which names the SANDBOX rather than the daemon when dialled from inside one. Set listen_addr to an address the sandbox can reach", addr)
+	}
+	if ip.IsLoopback() {
+		return "", fmt.Errorf("refusing to give this sandbox a callback credential: listen_addr %q is loopback, so a sandbox dialling it reaches ITSELF rather than this daemon — and nothing forwards the other way (the ssh runtime tunnels daemon→sandbox only). Set listen_addr to an address the sandbox can reach", addr)
+	}
+	// The port is RESOLVED rather than string-matched, for the same reason as the
+	// host above: "", "0", "00" and "000" are four spellings of port zero, they all
+	// resolve to 0, and net.Listen treats every one as "let the kernel pick" — so
+	// each literal I matched was one spelling out of an open-ended set (#3012
+	// review). LookupPort is the same resolution net.Listen performs, so an address
+	// it rejects could not have been bound either.
+	resolved, perr := net.LookupPort("tcp", port)
+	if perr != nil {
+		return "", fmt.Errorf("refusing to give this sandbox a callback credential: listen_addr %q has no resolvable port, so no callback URL can be derived from it", addr)
+	}
+	if resolved == 0 {
+		return "", fmt.Errorf("refusing to give this sandbox a callback credential: listen_addr %q asks the kernel to choose a port, so no fixed callback URL exists. Set an explicit port", addr)
+	}
+	// The RESOLVED port goes into the URL, so a service name ("…:http") becomes a
+	// number the sandbox's HTTP client can dial rather than being passed through.
+	return "http://" + net.JoinHostPort(host, strconv.Itoa(resolved)), nil
+}
+
+// sandboxCallbackPostureOK reports whether a credential handed out now would
+// actually be CHECKED when it comes back (#3012 review).
+//
+// require_token alone does not establish that, and believing it did was the
+// original bug in this refusal. authGate.authRequired exempts loopback peers
+// BEFORE it looks at any token, so on a loopback listen_addr with
+// require_loopback_token at its default false a same-host or host-network
+// sandbox reaches the whole control plane with no credential — and therefore no
+// scope at all. Minting there hands out something ceremonial and calls it a
+// boundary.
+//
+// The predicate is "will this request be authenticated", not "is a config key
+// set", which is why it mirrors the gate's own terms rather than restating them.
+//
+// It no longer carries a require_loopback_token branch. That check existed because
+// authGate exempts loopback peers before examining any token, so a loopback
+// listener would have enforced no scope — but sandboxCallbackURL now refuses every
+// loopback address outright, as undialable from a sandbox, so this is only ever
+// reached for an address the exemption cannot apply to. One rule, stated once,
+// beats the same rule half-stated in two places (#3012 review).
+func sandboxCallbackPostureOK(cfg *config.Config) error {
+	if !cfg.RequireToken {
+		return errSandboxCallbackNeedsRequireToken()
+	}
+	return nil
+}

--- a/daemon/sandbox_token.go
+++ b/daemon/sandbox_token.go
@@ -201,6 +201,26 @@ func errSandboxCallbackNeedsRequireToken() error {
 // listener that does not exist. #1856 hit the same divergence for the preview
 // origin; activeWebConfigAddr is the same answer for this one.
 func (m *Manager) mintSandboxCallback(cfg *config.Config, sessionID string) (sandboxGrant, error) {
+	return m.mintSandboxCallbackFenced(m.sandboxTokens.invalidationCount(), cfg, sessionID)
+}
+
+// mintSandboxCallbackFenced is mintSandboxCallback with the fence sampled by the
+// CALLER, for a caller that reads an input of its own first.
+//
+// The daemon's live minter reads m.Config() before calling in, and an argument is
+// evaluated before the function it is passed to runs — so sampling the fence in
+// here would leave that config read outside the window, and an invalidation
+// landing between the two would complete its sweep before the window opened
+// (#3065 review). The fence would then compare equal on both sides and the mint
+// would proceed on config that was already stale when it was read.
+//
+// This is the third time this exact boundary has moved: first the fence was
+// sampled after the address read, then after the config read moved out to the
+// caller. The rule that survives all three is the one stated below — every input
+// the credential depends on must be read INSIDE the window — and the only way to
+// keep it true when a caller acquires an input is to let the caller open the
+// window.
+func (m *Manager) mintSandboxCallbackFenced(fence uint64, cfg *config.Config, sessionID string) (sandboxGrant, error) {
 	if cfg == nil {
 		return sandboxGrant{}, errSandboxCallbackNeedsRequireToken()
 	}
@@ -216,7 +236,6 @@ func (m *Manager) mintSandboxCallback(cfg *config.Config, sessionID string) (san
 	// revokes every credential without touching a socket, so the generation stayed
 	// put and a mint in flight across it survived the sweep — provisioning a sandbox
 	// against a daemon that had just stopped authenticating anyone.
-	fence := m.sandboxTokens.invalidationCount()
 	active := m.activeWebConfigAddr(cfg.ListenAddr)
 	if strings.TrimSpace(active) == "" && strings.TrimSpace(cfg.ListenAddr) != "" {
 		return sandboxGrant{}, fmt.Errorf("refusing to give this sandbox a callback credential: listen_addr is %q but no control-plane listener is accepting on it, so a callback would have nothing to reach. Check the daemon log for the bind failure and fix listen_addr", cfg.ListenAddr)

--- a/daemon/sandbox_token.go
+++ b/daemon/sandbox_token.go
@@ -42,6 +42,18 @@ import (
 // them. Zero value is usable.
 type sandboxTokenRegistry struct {
 	mu sync.RWMutex
+	// invalidations counts events that voided EVERY outstanding credential at once
+	// — a listener rebind, a teardown, an unexpected listener death, or an auth
+	// posture relaxed to tokenless. It is the fence a mint checks across its whole
+	// window (#3065 review).
+	//
+	// It lives here rather than on the listener, and that IS the fix: the counter it
+	// replaces was the listener's binding generation, so it advanced for socket
+	// changes and stayed put for an auth-only change like require_token going false
+	// — and a mint in flight across that change survived the sweep meant to catch
+	// it. Every invalidation routes through revokeAll, so counting revokeAll counts
+	// invalidations by construction, whatever causes the next one.
+	invalidations uint64
 	// bySecret is the authorization lookup: presented credential -> session id.
 	bySecret map[string]string
 	// bySession is the revocation index, so ending a session drops its
@@ -126,7 +138,21 @@ func (r *sandboxTokenRegistry) revokeAll() int {
 	defer r.mu.Unlock()
 	n := len(r.bySession)
 	r.bySecret, r.bySession = nil, nil
+	// Advanced on every CALL, not only when something was dropped. A sweep that
+	// finds the registry empty still means an invalidating event happened, and the
+	// mint racing it has not registered its token yet — exactly the case a count
+	// gated on n > 0 would miss.
+	r.invalidations++
 	return n
+}
+
+// invalidationCount is the fence a mint compares across its window. A change
+// between two reads means every credential outstanding at any point in between was
+// voided, including one registered mid-window.
+func (r *sandboxTokenRegistry) invalidationCount() uint64 {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.invalidations
 }
 
 // requireTokenFixHint is the one-line fix named by the refusal below. Kept beside
@@ -174,65 +200,81 @@ func errSandboxCallbackNeedsRequireToken() error {
 // silently never connects — and would judge the loopback posture against a
 // listener that does not exist. #1856 hit the same divergence for the preview
 // origin; activeWebConfigAddr is the same answer for this one.
-func (m *Manager) mintSandboxCallback(cfg *config.Config, sessionID string) (url, token string, err error) {
+func (m *Manager) mintSandboxCallback(cfg *config.Config, sessionID string) (sandboxGrant, error) {
 	if cfg == nil {
-		return "", "", errSandboxCallbackNeedsRequireToken()
+		return sandboxGrant{}, errSandboxCallbackNeedsRequireToken()
 	}
-	// The generation is sampled BEFORE the address is read, not just before the mint
-	// (#3012 review). Sampling it after left the address read itself outside the
-	// window: a rebind landing in between would close the old listener, complete its
-	// revokeAll, and then be recorded as the "starting" generation — so the final
-	// comparison matched and the create finished with a live token paired to a
-	// closed URL. Everything the credential depends on must be read inside the
-	// window, and the address is the first of those reads.
-	gen := m.webBindGeneration()
+	// The fence is sampled BEFORE the address is read, not merely before the mint
+	// (#3012 review): an invalidation landing between the read and the sample would
+	// complete its sweep and then be recorded as the STARTING value, so the final
+	// comparison matched and the create finished with a live token paired to a dead
+	// endpoint. Everything the credential depends on is read inside the window, and
+	// the address is the first of those reads.
+	//
+	// It counts INVALIDATIONS, not listener rebinds (#3065 review). The listener
+	// generation could not see an auth-only change: require_token going false
+	// revokes every credential without touching a socket, so the generation stayed
+	// put and a mint in flight across it survived the sweep — provisioning a sandbox
+	// against a daemon that had just stopped authenticating anyone.
+	fence := m.sandboxTokens.invalidationCount()
 	active := m.activeWebConfigAddr(cfg.ListenAddr)
 	if strings.TrimSpace(active) == "" && strings.TrimSpace(cfg.ListenAddr) != "" {
-		return "", "", fmt.Errorf("refusing to give this sandbox a callback credential: listen_addr is %q but no control-plane listener is accepting on it, so a callback would have nothing to reach. Check the daemon log for the bind failure and fix listen_addr", cfg.ListenAddr)
+		return sandboxGrant{}, fmt.Errorf("refusing to give this sandbox a callback credential: listen_addr is %q but no control-plane listener is accepting on it, so a callback would have nothing to reach. Check the daemon log for the bind failure and fix listen_addr", cfg.ListenAddr)
 	}
 	// Dialability first, posture second. Both refuse before any secret exists, but
 	// the ORDER decides which message an operator reads, and a loopback listen_addr
 	// used to answer "enable require_loopback_token" — advice that would have led
 	// them to a well-enforced credential their sandbox still could not use.
-	url, err = sandboxCallbackURL(active)
+	url, err := sandboxCallbackURL(active)
 	if err != nil {
-		return "", "", err
+		return sandboxGrant{}, err
 	}
 	if err := sandboxCallbackPostureOK(cfg); err != nil {
-		return "", "", err
+		return sandboxGrant{}, err
 	}
-	// Snapshot the listener generation BEFORE minting and revalidate after, because
-	// nothing holds webListeners.mu across the mint (#3012 review). A listen_addr
-	// change racing this create would otherwise complete its rebind — including the
-	// revokeAll sweep — in the window between reading the address and registering
-	// the token, leaving a credential that survived the sweep while carrying the
-	// URL of the listener the sweep just closed.
-	//
 	// Revalidate-and-refuse rather than lock, deliberately. Holding the listener
 	// lock across a mint inverts the order bindWebLocked already uses (listener lock
 	// -> revokeAll -> registry lock) and is a deadlock waiting to happen. Refusing
-	// costs a create that the operator can retry against the new listener; the retry
-	// is honest, and the alternative is a session that looks provisioned and has a
-	// callback that never connects.
-	token, err = m.sandboxTokens.mint(sessionID)
+	// costs a create the operator can retry; the alternative is a session that looks
+	// provisioned with a callback that never connects.
+	token, err := m.sandboxTokens.mint(sessionID)
 	if err != nil {
-		return "", "", err
+		return sandboxGrant{}, err
 	}
-	if m.webBindGeneration() != gen {
+	if m.sandboxTokens.invalidationCount() != fence {
 		m.sandboxTokens.revoke(sessionID)
-		return "", "", fmt.Errorf("refusing to give this sandbox a callback credential: the control listener rebound while this session was being provisioned, so the callback address %q is already closed. Retry the create", url)
+		return sandboxGrant{}, errSandboxCallbackInvalidated(url)
 	}
-	return url, token, nil
+	return sandboxGrant{URL: url, Token: token, fence: fence}, nil
 }
 
-// webBindGeneration counts control-listener bindings, so a caller can tell whether
-// the listener moved underneath it. 0 when there is no listener owner (a bare
-// Manager, as tests construct), where nothing can rebind.
-func (m *Manager) webBindGeneration() uint64 {
-	if m.webListeners == nil {
-		return 0
-	}
-	return m.webListeners.bindGeneration()
+// sandboxGrant is an issued callback credential plus the fence it was issued
+// under, so the CALLER can revalidate later — after provisioning, which is the
+// slow part and therefore the widest window (#3065 review). Minting revalidates
+// its own window; only the create knows when provisioning finished.
+type sandboxGrant struct {
+	URL   string
+	Token string
+	// fence is the registry's invalidation count at the moment this grant's inputs
+	// were first read. Unexported: it is meaningless outside a comparison against
+	// invalidationCount(), and nothing should serialize or log it.
+	fence uint64
+}
+
+// stillValid reports whether nothing has invalidated outstanding credentials since
+// this grant was issued.
+func (g sandboxGrant) stillValid(r *sandboxTokenRegistry) bool {
+	return r.invalidationCount() == g.fence
+}
+
+// errSandboxCallbackInvalidated refuses a credential whose premises changed while
+// it was being issued, or while the sandbox it was issued for was provisioned.
+//
+// One message for both windows on purpose: from the operator's side they are the
+// same event — something voided every outstanding credential while this create was
+// in flight — and the same action answers both.
+func errSandboxCallbackInvalidated(url string) error {
+	return fmt.Errorf("refusing to give this sandbox a callback credential: the daemon's callback posture changed while this session was being provisioned — the control listener moved or closed, or require_token was disabled — so the callback address %q may already be dead. Retry the create", url)
 }
 
 // activeWebConfigAddr is the config address behind the control-plane listener that

--- a/daemon/sandbox_token_test.go
+++ b/daemon/sandbox_token_test.go
@@ -72,16 +72,17 @@ func TestSandboxTokenRegistry_SessionsDoNotShareCredentials(t *testing.T) {
 // The scope is what stops a compromised sandbox owning the host, so the denials
 // are asserted by name rather than by counting.
 func TestSandboxAllowedPath_DeniesTheOperatorOnlyVerbs(t *testing.T) {
-	// The scope is EMPTY, and that is the result rather than an oversight (#3012
-	// review). Asserted explicitly so nobody reads the absence as an accident and
-	// "restores" an entry without doing the owner-binding work first.
-	assert.Empty(t, sandboxAllowedPaths,
-		"no route may be admitted until the credential is bound to its owning session: the parameterised routes "+
-			"cannot be constrained to the caller's own repo/session by a route-level flag, and the parameterless "+
-			"ones answer from global state (SuggestSessionName avoids live titles across ALL repos, which a "+
-			"sandbox holding the finite wordlist can sample into an activity oracle)")
-	assert.False(t, sandboxAllowedPath("/v1/SuggestSessionName"),
-		"the last admitted route was withdrawn as a cross-repo collision oracle; re-admitting it needs owner-binding, not a smaller wordlist")
+	// The scope was EMPTY throughout #3012 — no route could be admitted while the
+	// credential was unbound — and #3056 admits exactly one, Snapshot, because its
+	// handler now narrows to the caller's own session. Admission alone is still not
+	// authorization: TestEverySandboxRouteEnforcesAnOwnerConstraint is what holds
+	// the two together, and this assertion only pins which routes are in the table.
+	assert.True(t, sandboxAllowedPath("/v1/Snapshot"),
+		"Snapshot is admitted under #3056 because its handler constrains to sandboxOwner(ctx); if it is being "+
+			"withdrawn, remove its entry from sandboxConstrainedRoutes too")
+	assert.Len(t, sandboxAllowedPaths, 1,
+		"the scope grew without this test noticing: every entry needs its own handler-side owner constraint, so a "+
+			"new one is a deliberate decision, never a default")
 	for _, path := range []string{
 		// DeliverPrompt runs instructions through every agent on the machine.
 		"/v1/DeliverPrompt",
@@ -91,15 +92,16 @@ func TestSandboxAllowedPath_DeniesTheOperatorOnlyVerbs(t *testing.T) {
 		// agent on the HOST (#3012 review). This one is why the rule is "cannot
 		// gain host authority" rather than "cannot name a session".
 		"/v1/CreateSession",
-		// These four NAME a session, so admitting them without binding the
-		// credential to its owner reproduces DeliverPrompt one agent at a time:
-		// SendPrompt and CreateTab take a session id directly, AddTask reaches one
-		// through Task.TargetSession, and Snapshot is the enumeration that makes
-		// any of them aimable.
+		// These three NAME a session, so admitting them without a per-route owner
+		// constraint reproduces DeliverPrompt one agent at a time: SendPrompt and
+		// CreateTab take a session id directly, and AddTask reaches one through
+		// Task.TargetSession. Snapshot used to be listed here as the enumeration
+		// that made them aimable; #3056 admitted it precisely because its handler
+		// now enforces the constraint these three still lack. Give them one and
+		// they can join it — that is the whole point of the contract.
 		"/v1/SendPrompt",
 		"/v1/CreateTab",
 		"/v1/AddTask",
-		"/v1/Snapshot",
 		// Read-only, and still host reconnaissance: ListProjects returns the
 		// operator's absolute project roots and ListDirectory walks the daemon's
 		// filesystem at an arbitrary path. The Add-project picker that consumes

--- a/daemon/sandbox_token_test.go
+++ b/daemon/sandbox_token_test.go
@@ -187,7 +187,7 @@ func TestAuthGate_SandboxCredentialIsScopedAndRevocable(t *testing.T) {
 func TestMintSandboxCallback_RefusesWithoutRequireToken(t *testing.T) {
 	m := &Manager{}
 
-	_, _, err := m.mintSandboxCallback(daemonTestConfig(false, "10.0.0.5:8443"), "sess-a")
+	_, err := m.mintSandboxCallback(daemonTestConfig(false, "10.0.0.5:8443"), "sess-a")
 	require.Error(t, err, "a credential against a listener that demands none enforces nothing")
 	assert.Contains(t, err.Error(), requireTokenFixHint,
 		"the refusal must name the one-line fix, or the operator is left guessing")
@@ -200,7 +200,7 @@ func TestMintSandboxCallback_RefusesWithoutRequireToken(t *testing.T) {
 
 	// An empty listen_addr has nothing to call back to, and is refused separately
 	// so the message can say which of the two is wrong.
-	_, _, err = m.mintSandboxCallback(daemonTestConfig(true, ""), "sess-a")
+	_, err = m.mintSandboxCallback(daemonTestConfig(true, ""), "sess-a")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "listen_addr")
 
@@ -237,7 +237,7 @@ func TestMintSandboxCallback_RefusesWithoutRequireToken(t *testing.T) {
 		// literal-IP rule covers this too.
 		"[fe80::1234%eth0]:8443",
 	} {
-		_, _, err = m.mintSandboxCallback(daemonTestConfig(true, addr), "sess-a")
+		_, err = m.mintSandboxCallback(daemonTestConfig(true, addr), "sess-a")
 		require.Errorf(t, err, "listen_addr %q is not dialable from a sandbox", addr)
 		assert.Emptyf(t, m.sandboxTokens.bySession, "a refused mint must leave no credential behind (%s)", addr)
 	}
@@ -245,22 +245,22 @@ func TestMintSandboxCallback_RefusesWithoutRequireToken(t *testing.T) {
 	// Loopback must be refused for being UNDIALABLE, not for the posture: telling
 	// an operator to set require_loopback_token would send them to a key that buys
 	// a well-enforced credential their sandbox still cannot use.
-	_, _, err = m.mintSandboxCallback(daemonTestConfig(true, "127.0.0.1:8443"), "sess-a")
+	_, err = m.mintSandboxCallback(daemonTestConfig(true, "127.0.0.1:8443"), "sess-a")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "reaches ITSELF")
 	assert.NotContains(t, err.Error(), "require_loopback_token")
 
-	url, token, err := m.mintSandboxCallback(daemonTestConfig(true, "10.0.0.5:8443"), "sess-a")
+	grant, err := m.mintSandboxCallback(daemonTestConfig(true, "10.0.0.5:8443"), "sess-a")
 	require.NoError(t, err)
-	assert.Equal(t, "http://10.0.0.5:8443", url)
+	assert.Equal(t, "http://10.0.0.5:8443", grant.URL)
 
 	// A service-name port resolves into the URL as a NUMBER, because an HTTP client
 	// inside the sandbox dials a port, not an /etc/services entry.
-	namedPort, _, nerr := m.mintSandboxCallback(daemonTestConfig(true, "10.0.0.5:http"), "sess-b")
+	namedGrant, nerr := m.mintSandboxCallback(daemonTestConfig(true, "10.0.0.5:http"), "sess-b")
 	require.NoError(t, nerr)
-	assert.Equal(t, "http://10.0.0.5:80", namedPort)
-	assert.NotEmpty(t, token)
-	owner, ok := m.sandboxTokens.sessionFor(token)
+	assert.Equal(t, "http://10.0.0.5:80", namedGrant.URL)
+	assert.NotEmpty(t, grant.Token)
+	owner, ok := m.sandboxTokens.sessionFor(grant.Token)
 	require.True(t, ok)
 	assert.Equal(t, "sess-a", owner)
 }

--- a/daemon/sandbox_token_test.go
+++ b/daemon/sandbox_token_test.go
@@ -1,0 +1,307 @@
+package daemon
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The sandbox callback credential's two non-negotiables (#2999): a sandbox never
+// holds the operator's authority, and af refuses to hand out a credential for a
+// listener that does not ask for one.
+
+func TestSandboxTokenRegistry_MintLookupRevoke(t *testing.T) {
+	var registry sandboxTokenRegistry
+
+	secret, err := registry.mint("sess-a")
+	require.NoError(t, err)
+	require.NotEmpty(t, secret)
+
+	owner, ok := registry.sessionFor(secret)
+	require.True(t, ok)
+	assert.Equal(t, "sess-a", owner)
+
+	// Revocation is what makes this per-session rather than a second master key.
+	registry.revoke("sess-a")
+	_, ok = registry.sessionFor(secret)
+	assert.False(t, ok, "a revoked credential must stop authenticating immediately")
+
+	// Idempotent: every teardown path calls this and none should fail for it.
+	registry.revoke("sess-a")
+	registry.revoke("never-existed")
+
+	// An empty presented credential must never match, or a caller sending no
+	// token at all would authenticate as whatever the zero value looked up.
+	_, ok = registry.sessionFor("")
+	assert.False(t, ok)
+}
+
+func TestSandboxTokenRegistry_ReMintRevokesThePrevious(t *testing.T) {
+	var registry sandboxTokenRegistry
+
+	first, err := registry.mint("sess-a")
+	require.NoError(t, err)
+	second, err := registry.mint("sess-a")
+	require.NoError(t, err)
+	require.NotEqual(t, first, second, "each mint must be a fresh secret")
+
+	_, ok := registry.sessionFor(first)
+	assert.False(t, ok, "re-provisioning a session must invalidate its old credential, not leave two live")
+	_, ok = registry.sessionFor(second)
+	assert.True(t, ok)
+}
+
+func TestSandboxTokenRegistry_SessionsDoNotShareCredentials(t *testing.T) {
+	var registry sandboxTokenRegistry
+	a, err := registry.mint("sess-a")
+	require.NoError(t, err)
+	b, err := registry.mint("sess-b")
+	require.NoError(t, err)
+	require.NotEqual(t, a, b)
+
+	// Revoking one must not disturb the other: teardown is per session.
+	registry.revoke("sess-a")
+	_, ok := registry.sessionFor(b)
+	assert.True(t, ok, "one session's teardown must not revoke another's credential")
+}
+
+// The scope is what stops a compromised sandbox owning the host, so the denials
+// are asserted by name rather than by counting.
+func TestSandboxAllowedPath_DeniesTheOperatorOnlyVerbs(t *testing.T) {
+	// The scope is EMPTY, and that is the result rather than an oversight (#3012
+	// review). Asserted explicitly so nobody reads the absence as an accident and
+	// "restores" an entry without doing the owner-binding work first.
+	assert.Empty(t, sandboxAllowedPaths,
+		"no route may be admitted until the credential is bound to its owning session: the parameterised routes "+
+			"cannot be constrained to the caller's own repo/session by a route-level flag, and the parameterless "+
+			"ones answer from global state (SuggestSessionName avoids live titles across ALL repos, which a "+
+			"sandbox holding the finite wordlist can sample into an activity oracle)")
+	assert.False(t, sandboxAllowedPath("/v1/SuggestSessionName"),
+		"the last admitted route was withdrawn as a cross-repo collision oracle; re-admitting it needs owner-binding, not a smaller wordlist")
+	for _, path := range []string{
+		// DeliverPrompt runs instructions through every agent on the machine.
+		"/v1/DeliverPrompt",
+		// CreateSession names NO session and reaches the same authority anyway, by
+		// creating the target itself: repo_path, backend, program and prompt are
+		// all caller-supplied, so the default/local backend starts an attacker's
+		// agent on the HOST (#3012 review). This one is why the rule is "cannot
+		// gain host authority" rather than "cannot name a session".
+		"/v1/CreateSession",
+		// These four NAME a session, so admitting them without binding the
+		// credential to its owner reproduces DeliverPrompt one agent at a time:
+		// SendPrompt and CreateTab take a session id directly, AddTask reaches one
+		// through Task.TargetSession, and Snapshot is the enumeration that makes
+		// any of them aimable.
+		"/v1/SendPrompt",
+		"/v1/CreateTab",
+		"/v1/AddTask",
+		"/v1/Snapshot",
+		// Read-only, and still host reconnaissance: ListProjects returns the
+		// operator's absolute project roots and ListDirectory walks the daemon's
+		// filesystem at an arbitrary path. The Add-project picker that consumes
+		// ListDirectory (#2788) is the operator's own client on the operator's own
+		// token, so denying it here costs nothing that works today.
+		"/v1/ListProjects",
+		"/v1/ListDirectory",
+		// The same oracle, quieter: both take a caller-supplied repo_path and
+		// answer through config.RepoFromPath, which wraps git's own stderr — so a
+		// guessed path comes back distinguishable as missing, permission-denied,
+		// or not-a-repo. Confirming a path is weaker than enumerating one; it is
+		// still the operator's layout, and admitting it would be an exception
+		// carved into the rule for convenience.
+		"/v1/ListBackends",
+		"/v1/ListPrograms",
+		// Parameterless, and still an oracle: it avoids live titles across ALL
+		// repos, and the sandbox holds the finite wordlist in the af binary af put
+		// there, so sampling reveals which combinations are persistently taken.
+		"/v1/SuggestSessionName",
+		"/v1/SetConfigValue",
+		"/v1/DeleteProject",
+		"/v1/KillSession",
+	} {
+		assert.Falsef(t, sandboxAllowedPath(path), "%s must never be reachable with a sandbox credential", path)
+	}
+	// Default deny: a path that is not in the table at all — including the WS
+	// planes and anything added later without opting in — is refused.
+	assert.False(t, sandboxAllowedPath("/v1/events"))
+	assert.False(t, sandboxAllowedPath("/v1/NotARoute"))
+}
+
+func TestAuthGate_SandboxCredentialIsScopedAndRevocable(t *testing.T) {
+	var registry sandboxTokenRegistry
+	secret, err := registry.mint("sess-a")
+	require.NoError(t, err)
+
+	gate := &authGate{
+		expectedToken: func() (string, error) { return "operator-token", nil },
+		sandboxTokens: &registry,
+	}
+	request := func(path, token string) *http.Request {
+		r := mustRequest(t, http.MethodPost, path)
+		r.Header.Set("Authorization", "Bearer "+token)
+		return r
+	}
+
+	// The shipped table admits NOTHING, so the gate's admit path is exercised
+	// against a temporary entry. Without this the positive branch would be dead and
+	// the revocation assertion below would pass for the wrong reason — every route
+	// is refused anyway.
+	sandboxAllowedPaths["/v1/TestOnlyAdmitted"] = true
+	t.Cleanup(func() { delete(sandboxAllowedPaths, "/v1/TestOnlyAdmitted") })
+
+	assert.True(t, admits(gate, request("/v1/TestOnlyAdmitted", secret)),
+		"a sandbox credential must authorize a route its scope admits")
+	assert.False(t, admits(gate, request("/v1/SuggestSessionName", secret)),
+		"and must not authorize the route withdrawn as an activity oracle")
+	assert.False(t, admits(gate, request("/v1/DeliverPrompt", secret)),
+		"a sandbox credential must NOT reach DeliverPrompt")
+	assert.False(t, admits(gate, request("/v1/SendPrompt", secret)),
+		"nor SendPrompt, which names a session and so reaches the same authority one agent at a time")
+	assert.False(t, admits(gate, request("/v1/CreateSession", secret)),
+		"nor CreateSession, which names no session and starts one on the host anyway")
+	assert.False(t, admits(gate, request("/v1/ListBackends", secret)),
+		"nor ListBackends, whose caller-supplied repo_path is a host path oracle")
+
+	// The operator's own token is unaffected by any of this.
+	assert.True(t, admits(gate, request("/v1/DeliverPrompt", "operator-token")))
+
+	// And revocation reaches the gate, not just the registry. Asserted against the
+	// one ADMITTED route: checking a denied route here would pass whether or not
+	// revocation did anything.
+	registry.revoke("sess-a")
+	assert.False(t, admits(gate, request("/v1/TestOnlyAdmitted", secret)),
+		"a revoked credential must stop authorizing at the gate")
+
+	// A gate with no registry (the agent-server, the preview origin) accepts no
+	// sandbox credential at all.
+	bare := &authGate{expectedToken: func() (string, error) { return "operator-token", nil }}
+	assert.False(t, admits(bare, request("/v1/TestOnlyAdmitted", secret)))
+}
+
+func TestMintSandboxCallback_RefusesWithoutRequireToken(t *testing.T) {
+	m := &Manager{}
+
+	_, _, err := m.mintSandboxCallback(daemonTestConfig(false, "10.0.0.5:8443"), "sess-a")
+	require.Error(t, err, "a credential against a listener that demands none enforces nothing")
+	assert.Contains(t, err.Error(), requireTokenFixHint,
+		"the refusal must name the one-line fix, or the operator is left guessing")
+
+	// Refused BEFORE minting: nothing may be left in the registry for a provision
+	// that did not happen.
+	_, ok := m.sandboxTokens.sessionFor("")
+	assert.False(t, ok)
+	assert.Empty(t, m.sandboxTokens.bySession, "a refused mint must leave no credential behind")
+
+	// An empty listen_addr has nothing to call back to, and is refused separately
+	// so the message can say which of the two is wrong.
+	_, _, err = m.mintSandboxCallback(daemonTestConfig(true, ""), "sess-a")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listen_addr")
+
+	// A BIND address is not a dialable one, and every way it can fail that test is
+	// refused (#3012 review). From inside a sandbox a wildcard names the SANDBOX;
+	// so does loopback, even more definitively — and nothing forwards a callback
+	// the other way, since the ssh runtime tunnels daemon→sandbox only. Port 0
+	// names nothing fixed at all.
+	// "10.0.0.5:" is the OTHER spelling of a kernel-selected port: SplitHostPort
+	// returns port "" with no error, so a check against the literal "0" alone let it
+	// through and produced "http://10.0.0.5:" (#3012 review).
+	// Every case here is a SPELLING the previous version of this check missed, and
+	// they are listed rather than reduced because each one was a separate review
+	// finding: an unspecified address and a zero port each have an open-ended set of
+	// textual forms, and matching literals recognised whichever ones I happened to
+	// think of. The code now parses instead — net.IP.IsUnspecified and
+	// net.LookupPort — so this table's job is to keep proving that.
+	for _, addr := range []string{
+		// Unspecified, four ways. net.Listen binds all of them identically.
+		"0.0.0.0:8443", ":8443", "[::]:8443", "[0:0:0:0:0:0:0:0]:8443", "[::ffff:0.0.0.0]:8443",
+		// Port zero, four ways. All resolve to 0 and mean "kernel picks".
+		"10.0.0.5:0", "10.0.0.5:", "10.0.0.5:00", "10.0.0.5:000",
+		// Loopback, three ways — the third is a NAME, and names are the reason the
+		// host must now be a literal IP at all.
+		"127.0.0.1:8443", "[::1]:8443", "localhost:8443",
+		// Loopback aliases: unbounded as a set (any /etc/hosts entry), which is why
+		// the rule is "literal IP" rather than a list of names to reject.
+		"ip6-localhost:8443", "localhost.localdomain:8443",
+		// A hostname is resolved by the SANDBOX, not by this daemon, so af cannot
+		// know what it points at over there — refused even when it looks routable.
+		"af-host.internal:8443",
+		// A zone identifier names an interface on the DAEMON's host, and its raw "%"
+		// is an invalid escape to Go's URL parser. net.ParseIP refuses it, so the
+		// literal-IP rule covers this too.
+		"[fe80::1234%eth0]:8443",
+	} {
+		_, _, err = m.mintSandboxCallback(daemonTestConfig(true, addr), "sess-a")
+		require.Errorf(t, err, "listen_addr %q is not dialable from a sandbox", addr)
+		assert.Emptyf(t, m.sandboxTokens.bySession, "a refused mint must leave no credential behind (%s)", addr)
+	}
+
+	// Loopback must be refused for being UNDIALABLE, not for the posture: telling
+	// an operator to set require_loopback_token would send them to a key that buys
+	// a well-enforced credential their sandbox still cannot use.
+	_, _, err = m.mintSandboxCallback(daemonTestConfig(true, "127.0.0.1:8443"), "sess-a")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reaches ITSELF")
+	assert.NotContains(t, err.Error(), "require_loopback_token")
+
+	url, token, err := m.mintSandboxCallback(daemonTestConfig(true, "10.0.0.5:8443"), "sess-a")
+	require.NoError(t, err)
+	assert.Equal(t, "http://10.0.0.5:8443", url)
+
+	// A service-name port resolves into the URL as a NUMBER, because an HTTP client
+	// inside the sandbox dials a port, not an /etc/services entry.
+	namedPort, _, nerr := m.mintSandboxCallback(daemonTestConfig(true, "10.0.0.5:http"), "sess-b")
+	require.NoError(t, nerr)
+	assert.Equal(t, "http://10.0.0.5:80", namedPort)
+	assert.NotEmpty(t, token)
+	owner, ok := m.sandboxTokens.sessionFor(token)
+	require.True(t, ok)
+	assert.Equal(t, "sess-a", owner)
+}
+
+// daemonTestConfig is the minimal config the refusal reads.
+func daemonTestConfig(requireToken bool, listenAddr string) *config.Config {
+	return &config.Config{RequireToken: requireToken, ListenAddr: listenAddr}
+}
+
+// A credential does not outlive the listener it was minted against (#3012 review).
+//
+// The callback URL is written into the sandbox's environment file at provision
+// time and nothing rewrites it, so a live listen_addr change leaves every running
+// sandbox calling a closed address. Leaving the token valid buys nothing — the
+// sandbox cannot reach the daemon to use it — and hides the fact that the
+// capability is gone.
+func TestSandboxTokenRegistry_RevokeAllDropsEveryCredential(t *testing.T) {
+	var registry sandboxTokenRegistry
+	a, err := registry.mint("sess-a")
+	require.NoError(t, err)
+	b, err := registry.mint("sess-b")
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, registry.revokeAll(), "the count is what the rebind log reports; a wrong one misreports the blast radius")
+	for _, secret := range []string{a, b} {
+		_, ok := registry.sessionFor(secret)
+		assert.False(t, ok, "a credential minted against the previous listener must not survive the rebind")
+	}
+
+	// Idempotent, and the registry must still be usable afterwards — the daemon
+	// keeps running and the next provision mints against the NEW listener.
+	assert.Equal(t, 0, registry.revokeAll())
+	fresh, err := registry.mint("sess-c")
+	require.NoError(t, err)
+	owner, ok := registry.sessionFor(fresh)
+	require.True(t, ok, "revokeAll must clear the registry, not break it")
+	assert.Equal(t, "sess-c", owner)
+}
+
+// admits reports only the gate's yes/no, for the tests that do not care which
+// principal was admitted. Tests that DO care call authorize directly and assert
+// the owner — see TestAuthGate_BindsTheCredentialToItsOwningSession.
+func admits(g *authGate, r *http.Request) bool {
+	_, ok := g.authorize(r)
+	return ok
+}

--- a/daemon/snapshot.go
+++ b/daemon/snapshot.go
@@ -100,12 +100,18 @@ func (s *controlServer) Snapshot(req SnapshotRequest, resp *SnapshotResponse) er
 // is worth anything, it has to hold here. An agent reading its OWN session's state
 // is also the most obviously legitimate thing a remote agent does.
 //
-// Two narrowings, and the second is the one that is easy to forget:
+// THREE narrowings. The first is the obvious one; the other two are each a
+// finding, because "show only the caller's own row" is not the same as "show only
+// what the caller may see":
 //
 //   - Instances is filtered to the owner's own id. Not to its repo, and not to a
 //     title match: the id is the stable identity (#1195), and titles are unique
 //     only per repo, so matching on one would let a same-titled session in another
 //     repo through.
+//   - Each surviving row is PROJECTED (sandboxSafeInstanceData). The owner's own
+//     row still carries the daemon host's layout — Path is the absolute repo root
+//     on the host — so narrowing alone handed back the operator layout that the
+//     path-oracle routes were withdrawn from this scope for (#3065 review).
 //   - DeliveryAlarms is emptied outright. An alarm names its target by TITLE, so
 //     filtering it would mean mapping the owner's id to a title and comparing —
 //     an identity conversion in the one place that must not get identity wrong.
@@ -141,8 +147,50 @@ func onlyOwnedBySandbox(instances []session.InstanceData, owner string) []sessio
 	owned := make([]session.InstanceData, 0, 1)
 	for _, d := range instances {
 		if d.ID != "" && d.ID == owner {
-			owned = append(owned, d)
+			owned = append(owned, sandboxSafeInstanceData(d))
 		}
 	}
 	return owned
+}
+
+// sandboxSafeInstanceData projects one session row down to what a sandbox may
+// learn about ITSELF (#3065 review).
+//
+// Narrowing to the owner's row is not sufficient, which is the finding: the row
+// itself carries the DAEMON HOST's layout. InstanceData.Path is the absolute
+// repository root on the host, Worktree carries host paths, TmuxName names a host
+// tmux session — none of which exist inside the sandbox, and all of which are
+// exactly the operator layout that ListDirectory and the repo-path routes were
+// withdrawn from the scope for. A credential correctly restricted to its own row
+// still read them.
+//
+// Built by CONSTRUCTION, not by blanking. Copying d and clearing a denylist would
+// leak every field added to InstanceData afterwards, silently, at the moment
+// someone else adds one — and this struct has thirty-odd fields and grows. Listing
+// what may go out means a new field is withheld until somebody decides otherwise,
+// which is the same default-deny the route scope uses. A test walks the projection
+// reflectively so a newly populated field has to be an explicit decision.
+//
+// What is included is the agent's own operational state: who it is, what it is
+// running, what state it is in. What is excluded is anything describing the HOST,
+// anything about other sessions, and the conversation/prompt payloads a sandbox
+// already has locally and does not need served back.
+func sandboxSafeInstanceData(d session.InstanceData) session.InstanceData {
+	return session.InstanceData{
+		ID:              d.ID,
+		TaskID:          d.TaskID,
+		Title:           d.Title,
+		Branch:          d.Branch,
+		Status:          d.Status,
+		Liveness:        d.Liveness,
+		InFlightOp:      d.InFlightOp,
+		LifecycleAction: d.LifecycleAction,
+		CurrentAgent:    d.CurrentAgent,
+		Program:         d.Program,
+		BackendType:     d.BackendType,
+		TaskRunActive:   d.TaskRunActive,
+		LimitResetAt:    d.LimitResetAt,
+		CreatedAt:       d.CreatedAt,
+		UpdatedAt:       d.UpdatedAt,
+	}
 }

--- a/daemon/snapshot.go
+++ b/daemon/snapshot.go
@@ -1,15 +1,21 @@
 package daemon
 
 import (
+	"context"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/session"
 )
 
-// Snapshot RPC types and the delivery-failure alarm projection (#960 PR 3,
-// #1238). Extracted from control.go so that file stays under its length ceiling
-// (#1145). The controlServer.Snapshot handler lives in control.go alongside the
-// other RPCs; this file owns the wire shapes and the alarm assembly.
+// Snapshot RPC types, the delivery-failure alarm projection, and the Snapshot
+// handler itself (#960 PR 3, #1238). Extracted from control.go so that file stays
+// under its length ceiling (#1145).
+//
+// The HANDLER moved here from control_server.go in #3056, when the owner
+// constraint pushed that file back over the limit — so this file now owns the
+// wire shapes, the alarm assembly, and the read that produces both. That is the
+// right grouping anyway: the constraint below decides what goes into these types,
+// and splitting the two across files is how they drift.
 //
 // The TUI's SnapshotWithAlarms read moved onto the HTTP apiclient in #1592 Phase
 // 2 PR3 (apiclient.Client.SnapshotWithAlarms), so the net/rpc SnapshotWithAlarms
@@ -68,4 +74,75 @@ func (s *controlServer) deliveryAlarms(repoID string) []DeliveryAlarm {
 		return nil
 	}
 	return s.watchers.deliveryAlarms(repoID, time.Now())
+}
+
+// It keeps the two-argument shape net/rpc requires by reflection, and passes a
+// bare context — so this path is never narrowed to a sandbox owner.
+//
+// That is correct rather than a bypass, and worth stating because it does not
+// look it: net/rpc is registered on the UNIX SOCKET only (0600, chmod'd at
+// creation), which is trusted transport and carries the operator's authority by
+// construction. A sandbox never reaches it — its callback dials the HTTP listener,
+// where servePosture binds the owner and the route below narrows. If net/rpc is
+// ever exposed on a network listener, this wrapper becomes the hole, and the fix
+// is to thread a real context rather than to widen the constraint.
+func (s *controlServer) Snapshot(req SnapshotRequest, resp *SnapshotResponse) error {
+	return s.snapshot(context.Background(), req, resp)
+}
+
+// snapshot is Snapshot with the request context, so it can see whether the caller
+// is a SANDBOX and narrow the answer to that sandbox's own session (#3056).
+//
+// This is the first route admitted to the sandbox callback scope, and it carries
+// the constraint that admission requires. Snapshot is a deliberate choice rather
+// than a convenient one: it is the enumeration that made every other route
+// aimable — #3012 denied it for exactly that reason — so if the owner constraint
+// is worth anything, it has to hold here. An agent reading its OWN session's state
+// is also the most obviously legitimate thing a remote agent does.
+//
+// Two narrowings, and the second is the one that is easy to forget:
+//
+//   - Instances is filtered to the owner's own id. Not to its repo, and not to a
+//     title match: the id is the stable identity (#1195), and titles are unique
+//     only per repo, so matching on one would let a same-titled session in another
+//     repo through.
+//   - DeliveryAlarms is emptied outright. An alarm names its target by TITLE, so
+//     filtering it would mean mapping the owner's id to a title and comparing —
+//     an identity conversion in the one place that must not get identity wrong.
+//     A sandbox has no use for watch-task delivery diagnostics anyway, so the
+//     honest answer is none rather than a mapping that could be off by one repo.
+//
+// The operator's own callers (unix socket, operator token) are untouched: they
+// carry no sandbox owner, so neither narrowing applies.
+func (s *controlServer) snapshot(ctx context.Context, req SnapshotRequest, resp *SnapshotResponse) error {
+	if err := s.requireManagerReady(); err != nil {
+		return err
+	}
+	if err := validateRPCRepoID(req.RepoID); err != nil {
+		return err
+	}
+	instances := s.manager.Snapshot(req.RepoID)
+	alarms := s.deliveryAlarms(req.RepoID)
+	if owner, isSandbox := sandboxOwner(ctx); isSandbox {
+		instances = onlyOwnedBySandbox(instances, owner)
+		alarms = nil
+	}
+	resp.Instances = instances
+	resp.DeliveryAlarms = alarms
+	return nil
+}
+
+// onlyOwnedBySandbox keeps just the caller's own session.
+//
+// Returns an EMPTY slice rather than nil when nothing matches, and never returns
+// the input unfiltered: an owner whose session has been archived or killed sees
+// nothing, which is correct, and is also the direction a bug here should fail in.
+func onlyOwnedBySandbox(instances []session.InstanceData, owner string) []session.InstanceData {
+	owned := make([]session.InstanceData, 0, 1)
+	for _, d := range instances {
+		if d.ID != "" && d.ID == owner {
+			owned = append(owned, d)
+		}
+	}
+	return owned
 }

--- a/daemon/tcpserver.go
+++ b/daemon/tcpserver.go
@@ -177,6 +177,10 @@ type livePosture struct {
 	// preview listener leaves it false: its gate posture is the fixed strict zero
 	// value (previewListenerPolicy).
 	policyFromConfig bool
+	// sandboxTokens admits per-session sandbox callback credentials (#2999). Set
+	// ONLY by the control-plane web listener: the preview origin carries no
+	// control plane, so a sandbox credential must never authenticate there.
+	sandboxTokens *sandboxTokenRegistry
 	// previewOrigin marks the web-tab preview listener, which carries no control
 	// plane and whose whole path space belongs to the previewed app. It is ONE flag
 	// because it is one fact, and three consequences follow from it (all in
@@ -280,6 +284,7 @@ func startTCPListenerWithListen(mux http.Handler, addr string, cfg *config.Confi
 				presentedToken:          presentedToken,
 				tokenDisabled:           policy.tokenDisabled,
 				loopbackExempt:          policy.loopbackExempt,
+				sandboxTokens:           live.sandboxTokens,
 			}
 			if live.policyFromConfig {
 				// The control-plane web listener: token/loopback posture from live

--- a/daemon/web_listener_policy_test.go
+++ b/daemon/web_listener_policy_test.go
@@ -228,5 +228,5 @@ func TestTCPListener_DefaultConfigServesNetworkPeersTokenless(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
 	req.RemoteAddr = "192.168.1.50:54321" // a genuine off-host peer
 	require.False(t, gate.authRequired(req), "a network peer needs no token under the default")
-	require.True(t, gate.authorize(req), "and is therefore authorized without one")
+	require.True(t, admits(gate, req), "and is therefore authorized without one")
 }

--- a/session/archive_sandbox.go
+++ b/session/archive_sandbox.go
@@ -101,7 +101,21 @@ func (i *Instance) ArchiveSandbox() (string, error) {
 	if err := as.Kill(); err != nil {
 		if TeardownStateUnknown(err) {
 			i.markRuntimeCleanupStateUnknown()
+			return branch, fmt.Errorf("pushed branch %q but failed to tear the sandbox down for session %q: %w", branch, i.Title, err)
 		}
+		// A KNOWN failure here still means the runtime is gone: remoteAgentServer.Kill
+		// tears the in-sandbox workspace down over REST and then reaps the sandbox,
+		// and it returns the REST error even when the reap SUCCEEDED — the same
+		// asymmetry manager_create.go documents for a failed remote create. So the
+		// credential must go with it (#3065 review).
+		//
+		// The runtime wiring is deliberately NOT reset here, unlike the success path
+		// below: the archive aborts to Lost and the retry machinery owns what happens
+		// to that wiring. Only the credential is settled, because "the runtime that
+		// owned it is gone" is already answered, and leaving it live means a copied
+		// token keeps authenticating until a recovery happens to replace it — or
+		// until the daemon restarts, if none ever does.
+		i.revokeSandboxCredential()
 		return branch, fmt.Errorf("pushed branch %q but failed to tear the sandbox down for session %q: %w", branch, i.Title, err)
 	}
 	// 4. Drop the dead remote wiring so the instance is an inert archived record
@@ -310,7 +324,6 @@ func (i *Instance) resetRemoteRuntime() {
 	i.remoteClient = nil
 	i.runtimeTeardown = nil
 	i.runtimeCleanupStateUnknown = false
-	creds := i.sandboxCreds
 	i.mu.Unlock()
 	// THE credential's revocation point (#3068). This function is reached only when
 	// a runtime was conclusively reaped — teardown succeeded, or failed in a way
@@ -324,6 +337,24 @@ func (i *Instance) resetRemoteRuntime() {
 	//
 	// Called OUTSIDE i.mu — revocation takes the daemon's registry lock, and holding
 	// a session lock across another subsystem's lock is how a deadlock gets built.
+	i.revokeSandboxCredential()
+}
+
+// revokeSandboxCredential drops this session's callback credential without
+// touching the runtime wiring.
+//
+// Separate from resetRemoteRuntime because the two are not always the same
+// event: an archive whose sandbox reap SUCCEEDED but whose in-sandbox REST kill
+// errored leaves the runtime gone while the wiring is deliberately retained for
+// the abort-to-Lost retry path. The credential is settled there; the wiring is
+// not (#3065 review).
+//
+// Called OUTSIDE i.mu — revocation takes the daemon's registry lock, and holding
+// a session lock across another subsystem's lock is how a deadlock gets built.
+func (i *Instance) revokeSandboxCredential() {
+	i.mu.RLock()
+	creds := i.sandboxCreds
+	i.mu.RUnlock()
 	if creds != nil {
 		creds.Revoke()
 	}

--- a/session/archive_sandbox.go
+++ b/session/archive_sandbox.go
@@ -192,6 +192,9 @@ func (i *Instance) reprovisionRemote() error {
 	if err != nil {
 		return fmt.Errorf("cannot re-provision session %q: %w", i.Title, err)
 	}
+	i.mu.RLock()
+	creds := i.sandboxCreds
+	i.mu.RUnlock()
 	// A failed archive/recovery can leave the old sandbox wiring live. Reap it
 	// before provisioning a replacement so bindProvisionResult never discards its
 	// only cleanup handle. An unknown outcome keeps the old wiring installed for a
@@ -199,9 +202,27 @@ func (i *Instance) reprovisionRemote() error {
 	if err := i.reapRemoteRuntimeForReplacement(); err != nil {
 		return fmt.Errorf("cannot re-provision session %q: previous sandbox cleanup state is unknown: %w", i.Title, err)
 	}
+	// Mint AFTER the reap, through the same helper the create path uses (#3068).
+	//
+	// The ordering is the load-bearing part, and it is now enforced by position
+	// rather than by care: the reap above revokes the old credential on its way out
+	// (resetRemoteRuntime), and it returns early — leaving the old wiring installed
+	// and its credential untouched — when the outcome is unknown. So a retained,
+	// possibly-live sandbox keeps working, and only a runtime that is provably gone
+	// is replaced by a fresh mint. Minting before this point severed callback from
+	// exactly that retained runtime, permanently and silently.
+	cred, err := mintForProvision(&spec, kind, creds)
+	if err != nil {
+		return fmt.Errorf("cannot re-provision session %q: its callback credential could not be re-issued, and restoring it without one would silently leave its agent unable to call af: %w", i.Title, err)
+	}
 	res, err := rt.Provision(spec)
 	if err != nil {
 		return fmt.Errorf("failed to re-provision sandbox for session %q: %w", i.Title, err)
+	}
+	// Same post-provision revalidation the create path performs. Doing it in one
+	// and not the other is exactly how these two drifted the first time.
+	if rerr := revalidateAfterProvision(cred); rerr != nil {
+		return fmt.Errorf("re-provisioned sandbox for session %q, but its callback credential was invalidated while it was being provisioned: %w", i.Title, rerr)
 	}
 	if err := i.bindProvisionResult(res); err != nil {
 		// The sandbox is up but its endpoint could not be wired — reap it so a
@@ -277,7 +298,23 @@ func (i *Instance) resetRemoteRuntime() {
 	i.remoteClient = nil
 	i.runtimeTeardown = nil
 	i.runtimeCleanupStateUnknown = false
+	creds := i.sandboxCreds
 	i.mu.Unlock()
+	// THE credential's revocation point (#3068). This function is reached only when
+	// a runtime was conclusively reaped — teardown succeeded, or failed in a way
+	// that still proves it is gone — and never when an unknown outcome retains the
+	// old wiring for a retry. So "the credential dies with the runtime it was
+	// minted for" holds by construction here, instead of being a rule each of kill,
+	// archive, restore and recover has to remember separately.
+	//
+	// It is what stops the worse of the two failure modes: a token minted for one
+	// runtime surviving into its replacement. The replacement mints its own.
+	//
+	// Called OUTSIDE i.mu — revocation takes the daemon's registry lock, and holding
+	// a session lock across another subsystem's lock is how a deadlock gets built.
+	if creds != nil {
+		creds.Revoke()
+	}
 }
 
 // markRuntimeCleanupStateUnknown makes an indeterminate reap durable without

--- a/session/archive_sandbox.go
+++ b/session/archive_sandbox.go
@@ -217,12 +217,24 @@ func (i *Instance) reprovisionRemote() error {
 	}
 	res, err := rt.Provision(spec)
 	if err != nil {
+		// The credential was minted for a sandbox that does not exist. Unlike the
+		// create path there is no session-level cleanup behind this — the old
+		// runtime was already reaped above — so leaving it registered strands a
+		// live token on nothing (#3065 review).
+		if creds != nil {
+			creds.Revoke()
+		}
 		return fmt.Errorf("failed to re-provision sandbox for session %q: %w", i.Title, err)
 	}
 	// Same post-provision revalidation the create path performs. Doing it in one
-	// and not the other is exactly how these two drifted the first time.
+	// and not the other is exactly how these two drifted the first time — and so is
+	// the cleanup: this reaps the replacement and revokes its credential through
+	// the same helper, because the previous runtime was already reset, so nothing
+	// else holds a handle and the next restore would see nothing to reap and
+	// provision a second sandbox alongside this orphan.
 	if rerr := revalidateAfterProvision(cred); rerr != nil {
-		return fmt.Errorf("re-provisioned sandbox for session %q, but its callback credential was invalidated while it was being provisioned: %w", i.Title, rerr)
+		return fmt.Errorf("re-provisioned sandbox for session %q, but its callback credential was invalidated while it was being provisioned: %w",
+			i.Title, discardUnusableSandbox(res, creds, rerr))
 	}
 	if err := i.bindProvisionResult(res); err != nil {
 		// The sandbox is up but its endpoint could not be wired — reap it so a

--- a/session/archive_sandbox.go
+++ b/session/archive_sandbox.go
@@ -172,6 +172,7 @@ func recoverSandbox(i *Instance) error {
 func (i *Instance) reprovisionRemote() error {
 	i.mu.RLock()
 	backend := i.backend
+	mintCallback := i.sandboxCallback
 	spec := ProvisionSpec{
 		RepoRoot:              i.Path,
 		Title:                 i.Title,
@@ -191,6 +192,26 @@ func (i *Instance) reprovisionRemote() error {
 	rt, err := ResolveRuntime(kind)
 	if err != nil {
 		return fmt.Errorf("cannot re-provision session %q: %w", i.Title, err)
+	}
+	// Re-mint the callback credential for the REPLACEMENT sandbox (#3065 review).
+	// Without this, every restored or recovered ssh/sandbox session came back with
+	// no AF_DAEMON_URL/AF_DAEMON_TOKEN at all — and because archiving revokes the
+	// old credential, a routine archive-then-restore ended that session's callback
+	// permanently while reporting success.
+	//
+	// Called OUTSIDE i.mu: minting takes the daemon's registry lock, and holding a
+	// session lock across another subsystem's lock is how a deadlock gets built.
+	//
+	// A refusal FAILS the re-provision rather than continuing without a credential.
+	// The mint refuses exactly when a credential could not be enforced or could not
+	// be dialled, and silently restoring a session whose callback will never work —
+	// after it had one — is the outcome this whole feature keeps arguing against.
+	if mintCallback != nil && kind.InjectsSandboxCallback() {
+		url, token, mintErr := mintCallback()
+		if mintErr != nil {
+			return fmt.Errorf("cannot re-provision session %q: %w", i.Title, mintErr)
+		}
+		spec.CallbackURL, spec.CallbackToken = url, token
 	}
 	// A failed archive/recovery can leave the old sandbox wiring live. Reap it
 	// before provisioning a replacement so bindProvisionResult never discards its

--- a/session/archive_sandbox.go
+++ b/session/archive_sandbox.go
@@ -229,15 +229,26 @@ func (i *Instance) reprovisionRemote() error {
 	if err != nil {
 		return fmt.Errorf("cannot re-provision session %q: its callback credential could not be re-issued, and restoring it without one would silently leave its agent unable to call af: %w", i.Title, err)
 	}
-	res, err := rt.Provision(spec)
-	if err != nil {
-		// The credential was minted for a sandbox that does not exist. Unlike the
-		// create path there is no session-level cleanup behind this — the old
-		// runtime was already reaped above — so leaving it registered strands a
-		// live token on nothing (#3065 review).
-		if creds != nil {
+	// ARMED HERE, disarmed only once the replacement is bound and live (#3065
+	// review). Every exit below this line abandons a credential minted for a
+	// sandbox that either does not exist or cannot be used, and unlike the create
+	// path there is no session-level cleanup behind them — the old runtime was
+	// already reaped above — so an abandoned credential strands a live token on
+	// nothing.
+	//
+	// Deferred rather than repeated at each return, because repeating it is what
+	// this review kept catching: provision-failure, revalidation-failure and
+	// bind-failure each needed the same line, and each was added only after a
+	// finding named it. A fourth exit added later gets it for free, and gets it
+	// FAIL-CLOSED, which is the direction an auth credential should default in.
+	replacementLive := false
+	defer func() {
+		if !replacementLive && cred.Granted() && creds != nil {
 			creds.Revoke()
 		}
+	}()
+	res, err := rt.Provision(spec)
+	if err != nil {
 		return fmt.Errorf("failed to re-provision sandbox for session %q: %w", i.Title, err)
 	}
 	// Same post-provision revalidation the create path performs. Doing it in one
@@ -267,6 +278,10 @@ func (i *Instance) reprovisionRemote() error {
 		}
 		return fmt.Errorf("failed to bind re-provisioned sandbox for session %q: %w", i.Title, err)
 	}
+	// The replacement is bound and live, so its credential belongs to it now. From
+	// here the runtime's own lifetime owns revocation again — resetRemoteRuntime on
+	// the next reap, revokeSandboxCredential on a known archive teardown failure.
+	replacementLive = true
 	return nil
 }
 

--- a/session/archive_sandbox.go
+++ b/session/archive_sandbox.go
@@ -172,7 +172,6 @@ func recoverSandbox(i *Instance) error {
 func (i *Instance) reprovisionRemote() error {
 	i.mu.RLock()
 	backend := i.backend
-	mintCallback := i.sandboxCallback
 	spec := ProvisionSpec{
 		RepoRoot:              i.Path,
 		Title:                 i.Title,
@@ -192,26 +191,6 @@ func (i *Instance) reprovisionRemote() error {
 	rt, err := ResolveRuntime(kind)
 	if err != nil {
 		return fmt.Errorf("cannot re-provision session %q: %w", i.Title, err)
-	}
-	// Re-mint the callback credential for the REPLACEMENT sandbox (#3065 review).
-	// Without this, every restored or recovered ssh/sandbox session came back with
-	// no AF_DAEMON_URL/AF_DAEMON_TOKEN at all — and because archiving revokes the
-	// old credential, a routine archive-then-restore ended that session's callback
-	// permanently while reporting success.
-	//
-	// Called OUTSIDE i.mu: minting takes the daemon's registry lock, and holding a
-	// session lock across another subsystem's lock is how a deadlock gets built.
-	//
-	// A refusal FAILS the re-provision rather than continuing without a credential.
-	// The mint refuses exactly when a credential could not be enforced or could not
-	// be dialled, and silently restoring a session whose callback will never work —
-	// after it had one — is the outcome this whole feature keeps arguing against.
-	if mintCallback != nil && kind.InjectsSandboxCallback() {
-		url, token, mintErr := mintCallback()
-		if mintErr != nil {
-			return fmt.Errorf("cannot re-provision session %q: %w", i.Title, mintErr)
-		}
-		spec.CallbackURL, spec.CallbackToken = url, token
 	}
 	// A failed archive/recovery can leave the old sandbox wiring live. Reap it
 	// before provisioning a replacement so bindProvisionResult never discards its

--- a/session/backend_sandbox.go
+++ b/session/backend_sandbox.go
@@ -138,6 +138,9 @@ func (p *sandboxProvisioner) provision() (ProvisionResult, error) {
 	if err := p.verifyCopiedBinary(); err != nil {
 		return ProvisionResult{}, err
 	}
+	if err := w.writeCallbackEnv(sshShortStepTimeout); err != nil {
+		return ProvisionResult{}, p.sandboxErr(err)
+	}
 	if err := w.startAgentServer(sshShortStepTimeout); err != nil {
 		return ProvisionResult{}, p.sandboxErr(err)
 	}

--- a/session/backend_ssh.go
+++ b/session/backend_ssh.go
@@ -245,6 +245,9 @@ func (p *sshProvisioner) provision() (ProvisionResult, error) {
 	if copyErr != nil {
 		return ProvisionResult{}, p.sshErr(copyErr)
 	}
+	if err := w.writeCallbackEnv(sshShortStepTimeout); err != nil {
+		return ProvisionResult{}, p.sshErr(err)
+	}
 	if err := w.startAgentServer(sshShortStepTimeout); err != nil {
 		return ProvisionResult{}, p.sshErr(err)
 	}

--- a/session/instance.go
+++ b/session/instance.go
@@ -265,23 +265,6 @@ type Instance struct {
 	// outer runtime's agent-server flags. Local sessions normally source the
 	// same setting from global config during Provision.
 	sessionEnvPassthrough []string
-	// sandboxCallback re-mints this session's callback credential (#2999). Kept on
-	// the instance because RE-PROVISIONING needs it: reprovisionRemote builds a
-	// fresh ProvisionSpec for a restored or recovered sandbox, and without this it
-	// built one with no credential at all — so a routine archive/restore silently
-	// ended callback for that session, permanently, since archiving also revokes the
-	// old credential (#3065 review).
-	//
-	// Calling it again is the correct operation rather than a workaround: a mint
-	// REPLACES the session's previous credential, so the replacement sandbox gets a
-	// fresh one and the old secret — which the dead sandbox may still hold — stops
-	// authenticating. Set once at construction and never mutated, so reading it does
-	// not need i.mu; it is read under the lock anyway because the spec around it is.
-	//
-	// nil for a local session, and for any instance built without a daemon behind it
-	// (tests, the agent-server's own in-sandbox instances) — reprovision then keeps
-	// today's behaviour of provisioning without a callback.
-	sandboxCallback func() (url, token string, err error)
 
 	// The below fields are initialized upon calling Start().
 

--- a/session/instance.go
+++ b/session/instance.go
@@ -265,6 +265,13 @@ type Instance struct {
 	// outer runtime's agent-server flags. Local sessions normally source the
 	// same setting from global config during Provision.
 	sessionEnvPassthrough []string
+	// sandboxCreds mints and revokes this session's callback credential (#3068).
+	// Held here because the RUNTIME's lifetime drives it: provisioning a
+	// replacement mints, and reaping a runtime revokes. Set at construction for a
+	// created session and attached by the daemon for one loaded from disk — without
+	// that second half every restore after a daemon restart would silently skip it.
+	// nil for a local session and for any instance with no daemon behind it.
+	sandboxCreds SandboxCredentials
 
 	// The below fields are initialized upon calling Start().
 

--- a/session/instance.go
+++ b/session/instance.go
@@ -265,6 +265,23 @@ type Instance struct {
 	// outer runtime's agent-server flags. Local sessions normally source the
 	// same setting from global config during Provision.
 	sessionEnvPassthrough []string
+	// sandboxCallback re-mints this session's callback credential (#2999). Kept on
+	// the instance because RE-PROVISIONING needs it: reprovisionRemote builds a
+	// fresh ProvisionSpec for a restored or recovered sandbox, and without this it
+	// built one with no credential at all — so a routine archive/restore silently
+	// ended callback for that session, permanently, since archiving also revokes the
+	// old credential (#3065 review).
+	//
+	// Calling it again is the correct operation rather than a workaround: a mint
+	// REPLACES the session's previous credential, so the replacement sandbox gets a
+	// fresh one and the old secret — which the dead sandbox may still hold — stops
+	// authenticating. Set once at construction and never mutated, so reading it does
+	// not need i.mu; it is read under the lock anyway because the spec around it is.
+	//
+	// nil for a local session, and for any instance built without a daemon behind it
+	// (tests, the agent-server's own in-sandbox instances) — reprovision then keeps
+	// today's behaviour of provisioning without a callback.
+	sandboxCallback func() (url, token string, err error)
 
 	// The below fields are initialized upon calling Start().
 

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -412,10 +412,9 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 	}
 
 	return &Instance{
-		ID:              id,
-		sandboxCallback: opts.SandboxCallback,
-		TaskID:          opts.TaskID,
-		Title:           opts.Title,
+		ID:     id,
+		TaskID: opts.TaskID,
+		Title:  opts.Title,
 		// A task delivery's run begins here and ends when the agent goes idle
 		// (#1892). Only a task-spawned session has a run to bound; a user's session
 		// is never counted against a cap.

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -412,9 +412,10 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 	}
 
 	return &Instance{
-		ID:     id,
-		TaskID: opts.TaskID,
-		Title:  opts.Title,
+		ID:              id,
+		sandboxCallback: opts.SandboxCallback,
+		TaskID:          opts.TaskID,
+		Title:           opts.Title,
 		// A task delivery's run begins here and ends when the agent goes idle
 		// (#1892). Only a task-spawned session has a run to bound; a user's session
 		// is never counted against a cap.

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/internal/sessionenv"
+	"github.com/sachiniyer/agent-factory/log"
 )
 
 // Options for creating a new instance
@@ -167,10 +168,45 @@ func defaultBackendFactory(opts InstanceOptions, absPath string) (ProvisionResul
 	// Revalidate now that the sandbox exists: provisioning is the long window, and
 	// a listener move or an auth change inside it leaves the sandbox holding a
 	// credential that was revoked while it was being written in.
+	//
+	// A failure here must REAP what was just provisioned. NewInstance discards the
+	// ProvisionResult of a failed factory call, so nothing downstream retains
+	// res.Teardown — returning the error alone leaks the sandbox with no handle
+	// left to reap it (#3065 review). This is the same discipline every other
+	// failure exit on a provisioned runtime already follows; a new exit does not
+	// get to skip it.
 	if rerr := revalidateAfterProvision(cred); rerr != nil {
-		return res, rerr
+		return ProvisionResult{}, discardUnusableSandbox(res, opts.SandboxCredentials, rerr)
 	}
 	return res, nil
+}
+
+// discardUnusableSandbox reaps a sandbox that was provisioned but must not be
+// used, and revokes the credential minted for it.
+//
+// Both halves matter and both were missing. The runtime leaks without the reap,
+// because the caller drops the ProvisionResult on error and with it the only
+// cleanup handle. The credential leaks without the revoke, because it is
+// registered against a session whose sandbox no longer exists — a token minted
+// for a runtime that is gone, which is the state this feature exists to prevent.
+//
+// A teardown that reports an UNKNOWN outcome is joined into the returned error
+// rather than swallowed: the sandbox may still be running, and the operator is
+// the only one who can settle it.
+func discardUnusableSandbox(res ProvisionResult, creds SandboxCredentials, cause error) error {
+	if creds != nil {
+		creds.Revoke()
+	}
+	if res.Teardown == nil {
+		return cause
+	}
+	if terr := res.Teardown(); terr != nil {
+		if TeardownStateUnknown(terr) {
+			return fmt.Errorf("%w; and the sandbox provisioned for it could not be confirmed torn down, so it may still be running: %w", cause, terr)
+		}
+		log.WarningLog.Printf("discarded sandbox teardown reported a completed error: %v", terr)
+	}
+	return cause
 }
 
 // resolveBackendKind decides which runtime a new session uses, in precedence

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -27,6 +27,12 @@ type InstanceOptions struct {
 	// a user-created session. It is what lets the daemon count a task's in-flight
 	// sessions for the watch-task concurrency limit without guessing from titles.
 	TaskID string
+	// SandboxCallback mints the per-session credential a provisioned sandbox uses
+	// to call back into the daemon (#2999). It is a FUNCTION rather than a pair of
+	// values so it runs only for off-box kinds: session cannot import daemon, and
+	// the daemon must not mint (or refuse) for a local create that will never use
+	// one. Nil ⇒ no callback, which is every non-daemon caller.
+	SandboxCallback func() (url, token string, err error)
 	// Path is the path to the workspace.
 	Path string
 	// Program is the program to run in the instance (e.g. "claude", "aider --model ollama_chat/gemma3:1b")
@@ -139,6 +145,18 @@ func defaultBackendFactory(opts InstanceOptions, absPath string) (ProvisionResul
 	// launch_cmd, which does the clone on the user's infra).
 	if kind.ProvisionsOffBox() {
 		spec.CloneURL = originRemoteURL(absPath)
+		// Mint the callback credential ONLY here, for kinds that actually provision
+		// a machine to call back from. Minting unconditionally would make every
+		// local create fail whenever require_token is off, turning a sandbox-only
+		// refusal into a total outage — the credential is scoped to the feature
+		// that needs it, and so is its refusal.
+		if opts.SandboxCallback != nil && kind.InjectsSandboxCallback() {
+			url, token, err := opts.SandboxCallback()
+			if err != nil {
+				return ProvisionResult{}, err
+			}
+			spec.CallbackURL, spec.CallbackToken = url, token
+		}
 	}
 	return rt.Provision(spec)
 }

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -27,12 +27,17 @@ type InstanceOptions struct {
 	// a user-created session. It is what lets the daemon count a task's in-flight
 	// sessions for the watch-task concurrency limit without guessing from titles.
 	TaskID string
-	// SandboxCallback mints the per-session credential a provisioned sandbox uses
-	// to call back into the daemon (#2999). It is a FUNCTION rather than a pair of
-	// values so it runs only for off-box kinds: session cannot import daemon, and
-	// the daemon must not mint (or refuse) for a local create that will never use
-	// one. Nil ⇒ no callback, which is every non-daemon caller.
-	SandboxCallback func() (url, token string, err error)
+	// SandboxCredentials mints and revokes the per-session credential a provisioned
+	// sandbox uses to call back into the daemon (#2999, #3068). An INTERFACE rather
+	// than a pair of values so it runs only for off-box kinds — session cannot
+	// import daemon, and the daemon must not mint (or refuse) for a local create
+	// that will never use one — and rather than a bare mint function because the
+	// runtime's lifetime drives BOTH halves: a replacement sandbox mints, a reaped
+	// runtime revokes. Nil ⇒ no callback, which is every non-daemon caller.
+	//
+	// Held on the Instance too, so restore and recovery can provision a replacement
+	// through the same path as the original create (see sandbox_credentials.go).
+	SandboxCredentials SandboxCredentials
 	// Path is the path to the workspace.
 	Path string
 	// Program is the program to run in the instance (e.g. "claude", "aider --model ollama_chat/gemma3:1b")
@@ -145,20 +150,27 @@ func defaultBackendFactory(opts InstanceOptions, absPath string) (ProvisionResul
 	// launch_cmd, which does the clone on the user's infra).
 	if kind.ProvisionsOffBox() {
 		spec.CloneURL = originRemoteURL(absPath)
-		// Mint the callback credential ONLY here, for kinds that actually provision
-		// a machine to call back from. Minting unconditionally would make every
-		// local create fail whenever require_token is off, turning a sandbox-only
-		// refusal into a total outage — the credential is scoped to the feature
-		// that needs it, and so is its refusal.
-		if opts.SandboxCallback != nil && kind.InjectsSandboxCallback() {
-			url, token, err := opts.SandboxCallback()
-			if err != nil {
-				return ProvisionResult{}, err
-			}
-			spec.CallbackURL, spec.CallbackToken = url, token
-		}
 	}
-	return rt.Provision(spec)
+	// Mint through the SHARED helper, which the replacement path uses too, so the
+	// two cannot diverge on which kinds get a credential or on what a refusal
+	// means. Scoped to off-box kinds inside it: minting unconditionally would make
+	// every local create fail whenever require_token is off, turning a sandbox-only
+	// refusal into a total outage.
+	cred, err := mintForProvision(&spec, kind, opts.SandboxCredentials)
+	if err != nil {
+		return ProvisionResult{}, err
+	}
+	res, err := rt.Provision(spec)
+	if err != nil {
+		return res, err
+	}
+	// Revalidate now that the sandbox exists: provisioning is the long window, and
+	// a listener move or an auth change inside it leaves the sandbox holding a
+	// credential that was revoked while it was being written in.
+	if rerr := revalidateAfterProvision(cred); rerr != nil {
+		return res, rerr
+	}
+	return res, nil
 }
 
 // resolveBackendKind decides which runtime a new session uses, in precedence
@@ -412,9 +424,10 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 	}
 
 	return &Instance{
-		ID:     id,
-		TaskID: opts.TaskID,
-		Title:  opts.Title,
+		ID:           id,
+		sandboxCreds: opts.SandboxCredentials,
+		TaskID:       opts.TaskID,
+		Title:        opts.Title,
 		// A task delivery's run begins here and ends when the agent goes idle
 		// (#1892). Only a task-spawned session has a run to bound; a user's session
 		// is never counted against a cap.

--- a/session/runtime.go
+++ b/session/runtime.go
@@ -67,6 +67,21 @@ type ProvisionSpec struct {
 	// Program is the agent program to run in the workspace (empty ⇒ the config
 	// default). Passed through to the sandbox's `af agent-server --program`.
 	Program string
+	// CallbackURL and CallbackToken let the agent INSIDE a sandbox call back into
+	// the daemon (#2999) — the reverse of the daemon-drives-sandbox direction. They
+	// are AF_DAEMON_URL / AF_DAEMON_TOKEN, which apiclient already reads, so no new
+	// CLI surface exists for them.
+	//
+	// The token is per-session, scoped and revocable — never the operator's, which
+	// grants DeliverPrompt over every agent on the machine. The scope it currently
+	// carries is deliberately one route (SuggestSessionName): it does not include
+	// creating a session, which would start an agent on the host with a
+	// caller-supplied program, nor the repo/path reads, whose caller-supplied paths
+	// are a host oracle (#3012 review). See HTTPRoute.sandboxAllowed for the rule
+	// and what widening it waits on. Empty means no callback was granted, which is
+	// the normal case for a local session and also what a refusal leaves behind.
+	CallbackURL   string
+	CallbackToken string
 	// CloneURL is the git remote an off-box runtime clones the workspace from —
 	// the repo's `origin` for a real repo, or a file:// / bind-mounted path for a
 	// self-contained test. Empty for the in-process local runtime. On a fresh
@@ -168,6 +183,19 @@ var backendProvisionsOffBox = map[BackendKind]bool{
 // An unregistered kind reports false, which is the conservative answer —
 // ParseBackendKind rejects those before they reach a runtime.
 func (k BackendKind) ProvisionsOffBox() bool { return backendProvisionsOffBox[k] }
+
+// InjectsSandboxCallback reports whether this kind's provisioner actually
+// delivers the #2999 callback credential into the workspace.
+//
+// Narrower than ProvisionsOffBox on purpose (#3012 review). Only the ssh and
+// sandbox provisioners call writeCallbackEnv; docker and hook do not read the
+// spec fields at all. Minting for them would have been strictly harmful — the
+// create would newly fail whenever require_token was off, and buy the agent
+// nothing when it succeeded, because nothing carries the credential in. A
+// capability nobody delivers must not impose its precondition.
+func (k BackendKind) InjectsSandboxCallback() bool {
+	return k == BackendSSH || k == BackendSandbox
+}
 
 // SetRuntimeForTest replaces the Runtime registered for kind with ctor and
 // returns a restore function. It is the exported form of the registry swap the

--- a/session/sandbox_credentials.go
+++ b/session/sandbox_credentials.go
@@ -1,0 +1,157 @@
+package session
+
+import "github.com/sachiniyer/agent-factory/log"
+
+// The sandbox callback credential's binding to a RUNTIME's lifetime (#3068).
+//
+// The credential (#2999) is minted for a specific provisioned sandbox and bound
+// to the session that owns it (#3056). The lifecycle question this file answers
+// is the one four review rounds kept re-opening: a session's runtime is not
+// permanent. Archive restore and Lost-session recovery REAP the old sandbox and
+// provision a replacement, and a credential minted for the reaped one is wrong in
+// both directions —
+//
+//   - carried forward, it is a token minted for one runtime being presented from
+//     another, which is worse than having none;
+//   - dropped, the recovered agent silently loses the ability to call af, with
+//     nothing on any surface explaining why.
+//
+// So the credential SUBSCRIBES to the runtime's lifetime rather than being
+// refreshed by whoever remembers. Two rules, each in exactly one place:
+//
+//	MINT on provisioning a sandbox — mintForProvision, called by the create path
+//	and the replacement path through the same function.
+//	REVOKE on the runtime being conclusively reaped — Instance.resetRemoteRuntime,
+//	which is reached only when a teardown SUCCEEDED or failed knowably, never when
+//	an unknown outcome retains the old wiring for a retry.
+//
+// That second rule is why ordering is correct by construction rather than by
+// care: a replacement provisions after the reap, the reap revokes, and the mint
+// that follows cannot strand a credential on a runtime that is still alive. An
+// earlier attempt minted before the reap and permanently severed callback from
+// exactly that retained runtime (#3065 review).
+//
+// Three separate sites — listener rebind, listener teardown, unexpected listener
+// death — each had to be taught the invalidation rule independently before it was
+// moved onto the state it describes. This is the same correction applied to the
+// runtime half.
+
+// SandboxCredential is one minted callback credential: what to inject, plus the
+// check that says it is still valid.
+type SandboxCredential struct {
+	// URL and Token are injected into the sandbox as AF_DAEMON_URL and
+	// AF_DAEMON_TOKEN. Empty when no credential was granted.
+	URL, Token string
+	// Revalidate reports whether the grant still holds. Provisioning is the long
+	// window — an ssh clone and a binary copy — and a listener move or an auth
+	// posture change inside it revokes the credential and closes its URL while the
+	// sandbox has already had the stale pair written in. Every path that provisions
+	// must call this AFTER Provision returns, not only the create path: doing it in
+	// one and not the other is how the two drifted the first time.
+	//
+	// nil when there is nothing to revalidate.
+	Revalidate func() error
+}
+
+// Granted reports whether a credential was actually issued.
+func (c SandboxCredential) Granted() bool { return c.Token != "" }
+
+// SandboxCredentials mints and revokes one session's callback credential. The
+// daemon implements it; package session holds only this interface, so the runtime
+// lifecycle can drive the credential without session depending on the daemon's
+// registry.
+//
+// Nil on an Instance means no daemon is backing it — a local session, or an
+// instance built by a test or by the agent-server inside a sandbox — and every
+// call site treats nil as "no credential", never as an error.
+type SandboxCredentials interface {
+	// Mint issues a fresh credential for this session, REPLACING and thereby
+	// revoking any credential the session already held. Replacing is the point on
+	// the reprovision path: the sandbox being replaced may still hold the old
+	// secret, and it must stop working.
+	Mint() (SandboxCredential, error)
+	// Revoke drops the session's credential. Idempotent — every teardown path
+	// calls it and none should fail for it.
+	Revoke()
+}
+
+// mintForProvision fills spec's callback fields for a kind that provisions a
+// sandbox, and returns the credential so the caller can revalidate it after
+// provisioning.
+//
+// THE one place both the create path and the replacement path mint, which is the
+// whole point: the previous shape had create minting inside the backend factory
+// and reprovision building its own ProvisionSpec by hand, so the replacement path
+// simply had no credential — and when that was fixed by adding a second mint call
+// site, that site immediately drifted on live-config, ordering, and revalidation.
+//
+// A kind that does not inject a callback, or a session with no daemon behind it,
+// returns a zero credential and leaves spec untouched. A mint that REFUSES is
+// propagated: the refusals exist for postures where a credential could not be
+// enforced or could not be dialled, and provisioning a sandbox that will silently
+// fail to call back is the outcome this feature exists to prevent.
+func mintForProvision(spec *ProvisionSpec, kind BackendKind, creds SandboxCredentials) (SandboxCredential, error) {
+	if !kind.InjectsSandboxCallback() {
+		// This kind never had a callback; nothing is lost and nothing to say.
+		return SandboxCredential{}, nil
+	}
+	if creds == nil {
+		// A kind that WOULD take a credential, with nothing able to mint one. Said
+		// out loud rather than returned as a silent zero (#3068): losing callback
+		// quietly is one of the two failure modes this file exists to prevent, and
+		// the shape that produces it — an instance the daemon never attached a
+		// minter to — is exactly the bug that shipped and was invisible.
+		//
+		// Not an error, because it is also the ordinary state for an instance with
+		// no daemon behind it (a test, the agent-server inside a sandbox). A line in
+		// the log is the difference between "this build has no callback here" and
+		// "this session silently lost one".
+		log.WarningLog.Printf("provisioning a %s sandbox with no callback credential: nothing is available to mint one, so its agent will not be able to call af", kind)
+		return SandboxCredential{}, nil
+	}
+	cred, err := creds.Mint()
+	if err != nil {
+		return SandboxCredential{}, err
+	}
+	spec.CallbackURL, spec.CallbackToken = cred.URL, cred.Token
+	return cred, nil
+}
+
+// revalidateAfterProvision re-checks a credential once the sandbox it was minted
+// for exists. Returns nil when there is nothing to check.
+func revalidateAfterProvision(cred SandboxCredential) error {
+	if !cred.Granted() || cred.Revalidate == nil {
+		return nil
+	}
+	return cred.Revalidate()
+}
+
+// SetSandboxCredentials attaches the daemon-backed minter to an instance the
+// daemon materialized from disk.
+//
+// Exported for exactly that: FromInstanceData rebuilds an inert instance and
+// cannot know about the daemon, so without this every session loaded after a
+// restart would provision its replacement with no credential and no error —
+// which is what the first version of this shipped (#3065 review).
+//
+// Set-once in practice, but written under i.mu because reprovisionRemote reads it
+// under the read lock while a restore may be materializing instances.
+func (i *Instance) SetSandboxCredentials(c SandboxCredentials) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.sandboxCreds = c
+}
+
+// SandboxCredentialsAttached reports whether this instance can mint a callback
+// credential for a sandbox provisioned on its behalf.
+//
+// Exported narrowly so the daemon can ASSERT its own wiring: the failure this
+// guards is an instance materialized from disk that nobody attached a minter to,
+// which produces no error and no symptom until a restore quietly comes back
+// without a callback (#3065 review). A predicate the daemon's tests can read is
+// the difference between that being caught and being shipped.
+func (i *Instance) SandboxCredentialsAttached() bool {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.sandboxCreds != nil
+}

--- a/session/sandbox_credentials_test.go
+++ b/session/sandbox_credentials_test.go
@@ -1,0 +1,112 @@
+package session
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The credential subscribes to the RUNTIME's lifetime (#3068): provisioning a
+// sandbox mints, reaping one revokes, and both happen in one place each.
+
+type fakeCreds struct {
+	mints    int
+	revokes  int
+	mintErr  error
+	invalid  error
+	lastCred SandboxCredential
+}
+
+func (f *fakeCreds) Mint() (SandboxCredential, error) {
+	f.mints++
+	if f.mintErr != nil {
+		return SandboxCredential{}, f.mintErr
+	}
+	f.lastCred = SandboxCredential{
+		URL:        "http://10.0.0.5:8443",
+		Token:      "secret",
+		Revalidate: func() error { return f.invalid },
+	}
+	return f.lastCred, nil
+}
+
+func (f *fakeCreds) Revoke() { f.revokes++ }
+
+func TestMintForProvision_OnlyForKindsThatInjectACallback(t *testing.T) {
+	creds := &fakeCreds{}
+
+	// A local kind must not mint: minting unconditionally would make every local
+	// create inherit a sandbox-only refusal.
+	var spec ProvisionSpec
+	cred, err := mintForProvision(&spec, BackendLocal, creds)
+	require.NoError(t, err)
+	assert.False(t, cred.Granted())
+	assert.Equal(t, 0, creds.mints)
+	assert.Empty(t, spec.CallbackToken)
+
+	// An injecting kind mints and populates the spec.
+	cred, err = mintForProvision(&spec, BackendSSH, creds)
+	require.NoError(t, err)
+	assert.True(t, cred.Granted())
+	assert.Equal(t, 1, creds.mints)
+	assert.Equal(t, "http://10.0.0.5:8443", spec.CallbackURL)
+	assert.Equal(t, "secret", spec.CallbackToken)
+
+	// No minter at all (a local session, a test, the in-sandbox agent-server) is a
+	// no-op rather than an error.
+	var bare ProvisionSpec
+	cred, err = mintForProvision(&bare, BackendSSH, nil)
+	require.NoError(t, err)
+	assert.False(t, cred.Granted())
+	assert.Empty(t, bare.CallbackToken)
+}
+
+// A refusal must FAIL the provision, not quietly produce a sandbox that cannot
+// call back — the mint refuses exactly when a credential could not be enforced or
+// could not be dialled.
+func TestMintForProvision_PropagatesARefusal(t *testing.T) {
+	refusal := errors.New("refusing to give this sandbox a callback credential: require_token is false")
+	creds := &fakeCreds{mintErr: refusal}
+	var spec ProvisionSpec
+	_, err := mintForProvision(&spec, BackendSSH, creds)
+	require.ErrorIs(t, err, refusal)
+	assert.Empty(t, spec.CallbackToken, "a refused mint must leave the spec without a credential")
+}
+
+func TestRevalidateAfterProvision_RunsOnlyWhenSomethingWasGranted(t *testing.T) {
+	assert.NoError(t, revalidateAfterProvision(SandboxCredential{}),
+		"nothing was granted, so there is nothing to invalidate")
+
+	invalidated := errors.New("invalidated")
+	assert.ErrorIs(t, revalidateAfterProvision(SandboxCredential{
+		Token: "secret", Revalidate: func() error { return invalidated },
+	}), invalidated)
+
+	assert.NoError(t, revalidateAfterProvision(SandboxCredential{
+		Token: "secret", Revalidate: func() error { return nil },
+	}))
+}
+
+// THE lifetime rule: a conclusively reaped runtime takes its credential with it,
+// in ONE place, so kill/archive/restore/recover do not each have to remember.
+//
+// This is the half that stops the worse failure mode — a token minted for one
+// runtime surviving into its replacement.
+func TestResetRemoteRuntime_RevokesTheCredential(t *testing.T) {
+	creds := &fakeCreds{}
+	i := &Instance{Title: "worker"}
+	i.SetSandboxCredentials(creds)
+
+	i.resetRemoteRuntime()
+	assert.Equal(t, 1, creds.revokes, "reaping a runtime must revoke the credential minted for it")
+
+	// Idempotent: every teardown path reaches this and none should fail for it.
+	i.resetRemoteRuntime()
+	assert.Equal(t, 2, creds.revokes)
+
+	// And an instance with no minter must not panic — that is every local session.
+	bare := &Instance{Title: "local"}
+	assert.NotPanics(t, func() { bare.resetRemoteRuntime() })
+}

--- a/session/sandbox_credentials_test.go
+++ b/session/sandbox_credentials_test.go
@@ -110,3 +110,32 @@ func TestResetRemoteRuntime_RevokesTheCredential(t *testing.T) {
 	bare := &Instance{Title: "local"}
 	assert.NotPanics(t, func() { bare.resetRemoteRuntime() })
 }
+
+// A KNOWN teardown failure still means the runtime is gone, so the credential
+// goes with it — while the runtime WIRING is deliberately left for the retry
+// path (#3065 review).
+//
+// remoteAgentServer.Kill tears the in-sandbox workspace down over REST and then
+// reaps the sandbox, and returns the REST error even when the reap succeeded. The
+// success path's revocation is therefore not reachable on that branch, and
+// leaving the credential live means a copied token keeps authenticating until
+// some later recovery happens to replace it.
+func TestRevokeSandboxCredential_IsSeparableFromResettingTheRuntime(t *testing.T) {
+	creds := &fakeCreds{}
+	i := &Instance{Title: "worker"}
+	i.SetSandboxCredentials(creds)
+
+	// Revoking alone must not disturb the wiring the retry path still needs.
+	i.runtimeTeardown = func() error { return nil }
+	i.revokeSandboxCredential()
+	assert.Equal(t, 1, creds.revokes)
+	assert.NotNil(t, i.runtimeTeardown, "settling the credential must not clear the wiring the abort-to-Lost retry owns")
+
+	// And the full reset still revokes, so the two agree on the common path.
+	i.resetRemoteRuntime()
+	assert.Equal(t, 2, creds.revokes)
+	assert.Nil(t, i.runtimeTeardown)
+
+	bare := &Instance{Title: "local"}
+	assert.NotPanics(t, func() { bare.revokeSandboxCredential() })
+}

--- a/session/sandbox_provision.go
+++ b/session/sandbox_provision.go
@@ -143,6 +143,33 @@ func (w *sandboxWorkspace) copyAfBinary(timeout time.Duration, binary io.Reader)
 // startAgentServer launches `af agent-server` headless on the remote, detached
 // via nohup with its banner + log redirected to files, bound to 127.0.0.1:0, and
 // captures the background PID.
+// writeCallbackEnv puts the daemon URL and the per-session callback token on the
+// remote, in a file only the sandbox user can read (#2999).
+//
+// Through STDIN and a file, never the launch command. A token in argv is visible
+// to `ps` for every user on that machine, which is the leak class #2684-#2771
+// exist for; `umask 077` before the redirect means the file is 0600 from the
+// moment it exists rather than briefly world-readable.
+//
+// No-op when no credential was granted, which is every local session and also a
+// sandbox whose mint was refused — so the refusal reaches the operator as the
+// create error it already is, not as a half-written file here.
+func (w *sandboxWorkspace) writeCallbackEnv(timeout time.Duration) error {
+	if w.spec.CallbackToken == "" {
+		return nil
+	}
+	body := fmt.Sprintf("AF_DAEMON_URL=%s\nAF_DAEMON_TOKEN=%s\n",
+		shellQuote(w.spec.CallbackURL), shellQuote(w.spec.CallbackToken))
+	script := "umask 077 && cat > " + shellQuote(w.CallbackEnvPath())
+	out, err := w.shell.Run(timeout, script, strings.NewReader(body), false)
+	if err != nil {
+		// The token is NOT in this message: the script names the path, not the
+		// value, and the value only ever travelled on stdin.
+		return fmt.Errorf("writing the sandbox callback environment failed: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
 func (w *sandboxWorkspace) startAgentServer(timeout time.Duration) error {
 	filteredInner, err := w.agentServerCommand()
 	if err != nil {
@@ -150,6 +177,25 @@ func (w *sandboxWorkspace) startAgentServer(timeout time.Duration) error {
 	}
 	launch := fmt.Sprintf("nohup %s >%s 2>%s </dev/null & echo $!",
 		filteredInner, shellQuote(w.BannerPath()), shellQuote(w.LogPath()))
+	if w.spec.CallbackToken != "" {
+		// Sourced into the shell that launches the agent-server, so the variables
+		// are in its ENVIRONMENT rather than its argv. AF_DAEMON_URL and
+		// AF_DAEMON_TOKEN are already on sessionenv's pass-through allowlist, so
+		// the filtered re-exec carries them through to the agent.
+		//
+		// SEPARATED BY ";" AND NOT "&&", which is load-bearing (#3012 review).
+		// `launch` ends in "... & echo $!", and `&` is a list separator that
+		// backgrounds everything to its LEFT in the AND-list — so chaining the setup
+		// with && made the whole chain one asynchronous job and `$!` reported the
+		// subshell instead of the agent-server. Teardown then compares that PID's
+		// argv against the session's af path, sees a shell (or a process already
+		// gone), treats it as reused/absent, removes the session directory, and
+		// leaves the real agent-server running. Measured: under bash the reported
+		// PID's comm is a process that has already exited; dash happens to optimise
+		// the tail call and reports the right PID, which is why this survives a
+		// casual test. `|| exit 1` keeps the abort-on-failure that && provided.
+		launch = "set -a && . " + shellQuote(w.CallbackEnvPath()) + " && set +a || exit 1; " + launch
+	}
 	out, err := w.shell.Run(timeout, launch, nil, false)
 	if err != nil {
 		return fmt.Errorf("starting af agent-server on the remote failed: %s: %w", strings.TrimSpace(string(out)), err)
@@ -215,4 +261,12 @@ func (w *sandboxWorkspace) readBanner(pollTimeout, pollInterval, stepTimeout tim
 func (w *sandboxWorkspace) WorkspacePath() string { return w.SessionDir + "/" + sshWorkspaceSubdir }
 func (w *sandboxWorkspace) AfPath() string        { return w.SessionDir + "/" + sshAfBinaryName }
 func (w *sandboxWorkspace) BannerPath() string    { return w.SessionDir + "/" + sshBannerName }
-func (w *sandboxWorkspace) LogPath() string       { return w.SessionDir + "/" + sshLogName }
+
+// CallbackEnvPath is the 0600 file holding AF_DAEMON_URL/AF_DAEMON_TOKEN. It sits
+// under SessionDir so the existing one-`rm -rf` teardown reaps the credential
+// with the rest of the session.
+func (w *sandboxWorkspace) CallbackEnvPath() string { return w.SessionDir + "/" + sshCallbackEnvName }
+
+const sshCallbackEnvName = "af-callback.env"
+
+func (w *sandboxWorkspace) LogPath() string { return w.SessionDir + "/" + sshLogName }


### PR DESCRIPTION
Closes #3056

Makes the sandbox callback credential's scope *expressible*, and admits one route under it.

## The problem this solves

#3012 spent nine review rounds and 26 findings establishing that a route-level allowlist cannot carry this credential, and its scope ended **empty**. Both halves of the surface failed, for opposite reasons:

- **Parameterised routes** need *the caller's own* repo or session — a bool on a route table cannot say that. `CreateSession` names no session and still starts an agent on the host; `ListBackends`/`ListPrograms` take a `repo_path` and answer through git's stderr as a path oracle.
- **Parameterless routes** answer from global state, because that is the only state they have. `SuggestSessionName` avoids live titles across all repos, and the sandbox holds the finite wordlist in the `af` binary af put there.

## What changes

**The gate carries the owner instead of discarding it.** `sandboxTokenRegistry.sessionFor` already returned the owning session; `authGate.authorize` converted it to a bool and dropped it. It now returns it, `servePosture` attaches it to the request context at the single point a credential is admitted, and the handler reads it via `sandboxOwner(ctx)`.

**Admission is not authorization.** The flag admits a route to the scope; the route's *handler* must also enforce its own owner constraint. Both conditions, or neither counts.

**That rule is now a test, not prose.** It was a doc comment before, and the old scope drifted from it four separate times — each because a route was judged against the rule by a reader. `sandboxConstrainedRoutes` names every route that has a constraint, and `TestEverySandboxRouteEnforcesAnOwnerConstraint` asserts it equals the scope table **in both directions**: opting a route in without a constraint fails, and deleting a constraint while leaving the route admitted fails.

## The admitted route: `Snapshot`

Chosen deliberately rather than conveniently. It is the enumeration that made every other route aimable — which is precisely why #3012 denied it — so if the constraint is worth anything, it has to hold here. It is also the most obviously legitimate thing a remote agent does: read its own session's state.

Two narrowings:

- **Instances** filter to the owner's **stable id**. Not the repo, and not the title: titles are unique only per repo, so a title match would let a same-titled session in another repo through.
- **DeliveryAlarms** are withheld outright. An alarm names its target by *title*, so filtering would need an id-to-title mapping in the one place that must not get identity wrong — and a sandbox has no use for watch-task delivery diagnostics.

## The operator is untouched

No owner on the context means operator authority, and **the bool is what says so, not the string**. A handler that filtered by "whatever id is present, empty matches nothing" would invert the two and hand every sandbox everything. `Snapshot`'s net/rpc wrapper passes a bare context on purpose — net/rpc is registered on the 0600 unix socket only, which is trusted transport — and says so, because it otherwise reads like a bypass.

## Acceptance test

#3056 asked for one that cannot be satisfied cosmetically: **a credential minted for session A must be refused when it aims at session B**, not merely that a route is allowlisted.

`TestSnapshot_SandboxCredentialSeesOnlyItsOwnSession` drives a real credentialed request through `newHTTPMux` + the real gate, not the handler with a hand-built context. The binding is a chain — registry → gate → request context → handler — and every link is somewhere a regression would silently restore full visibility while every unit test still passed. It asserts the **operator sees both sessions first**, so the narrowing cannot pass on an empty fixture or an unnoticed error response.

## Why the mechanism is in this PR too

None of #3012 is on master, and closing it was an explicit decision not to land the mechanism inert. So this carries both: ~1200 lines of already-reviewed mechanism (restored unchanged from `refs/pull/3012/head`, which answered 26 findings) plus the new binding. **For review, the new work is:** `daemon/sandbox_owner.go`, the `authorize`/`servePosture` change in `daemon/httpauth.go`, the `Snapshot` handler and its filter in `daemon/snapshot.go`, the route entry in `daemon/httproutes.go`, and `daemon/sandbox_owner_test.go`.

`control_server.go` crossed its length ceiling, so the `Snapshot` handler moved to `snapshot.go` — beside the wire types whose contents it decides, and the stale "the handler lives in control.go" header there is corrected rather than left to drift.

## Not in scope

The **operator-declared callback endpoint** (#3056's second slice) is untouched. `listen_addr` still derives the URL, with the literal-IP rule #3012 arrived at. That is a new config key and wants its own decision.

## Verification

`gofmt`, `go build ./...`, `go vet`, `golangci-lint --fast`, and `scripts/lint-file-length.sh` all clean locally. Daemon tests were **not** run on this host by standing rule — they spawn real daemons beside live sessions — so CI is the first run of the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
