### PR TITLE
fix(session): name what actually blocks a vscode tab off-box

### DIFF
--- a/session/backend.go
+++ b/session/backend.go
@@ -98,7 +98,14 @@ func (c Capabilities) RefuseTabKind(kind TabKind, target string) error {
 		return fmt.Errorf("this session cannot open a web tab yet: %s, so it would disappear at the next daemon restart — see #3062", notRestored)
 	case TabNeedsLocalWorktreeRead:
 		if c.Workspace != WorkspaceLocalWorktree {
-			return fmt.Errorf("this session cannot open a vscode tab: its editor is served by the daemon from the session's worktree, and this session's workspace runs off-box (docker/ssh/sandbox), so the daemon has no worktree to open — see #3054")
+			// Names the missing EDITOR, not the missing worktree path. The path is
+			// how today's implementation happens to fail — the daemon's
+			// code-server is rooted at a daemon-host directory — but it is not
+			// what blocks this. af runs no editor inside an off-box workspace and
+			// copies only the `af` binary there, so there is nothing to reach.
+			// Routing is not the obstacle either: the ssh runtime already carries
+			// a general TCP forward. See #3054, which carries the evidence.
+			return fmt.Errorf("this session cannot open a vscode tab: af runs no editor inside an off-box workspace (docker/ssh/sandbox) — the daemon's own code-server can only serve directories on the daemon host — see #3054")
 		}
 		return nil
 	default:

--- a/session/tab_spawn.go
+++ b/session/tab_spawn.go
@@ -35,6 +35,12 @@ func tabSpawnPreconditionErr(started, hasTmux, hasWorktree bool, kind TabKind) e
 	case TabNeedsMetadataOnly:
 		return nil
 	case TabNeedsLocalWorktreeRead:
+		// Accurate for THIS layer, which asks only what the instance can offer the
+		// daemon-local editor: that editor is rooted at a daemon-host directory,
+		// and an off-box instance has none. It is not the whole reason a vscode
+		// tab cannot work off-box — af runs no editor in the workspace at all —
+		// which Capabilities.RefuseTabKind states and #3054 carries the evidence
+		// for. Do not "fix" this by pointing the daemon's editor at a remote path.
 		if !hasWorktree {
 			return fmt.Errorf("cannot add a vscode tab to this session: its editor is rooted at the session's worktree on the daemon host, and this workspace runs off-box, so there is no worktree for the daemon to open (#3054)")
 		}


### PR DESCRIPTION
#3054 asked whether "VS Code cannot work off-box because the editor is served
from the daemon host" is a real constraint or an assumption. I filed that issue,
so this checks its claims against master rather than restating them.

**It is an assumption, and one of its claims is simply wrong.** The refusal now
names the actual blocker.

## What #3054 got wrong

It said an off-box vscode tab "would open nothing, or worse, whatever happens to
sit at the same path". It cannot: `ensureServerForInstance` rejects an empty
worktree explicitly (`daemon/vscode_server.go:608`), and `GetWorktreePath()`
returns `""` when `gitWorktree` is nil, which is every off-box instance. It fails
cleanly. Corrected on the issue.

## The transport is not the blocker

`sshProvisioner.startTunnel` already opens a **general TCP local-forward** — a
daemon-local loopback listener whose every accepted connection is proxied over
the ssh connection to any `remoteAddr`:

```go
// session/backend_ssh.go:585
func (p *sshProvisioner) startTunnel(remoteAddr string) (string, error)
func (p *sshProvisioner) forward(local net.Conn, remoteAddr string)  // io.Copy both ways
```

It carries the agent-server port today, and nothing in `forward` is
agent-server-specific. docker is narrower — one loopback port published at
`docker run` time (`-p 127.0.0.1::<dockerAgentPort>`), so a second service needs
either a restart or a proxy route on the agent-server, which already serves HTTP
(`/v1/agent/*`).

## What the blocker actually is

**af runs no editor inside an off-box workspace.** It `docker cp`s / streams only
the `af` binary in; nothing installs `code-server`.

That is a smaller obstacle than it sounds, because on the daemon host the editor
is *already* BYO: af resolves `vscode_server_binary`, else `code-server`, else
`openvscode-server` on PATH, and prints an install hint when it finds none
(`daemon/vscode_server.go:116,121`). af ships no editor there either. The off-box
equivalent is the same contract one machine over — "the image/host provides an
editor" — which is consistent with docker being deliberately BYO-image.

## What this PR changes

Only the stated reason, because that is what was wrong:

- `Capabilities.RefuseTabKind` now says af runs no editor inside an off-box
  workspace, instead of pointing at the missing worktree path.
- `tabSpawnPreconditionErr` keeps its worktree wording — accurate for the
  question that layer asks, what the instance can offer a *daemon-local* editor —
  with a note that it is not the whole reason, so the two do not read as
  contradicting each other.

The distinction is not cosmetic. The path reading invites someone to "fix" this
by pointing the daemon's code-server at a remote directory, which would serve a
path that does not exist on that host.

## What building it would take

Left to #3054, which I have restated. Not done here because it spans
`session/`, `daemon/` and the agent-server protocol, and because it turns on one
product decision that is not mine: whether an off-box workspace is *required* to
provide an editor (matching the host's BYO contract), or whether af should ship
one into the sandbox. Everything else is mechanical:

1. launch the editor inside the workspace via the agent-server;
2. route to it — ssh has the forward already; docker needs an agent-server proxy
   route or a second published port; hook returns its own endpoint;
3. resolve `TabKindVSCode` to that endpoint for `WorkspaceRemote` and flip the
   capability.

Local gates: `go build ./...`, `go vet ./...`, `gofmt -l .`,
`scripts/lint-file-length.sh`, `golangci-lint --fast`, full `session` package
(63s, green). No daemon/app tests on the host.

Refs #3054

— Captain Claude
