### PR TITLE
fix(daemon): make a retried archive join the running one, not start a second (#2997)

### DIFF
--- a/daemon/agentserver_archive_singleflight_test.go
+++ b/daemon/agentserver_archive_singleflight_test.go
@@ -1,0 +1,161 @@
+package daemon
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A retry must JOIN a running archive, never start a second one on the same
+// worktree (#2997 finding 2).
+//
+// The situation this reproduces: rpcHandler discards the request context, so a
+// client that gives up ends the request and not the server-side git work. The
+// daemon's preserveSandboxBeforeReap then refuses to reap and "keeps retrying" —
+// its own words — and that retry reaches this handler while the first archive is
+// still inside git add/commit/push.
+func TestSingleFlightArchive_RetryJoinsTheRunningArchive(t *testing.T) {
+	var s singleFlightArchive
+	var starts atomic.Int32
+	release := make(chan struct{})
+
+	archive := func() (string, error) {
+		starts.Add(1)
+		<-release // stands in for a push that outlasts the client's deadline
+		return "af/worker-archived", nil
+	}
+
+	const joiners = 4
+	var wg sync.WaitGroup
+	branches := make([]string, joiners)
+	errs := make([]error, joiners)
+	for i := range joiners {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			branches[i], errs[i] = s.do(archive)
+		}()
+	}
+
+	// Let them pile up on the in-flight attempt before it completes — that is the
+	// overlap window the finding is about.
+	require.Eventually(t, func() bool { return starts.Load() == 1 }, 2*time.Second, time.Millisecond,
+		"the first caller must have started the archive")
+	time.Sleep(50 * time.Millisecond)
+	assert.EqualValues(t, 1, starts.Load(),
+		"a concurrent retry started a SECOND archive: two git add/commit runs against one worktree")
+
+	close(release)
+	wg.Wait()
+
+	assert.EqualValues(t, 1, starts.Load(), "exactly one archive ran for %d concurrent requests", joiners)
+	for i := range joiners {
+		require.NoError(t, errs[i])
+		assert.Equal(t, "af/worker-archived", branches[i],
+			"a joiner must receive the branch the running archive produced — recovering the answer the timed-out "+
+				"caller never got is the reason this joins rather than refusing")
+	}
+}
+
+// The failure is shared too: joiners must not silently succeed on an archive that
+// failed, and must not each retry it in place.
+func TestSingleFlightArchive_SharesTheFailure(t *testing.T) {
+	var s singleFlightArchive
+	var starts atomic.Int32
+	release := make(chan struct{})
+	boom := errors.New("push rejected")
+
+	archive := func() (string, error) {
+		starts.Add(1)
+		<-release
+		return "", boom
+	}
+
+	var wg sync.WaitGroup
+	results := make([]error, 3)
+	for i := range 3 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, results[i] = s.do(archive)
+		}()
+	}
+	require.Eventually(t, func() bool { return starts.Load() == 1 }, 2*time.Second, time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	assert.EqualValues(t, 1, starts.Load())
+	for i := range 3 {
+		assert.ErrorIs(t, results[i], boom, "every joiner must see the archive's real outcome")
+	}
+}
+
+// A caller arriving AFTER one finishes starts a fresh archive: the slot is
+// released, not cached. An archive is a snapshot of a moment, and a later caller
+// wants the state as it is then rather than an old branch name.
+func TestSingleFlightArchive_LaterCallStartsAFreshArchive(t *testing.T) {
+	var s singleFlightArchive
+	var starts atomic.Int32
+	archive := func() (string, error) {
+		n := starts.Add(1)
+		if n == 1 {
+			return "af/first", nil
+		}
+		return "af/second", nil
+	}
+
+	branch, err := s.do(archive)
+	require.NoError(t, err)
+	assert.Equal(t, "af/first", branch)
+
+	branch, err = s.do(archive)
+	require.NoError(t, err)
+	assert.Equal(t, "af/second", branch, "a sequential call must run again, not replay a cached result")
+	assert.EqualValues(t, 2, starts.Load())
+}
+
+// A joiner does not outwait its own caller (#2997 finding 2).
+//
+// runGitCommand has no timeout, so a stalled push can run indefinitely; without a
+// bound, every retry would park a handler goroutine on it forever and they would
+// accumulate one per retry. The expiry is an ERROR rather than an empty branch,
+// because the caller must read it as "we do not know" — which is what makes
+// preserveSandboxBeforeReap refuse to reap instead of reaping onto a branch that
+// may not exist.
+func TestSingleFlightArchive_JoinerDoesNotWaitForever(t *testing.T) {
+	prev := archiveJoinTimeout
+	archiveJoinTimeout = 40 * time.Millisecond
+	t.Cleanup(func() { archiveJoinTimeout = prev })
+
+	var s singleFlightArchive
+	stall := make(chan struct{})
+	t.Cleanup(func() { close(stall) })
+	leaderRunning := make(chan struct{})
+
+	go func() {
+		_, _ = s.do(func() (string, error) {
+			close(leaderRunning)
+			<-stall // a push that never finishes
+			return "", nil
+		})
+	}()
+	<-leaderRunning
+
+	start := time.Now()
+	branch, err := s.do(func() (string, error) {
+		t.Error("the joiner started a SECOND archive instead of waiting for the running one")
+		return "", nil
+	})
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "a joiner that gives up must report an error, not an empty branch that reads as success")
+	assert.Empty(t, branch)
+	assert.Contains(t, err.Error(), "not starting a second one",
+		"the message must say why it refused, so an operator is not left guessing")
+	assert.Less(t, elapsed, 2*time.Second, "the joiner must give up on its own bound, not block on the stalled push")
+}

--- a/daemon/agentserver_headless.go
+++ b/daemon/agentserver_headless.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"sync"
 	"syscall"
+	"time"
 
 	"github.com/coder/websocket"
 	"github.com/sachiniyer/agent-factory/config"
@@ -54,6 +56,109 @@ type headlessServer struct {
 	// session lifecycle events belong to the daemon that drives this server, not
 	// to the server itself (§1.1: not the orchestrator).
 	events *eventsHub
+	// archive collapses concurrent /v1/agent/archive requests onto one in-flight
+	// archive (#2997 finding 2). See singleFlightArchive.
+	archive singleFlightArchive
+}
+
+// singleFlightArchive makes a second /v1/agent/archive request JOIN the archive
+// already running instead of starting another one (#2997 finding 2).
+//
+// THE PROBLEM IT SOLVES, which is a property of the wire and not of this server:
+// the mutating RPCs are registered through rpcHandler, which discards the request
+// context, so a client that gives up ends the REQUEST and not the server-side
+// mutation. The daemon gives up on its own schedule — AgentArchiveCallTimeout is
+// 3 minutes and the caller's outer bound sits 30s ABOVE it — and then
+// preserveSandboxBeforeReap refuses to reap and says, in its own error text, that
+// "the daemon keeps retrying". That retry is the second actor: it issues another
+// /v1/agent/archive while the first is still inside git add/commit/push on the
+// same worktree.
+//
+// Two concurrent archives on one worktree is the harm — contending on index.lock
+// at best, interleaving a snapshot commit with another's staging at worst.
+//
+// WHY JOIN RATHER THAN REFUSE. A refusal would also stop the overlap, and it was
+// the obvious answer, but it throws away the thing the retry actually needs. The
+// first archive pushes a branch and returns its name to a client that has already
+// hung up, so the daemon never learns it — and preserveSandboxBeforeReap treats an
+// unknown branch as a refusal to reap, so the session stays stuck exactly as it
+// was. Joining turns the retry into the mechanism that RECOVERS the answer: it
+// waits out the in-flight push and returns the same branch, so the loop converges
+// instead of restarting a three-minute operation it will abandon again.
+//
+// WHY NOT CANCELLATION. Threading the request context into the git commands is the
+// other option the issue names, and it requires deciding what cancelling between
+// `add` and `commit` means — a half-staged index is not a state this code can
+// safely leave behind. Joining needs no such decision, because nothing is
+// interrupted.
+//
+// SCOPE: archive only, deliberately. Kill mutates the same workspace and is not
+// fenced here, because blocking a teardown behind a three-minute push is a worse
+// failure than the one being fixed. It is also not reachable from the path above:
+// preserveSandboxBeforeReap refuses to reap when the archive result is unknown, so
+// the retry loop re-archives rather than killing.
+type singleFlightArchive struct {
+	mu     sync.Mutex
+	active *archiveAttempt
+}
+
+// archiveAttempt is one in-flight archive and its eventual result. done is closed
+// once branch/err are written, which is what orders a joiner's read after the
+// leader's write.
+type archiveAttempt struct {
+	done   chan struct{}
+	branch string
+	err    error
+}
+
+// archiveJoinTimeout bounds how long a joining request waits for the archive
+// already running.
+//
+// Set to the CLIENT's own budget for this call, deliberately: a joiner that
+// outwaited its caller would be holding a handler goroutine for an answer nobody
+// is listening for any more, and since every refused reap produces another retry,
+// those would accumulate one per retry for as long as a stalled push lasts —
+// runGitCommand has no timeout of its own, so "as long as" can be unbounded.
+//
+// Expiring is not a regression on today's behaviour: the caller has given up by
+// then either way. What it costs is the joiner's chance to recover the branch,
+// which is only lost in the case where there was no answer to recover.
+var archiveJoinTimeout = session.AgentArchiveCallTimeout
+
+// do runs archive, or joins the one already running and returns its result.
+func (s *singleFlightArchive) do(archive func() (string, error)) (string, error) {
+	s.mu.Lock()
+	if joined := s.active; joined != nil {
+		s.mu.Unlock()
+		timer := time.NewTimer(archiveJoinTimeout)
+		defer timer.Stop()
+		select {
+		case <-joined.done:
+			return joined.branch, joined.err
+		case <-timer.C:
+			// An error, not an empty branch. The caller must read this as "we do not
+			// know", which is what makes it refuse to reap rather than reap onto a
+			// branch that may not exist — the same rule archiveWithin states.
+			return "", fmt.Errorf("an archive of this workspace has been running for over %s and has not finished; "+
+				"not starting a second one against the same worktree", archiveJoinTimeout)
+		}
+	}
+	attempt := &archiveAttempt{done: make(chan struct{})}
+	s.active = attempt
+	s.mu.Unlock()
+
+	attempt.branch, attempt.err = archive()
+
+	// Closed BEFORE the slot is cleared, so a request that grabbed this attempt
+	// microseconds ago gets its result rather than blocking on a channel whose
+	// writer has moved on. Clearing after also means the next caller starts a fresh
+	// archive, which is correct: a completed archive is a snapshot of a moment, and
+	// a later caller wants the state as it is then, not a cached branch name.
+	close(attempt.done)
+	s.mu.Lock()
+	s.active = nil
+	s.mu.Unlock()
+	return attempt.branch, attempt.err
 }
 
 // AgentServerOptions configures a headless agent-server process.
@@ -364,7 +469,9 @@ type agentArchiveResponse struct {
 // Archive commits + pushes the workspace's branch to origin, making it durable
 // on GitHub before the daemon reaps this sandbox (#1592 Phase 4 PR6).
 func (hs *headlessServer) Archive(_ struct{}, resp *agentArchiveResponse) error {
-	branch, err := hs.as.Archive()
+	// Single-flighted: a retry that arrives while an archive is still running joins
+	// it instead of starting a second one on the same worktree (#2997 finding 2).
+	branch, err := hs.archive.do(hs.as.Archive)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #2997

Finding 2 — archive cancellation does not reach the sandbox. Finding 1 landed in `7719bfd7` (#3004).

## Verified live against master, not taken from the issue

Every link checked on `origin/master` before writing anything, because this finding was once dismissed as non-reproducing and that dismissal had to be retracted:

| Link | On master |
|---|---|
| `/v1/agent/archive` registered context-free | `agentserver_headless.go:211` — `rpcHandler(hs.Archive)` |
| `rpcHandler` discards the request context | `httpserver.go:248` — `rpcHandlerCtx(func(_ context.Context, …))` |
| Client gives up on its own schedule | `AgentArchiveCallTimeout = 3 * time.Minute`, and `sandboxPushTimeout = AgentArchiveCallTimeout + 30s` orders the daemon's outer bound *above* it |
| In-sandbox git is unbounded | `worktree_push.go` — `status` / `add -A` / `commit` through `runGitCommand`, no timeout |
| Nothing fences the handler | `hs.Archive` called straight through |

**What makes it reachable is a retry loop that names itself.** On that timeout `preserveSandboxBeforeReap` refuses to reap and tells the user *"the daemon keeps retrying"*. That retry issues a second `/v1/agent/archive` while the first is still inside git on the same worktree — contending on `index.lock` at best, interleaving a snapshot commit with another's staging at worst.

## The fix: join, don't start a second

A second request joins the archive already running and returns its result.

**Refusing would also stop the overlap** and was the obvious answer. It throws away what the retry actually needs: the first archive pushes a branch and returns its name to a client that has already hung up, so the daemon never learns it — and an unknown branch is precisely what `preserveSandboxBeforeReap` treats as a refusal to reap, so the session stays stuck exactly as it was. Joining makes the retry the mechanism that **recovers** the answer, so the loop converges instead of restarting a three-minute operation it will abandon again.

**The join is bounded by the client's own budget.** `runGitCommand` has no timeout, so a stalled push can run indefinitely, and an unbounded join would park a handler goroutine per retry for as long as that lasts. Expiring costs nothing the caller still wanted — it has given up by then either way — and it expires as an **error**, never an empty branch, because the caller must read it as "we do not know" and refuse to reap. That is the same rule `archiveWithin` already states for its own timeout.

## What this deliberately does not fix

**Cancellation still does not reach the sandbox.** `rpcHandler` discards the context for every mutating RPC on that server, and threading it into the git commands means deciding what cancelling between `add` and `commit` leaves behind — a half-staged index is not a state this code can safely abandon. This closes the consequence the finding names without needing that decision, which is the issue's own option (b).

**Kill is out of scope.** It mutates the same workspace, but fencing it would block a teardown behind a three-minute push — a worse failure than the one being fixed. It is also unreachable from this path: the reap is refused while the archive result is unknown, so the retry loop re-archives rather than killing.

## Tests

Three, each pinning a behaviour rather than the implementation: concurrent requests run **one** archive and all receive its branch; a failure is shared rather than silently succeeding or being re-run per joiner; and a joiner gives up on its own bound rather than blocking on a stalled push, with an error that says why. The first asserts the second archive never starts, which is the defect itself.

Daemon tests were not run on this host by standing rule — CI is their first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
