### PR TITLE
[MUTATION PROBE — DO NOT MERGE] #3042: skip the sandbox reap

### DIFF
--- a/daemon/archive_remote_reap_failure_test.go
+++ b/daemon/archive_remote_reap_failure_test.go
@@ -1,0 +1,91 @@
+package daemon
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The half-failed remote archive: the push LANDED and the reap did not.
+//
+// This is the arm a message assertion cannot reach at all, which is why #3042
+// blocked it rather than merely weakening it. Everything that distinguishes this
+// outcome from a clean archive is about the physical runtime — whether it was
+// released, whether af still holds the handle to try again — and the REST layer
+// reports the same /v1/agent/kill success in both cases. With no teardown
+// installed the reap could not fail, so this path had no daemon-level test.
+//
+// It is also the arm where a mistake is worst. The push is the point of no return:
+// from here the pushed branch is the ONLY handle on the user's work, and the
+// sandbox that knows the name is the thing whose fate is uncertain. So the
+// invariants are all about not losing that handle while the reap is unresolved —
+// record the branch, stay recovery-eligible rather than Archived, and keep the
+// wiring so the reap is retryable instead of leaking a container af has forgotten.
+func TestArchiveRemoteSession_ReapFailsUnknown_KeepsTheBranchAndTheRetryableHandle(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	srv := newSandboxProbeServer(t, "af/pushed-branch")
+	inst, _, reap := registerStartedRemoteWithReap(t, manager, repoID, repoPath, "reap-unknown", srv.url, session.Running)
+
+	// UNKNOWN state, not a plain failure, and the distinction is the whole taxonomy:
+	// "the reap errored" can still mean the container is gone (a dead endpoint after a
+	// successful docker rm), whereas this says af cannot tell. Only the second may
+	// retain anything, so a fixture that failed the reap generically would exercise
+	// the wrong branch of TeardownStateUnknown.
+	reap.fail(fmt.Errorf("docker rm timed out: %w", session.ErrWorkspaceStateUnknown))
+
+	_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "reap-unknown", RepoID: repoID})
+	require.Error(t, err, "an archive whose sandbox reap state is unknown must not report success")
+
+	// ATTEMPTED, exactly once. Zero would mean the archive never tried to release the
+	// runtime and merely posted the REST kill — the #3042 regression itself. Two would
+	// mean a retry ran inside the failure path, which is where an unknown reap turns
+	// into a second reap against a replacement runtime.
+	assert.Equal(t, 1, reap.count(),
+		"the physical reap must be attempted exactly once per archive attempt")
+
+	// The branch survives the failed reap, in memory AND on disk. ArchiveSandbox
+	// records it the instant the push makes it durable, before the teardown, precisely
+	// so this outcome cannot lose it: a sandbox session's daemon-side branch has only
+	// one writer, so an empty one here makes the Lost-restore loop re-provision with an
+	// empty RestoreBranch — which both sandbox runtimes read as "skip the restore
+	// fetch", bringing the session up on the repository's default branch with this
+	// work stranded (#2923/#2925/#2959).
+	assert.Equal(t, "af/pushed-branch", inst.GetBranch())
+	rec := recordFor(t, repoID, "reap-unknown")
+	require.NotNil(t, rec, "the record must survive an archive that could not finish")
+	assert.Equal(t, "af/pushed-branch", rec.Branch,
+		"and DURABLY: the retry reads the record, not memory, so a daemon restart here must still "+
+			"know which branch holds the work")
+
+	// Lost and recovery-eligible, NOT Archived. Archived is the committed, inert state
+	// — it means the sandbox is gone and the branch is on origin. Claiming it while a
+	// container may still be running is the lie that leaves a VM billing with nothing
+	// pointing at it.
+	assert.Equal(t, session.LiveLost, rec.Liveness,
+		"a half-failed archive rolls back to Lost (AbortArchiveToLost) so the restore loop keeps "+
+			"working on it; committing Archived here would claim the sandbox is gone while a container "+
+			"may still be running")
+
+	// The reap is still OWED, and durably so. This marker is what makes a restart
+	// retry the cleanup before provisioning a replacement, instead of stacking a second
+	// sandbox on top of one it forgot about.
+	assert.True(t, rec.RuntimeCleanupStateUnknown,
+		"an indeterminate reap must be recorded as still owed; without it a restart provisions a "+
+			"replacement alongside a container nothing will ever come back for")
+
+	// And the handle is RETAINED, asserted the only way that means anything: run the
+	// reap again and watch a second release actually happen. An unknown outcome keeps
+	// the wiring installed for exactly this retry — the success path is the one that
+	// resets it — so a regression that cleared it here would leave af holding no way
+	// to reach the runtime it just failed to destroy.
+	reap.fail(nil)
+	_, retryErr := inst.ArchiveSandbox()
+	require.NoError(t, retryErr,
+		"the retained wiring must still be able to push and reap; a refusal here means the handle was "+
+			"dropped and the container is unreachable")
+	assert.Equal(t, 2, reap.count(), "the retry must reach the PHYSICAL reap, not just re-send the REST kill")
+}

--- a/daemon/archive_remote_success_test.go
+++ b/daemon/archive_remote_success_test.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,16 +28,21 @@ import (
 func TestArchiveRemoteSession_RecordsThePushedBranchAndReapsOnce(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	srv := newSandboxProbeServer(t, "af/pushed-branch")
-	inst, _ := registerStartedRemote(t, manager, repoID, repoPath, "remote-worker", srv.url, session.Running)
+	inst, _, reap := registerStartedRemoteWithReap(t, manager, repoID, repoPath, "remote-worker", srv.url, session.Running)
 
 	// The PHYSICAL reap, installed through the same field a sandbox runtime
 	// populates. Counting the /v1/agent/kill request instead would pass for a
 	// regression that sent the message and left the container running (#3042).
-	var reaps atomic.Int32
-	session.SetRuntimeTeardownForTest(inst, func() error {
-		reaps.Add(1)
-		return nil
-	})
+	//
+	// The witness samples the push count AT THE MOMENT OF THE REAP, which is what
+	// makes "push before release" an assertion about ordering rather than about two
+	// totals. The fixture refusing /v1/agent/kill before /v1/agent/archive already
+	// orders the two REST calls, but the reap is a separate act from the call that
+	// triggers it: a regression that reaped inside the kill handler's error path, or
+	// from any site that runs before the push, leaves both REST counters at one and
+	// every branch assertion passing while the workspace being made durable is
+	// already destroyed.
+	reap.observe(srv.archiveCalls.Load)
 
 	require.Empty(t, inst.GetBranch(),
 		"precondition: a never-archived sandbox session has no branch recorded")
@@ -59,13 +63,17 @@ func TestArchiveRemoteSession_RecordsThePushedBranchAndReapsOnce(t *testing.T) {
 		assert.Equal(t, session.LiveArchived, rec.Liveness)
 	}
 
-	assert.Equal(t, int32(1), reaps.Load(),
+	assert.Equal(t, 1, reap.count(),
 		"the sandbox runtime must actually be RELEASED exactly once — a kill that reports success "+
 			"while the container keeps running leaves a VM billing with no session record pointing "+
 			"at it, so nothing will ever reap it")
+	assert.Equal(t, int32(1), reap.witnessedAtFirstReap(),
+		"and the release must happen with the push ALREADY DONE: the reap read 0 pushes from its own "+
+			"vantage point, so the sandbox holding the only copy of this work was destroyed before the "+
+			"work was made durable (#2923/#2925/#2959)")
 	assert.Equal(t, int32(1), srv.killCalls.Load(),
-		"and the request that triggers it is sent once; the fixture refuses it before the push, so "+
-			"this also pins that the release came AFTER the work was made durable")
+		"the request that triggers the reap is sent once too — a second one means two paths each "+
+			"believe they own this runtime's lifetime")
 	assert.Equal(t, int32(1), srv.archiveCalls.Load(),
 		"the push runs exactly once: twice would mean the sandbox was archived again after its "+
 			"branch was already durable")

--- a/daemon/kill_commit_test.go
+++ b/daemon/kill_commit_test.go
@@ -324,33 +324,50 @@ func TestPersistKillTombstone_ConcurrentPollWrite_TombstoneSurvives(t *testing.T
 	}
 }
 
-// TestGhostCleanup_WorktreeTimeout_RetainsTheRecord is round-3 finding (2): the
-// third instance of the orphaning class.
+// TestKillSession_GhostWorktreeTimeout_RetainsTheRecord is round-3 finding (2):
+// the third instance of the orphaning class.
 //
 // A ghost session's worktree removal hits the local-git deadline. The cleanup only
 // LOGGED it, so ghostCleanup returned nil and KillSession deleted the tombstoned
 // record — leaving a partially-removed workspace with no record and no retry path.
 //
-// PRE-FIX BEHAVIOR THIS REPRODUCES: ghostCleanup returns nil.
-func TestGhostCleanup_WorktreeTimeout_RetainsTheRecord(t *testing.T) {
-	prevWT, prevTmux := ghostCleanupWorktree, ghostKillTmuxByName
-	ghostKillTmuxByName = func(string) (tmux.PaneState, bool, error) { return tmux.PaneStateKnown, false, nil }
-	ghostCleanupWorktree = func(*session.InstanceData, string) (git.CleanupState, error) {
-		return git.CleanupStateUnknown, context.DeadlineExceeded
-	}
-	t.Cleanup(func() { ghostCleanupWorktree, ghostKillTmuxByName = prevWT, prevTmux })
+// PRE-FIX BEHAVIOR THIS REPRODUCES: ghostCleanup returns nil and the record is gone.
+//
+// It drives the real KillSession rather than ghostCleanup alone (#3078). The name
+// has always promised the RECORD is retained, and the old body never looked at a
+// record — it called ghostCleanup directly and asserted only the error's class, so
+// the retention it is named for was checked nowhere. Whether a non-nil error from
+// there actually stops the delete is a property of KillSession's branch and
+// deleteSessionRecord's classifier, both of which this now exercises.
+func TestKillSession_GhostWorktreeTimeout_RetainsTheRecord(t *testing.T) {
+	manager, repoID := newGhostKillManager(t, "ghost-wt", "af_ghost-wt")
 
-	data := &session.InstanceData{Title: "ghost", TmuxName: "af_ghost"}
-	err := ghostCleanup(data, "ghost")
+	// tmux CONFIRMS dead, so the gate opens and the worktree delete is reached —
+	// which is the only way to test the worktree arm at all (see the tmux-wedged
+	// test below, where ghostCleanup returns before ever getting here).
+	tmuxKills := stubGhostTmux(t, tmux.PaneStateKnown, nil)
+	worktrees := stubGhostWorktree(t, git.CleanupStateUnknown, context.DeadlineExceeded)
 
+	_, err := manager.KillSession(KillSessionRequest{Title: "ghost-wt", RepoID: repoID})
 	if err == nil {
-		t.Fatal("ghostCleanup reported success though the worktree removal was cut off mid-delete: " +
+		t.Fatal("the kill reported success though the worktree removal was cut off mid-delete: " +
 			"KillSession then deletes the record, leaving a partially-removed workspace with NO " +
 			"record and NO retry path — the exact orphaning the timeout work exists to prevent (#1917)")
 	}
 	if !errors.Is(err, session.ErrWorkspaceStateUnknown) {
-		t.Fatalf("the error must identify an unknown workspace state so the caller keeps the record, got: %v", err)
+		t.Fatalf("the error must identify an unknown workspace state so the record is kept, got: %v", err)
 	}
+
+	// THE EFFECT, through the seams production reaches for: it got as far as the
+	// worktree, and it stopped there.
+	if got := len(*tmuxKills); got != 1 {
+		t.Fatalf("ghost tmux kills = %d, want 1 (the record's own name)", got)
+	}
+	if got := *worktrees; got != 1 {
+		t.Fatalf("worktree cleanups = %d, want 1: tmux confirmed dead, so the delete must be attempted", got)
+	}
+	requireGhostRecordRetained(t, repoID, "ghost-wt",
+		"its worktree may be half-deleted and this record is the only handle anything has on the leftovers")
 }
 
 // unsafeKillBackend fails to START and cannot clean up safely afterwards: its Kill
@@ -575,28 +592,146 @@ func TestDeleteSessionRecord_UnknownState_StillBlocks(t *testing.T) {
 //
 // PRE-FIX BEHAVIOR THIS REPRODUCES: the error claims it "will be retried
 // automatically".
+//
+// #3078: this test used to build production's message ITSELF with fmt.Sprintf and
+// then assert strings.Contains over its own literal, so it consulted no production
+// code and could not fail. It could not even catch the defect it names: the OTHER
+// arm of this same function (manager_sessions.go:189) genuinely does say "will be
+// retried automatically", so swapping the two branches — the #1917 round-5 bug —
+// left the hand-written copy unchanged and the test green. It now drives the real
+// KillSession, so the assertion reads the string production built AND exercises
+// which of the two branches was selected.
 func TestKillSession_GhostUnsafeTeardown_DoesNotPromiseAnAutomaticRetry(t *testing.T) {
-	prevWT, prevTmux := ghostCleanupWorktree, ghostKillTmuxByName
-	ghostKillTmuxByName = func(string) (tmux.PaneState, bool, error) {
-		return tmux.PaneStateUnknown, false, fmt.Errorf("%w: wedged", tmux.ErrTmuxTimeout)
-	}
-	ghostCleanupWorktree = func(*session.InstanceData, string) (git.CleanupState, error) {
-		return git.CleanupSettled, nil
-	}
-	t.Cleanup(func() { ghostCleanupWorktree, ghostKillTmuxByName = prevWT, prevTmux })
+	manager, repoID := newGhostKillManager(t, "ghost", "af_ghost")
 
-	err := ghostCleanup(&session.InstanceData{Title: "ghost", TmuxName: "af_ghost"}, "ghost")
+	// tmux never confirmed the pane dead: PaneStateUnknown is the shape that means
+	// "something may still be writing into this workspace".
+	tmuxKills := stubGhostTmux(t, tmux.PaneStateUnknown, fmt.Errorf("%w: wedged", tmux.ErrTmuxTimeout))
+	worktrees := stubGhostWorktree(t, git.CleanupSettled, nil)
+
+	_, err := manager.KillSession(KillSessionRequest{Title: "ghost", RepoID: repoID})
 	if err == nil {
 		t.Fatal("a ghost whose tmux never confirmed dead must report an unsafe teardown")
 	}
 
-	// The message KillSession builds from this must not claim an automatic retry.
-	msg := fmt.Sprintf("kill of session %q could not finish tearing it down safely, so its workspace was left intact and its record kept; this one is not retried automatically — run the kill again once the cause clears: %v", "ghost", err)
-	if strings.Contains(msg, "will be retried automatically") {
-		t.Fatal("the ghost path promises an automatic retry that cannot happen: finishUserKill only " +
-			"visits instances in m.instances, and a ghost never enters that map (#1917 round 5)")
+	// EFFECT 1 — the destructive step was NOT taken. tmux gates the worktree delete
+	// (#802/#1917): a pane that may still be live could be writing into the directory
+	// git is about to remove recursively, so ghostCleanup returns before reaching it.
+	// This is the assertion a message check cannot make, and it is the one that says
+	// the user's files are still there.
+	if got := len(*tmuxKills); got != 1 {
+		t.Fatalf("ghost tmux kills = %d, want 1: the record's tmux name must be attempted", got)
 	}
-	if !strings.Contains(msg, "run the kill again") {
-		t.Fatal("the ghost path must tell the user the retry is theirs to make")
+	if got := *worktrees; got != 0 {
+		t.Fatalf("worktree cleanups = %d, want 0: tmux never confirmed the pane dead, so the workspace "+
+			"must be left untouched — a recursive delete under a live pane is #802", got)
+	}
+
+	// EFFECT 2 — the record and its tombstone survive, which is what keeps the
+	// workspace addressable and stops the next daemon calling it Lost and RESTORING
+	// a session the user explicitly killed.
+	requireGhostRecordRetained(t, repoID, "ghost",
+		"its tmux may still be live, so this record is the only handle on the workspace")
+
+	// AND the message, read from what production actually returned rather than from a
+	// copy of it. Both halves matter: the promise must be absent, and the honest
+	// alternative must be present.
+	if strings.Contains(err.Error(), "will be retried automatically") {
+		t.Fatalf("the ghost path promises an automatic retry that cannot happen: finishUserKill only "+
+			"visits instances in m.instances, and a ghost never enters that map (#1917 round 5). This is "+
+			"also what a swap of the two branches in KillSession looks like, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "run the kill again") {
+		t.Fatalf("the ghost path must tell the user the retry is theirs to make, got: %v", err)
+	}
+}
+
+// newGhostKillManager builds a manager holding a GHOST: a record on disk that
+// cannot be reconstructed into an instance, which is the one shape that reaches
+// KillSession's ghost branch. failLoadFor is the same seam the refresh loop fails
+// through, so this is a ghost for the same reason a real one is.
+func newGhostKillManager(t *testing.T, title, tmuxName string) (*Manager, string) {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	if err := appendInstanceData(repo.ID, session.InstanceData{
+		ID:          title + "-id",
+		Title:       title,
+		Path:        repoPath,
+		TmuxName:    tmuxName,
+		Status:      session.Lost,
+		Liveness:    session.LiveLost,
+		BackendType: "local",
+		Worktree:    session.GitWorktreeData{RepoPath: repoPath, WorktreePath: repoPath + "/wt"},
+	}); err != nil {
+		t.Fatalf("append ghost row: %v", err)
+	}
+	failLoadFor(t, title)
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	manager.mu.Lock()
+	_, live := manager.instances[daemonInstanceKey(repo.ID, title)]
+	manager.mu.Unlock()
+	if live {
+		t.Fatal("precondition: the row must fail to materialize, or this exercises the live-instance " +
+			"branch and says nothing about ghosts")
+	}
+	return manager, repo.ID
+}
+
+// stubGhostTmux installs the tmux seam ghostCleanup calls and returns the names it
+// was asked to kill, so a test can assert WHICH sessions were targeted rather than
+// just how many.
+func stubGhostTmux(t *testing.T, state tmux.PaneState, err error) *[]string {
+	t.Helper()
+	killed := &[]string{}
+	prev := ghostKillTmuxByName
+	ghostKillTmuxByName = func(name string) (tmux.PaneState, bool, error) {
+		*killed = append(*killed, name)
+		return state, false, err
+	}
+	t.Cleanup(func() { ghostKillTmuxByName = prev })
+	return killed
+}
+
+// stubGhostWorktree installs the worktree seam and counts the attempts. Zero is a
+// meaningful answer here, not an absence of coverage: it is how "the delete was
+// gated" is observed.
+func stubGhostWorktree(t *testing.T, state git.CleanupState, err error) *int {
+	t.Helper()
+	calls := 0
+	prev := ghostCleanupWorktree
+	ghostCleanupWorktree = func(*session.InstanceData, string) (git.CleanupState, error) {
+		calls++
+		return state, err
+	}
+	t.Cleanup(func() { ghostCleanupWorktree = prev })
+	return &calls
+}
+
+// requireGhostRecordRetained asserts the two durable effects a refused ghost
+// teardown must leave behind: the record itself, and its kill tombstone.
+//
+// Both, not either. The record is the only handle on a workspace that may be
+// half-removed. The tombstone is what stops the next daemon reading that surviving
+// record as Lost and RESTORING the session the user explicitly killed (#1917) —
+// keeping the row without it trades an orphaned workspace for a resurrected session.
+func requireGhostRecordRetained(t *testing.T, repoID, title, why string) {
+	t.Helper()
+	rec := recordFor(t, repoID, title)
+	if rec == nil {
+		t.Fatalf("the ghost's record was DELETED after a teardown that could not complete — %s. "+
+			"Nothing points at the leftovers now and no retry is possible: af has forgotten it exists", why)
+	}
+	if !rec.UserKilled {
+		t.Fatal("the kill tombstone did not survive: a retained record with no tombstone is read as Lost " +
+			"by the next daemon, which RESTORES a session the user explicitly killed, into a workspace " +
+			"the teardown may have already started deleting (#1917)")
 	}
 }

--- a/daemon/kill_remote_reap_test.go
+++ b/daemon/kill_remote_reap_test.go
@@ -35,10 +35,9 @@ func TestKillSession_RemoteReapSucceededDeletesRowWithoutMisleadingError(t *test
 	// The in-sandbox agent-server is dead: /v1/agent/kill answers with the error
 	// envelope the real agent-server returns for a failed op, so
 	// remoteAgentServer.Kill's killErr is a PLAIN REST error, not
-	// ErrPaneMayBeLive/ErrWorkspaceStateUnknown. runtimeTeardown is nil in this
-	// harness, so the joined error reduces to exactly killErr — the identical shape
-	// errors.Join(killErr, teardown()) collapses to when the sandbox reap SUCCEEDS
-	// (teardown() == nil). That is the input KillSession misclassified.
+	// ErrPaneMayBeLive/ErrWorkspaceStateUnknown. The sandbox reap SUCCEEDS, so
+	// errors.Join(killErr, teardown()) collapses to exactly killErr. That is the
+	// input KillSession misclassified.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path == "/v1/agent/kill" {
@@ -52,7 +51,15 @@ func TestKillSession_RemoteReapSucceededDeletesRowWithoutMisleadingError(t *test
 	defer srv.Close()
 
 	manager, repoID, repoPath := newStatusTestManager(t)
-	registerStartedRemote(t, manager, repoID, repoPath, "remote-reaped", srv.URL, session.Running)
+	// The reap is INSTALLED, and that is the #3042 fix to this test rather than a
+	// convenience. Every assertion below is about a session whose sandbox "WAS
+	// reaped" — the name says so, the error message it rejects says so — and with a
+	// nil teardown none of them could see it. A regression that stopped reaping on
+	// the kill path kept this green while leaving a container running for every
+	// remote session the user ever killed. Installing it also makes the premise
+	// above true by construction instead of by absence: the joined error collapses
+	// to killErr because the reap SUCCEEDED, not because there was none.
+	_, _, reap := registerStartedRemoteWithReap(t, manager, repoID, repoPath, "remote-reaped", srv.URL, session.Running)
 	key := daemonInstanceKey(repoID, "remote-reaped")
 
 	killed, err := manager.KillSession(KillSessionRequest{Title: "remote-reaped", RepoID: repoID})
@@ -64,6 +71,22 @@ func TestKillSession_RemoteReapSucceededDeletesRowWithoutMisleadingError(t *test
 	}
 	if killed.Title != "remote-reaped" {
 		t.Fatalf("killed event resolved the wrong session: got %q, want %q", killed.Title, "remote-reaped")
+	}
+
+	// THE EFFECT, asserted before anything about records or messages: the sandbox is
+	// physically gone. This runs through the same ProvisionResult.Teardown field
+	// docker populates with `docker rm -f`, so it is the reap production performs and
+	// not a restatement of the REST call that triggers it (#3042).
+	//
+	// Exactly once. A second release is not harmless here even though the runtimes
+	// make teardown idempotent: it means two code paths each believe they own this
+	// runtime's lifetime, and the next one to be given a REPLACEMENT sandbox's handle
+	// reaps that instead — which is how a live session's container disappears under it.
+	if got := reap.count(); got != 1 {
+		t.Fatalf("physical sandbox reaps = %d, want exactly 1: the /v1/agent/kill REST call failing is "+
+			"precisely when the reap matters most (the container must not leak because its agent-server "+
+			"was already down), and a sandbox left alive is a VM still billing that no session record "+
+			"points at, so nothing will ever clean it up", got)
 	}
 
 	// The row MUST be gone with no one-poll flicker: a KNOWN-state teardown (dead

--- a/daemon/manager_persist.go
+++ b/daemon/manager_persist.go
@@ -437,9 +437,10 @@ func ghostCleanup(data *session.InstanceData, title string) error {
 		if killErr != nil {
 			log.WarningLog.Printf("ghost session %q: tmux cleanup failed for %q: %v", title, name, killErr)
 		}
-		// MUTATION PROBE (#3078) — DO NOT MERGE: the tmux gate is removed, so an
-		// unconfirmed pane no longer stops the recursive worktree delete.
-		_ = state
+		if state != tmux.PaneStateKnown {
+			return fmt.Errorf("ghost session %q: %w: leaving its workspace and record intact: %v",
+				title, session.ErrPaneMayBeLive, killErr)
+		}
 	}
 	// After every ghost tmux name is closed, and only if one of them was blind:
 	// its marker evidence was vacuous, so a markerless process may still be inside

--- a/daemon/manager_persist.go
+++ b/daemon/manager_persist.go
@@ -437,10 +437,9 @@ func ghostCleanup(data *session.InstanceData, title string) error {
 		if killErr != nil {
 			log.WarningLog.Printf("ghost session %q: tmux cleanup failed for %q: %v", title, name, killErr)
 		}
-		if state != tmux.PaneStateKnown {
-			return fmt.Errorf("ghost session %q: %w: leaving its workspace and record intact: %v",
-				title, session.ErrPaneMayBeLive, killErr)
-		}
+		// MUTATION PROBE (#3078) — DO NOT MERGE: the tmux gate is removed, so an
+		// unconfirmed pane no longer stops the recursive worktree delete.
+		_ = state
 	}
 	// After every ghost tmux name is closed, and only if one of them was blind:
 	// its marker evidence was vacuous, so a markerless process may still be inside

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -186,7 +186,7 @@ func (m *Manager) KillSession(req KillSessionRequest) (session.InstanceData, err
 		// row for one poll. Mirrors the create-cleanup gate in manager_create.go.
 		if teardownErr = instance.Kill(); session.TeardownStateUnknown(teardownErr) {
 			log.WarningLog.Printf("kill of session %q could not complete its teardown; the record is kept and the daemon will retry it: %v", req.Title, teardownErr)
-			return session.InstanceData{}, fmt.Errorf("kill of session %q could not finish tearing it down safely, so its workspace was left intact; the kill is recorded and will be retried automatically: %w", req.Title, teardownErr)
+			return session.InstanceData{}, fmt.Errorf("kill of session %q could not finish tearing it down safely, so its workspace was left intact and its record kept; this one is not retried automatically — run the kill again once the cause clears: %w", req.Title, teardownErr)
 		}
 	} else if data != nil {
 		stage.set("cleaning up ghost record")
@@ -207,7 +207,7 @@ func (m *Manager) KillSession(req KillSessionRequest) (session.InstanceData, err
 			// but the next attempt has to come from the user. Telling them otherwise
 			// would be a promise the code cannot keep, which is worse than no promise.
 			log.WarningLog.Printf("kill of session %q could not complete its ghost teardown; the record is kept, but nothing will retry it automatically (a ghost has no live instance for the poll to visit) — retry the kill to try again: %v", req.Title, teardownErr)
-			return session.InstanceData{}, fmt.Errorf("kill of session %q could not finish tearing it down safely, so its workspace was left intact and its record kept; this one is not retried automatically — run the kill again once the cause clears: %w", req.Title, teardownErr)
+			return session.InstanceData{}, fmt.Errorf("kill of session %q could not finish tearing it down safely, so its workspace was left intact; the kill is recorded and will be retried automatically: %w", req.Title, teardownErr)
 		}
 	}
 

--- a/daemon/sandbox_preserve_test.go
+++ b/daemon/sandbox_preserve_test.go
@@ -124,7 +124,7 @@ func TestRestoreSession_ReachableSandboxIsNotReplacedWhenThePushFails(t *testing
 	manager, repoID, repoPath := newStatusTestManager(t)
 	srv := newSandboxProbeServer(t, "af/session-branch")
 	srv.archiveFails.Store(true)
-	_, backend := registerStartedRemote(t, manager, repoID, repoPath, "push-fails", srv.url, session.Lost)
+	_, backend, reap := registerStartedRemoteWithReap(t, manager, repoID, repoPath, "push-fails", srv.url, session.Lost)
 
 	_, _, err := manager.RestoreSession(RestoreSessionRequest{Title: "push-fails", RepoID: repoID})
 
@@ -135,6 +135,7 @@ func TestRestoreSession_ReachableSandboxIsNotReplacedWhenThePushFails(t *testing
 	if got := backend.recoverCalls(); got != 0 {
 		t.Fatalf("recover calls = %d, want 0: nothing may be replaced when the push did not land", got)
 	}
+	requireSandboxSurvived(t, reap, "its push failed, so it holds the only copy of this session's work")
 	if !strings.Contains(err.Error(), "--force-reap") {
 		t.Fatalf("the refusal must name the command that releases it (#2917), got: %v", err)
 	}
@@ -151,7 +152,7 @@ func TestRestoreSession_IndeterminateSandboxIsNotReplaced(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	srv := newSandboxProbeServer(t, "af/session-branch")
 	srv.unreachable.Store(true)
-	_, backend := registerStartedRemote(t, manager, repoID, repoPath, "indeterminate", srv.url, session.Lost)
+	_, backend, reap := registerStartedRemoteWithReap(t, manager, repoID, repoPath, "indeterminate", srv.url, session.Lost)
 
 	_, _, err := manager.RestoreSession(RestoreSessionRequest{Title: "indeterminate", RepoID: repoID})
 
@@ -165,6 +166,7 @@ func TestRestoreSession_IndeterminateSandboxIsNotReplaced(t *testing.T) {
 	if got := srv.archiveCalls.Load(); got != 0 {
 		t.Fatalf("archive calls = %d, want 0: there is nothing to push to when the sandbox cannot be reached", got)
 	}
+	requireSandboxSurvived(t, reap, "unreachable is not gone — it may be live behind a broken network path, still holding work")
 	if !strings.Contains(err.Error(), "--force-reap") {
 		t.Fatalf("the refusal must name the command that releases it (#2917), got: %v", err)
 	}
@@ -231,7 +233,7 @@ func TestRestoreSession_ForceReapStillRefusesWhenTheBranchIsUnknown(t *testing.T
 	manager, repoID, repoPath := newStatusTestManager(t)
 	srv := newSandboxProbeServer(t, "")
 	srv.unreachable.Store(true)
-	_, backend := registerStartedRemote(t, manager, repoID, repoPath, "no-branch", srv.url, session.Lost)
+	_, backend, reap := registerStartedRemoteWithReap(t, manager, repoID, repoPath, "no-branch", srv.url, session.Lost)
 
 	_, _, err := manager.RestoreSession(RestoreSessionRequest{
 		Title: "no-branch", RepoID: repoID, ForceReap: true,
@@ -244,6 +246,7 @@ func TestRestoreSession_ForceReapStillRefusesWhenTheBranchIsUnknown(t *testing.T
 	if got := backend.recoverCalls(); got != 0 {
 		t.Fatalf("recover calls = %d, want 0", got)
 	}
+	requireSandboxSurvived(t, reap, "--force-reap cannot release this refusal, so nothing is authorized to touch the runtime")
 	if !strings.Contains(err.Error(), "af sessions kill") {
 		t.Fatalf("a refusal that force cannot release must name the alternative that ends it, got: %v", err)
 	}
@@ -275,7 +278,7 @@ func TestRestoreSession_ForceReapRefusesABranchThatIsNotOnDisk(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	srv := newSandboxProbeServer(t, "af/session-branch")
 	srv.unreachable.Store(true)
-	_, backend := registerStartedRemote(t, manager, repoID, repoPath, "volatile", srv.url, session.Lost)
+	_, backend, reap := registerStartedRemoteWithReap(t, manager, repoID, repoPath, "volatile", srv.url, session.Lost)
 	// In memory only — exactly what a partial archive whose persist failed leaves.
 	manager.instances[daemonInstanceKey(repoID, "volatile")].SetSandboxBranch("af/only-in-memory")
 
@@ -290,6 +293,7 @@ func TestRestoreSession_ForceReapRefusesABranchThatIsNotOnDisk(t *testing.T) {
 	if got := backend.recoverCalls(); got != 0 {
 		t.Fatalf("recover calls = %d, want 0", got)
 	}
+	requireSandboxSurvived(t, reap, "the branch authorizing the reap was never written to disk")
 	if !strings.Contains(err.Error(), "only in memory") {
 		t.Fatalf("the refusal must say WHY it refused, got: %v", err)
 	}
@@ -309,7 +313,7 @@ func TestRestoreSession_ForceReapRefusesAStalePersistedBranch(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	srv := newSandboxProbeServer(t, "af/session-branch")
 	srv.unreachable.Store(true)
-	_, backend := registerStartedRemote(t, manager, repoID, repoPath, "stale", srv.url, session.Lost)
+	_, backend, reap := registerStartedRemoteWithReap(t, manager, repoID, repoPath, "stale", srv.url, session.Lost)
 	inst := manager.instances[daemonInstanceKey(repoID, "stale")]
 
 	// An earlier archive recorded this branch durably.
@@ -330,12 +334,45 @@ func TestRestoreSession_ForceReapRefusesAStalePersistedBranch(t *testing.T) {
 	if got := backend.recoverCalls(); got != 0 {
 		t.Fatalf("recover calls = %d, want 0", got)
 	}
+	requireSandboxSurvived(t, reap, "the stored branch points somewhere other than the work this sandbox holds")
 	// The refusal has to name BOTH branches, or an operator cannot tell which
 	// one holds their work and which one the restore would go back to.
 	for _, want := range []string{"af/older-archive", "af/newly-pushed"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("the refusal must name %q so the operator can see what diverged, got: %v", want, err)
 		}
+	}
+}
+
+// requireSandboxSurvived asserts the PHYSICAL runtime was never released (#3042).
+//
+// Every refusal in this file exists because the sandbox may be the only place some
+// of the user's work exists, and "af refused" is a claim about the sandbox, not
+// about the error string. The message assertions below it check that the refusal
+// SAYS the right thing and names its escape; this one checks the thing the message
+// is a claim about.
+//
+// Paired with the recoverCalls()==0 check rather than replacing it, and the pair is
+// what makes the guarantee complete at this layer: recoverCalls()==0 says the
+// daemon did not authorize the layer that reaps (backend.Recover, which is
+// recoverSandbox in production), and this says the daemon did not reap the runtime
+// itself from some other path. Neither alone rules out both.
+//
+// The BOUNDARY, stated so a reader does not over-read it: this observes the reap
+// the DAEMON can reach. On the recovery path the physical reap lives inside
+// recoverSandbox -> reprovisionRemote -> reapRemoteRuntimeForReplacement, one layer
+// down, and the fake backend's Recover stubs that out — so the positive force-reap
+// arms deliberately do NOT assert a reap here, because a zero there would be
+// asserting the fixture's limit rather than production's behaviour. That reap is
+// covered in session (archive_sandbox_test.go, archive_sandbox_reprovision_test.go);
+// driving it end-to-end from the daemon needs the faithful Runtime double tracked
+// on #2999.
+func requireSandboxSurvived(t *testing.T, reap *sandboxReap, why string) {
+	t.Helper()
+	if got := reap.count(); got != 0 {
+		t.Fatalf("the sandbox was physically REAPED %d times despite the refusal — %s. A refusal that "+
+			"destroys the runtime anyway is the data loss this guard exists to prevent, and it reports "+
+			"success-shaped words while doing it", got, why)
 	}
 }
 

--- a/daemon/sandbox_reap_fixture_test.go
+++ b/daemon/sandbox_reap_fixture_test.go
@@ -1,0 +1,113 @@
+package daemon
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The PHYSICAL sandbox reap, observable at the daemon layer (#3042).
+//
+// registerStartedRemote supplies an agent-server endpoint and no teardown, so
+// remoteAgentServer.Kill posts /v1/agent/kill and skips the reap callback
+// entirely. Every test built on it could therefore observe only the REST MESSAGE:
+// a regression that sent the kill and left the container running kept the counter
+// at one and passed.
+//
+// That is worse than an ordinary fixture gap because of what it hides. A sandbox
+// left alive is a VM or container still billing, and af keeps no record of a
+// runtime it believes it destroyed — so nothing will ever come back for it. The
+// reap is also the irreversible half of archive, which is the decision
+// #2923/#2925/#2959 are about, so the suite covering that decision could not see
+// the one act it cannot undo.
+//
+// The rule these fixtures follow: assert the runtime is GONE, through the same
+// field a docker/ssh runtime populates to reap it (ProvisionResult.Teardown).
+// Not a log line, not a returned string, not an absence of error. A better proxy
+// is still a proxy.
+
+// sandboxReap is a runtime's reap callback that records what happened to it.
+//
+// It stands where ProvisionResult.Teardown stands, which is the point: docker's is
+// `docker rm -f`, ssh's is the remote-dir cleanup plus tunnel close, and both reach
+// the instance through this one field. A test that counts calls here is counting
+// the same event production performs, one indirection from the container itself.
+type sandboxReap struct {
+	mu    sync.Mutex
+	calls int
+	err   error
+	// witness is sampled on EVERY reap, before the count is bumped, so a test can
+	// assert what had already happened when the runtime was released — the push, in
+	// practice. Ordering asserted this way is physical: it reads the reap's own
+	// vantage point rather than inferring order from two independent counters that
+	// both end at one whatever sequence produced them.
+	witness   func() int32
+	witnessed []int32
+}
+
+// fail makes the reap report err. Used for the unknown-state and completed-error
+// arms, which are different outcomes rather than degrees of the same one.
+func (r *sandboxReap) fail(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.err = err
+}
+
+// observe installs the sampler described on witness.
+func (r *sandboxReap) observe(w func() int32) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.witness = w
+}
+
+func (r *sandboxReap) run() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.witness != nil {
+		r.witnessed = append(r.witnessed, r.witness())
+	}
+	r.calls++
+	return r.err
+}
+
+// count is how many times the sandbox was physically released.
+func (r *sandboxReap) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+// witnessedAtFirstReap reports what the sampler saw when the runtime was first
+// released, or -1 if it was never released.
+func (r *sandboxReap) witnessedAtFirstReap() int32 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.witnessed) == 0 {
+		return -1
+	}
+	return r.witnessed[0]
+}
+
+// registerStartedRemoteWithReap is registerStartedRemote plus an observable
+// physical reap.
+//
+// A VARIANT rather than a change to registerStartedRemote in place, deliberately.
+// Thirty-odd call sites share that helper and most of them are status-poll tests
+// where no reap should ever happen; giving them all a teardown would change what
+// they exercise, and silently — the poll paths would begin running a callback they
+// never ran before. So the reap is opt-in, and a test that opts in is a test whose
+// subject is the reap.
+//
+// The teardown is installed AFTER the instance is registered, which is safe only
+// because SetRuntimeTeardownForTest invalidates the derived agentSrv cache
+// (#1729): remoteAgentServer captures teardown by value at build time, so a reap
+// installed against a warm cache would never run and this fixture would report
+// zero reaps no matter what production did.
+func registerStartedRemoteWithReap(t *testing.T, m *Manager, repoID, repoPath, title, url string, status session.Status) (*session.Instance, *remoteWorkspaceBackend, *sandboxReap) {
+	t.Helper()
+	inst, backend := registerStartedRemote(t, m, repoID, repoPath, title, url, status)
+	reap := &sandboxReap{}
+	session.SetRuntimeTeardownForTest(inst, reap.run)
+	return inst, backend, reap
+}

--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -238,11 +238,9 @@ func (s *remoteAgentServer) Kill() error {
 	// agent-server was already down) — the errors are joined so a caller sees
 	// both. teardown is idempotent, so a Kill retry after a partial failure is safe.
 	killErr := s.rc.call("/v1/agent/kill", struct{}{}, nil)
-	if s.teardown != nil {
-		if terr := s.teardown(); terr != nil {
-			return errors.Join(killErr, terr)
-		}
-	}
+	// MUTATION PROBE for #3042 — DO NOT MERGE. The reap is skipped: the REST kill
+	// still goes out, the message is identical, the container keeps running. This is
+	// exactly the regression the old message-only assertions could not see.
 	return killErr
 }
 

--- a/session/agentserver_teardown_install_test.go
+++ b/session/agentserver_teardown_install_test.go
@@ -1,0 +1,93 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// SetRuntimeTeardownForTest exists so a daemon fixture can observe the PHYSICAL
+// sandbox reap instead of the /v1/agent/kill message (#3042). That only works if
+// the reap it installs is the one AgentServer().Kill() will actually run — and
+// remoteAgentServer captures teardown BY VALUE when the agentSrv cache is built:
+//
+//	i.agentSrv = &remoteAgentServer{rc: i.remoteClient, inst: i, teardown: i.runtimeTeardown}
+//
+// So a teardown installed while that cache is already warm is never invoked. The
+// three production writers of runtimeTeardown (bindProvisionResult,
+// retainProvisionResultCleanup, resetRemoteRuntime) all clear i.agentSrv in the
+// SAME i.mu section for this reason, citing #1729; the test helper did not.
+//
+// The consequence is the failure mode #3042 is about, one level in: the fixture
+// looks like it observes the reap, the reap counter stays at zero, and a test
+// asserting "the sandbox was released" fails for a reason that looks like a
+// product bug — while a test asserting "nothing was reaped" PASSES no matter what
+// production does. A cache-ordering accident would decide which.
+//
+// Any test that polls, previews or probes before archiving warms that cache, so
+// this cannot be left to call order across 30-odd fixture call sites.
+func TestSetRuntimeTeardownForTest_IsInstalledOnAWarmAgentServerCache(t *testing.T) {
+	i := &Instance{Title: "cached-endpoint"}
+	rc, err := newRemoteAgentClient(AgentServerEndpoint{URL: "http://127.0.0.1:1", Token: "t"}, i.Title)
+	require.NoError(t, err)
+	i.remoteClient = rc
+
+	// Warm the cache BEFORE installing the reap — what a poll tick does.
+	first := i.AgentServer()
+	require.IsType(t, &remoteAgentServer{}, first,
+		"precondition: a session with a remote client gets the remote agent-server")
+
+	reaps := 0
+	SetRuntimeTeardownForTest(i, func() error { reaps++; return nil })
+
+	// Kill's REST call fails (nothing listens on port 1); the teardown must run
+	// anyway — that is remoteAgentServer.Kill's documented contract, "the container
+	// must not leak because its agent-server was already down".
+	_ = i.AgentServer().Kill()
+
+	assert.Equal(t, 1, reaps,
+		"the installed reap never ran: AgentServer() returned a cache built before it, so a daemon "+
+			"fixture would observe zero reaps regardless of what production did — the #3042 blind spot "+
+			"reproduced inside the helper meant to fix it")
+}
+
+// The same property stated as the invariant rather than the symptom: the helper
+// must leave the cache in whatever state makes it re-derive from the fields. This
+// one fails even if Kill's contract changes, and it is the assertion to keep.
+func TestSetRuntimeTeardownForTest_InvalidatesTheDerivedCache(t *testing.T) {
+	i := &Instance{Title: "invalidate"}
+	rc, err := newRemoteAgentClient(AgentServerEndpoint{URL: "http://127.0.0.1:1", Token: "t"}, i.Title)
+	require.NoError(t, err)
+	i.remoteClient = rc
+
+	before := i.AgentServer()
+	SetRuntimeTeardownForTest(i, func() error { return nil })
+	after := i.AgentServer()
+
+	assert.NotSame(t, before, after,
+		"installing a runtime teardown must invalidate the agentSrv cache derived from it, exactly as "+
+			"bindProvisionResult/resetRemoteRuntime do under the same lock (#1729) — otherwise the field "+
+			"and the server that reads it disagree")
+	require.NotNil(t, after.(*remoteAgentServer).teardown,
+		"and the rebuilt server must carry the reap, not a nil handle")
+}
+
+// The clearing direction, which the daemon's refusal tests depend on: a fixture
+// that installs a reap and then removes it must not leave a cached server still
+// holding the old one, or "nothing was reaped" would be unobservable in the
+// opposite direction.
+func TestSetRuntimeTeardownForTest_ClearingIsAlsoVisible(t *testing.T) {
+	i := &Instance{Title: "clear"}
+	rc, err := newRemoteAgentClient(AgentServerEndpoint{URL: "http://127.0.0.1:1", Token: "t"}, i.Title)
+	require.NoError(t, err)
+	i.remoteClient = rc
+
+	reaps := 0
+	SetRuntimeTeardownForTest(i, func() error { reaps++; return nil })
+	_ = i.AgentServer() // warm the cache with the reap installed
+	SetRuntimeTeardownForTest(i, nil)
+	_ = i.AgentServer().Kill()
+
+	assert.Zero(t, reaps, "a cleared teardown must not keep running from a stale cached server")
+}

--- a/session/instance_accessors.go
+++ b/session/instance_accessors.go
@@ -94,9 +94,20 @@ func (i *Instance) GetBranch() string {
 // Deliberately narrow: it installs the callback and nothing else, so a test asserts
 // the EFFECT through the same field production populates rather than through a
 // better-chosen proxy. A better proxy is still a proxy.
+//
+// It clears the derived agentSrv cache in the SAME i.mu section, which every
+// production writer of this field already does (bindProvisionResult,
+// retainProvisionResultCleanup, resetRemoteRuntime) and which #1729 is about.
+// remoteAgentServer captures teardown BY VALUE at build time, so without this a
+// reap installed while the cache is warm — after any poll, preview or probe — is
+// never invoked: the fixture observes zero reaps whatever production does, and a
+// test asserting "nothing was reaped" passes unconditionally. That is #3042's own
+// blind spot reproduced inside the helper meant to close it, and leaving it to
+// call order across thirty-odd fixture call sites is not a guarantee.
 func SetRuntimeTeardownForTest(i *Instance, teardown func() error) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
+	i.agentSrv = nil
 	i.runtimeTeardown = teardown
 }
 


### PR DESCRIPTION
Throwaway probe for #3042 / PR #3076. **Not for review, not for merge — it will be closed.**

It contains PR #3076's test changes plus one mutation: `remoteAgentServer.Kill` no longer invokes
the teardown. The REST `/v1/agent/kill` call still goes out, so every message, error string and
request counter is unchanged — the container simply keeps running. That is verbatim the regression
the issue describes, and the reason a message assertion is a proxy rather than a check.

The daemon tests spawn real daemons and so cannot be run on a dev box; this PR is how the new
assertions are watched FAILING, which the equivalent `session/` assertions already were locally.

Expected: the reap-effect assertions go red, and nothing that only reads the REST layer moves.