### PR TITLE
test(daemon): assert the ghost kill's EFFECT, not a message the test wrote itself (#3078)

### DIFF
--- a/daemon/kill_commit_test.go
+++ b/daemon/kill_commit_test.go
@@ -324,33 +324,50 @@ func TestPersistKillTombstone_ConcurrentPollWrite_TombstoneSurvives(t *testing.T
 	}
 }
 
-// TestGhostCleanup_WorktreeTimeout_RetainsTheRecord is round-3 finding (2): the
-// third instance of the orphaning class.
+// TestKillSession_GhostWorktreeTimeout_RetainsTheRecord is round-3 finding (2):
+// the third instance of the orphaning class.
 //
 // A ghost session's worktree removal hits the local-git deadline. The cleanup only
 // LOGGED it, so ghostCleanup returned nil and KillSession deleted the tombstoned
 // record — leaving a partially-removed workspace with no record and no retry path.
 //
-// PRE-FIX BEHAVIOR THIS REPRODUCES: ghostCleanup returns nil.
-func TestGhostCleanup_WorktreeTimeout_RetainsTheRecord(t *testing.T) {
-	prevWT, prevTmux := ghostCleanupWorktree, ghostKillTmuxByName
-	ghostKillTmuxByName = func(string) (tmux.PaneState, bool, error) { return tmux.PaneStateKnown, false, nil }
-	ghostCleanupWorktree = func(*session.InstanceData, string) (git.CleanupState, error) {
-		return git.CleanupStateUnknown, context.DeadlineExceeded
-	}
-	t.Cleanup(func() { ghostCleanupWorktree, ghostKillTmuxByName = prevWT, prevTmux })
+// PRE-FIX BEHAVIOR THIS REPRODUCES: ghostCleanup returns nil and the record is gone.
+//
+// It drives the real KillSession rather than ghostCleanup alone (#3078). The name
+// has always promised the RECORD is retained, and the old body never looked at a
+// record — it called ghostCleanup directly and asserted only the error's class, so
+// the retention it is named for was checked nowhere. Whether a non-nil error from
+// there actually stops the delete is a property of KillSession's branch and
+// deleteSessionRecord's classifier, both of which this now exercises.
+func TestKillSession_GhostWorktreeTimeout_RetainsTheRecord(t *testing.T) {
+	manager, repoID := newGhostKillManager(t, "ghost-wt", "af_ghost-wt")
 
-	data := &session.InstanceData{Title: "ghost", TmuxName: "af_ghost"}
-	err := ghostCleanup(data, "ghost")
+	// tmux CONFIRMS dead, so the gate opens and the worktree delete is reached —
+	// which is the only way to test the worktree arm at all (see the tmux-wedged
+	// test below, where ghostCleanup returns before ever getting here).
+	tmuxKills := stubGhostTmux(t, tmux.PaneStateKnown, nil)
+	worktrees := stubGhostWorktree(t, git.CleanupStateUnknown, context.DeadlineExceeded)
 
+	_, err := manager.KillSession(KillSessionRequest{Title: "ghost-wt", RepoID: repoID})
 	if err == nil {
-		t.Fatal("ghostCleanup reported success though the worktree removal was cut off mid-delete: " +
+		t.Fatal("the kill reported success though the worktree removal was cut off mid-delete: " +
 			"KillSession then deletes the record, leaving a partially-removed workspace with NO " +
 			"record and NO retry path — the exact orphaning the timeout work exists to prevent (#1917)")
 	}
 	if !errors.Is(err, session.ErrWorkspaceStateUnknown) {
-		t.Fatalf("the error must identify an unknown workspace state so the caller keeps the record, got: %v", err)
+		t.Fatalf("the error must identify an unknown workspace state so the record is kept, got: %v", err)
 	}
+
+	// THE EFFECT, through the seams production reaches for: it got as far as the
+	// worktree, and it stopped there.
+	if got := len(*tmuxKills); got != 1 {
+		t.Fatalf("ghost tmux kills = %d, want 1 (the record's own name)", got)
+	}
+	if got := *worktrees; got != 1 {
+		t.Fatalf("worktree cleanups = %d, want 1: tmux confirmed dead, so the delete must be attempted", got)
+	}
+	requireGhostRecordRetained(t, repoID, "ghost-wt",
+		"its worktree may be half-deleted and this record is the only handle anything has on the leftovers")
 }
 
 // unsafeKillBackend fails to START and cannot clean up safely afterwards: its Kill
@@ -575,28 +592,146 @@ func TestDeleteSessionRecord_UnknownState_StillBlocks(t *testing.T) {
 //
 // PRE-FIX BEHAVIOR THIS REPRODUCES: the error claims it "will be retried
 // automatically".
+//
+// #3078: this test used to build production's message ITSELF with fmt.Sprintf and
+// then assert strings.Contains over its own literal, so it consulted no production
+// code and could not fail. It could not even catch the defect it names: the OTHER
+// arm of this same function (manager_sessions.go:189) genuinely does say "will be
+// retried automatically", so swapping the two branches — the #1917 round-5 bug —
+// left the hand-written copy unchanged and the test green. It now drives the real
+// KillSession, so the assertion reads the string production built AND exercises
+// which of the two branches was selected.
 func TestKillSession_GhostUnsafeTeardown_DoesNotPromiseAnAutomaticRetry(t *testing.T) {
-	prevWT, prevTmux := ghostCleanupWorktree, ghostKillTmuxByName
-	ghostKillTmuxByName = func(string) (tmux.PaneState, bool, error) {
-		return tmux.PaneStateUnknown, false, fmt.Errorf("%w: wedged", tmux.ErrTmuxTimeout)
-	}
-	ghostCleanupWorktree = func(*session.InstanceData, string) (git.CleanupState, error) {
-		return git.CleanupSettled, nil
-	}
-	t.Cleanup(func() { ghostCleanupWorktree, ghostKillTmuxByName = prevWT, prevTmux })
+	manager, repoID := newGhostKillManager(t, "ghost", "af_ghost")
 
-	err := ghostCleanup(&session.InstanceData{Title: "ghost", TmuxName: "af_ghost"}, "ghost")
+	// tmux never confirmed the pane dead: PaneStateUnknown is the shape that means
+	// "something may still be writing into this workspace".
+	tmuxKills := stubGhostTmux(t, tmux.PaneStateUnknown, fmt.Errorf("%w: wedged", tmux.ErrTmuxTimeout))
+	worktrees := stubGhostWorktree(t, git.CleanupSettled, nil)
+
+	_, err := manager.KillSession(KillSessionRequest{Title: "ghost", RepoID: repoID})
 	if err == nil {
 		t.Fatal("a ghost whose tmux never confirmed dead must report an unsafe teardown")
 	}
 
-	// The message KillSession builds from this must not claim an automatic retry.
-	msg := fmt.Sprintf("kill of session %q could not finish tearing it down safely, so its workspace was left intact and its record kept; this one is not retried automatically — run the kill again once the cause clears: %v", "ghost", err)
-	if strings.Contains(msg, "will be retried automatically") {
-		t.Fatal("the ghost path promises an automatic retry that cannot happen: finishUserKill only " +
-			"visits instances in m.instances, and a ghost never enters that map (#1917 round 5)")
+	// EFFECT 1 — the destructive step was NOT taken. tmux gates the worktree delete
+	// (#802/#1917): a pane that may still be live could be writing into the directory
+	// git is about to remove recursively, so ghostCleanup returns before reaching it.
+	// This is the assertion a message check cannot make, and it is the one that says
+	// the user's files are still there.
+	if got := len(*tmuxKills); got != 1 {
+		t.Fatalf("ghost tmux kills = %d, want 1: the record's tmux name must be attempted", got)
 	}
-	if !strings.Contains(msg, "run the kill again") {
-		t.Fatal("the ghost path must tell the user the retry is theirs to make")
+	if got := *worktrees; got != 0 {
+		t.Fatalf("worktree cleanups = %d, want 0: tmux never confirmed the pane dead, so the workspace "+
+			"must be left untouched — a recursive delete under a live pane is #802", got)
+	}
+
+	// EFFECT 2 — the record and its tombstone survive, which is what keeps the
+	// workspace addressable and stops the next daemon calling it Lost and RESTORING
+	// a session the user explicitly killed.
+	requireGhostRecordRetained(t, repoID, "ghost",
+		"its tmux may still be live, so this record is the only handle on the workspace")
+
+	// AND the message, read from what production actually returned rather than from a
+	// copy of it. Both halves matter: the promise must be absent, and the honest
+	// alternative must be present.
+	if strings.Contains(err.Error(), "will be retried automatically") {
+		t.Fatalf("the ghost path promises an automatic retry that cannot happen: finishUserKill only "+
+			"visits instances in m.instances, and a ghost never enters that map (#1917 round 5). This is "+
+			"also what a swap of the two branches in KillSession looks like, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "run the kill again") {
+		t.Fatalf("the ghost path must tell the user the retry is theirs to make, got: %v", err)
+	}
+}
+
+// newGhostKillManager builds a manager holding a GHOST: a record on disk that
+// cannot be reconstructed into an instance, which is the one shape that reaches
+// KillSession's ghost branch. failLoadFor is the same seam the refresh loop fails
+// through, so this is a ghost for the same reason a real one is.
+func newGhostKillManager(t *testing.T, title, tmuxName string) (*Manager, string) {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	if err := appendInstanceData(repo.ID, session.InstanceData{
+		ID:          title + "-id",
+		Title:       title,
+		Path:        repoPath,
+		TmuxName:    tmuxName,
+		Status:      session.Lost,
+		Liveness:    session.LiveLost,
+		BackendType: "local",
+		Worktree:    session.GitWorktreeData{RepoPath: repoPath, WorktreePath: repoPath + "/wt"},
+	}); err != nil {
+		t.Fatalf("append ghost row: %v", err)
+	}
+	failLoadFor(t, title)
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	manager.mu.Lock()
+	_, live := manager.instances[daemonInstanceKey(repo.ID, title)]
+	manager.mu.Unlock()
+	if live {
+		t.Fatal("precondition: the row must fail to materialize, or this exercises the live-instance " +
+			"branch and says nothing about ghosts")
+	}
+	return manager, repo.ID
+}
+
+// stubGhostTmux installs the tmux seam ghostCleanup calls and returns the names it
+// was asked to kill, so a test can assert WHICH sessions were targeted rather than
+// just how many.
+func stubGhostTmux(t *testing.T, state tmux.PaneState, err error) *[]string {
+	t.Helper()
+	killed := &[]string{}
+	prev := ghostKillTmuxByName
+	ghostKillTmuxByName = func(name string) (tmux.PaneState, bool, error) {
+		*killed = append(*killed, name)
+		return state, false, err
+	}
+	t.Cleanup(func() { ghostKillTmuxByName = prev })
+	return killed
+}
+
+// stubGhostWorktree installs the worktree seam and counts the attempts. Zero is a
+// meaningful answer here, not an absence of coverage: it is how "the delete was
+// gated" is observed.
+func stubGhostWorktree(t *testing.T, state git.CleanupState, err error) *int {
+	t.Helper()
+	calls := 0
+	prev := ghostCleanupWorktree
+	ghostCleanupWorktree = func(*session.InstanceData, string) (git.CleanupState, error) {
+		calls++
+		return state, err
+	}
+	t.Cleanup(func() { ghostCleanupWorktree = prev })
+	return &calls
+}
+
+// requireGhostRecordRetained asserts the two durable effects a refused ghost
+// teardown must leave behind: the record itself, and its kill tombstone.
+//
+// Both, not either. The record is the only handle on a workspace that may be
+// half-removed. The tombstone is what stops the next daemon reading that surviving
+// record as Lost and RESTORING the session the user explicitly killed (#1917) —
+// keeping the row without it trades an orphaned workspace for a resurrected session.
+func requireGhostRecordRetained(t *testing.T, repoID, title, why string) {
+	t.Helper()
+	rec := recordFor(t, repoID, title)
+	if rec == nil {
+		t.Fatalf("the ghost's record was DELETED after a teardown that could not complete — %s. "+
+			"Nothing points at the leftovers now and no retry is possible: af has forgotten it exists", why)
+	}
+	if !rec.UserKilled {
+		t.Fatal("the kill tombstone did not survive: a retained record with no tombstone is read as Lost " +
+			"by the next daemon, which RESTORES a session the user explicitly killed, into a workspace " +
+			"the teardown may have already started deleting (#1917)")
 	}
 }

--- a/daemon/kill_commit_test.go
+++ b/daemon/kill_commit_test.go
@@ -545,6 +545,12 @@ func TestFailedCreateCleanupRetryPublishesRemoval(t *testing.T) {
 func TestDeleteSessionRecord_EndpointDeadButWorkspaceGone_ClearsTheTombstone(t *testing.T) {
 	manager, repoID, _ := installRaceBackend(t, &raceBackend{}, "remote-ish")
 
+	// The record must EXIST first, or "it is gone" below passes vacuously and this
+	// test would keep reporting success against a fixture that stopped writing one.
+	if rec := recordFor(t, repoID, "remote-ish"); rec == nil {
+		t.Fatal("precondition: there must be a record on disk for the delete to clear")
+	}
+
 	endpointDead := fmt.Errorf("kill agent: dial tcp: connection refused")
 	deleted, err := manager.deleteSessionRecord(repoID, "remote-ish", "", endpointDead)
 
@@ -556,6 +562,18 @@ func TestDeleteSessionRecord_EndpointDeadButWorkspaceGone_ClearsTheTombstone(t *
 	}
 	if !deleted {
 		t.Fatal("the record was not deleted despite the workspace being gone")
+	}
+	// THE EFFECT, not the report (#3078). `deleted` is deleteSessionRecord's own
+	// account of what it did; the tombstone clearing is a fact about STORAGE. A
+	// delete that returned true while its write was lost leaves finishUserKill
+	// retrying a dead endpoint on every poll forever — the exact stuck-by-default
+	// this test is named for — and the boolean cannot see it.
+	//
+	// Its sibling below already reads the record to prove a refused delete RETAINED
+	// it. The two halves of one guard have to be observed the same way, or the
+	// direction that matters more here is the one taken on trust.
+	if rec := recordFor(t, repoID, "remote-ish"); rec != nil {
+		t.Fatalf("deleteSessionRecord reported success but the record is still on disk: %+v", rec)
 	}
 }
 


### PR DESCRIPTION
Found by the sibling sweep on #3042. It is the same disease taken one step further: not a
proxy for an effect, but a **tautology**.

```go
// The message KillSession builds from this must not claim an automatic retry.
msg := fmt.Sprintf("kill of session %q could not finish tearing it down safely, so its workspace was left intact and its record kept; this one is not retried automatically — run the kill again once the cause clears: %v", "ghost", err)
if strings.Contains(msg, "will be retried automatically") { … }
```

The test copied production's string into the test file and asserted on its own copy. No
production code was consulted, so `KillSession` could be changed to say anything and it stayed
green forever.

**And it could not catch the bug it was written for.** The other arm of the same function does
say the forbidden words:

- `manager_sessions.go:189` (live instance) — "the kill is recorded and will be retried automatically"
- `manager_sessions.go:210` (ghost) — "this one is not retried automatically — run the kill again once the cause clears"

Swapping those two is the #1917 round-5 defect the test names, and it would not have noticed,
because it never read either one.

## The neighbour had it too

`TestGhostCleanup_WorktreeTimeout_RetainsTheRecord` — the name promises the record is retained
and its comment explains that `KillSession` would otherwise delete it, leaving "a
partially-removed workspace with NO record and NO retry path". The body called `ghostCleanup`
directly and asserted only the returned error's class. **There is no manager, no repo and no
storage anywhere in the test** — the retention it is named for was checked nowhere. Whether a
non-nil error there actually stops the delete is a property of `KillSession`'s branch and
`deleteSessionRecord`'s classifier, and neither was exercised.

## What both assert now

Both drive the real `KillSession` against a real ghost — a record on disk that fails to
reconstruct, built through `failLoadFor`, the same seam the refresh loop fails through. Effects
are read through `ghostKillTmuxByName` and `ghostCleanupWorktree`, which are the package-level
vars production itself calls.

**Wedged tmux** (the unsafe-teardown case):
- the record's tmux name was targeted, and
- **the worktree delete was NOT attempted — zero calls.** tmux gates it (#802/#1917): a pane that
  may still be live could be writing into the directory git is about to remove recursively. This
  is the assertion a message check cannot make, and the one that says the user's files are still
  there. Zero is the answer, not an absence of coverage.
- the record AND its tombstone survive — the record is the only handle on the workspace, and
  without the tombstone the next daemon reads that surviving row as Lost and RESTORES a session
  the user explicitly killed.
- then the message, read from what production returned: the promise absent, the honest
  alternative present. Kept rather than dropped, because the wording is the original finding —
  it is just no longer the only thing checked, and it now also pins which branch ran.

**Worktree timeout**: tmux confirms dead so the gate opens, the delete IS attempted, it reports
an unknown state, and the record plus tombstone survive.

## Verification

The daemon package is CI-only, so the mutation proof runs there. The #3077 probe already up for
#3042 mutates `remoteAgentServer.Kill`, which is a disjoint path — a ghost has no remote runtime
at all, so skipping the sandbox reap cannot turn these red. The mutations that fit this defect
class are the two the old tests could not catch, and I will push them to that probe branch and
post the red run: **swap the two `manager_sessions.go` messages**, and **remove the tmux gate in
`ghostCleanup`** so the destructive step proceeds under a possibly-live pane.

Closes #3078