### PR TITLE
test(commands): isolate config tests from the ambient repository, not the home (#3058)

### DIFF
--- a/commands/configcmd_test.go
+++ b/commands/configcmd_test.go
@@ -16,12 +16,45 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// tempAFHome points AGENT_FACTORY_HOME at a fresh temp dir so config reads
-// materialize DefaultConfig there instead of touching the real home or a
-// running daemon's config.
+// tempAFHome isolates config resolution from the developer's machine: a fresh
+// AGENT_FACTORY_HOME so reads materialize DefaultConfig there instead of touching
+// the real home or a running daemon's config, AND a working directory outside any
+// git repository.
+//
+// THE SECOND HALF IS THE ONE THAT WAS MISSING (#3058), and the first half is why
+// that was hard to see. `af config get` resolves the CURRENT REPOSITORY by default
+// — configReadProjectSelector falls back to config.CurrentRepo() when no --repo is
+// passed — so a test run from inside this checkout resolves the repo-shared layer
+// at <repo>/.agent-factory/config.toml. That layer outranks both built-in and
+// global, so a developer with a checked-in default_program there fails
+// TestConfigGetScalarBare with their own value, while AGENT_FACTORY_HOME sits
+// correctly sandboxed and looks like it has already handled this.
+//
+// It is also not the developer's HOME that leaks, which is what the issue reported:
+// the home is sandboxed twice over, by TestMain's testguard.SandboxHome and again
+// here. What leaks is a file in the repository, untracked, which is why CI is green
+// — and why the failure follows the machine rather than the branch. CurrentRepo
+// resolves to the MAIN worktree, so a linked worktree reads the main checkout's
+// file even when its own tree has none.
+//
+// A test that genuinely wants project scope passes --repo explicitly; leaving the
+// ambient repository out is what makes "assert the compiled-in default" mean that.
 func tempAFHome(t *testing.T) {
 	t.Helper()
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	leaveAmbientRepo(t)
+}
+
+// leaveAmbientRepo moves the test out of any git repository, so a command that
+// resolves the CURRENT repo by default resolves none.
+//
+// Separate from tempAFHome because the two isolations are needed independently: a
+// test that asserts on the config FILE sets its own AGENT_FACTORY_HOME to a path
+// it knows, and still must not inherit this checkout's repo-shared layer when it
+// reads a value back through `af config get`.
+func leaveAmbientRepo(t *testing.T) {
+	t.Helper()
+	t.Chdir(t.TempDir())
 }
 
 func captureProcessStderr(t *testing.T, fn func()) string {
@@ -365,6 +398,7 @@ func TestConfigGetUnknownKeyJSONRootSuppressesCobraAndLog(t *testing.T) {
 func TestConfigSetWritesAndReflects(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", home)
+	leaveAmbientRepo(t)
 	path := filepath.Join(home, "config.toml")
 	if err := os.WriteFile(path, []byte("# hi\ndefault_program = 'claude'  # note\n"), 0644); err != nil {
 		t.Fatal(err)
@@ -403,6 +437,7 @@ func TestConfigSetWritesAndReflects(t *testing.T) {
 func TestConfigSetEchoesKeyValueAndRoundTrips(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", home)
+	leaveAmbientRepo(t)
 	path := filepath.Join(home, "config.toml")
 
 	setCmd := &cobra.Command{}


### PR DESCRIPTION
Closes #3058

The reported failures are real and reproduce on this machine. **The diagnosis in the issue is not**, and the fix it proposes is already in the tree and does not work.

## What the issue says, and why it can't be right

> they do not isolate `AGENT_FACTORY_HOME`, so `configGetCmd` resolves through the operator's live global config
>
> Fix: point `AGENT_FACTORY_HOME` at a `t.TempDir()` for these cases

`AGENT_FACTORY_HOME` is isolated **twice over** already: `TestMain` calls `testguard.SandboxHome()` for the whole package (#1056), and `TestConfigGetScalarBare` calls `tempAFHome(t)` on its first line. Both tests fail anyway.

## What actually happens

The resolver's own candidate trace, dumped from inside a failing test:

```
built-in      shadowed   claude
global        shadowed   claude   /tmp/…/001/config.toml        ← isolation is working
legacy repo   disallowed
repo-shared   WINNER     codex    <checkout>/.agent-factory/config.toml
personal      absent
```

`af config get` **resolves the current repository by default** — `configReadProjectSelector` falls back to `config.CurrentRepo()` when no `--repo` is passed — so a test run from inside this checkout picks up the repo-shared layer, and that layer outranks both built-in and global.

Two details that explain the reported symptoms exactly:

- **The file is untracked.** That is why CI is green, and why the failure follows the *machine* rather than the branch. The issue's "CI has no such file" intuition was right about the effect and wrong about which file.
- **`CurrentRepo` resolves to the MAIN worktree.** So a linked worktree reads the main checkout's config even when its own tree has none — which is the case here.

So the leak is not the developer's home. It is a file in the repository.

## The fix

Leave the ambient repository, not the home. `tempAFHome` now does both, and the cwd half is separable as `leaveAmbientRepo` because a test that asserts on the config **file** sets its own known `AGENT_FACTORY_HOME` and still must not inherit this checkout's repo layer when it reads a value back.

A test that genuinely wants project scope passes `--repo`; leaving the ambient repo out is what makes "assert the compiled-in default" mean that.

## The sweep

Done by predicate rather than by grepping for a pattern, since "currently green by luck" is precisely a property you cannot see in the source: every test driving a command that resolves the current repo, without isolating cwd. Three hits.

- `TestConfigSetEchoesKeyValueAndRoundTrips` — **real**. It reads `daemon_poll_interval` back through `af config get` and asserts the value; it passes only because nobody's checked-in config happens to set that key. Fixed.
- `TestConfigSetWritesAndReflects` — asserts on the file directly, so its assertion is not exposed today. Isolated anyway; it costs a line and removes a latent trap.
- `TestConfigSetUnsetProjectRoundTrip` — **false positive** of my detector. It assigns `configSetProjectFlag` and is project-scoped on purpose. Left alone.

Re-running the sweep after the fix reports zero.

## Verification

Both reported failures reproduced before the change and pass after. All 45 tests in the files that use the helper pass. `gofmt`, `go build ./...`, `golangci-lint --fast`, `scripts/lint-file-length.sh` clean.

Only `commands/` tests were run locally, and only by name — the package also contains tmux- and daemon-touching tests that must not run on this host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
