### PR TITLE
fix(accounts): make --account work with claude by giving af's generated launch arguments provenance (#3083)

### DIFF
--- a/internal/sessionenv/account.go
+++ b/internal/sessionenv/account.go
@@ -56,6 +56,28 @@ type Account struct {
 	// Only an EXACT match is honoured — never a basename — so a repository file
 	// that merely shares the name is still refused (#2983 review).
 	TrustedWrapper string
+	// GeneratedArgs are the argument words af's OWN launcher appended to this
+	// session's program, in order, unquoted.
+	//
+	// This is the same shape of claim as TrustedWrapper, for the same reason. The
+	// local launch rewrites a bare `claude` into `claude --session-id <uuid>
+	// --plugin-dir <dir>` before the pane shim sees it, so the guard's no-arguments
+	// rule refused af's OWN output and the pane exited 127 (#3083). No amount of
+	// inspecting the string recovers "af wrote these"; the launcher knows, so it
+	// says so.
+	//
+	// It is deliberately NOT a list of permitted flags. The guard exists because
+	// enumerating unsafe forms failed across four grammars, and its rule is to prove
+	// good shapes rather than hunt bad ones — so an allowlist of `--session-id` and
+	// `--plugin-dir` would rebuild that mistake one layer in, and the next generated
+	// flag would reopen it. These are VALUES the launcher produced on this launch:
+	// the uuid and the directory are compared whole and positionally, so nothing a
+	// repository can write into program_overrides matches them, and a flag af did
+	// not generate is still refused however harmless it looks.
+	//
+	// Empty means af appended nothing, which is every non-claude agent today and
+	// the only behaviour before this field existed.
+	GeneratedArgs []string
 }
 
 // accountConfigVars maps an agent to the variable that relocates its credential
@@ -185,7 +207,13 @@ func ApplyAccount(env []string, command string, account Account) ([]string, erro
 	for _, selector := range GuardedSelectors() {
 		refused[selector] = struct{}{}
 	}
-	if overrides, provable := commandOverridesName(command, account.Agent, account.TrustedWrapper, refused); overrides || !provable {
+	proof := commandProof{
+		agent:          account.Agent,
+		trustedWrapper: account.TrustedWrapper,
+		generated:      account.GeneratedArgs,
+		names:          refused,
+	}
+	if overrides, provable := commandOverridesName(command, proof); overrides || !provable {
 		if !provable {
 			return nil, fmt.Errorf(
 				"account %q cannot scope agent %q: its program could not be proven to be a direct %s invocation free of "+

--- a/internal/sessionenv/account_command.go
+++ b/internal/sessionenv/account_command.go
@@ -33,7 +33,19 @@ import (
 // agent, and a modelled `env` wrapper around one — and reports everything else
 // as UNPROVABLE. New syntax then arrives as a refusal to scope rather than as a
 // silent bypass, which is the direction this repo can afford to be wrong in.
-func commandOverridesName(command, agent, trustedWrapper string, names map[string]struct{}) (overrides, provable bool) {
+// commandProof is what the CALLER knows and the string cannot say: which agent
+// this account scopes, which af binary generated the handoff, and which argument
+// words af's own launcher appended. Grouped because all three are provenance
+// supplied from outside, and a five-argument recursion invited passing them in
+// the wrong order.
+type commandProof struct {
+	agent          string
+	trustedWrapper string
+	generated      []string
+	names          map[string]struct{}
+}
+
+func commandOverridesName(command string, proof commandProof) (overrides, provable bool) {
 	if command == "" {
 		return false, true
 	}
@@ -41,10 +53,10 @@ func commandOverridesName(command, agent, trustedWrapper string, names map[strin
 	if !ok {
 		return false, false
 	}
-	return callOverridesName(call, agent, trustedWrapper, names, 0)
+	return callOverridesName(call, proof, 0)
 }
 
-func callOverridesName(call *syntax.CallExpr, agent, trustedWrapper string, names map[string]struct{}, depth int) (overrides, provable bool) {
+func callOverridesName(call *syntax.CallExpr, proof commandProof, depth int) (overrides, provable bool) {
 	if depth > maxNestedProgramDepth {
 		return false, false
 	}
@@ -59,7 +71,6 @@ func callOverridesName(call *syntax.CallExpr, agent, trustedWrapper string, name
 		if assign != nil && assign.Name != nil {
 			return true, true
 		}
-		_ = names
 	}
 
 	words := call.Args
@@ -90,16 +101,16 @@ func callOverridesName(call *syntax.CallExpr, agent, trustedWrapper string, name
 	// a bare name refuses af's own launch on those backends — the same
 	// name-is-not-provenance problem in reverse: here the path IS trusted and the
 	// spelling cannot say so, which is why the caller supplies it.
-	if nested, ok := literalAgentServerProgram(call); ok && isTrustedAfBinary(words[0], trustedWrapper) {
+	if nested, ok := literalAgentServerProgram(call); ok && isTrustedAfBinary(words[0], proof.trustedWrapper) {
 		inner, ok := singleSimpleCall(nested)
 		if !ok {
 			return false, false
 		}
-		return callOverridesName(inner, agent, trustedWrapper, names, depth+1)
+		return callOverridesName(inner, proof, depth+1)
 	}
 
 	if isBareName(words[0], "env") {
-		return envOverridesName(words[1:], agent, names)
+		return envOverridesName(words[1:], proof)
 	}
 
 	// Anything else is unprovable, and that includes commands that look
@@ -124,12 +135,61 @@ func callOverridesName(call *syntax.CallExpr, agent, trustedWrapper string, name
 	// help points at --settings for auth. Enumerating those per agent is the same
 	// losing game as enumerating shell forms, one layer down, so a scoped
 	// invocation carries no arguments at all (#2983 review).
+	// af's OWN generated arguments are removed here, by PROVENANCE rather than by
+	// shape (#3083). What remains must still satisfy the no-arguments rule below
+	// unchanged — this widens what af can prove about its own output, not what the
+	// rule accepts from anywhere else.
+	words, ok := stripGeneratedArgs(words, proof.generated)
+	if !ok {
+		return false, false
+	}
 	if len(words) == 1 {
-		if executable, ok := literalShellWord(words[0]); ok && executableIsAgent(executable, agent) {
+		if executable, ok := literalShellWord(words[0]); ok && executableIsAgent(executable, proof.agent) {
 			return false, true
 		}
 	}
 	return false, false
+}
+
+// stripGeneratedArgs removes the launcher's declared trailing argument words and
+// reports whether the command ended in exactly them.
+//
+// EXACT, POSITIONAL, and ANCHORED TO THE END — three properties that together are
+// what makes this provenance instead of an allowlist:
+//
+//   - Exact: each word is compared whole against the value the launcher generated
+//     on THIS launch — a specific uuid, a specific plugin directory. A repository
+//     writing `--session-id` into program_overrides does not match, because it
+//     cannot know the uuid. Matching the FLAG NAME instead would be the allowlist
+//     this guard exists to avoid, and would accept any value including one that
+//     redirects identity.
+//   - Positional: order is fixed, so nothing can be reordered to slip an extra
+//     word between two declared ones.
+//   - Anchored, with the COUNT required to match: the command must be the agent
+//     plus these words and nothing else. Merely "contains" or "ends with" would
+//     leave room for an argument in front of them.
+//
+// Every word must also be a shell LITERAL. callIsLiteral has already established
+// that for the whole call, so this is the narrower restatement that survives if
+// that check ever moves: a word whose text matches after expansion is not the
+// word af generated.
+func stripGeneratedArgs(words []*syntax.Word, generated []string) ([]*syntax.Word, bool) {
+	if len(generated) == 0 {
+		return words, true
+	}
+	// The executable plus exactly the declared words. Anything else is unprovable,
+	// including FEWER words than declared: that means the command is not the one the
+	// launcher described, so its description does not apply to it.
+	if len(words) != len(generated)+1 {
+		return nil, false
+	}
+	for idx, want := range generated {
+		got, ok := literalShellWord(words[idx+1])
+		if !ok || got != want {
+			return nil, false
+		}
+	}
+	return words[:1], true
 }
 
 // envOverridesName decides an `env` wrapper through envcommand.Parse, the
@@ -141,7 +201,7 @@ func callOverridesName(call *syntax.CallExpr, agent, trustedWrapper string, name
 // and a second implementation of the same grammar is a second thing to keep in
 // step. Anything Parse rejects is unprovable by definition, because Parse's own
 // contract is to refuse rather than silently model a different environment.
-func envOverridesName(args []*syntax.Word, agent string, names map[string]struct{}) (overrides, provable bool) {
+func envOverridesName(args []*syntax.Word, proof commandProof) (overrides, provable bool) {
 	literals, ok := literalCommandArgs(args)
 	if !ok {
 		return false, false
@@ -174,7 +234,6 @@ func envOverridesName(args []*syntax.Word, agent string, names map[string]struct
 	if invocation.Chdir != "" {
 		return true, true
 	}
-	_ = names
 	if invocation.CommandIndex < 0 || invocation.CommandIndex >= len(literals) {
 		// env with no command to run: nothing launches, so nothing is redirected.
 		return false, true
@@ -192,10 +251,18 @@ func envOverridesName(args []*syntax.Word, agent string, names map[string]struct
 	// account after af and tmux believe the session ended. Enumerating signal
 	// options would be the fifth grammar this guard tried to enumerate; this is
 	// the last one it needs (#2983 review).
-	if invocation.CommandIndex != 0 || len(literals) != 1 {
+	// The command operand plus exactly af's declared generated words, and nothing
+	// else — the same provenance rule the direct branch applies, so `env` does not
+	// become the wrapper that reaches a laxer version of it (#3083).
+	if invocation.CommandIndex != 0 || len(literals) != len(proof.generated)+1 {
 		return false, false
 	}
-	if executableIsAgent(literals[invocation.CommandIndex], agent) {
+	for idx, want := range proof.generated {
+		if literals[idx+1] != want {
+			return false, false
+		}
+	}
+	if executableIsAgent(literals[invocation.CommandIndex], proof.agent) {
 		return false, true
 	}
 	return false, false

--- a/internal/sessionenv/account_generated_args.go
+++ b/internal/sessionenv/account_generated_args.go
@@ -1,0 +1,65 @@
+package sessionenv
+
+// GeneratedArgsBetween reports the argument words a launcher appended to base to
+// reach final, for Account.GeneratedArgs (#3083).
+//
+// It lives beside the guard that consumes the answer, and that is the point
+// rather than convenience. Producer and consumer MUST tokenize identically: if
+// the launcher split its own rewrite one way and the guard split the executed
+// command another, the declaration would describe something other than what is
+// checked, and the disagreement would surface as an unexplained 127 in a pane. So
+// both go through singleSimpleCall and literalShellWord, and neither owns a
+// second copy of the rules.
+//
+// This is a statement af makes about its OWN work — "I turned base into final,
+// and here is precisely what I added" — computed where both strings are in hand.
+// The launcher cannot be asked to remember a list; the two strings are what it
+// actually has, and the difference between them is derivable without inspecting
+// what the added words MEAN. Nothing here looks at flag names.
+//
+// It fails closed, and every refusal is a launch that stays refused rather than a
+// launch that proceeds unverified:
+//
+//   - either string not a single simple command, or not fully literal
+//   - final not a positional extension of base (a rewrite that changed an
+//     existing word rather than appending, which is not what this can describe)
+//   - base carrying assignments, or the two disagreeing on the executable
+//
+// A base equal to final yields no words and true: that is the ordinary
+// non-claude launch, where af appends nothing.
+func GeneratedArgsBetween(base, final string) ([]string, bool) {
+	baseCall, ok := singleSimpleCall(base)
+	if !ok || !callIsLiteral(baseCall) || len(baseCall.Assigns) > 0 {
+		return nil, false
+	}
+	finalCall, ok := singleSimpleCall(final)
+	if !ok || !callIsLiteral(finalCall) || len(finalCall.Assigns) > 0 {
+		return nil, false
+	}
+	baseWords, ok := literalCommandArgs(baseCall.Args)
+	if !ok || len(baseWords) == 0 {
+		return nil, false
+	}
+	finalWords, ok := literalCommandArgs(finalCall.Args)
+	if !ok || len(finalWords) < len(baseWords) {
+		return nil, false
+	}
+	// EVERY leading word must be unchanged, not merely the executable. A rewrite
+	// that edited one of the user's own arguments while appending is not "af added
+	// these", and describing it that way would hand the guard a claim that does not
+	// match the command.
+	for idx, want := range baseWords {
+		if finalWords[idx] != want {
+			return nil, false
+		}
+	}
+	added := finalWords[len(baseWords):]
+	if len(added) == 0 {
+		return nil, true
+	}
+	// A fresh slice: the caller stores this on an Account that outlives the parse,
+	// and handing back a view into finalWords invites an aliasing surprise.
+	out := make([]string, len(added))
+	copy(out, added)
+	return out, true
+}

--- a/internal/sessionenv/account_generated_args_test.go
+++ b/internal/sessionenv/account_generated_args_test.go
@@ -1,0 +1,253 @@
+package sessionenv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// af's real generated claude launch, as the local backend produces it: the
+// conversation injection appends `--session-id <uuid>` and the guidance seam
+// appends `--plugin-dir <dir>`. Written as the pair the launcher would declare,
+// so a test cannot accidentally agree with the guard by using a simplified shape.
+const (
+	genSessionID = "0b6f2c1e-8a44-4d0e-9f31-7c5b2a9e4d10"
+	genPluginDir = "/home/op/.local/share/agent-factory/plugins/af"
+)
+
+func claudeAccount(generated ...string) Account {
+	return Account{
+		Agent:         "claude",
+		Name:          "work",
+		Dir:           "/afhome/accounts/claude/work",
+		GeneratedArgs: generated,
+	}
+}
+
+func afGeneratedClaudeArgs() []string {
+	return []string{"--session-id", genSessionID, "--plugin-dir", genPluginDir}
+}
+
+// THE BUG (#3083): the guard rejected arguments af itself authored, so an
+// account-scoped claude session exited 127.
+//
+// Declaring them makes the launch provable, and the assertion is the whole point
+// of the feature rather than the guard's boolean: the account's directory is what
+// the session sees, and the ambient key that would outrank it is gone.
+func TestApplyAccount_AcceptsAfsOwnGeneratedClaudeLaunch(t *testing.T) {
+	command := "claude --session-id " + genSessionID + " --plugin-dir " + genPluginDir
+	ambient := []string{"PATH=/usr/bin", "ANTHROPIC_API_KEY=sk-ambient", "HOME=/home/op"}
+
+	scoped, err := ApplyAccount(ambient, command, claudeAccount(afGeneratedClaudeArgs()...))
+	require.NoError(t, err,
+		"af generated --session-id and --plugin-dir itself, so the guard was refusing its own output")
+
+	dir, ok := envValue(scoped, "CLAUDE_CONFIG_DIR")
+	require.True(t, ok, "the account's credential root must be injected")
+	require.Equal(t, "/afhome/accounts/claude/work", dir)
+	_, leaked := envValue(scoped, "ANTHROPIC_API_KEY")
+	require.False(t, leaked,
+		"an ambient API key outranks the config directory, so leaving it makes the account selection silently a no-op")
+}
+
+// The SAME launch with nothing declared is still refused, which is the behaviour
+// before this field existed. The mechanism widens what af can prove about its own
+// output; it does not loosen the rule for anyone else.
+func TestApplyAccount_UndeclaredArgumentsAreStillRefused(t *testing.T) {
+	command := "claude --session-id " + genSessionID + " --plugin-dir " + genPluginDir
+	_, err := ApplyAccount([]string{"PATH=/usr/bin"}, command, claudeAccount())
+	require.Error(t, err, "arguments nobody vouched for are not provable just because they look like af's")
+	require.Contains(t, err.Error(), "could not be proven")
+}
+
+// THE TEST THAT SEPARATES PROVENANCE FROM AN ALLOWLIST, and the reason this is
+// not a list of permitted flags.
+//
+// A repository can write anything into program_overrides, including the exact
+// flag NAMES af uses. What it cannot do is know the uuid af minted for this
+// launch or the plugin directory af resolved. So the comparison is against the
+// VALUES the launcher generated, whole — which means a flag-name match buys an
+// attacker nothing.
+//
+// An allowlist of `--session-id` and `--plugin-dir` would accept every one of
+// these, and `--plugin-dir` in particular hands claude a repository-chosen
+// directory of plugin code.
+func TestApplyAccount_GeneratedArgsAreValuesNotFlagNames(t *testing.T) {
+	generated := afGeneratedClaudeArgs()
+	for _, test := range []struct {
+		name    string
+		command string
+		why     string
+	}{
+		{
+			name:    "a different session id",
+			command: "claude --session-id attacker-chosen --plugin-dir " + genPluginDir,
+			why:     "the flag name matches and the value does not; only the value is evidence af wrote it",
+		},
+		{
+			name:    "a different plugin dir",
+			command: "claude --session-id " + genSessionID + " --plugin-dir /repo/evil-plugins",
+			why:     "--plugin-dir loads repository code into claude; accepting the flag regardless of value is the allowlist mistake",
+		},
+		{
+			name:    "an extra argument after the declared ones",
+			command: "claude --session-id " + genSessionID + " --plugin-dir " + genPluginDir + " --settings /repo/auth.json",
+			why:     "claude's --settings can redirect auth; the declared suffix must be the WHOLE argument list, not a prefix of it",
+		},
+		{
+			name:    "an extra argument before the declared ones",
+			command: "claude --settings /repo/auth.json --session-id " + genSessionID + " --plugin-dir " + genPluginDir,
+			why:     "anchoring only the tail would let anything sit in front of it",
+		},
+		{
+			name:    "the declared words reordered",
+			command: "claude --plugin-dir " + genPluginDir + " --session-id " + genSessionID,
+			why:     "position is part of the claim; reordering is a different command than the one described",
+		},
+		{
+			name:    "fewer words than declared",
+			command: "claude --session-id " + genSessionID,
+			why:     "the command is not the one the launcher described, so its description does not apply to it",
+		},
+		{
+			name:    "a value that is a command substitution",
+			command: "claude --session-id " + genSessionID + " --plugin-dir \"$(cat /repo/x)\"",
+			why:     "/bin/sh expands this BEFORE claude starts, so the text that matches is not the word af generated",
+		},
+		{
+			name:    "an identity assignment in front of a correctly declared suffix",
+			command: "ANTHROPIC_API_KEY=sk-repo claude --session-id " + genSessionID + " --plugin-dir " + genPluginDir,
+			why:     "provenance for the arguments says nothing about an assignment prefix, which outranks the account directory",
+		},
+		{
+			name:    "a different agent carrying claude's declared suffix",
+			command: "codex --session-id " + genSessionID + " --plugin-dir " + genPluginDir,
+			why:     "CLAUDE_CONFIG_DIR means nothing to codex, so it would authenticate from its own default home",
+		},
+		{
+			name:    "a path-qualified agent with a correct suffix",
+			command: "./claude --session-id " + genSessionID + " --plugin-dir " + genPluginDir,
+			why:     "a basename is not provenance; ./claude is an arbitrary repository file handed the account root",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ApplyAccount([]string{"PATH=/usr/bin"}, test.command, claudeAccount(generated...))
+			require.Error(t, err, test.why)
+		})
+	}
+}
+
+// The `env` wrapper must reach the SAME rule, not a laxer one. It is the one
+// wrapper this guard models, so it is also the obvious place for the provenance
+// check to be forgotten.
+func TestApplyAccount_EnvWrapperAppliesTheSameProvenanceRule(t *testing.T) {
+	generated := afGeneratedClaudeArgs()
+	suffix := " --session-id " + genSessionID + " --plugin-dir " + genPluginDir
+
+	scoped, err := ApplyAccount([]string{"PATH=/usr/bin", "ANTHROPIC_API_KEY=sk-ambient"},
+		"env claude"+suffix, claudeAccount(generated...))
+	require.NoError(t, err, "env around af's own generated launch is the same provable shape")
+	dir, ok := envValue(scoped, "CLAUDE_CONFIG_DIR")
+	require.True(t, ok)
+	require.Equal(t, "/afhome/accounts/claude/work", dir)
+
+	for _, test := range []struct{ name, command, why string }{
+		{"a mutation through env", "env ANTHROPIC_API_KEY=sk-repo claude" + suffix,
+			"env-borne assignments recreate an identity that outranks the account directory"},
+		{"an undeclared value through env", "env claude --session-id attacker --plugin-dir " + genPluginDir,
+			"the env branch must compare values too, or it becomes the laxer path"},
+		{"an extra operand through env", "env claude" + suffix + " --settings /repo/auth.json",
+			"the declared suffix is the whole operand list here as well"},
+		{"an env option in front", "env -i claude" + suffix,
+			"-i drops the injected root entirely"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ApplyAccount([]string{"PATH=/usr/bin"}, test.command, claudeAccount(generated...))
+			require.Error(t, err, test.why)
+		})
+	}
+}
+
+// A declared suffix must not become a way to smuggle arguments past the
+// no-arguments rule for an agent af did NOT generate a launch for. Codex takes no
+// generated arguments today, so an empty declaration must keep refusing them —
+// this is the regression guard for "someone wires GeneratedArgs globally".
+func TestApplyAccount_EmptyDeclarationKeepsTheNoArgumentRule(t *testing.T) {
+	account := Account{Agent: "codex", Name: "work", Dir: "/afhome/accounts/codex/work"}
+
+	scoped, err := ApplyAccount([]string{"PATH=/usr/bin", "OPENAI_API_KEY=sk-ambient"}, "codex", account)
+	require.NoError(t, err, "a bare invocation is the shape that was always provable")
+	_, leaked := envValue(scoped, "OPENAI_API_KEY")
+	require.False(t, leaked)
+
+	_, err = ApplyAccount([]string{"PATH=/usr/bin"},
+		`codex -c cli_auth_credentials_store="keyring"`, account)
+	require.Error(t, err,
+		"this makes codex ignore the account's auth.json for the machine-wide keyring; an empty declaration "+
+			"must leave that refusal exactly as it was")
+}
+
+// The producer and the guard must agree by construction, so the round trip is the
+// assertion: whatever GeneratedArgsBetween reports for a rewrite, ApplyAccount
+// must accept for the rewritten command. A test that hand-writes the declaration
+// proves the guard works on a list somebody typed, not on af's own output.
+func TestGeneratedArgsBetween_RoundTripsThroughTheGuard(t *testing.T) {
+	base := "claude"
+	final := "claude --session-id " + genSessionID + " --plugin-dir " + genPluginDir
+
+	generated, ok := GeneratedArgsBetween(base, final)
+	require.True(t, ok)
+	require.Equal(t, afGeneratedClaudeArgs(), generated)
+
+	_, err := ApplyAccount([]string{"PATH=/usr/bin"}, final, claudeAccount(generated...))
+	require.NoError(t, err, "the launcher's own description of its rewrite must satisfy the guard")
+}
+
+// A program_overrides base keeps working: af appends to whatever the operator
+// configured, and only af's addition is declared. The base still has to pass the
+// guard's own rules, so this pair is refused for the base — which is correct, and
+// is why the declaration cannot launder a bad base.
+func TestGeneratedArgsBetween_DescribesOnlyTheAddition(t *testing.T) {
+	generated, ok := GeneratedArgsBetween("claude --settings /repo/auth.json",
+		"claude --settings /repo/auth.json --session-id "+genSessionID)
+	require.True(t, ok, "the difference is computable without judging what the words mean")
+	require.Equal(t, []string{"--session-id", genSessionID}, generated)
+
+	_, err := ApplyAccount([]string{"PATH=/usr/bin"},
+		"claude --settings /repo/auth.json --session-id "+genSessionID, claudeAccount(generated...))
+	require.Error(t, err,
+		"the operator's own --settings is NOT af-authored, so it remains unprovable — declaring af's "+
+			"addition must not vouch for the base it was appended to")
+}
+
+func TestGeneratedArgsBetween_FailsClosed(t *testing.T) {
+	for _, test := range []struct{ name, base, final, why string }{
+		{"an edited leading word", "claude", "claude-next --session-id x",
+			"the executable changed, so this is not an append"},
+		{"a changed user argument", "claude --model a", "claude --model b --session-id x",
+			"a rewrite that edits an existing word cannot honestly be described as an addition"},
+		{"final shorter than base", "claude --model a", "claude",
+			"nothing was appended; something was removed"},
+		{"a command substitution in the addition", "claude", "claude --plugin-dir \"$(cat /x)\"",
+			"the word af generated is not the text that survives expansion"},
+		{"two commands", "claude", "claude --session-id x; evil",
+			"not a single simple command"},
+		{"an assignment prefix", "claude", "ANTHROPIC_API_KEY=sk claude --session-id x",
+			"an assignment is not an appended argument, and this one recreates an identity"},
+		{"an empty base", "", "claude --session-id x", "there is no base to append to"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, ok := GeneratedArgsBetween(test.base, test.final)
+			require.False(t, ok, test.why)
+		})
+	}
+}
+
+// Identical strings are the ordinary non-claude launch: af appends nothing, and
+// the empty declaration must keep the no-arguments rule intact rather than being
+// mistaken for "unknown".
+func TestGeneratedArgsBetween_NoRewriteDeclaresNothing(t *testing.T) {
+	generated, ok := GeneratedArgsBetween("codex", "codex")
+	require.True(t, ok)
+	require.Empty(t, generated)
+}

--- a/session/account_generated_launch_test.go
+++ b/session/account_generated_launch_test.go
@@ -1,0 +1,97 @@
+package session
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/internal/sessionenv"
+)
+
+// #3083's test bar, and it is a bar about the FIXTURE rather than the assertion:
+// "a test that passes on a hand-written bare `claude` proves nothing about the
+// path that actually runs."
+//
+// So this drives af's real generators — planLaunchConversation, which appends
+// `--session-id <uuid>`, and injectSystemPrompt, which appends `--plugin-dir
+// <dir>` after creating that directory — and scopes the command they produce.
+// Nothing here writes a command string by hand, which is why it lives in package
+// session: both generators are unexported, and a copy of their output in
+// internal/sessionenv would be exactly the simplified shape the bar rules out.
+func TestAccountScopesAfsRealGeneratedClaudeLaunch(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const base = "claude"
+	withConversation, conversation := planLaunchConversation("11111111-2222-3333-4444-555555555555", base)
+	command := injectSystemPrompt(withConversation)
+
+	// The fixture must be the REWRITTEN command, not a bare invocation that would
+	// have passed before #3083 existed. Asserted rather than assumed: if either
+	// generator stopped appending — a plugin-dir failure logs and returns the input
+	// unchanged — this test would silently regress into the hand-written case the
+	// bar rejects.
+	require.NotEqual(t, base, command,
+		"af's generators appended nothing, so this proves nothing about the account path that actually runs")
+	require.Contains(t, command, "--session-id "+conversation.ID)
+	require.Contains(t, command, "--plugin-dir ")
+
+	generated, ok := sessionenv.GeneratedArgsBetween(base, command)
+	require.True(t, ok, "the launcher must be able to describe its own rewrite")
+	require.NotEmpty(t, generated)
+
+	ambient := []string{
+		"PATH=/usr/bin",
+		"HOME=/home/op",
+		"ANTHROPIC_API_KEY=sk-ambient-outranks-the-account-dir",
+		"CLAUDE_CODE_OAUTH_TOKEN=oauth-ambient",
+	}
+	account := sessionenv.Account{
+		Agent:         "claude",
+		Name:          "work",
+		Dir:           t.TempDir(),
+		GeneratedArgs: generated,
+	}
+
+	scoped, err := sessionenv.ApplyAccount(ambient, command, account)
+	require.NoError(t, err,
+		"the pane exited 127 here (#3083): af generated --session-id and --plugin-dir, and the account "+
+			"boundary refused its own output")
+
+	require.Equal(t, account.Dir, envLookup(t, scoped, "CLAUDE_CONFIG_DIR"),
+		"the session must see THIS account's credential root")
+	require.NotContains(t, envNames(scoped), "ANTHROPIC_API_KEY",
+		"an ambient API key takes precedence over CLAUDE_CONFIG_DIR, so leaving it makes the account "+
+			"selection silently a no-op — the exact failure the feature exists to prevent")
+	require.NotContains(t, envNames(scoped), "CLAUDE_CODE_OAUTH_TOKEN")
+
+	// And the negative half against the SAME real command: without the declaration
+	// it is still refused. This is what makes the positive result mean "provenance
+	// was verified" rather than "the guard got looser".
+	_, err = sessionenv.ApplyAccount(ambient, command, sessionenv.Account{
+		Agent: account.Agent, Name: account.Name, Dir: account.Dir,
+	})
+	require.Error(t, err,
+		"af's real generated command must remain unprovable when nothing vouches for the added arguments")
+}
+
+func envNames(env []string) []string {
+	names := make([]string, 0, len(env))
+	for _, kv := range env {
+		if name, _, ok := strings.Cut(kv, "="); ok {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func envLookup(t *testing.T, env []string, name string) string {
+	t.Helper()
+	for _, kv := range env {
+		if k, v, ok := strings.Cut(kv, "="); ok && k == name {
+			return v
+		}
+	}
+	t.Fatalf("%s is not present in the scoped environment", name)
+	return ""
+}


### PR DESCRIPTION
The local launch rewrites `claude` into `claude --session-id <uuid> --plugin-dir <dir>` before the
pane shim sees it, and the account boundary accepts only a bare, argument-free invocation. **So the
guard was rejecting arguments af itself authored**, and the pane exited 127.

## Provenance, not shape

`Account.GeneratedArgs` is the same kind of claim `TrustedWrapper` already makes, for the same
reason: no amount of inspecting the string recovers "af wrote these", so the launcher says so.

**Explicitly not a flag allowlist.** That guard exists because enumerating unsafe forms failed across
four grammars, and its rule is to prove good shapes rather than hunt bad ones — adding
`--session-id` and `--plugin-dir` to a permitted list rebuilds that mistake one layer in, and the
next generated flag reopens it. What is compared are the **values this launch produced**: a specific
uuid, a specific plugin directory, matched whole and positionally, with the count required to match
so the declared suffix is the entire argument list. A repository can write the flag NAMES into
`program_overrides`; it cannot know the uuid af minted.

That distinction is load-bearing rather than rhetorical, and `--plugin-dir` is why: an allowlist
keyed on the flag name accepts `--plugin-dir /repo/evil-plugins` and hands claude a
repository-chosen directory of plugin code.

The strip runs immediately before the existing no-arguments rule and what remains must still satisfy
it unchanged. So this widens what af can prove about **its own output**, not what the rule accepts
from anywhere else — an empty declaration is byte-for-byte today's behaviour, which is every
non-claude agent.

The `env` branch gets the same rule. It is the one wrapper this guard models, so it is the obvious
place for the check to be forgotten, and a laxer path there would be the whole bypass.

## Producer and consumer share one tokenizer

`GeneratedArgsBetween(base, final)` computes the declaration where both strings are in hand, and it
lives beside the guard deliberately: if the launcher split its rewrite one way and the guard split
the executed command another, the declaration would describe something other than what is checked,
and the disagreement would surface as an unexplained 127 in a pane. Both go through
`singleSimpleCall`/`literalShellWord`; neither owns a second copy of the rules.

It fails closed — a rewrite that edited an existing word, an assignment prefix, a command
substitution, two commands — and every refusal is a launch that stays refused rather than one that
proceeds unverified. Declaring af's addition also does **not** vouch for the base it was appended
to: an operator's own `--settings` in `program_overrides` remains unprovable, which is asserted.

## Why not "apply the boundary before the rewrite"

The issue leaned that way and I went the other, so the reasoning should be visible. Verifying the
pre-rewrite command means the string that is **checked** is not the string that `/bin/sh` **runs**.
Both designs end up trusting af's own additions, but this one keeps the guard's guarantee a property
of the executed command, and refuses anything the launcher did not explicitly declare. It also
needs no "verified string ≠ executed string" caveat for the next reader.

## Tests

Two layers, and the second is the issue's own bar — *"a test that passes on a hand-written bare
`claude` proves nothing about the path that actually runs."*

- `internal/sessionenv`: the mechanism, weighted toward the ten negatives — wrong uuid, wrong plugin
  dir, extra argument before and after, reordered, too few, command-substituted value, assignment
  prefix, cross-agent, path-qualified agent — plus the same set through `env`.
- `session`: drives the **real** generators (`planLaunchConversation` → `injectSystemPrompt`, which
  creates the plugin dir) and scopes what they produce. It asserts the fixture actually got rewritten,
  so a generator that stopped appending cannot silently regress it into the hand-written case the bar
  rejects; and it re-runs the same real command with nothing declared, which must still be refused —
  that is what makes the positive result mean "provenance was verified" rather than "the guard got
  looser".

Both mutation-proved locally (this package runs on a dev box, unlike `daemon/`):

- Implemented as a **flag-name allowlist**, the value- and position-sensitive cases go red —
  `a_different_session_id`, `a_different_plugin_dir`, `the_declared_words_reordered`,
  `fewer_words_than_declared`.
- With the declaration **ignored** (pre-#3083 behaviour), the real-command test reproduces the bug:
  `the pane exited 127 here (#3083): af generated --session-id and --plugin-dir, and the account
  boundary refused its own output`.

## Now complete end to end

#3075 merged, so the second commit wires the declaration through its protocol and `--account` with
claude works.

`setLaunchProgram` pairs `SetProgram` with `SetGeneratedArgs` in ONE call at every local launch site
— first launch, prepared create, restore, respawn. One function rather than two calls at four sites
because a declaration describing a different program string than the one installed would be worse
than none: it would be a false claim about the command that runs, and pairing them makes that drift
unrepresentable. `CreateLaunchPlan` freezes the pre-rewrite base alongside its program, rather than
re-resolving it at launch, for the same reason — `program_overrides` could read differently by then.

The declaration travels **length-prefixed** in argv beside the account name, matching how the extras
count already works. A generated argument is an arbitrary string — the plugin directory can contain
a space, which a test uses — so any delimiter could appear inside one and a mis-split would hand the
guard a different claim than the launcher made. `execInvocation` checks the exact total only after
both counts are known, because a length that merely *fits* leaves room for an unaccounted argument
between the two lists.

Nothing new travels that is not already visible: the generated words appear in the command operand
beside them. What argv gains is the CLAIM that af authored them.

**`SwapAgent` deliberately declares nothing.** It changes which agent runs, so an account selection
for the outgoing agent does not transfer; it therefore fails closed and refuses, which is its
behaviour today. Called out rather than left as an apparent oversight.

### Added tests

- **The argv round trip**, driven through `WrapAccountCommand` → `execInvocation` with `processExec`
  stubbed, asserting the ENVIRONMENT the pane would have received: `CLAUDE_CONFIG_DIR` is the
  account's and `ANTHROPIC_API_KEY` is gone. Without the declaration arriving word-for-word
  `ApplyAccount` refuses and `execInvocation` errors, so the scoped environ *is* the proof. The
  plugin dir in the fixture contains a space.
- **Miscounted argv is refused, not guessed at** — truncated, over-count, negative, non-numeric, and
  one unaccounted trailing argument.
- **`setLaunchProgram` fails closed** on a base it cannot relate to the final command (an assignment
  prefix), declaring nothing so the launch is refused rather than proceeding unverified.

Verified `gofmt`, `go build ./...`, `go vet`, `golangci-lint --fast`, `scripts/lint-file-length.sh`,
the full `internal/sessionenv` and `session` suites (62s, green) and `session/tmux`. Cross-built for
`darwin/arm64` and `windows/amd64` — the protocol test is `//go:build !windows` tagged because it
drives `execInvocation`/`processExec`, which the windows stub does not have.

Closes #3083