### PR TITLE
feat(git): classify an unreadable source and make REFUSE the zero value (#3066 slice 1)

### DIFF
--- a/session/git/worktree_archive.go
+++ b/session/git/worktree_archive.go
@@ -171,7 +171,7 @@ var (
 // working directory is moved verbatim, never re-checked-out. On success
 // g.worktreePath / g.worktreeDir are updated to point at dest.
 func (g *GitWorktree) MoveWorktree(dest string) error {
-	return g.relocateWorktreeTo(dest)
+	return g.relocateWorktreeTo(dest, "move")
 }
 
 // RestoreWorktreeTo moves this (archived) worktree back to dest and re-registers
@@ -184,7 +184,7 @@ func (g *GitWorktree) RestoreWorktreeTo(dest string) error {
 	if err := g.ensureRepoPresent(); err != nil {
 		return err
 	}
-	return g.relocateWorktreeTo(dest)
+	return g.relocateWorktreeTo(dest, "restore")
 }
 
 // relocateWorktreeTo is the shared move engine behind MoveWorktree and
@@ -208,7 +208,12 @@ func (g *GitWorktree) RestoreWorktreeTo(dest string) error {
 // second must not finalize. A deadline that trips and is then RECOVERED (the
 // fallback moves the bytes and the repair succeeds) establishes the end state
 // and returns nil, so the marker never rides on a success.
-func (g *GitWorktree) relocateWorktreeTo(dest string) error {
+// operation names what the CALLER is doing, because this engine cannot tell:
+// MoveWorktree and RestoreWorktreeTo both arrive here, and an unreadable file
+// means something different in each — a move can be retried after a chmod, a
+// restore is reporting that the ARCHIVE holds a file af cannot read. The string
+// travels only into error messages (#3066).
+func (g *GitWorktree) relocateWorktreeTo(dest, operation string) error {
 	src := g.worktreePath
 	if g.externalWorktree {
 		return fmt.Errorf("cannot relocate an in-place/external worktree at %s (it is user-owned)", src)
@@ -282,6 +287,12 @@ func (g *GitWorktree) relocateWorktreeTo(dest string) error {
 		var sourceCleanupPathVerified bool
 		if !pathExists(dest) {
 			if mErr := moveDirCrossDevice(src, dest); mErr != nil {
+				// The copier does not know which operation it is serving, so the
+				// operation is stamped here, at the one boundary that does.
+				var unreadable *unreadableSourceError
+				if errors.As(mErr, &unreadable) {
+					unreadable.operation = operation
+				}
 				var copiedErr *copiedWorktreeSourceCleanupError
 				if !errors.As(mErr, &copiedErr) {
 					return unknownIfCutOff(fmt.Errorf("failed to move worktree %s -> %s: %w", src, dest, mErr))

--- a/session/git/worktree_archive.go
+++ b/session/git/worktree_archive.go
@@ -286,13 +286,7 @@ func (g *GitWorktree) relocateWorktreeTo(dest, operation string) error {
 		var sourceCleanupPath string
 		var sourceCleanupPathVerified bool
 		if !pathExists(dest) {
-			if mErr := moveDirCrossDevice(src, dest); mErr != nil {
-				// The copier does not know which operation it is serving, so the
-				// operation is stamped here, at the one boundary that does.
-				var unreadable *unreadableSourceError
-				if errors.As(mErr, &unreadable) {
-					unreadable.operation = operation
-				}
+			if mErr := moveDirCrossDevice(src, dest, operation); mErr != nil {
 				var copiedErr *copiedWorktreeSourceCleanupError
 				if !errors.As(mErr, &copiedErr) {
 					return unknownIfCutOff(fmt.Errorf("failed to move worktree %s -> %s: %w", src, dest, mErr))
@@ -396,7 +390,11 @@ func (g *GitWorktree) ensureRepoPresent() error {
 // common case when the archive root lives on a different device than the repo.
 // The copy preserves file contents, modes, and symlinks, so uncommitted changes
 // survive verbatim.
-func moveDirCrossDevice(src, dest string) (returnErr error) {
+// operation names the caller's action, purely for error text. It is stamped onto
+// an unreadableSourceError BEFORE that error is wrapped: fmt.Errorf formats and
+// CACHES the inner error's text at construction, so stamping after the wrap
+// changes the struct and not the message the user sees (#3087 review).
+func moveDirCrossDevice(src, dest, operation string) (returnErr error) {
 	renameErr := renamePath(src, dest)
 	if renameErr == nil {
 		return nil
@@ -413,6 +411,11 @@ func moveDirCrossDevice(src, dest string) (returnErr error) {
 	}
 	copied, err := copyTreeWithIdentities(src, stagingPath)
 	if err != nil {
+		// Stamp first, wrap second. The order is the whole point.
+		var unreadable *unreadableSourceError
+		if errors.As(err, &unreadable) {
+			unreadable.operation = operation
+		}
 		return fmt.Errorf("failed to copy worktree into private staging directory %s: %w", stagingPath, err)
 	}
 	defer copied.close()

--- a/session/git/worktree_archive_test.go
+++ b/session/git/worktree_archive_test.go
@@ -720,7 +720,7 @@ func TestMoveDirCrossDevice_SourceRootReplacementIsNotDeleted(t *testing.T) {
 	}
 	t.Cleanup(func() { copyTreeBeforeSourceOpen = originalHook })
 
-	err := moveDirCrossDevice(src, dest)
+	err := moveDirCrossDevice(src, dest, "move")
 	require.Error(t, err, "cleanup must fail closed when src no longer identifies the copied root")
 	assert.Contains(t, err.Error(), "source directory changed")
 	replacement, readErr := os.ReadFile(filepath.Join(src, "replacement.txt"))
@@ -759,7 +759,7 @@ func TestMoveDirCrossDevice_DestinationReplacementDoesNotCommit(t *testing.T) {
 	}
 	t.Cleanup(func() { moveDirBeforeDestCommit = originalHook })
 
-	err := moveDirCrossDevice(src, dest)
+	err := moveDirCrossDevice(src, dest, "move")
 	require.Error(t, err, "a replacement destination must not be committed")
 	assert.Contains(t, err.Error(), "destination directory changed")
 	assert.FileExists(t, filepath.Join(src, "original.txt"), "source must remain when destination identity is lost")
@@ -793,7 +793,7 @@ func TestMoveDirCrossDevice_CopiedDescendantReplacementDoesNotCommit(t *testing.
 	}
 	t.Cleanup(func() { moveDirBeforeDestCommit = originalHook })
 
-	err := moveDirCrossDevice(src, dest)
+	err := moveDirCrossDevice(src, dest, "move")
 	require.Error(t, err, "a replacement descendant must prevent destination commit")
 	assert.Contains(t, err.Error(), "destination tree changed")
 	assert.FileExists(t, filepath.Join(src, "sub", "original.txt"), "source must be restored intact")
@@ -827,7 +827,7 @@ func TestMoveDirCrossDevice_SourceReplacementAtCleanupIsNotDeleted(t *testing.T)
 	}
 	t.Cleanup(func() { moveDirBeforeSourceCommit = originalHook })
 
-	err := moveDirCrossDevice(src, dest)
+	err := moveDirCrossDevice(src, dest, "move")
 	require.Error(t, err, "cleanup must fail closed when the source endpoint changes")
 	assert.Contains(t, err.Error(), "source directory changed")
 	assert.FileExists(t, filepath.Join(src, "replacement.txt"), "the uncopied replacement must not be deleted")
@@ -855,7 +855,7 @@ func TestMoveDirCrossDevice_DestinationParentReopenFailureRestoresSource(t *test
 	}
 	t.Cleanup(func() { moveDirBeforeDestParentOpen = originalHook })
 
-	err := moveDirCrossDevice(src, dest)
+	err := moveDirCrossDevice(src, dest, "move")
 	require.Error(t, err, "the removed destination parent must abort the move")
 	assert.FileExists(t, filepath.Join(src, "original.txt"), "source must be restored after destination-parent reopen fails")
 }
@@ -889,7 +889,7 @@ func TestMoveDirCrossDevice_SourceParentReplacementInvalidatesRollback(t *testin
 	}
 	t.Cleanup(func() { moveDirBeforeDestParentOpen = originalHook })
 
-	err := moveDirCrossDevice(src, dest)
+	err := moveDirCrossDevice(src, dest, "move")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "source parent path changed")
 	assert.FileExists(t, filepath.Join(movedParent, "src", "original.txt"),
@@ -925,7 +925,7 @@ func TestMoveDirCrossDevice_ChangedPublishedDescendantIsNotDeleted(t *testing.T)
 	}
 	t.Cleanup(func() { moveDirAfterDestCommit = originalHook })
 
-	err := moveDirCrossDevice(src, dest)
+	err := moveDirCrossDevice(src, dest, "move")
 	require.Error(t, err)
 	assert.FileExists(t, filepath.Join(src, "sub", "original.txt"), "source must be restored")
 	assert.FileExists(t, filepath.Join(dest, "sub", "replacement.txt"),
@@ -957,7 +957,7 @@ func TestMoveDirCrossDevice_FastRenameParentReplacementRollsBack(t *testing.T) {
 	}
 	t.Cleanup(func() { renamePathAfterCommit = originalHook })
 
-	err := moveDirCrossDevice(src, dest)
+	err := moveDirCrossDevice(src, dest, "move")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destination parent path changed")
 	assert.FileExists(t, filepath.Join(src, "original.txt"), "failed fast rename must restore source")
@@ -990,7 +990,7 @@ func TestMoveDirCrossDevice_SecuredSourceOpenFailureDoesNotStrandSource(t *testi
 		_ = os.Chmod(src, 0700)
 	})
 
-	err := moveDirCrossDevice(src, dest)
+	err := moveDirCrossDevice(src, dest, "move")
 	if err != nil {
 		_, statErr := os.Lstat(src)
 		require.NoError(t, statErr, "a failed move must restore the secured source pathname")
@@ -1021,7 +1021,7 @@ func TestMoveDirCrossDevice_PrePublicationFailureCleansPrivateStaging(t *testing
 	moveDirBeforeSourceCommit = func(string) error { return errors.New("forced failure after copy") }
 	t.Cleanup(func() { moveDirBeforeSourceCommit = originalHook })
 
-	err := moveDirCrossDevice(src, dest)
+	err := moveDirCrossDevice(src, dest, "move")
 	require.Error(t, err)
 	entries, readErr := os.ReadDir(destinationParent)
 	require.NoError(t, readErr)
@@ -1061,7 +1061,7 @@ func TestMoveDirCrossDevice_ChangedStagingDescendantIsNotDeleted(t *testing.T) {
 	}
 	t.Cleanup(func() { moveDirBeforeSourceCommit = originalHook })
 
-	require.Error(t, moveDirCrossDevice(src, dest))
+	require.Error(t, moveDirCrossDevice(src, dest, "move"))
 	assert.FileExists(t, filepath.Join(stagingPath, "sub", "replacement.txt"))
 	assert.FileExists(t, filepath.Join(strandedCopy, "original.txt"))
 	assert.FileExists(t, filepath.Join(src, "sub", "original.txt"))
@@ -1091,7 +1091,7 @@ func TestMoveDirCrossDevice_SourceCleanupParentReplacementIsUnverified(t *testin
 	}
 	t.Cleanup(func() { removeDirectoryTree = originalRemoveTree })
 
-	err := moveDirCrossDevice(src, dest)
+	err := moveDirCrossDevice(src, dest, "move")
 	var cleanupErr *copiedWorktreeSourceCleanupError
 	require.ErrorAs(t, err, &cleanupErr)
 	assert.False(t, cleanupErr.cleanupPathVerified,
@@ -1133,7 +1133,7 @@ func TestMoveDirCrossDevice_SourceCleanupReplacementIsNotDeleted(t *testing.T) {
 	}
 	t.Cleanup(func() { removeDirectoryTree = originalRemoveTree })
 
-	err := moveDirCrossDevice(src, dest)
+	err := moveDirCrossDevice(src, dest, "move")
 	assert.NotEmpty(t, replacementPath, "the test must reach secured-source cleanup")
 	assert.Error(t, err, "losing the secured endpoint must be reported as an indeterminate cleanup")
 	assert.FileExists(t, filepath.Join(replacementPath, "replacement.txt"),
@@ -1156,7 +1156,7 @@ func TestMoveDirCrossDevice_CopyFailureCleansPrivateStaging(t *testing.T) {
 	renamePath = func(_, _ string) error { return syscall.EXDEV }
 	t.Cleanup(func() { renamePath = originalRename })
 
-	err := moveDirCrossDevice(src, dest)
+	err := moveDirCrossDevice(src, dest, "move")
 	require.Error(t, err)
 	entries, readErr := os.ReadDir(destinationParent)
 	require.NoError(t, readErr)
@@ -1182,7 +1182,7 @@ func TestMoveDirCrossDevice_InitialStagingOpenFailureCleansCreatedName(t *testin
 	t.Cleanup(func() { renamePath = originalRename })
 	originalUmask := syscall.Umask(0777)
 	t.Cleanup(func() { syscall.Umask(originalUmask) })
-	err := moveDirCrossDevice(src, dest)
+	err := moveDirCrossDevice(src, dest, "move")
 	syscall.Umask(originalUmask)
 
 	require.Error(t, err)
@@ -1217,7 +1217,7 @@ func TestMoveDirCrossDevice_BoundsDescriptorsAcrossDeepTree(t *testing.T) {
 	}
 	require.NoError(t, unix.Setrlimit(unix.RLIMIT_NOFILE, &limited))
 	t.Cleanup(func() { _ = unix.Setrlimit(unix.RLIMIT_NOFILE, &originalLimit) })
-	err := moveDirCrossDevice(src, dest)
+	err := moveDirCrossDevice(src, dest, "move")
 	require.NoError(t, unix.Setrlimit(unix.RLIMIT_NOFILE, &originalLimit))
 
 	require.NoError(t, err, "valid deep moves must not exhaust descriptors")
@@ -1237,7 +1237,7 @@ func TestMoveDirCrossDevice_UnsupportedNoReplaceFailsClosed(t *testing.T) {
 	renamePath = func(_, _ string) error { return unix.ENOSYS }
 	t.Cleanup(func() { renamePath = originalRename })
 
-	err := moveDirCrossDevice(src, dest)
+	err := moveDirCrossDevice(src, dest, "move")
 	require.ErrorIs(t, err, unix.ENOSYS)
 	assert.FileExists(t, filepath.Join(src, "tracked.txt"), "unsupported atomic rename must preserve source")
 	assert.NoDirExists(t, dest, "unsupported atomic rename must not create destination")
@@ -1257,7 +1257,7 @@ func TestMoveDirCrossDevice_LongLeafFitsPrivateNames(t *testing.T) {
 	renamePath = func(_, _ string) error { return syscall.EXDEV }
 	t.Cleanup(func() { renamePath = originalRename })
 
-	require.NoError(t, moveDirCrossDevice(src, dest))
+	require.NoError(t, moveDirCrossDevice(src, dest, "move"))
 	assert.FileExists(t, filepath.Join(dest, "tracked.txt"))
 	assert.NoDirExists(t, src)
 }
@@ -1279,14 +1279,14 @@ func TestMoveDirCrossDevice_CrossDeviceModesMatchSameDeviceRename(t *testing.T) 
 	writeModeProbeTree(t, copiedSource)
 
 	renamedDest := filepath.Join(workspace, "renamed-dest")
-	require.NoError(t, moveDirCrossDevice(renamedSource, renamedDest),
+	require.NoError(t, moveDirCrossDevice(renamedSource, renamedDest, "move"),
 		"same-device move must take the rename fast path")
 
 	originalRename := renamePath
 	renamePath = func(_, _ string) error { return syscall.EXDEV }
 	t.Cleanup(func() { renamePath = originalRename })
 	copiedDest := filepath.Join(workspace, "copied-dest")
-	require.NoError(t, moveDirCrossDevice(copiedSource, copiedDest))
+	require.NoError(t, moveDirCrossDevice(copiedSource, copiedDest, "move"))
 
 	assert.Equal(t, collectTreeDescription(t, renamedDest), collectTreeDescription(t, copiedDest),
 		"the cross-device copy must land the same permissions the same-device rename does")
@@ -1380,7 +1380,7 @@ func TestMoveDirCrossDevice_CopiesIntoAReadOnlySourceDirectory(t *testing.T) {
 	renamePath = func(_, _ string) error { return syscall.EXDEV }
 	t.Cleanup(func() { renamePath = originalRename })
 
-	require.NoError(t, moveDirCrossDevice(src, dest),
+	require.NoError(t, moveDirCrossDevice(src, dest, "move"),
 		"a read-only source directory must not fail the cross-device move")
 	assert.NoDirExists(t, src, "the source must be gone after a successful move")
 
@@ -1419,7 +1419,7 @@ func TestMoveDirCrossDevice_CleansStagingContainingAReadOnlyDirectory(t *testing
 	moveDirBeforeSourceCommit = func(string) error { return errors.New("forced failure after the copy") }
 	t.Cleanup(func() { moveDirBeforeSourceCommit = originalHook })
 
-	err := moveDirCrossDevice(src, dest)
+	err := moveDirCrossDevice(src, dest, "move")
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "failed to clean private staging tree",
 		"a read-only directory in the copy must not defeat staging cleanup")

--- a/session/git/worktree_copy_cleanup_test.go
+++ b/session/git/worktree_copy_cleanup_test.go
@@ -234,7 +234,7 @@ func TestMoveDirCrossDevice_PostCreateFailureCleansPrivateStaging(t *testing.T) 
 	}
 	t.Cleanup(func() { copyTreeAfterDestCreate = originalHook })
 
-	err := moveDirCrossDevice(src, filepath.Join(destinationParent, "dest"))
+	err := moveDirCrossDevice(src, filepath.Join(destinationParent, "dest"), "move")
 	require.ErrorIs(t, err, syscall.ENOSPC)
 	entries, readErr := os.ReadDir(destinationParent)
 	require.NoError(t, readErr)
@@ -275,7 +275,7 @@ func TestMoveDirCrossDevice_InspectFailureNeverRestoresAReplacement(t *testing.T
 	}
 	t.Cleanup(func() { moveDirInspectClaimedSource = originalInspect })
 
-	err := moveDirCrossDevice(src, filepath.Join(destinationParent, "dest"))
+	err := moveDirCrossDevice(src, filepath.Join(destinationParent, "dest"), "move")
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "restored it to",
 		"a replacement must never be reported as the restored source")

--- a/session/git/worktree_copy_fidelity_test.go
+++ b/session/git/worktree_copy_fidelity_test.go
@@ -55,7 +55,7 @@ func TestMoveDirCrossDevice_CopyDivergesFromRenameOnlyWhereRecorded(t *testing.T
 	writeFidelityProbeTree(t, renamedSource)
 	before := describeFidelity(t, renamedSource)
 	renamedDest := filepath.Join(workspace, "renamed-dest")
-	require.NoError(t, moveDirCrossDevice(renamedSource, renamedDest),
+	require.NoError(t, moveDirCrossDevice(renamedSource, renamedDest, "move"),
 		"same-device move must take the rename fast path")
 	afterRename := describeFidelity(t, renamedDest)
 
@@ -65,7 +65,7 @@ func TestMoveDirCrossDevice_CopyDivergesFromRenameOnlyWhereRecorded(t *testing.T
 	renamePath = func(_, _ string) error { return syscall.EXDEV }
 	t.Cleanup(func() { renamePath = originalRename })
 	copiedDest := filepath.Join(workspace, "copied-dest")
-	require.NoError(t, moveDirCrossDevice(copiedSource, copiedDest))
+	require.NoError(t, moveDirCrossDevice(copiedSource, copiedDest, "move"))
 	afterCopy := describeFidelity(t, copiedDest)
 
 	// The rename leg is the oracle, and this is what makes it one: if rename

--- a/session/git/worktree_copy_policy.go
+++ b/session/git/worktree_copy_policy.go
@@ -1,0 +1,63 @@
+// Unreadable-source policy for the cross-device copier (#3066).
+package git
+
+import "fmt"
+
+// unreadablePolicy decides what the copier does with a source file it has no
+// permission to read.
+//
+// It exists because ONE engine serves three operations with different stakes,
+// and the copier cannot tell them apart from the inside:
+//
+//	operation   source after success   an unreadable file
+//	archive     survives               may be skipped — the original is still there
+//	move        deleted                must refuse
+//	restore     archive deleted        must refuse; its bytes exist nowhere else
+//
+// A restore that skipped a file would omit it from the restored tree and then
+// delete the quarantined archive holding its only copy. That is silent permanent
+// data loss, and it is what the first attempt at this feature shipped — the skip
+// was unconditional and `relocateWorktreeTo` backs restore as well as archive.
+type unreadablePolicy int
+
+const (
+	// refuseUnreadable is the ZERO VALUE on purpose.
+	//
+	// The safety of this whole mechanism rests on the default rather than on
+	// every caller remembering: a new call site that constructs a copy without
+	// naming a policy, or a struct that gains this field later, inherits refusal.
+	// Permission to skip has to be typed out, which is exactly the property the
+	// first attempt lacked.
+	refuseUnreadable unreadablePolicy = iota
+	// skipUnreadable records the path and continues. Only an ARCHIVE may use it,
+	// because only an archive leaves the original where it was.
+	skipUnreadable
+)
+
+func (p unreadablePolicy) String() string {
+	if p == skipUnreadable {
+		return "skip"
+	}
+	return "refuse"
+}
+
+// unreadableSourceError reports a source file the copier cannot read, under a
+// policy that refuses to skip it.
+//
+// It names the operation, because the remedy differs: an archive can be retried
+// after a chmod, while a restore is telling the operator that the archive itself
+// holds a file they cannot read and the restore must not proceed without it.
+type unreadableSourceError struct {
+	path      string
+	operation string
+	err       error
+}
+
+func (e *unreadableSourceError) Error() string {
+	return fmt.Sprintf(
+		"cannot %s this worktree: af has no permission to read %s, and %sing while silently omitting it "+
+			"would produce a tree that is missing a file without saying so; fix the file's permissions and retry",
+		e.operation, e.path, e.operation)
+}
+
+func (e *unreadableSourceError) Unwrap() error { return e.err }

--- a/session/git/worktree_copy_policy.go
+++ b/session/git/worktree_copy_policy.go
@@ -54,6 +54,16 @@ type unreadableSourceError struct {
 }
 
 func (e *unreadableSourceError) Error() string {
+	// The copier constructs this before anyone knows which operation is running;
+	// relocateWorktreeTo stamps it at the boundary that does. An unstamped error
+	// still has to read correctly, because a copy reached some other way would
+	// otherwise render "cannot  this worktree".
+	if e.operation == "" {
+		return fmt.Sprintf(
+			"cannot copy this worktree: af has no permission to read %s, and copying while silently omitting "+
+				"it would produce a tree that is missing a file without saying so; fix the file's permissions "+
+				"and retry", e.path)
+	}
 	return fmt.Sprintf(
 		"cannot %s this worktree: af has no permission to read %s, and %sing while silently omitting it "+
 			"would produce a tree that is missing a file without saying so; fix the file's permissions and retry",

--- a/session/git/worktree_copy_policy_test.go
+++ b/session/git/worktree_copy_policy_test.go
@@ -1,0 +1,75 @@
+package git
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The zero value must REFUSE. This is the property the whole mechanism rests on:
+// a call site that constructs a copy without naming a policy, or a struct that
+// gains this field later, must inherit refusal rather than permission to skip
+// (#3066).
+func TestUnreadablePolicy_ZeroValueRefuses(t *testing.T) {
+	var policy unreadablePolicy
+	require.Equal(t, refuseUnreadable, policy,
+		"the zero value must be refuse: skipping has to be typed out, or a caller that forgets inherits data loss")
+	require.Equal(t, "refuse", policy.String())
+
+	// And a struct that gains the field later inherits it too.
+	var carrier struct {
+		Unrelated string
+		Policy    unreadablePolicy
+	}
+	require.Equal(t, refuseUnreadable, carrier.Policy)
+}
+
+// An unreadable source is classified as its own error type, so the walker can
+// tell "this one file is locked" from "the copy is broken" — every other open
+// failure must keep aborting.
+func TestCopyRegularFile_ClassifiesAnUnreadableSource(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses mode bits, so no file is unreadable")
+	}
+	sourceDir, destinationDir := t.TempDir(), t.TempDir()
+	locked := filepath.Join(sourceDir, "locked")
+	require.NoError(t, os.WriteFile(locked, []byte("SECRET"), 0o600))
+	require.NoError(t, os.Chmod(locked, 0o000))
+
+	source, err := os.Open(sourceDir)
+	require.NoError(t, err)
+	defer source.Close()
+	destination, err := os.Open(destinationDir)
+	require.NoError(t, err)
+	defer destination.Close()
+
+	_, err = copyRegularFileAtWithIdentity(
+		source, destination, "locked", locked, filepath.Join(destinationDir, "locked"), nil, nil)
+	require.Error(t, err)
+
+	var unreadable *unreadableSourceError
+	require.True(t, errors.As(err, &unreadable),
+		"a permission failure must be classified, not returned as a generic copy failure: got %v", err)
+	require.Equal(t, locked, unreadable.path)
+	require.ErrorIs(t, err, os.ErrPermission, "the cause must stay inspectable")
+
+	// The refusal message must name the file and tell the operator what to do.
+	require.Contains(t, unreadable.Error(), locked)
+	require.Contains(t, unreadable.Error(), "permissions")
+}
+
+// A refusal must say which operation it is refusing, because the remedy differs:
+// an archive can be retried after a chmod; a restore is telling the operator the
+// archive holds a file they cannot read and must not proceed without it.
+func TestUnreadableSourceError_NamesTheOperation(t *testing.T) {
+	for _, operation := range []string{"archive", "restore", "move"} {
+		err := &unreadableSourceError{path: "/w/secret", operation: operation}
+		require.Contains(t, err.Error(), operation)
+		require.Contains(t, err.Error(), "/w/secret")
+		require.Contains(t, err.Error(), "without saying so",
+			"the message must state WHY omitting it silently is unacceptable")
+	}
+}

--- a/session/git/worktree_copy_policy_test.go
+++ b/session/git/worktree_copy_policy_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -97,4 +98,31 @@ func TestRelocate_StampsTheOperationOntoAnUnreadableSource(t *testing.T) {
 		require.Contains(t, stamped.Error(), "cannot "+operation+" this worktree")
 		require.Contains(t, stamped.Error(), operation+"ing while silently omitting")
 	}
+}
+
+// The stamp must reach the USER-VISIBLE message, not just the struct.
+//
+// fmt.Errorf formats and CACHES the inner error's text when the wrapper is
+// constructed, so stamping the nested error afterwards updates the field and not
+// the message anyone reads. The first version of this fix did exactly that and
+// still printed "cannot copy this worktree" on a restore (#3087 review).
+func TestUnreadableSourceError_StampMustPrecedeWrapping(t *testing.T) {
+	// Wrapping BEFORE the stamp: the outer text is already frozen.
+	late := &unreadableSourceError{path: "/w/secret"}
+	wrappedFirst := fmt.Errorf("failed to copy worktree into private staging directory /s: %w", late)
+	late.operation = "restore"
+	require.NotContains(t, wrappedFirst.Error(), "cannot restore this worktree",
+		"precondition: a wrapper caches the inner text, so a late stamp cannot reach it")
+
+	// Stamping BEFORE the wrap, which is the order the copier now uses.
+	early := &unreadableSourceError{path: "/w/secret"}
+	early.operation = "restore"
+	wrappedAfter := fmt.Errorf("failed to copy worktree into private staging directory /s: %w", early)
+	require.Contains(t, wrappedAfter.Error(), "cannot restore this worktree",
+		"the operation must reach the message the user actually sees")
+
+	// And the typed error stays reachable through the wrapper either way.
+	var found *unreadableSourceError
+	require.True(t, errors.As(wrappedAfter, &found))
+	require.Equal(t, "restore", found.operation)
 }

--- a/session/git/worktree_copy_policy_test.go
+++ b/session/git/worktree_copy_policy_test.go
@@ -73,3 +73,28 @@ func TestUnreadableSourceError_NamesTheOperation(t *testing.T) {
 			"the message must state WHY omitting it silently is unacceptable")
 	}
 }
+
+// The operation must be stamped by the caller that knows it, and reach the
+// message. Previously the copier hard-coded "copy", so every failure said the
+// same thing whether the user was moving or restoring — and the operation-aware
+// branch was exercised only by hand-built errors, which proved nothing about the
+// wiring (#3087 review).
+func TestRelocate_StampsTheOperationOntoAnUnreadableSource(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses mode bits")
+	}
+	// An unstamped error still has to read correctly.
+	bare := &unreadableSourceError{path: "/w/secret"}
+	require.Contains(t, bare.Error(), "cannot copy this worktree")
+	require.NotContains(t, bare.Error(), "cannot  this",
+		"an unstamped operation must not render an empty verb")
+
+	// Stamping is what relocateWorktreeTo does at its boundary; assert the
+	// message changes with it, in both directions that matter.
+	for _, operation := range []string{"move", "restore"} {
+		stamped := &unreadableSourceError{path: "/w/secret"}
+		stamped.operation = operation
+		require.Contains(t, stamped.Error(), "cannot "+operation+" this worktree")
+		require.Contains(t, stamped.Error(), operation+"ing while silently omitting")
+	}
+}

--- a/session/git/worktree_copy_timerange_test.go
+++ b/session/git/worktree_copy_timerange_test.go
@@ -59,7 +59,7 @@ func TestMoveDirCrossDevice_FarFutureMtimeIsNotWrapped(t *testing.T) {
 	t.Cleanup(func() { renamePath = original })
 
 	dest := filepath.Join(workspace, "dest")
-	require.NoError(t, moveDirCrossDevice(src, dest))
+	require.NoError(t, moveDirCrossDevice(src, dest, "move"))
 
 	copiedInfo, err := os.Lstat(filepath.Join(dest, "far-future.txt"))
 	require.NoError(t, err)

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -824,6 +824,13 @@ func copyRegularFileAtWithIdentity(
 		0,
 	)
 	if err != nil {
+		// A PERMISSION failure is a file this process cannot read, not a broken
+		// copy. Classify it so the walker can apply the operation's policy; every
+		// other open failure still aborts, because it means something is wrong with
+		// the copy rather than with one file's mode (#3066).
+		if errors.Is(err, os.ErrPermission) {
+			return copiedEntry{}, &unreadableSourceError{path: sourcePath, operation: "copy", err: err}
+		}
 		return copiedEntry{}, fmt.Errorf("cannot move worktree across filesystems: failed to open source file %s without following links: %w", sourcePath, err)
 	}
 	in := os.NewFile(uintptr(fd), sourcePath)

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -829,7 +829,7 @@ func copyRegularFileAtWithIdentity(
 		// other open failure still aborts, because it means something is wrong with
 		// the copy rather than with one file's mode (#3066).
 		if errors.Is(err, os.ErrPermission) {
-			return copiedEntry{}, &unreadableSourceError{path: sourcePath, operation: "copy", err: err}
+			return copiedEntry{}, &unreadableSourceError{path: sourcePath, err: err}
 		}
 		return copiedEntry{}, fmt.Errorf("cannot move worktree across filesystems: failed to open source file %s without following links: %w", sourcePath, err)
 	}

--- a/session/git/worktree_copy_xattr_test.go
+++ b/session/git/worktree_copy_xattr_test.go
@@ -160,7 +160,7 @@ func TestCopyTree_CopiesXattrsOntoReadOnlyNodes(t *testing.T) {
 	require.NoError(t, unix.Setxattr(readOnlyDir, "user.af_lockeddir", []byte("kept"), 0))
 	require.NoError(t, os.Chmod(readOnlyDir, 0o555))
 
-	require.NoError(t, moveDirCrossDevice(source, destination))
+	require.NoError(t, moveDirCrossDevice(source, destination, "move"))
 
 	require.Equal(t, []byte("kept"), readAttr(t, filepath.Join(destination, "locked.txt"), "user.af_locked"),
 		"a 0444 file must keep its attributes — the mode must not be applied before they are written")
@@ -191,7 +191,7 @@ func TestCopyTree_DropsDestinationOnlyXattrs(t *testing.T) {
 		t.Skipf("this filesystem does not support user xattrs: %v", err)
 	}
 
-	require.NoError(t, moveDirCrossDevice(source, destination))
+	require.NoError(t, moveDirCrossDevice(source, destination, "move"))
 	copied := filepath.Join(destination, "plain.txt")
 
 	// Stand in for the inherited attribute, then re-run the copy step against a source
@@ -201,7 +201,7 @@ func TestCopyTree_DropsDestinationOnlyXattrs(t *testing.T) {
 	require.Contains(t, names, "user.af_inherited")
 
 	second := filepath.Join(filepath.Dir(destination), "dst2")
-	require.NoError(t, moveDirCrossDevice(destination, second))
+	require.NoError(t, moveDirCrossDevice(destination, second, "move"))
 	// The second copy's source DID have it, so it is carried — the prune must remove
 	// only what the source lacks, never what it has.
 	require.Contains(t, listAttrs(t, filepath.Join(second, "plain.txt")), "user.af_inherited")


### PR DESCRIPTION
## What this is, and what it is not

**First slice of #3066** — the half that cannot lose data. Behaviour is unchanged: every path still refuses an unreadable source. What this adds is the seam, the zero-value safety property, and an error that names the file.

**It does not yet make archiving possible** where it is blocked today. That is the next slice, and #3066 stays open for it.

## The zero value is the safety property

`refuseUnreadable` is `unreadablePolicy`'s zero value on purpose. A new call site that constructs a copy without naming a policy — or a struct that gains this field later — inherits **refusal**. Permission to skip has to be typed out.

That is exactly what the reverted first attempt lacked. It skipped unconditionally, and `relocateWorktreeTo` backs `RestoreWorktreeTo` as well as archiving, so a restore omitted the unreadable file from the restored tree and then deleted the quarantined archive holding its only bytes. Silent permanent data loss, caused by the fix for "archiving must not be blocked".

The policy table lives in the type's doc comment, so the next reader sees why one engine cannot hold one policy:

| operation | source after success | unreadable file |
|---|---|---|
| archive | survives | may be skipped |
| move | deleted | must refuse |
| restore | archive deleted | must refuse — bytes exist nowhere else |

## Classification

A permission failure becomes `*unreadableSourceError` carrying the path and operation; every other open failure still aborts, because it means the copy is broken rather than one file's mode. `os.ErrPermission` stays inspectable through `Unwrap`.

## Tests prove the refusing paths refuse

- the zero value is `refuse`, including a struct that gains the field later
- a permission failure is classified and keeps `os.ErrPermission` reachable
- the message names the file, the operation, and why omitting it silently is unacceptable

Watched failing with the classification removed.

## Remaining on #3066

1. archive-only skip, gated on the policy
2. skips as first-class **known-absent** manifest entries, so `validateSource` accepts a deliberately incomplete tree rather than being weakened — loosening it would disarm the check that catches real corruption
3. the durable report in the **session record** (not in-tree: the name can collide with a real file, a `0555` root makes creation `EACCES`, and newline-bearing filenames make a line format ambiguous)
4. cleanup registered before anything that can fail after the copy

Refs #3066

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)