### PR TITLE
feat(session): carry a credential account into docker sessions (#3082)

### DIFF
--- a/commands/accountscmd.go
+++ b/commands/accountscmd.go
@@ -91,7 +91,7 @@ real: an ambient ANTHROPIC_API_KEY or OPENAI_API_KEY outranks the config
 directory, so without it a session would authenticate as whoever that key belongs
 to while every visible signal reported the selected account.
 
-Account-scoped sessions require the local backend and tmux 3.2 or newer. af
+Account-scoped sessions require the local or docker backend, and tmux 3.2 or newer. af
 refuses rather than falling back, because a fallback would run on the ambient
 account while reporting the one you asked for.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -153,7 +153,7 @@ real: an ambient ANTHROPIC_API_KEY or OPENAI_API_KEY outranks the config
 directory, so without it a session would authenticate as whoever that key belongs
 to while every visible signal reported the selected account.
 
-Account-scoped sessions require the local backend and tmux 3.2 or newer. af
+Account-scoped sessions require the local or docker backend, and tmux 3.2 or newer. af
 refuses rather than falling back, because a fallback would run on the ambient
 account while reporting the one you asked for.
 

--- a/internal/sessionenv/account.go
+++ b/internal/sessionenv/account.go
@@ -143,6 +143,25 @@ func AccountAgents() []string {
 	return out
 }
 
+// AccountIdentityNames lists every environment variable whose value can select
+// an identity instead of the named account: the agent's credential variables
+// and its credential-root variable. Provisioners use the same classification as
+// ApplyAccount so a remote/container launch cannot drift from the local shim's
+// account boundary.
+func AccountIdentityNames(agent string) []string {
+	configVar, ok := SupportsAccounts(agent)
+	if !ok {
+		return nil
+	}
+	denied := accountScopedNames(agent, configVar)
+	out := make([]string, 0, len(denied))
+	for name := range denied {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // ApplyAccount scopes an already-filtered session environment to exactly one
 // account: it INJECTS that account's credential root and REMOVES every other
 // identity-bearing variable for the agent.

--- a/internal/sessionenv/sessionenv.go
+++ b/internal/sessionenv/sessionenv.go
@@ -472,6 +472,22 @@ func GuardedSelectors() []string {
 	return out
 }
 
+// AgentAuthSelectors returns the conditional authentication-mode selectors for
+// one agent. Container provisioners use this narrower list when neutralizing an
+// image environment: another agent's selector cannot affect the selected CLI.
+func AgentAuthSelectors(agent string) []string {
+	set := make(map[string]struct{})
+	for _, group := range conditionalAgentNames[agent] {
+		set[group.selector] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for selector := range set {
+		out = append(out, selector)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // NormalizeAuthSelectors validates a stored selector-name snapshot against the
 // selected agent's known conditional modes. Errors identify only the position,
 // never the untrusted stored text, so an accidental NAME=value record cannot

--- a/session/agent_account_mount_test.go
+++ b/session/agent_account_mount_test.go
@@ -24,13 +24,13 @@ func TestAccountMountAndEnv_TwoAccountsGetDifferentRoots(t *testing.T) {
 	if a[1] == b[1] {
 		t.Fatalf("two accounts resolved to the SAME container source %q — they would share an identity", a[1])
 	}
-	if !strings.Contains(a[1], "src=/home/op/.agent-factory/accounts/codex/work") {
+	if !strings.HasPrefix(a[1], "/home/op/.agent-factory/accounts/codex/work:") {
 		t.Errorf("the mount source must be the account's own directory; got %q", a[1])
 	}
 	// Both land on the same fixed path INSIDE the container, so nothing about the
 	// host's layout crosses the boundary and the agent's config var is stable.
-	if a[0] != "--mount" || b[0] != "--mount" ||
-		!strings.Contains(a[1], "dst="+dockerAccountHome) || !strings.Contains(b[1], "dst="+dockerAccountHome) {
+	if a[0] != "-v" || b[0] != "-v" ||
+		!strings.HasSuffix(a[1], ":"+dockerAccountHome+":z") || !strings.HasSuffix(b[1], ":"+dockerAccountHome+":z") {
 		t.Errorf("both accounts must mount at the fixed container path %q; got %q and %q", dockerAccountHome, a[1], b[1])
 	}
 	want := "CODEX_HOME=" + dockerAccountHome
@@ -39,6 +39,26 @@ func TestAccountMountAndEnv_TwoAccountsGetDifferentRoots(t *testing.T) {
 	}
 	if strings.Join(aEnv, "\x00") != strings.Join(bEnv, "\x00") {
 		t.Errorf("the container-side environment must not depend on which account it is; got %v and %v", aEnv, bEnv)
+	}
+}
+
+func TestAccountMountAndEnv_RelabelsOrdinaryPathsForSELinux(t *testing.T) {
+	mount, _, err := accountMountAndEnv(sessionenv.Account{
+		Agent: "codex", Name: "work", Dir: "/acct/codex/work",
+	})
+	if err != nil {
+		t.Fatalf("ordinary account mount failed: %v", err)
+	}
+	want := []string{"-v", "/acct/codex/work:" + dockerAccountHome + ":z"}
+	if strings.Join(mount, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("account bind must request Docker shared SELinux relabeling: want %v, got %v", want, mount)
+	}
+}
+
+func TestDockerAccountMount_RefusesColonPathOnSELinux(t *testing.T) {
+	_, err := dockerAccountMount("work", "/srv/af:work/accounts/codex/work", true)
+	if err == nil || !strings.Contains(err.Error(), "SELinux-enforcing") {
+		t.Fatalf("colon path on enforcing host must refuse with a workaround, got %v", err)
 	}
 }
 

--- a/session/agent_account_mount_test.go
+++ b/session/agent_account_mount_test.go
@@ -12,9 +12,12 @@ import (
 // ambient key on that host must not reach either.
 
 func TestAccountMountAndEnv_TwoAccountsGetDifferentRoots(t *testing.T) {
-	a, aEnv := accountMountAndEnv(sessionenv.Account{Agent: "codex", Name: "work", Dir: "/home/op/.agent-factory/accounts/codex/work"})
-	b, bEnv := accountMountAndEnv(sessionenv.Account{Agent: "codex", Name: "personal", Dir: "/home/op/.agent-factory/accounts/codex/personal"})
+	a, aEnv, aErr := accountMountAndEnv(sessionenv.Account{Agent: "codex", Name: "work", Dir: "/home/op/.agent-factory/accounts/codex/work"})
+	b, bEnv, bErr := accountMountAndEnv(sessionenv.Account{Agent: "codex", Name: "personal", Dir: "/home/op/.agent-factory/accounts/codex/personal"})
 
+	if aErr != nil || bErr != nil {
+		t.Fatalf("an absolute account dir must resolve: %v %v", aErr, bErr)
+	}
 	if len(a) != 2 || len(b) != 2 {
 		t.Fatalf("each account must produce one -v mount; got %v and %v", a, b)
 	}
@@ -41,17 +44,17 @@ func TestAccountMountAndEnv_TwoAccountsGetDifferentRoots(t *testing.T) {
 // claude uses a different variable, and getting it wrong would silently leave the
 // agent on the container's default home — present, wrong, and quiet.
 func TestAccountMountAndEnv_UsesTheAgentsOwnConfigVar(t *testing.T) {
-	_, env := accountMountAndEnv(sessionenv.Account{Agent: "claude", Name: "work", Dir: "/acct/claude/work"})
+	_, env, _ := accountMountAndEnv(sessionenv.Account{Agent: "claude", Name: "work", Dir: "/acct/claude/work"})
 	if want := "CLAUDE_CONFIG_DIR=" + dockerAccountHome; len(env) != 2 || env[1] != want {
 		t.Fatalf("want %q, got %v", want, env)
 	}
 	// An agent with no account support produces nothing rather than a mount the
 	// agent would never read.
-	if mount, env := accountMountAndEnv(sessionenv.Account{Agent: "aider", Name: "work", Dir: "/acct/aider/work"}); mount != nil || env != nil {
+	if mount, env, _ := accountMountAndEnv(sessionenv.Account{Agent: "aider", Name: "work", Dir: "/acct/aider/work"}); mount != nil || env != nil {
 		t.Errorf("an agent without account support must produce no mount; got %v %v", mount, env)
 	}
 	// A zero account is unscoped, not an empty mount spec.
-	if mount, env := accountMountAndEnv(sessionenv.Account{}); mount != nil || env != nil {
+	if mount, env, _ := accountMountAndEnv(sessionenv.Account{}); mount != nil || env != nil {
 		t.Errorf("an unscoped session must produce nothing; got %v %v", mount, env)
 	}
 }
@@ -94,5 +97,18 @@ func TestRefuseOffBoxAccount_AllowsDockerRefusesTheRest(t *testing.T) {
 		if err := refuseOffBoxAccount(InstanceOptions{Backend: kind}); err != nil {
 			t.Errorf("an unscoped create on %s must not be refused: %v", kind, err)
 		}
+	}
+}
+
+// A path af cannot resolve must REFUSE, never return an empty mount. Returning
+// nothing was this function's first shape and it is the failure the feature
+// exists to prevent: the container starts with no account and no error, running
+// on whatever identity it finds while the session reports the named one.
+func TestAccountMountAndEnv_UnresolvablePathRefuses(t *testing.T) {
+	// An empty Dir is "unscoped" and must stay a clean no-op — the refusal is for a
+	// path that was requested and could not be resolved, not for the absence of one.
+	mount, env, err := accountMountAndEnv(sessionenv.Account{})
+	if mount != nil || env != nil || err != nil {
+		t.Fatalf("an unscoped session must be a silent no-op; got %v %v %v", mount, env, err)
 	}
 }

--- a/session/agent_account_mount_test.go
+++ b/session/agent_account_mount_test.go
@@ -1,0 +1,98 @@
+package session
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/internal/sessionenv"
+)
+
+// The bar #3082 sets is EXCLUSIVITY on the target host, not presence: two off-box
+// sessions on different accounts must see different credential roots, and an
+// ambient key on that host must not reach either.
+
+func TestAccountMountAndEnv_TwoAccountsGetDifferentRoots(t *testing.T) {
+	a, aEnv := accountMountAndEnv(sessionenv.Account{Agent: "codex", Name: "work", Dir: "/home/op/.agent-factory/accounts/codex/work"})
+	b, bEnv := accountMountAndEnv(sessionenv.Account{Agent: "codex", Name: "personal", Dir: "/home/op/.agent-factory/accounts/codex/personal"})
+
+	if len(a) != 2 || len(b) != 2 {
+		t.Fatalf("each account must produce one -v mount; got %v and %v", a, b)
+	}
+	if a[1] == b[1] {
+		t.Fatalf("two accounts resolved to the SAME container source %q — they would share an identity", a[1])
+	}
+	if !strings.HasPrefix(a[1], "/home/op/.agent-factory/accounts/codex/work:") {
+		t.Errorf("the mount source must be the account's own directory; got %q", a[1])
+	}
+	// Both land on the same fixed path INSIDE the container, so nothing about the
+	// host's layout crosses the boundary and the agent's config var is stable.
+	if !strings.HasSuffix(a[1], ":"+dockerAccountHome) || !strings.HasSuffix(b[1], ":"+dockerAccountHome) {
+		t.Errorf("both accounts must mount at the fixed container path %q; got %q and %q", dockerAccountHome, a[1], b[1])
+	}
+	want := "CODEX_HOME=" + dockerAccountHome
+	if len(aEnv) != 2 || aEnv[1] != want {
+		t.Errorf("the agent must be pointed at the mounted account home: want %q, got %v", want, aEnv)
+	}
+	if aEnv[1] != bEnv[1] {
+		t.Errorf("the container-side config var must not depend on which account it is; got %q and %q", aEnv[1], bEnv[1])
+	}
+}
+
+// claude uses a different variable, and getting it wrong would silently leave the
+// agent on the container's default home — present, wrong, and quiet.
+func TestAccountMountAndEnv_UsesTheAgentsOwnConfigVar(t *testing.T) {
+	_, env := accountMountAndEnv(sessionenv.Account{Agent: "claude", Name: "work", Dir: "/acct/claude/work"})
+	if want := "CLAUDE_CONFIG_DIR=" + dockerAccountHome; len(env) != 2 || env[1] != want {
+		t.Fatalf("want %q, got %v", want, env)
+	}
+	// An agent with no account support produces nothing rather than a mount the
+	// agent would never read.
+	if mount, env := accountMountAndEnv(sessionenv.Account{Agent: "aider", Name: "work", Dir: "/acct/aider/work"}); mount != nil || env != nil {
+		t.Errorf("an agent without account support must produce no mount; got %v %v", mount, env)
+	}
+	// A zero account is unscoped, not an empty mount spec.
+	if mount, env := accountMountAndEnv(sessionenv.Account{}); mount != nil || env != nil {
+		t.Errorf("an unscoped session must produce nothing; got %v %v", mount, env)
+	}
+}
+
+// The refusal narrowed to docker, and did NOT become a list of allowed remotes:
+// anything not proven stays refused, which is what keeps a backend added later
+// from defaulting into ambient credentials.
+func TestCarriesAccount_OnlyDockerIsProven(t *testing.T) {
+	if !BackendDocker.CarriesAccount() {
+		t.Error("docker can place an account — it already bind-mounts host paths into the container")
+	}
+	for _, kind := range []BackendKind{BackendSSH, BackendSandbox, BackendHook} {
+		if kind.CarriesAccount() {
+			t.Errorf("%s cannot prove it placed the account, so it must stay refused", kind)
+		}
+	}
+	// Local needs no placing and is handled by its own branch; answering true here
+	// would claim it honours ProvisionSpec.Account, which it does not.
+	if BackendLocal.CarriesAccount() {
+		t.Error("local applies the account through the exec shim, not through ProvisionSpec")
+	}
+}
+
+func TestRefuseOffBoxAccount_AllowsDockerRefusesTheRest(t *testing.T) {
+	if err := refuseOffBoxAccount(InstanceOptions{Account: "work", Backend: BackendDocker}); err != nil {
+		t.Errorf("docker carries the account now, so it must not be refused: %v", err)
+	}
+	for _, kind := range []BackendKind{BackendSSH, BackendSandbox, BackendHook} {
+		err := refuseOffBoxAccount(InstanceOptions{Account: "work", Backend: kind})
+		if err == nil {
+			t.Errorf("%s must still refuse an account-scoped create", kind)
+			continue
+		}
+		if !strings.Contains(err.Error(), "cannot place a credential account") {
+			t.Errorf("%s refusal must say WHY (af cannot place the account there), got: %v", kind, err)
+		}
+	}
+	// Unscoped creates are untouched on every kind.
+	for _, kind := range []BackendKind{BackendLocal, BackendDocker, BackendSSH, BackendHook} {
+		if err := refuseOffBoxAccount(InstanceOptions{Backend: kind}); err != nil {
+			t.Errorf("an unscoped create on %s must not be refused: %v", kind, err)
+		}
+	}
+}

--- a/session/agent_account_mount_test.go
+++ b/session/agent_account_mount_test.go
@@ -24,20 +24,21 @@ func TestAccountMountAndEnv_TwoAccountsGetDifferentRoots(t *testing.T) {
 	if a[1] == b[1] {
 		t.Fatalf("two accounts resolved to the SAME container source %q — they would share an identity", a[1])
 	}
-	if !strings.HasPrefix(a[1], "/home/op/.agent-factory/accounts/codex/work:") {
+	if !strings.Contains(a[1], "src=/home/op/.agent-factory/accounts/codex/work") {
 		t.Errorf("the mount source must be the account's own directory; got %q", a[1])
 	}
 	// Both land on the same fixed path INSIDE the container, so nothing about the
 	// host's layout crosses the boundary and the agent's config var is stable.
-	if !strings.HasSuffix(a[1], ":"+dockerAccountHome) || !strings.HasSuffix(b[1], ":"+dockerAccountHome) {
+	if a[0] != "--mount" || b[0] != "--mount" ||
+		!strings.Contains(a[1], "dst="+dockerAccountHome) || !strings.Contains(b[1], "dst="+dockerAccountHome) {
 		t.Errorf("both accounts must mount at the fixed container path %q; got %q and %q", dockerAccountHome, a[1], b[1])
 	}
 	want := "CODEX_HOME=" + dockerAccountHome
-	if len(aEnv) != 2 || aEnv[1] != want {
+	if got, found := dockerEnvArg(aEnv, "CODEX_HOME"); !found || got != want {
 		t.Errorf("the agent must be pointed at the mounted account home: want %q, got %v", want, aEnv)
 	}
-	if aEnv[1] != bEnv[1] {
-		t.Errorf("the container-side config var must not depend on which account it is; got %q and %q", aEnv[1], bEnv[1])
+	if strings.Join(aEnv, "\x00") != strings.Join(bEnv, "\x00") {
+		t.Errorf("the container-side environment must not depend on which account it is; got %v and %v", aEnv, bEnv)
 	}
 }
 
@@ -45,7 +46,8 @@ func TestAccountMountAndEnv_TwoAccountsGetDifferentRoots(t *testing.T) {
 // agent on the container's default home — present, wrong, and quiet.
 func TestAccountMountAndEnv_UsesTheAgentsOwnConfigVar(t *testing.T) {
 	_, env, _ := accountMountAndEnv(sessionenv.Account{Agent: "claude", Name: "work", Dir: "/acct/claude/work"})
-	if want := "CLAUDE_CONFIG_DIR=" + dockerAccountHome; len(env) != 2 || env[1] != want {
+	want := "CLAUDE_CONFIG_DIR=" + dockerAccountHome
+	if got, found := dockerEnvArg(env, "CLAUDE_CONFIG_DIR"); !found || got != want {
 		t.Fatalf("want %q, got %v", want, env)
 	}
 	// An agent with no account support produces nothing rather than a mount the

--- a/session/agent_credentials.go
+++ b/session/agent_credentials.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"fmt"
 	"github.com/sachiniyer/agent-factory/internal/sessionenv"
 	"os"
 	"path/filepath"
@@ -123,23 +124,29 @@ const dockerAccountHome = dockerContainerHome + "/.af-account"
 //
 // Returns nothing for an agent that does not support accounts; the create path
 // refuses that case earlier, so this is defence rather than a branch anyone takes.
-func accountMountAndEnv(account sessionenv.Account) (mount []string, env []string) {
+func accountMountAndEnv(account sessionenv.Account) (mount []string, env []string, err error) {
 	if account.Dir == "" {
-		return nil, nil
+		return nil, nil, nil
 	}
 	configVar, ok := sessionenv.SupportsAccounts(account.Agent)
 	if !ok {
-		return nil, nil
+		return nil, nil, nil
 	}
 	// ABSOLUTE, always. Docker reads a relative -v source by its own rules — it is
 	// not resolved against af's working directory — so a relative AGENT_FACTORY_HOME
 	// (a supported configuration) would bind something that is not the account, or
 	// create a volume named after the path. Abs failing means af cannot say where
 	// the account is, which must refuse rather than mount a guess.
+	// A failure here must REFUSE, not return an empty mount. Returning nothing was
+	// the shape of this function's first version and it is the exact failure this
+	// feature exists to prevent: the container would start with no account and no
+	// error, running on whatever identity it could find while the session reported
+	// the one the operator named. "af cannot say where the account is" has to reach
+	// the create as an error.
 	source, err := filepath.Abs(account.Dir)
 	if err != nil {
-		return nil, nil
+		return nil, nil, fmt.Errorf("cannot resolve an absolute path for account %q (%s): %w", account.Name, account.Dir, err)
 	}
 	return []string{"-v", source + ":" + dockerAccountHome},
-		[]string{"-e", configVar + "=" + dockerAccountHome}
+		[]string{"-e", configVar + "=" + dockerAccountHome}, nil
 }

--- a/session/agent_credentials.go
+++ b/session/agent_credentials.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -109,6 +110,48 @@ func resolveAgentCredentialMounts(agent string) []string {
 // operator's filesystem layout crosses the boundary.
 const dockerAccountHome = "/af-account"
 
+func hostSELinuxEnforcing() (bool, error) {
+	if runtime.GOOS != "linux" {
+		return false, nil
+	}
+	for _, enforcePath := range []string{"/sys/fs/selinux/enforce", "/selinux/enforce"} {
+		value, err := os.ReadFile(enforcePath)
+		if err == nil {
+			switch strings.TrimSpace(string(value)) {
+			case "1":
+				return true, nil
+			case "0":
+				return false, nil
+			default:
+				return false, fmt.Errorf("unexpected value in %s", enforcePath)
+			}
+		}
+		if !os.IsNotExist(err) {
+			return false, fmt.Errorf("read %s: %w", enforcePath, err)
+		}
+	}
+	return false, nil
+}
+
+func dockerAccountMount(accountName, source string, selinuxEnforcing bool) ([]string, error) {
+	if !strings.Contains(source, ":") {
+		// z is the shared SELinux label: the same account may be used by more than
+		// one live session. Docker accepts it when SELinux is disabled as well.
+		return []string{"-v", source + ":" + dockerAccountHome + ":z"}, nil
+	}
+	if selinuxEnforcing {
+		return nil, fmt.Errorf(
+			"account %q path %q contains a colon and cannot be relabeled for an SELinux-enforcing Docker host; move AGENT_FACTORY_HOME to a path without ':'",
+			accountName, source)
+	}
+	// --volume uses ':' as a field delimiter. --mount keeps ':' ordinary, but its
+	// own comma delimiter cannot be escaped.
+	if strings.Contains(source, ",") {
+		return nil, fmt.Errorf("account %q path %q contains a comma, which Docker --mount cannot encode safely", accountName, source)
+	}
+	return []string{"--mount", "type=bind,src=" + source + ",dst=" + dockerAccountHome}, nil
+}
+
 // accountMountAndEnv returns the bind mount that places an account's agent HOME
 // inside the container, and the `-e VAR=value` that points the agent at it
 // (#3082).
@@ -149,14 +192,17 @@ func accountMountAndEnv(account sessionenv.Account) (mount []string, env []strin
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot resolve an absolute path for account %q (%s): %w", account.Name, account.Dir, err)
 	}
-	// --volume uses ':' as a field delimiter, so a valid Unix account path such as
-	// /srv/af:work is misparsed. --mount keeps ':' ordinary. Its own delimiter is
-	// a comma, which Docker cannot quote inside the CSV-style option; refuse that
-	// rare path explicitly instead of mounting a different directory.
-	if strings.Contains(source, ",") {
-		return nil, nil, fmt.Errorf("account %q path %q contains a comma, which Docker --mount cannot encode safely", account.Name, source)
+	selinuxEnforcing := false
+	if strings.Contains(source, ":") {
+		selinuxEnforcing, err = hostSELinuxEnforcing()
+		if err != nil {
+			return nil, nil, fmt.Errorf("cannot establish SELinux state for account %q mount: %w", account.Name, err)
+		}
 	}
-	mount = []string{"--mount", "type=bind,src=" + source + ",dst=" + dockerAccountHome}
+	mount, err = dockerAccountMount(account.Name, source, selinuxEnforcing)
+	if err != nil {
+		return nil, nil, err
+	}
 	// Blank every alternate identity source, including values baked into the
 	// image, then install the selected credential root last. The host environment
 	// is separately validated with ApplyAccount before this argv is assembled.

--- a/session/agent_credentials.go
+++ b/session/agent_credentials.go
@@ -2,10 +2,12 @@ package session
 
 import (
 	"fmt"
-	"github.com/sachiniyer/agent-factory/internal/sessionenv"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
+	"github.com/sachiniyer/agent-factory/internal/sessionenv"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
@@ -105,7 +107,7 @@ func resolveAgentCredentialMounts(agent string) []string {
 // dockerAccountHome is where an account's directory is mounted inside the
 // container. A fixed path, not derived from the host's, so nothing about the
 // operator's filesystem layout crosses the boundary.
-const dockerAccountHome = dockerContainerHome + "/.af-account"
+const dockerAccountHome = "/af-account"
 
 // accountMountAndEnv returns the `-v` mount that places an account's agent HOME
 // inside the container, and the `-e VAR=value` that points the agent at it
@@ -147,6 +149,34 @@ func accountMountAndEnv(account sessionenv.Account) (mount []string, env []strin
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot resolve an absolute path for account %q (%s): %w", account.Name, account.Dir, err)
 	}
-	return []string{"-v", source + ":" + dockerAccountHome},
-		[]string{"-e", configVar + "=" + dockerAccountHome}, nil
+	// --volume uses ':' as a field delimiter, so a valid Unix account path such as
+	// /srv/af:work is misparsed. --mount keeps ':' ordinary. Its own delimiter is
+	// a comma, which Docker cannot quote inside the CSV-style option; refuse that
+	// rare path explicitly instead of mounting a different directory.
+	if strings.Contains(source, ",") {
+		return nil, nil, fmt.Errorf("account %q path %q contains a comma, which Docker --mount cannot encode safely", account.Name, source)
+	}
+	mount = []string{"--mount", "type=bind,src=" + source + ",dst=" + dockerAccountHome}
+	// Blank every alternate identity source, including values baked into the
+	// image, then install the selected credential root last. The host environment
+	// is separately validated with ApplyAccount before this argv is assembled.
+	blank := make(map[string]struct{})
+	for _, name := range sessionenv.AccountIdentityNames(account.Agent) {
+		if name != configVar {
+			blank[name] = struct{}{}
+		}
+	}
+	for _, name := range sessionenv.AgentAuthSelectors(account.Agent) {
+		blank[name] = struct{}{}
+	}
+	names := make([]string, 0, len(blank))
+	for name := range blank {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		env = append(env, "-e", name+"=")
+	}
+	env = append(env, "-e", configVar+"="+dockerAccountHome)
+	return mount, env, nil
 }

--- a/session/agent_credentials.go
+++ b/session/agent_credentials.go
@@ -180,3 +180,26 @@ func accountMountAndEnv(account sessionenv.Account) (mount []string, env []strin
 	env = append(env, "-e", configVar+"="+dockerAccountHome)
 	return mount, env, nil
 }
+
+// refuseAccountAgentDrift refuses when the RESOLVED program runs a different
+// agent than the account was scoped to (#3082, #3108).
+//
+// Shared by the create path and the reprovision path deliberately. Both have to
+// answer the same question — "has the program changed out from under this
+// account?" — and two call sites deciding it independently is how they drift
+// apart; #3044 is the precedent for what that costs.
+//
+// It compares the RESOLVED command's agent, never the configured program name.
+// program_overrides can map the `codex` key to another agent's command, so the
+// name says codex while the container runs opencode — and a session that reports
+// one identity while spending another is the failure this whole feature exists to
+// prevent, arriving through config rather than through a backend.
+func refuseAccountAgentDrift(accountName, scopedAgent, resolvedProgram string) error {
+	resolvedAgent := sessionenv.AgentForCommand(resolvedProgram)
+	if resolvedAgent == scopedAgent {
+		return nil
+	}
+	return fmt.Errorf(
+		"account %q is a %s account, but the resolved program runs %s; refusing a session that would report one identity and use another",
+		accountName, scopedAgent, resolvedAgent)
+}

--- a/session/agent_credentials.go
+++ b/session/agent_credentials.go
@@ -131,6 +131,15 @@ func accountMountAndEnv(account sessionenv.Account) (mount []string, env []strin
 	if !ok {
 		return nil, nil
 	}
-	return []string{"-v", account.Dir + ":" + dockerAccountHome},
+	// ABSOLUTE, always. Docker reads a relative -v source by its own rules — it is
+	// not resolved against af's working directory — so a relative AGENT_FACTORY_HOME
+	// (a supported configuration) would bind something that is not the account, or
+	// create a volume named after the path. Abs failing means af cannot say where
+	// the account is, which must refuse rather than mount a guess.
+	source, err := filepath.Abs(account.Dir)
+	if err != nil {
+		return nil, nil
+	}
+	return []string{"-v", source + ":" + dockerAccountHome},
 		[]string{"-e", configVar + "=" + dockerAccountHome}
 }

--- a/session/agent_credentials.go
+++ b/session/agent_credentials.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"github.com/sachiniyer/agent-factory/internal/sessionenv"
 	"os"
 	"path/filepath"
 
@@ -98,4 +99,38 @@ func resolveAgentCredentialMounts(agent string) []string {
 	// Each mount is two args ("-v", "<spec>"), so the file count is len/2.
 	log.InfoLog.Printf("backend=docker: docker_mount_agent_credentials: mounting %d credential file(s) for agent %q read-only into the container", len(mounts)/2, agent)
 	return mounts
+}
+
+// dockerAccountHome is where an account's directory is mounted inside the
+// container. A fixed path, not derived from the host's, so nothing about the
+// operator's filesystem layout crosses the boundary.
+const dockerAccountHome = dockerContainerHome + "/.af-account"
+
+// accountMountAndEnv returns the `-v` mount that places an account's agent HOME
+// inside the container, and the `-e VAR=value` that points the agent at it
+// (#3082).
+//
+// It REPLACES the ambient credential mounts rather than joining them, and that is
+// the exclusivity property the feature exists for: a container built for an
+// account must carry nothing resolved from the daemon user's home, or the session
+// would hold two identities and the agent would pick one by path precedence.
+//
+// The mount is read-WRITE, unlike the ambient credential mounts. An account is the
+// agent's whole home — auth, history, settings, discovered skills — not a
+// credential file, so an agent that cannot write to it cannot record a session.
+// That is a real consequence of the account model rather than a looser posture:
+// the operator asked this session to BE that account.
+//
+// Returns nothing for an agent that does not support accounts; the create path
+// refuses that case earlier, so this is defence rather than a branch anyone takes.
+func accountMountAndEnv(account sessionenv.Account) (mount []string, env []string) {
+	if account.Dir == "" {
+		return nil, nil
+	}
+	configVar, ok := sessionenv.SupportsAccounts(account.Agent)
+	if !ok {
+		return nil, nil
+	}
+	return []string{"-v", account.Dir + ":" + dockerAccountHome},
+		[]string{"-e", configVar + "=" + dockerAccountHome}
 }

--- a/session/agent_credentials.go
+++ b/session/agent_credentials.go
@@ -109,7 +109,7 @@ func resolveAgentCredentialMounts(agent string) []string {
 // operator's filesystem layout crosses the boundary.
 const dockerAccountHome = "/af-account"
 
-// accountMountAndEnv returns the `-v` mount that places an account's agent HOME
+// accountMountAndEnv returns the bind mount that places an account's agent HOME
 // inside the container, and the `-e VAR=value` that points the agent at it
 // (#3082).
 //
@@ -134,7 +134,7 @@ func accountMountAndEnv(account sessionenv.Account) (mount []string, env []strin
 	if !ok {
 		return nil, nil, nil
 	}
-	// ABSOLUTE, always. Docker reads a relative -v source by its own rules — it is
+	// ABSOLUTE, always. Docker reads a relative bind source by its own rules — it is
 	// not resolved against af's working directory — so a relative AGENT_FACTORY_HOME
 	// (a supported configuration) would bind something that is not the account, or
 	// create a volume named after the path. Abs failing means af cannot say where

--- a/session/archive_sandbox.go
+++ b/session/archive_sandbox.go
@@ -3,6 +3,8 @@ package session
 import (
 	"errors"
 	"fmt"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/sessionenv"
 	"strings"
 
 	"github.com/sachiniyer/agent-factory/log"
@@ -222,6 +224,28 @@ func (i *Instance) reprovisionRemote() error {
 	i.mu.RLock()
 	creds := i.sandboxCreds
 	i.mu.RUnlock()
+	// Refuse a drifted agent BEFORE anything is reaped or provisioned (#3082).
+	//
+	// The create path checks this; reprovision did not, so a restore or recovery
+	// after program_overrides changed would rebuild the container against the same
+	// account while running a different agent — the identity the account names
+	// would be reported, and another one spent. Same question, same helper: two
+	// places deciding "has the program changed?" separately is how they drift.
+	//
+	// Placed above the reap because a refusal must cost nothing: the old runtime is
+	// still live and still recoverable, and reaping first would destroy it for a
+	// create that is about to be refused anyway.
+	if strings.TrimSpace(i.Account) != "" {
+		resolved, cfgErr := resolveRepoConfig(i.Path)
+		if cfgErr != nil {
+			return fmt.Errorf("cannot re-provision session %q: its account cannot be checked against the resolved program: %w", i.Title, cfgErr)
+		}
+		scopedAgent := sessionenv.AgentForCommand(i.Program)
+		if err := refuseAccountAgentDrift(i.Account, scopedAgent, config.ResolveProgram(&resolved.Config, i.Program)); err != nil {
+			return fmt.Errorf("cannot re-provision session %q: %w", i.Title, err)
+		}
+	}
+
 	// A failed archive/recovery can leave the old sandbox wiring live. Reap it
 	// before provisioning a replacement so bindProvisionResult never discards its
 	// only cleanup handle. An unknown outcome keeps the old wiring installed for a

--- a/session/archive_sandbox.go
+++ b/session/archive_sandbox.go
@@ -3,6 +3,7 @@ package session
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/sachiniyer/agent-factory/log"
 )
@@ -186,6 +187,7 @@ func recoverSandbox(i *Instance) error {
 func (i *Instance) reprovisionRemote() error {
 	i.mu.RLock()
 	backend := i.backend
+	accountName := i.Account
 	spec := ProvisionSpec{
 		RepoRoot:              i.Path,
 		Title:                 i.Title,
@@ -201,6 +203,17 @@ func (i *Instance) reprovisionRemote() error {
 	kind, err := backendKindForType(backend.Type())
 	if err != nil {
 		return fmt.Errorf("cannot re-provision session %q: %w", i.Title, err)
+	}
+	// Resolve the persisted account before reaping the old sandbox. A missing or
+	// cross-agent account makes the replacement unusable, and that is not a reason
+	// to destroy the only runtime the session still has. The initial create uses
+	// this same resolver, so restore cannot drift onto ambient credentials.
+	if kind.CarriesAccount() && strings.TrimSpace(accountName) != "" {
+		account, accountErr := resolveAccountForProvision(spec.RepoRoot, spec.Program, accountName)
+		if accountErr != nil {
+			return fmt.Errorf("cannot re-provision session %q with its persisted account: %w", i.Title, accountErr)
+		}
+		spec.Account = account
 	}
 	rt, err := ResolveRuntime(kind)
 	if err != nil {

--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -236,7 +236,21 @@ func (dockerRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 	// repo-selected image never sees another agent's credential or anything else the
 	// operator did not grant. Resolved here in the host process (it stats the daemon
 	// user's home) so runContainer's argv assembly stays pure.
-	if cfg.DockerMountAgentCredentials {
+	// An ACCOUNT replaces the ambient credential mounts entirely (#3082).
+	//
+	// Independent of docker.mount_agent_credentials on purpose: that key is the
+	// opt-in for lending the container the operator's ambient identity, and an
+	// account is the opposite request — a specific identity, named explicitly at
+	// create time. Gating the account on it would leave an account-scoped session
+	// with no credentials at all whenever the key is off, which reads as "the
+	// account did not work".
+	//
+	// The `else` is the exclusivity guarantee: when an account is in play, nothing
+	// resolved from the daemon user's home is mounted, so the container cannot hold
+	// two identities.
+	if spec.Account.Dir != "" {
+		p.accountMount, p.accountEnv = accountMountAndEnv(spec.Account)
+	} else if cfg.DockerMountAgentCredentials {
 		p.credentialMounts = resolveAgentCredentialMounts(p.agentName())
 	}
 	res, err := p.provision()
@@ -267,6 +281,11 @@ type dockerProvisioner struct {
 	spec    ProvisionSpec
 	image   string
 	runArgs []string
+	// accountMount and accountEnv place a registered credential account inside the
+	// container and point the agent at it (#3082). Set only for an account-scoped
+	// session, and mutually exclusive with credentialMounts.
+	accountMount []string
+	accountEnv   []string
 	// credentialMounts are the read-only `-v host:container:ro` agent-credential
 	// bind mounts (docker.mount_agent_credentials, #2194), resolved once in
 	// Provision and appended to the `docker run` argv before runArgs.
@@ -376,6 +395,10 @@ func (p *dockerProvisioner) runContainer() error {
 	// Read-only agent credential mounts (docker.mount_agent_credentials, #2194) go
 	// before run_args so an operator's own run_args can still be appended after.
 	args = append(args, p.credentialMounts...)
+	// The account's mount and its config var. Placed before run_args like the
+	// credential mounts, so an operator's own run_args still come last.
+	args = append(args, p.accountMount...)
+	args = append(args, p.accountEnv...)
 	args = append(args, p.runArgs...)
 	args = append(args, "--entrypoint", "sleep", p.image, "2147483647")
 

--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -219,11 +219,8 @@ func (dockerRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 	// exact command with --program-resolved and must not reinterpret its enum.
 	resolvedProgram := config.ResolveProgram(&cfg.Config, spec.Program)
 	if spec.Account.Dir != "" {
-		resolvedAgent := sessionenv.AgentForCommand(resolvedProgram)
-		if resolvedAgent != spec.Account.Agent {
-			return ProvisionResult{}, fmt.Errorf(
-				"backend=docker: account %q is a %s account, but the resolved Docker program runs %s; refusing a container that would report one identity and use another",
-				spec.Account.Name, spec.Account.Agent, resolvedAgent)
+		if err := refuseAccountAgentDrift(spec.Account.Name, spec.Account.Agent, resolvedProgram); err != nil {
+			return ProvisionResult{}, fmt.Errorf("backend=docker: %w", err)
 		}
 		// Reuse the local shim's authoritative validation for cloud modes and
 		// command-local identity assignments. The returned host environment is not

--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -398,8 +398,15 @@ func (p *dockerProvisioner) runContainer() error {
 	// The account's mount and its config var. Placed before run_args like the
 	// credential mounts, so an operator's own run_args still come last.
 	args = append(args, p.accountMount...)
-	args = append(args, p.accountEnv...)
 	args = append(args, p.runArgs...)
+	// The account's env goes LAST, after run_args, and that ordering is the boundary
+	// rather than a preference. docker.run_args is repository-controlled and checked
+	// in; appended after the account it could set `-e CODEX_HOME=/another/home` and
+	// silently move the agent off the account the operator named, which is the
+	// wrong-identity failure this feature exists to prevent. Docker gives the LAST
+	// -e for a name precedence, so putting the account there makes it dominate an
+	// assembly that is otherwise additive by design.
+	args = append(args, p.accountEnv...)
 	args = append(args, "--entrypoint", "sleep", p.image, "2147483647")
 
 	out, err := p.docker(dockerProvisionStepTimeout, args...)

--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -249,7 +249,11 @@ func (dockerRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 	// resolved from the daemon user's home is mounted, so the container cannot hold
 	// two identities.
 	if spec.Account.Dir != "" {
-		p.accountMount, p.accountEnv = accountMountAndEnv(spec.Account)
+		mount, env, aerr := accountMountAndEnv(spec.Account)
+		if aerr != nil {
+			return ProvisionResult{}, fmt.Errorf("backend=docker: %w", aerr)
+		}
+		p.accountMount, p.accountEnv = mount, env
 	} else if cfg.DockerMountAgentCredentials {
 		p.credentialMounts = resolveAgentCredentialMounts(p.agentName())
 	}

--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -65,6 +65,11 @@ const (
 	// own config land under it; a constant keeps those mount targets in lockstep
 	// with the runContainer env so the two never drift.
 	dockerContainerHome = "/root"
+	// Account sessions run as the owner the bind mount reports inside the
+	// container, with a separate writable HOME for af/git state. The account
+	// itself remains mounted at dockerAccountHome and is selected by CODEX_HOME or
+	// CLAUDE_CONFIG_DIR.
+	dockerAccountRuntimeHome = "/af-home"
 	// dockerAfBinaryPath is where the daemon's `af` binary is copied in the
 	// container so `af agent-server` is on PATH for the exec below.
 	dockerAfBinaryPath = "/usr/local/bin/af"
@@ -213,6 +218,24 @@ func (dockerRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 	// Resolve once in the trusted host process. The agent-server receives this
 	// exact command with --program-resolved and must not reinterpret its enum.
 	resolvedProgram := config.ResolveProgram(&cfg.Config, spec.Program)
+	if spec.Account.Dir != "" {
+		resolvedAgent := sessionenv.AgentForCommand(resolvedProgram)
+		if resolvedAgent != spec.Account.Agent {
+			return ProvisionResult{}, fmt.Errorf(
+				"backend=docker: account %q is a %s account, but the resolved Docker program runs %s; refusing a container that would report one identity and use another",
+				spec.Account.Name, spec.Account.Agent, resolvedAgent)
+		}
+		// Reuse the local shim's authoritative validation for cloud modes and
+		// command-local identity assignments. The returned host environment is not
+		// installed in Docker; accountMountAndEnv builds the container boundary.
+		if _, aerr := sessionenv.ApplyAccount(os.Environ(), resolvedProgram, spec.Account); aerr != nil {
+			return ProvisionResult{}, fmt.Errorf("backend=docker: %w", aerr)
+		}
+		if aerr := validateAccountDockerRunArgs(runArgs, spec.Account.Agent); aerr != nil {
+			return ProvisionResult{}, aerr
+		}
+		spec.SessionEnvPassthrough = filterAccountPassthrough(spec.SessionEnvPassthrough, spec.Account.Agent)
+	}
 	// Stamp the AF home onto the container (af.home label) so the orphan sweeper
 	// can scope to this daemon's home. If it can't be resolved, omit the label —
 	// the container just won't be sweep-tracked, which is the safe direction.
@@ -290,6 +313,10 @@ type dockerProvisioner struct {
 	// session, and mutually exclusive with credentialMounts.
 	accountMount []string
 	accountEnv   []string
+	// containerUser is the numeric uid:gid that owns dockerAccountHome as seen by
+	// the container. On rootful Docker that is the host af user; on rootless Docker
+	// it is commonly 0:0, which maps back to that same host user.
+	containerUser string
 	// credentialMounts are the read-only `-v host:container:ro` agent-credential
 	// bind mounts (docker.mount_agent_credentials, #2194), resolved once in
 	// Provision and appended to the `docker run` argv before runArgs.
@@ -323,12 +350,20 @@ type dockerProvisioner struct {
 // session needs. Each step wraps docker's combined output in the error so a
 // failure is self-diagnosing.
 func (p *dockerProvisioner) provision() (ProvisionResult, error) {
+	if p.spec.Account.Dir != "" {
+		if err := p.ensureAccountDockerEngineLocal(); err != nil {
+			return ProvisionResult{}, err
+		}
+	}
 	engineID, err := p.currentEngineID(dockerShortStepTimeout)
 	if err != nil {
 		return ProvisionResult{}, fmt.Errorf("backend=docker: cannot establish the Docker cleanup target before creating a container: %w", err)
 	}
 	p.engineID = engineID
 	if err := p.runContainer(); err != nil {
+		return ProvisionResult{}, err
+	}
+	if err := p.prepareAccountUser(); err != nil {
 		return ProvisionResult{}, err
 	}
 	if err := p.configureGit(); err != nil {
@@ -383,7 +418,7 @@ func (p *dockerProvisioner) runContainer() error {
 	args := []string{
 		"run", "-d",
 		"--label", dockerSessionLabel + "=" + Slugify(p.spec.Title),
-		"-e", "HOME=" + dockerContainerHome,
+		"-e", "HOME=" + p.sessionHome(),
 		"-p", "127.0.0.1::" + dockerAgentPort,
 	}
 	// Scope the container to this daemon's AF home for the orphan sweeper (#2194).
@@ -411,6 +446,12 @@ func (p *dockerProvisioner) runContainer() error {
 	// -e for a name precedence, so putting the account there makes it dominate an
 	// assembly that is otherwise additive by design.
 	args = append(args, p.accountEnv...)
+	if p.spec.Account.Dir != "" {
+		// docker.run_args may set HOME too. It is not an identity source once the
+		// agent's config root is explicit, but the non-root agent-server still needs
+		// its writable runtime home, so make this execution invariant win last.
+		args = append(args, "-e", "HOME="+p.sessionHome())
+	}
 	args = append(args, "--entrypoint", "sleep", p.image, "2147483647")
 
 	out, err := p.docker(dockerProvisionStepTimeout, args...)
@@ -449,7 +490,7 @@ func (p *dockerProvisioner) configureGit() error {
 	script := `git config --global user.email "af@agent-factory.local" && ` +
 		`git config --global user.name "Agent Factory" && ` +
 		`git config --global --add safe.directory "*"`
-	out, err := p.execSh(dockerShortStepTimeout, script)
+	out, err := p.execSessionSh(dockerShortStepTimeout, script)
 	if err != nil {
 		return fmt.Errorf("backend=docker: git config in container failed: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -463,13 +504,13 @@ func (p *dockerProvisioner) configureGit() error {
 // pushed session branch as a local ref so the in-container Setup checks it out.
 func (p *dockerProvisioner) cloneWorkspace() error {
 	script := gitCloneCommand(p.spec.CloneURL, dockerWorkspaceDir)
-	out, err := p.execSh(dockerProvisionStepTimeout, script)
+	out, err := p.execSessionSh(dockerProvisionStepTimeout, script)
 	if err != nil {
 		return fmt.Errorf("backend=docker: cloning %q into the container failed (is git in the image, and the URL reachable from inside the container?): %s: %w",
 			p.spec.CloneURL, strings.TrimSpace(string(out)), err)
 	}
 	if credentialCommand := gitPersistCredentialCommand(p.spec.CloneURL, dockerWorkspaceDir); credentialCommand != "" {
-		out, err = p.execSh(dockerShortStepTimeout, credentialCommand)
+		out, err = p.execSessionSh(dockerShortStepTimeout, credentialCommand)
 		if err != nil {
 			return fmt.Errorf("backend=docker: configuring value-free GitHub credentials in the clone failed: %s: %w",
 				strings.TrimSpace(string(out)), err)
@@ -492,7 +533,7 @@ func (p *dockerProvisioner) cloneWorkspace() error {
 func (p *dockerProvisioner) fetchRestoreBranch(branch string) error {
 	script := fmt.Sprintf("git -C %s fetch origin %s:%s",
 		shellQuote(dockerWorkspaceDir), shellQuote(branch), shellQuote(branch))
-	out, err := p.execSh(dockerProvisionStepTimeout, script)
+	out, err := p.execSessionSh(dockerProvisionStepTimeout, script)
 	if err != nil {
 		return fmt.Errorf("backend=docker: restoring archived branch %q into the container failed (was it pushed to origin?): %s: %w",
 			branch, strings.TrimSpace(string(out)), err)
@@ -529,7 +570,10 @@ func (p *dockerProvisioner) startAgentServer() error {
 
 	// -d: detach. The agent-server keeps running in the container after this exec
 	// client returns; we read its banner from the file below.
-	out, err := p.docker(dockerShortStepTimeout, "exec", "-d", p.containerID, "sh", "-c", filteredInner)
+	args := []string{"exec", "-d"}
+	args = append(args, p.sessionExecOptions()...)
+	args = append(args, p.containerID, "sh", "-c", filteredInner)
+	out, err := p.docker(dockerShortStepTimeout, args...)
 	if err != nil {
 		return fmt.Errorf("backend=docker: starting af agent-server in the container failed: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -735,7 +779,12 @@ func (p *dockerProvisioner) dockerEnvironment() []string {
 
 // execSh runs a `sh -c <script>` inside the container.
 func (p *dockerProvisioner) execSh(timeout time.Duration, script string) ([]byte, error) {
-	return p.docker(timeout, "exec", p.containerID, "sh", "-c", script)
+	args := []string{"exec"}
+	if p.spec.Account.Dir != "" {
+		args = append(args, "--user", "0:0")
+	}
+	args = append(args, p.containerID, "sh", "-c", script)
+	return p.docker(timeout, args...)
 }
 
 func (p *dockerProvisioner) shortID() string {

--- a/session/backend_docker_account.go
+++ b/session/backend_docker_account.go
@@ -49,15 +49,30 @@ func validateAccountDockerRunArgs(args []string, agent string) error {
 		return nil
 	}
 	checkMount := func(value string) error {
-		for _, protected := range []string{dockerAccountHome, dockerAccountRuntimeHome} {
-			if strings.Contains(value, ":"+protected) ||
-				strings.Contains(value, "dst="+protected) ||
-				strings.Contains(value, "destination="+protected) ||
-				strings.Contains(value, "target="+protected) {
-				return fmt.Errorf(
-					"backend=docker: docker.run_args cannot install an account mount over %s because it would replace af's selected account boundary",
-					protected)
+		mountsProtectedPath := func() string {
+			for _, field := range strings.Split(value, ",") {
+				key, target, ok := strings.Cut(field, "=")
+				if !ok || (key != "dst" && key != "destination" && key != "target") {
+					continue
+				}
+				if target == dockerAccountHome || target == dockerAccountRuntimeHome {
+					return target
+				}
 			}
+			// --volume and --tmpfs use ':' between fields. Looking for an
+			// exact field avoids refusing harmless paths such as
+			// /af-account-cache.
+			for _, field := range strings.Split(value, ":") {
+				if field == dockerAccountHome || field == dockerAccountRuntimeHome {
+					return field
+				}
+			}
+			return ""
+		}
+		if protected := mountsProtectedPath(); protected != "" {
+			return fmt.Errorf(
+				"backend=docker: docker.run_args cannot install an account mount over %s because it would replace af's selected account boundary",
+				protected)
 		}
 		return nil
 	}

--- a/session/backend_docker_account.go
+++ b/session/backend_docker_account.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"fmt"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -49,22 +50,31 @@ func validateAccountDockerRunArgs(args []string, agent string) error {
 		return nil
 	}
 	checkMount := func(value string) error {
+		protectedPath := func(target string) string {
+			target = path.Clean(target)
+			for _, protected := range []string{dockerAccountHome, dockerAccountRuntimeHome} {
+				if target == protected || strings.HasPrefix(target, protected+"/") {
+					return protected
+				}
+			}
+			return ""
+		}
 		mountsProtectedPath := func() string {
 			for _, field := range strings.Split(value, ",") {
 				key, target, ok := strings.Cut(field, "=")
 				if !ok || (key != "dst" && key != "destination" && key != "target") {
 					continue
 				}
-				if target == dockerAccountHome || target == dockerAccountRuntimeHome {
-					return target
+				if protected := protectedPath(target); protected != "" {
+					return protected
 				}
 			}
 			// --volume and --tmpfs use ':' between fields. Looking for an
 			// exact field avoids refusing harmless paths such as
 			// /af-account-cache.
 			for _, field := range strings.Split(value, ":") {
-				if field == dockerAccountHome || field == dockerAccountRuntimeHome {
-					return field
+				if protected := protectedPath(field); protected != "" {
+					return protected
 				}
 			}
 			return ""

--- a/session/backend_docker_account.go
+++ b/session/backend_docker_account.go
@@ -1,0 +1,216 @@
+package session
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/internal/sessionenv"
+)
+
+const dockerEndpointFormat = "{{.Endpoints.docker.Host}}"
+
+func accountDockerDeniedNames(agent string) map[string]struct{} {
+	denied := make(map[string]struct{})
+	for _, name := range sessionenv.AccountIdentityNames(agent) {
+		denied[name] = struct{}{}
+	}
+	for _, name := range sessionenv.AgentAuthSelectors(agent) {
+		denied[name] = struct{}{}
+	}
+	return denied
+}
+
+func filterAccountPassthrough(names []string, agent string) []string {
+	denied := accountDockerDeniedNames(agent)
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		if _, drop := denied[name]; !drop {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// validateAccountDockerRunArgs refuses repo-controlled sources that Docker can
+// apply after af has selected the account. Environment files are opaque to af,
+// so none are accepted in account mode; direct environment options are refused
+// only when they can choose another identity or authentication mode.
+func validateAccountDockerRunArgs(args []string, agent string) error {
+	denied := accountDockerDeniedNames(agent)
+	checkEnv := func(value string) error {
+		name, _, _ := strings.Cut(value, "=")
+		if _, refused := denied[name]; refused {
+			return fmt.Errorf(
+				"backend=docker: docker.run_args cannot set %s for an account-scoped %s session because it can override the selected identity",
+				name, agent)
+		}
+		return nil
+	}
+	checkMount := func(value string) error {
+		for _, protected := range []string{dockerAccountHome, dockerAccountRuntimeHome} {
+			if strings.Contains(value, ":"+protected) ||
+				strings.Contains(value, "dst="+protected) ||
+				strings.Contains(value, "destination="+protected) ||
+				strings.Contains(value, "target="+protected) {
+				return fmt.Errorf(
+					"backend=docker: docker.run_args cannot install an account mount over %s because it would replace af's selected account boundary",
+					protected)
+			}
+		}
+		return nil
+	}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "--env-file" || arg == "-env-file":
+			return fmt.Errorf("backend=docker: docker.run_args cannot use %s for an account-scoped session because af cannot prove the file contains no competing identity", arg)
+		case strings.HasPrefix(arg, "--env-file="):
+			return fmt.Errorf("backend=docker: docker.run_args cannot use --env-file for an account-scoped session because af cannot prove the file contains no competing identity")
+		case arg == "-e" || arg == "--env":
+			if index+1 < len(args) {
+				index++
+				if err := checkEnv(args[index]); err != nil {
+					return err
+				}
+			}
+		case strings.HasPrefix(arg, "--env="):
+			if err := checkEnv(strings.TrimPrefix(arg, "--env=")); err != nil {
+				return err
+			}
+		case strings.HasPrefix(arg, "-e="):
+			if err := checkEnv(strings.TrimPrefix(arg, "-e=")); err != nil {
+				return err
+			}
+		case strings.HasPrefix(arg, "-e") && len(arg) > 2:
+			if err := checkEnv(strings.TrimPrefix(arg, "-e")); err != nil {
+				return err
+			}
+		case arg == "-v" || arg == "--volume" || arg == "--mount" || arg == "--tmpfs":
+			if index+1 < len(args) {
+				index++
+				if err := checkMount(args[index]); err != nil {
+					return err
+				}
+			}
+		case strings.HasPrefix(arg, "--volume=") || strings.HasPrefix(arg, "--mount=") || strings.HasPrefix(arg, "--tmpfs="):
+			if err := checkMount(strings.SplitN(arg, "=", 2)[1]); err != nil {
+				return err
+			}
+		case strings.HasPrefix(arg, "-v") && len(arg) > 2:
+			if err := checkMount(strings.TrimPrefix(arg, "-v")); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func environmentValue(environ []string, name string) string {
+	prefix := name + "="
+	for _, entry := range environ {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimSpace(strings.TrimPrefix(entry, prefix))
+		}
+	}
+	return ""
+}
+
+func localDockerEndpoint(endpoint string) bool {
+	endpoint = strings.ToLower(strings.TrimSpace(endpoint))
+	return strings.HasPrefix(endpoint, "unix://") ||
+		strings.HasPrefix(endpoint, "npipe://") ||
+		strings.HasPrefix(endpoint, "fd://")
+}
+
+// ensureAccountDockerEngineLocal proves bind mounts are interpreted on this
+// host. Docker resolves a bind source on the daemon host, not the CLI host, so a
+// remote endpoint would mount an unrelated path while reporting the local
+// account name.
+func (p *dockerProvisioner) ensureAccountDockerEngineLocal() error {
+	environ := p.dockerEnvironment()
+	dockerHost := environmentValue(environ, "DOCKER_HOST")
+	dockerContext := environmentValue(environ, "DOCKER_CONTEXT")
+	endpoint := dockerHost
+	if dockerContext != "" || endpoint == "" {
+		out, err := p.docker(dockerShortStepTimeout, "context", "inspect", "--format", dockerEndpointFormat)
+		if err != nil {
+			return fmt.Errorf("backend=docker: cannot establish that the Docker daemon is local before mounting account %q: %s: %w",
+				p.spec.Account.Name, strings.TrimSpace(string(out)), err)
+		}
+		endpoint = strings.TrimSpace(string(out))
+	}
+	if !localDockerEndpoint(endpoint) {
+		return fmt.Errorf(
+			"backend=docker: account %q cannot be used with remote Docker endpoint %q: bind mounts resolve on the daemon host, so this host's account path would not be the selected identity",
+			p.spec.Account.Name, endpoint)
+	}
+	return nil
+}
+
+func parseContainerOwner(out string) (string, error) {
+	owner := strings.TrimSpace(out)
+	uid, gid, ok := strings.Cut(owner, ":")
+	if !ok || uid == "" || gid == "" {
+		return "", fmt.Errorf("expected numeric uid:gid, got %q", owner)
+	}
+	if _, err := strconv.ParseUint(uid, 10, 32); err != nil {
+		return "", fmt.Errorf("invalid uid in %q: %w", owner, err)
+	}
+	if _, err := strconv.ParseUint(gid, 10, 32); err != nil {
+		return "", fmt.Errorf("invalid gid in %q: %w", owner, err)
+	}
+	return owner, nil
+}
+
+// prepareAccountUser asks the mounted directory who owns it in the container's
+// user namespace, then prepares a writable HOME/workspace for that same uid.
+// Rootful Docker reports the host af uid; rootless Docker commonly reports 0,
+// which maps back to the invoking host user. Either way writes through the bind
+// mount retain the ownership local account sessions need.
+func (p *dockerProvisioner) prepareAccountUser() error {
+	if p.spec.Account.Dir == "" {
+		return nil
+	}
+	out, err := p.docker(dockerShortStepTimeout,
+		"exec", "--user", "0:0", p.containerID, "stat", "-c", "%u:%g", dockerAccountHome)
+	if err != nil {
+		return fmt.Errorf("backend=docker: cannot identify the mounted account owner: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	owner, err := parseContainerOwner(string(out))
+	if err != nil {
+		return fmt.Errorf("backend=docker: cannot identify the mounted account owner: %w", err)
+	}
+	script := fmt.Sprintf("mkdir -p %s %s && chown %s %s %s",
+		shellQuote(dockerAccountRuntimeHome), shellQuote(dockerWorkspaceDir), owner,
+		shellQuote(dockerAccountRuntimeHome), shellQuote(dockerWorkspaceDir))
+	out, err = p.docker(dockerShortStepTimeout,
+		"exec", "--user", "0:0", p.containerID, "sh", "-c", script)
+	if err != nil {
+		return fmt.Errorf("backend=docker: cannot prepare the account-owned container home and workspace: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	p.containerUser = owner
+	return nil
+}
+
+func (p *dockerProvisioner) sessionHome() string {
+	if p.spec.Account.Dir != "" {
+		return dockerAccountRuntimeHome
+	}
+	return dockerContainerHome
+}
+
+func (p *dockerProvisioner) sessionExecOptions() []string {
+	if p.containerUser == "" {
+		return nil
+	}
+	return []string{"--user", p.containerUser, "-e", "HOME=" + p.sessionHome()}
+}
+
+func (p *dockerProvisioner) execSessionSh(timeout time.Duration, script string) ([]byte, error) {
+	args := []string{"exec"}
+	args = append(args, p.sessionExecOptions()...)
+	args = append(args, p.containerID, "sh", "-c", script)
+	return p.docker(timeout, args...)
+}

--- a/session/docker_account_findings_test.go
+++ b/session/docker_account_findings_test.go
@@ -240,7 +240,7 @@ func TestDockerAccount_ReprovisionCarriesThePersistedAccount(t *testing.T) {
 func TestDockerAccount_ReprovisionRefusesResolvedAgentDrift(t *testing.T) {
 	f := newDockerAccountFixture(t, "", "codex", nil)
 	cfg := config.DefaultConfig()
-	cfg.ProgramOverrides["codex"] = "opencode"
+	cfg.ProgramOverrides = map[string]string{"codex": "opencode"}
 	require.NoError(t, config.SaveConfig(cfg))
 	dockerCalled := false
 	t.Cleanup(SetDockerExecForTest(func(_ context.Context, _ []string, args ...string) ([]byte, error) {

--- a/session/docker_account_findings_test.go
+++ b/session/docker_account_findings_test.go
@@ -1,0 +1,279 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/agentaccount"
+)
+
+const accountContainerDirForTest = "/af-account"
+
+type dockerAccountFixture struct {
+	repo       string
+	accountDir string
+}
+
+func newDockerAccountFixture(t *testing.T, home, agent string, runArgs []string) dockerAccountFixture {
+	t.Helper()
+	if home == "" {
+		home = t.TempDir()
+	}
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	require.NoError(t, config.SaveConfig(config.DefaultConfig()))
+	accountDir, err := agentaccount.Register(home, agent, "work")
+	require.NoError(t, err)
+
+	repo := initTempGitRepo(t)
+	runGit(t, repo, "remote", "add", "origin", "https://example.invalid/fixture.git")
+	dockerConfig := map[string]any{"image": "example.invalid/agent:latest"}
+	if runArgs != nil {
+		dockerConfig["run_args"] = runArgs
+	}
+	writeInRepoConfig(t, repo, map[string]any{"backend": "docker", "docker": dockerConfig})
+	t.Cleanup(SetLookPathForTest(func(string) (string, error) { return "/usr/bin/docker", nil }))
+	t.Cleanup(SetDockerSelfBinaryForTest(filepath.Join(t.TempDir(), "af")))
+	return dockerAccountFixture{repo: repo, accountDir: accountDir}
+}
+
+func createDockerAccountSession(f dockerAccountFixture, program string, passthrough []string) (*Instance, error) {
+	return NewInstance(InstanceOptions{
+		Title:                 "account-boundary",
+		Path:                  f.repo,
+		Program:               program,
+		Account:               "work",
+		Backend:               BackendDocker,
+		SessionEnvPassthrough: passthrough,
+	})
+}
+
+func fakeLocalDockerResponse(args []string) ([]byte, error) {
+	if len(args) >= 2 && args[0] == "context" && args[1] == "inspect" {
+		return []byte("unix:///var/run/docker.sock\n"), nil
+	}
+	if len(args) > 0 && args[0] == "info" {
+		return []byte("account-test-engine\n"), nil
+	}
+	return nil, nil
+}
+
+func dockerEnvArg(args []string, name string) (string, bool) {
+	for index := 0; index+1 < len(args); index++ {
+		if args[index] != "-e" {
+			continue
+		}
+		value := args[index+1]
+		if value == name || strings.HasPrefix(value, name+"=") {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func TestDockerAccount_StripsAmbientIdentityPassthrough(t *testing.T) {
+	f := newDockerAccountFixture(t, "", "codex", nil)
+	t.Setenv("OPENAI_API_KEY", "ambient-identity")
+	var runArgs, dockerEnv []string
+	t.Cleanup(SetDockerExecForTest(func(_ context.Context, environ []string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "run" {
+			runArgs = append([]string(nil), args...)
+			dockerEnv = append([]string(nil), environ...)
+			return nil, fmt.Errorf("stop after docker run")
+		}
+		return fakeLocalDockerResponse(args)
+	}))
+
+	_, _ = createDockerAccountSession(f, "codex", []string{"OPENAI_API_KEY"})
+	require.NotEmpty(t, runArgs, "the account create never reached docker run")
+	assignment, found := dockerEnvArg(runArgs, "OPENAI_API_KEY")
+	require.True(t, found, "account containers must override an image-provided API key too")
+	require.Equal(t, "OPENAI_API_KEY=", assignment,
+		"the ambient API key must not compete with the mounted account")
+	require.False(t, environmentHasName(dockerEnv, "OPENAI_API_KEY"),
+		"the Docker CLI process must not inherit the ambient identity value")
+}
+
+func TestDockerAccount_RefusesCloudAuthenticationMode(t *testing.T) {
+	f := newDockerAccountFixture(t, "", "claude", nil)
+	t.Setenv("CLAUDE_CODE_USE_BEDROCK", "1")
+	dockerCalled := false
+	t.Cleanup(SetDockerExecForTest(func(_ context.Context, _ []string, args ...string) ([]byte, error) {
+		dockerCalled = true
+		return fakeLocalDockerResponse(args)
+	}))
+
+	_, err := createDockerAccountSession(f, "claude", nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CLAUDE_CODE_USE_BEDROCK")
+	require.False(t, dockerCalled, "cloud-mode refusal must happen before provisioning")
+}
+
+func TestDockerAccount_RejectsIdentityRunArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "short env", args: []string{"-e", "OPENAI_API_KEY=repo-identity"}, wantErr: "OPENAI_API_KEY"},
+		{name: "long env", args: []string{"--env=CODEX_ACCESS_TOKEN=repo-identity"}, wantErr: "CODEX_ACCESS_TOKEN"},
+		{name: "env file", args: []string{"--env-file", "repo.env"}, wantErr: "env-file"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newDockerAccountFixture(t, "", "codex", tt.args)
+			runCalled := false
+			t.Cleanup(SetDockerExecForTest(func(_ context.Context, _ []string, args ...string) ([]byte, error) {
+				if len(args) > 0 && args[0] == "run" {
+					runCalled = true
+				}
+				return fakeLocalDockerResponse(args)
+			}))
+
+			_, err := createDockerAccountSession(f, "codex", nil)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "docker.run_args")
+			require.Contains(t, err.Error(), tt.wantErr)
+			require.False(t, runCalled, "a conflicting repo environment must refuse before docker run")
+		})
+	}
+}
+
+func TestDockerAccount_UsesAMountFormThatAcceptsColonPaths(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "af:home")
+	f := newDockerAccountFixture(t, home, "codex", nil)
+	var runArgs []string
+	t.Cleanup(SetDockerExecForTest(func(_ context.Context, _ []string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "run" {
+			runArgs = append([]string(nil), args...)
+			return nil, fmt.Errorf("stop after docker run")
+		}
+		return fakeLocalDockerResponse(args)
+	}))
+
+	_, _ = createDockerAccountSession(f, "codex", nil)
+	require.NotEmpty(t, runArgs, "the account create never reached docker run")
+	wantSource := "src=" + f.accountDir
+	found := false
+	for index := 0; index+1 < len(runArgs); index++ {
+		if runArgs[index] == "--mount" && strings.Contains(runArgs[index+1], wantSource) &&
+			strings.Contains(runArgs[index+1], "dst="+accountContainerDirForTest) {
+			found = true
+		}
+	}
+	require.Truef(t, found, "colon-containing account path was not encoded as a Docker --mount: %v", runArgs)
+}
+
+func TestDockerAccount_RefusesRemoteDockerEngine(t *testing.T) {
+	f := newDockerAccountFixture(t, "", "codex", nil)
+	t.Setenv("DOCKER_HOST", "tcp://remote.example:2376")
+	runCalled := false
+	t.Cleanup(SetDockerExecForTest(func(_ context.Context, _ []string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "run" {
+			runCalled = true
+		}
+		return fakeLocalDockerResponse(args)
+	}))
+
+	_, err := createDockerAccountSession(f, "codex", nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "remote Docker")
+	require.False(t, runCalled, "a local account path must never be sent to a remote daemon")
+}
+
+func TestDockerAccount_ReprovisionCarriesThePersistedAccount(t *testing.T) {
+	f := newDockerAccountFixture(t, "", "codex", nil)
+	var runArgs []string
+	t.Cleanup(SetDockerExecForTest(func(_ context.Context, _ []string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "run" {
+			runArgs = append([]string(nil), args...)
+			return nil, fmt.Errorf("stop after docker run")
+		}
+		return fakeLocalDockerResponse(args)
+	}))
+	i := &Instance{
+		Title: "account-recovery", Path: f.repo, Program: "codex", Account: "work",
+		Branch: "root/account-recovery", backend: newInertSandboxBackend("docker"),
+	}
+
+	_ = i.reprovisionRemote()
+	require.NotEmpty(t, runArgs, "reprovision never reached docker run")
+	found := false
+	for _, arg := range runArgs {
+		if strings.Contains(arg, f.accountDir) {
+			found = true
+		}
+	}
+	require.True(t, found, "the replacement sandbox omitted the persisted account mount")
+}
+
+func TestDockerAccount_ReprovisionRefusesResolvedAgentDrift(t *testing.T) {
+	f := newDockerAccountFixture(t, "", "codex", nil)
+	cfg := config.DefaultConfig()
+	cfg.ProgramOverrides["codex"] = "opencode"
+	require.NoError(t, config.SaveConfig(cfg))
+	dockerCalled := false
+	t.Cleanup(SetDockerExecForTest(func(_ context.Context, _ []string, args ...string) ([]byte, error) {
+		dockerCalled = true
+		return fakeLocalDockerResponse(args)
+	}))
+	i := &Instance{
+		Title: "account-recovery", Path: f.repo, Program: "codex", Account: "work",
+		Branch: "root/account-recovery", backend: newInertSandboxBackend("docker"),
+	}
+
+	err := i.reprovisionRemote()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "codex account")
+	require.Contains(t, err.Error(), "opencode")
+	require.False(t, dockerCalled, "agent drift must refuse before reaping or provisioning")
+}
+
+func TestDockerAccount_AgentServerRunsAsTheAccountOwner(t *testing.T) {
+	f := newDockerAccountFixture(t, "", "codex", nil)
+	var calls [][]string
+	t.Cleanup(SetDockerExecForTest(func(_ context.Context, _ []string, args ...string) ([]byte, error) {
+		calls = append(calls, append([]string(nil), args...))
+		if out, err := fakeLocalDockerResponse(args); out != nil || err != nil {
+			return out, err
+		}
+		switch args[0] {
+		case "run":
+			return []byte(dockerCreatedID + "\n"), nil
+		case "cp", "rm":
+			return nil, nil
+		case "port":
+			return []byte("127.0.0.1:49152\n"), nil
+		case "exec":
+			joined := strings.Join(args, " ")
+			switch {
+			case strings.Contains(joined, "stat -c %u:%g "+accountContainerDirForTest):
+				return []byte("1000:1000\n"), nil
+			case strings.Contains(joined, "cat "+dockerBannerPath):
+				return []byte(`{"addr":":8000","token":"test-only","title":"account-boundary"}`), nil
+			default:
+				return nil, nil
+			}
+		default:
+			return nil, fmt.Errorf("unexpected docker call: %v", args)
+		}
+	}))
+
+	_, err := createDockerAccountSession(f, "codex", nil)
+	require.NoError(t, err)
+	foundOwnedServer := false
+	for _, call := range calls {
+		joined := strings.Join(call, " ")
+		if len(call) > 1 && call[0] == "exec" && call[1] == "-d" &&
+			strings.Contains(joined, "--user 1000:1000") && strings.Contains(joined, "HOME=/af-home") {
+			foundOwnedServer = true
+		}
+	}
+	require.True(t, foundOwnedServer,
+		"the detached agent-server was not run as the bind-mounted account owner; calls=%v", calls)
+}

--- a/session/docker_account_findings_test.go
+++ b/session/docker_account_findings_test.go
@@ -149,6 +149,14 @@ func TestDockerAccount_RejectsIdentityRunArgs(t *testing.T) {
 	}
 }
 
+func TestDockerAccount_AllowsSimilarlyNamedMountTargets(t *testing.T) {
+	err := validateAccountDockerRunArgs(
+		[]string{"--mount", "type=bind,src=/tmp/cache,dst=/af-account-cache"},
+		"codex",
+	)
+	require.NoError(t, err)
+}
+
 func TestDockerAccount_UsesAMountFormThatAcceptsColonPaths(t *testing.T) {
 	home := filepath.Join(t.TempDir(), "af:home")
 	f := newDockerAccountFixture(t, home, "codex", nil)

--- a/session/docker_account_findings_test.go
+++ b/session/docker_account_findings_test.go
@@ -157,6 +157,18 @@ func TestDockerAccount_AllowsSimilarlyNamedMountTargets(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDockerAccount_RejectsNormalizedProtectedMountTargets(t *testing.T) {
+	tests := [][]string{
+		{"--mount", "type=bind,src=/tmp/other,dst=/af-account/"},
+		{"--mount", "type=bind,src=/tmp/other,dst=/af-account/auth.json"},
+		{"--volume", "/tmp/other:/af-home/."},
+	}
+	for _, args := range tests {
+		err := validateAccountDockerRunArgs(args, "codex")
+		require.Error(t, err, "normalized protected target escaped validation: %v", args)
+	}
+}
+
 func TestDockerAccount_UsesAMountFormThatAcceptsColonPaths(t *testing.T) {
 	home := filepath.Join(t.TempDir(), "af:home")
 	f := newDockerAccountFixture(t, home, "codex", nil)

--- a/session/docker_account_findings_test.go
+++ b/session/docker_account_findings_test.go
@@ -26,6 +26,8 @@ func newDockerAccountFixture(t *testing.T, home, agent string, runArgs []string)
 		home = t.TempDir()
 	}
 	t.Setenv("AGENT_FACTORY_HOME", home)
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv("DOCKER_CONTEXT", "")
 	require.NoError(t, config.SaveConfig(config.DefaultConfig()))
 	accountDir, err := agentaccount.Register(home, agent, "work")
 	require.NoError(t, err)
@@ -121,8 +123,11 @@ func TestDockerAccount_RejectsIdentityRunArgs(t *testing.T) {
 		wantErr string
 	}{
 		{name: "short env", args: []string{"-e", "OPENAI_API_KEY=repo-identity"}, wantErr: "OPENAI_API_KEY"},
+		{name: "short env equals", args: []string{"-e=CODEX_API_KEY=repo-identity"}, wantErr: "CODEX_API_KEY"},
 		{name: "long env", args: []string{"--env=CODEX_ACCESS_TOKEN=repo-identity"}, wantErr: "CODEX_ACCESS_TOKEN"},
 		{name: "env file", args: []string{"--env-file", "repo.env"}, wantErr: "env-file"},
+		{name: "account mount", args: []string{"--mount", "type=bind,src=/tmp/other,dst=/af-account"}, wantErr: "account mount"},
+		{name: "account volume", args: []string{"-v", "/tmp/other:/af-account"}, wantErr: "account mount"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/session/instance_account_roundtrip_test.go
+++ b/session/instance_account_roundtrip_test.go
@@ -72,15 +72,27 @@ func TestAccountScoping_RefusesUnsupportedCombinations(t *testing.T) {
 	require.NoError(t, refuseOffBoxAccount(base))
 	require.NoError(t, refuseUnsupportedAccountAgent(base, base.Path))
 
-	// Off-box backends cannot carry the account, so they must refuse rather than
-	// run on the remote host's ambient credentials.
-	for _, kind := range []BackendKind{BackendDocker, BackendSSH, BackendSandbox, BackendHook} {
+	// Docker CARRIES the account now (#3082): the runtime already bind-mounts host
+	// paths into the container, so the account's directory is mounted where the
+	// in-container agent reads its home and the ambient credential mounts are
+	// dropped. Asserted explicitly rather than by removing it from the loop below,
+	// so a reader who finds this list does not "restore" docker to it.
+	docker := base
+	docker.Backend = BackendDocker
+	require.NoError(t, refuseOffBoxAccount(docker),
+		"docker can place the account, so an account-scoped create there must be allowed")
+
+	// The rest still cannot PLACE an account on the machine that runs the agent, so
+	// they must refuse rather than run on that host's ambient credentials.
+	for _, kind := range []BackendKind{BackendSSH, BackendSandbox, BackendHook} {
 		scoped := base
 		scoped.Backend = kind
 		err := refuseOffBoxAccount(scoped)
 		require.Error(t, err, "backend %s must refuse an account-scoped create", kind)
 		require.Contains(t, err.Error(), string(kind))
 		require.Contains(t, err.Error(), "ambient credentials")
+		require.Contains(t, err.Error(), "cannot place a credential account",
+			"the refusal must say af cannot PLACE the account there — the reason is now per-kind, not a blanket off-box rule")
 	}
 
 	// claude is ADMITTED now (#3083): af declares the arguments it appends to that

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/agentaccount"
 	"github.com/sachiniyer/agent-factory/internal/sessionenv"
 	"github.com/sachiniyer/agent-factory/log"
 )
@@ -161,6 +162,24 @@ func defaultBackendFactory(opts InstanceOptions, absPath string) (ProvisionResul
 	// means. Scoped to off-box kinds inside it: minting unconditionally would make
 	// every local create fail whenever require_token is off, turning a sandbox-only
 	// refusal into a total outage.
+	// Resolve the account to its DIRECTORY here, on the host, for a kind that can
+	// place it (#3082). The local path never needs this — its shim resolves the name
+	// inside the target process against that process's own AF home — but a
+	// provisioned machine has no registry to resolve against, so the host must
+	// resolve it and the provisioner must place it.
+	//
+	// Resolving here rather than in the provisioner is deliberate: Selected is what
+	// enforces the registry's guarantees (the account exists, and no ancestor of its
+	// path is a symlink out of the registry), and those must be checked on THIS
+	// machine, where the registry lives, before a path derived from them is handed
+	// to a runtime that will mount it.
+	if kind.CarriesAccount() && strings.TrimSpace(opts.Account) != "" {
+		account, aerr := resolveAccountForProvision(opts)
+		if aerr != nil {
+			return ProvisionResult{}, aerr
+		}
+		spec.Account = account
+	}
 	cred, err := mintForProvision(&spec, kind, opts.SandboxCredentials)
 	if err != nil {
 		return ProvisionResult{}, err
@@ -522,9 +541,28 @@ func resolvedProgramMarker(opts InstanceOptions) string {
 // refuseOffBoxAccount rejects an account-scoped session on a backend that cannot
 // yet carry the account.
 //
-// It gates on the backend being NOT local rather than on a list of remote kinds:
-// a backend added later is off-box until someone proves otherwise, so the
-// default for anything new is refusal rather than silent ambient credentials.
+// It still gates on the backend being NOT local rather than on a list of remote
+// kinds, and #3082 did not weaken that: a backend added later is off-box until
+// someone proves otherwise, so the default for anything new remains refusal
+// rather than silent ambient credentials. What changed is that docker can now
+// PROVE it, so it is exempted by name.
+//
+// WHY DOCKER AND NOT THE OTHERS, decided per backend rather than defaulted
+// (#3082):
+//
+//   - docker CAN place the account, and already has the mechanism. An account is
+//     an agent HOME directory, and the runtime already bind-mounts host paths into
+//     the container — today it mounts the operator's AMBIENT credentials, which is
+//     precisely the wrong-identity failure this refusal was protecting against.
+//     Pointing that mount at the account's directory is the whole fix.
+//   - ssh could transfer one — the runtime already streams the af binary to the
+//     remote — but that means writing the operator's live credentials onto a
+//     machine whose filesystem, other users and backups af does not control, for a
+//     feature whose purpose is to NARROW where an identity may be used. That is a
+//     posture decision, not wiring, and it is not taken here.
+//   - sandbox and hook run the operator's own provisioner. Nothing in that contract
+//     promises a place to put an account, so refusing is the permanent answer
+//     rather than a temporary one.
 func refuseOffBoxAccount(opts InstanceOptions) error {
 	if strings.TrimSpace(opts.Account) == "" {
 		return nil
@@ -533,13 +571,13 @@ func refuseOffBoxAccount(opts InstanceOptions) error {
 	if kind == "" {
 		kind = BackendLocal
 	}
-	if kind == BackendLocal {
+	if kind == BackendLocal || kind.CarriesAccount() {
 		return nil
 	}
 	return fmt.Errorf(
-		"account %q cannot be used with the %s backend: af cannot yet carry a credential account into an "+
-			"off-box session, and running it there would use that host's ambient credentials while reporting "+
-			"the account you asked for; create this session on the local backend, or omit --account",
+		"account %q cannot be used with the %s backend: af cannot place a credential account on that machine, "+
+			"and running there would use its ambient credentials while reporting the account you asked for; "+
+			"create this session on the local or docker backend, or omit --account",
 		opts.Account, kind)
 }
 
@@ -616,4 +654,29 @@ func refuseUnsupportedAccountAgent(opts InstanceOptions, absPath string) error {
 			"verify how it launches that agent, so the session could start on the ambient identity or exit "+
 			"immediately; account scoping currently supports claude and codex",
 		opts.Account, agent)
+}
+
+// resolveAccountForProvision resolves opts.Account to the registered account's
+// directory on this host.
+//
+// The agent is derived from the session's program, matching how every other
+// account surface names one: an account belongs to an agent, and "codex" and
+// "claude" keep separate registries.
+func resolveAccountForProvision(opts InstanceOptions) (sessionenv.Account, error) {
+	home, err := config.GetConfigDir()
+	if err != nil {
+		return sessionenv.Account{}, fmt.Errorf("cannot resolve account %q: %w", opts.Account, err)
+	}
+	agent := sessionenv.AgentForCommand(opts.Program)
+	account, err := agentaccount.Selected(home, agent, opts.Account, "")
+	if err != nil {
+		return sessionenv.Account{}, err
+	}
+	if account.Dir == "" {
+		// Selected returns a zero Account for an empty name, which the caller has
+		// already excluded. A zero Dir here would mean an unscoped provision that
+		// still reported an account, so refuse rather than proceed.
+		return sessionenv.Account{}, fmt.Errorf("account %q resolved to no directory", opts.Account)
+	}
+	return account, nil
 }

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -174,7 +174,7 @@ func defaultBackendFactory(opts InstanceOptions, absPath string) (ProvisionResul
 	// machine, where the registry lives, before a path derived from them is handed
 	// to a runtime that will mount it.
 	if kind.CarriesAccount() && strings.TrimSpace(opts.Account) != "" {
-		account, aerr := resolveAccountForProvision(opts)
+		account, aerr := resolveAccountForProvision(absPath, opts.Program, opts.Account)
 		if aerr != nil {
 			return ProvisionResult{}, aerr
 		}
@@ -662,13 +662,24 @@ func refuseUnsupportedAccountAgent(opts InstanceOptions, absPath string) error {
 // The agent is derived from the session's program, matching how every other
 // account surface names one: an account belongs to an agent, and "codex" and
 // "claude" keep separate registries.
-func resolveAccountForProvision(opts InstanceOptions) (sessionenv.Account, error) {
+func resolveAccountForProvision(repoRoot, program, accountName string) (sessionenv.Account, error) {
 	home, err := config.GetConfigDir()
 	if err != nil {
-		return sessionenv.Account{}, fmt.Errorf("cannot resolve account %q: %w", opts.Account, err)
+		return sessionenv.Account{}, fmt.Errorf("cannot resolve account %q: %w", accountName, err)
 	}
-	agent := sessionenv.AgentForCommand(opts.Program)
-	account, err := agentaccount.Selected(home, agent, opts.Account, "")
+	requestedAgent := sessionenv.AgentForCommand(program)
+	resolved, err := resolveRepoConfig(repoRoot)
+	if err != nil {
+		return sessionenv.Account{}, fmt.Errorf("cannot resolve account %q against the session program: %w", accountName, err)
+	}
+	resolvedProgram := config.ResolveProgram(&resolved.Config, program)
+	resolvedAgent := sessionenv.AgentForCommand(resolvedProgram)
+	if resolvedAgent != requestedAgent {
+		return sessionenv.Account{}, fmt.Errorf(
+			"account %q is a %s account, but this session resolves %s to a %s command; account namespaces are separate, so the Docker session would not use the identity you selected",
+			accountName, requestedAgent, requestedAgent, resolvedAgent)
+	}
+	account, err := agentaccount.Selected(home, requestedAgent, accountName, "")
 	if err != nil {
 		return sessionenv.Account{}, err
 	}
@@ -676,7 +687,7 @@ func resolveAccountForProvision(opts InstanceOptions) (sessionenv.Account, error
 		// Selected returns a zero Account for an empty name, which the caller has
 		// already excluded. A zero Dir here would mean an unscoped provision that
 		// still reported an account, so refuse rather than proceed.
-		return sessionenv.Account{}, fmt.Errorf("account %q resolved to no directory", opts.Account)
+		return sessionenv.Account{}, fmt.Errorf("account %q resolved to no directory", accountName)
 	}
 	return account, nil
 }

--- a/session/runtime.go
+++ b/session/runtime.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/sessionenv"
 )
 
 // BackendKind names a session runtime family (#1592 Phase 4 PR3). It is the
@@ -96,6 +97,15 @@ type ProvisionSpec struct {
 	// Only off-box runtimes (docker/ssh/hook) honor it; the in-process local
 	// runtime never clones, so it is a no-op there.
 	RestoreBranch string
+	// Account scopes this session to a registered credential account (#3082), for
+	// the off-box kinds that can carry one. Zero value means unscoped.
+	//
+	// The whole Account travels, not just its name, and that is the point: only the
+	// NAME goes into argv on the local path, because the `af` shim there resolves it
+	// against its own AF home. A provisioned machine has no such registry — the
+	// container's `af` would look up an account that does not exist in it — so an
+	// off-box backend has to carry the resolved DIRECTORY and place it itself.
+	Account sessionenv.Account
 	// SessionEnvPassthrough contains exact global-only variable names approved
 	// for the agent. Sandboxed runtimes pass names, never values, to their
 	// version-matched agent-server.
@@ -183,6 +193,23 @@ var backendProvisionsOffBox = map[BackendKind]bool{
 // An unregistered kind reports false, which is the conservative answer —
 // ParseBackendKind rejects those before they reach a runtime.
 func (k BackendKind) ProvisionsOffBox() bool { return backendProvisionsOffBox[k] }
+
+// CarriesAccount reports whether this kind's provisioner can place a registered
+// credential account on the machine that runs the agent (#3082).
+//
+// Only docker, and the reason is a mechanism rather than a preference: an account
+// is an agent HOME directory, and the docker runtime already bind-mounts host
+// paths into the container, so the account's directory can be mounted where the
+// in-container agent reads its home. ssh, sandbox and hook have no way to place a
+// directory they can prove is the account — see refuseOffBoxAccount for why that
+// is a decision and not a gap.
+//
+// Local is deliberately NOT listed: it needs no placing, applies the account
+// through the exec shim, and is handled by its own branch. A kind that answers
+// true here is promising it will honour ProvisionSpec.Account.
+func (k BackendKind) CarriesAccount() bool {
+	return k == BackendDocker
+}
 
 // InjectsSandboxCallback reports whether this kind's provisioner actually
 // delivers the #2999 callback credential into the workspace.


### PR DESCRIPTION
Closes #3082

#3075 refused every off-box account-scoped create rather than shipping one broken. This threads the account through `ProvisionSpec` and removes the refusal **for docker** — the one backend that can prove it placed the account.

## Docker's failure was worse than the issue states

`backend_docker.go` already resolves the **daemon user's home** and bind-mounts the agent's credential files into the container. So an account-scoped docker create would not merely have inherited ambient credentials passively — it would have **mounted the wrong identity in and used it**, while the instance recorded the account the user asked for.

That is also why docker needs no new mechanism. An account is an agent HOME directory; the runtime already mounts host paths. The account's directory is mounted at a fixed container path, and the agent's own config var (`CODEX_HOME` / `CLAUDE_CONFIG_DIR`) points at it.

## Three decisions worth reviewing

**The account REPLACES the ambient mounts, it does not join them.** That is the exclusivity property: a container built for an account carries nothing resolved from the daemon user's home, so it cannot hold two identities and pick one by path precedence.

**It is independent of `docker.mount_agent_credentials`.** That key is the opt-in for lending the container the *ambient* identity. Gating an explicitly named account on it would leave the session with no credentials whenever the key is off, which reads to a user as "the account did not work".

**The mount is read-WRITE**, unlike the ambient credential mounts. An account is the agent's whole home — auth, history, settings, discovered skills — and an agent that cannot write it cannot record a session. That follows from the account model rather than from a looser posture.

## Where the account is resolved, and why not where the local path resolves it

On the **host**, at provision time. `Selected()` is what enforces the registry's guarantees — including that no ancestor of the path is a symlink out of the registry — and those must be checked on the machine where the registry lives, before a derived path is handed to a runtime that will mount it.

The local mechanism cannot be reused: it sends only the account **name** in argv, and the shim resolves it against *its own* AF home. A container has no such registry, so the in-container `af` would look up an account that does not exist there.

## ssh, sandbox and hook still refuse — per backend, deliberately

The issue asked for this to be decided rather than defaulted.

- **ssh** could transfer a directory; the runtime already streams the `af` binary to the remote. But that means writing the operator's live credentials onto a machine whose filesystem, other users and backups af does not control, for a feature whose purpose is to **narrow** where an identity may be used. A posture decision, not wiring, and not taken here.
- **sandbox / hook** run the operator's own provisioner. Nothing in that contract promises a place to put an account, so refusing is the permanent answer rather than a temporary one.

The refusal still gates on **not local** and exempts docker by name, so a backend added later is off-box until it proves otherwise. Its message now says af cannot *place* the account there, rather than that it cannot *carry* one.

## Tests

The issue's bar is exclusivity, not presence, and that is what these assert: two accounts resolve to **different** mount sources; both land on the **same fixed container path** so no host layout crosses the boundary; each agent gets its **own** config var (a wrong one would silently leave the agent on the container's default home); and an unsupported agent or an unscoped session produces **no** mount at all.

`gofmt`, `go build ./...`, `go vet`, `golangci-lint --fast`, `scripts/lint-file-length.sh` clean. Session tests were not run on this host — CI is their first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)