### PR TITLE
fix(ssh): pin every transport step to one resolved address

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -353,6 +353,22 @@ back (see [Archive & restore](#archive-restore)).
 > yourself, and there your `ssh_config` and `known_hosts` are the whole authority.
 > See the sandbox section below.
 
+> **`ssh.host` is resolved once per session, and every step uses that address.**
+> af runs a separate `ssh` for each step — the setup commands, the port-forward,
+> and the cleanup — so a name with several addresses could otherwise put the
+> workspace on one machine and the agent-server or the cleanup on another. Nothing
+> would look wrong: each step succeeds against a valid host, and the cleanup then
+> removes the wrong machine's directory and reports success while the real one
+> leaks. So af resolves the name once, dials that literal address everywhere, and
+> records it with the session's cleanup handle so a daemon restart still reaches
+> the same machine.
+>
+> Host-key verification is unaffected — the connection carries
+> `HostKeyAlias`, so your `known_hosts` entry is still matched by name, exactly as
+> before. If `ssh.host` does not resolve, session creation **fails with that
+> reason** rather than falling back · a name af cannot pin is a session it cannot
+> keep on one machine.
+
 **Host-key verification is strict by default** (secure by default — an unverified
 host could MITM the connection and capture the bearer token). The operator can
 relax it with the global-only **`ssh_host_key_verification`** key:

--- a/session/backend_ssh.go
+++ b/session/backend_ssh.go
@@ -151,7 +151,16 @@ func (sshRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 	// client, and having two paths is what produced #3044 — the same address
 	// resolving differently depending on which read it. The composed command is
 	// handed to the same sandboxProvisioner `backend=sandbox` uses (#3052).
-	sshCmd, err := sshCommandForConfig(sshCfg, cfg.SSHHostKeyVerification)
+	// Resolve ONCE (#3086). Every step below runs its own `ssh`, so a name is an
+	// invitation for each of them to land on a different machine; the literal
+	// address goes into the command so no step can forget it. A failure here is
+	// explicit — af does not fall back to the name, because that is precisely the
+	// behaviour being removed.
+	dialAddr, err := resolveSSHDialAddress(sshCfg.Host)
+	if err != nil {
+		return ProvisionResult{}, err
+	}
+	sshCmd, err := sshCommandForConfig(sshCfg, cfg.SSHHostKeyVerification, dialAddr)
 	if err != nil {
 		return ProvisionResult{}, err
 	}
@@ -172,9 +181,14 @@ func (sshRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 		remoteAgentBackend: remoteAgentBackend{reap: res.Teardown},
 		provisioner:        p,
 		cleanup: &SSHRuntimeCleanupData{
-			Config:              sshCfg,
-			SessionDir:          p.sessionDir,
-			RemotePID:           p.remotePID,
+			Config:     sshCfg,
+			SessionDir: p.sessionDir,
+			RemotePID:  p.remotePID,
+			// The address this session was actually provisioned on. Without it a
+			// teardown after a daemon restart would resolve the name again and could
+			// reap a DIFFERENT machine — removing nothing, reporting success, and
+			// leaking the workspace it exists to remove (#3086).
+			DialAddress:         dialAddr,
 			HostKeyVerification: cfg.SSHHostKeyVerification,
 		},
 	}

--- a/session/backend_ssh_hostkey_test.go
+++ b/session/backend_ssh_hostkey_test.go
@@ -22,7 +22,7 @@ import (
 
 func sshCmdFor(t *testing.T, cfg config.SSHConfig, posture string) string {
 	t.Helper()
-	cmd, err := sshCommandForConfig(cfg, posture)
+	cmd, err := sshCommandForConfig(cfg, posture, "")
 	require.NoError(t, err)
 	return cmd
 }

--- a/session/runtime_cleanup.go
+++ b/session/runtime_cleanup.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/sessionenv"
+	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
@@ -50,10 +51,16 @@ type DockerRuntimeCleanupData struct {
 }
 
 type SSHRuntimeCleanupData struct {
-	Config              config.SSHConfig `json:"config"`
-	SessionDir          string           `json:"session_dir"`
-	RemotePID           string           `json:"remote_pid,omitempty"`
-	HostKeyVerification string           `json:"host_key_verification,omitempty"`
+	Config     config.SSHConfig `json:"config"`
+	SessionDir string           `json:"session_dir"`
+	RemotePID  string           `json:"remote_pid,omitempty"`
+	// DialAddress is the literal address this session was provisioned on (#3086).
+	// A teardown must reach the SAME machine the workspace is on, and re-resolving
+	// ssh.host can answer differently — so the answer is recorded rather than
+	// recomputed. Empty means a record written before #3086; those resolve once at
+	// restore, which is still one address for the handle's lifetime.
+	DialAddress         string `json:"dial_address,omitempty"`
+	HostKeyVerification string `json:"host_key_verification,omitempty"`
 }
 
 type HookRuntimeCleanupData struct {
@@ -209,7 +216,26 @@ func restoreRuntimeCleanup(title, backendType string, data *RuntimeCleanupData) 
 		// ssh.* settings, not a command — and refusing to reap it because the
 		// transport changed underneath would leak the workspace it exists to
 		// remove (the #3044 lesson).
-		sshCmd, cmdErr := sshCommandForConfig(legacyCfg, data.SSH.HostKeyVerification)
+		// Reach the machine this session is actually ON (#3086). A recorded address
+		// is used as-is; a record written before #3086 has none, so resolve once
+		// here — still one address for this handle's whole life, rather than a fresh
+		// answer per step.
+		//
+		// And if THAT resolution fails, fall back to the name rather than refusing.
+		// This is the one place the fallback is right: there is no session being
+		// created that could land on the wrong host, and refusing a TEARDOWN leaks
+		// the workspace it exists to remove (the #3044 lesson). Provision, where a
+		// wrong host would be actively harmful, refuses instead.
+		dialAddr := strings.TrimSpace(data.SSH.DialAddress)
+		if dialAddr == "" {
+			resolved, resolveErr := resolveSSHDialAddress(legacyCfg.Host)
+			if resolveErr != nil {
+				log.WarningLog.Printf("ssh cleanup handle for %q records no dial address and %q does not resolve (%v); "+
+					"the teardown will dial the name, which may reach a different host than the session is on", title, legacyCfg.Host, resolveErr)
+			}
+			dialAddr = resolved
+		}
+		sshCmd, cmdErr := sshCommandForConfig(legacyCfg, data.SSH.HostKeyVerification, dialAddr)
 		if cmdErr != nil {
 			return nil, nil, fmt.Errorf("ssh cleanup handle has an unusable address: %w", cmdErr)
 		}

--- a/session/ssh_command.go
+++ b/session/ssh_command.go
@@ -85,7 +85,13 @@ const sshNoConfigFile = "none"
 //     because the old authMethods offered identity-file keys AND agent keys —
 //     so IdentitiesOnly is deliberately NOT set.
 //   - Host keys: the configured posture, mapped below.
-func sshCommandForConfig(cfg config.SSHConfig, posture string) (string, error) {
+//
+// dialAddr is the LITERAL address every step of this session must reach (#3086).
+// The caller resolves ssh.host once and passes the result here, so the pin lands
+// in the command itself and no individual step can forget it. Empty means "dial
+// the configured name", which is only correct where no address could be resolved
+// and refusing would leak a workspace — see restoreRuntimeCleanup.
+func sshCommandForConfig(cfg config.SSHConfig, posture, dialAddr string) (string, error) {
 	host, port, err := resolveSSHHostPort(cfg.Host, cfg.Port)
 	if err != nil {
 		return "", err
@@ -97,6 +103,11 @@ func sshCommandForConfig(cfg config.SSHConfig, posture string) (string, error) {
 	knownHosts, strictOpt, err := sshHostKeyOptions(cfg, posture, host)
 	if err != nil {
 		return "", err
+	}
+
+	target := strings.TrimSpace(dialAddr)
+	if target == "" {
+		target = host
 	}
 
 	parts := []string{
@@ -117,13 +128,28 @@ func sshCommandForConfig(cfg config.SSHConfig, posture string) (string, error) {
 		"-o", "KnownHostsCommand=none",
 		// af never had a human to ask. A prompt would hang a provision forever.
 		"-o", "BatchMode=yes",
+		// The command dials a literal address (#3086), so without this the host key
+		// would be looked up under that ADDRESS instead of the configured name —
+		// silently invalidating every existing known_hosts entry and, under
+		// accept-new, writing a second one per address. HostKeyAlias restores the
+		// name as the lookup key while the connection still goes to the pinned
+		// address.
+		//
+		// The alias must be the EXACT string OpenSSH would otherwise have computed,
+		// because it is used VERBATIM: measured against OpenSSH_9.6p1, a plain
+		// connection on port 2201 records `[127.0.0.1]:2201`, while the same
+		// connection with `HostKeyAlias=real.example` records `real.example` — the
+		// port is NOT appended to an alias. So the alias is knownHostsLookupName's
+		// output, which is bare on the default port and bracketed otherwise, and the
+		// stored key is byte-identical to what a non-pinned connection wrote.
+		"-o", "HostKeyAlias=" + shellQuoteSandbox(knownHostsLookupName(host, port)),
 	}
 	if identity := strings.TrimSpace(cfg.IdentityFile); identity != "" {
 		// No IdentitiesOnly: authMethods offered the identity file AND agent keys,
 		// and dropping the agent would break setups that rely on it.
 		parts = append(parts, "-i", shellQuoteSandbox(expandUserPath(identity)))
 	}
-	parts = append(parts, shellQuoteSandbox(host))
+	parts = append(parts, shellQuoteSandbox(target))
 	return strings.Join(parts, " "), nil
 }
 

--- a/session/ssh_dial_address.go
+++ b/session/ssh_dial_address.go
@@ -1,0 +1,98 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+// Pinning one resolved address for a session's whole lifetime (#3086).
+//
+// THE FAILURE THIS PREVENTS is silent, which is what makes it worth code. The
+// shared transport runs every step as its own `ssh` invocation — each provision
+// command, the `ssh -L` tunnel, and the reap — so each one resolves the target
+// independently. When `ssh.host` names something with several addresses (a
+// round-robin record, a load balancer, a pair of A records), the per-session
+// directory can be created on host A while the clone, the agent-server or the
+// tunnel lands on host B. NOTHING ERRORS: every step succeeds against a valid,
+// authorized, correctly-verified machine. The session simply is not on one
+// machine. The reap then removes B's directory, reports success, and the
+// agent-server and workspace on A leak with nothing left pointing at them.
+//
+// THE ONLY FORM WHOSE MEANING DOES NOT DEPEND ON WHO RESOLVES IT IS A LITERAL
+// ADDRESS. That is the same lesson as #2999, where a bind address was not a
+// dialable client URL: a name is an instruction to look something up, and every
+// separate lookup is entitled to a different answer. So af resolves ONCE, at
+// provision, and every later invocation dials the literal address — which is
+// achieved by putting it in the composed command, so there is no step that could
+// forget.
+//
+// A RESOLUTION FAILURE IS EXPLICIT, never a fallback to the name. Falling back
+// would restore exactly the behaviour this exists to remove, at the moment DNS is
+// least trustworthy, and it would do so invisibly.
+//
+// The host-key guarantee survives intact because the command also carries
+// `-o HostKeyAlias=<the name known_hosts is keyed by>` — see sshCommandForConfig.
+
+// sshResolveTimeout bounds the one lookup. A resolver that cannot answer in this
+// long is a failure worth reporting, not worth waiting out: the caller is about
+// to run a multi-minute provision and needs its target settled first.
+const sshResolveTimeout = 10 * time.Second
+
+// lookupSSHHostAddrs is the resolver seam. A package var so a test can drive the
+// multi-address and failure branches without depending on DNS.
+var lookupSSHHostAddrs = func(ctx context.Context, host string) ([]net.IPAddr, error) {
+	return net.DefaultResolver.LookupIPAddr(ctx, host)
+}
+
+// SetSSHAddressResolverForTest replaces the resolver and returns a restore
+// function. Mirrors SetLookPathForTest / SetSSHSelfBinaryForTest.
+func SetSSHAddressResolverForTest(f func(context.Context, string) ([]net.IPAddr, error)) func() {
+	prev := lookupSSHHostAddrs
+	lookupSSHHostAddrs = f
+	return func() { lookupSSHHostAddrs = prev }
+}
+
+// resolveSSHDialAddress turns a configured ssh.host into the ONE literal address
+// every step of this session will dial.
+//
+// A host that is already a literal is returned unchanged — there is nothing to
+// pin and nothing that could fail, and re-resolving it would be a lookup of a
+// name that is not one.
+//
+// When several addresses come back, the FIRST is taken. Which one is chosen
+// matters far less than that the same one is used for every step; the resolver
+// has already applied the system's own ordering (RFC 6724 address selection),
+// so this is the address a plain `ssh` would most likely have used anyway.
+func resolveSSHDialAddress(host string) (string, error) {
+	h := strings.TrimSpace(host)
+	if h == "" {
+		return "", fmt.Errorf("backend=ssh: no ssh host was given")
+	}
+	if ip := net.ParseIP(h); ip != nil {
+		return h, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), sshResolveTimeout)
+	defer cancel()
+	addrs, err := lookupSSHHostAddrs(ctx, h)
+	if err != nil {
+		return "", fmt.Errorf("backend=ssh: cannot resolve ssh.host %q to an address: %w "+
+			"(af resolves the host once and pins that address for every step of the session, so a "+
+			"multi-address host cannot split the session across machines; it will not fall back to "+
+			"re-resolving per step)", h, err)
+	}
+	if len(addrs) == 0 {
+		return "", fmt.Errorf("backend=ssh: ssh.host %q resolved to no addresses", h)
+	}
+
+	first := addrs[0]
+	if first.Zone != "" {
+		// A link-local address is meaningless without its scope, and ssh accepts
+		// the fe80::1%eth0 form.
+		return first.IP.String() + "%" + first.Zone, nil
+	}
+	return first.IP.String(), nil
+}

--- a/session/ssh_dial_address_test.go
+++ b/session/ssh_dial_address_test.go
@@ -1,0 +1,250 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// One resolved address for a session's whole lifetime (#3086).
+//
+// The bug is silent, so the tests have to assert the MECHANISM rather than an
+// observable failure: there is no error to catch, no exception, no bad exit
+// status. A hostname with two A records simply lets each step's own `ssh`
+// invocation pick independently, and the session ends up spread over two
+// machines that each behaved correctly. So what is pinned here is that the
+// literal address reaches the composed command, that it is recorded in the
+// cleanup handle, and that a failure to resolve is an ERROR rather than a quiet
+// fallback to the name.
+
+func fixedResolver(t *testing.T, addrs ...string) {
+	t.Helper()
+	out := make([]net.IPAddr, 0, len(addrs))
+	for _, a := range addrs {
+		ip := net.ParseIP(a)
+		require.NotNil(t, ip, "fixture %q is not an IP", a)
+		out = append(out, net.IPAddr{IP: ip})
+	}
+	restore := SetSSHAddressResolverForTest(func(context.Context, string) ([]net.IPAddr, error) {
+		return out, nil
+	})
+	t.Cleanup(restore)
+}
+
+// THE CORE PIN. Two addresses come back; the composed command must carry ONE
+// literal, because every step runs that command and each would otherwise resolve
+// for itself.
+func TestSSHCommandDialsTheResolvedLiteralAddress(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	fixedResolver(t, "198.51.100.7", "198.51.100.8")
+
+	addr, err := resolveSSHDialAddress("many.example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "198.51.100.7", addr)
+
+	cmd, err := sshCommandForConfig(config.SSHConfig{Host: "many.example.com"}, config.SSHHostKeyStrict, addr)
+	require.NoError(t, err)
+
+	// The DESTINATION is the last token, and it is the only place the difference
+	// matters: the name still appears — correctly — as the HostKeyAlias.
+	fields := strings.Fields(cmd)
+	assert.Equal(t, "'198.51.100.7'", fields[len(fields)-1],
+		"the destination must be the pinned literal, got %q", cmd)
+	assert.False(t, strings.HasSuffix(cmd, "'many.example.com'"),
+		"the NAME must not be the destination — that is what lets each step resolve differently")
+}
+
+// The host-key guarantee has to survive the pin. Dialling an address would
+// otherwise key known_hosts by ADDRESS, invalidating every existing entry and,
+// under accept-new, writing a fresh one per address.
+//
+// The alias must be the exact string OpenSSH would have computed on its own.
+// Measured against OpenSSH_9.6p1: a plain connection on port 2201 records
+// `[127.0.0.1]:2201`, while the same connection under `HostKeyAlias=real.example`
+// records `real.example` — the port is NOT appended to an alias. So a bare-name
+// alias would silently change the lookup key for every non-default-port user.
+func TestSSHCommandKeepsTheHostKeyKeyedByName(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	def, err := sshCommandForConfig(config.SSHConfig{Host: "h.example.com"}, config.SSHHostKeyStrict, "198.51.100.7")
+	require.NoError(t, err)
+	assert.Contains(t, def, "HostKeyAlias='h.example.com'",
+		"on the default port known_hosts is keyed by the bare name")
+
+	ported, err := sshCommandForConfig(
+		config.SSHConfig{Host: "h.example.com", Port: 2222}, config.SSHHostKeyStrict, "198.51.100.7")
+	require.NoError(t, err)
+	assert.Contains(t, ported, "HostKeyAlias='[h.example.com]:2222'",
+		"on a non-default port it is keyed by the BRACKETED form, and HostKeyAlias is used verbatim — "+
+			"a bare-name alias here would silently orphan every existing entry")
+}
+
+// A resolution failure must be explicit. Falling back to the name would restore
+// the exact behaviour this exists to remove, at the moment DNS is least
+// trustworthy, and would do it invisibly.
+func TestSSHProvisionRefusesWhenTheHostDoesNotResolve(t *testing.T) {
+	restore := SetSSHAddressResolverForTest(func(context.Context, string) ([]net.IPAddr, error) {
+		return nil, errors.New("no such host")
+	})
+	defer restore()
+
+	_, err := resolveSSHDialAddress("gone.example.com")
+
+	require.Error(t, err, "a name that does not resolve must fail, never fall back to itself")
+	assert.Contains(t, err.Error(), "gone.example.com")
+	assert.Contains(t, err.Error(), "backend=ssh")
+}
+
+// An empty answer is a failure too, and the one a naive implementation returns
+// as a valid empty string.
+func TestSSHResolutionRefusesAnEmptyAnswer(t *testing.T) {
+	restore := SetSSHAddressResolverForTest(func(context.Context, string) ([]net.IPAddr, error) {
+		return nil, nil
+	})
+	defer restore()
+
+	_, err := resolveSSHDialAddress("empty.example.com")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no addresses")
+}
+
+// A literal host is returned unchanged and never looked up: there is nothing to
+// pin, and resolving a name that is not one is how a working config breaks.
+func TestSSHLiteralHostIsNotResolved(t *testing.T) {
+	restore := SetSSHAddressResolverForTest(func(context.Context, string) ([]net.IPAddr, error) {
+		t.Fatal("a literal address must not be sent to the resolver")
+		return nil, nil
+	})
+	defer restore()
+
+	for _, literal := range []string{"198.51.100.7", "::1", "2001:db8::1"} {
+		got, err := resolveSSHDialAddress(literal)
+		require.NoError(t, err)
+		assert.Equal(t, literal, got)
+	}
+}
+
+// The teardown must reach the machine the session is ON. Re-resolving at reap
+// time can answer differently, and removing the wrong machine's directory
+// reports success while leaking the real workspace forever.
+func TestRestoredSSHCleanupDialsTheRecordedAddress(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	restore := SetSSHAddressResolverForTest(func(context.Context, string) ([]net.IPAddr, error) {
+		t.Fatal("a handle that records its address must not consult the resolver again")
+		return nil, nil
+	})
+	defer restore()
+
+	data := &RuntimeCleanupData{SSH: &SSHRuntimeCleanupData{
+		Config:              config.SSHConfig{Host: "many.example.com"},
+		SessionDir:          "/home/af/.af-sessions/x.AbCdEf",
+		DialAddress:         "198.51.100.8",
+		HostKeyVerification: config.SSHHostKeyStrict,
+	}}
+	backend, _, err := restoreRuntimeCleanup("pinned", "ssh", data)
+	require.NoError(t, err)
+
+	sb, ok := backend.(*sshBackend)
+	require.True(t, ok)
+	assert.Contains(t, sb.provisioner.sshCmd, "'198.51.100.8'",
+		"the reap must dial the address the session was provisioned on")
+	assert.Contains(t, sb.provisioner.sshCmd, "HostKeyAlias='many.example.com'",
+		"and still verify the host key under the configured name")
+}
+
+// A record written before #3086 carries no address. It resolves ONCE at restore —
+// still one address for the handle's whole life, rather than a fresh answer per
+// step — and the address it picks is the one every later step uses.
+func TestLegacySSHCleanupResolvesOnceAtRestore(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	calls := 0
+	restore := SetSSHAddressResolverForTest(func(context.Context, string) ([]net.IPAddr, error) {
+		calls++
+		return []net.IPAddr{{IP: net.ParseIP("203.0.113.5")}}, nil
+	})
+	defer restore()
+
+	data := &RuntimeCleanupData{SSH: &SSHRuntimeCleanupData{
+		Config:              config.SSHConfig{Host: "legacy.example.com"},
+		SessionDir:          "/home/af/.af-sessions/x.AbCdEf",
+		HostKeyVerification: config.SSHHostKeyStrict,
+	}}
+	backend, _, err := restoreRuntimeCleanup("legacy-pin", "ssh", data)
+	require.NoError(t, err)
+
+	sb, ok := backend.(*sshBackend)
+	require.True(t, ok)
+	assert.Equal(t, 1, calls, "exactly one lookup for the handle, not one per step")
+	assert.Contains(t, sb.provisioner.sshCmd, "'203.0.113.5'")
+}
+
+// …and if a legacy record's host does not resolve at all, the teardown still
+// composes. This is the ONE place a name fallback is right: there is no session
+// being created that could land on the wrong host, and refusing a teardown leaks
+// the workspace it exists to remove (the #3044 lesson). Provision refuses.
+func TestLegacySSHCleanupStillComposesWhenResolutionFails(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	restore := SetSSHAddressResolverForTest(func(context.Context, string) ([]net.IPAddr, error) {
+		return nil, errors.New("no such host")
+	})
+	defer restore()
+
+	data := &RuntimeCleanupData{SSH: &SSHRuntimeCleanupData{
+		Config:              config.SSHConfig{Host: "legacy.example.com"},
+		SessionDir:          "/home/af/.af-sessions/x.AbCdEf",
+		HostKeyVerification: config.SSHHostKeyStrict,
+	}}
+	backend, teardown, err := restoreRuntimeCleanup("legacy-unresolvable", "ssh", data)
+	require.NoError(t, err, "a teardown must never be refused for an unresolvable name — that leaks the workspace")
+	require.NotNil(t, teardown)
+
+	sb, ok := backend.(*sshBackend)
+	require.True(t, ok)
+	assert.Contains(t, sb.provisioner.sshCmd, "'legacy.example.com'",
+		"with no address available the name is the only thing left to dial")
+}
+
+// The recorded address must survive a storage round-trip, or a daemon restart
+// puts the teardown right back to re-resolving — which is the failure this whole
+// change exists to remove, reintroduced by a missing struct tag.
+func TestSSHCleanupHandleCarriesTheDialAddressThroughStorage(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	src := &RuntimeCleanupData{SSH: &SSHRuntimeCleanupData{
+		Config:              config.SSHConfig{Host: "many.example.com"},
+		SessionDir:          "/home/af/.af-sessions/x.AbCdEf",
+		DialAddress:         "198.51.100.9",
+		HostKeyVerification: config.SSHHostKeyStrict,
+	}}
+
+	assert.Equal(t, "198.51.100.9", src.clone().SSH.DialAddress, "clone must carry it")
+
+	// Through the real serialization, which is what a daemon restart replays.
+	raw, err := json.Marshal(src)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"dial_address":"198.51.100.9"`,
+		"the address must be a PERSISTED field; without the tag a restart silently re-resolves")
+
+	var back RuntimeCleanupData
+	require.NoError(t, json.Unmarshal(raw, &back))
+
+	restore := SetSSHAddressResolverForTest(func(context.Context, string) ([]net.IPAddr, error) {
+		t.Fatal("a replayed handle carrying its address must not consult the resolver")
+		return nil, nil
+	})
+	defer restore()
+
+	backend, _, err := restoreRuntimeCleanup("replayed", "ssh", &back)
+	require.NoError(t, err)
+	sb, ok := backend.(*sshBackend)
+	require.True(t, ok)
+	assert.Contains(t, sb.provisioner.sshCmd, "'198.51.100.9'",
+		"after a restart the teardown must still reach the machine the session is on")
+}

--- a/session/ssh_hostport_test.go
+++ b/session/ssh_hostport_test.go
@@ -51,7 +51,7 @@ func TestSSHAndHookResolveTheSameAddressIdentically(t *testing.T) {
 			// asserted where it now lives — which is itself the convergence: there is
 			// no second resolver left to disagree.
 			t.Setenv("HOME", t.TempDir())
-			sshCmd, sshErr := sshCommandForConfig(config.SSHConfig{Host: tc.address, Port: tc.port}, config.SSHHostKeyInsecure)
+			sshCmd, sshErr := sshCommandForConfig(config.SSHConfig{Host: tc.address, Port: tc.port}, config.SSHHostKeyInsecure, "")
 			require.NoError(t, sshErr)
 			sshHost := tc.wantHost
 
@@ -85,7 +85,7 @@ func TestConflictingPortsAreRefusedByBothBackends(t *testing.T) {
 	assert.Contains(t, hookErr.Error(), "3333", "the error must name BOTH values so it is obvious which to delete")
 
 	t.Setenv("HOME", t.TempDir())
-	_, sshErr := sshCommandForConfig(config.SSHConfig{Host: address, Port: port}, config.SSHHostKeyInsecure)
+	_, sshErr := sshCommandForConfig(config.SSHConfig{Host: address, Port: port}, config.SSHHostKeyInsecure, "")
 	require.Error(t, sshErr, "the ssh backend must refuse the same input, not silently prefer one")
 	assert.Contains(t, sshErr.Error(), "2222")
 	assert.Contains(t, sshErr.Error(), "3333")
@@ -137,7 +137,7 @@ func TestLegacyConflictingCleanupHandleCanStillReap(t *testing.T) {
 // filesystem or the network.
 func TestSSHAddressConflictIsDiagnosedBeforeAnythingLocal(t *testing.T) {
 	t.Setenv("HOME", t.TempDir()) // no keys, no known_hosts: a local check would fail too
-	_, err := sshCommandForConfig(config.SSHConfig{Host: "10.0.0.7:2222", Port: 3333}, config.SSHHostKeyStrict)
+	_, err := sshCommandForConfig(config.SSHConfig{Host: "10.0.0.7:2222", Port: 3333}, config.SSHHostKeyStrict, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "2222", "the ADDRESS conflict must win over any local prerequisite failure")
 	assert.Contains(t, err.Error(), "3333")


### PR DESCRIPTION
Closes #3086.

**Stacked on #3061** (base is `siyer/3052-ssh-converge`); retargeting to `master` once that lands. The convergence is what makes this reachable — before it, `backend=ssh` held one x/crypto client for the lifecycle and the question could not arise.

## The failure, and why it needs code rather than care

The shared transport runs every step as its **own** `ssh` invocation — each provision command through `buildRunCommand`, the `ssh -L` tunnel through its own `exec.Command`, the reap through `Run` again. Each one resolves the target independently.

So when `ssh.host` names something with several addresses — a round-robin record, a load balancer, a pair of A records — the per-session directory can be created on host **A** while the clone, the agent-server, or the tunnel lands on host **B**.

**Nothing errors.** Every step succeeds against a valid, authorized, correctly host-key-verified machine. There is no bad exit status to catch and no exception to log. The session simply is not on one machine. The reap then removes B's directory, reports success, latches, and the agent-server and workspace on A leak with nothing left pointing at them.

That is why the tests here assert the *mechanism* — the literal in the composed command, the address in the handle — rather than an observable symptom. There is no symptom.

## The fix

**The only form whose meaning does not depend on who resolves it is a literal address.** Same principle as #2999's finding that a bind address is not a dialable client URL: a name is an instruction to look something up, and every separate lookup is entitled to a different answer.

- **Resolve once**, at provision.
- **Pin it in the composed command.** That is what makes it unforgettable — there is no per-step code path that could skip it, because every step *is* that command. The tunnel and the reap inherit the pin for free.
- **Record it in the cleanup handle**, so a teardown after a daemon restart still reaches the machine the session is actually on.
- **Resolution failure is explicit.** Provision refuses. Falling back to the name would restore exactly the behaviour being removed, at the moment DNS is least trustworthy, and do it invisibly.

The one place a fallback *is* right: a pre-#3086 handle whose host no longer resolves. There is no session being created that could land on the wrong host, and refusing a **teardown** leaks the workspace it exists to remove — the #3044 lesson. A pre-#3086 handle that *does* resolve gets one lookup at restore, so it too is pinned for its whole life rather than per step.

## Host-key verification survives intact — and this is the part I measured rather than reasoned

Dialling a literal address would key `known_hosts` by **address**, silently invalidating every existing entry and, under `accept-new`, writing a fresh one per address. So the command carries `-o HostKeyAlias`.

The alias has to be the **exact** string OpenSSH would otherwise have computed, and my first instinct — alias to the bare host name — was wrong. Measured against OpenSSH_9.6p1 with a throwaway loopback sshd:

| connection | key recorded in known_hosts |
|---|---|
| `-p 2201 127.0.0.1` | `[127.0.0.1]:2201` |
| `-p 2201 -o HostKeyAlias=real.example 127.0.0.1` | `real.example` |

**The port is not appended to an alias.** A bare-name alias would therefore have silently orphaned every existing entry for a non-default-port host — the exact class of silent, security-relevant regression this PR series exists to avoid. So the alias is `knownHostsLookupName`'s output: bare on port 22, `[host]:port` otherwise, byte-identical to what a non-pinned connection writes. That also keeps it in agreement with the legacy-tombstone probe from #3061, which computes the same name.

Then the acceptance check, end to end:

```
# a store holding ONLY the name-keyed entry
$ printf '[real.example]:2201 %s\n' "$(cut -d' ' -f1,2 hostkey.pub)" > kh

# dial the literal IP with the alias, STRICT
$ ssh -F none -o StrictHostKeyChecking=yes -o UserKnownHostsFile=kh \
      -p 2201 -o 'HostKeyAlias=[real.example]:2201' 127.0.0.1 true
siyer@127.0.0.1: Permission denied (publickey,…)   # host key VERIFIED; auth fails, as expected

# and the control, WITHOUT the alias — this is what proves the alias is load-bearing
$ ssh -F none -o StrictHostKeyChecking=yes -o UserKnownHostsFile=kh -p 2201 127.0.0.1 true
No ED25519 host key is known for [127.0.0.1]:2201 and you have requested strict checking.
Host key verification failed.
```

## Scope: `backend=sandbox` is deliberately not pinned

`sandbox_ssh` is the operator's own free-form command, and af does not know which token in it is the host. The operator owns that choice there, as they own `ssh_config` and `known_hosts` for that backend. The issue was filed against "the shared transport"; this is the half af can actually pin, and the docs say so rather than implying both are covered.

## Tests — each watched failing first

| Guarantee | Mutation that must break it |
|---|---|
| the command dials the resolved literal, not the name | dial `host` again |
| the host key stays keyed by name | drop `HostKeyAlias` |
| …and by the **bracketed** name on a non-default port | alias to the bare name |
| a name that does not resolve **fails** | fall back to the name |
| an empty answer is a failure, not an empty address | drop the length check |
| a literal host is never sent to the resolver | — (the fake resolver `t.Fatal`s) |
| a recorded handle dials its recorded address | ignore it, re-resolve |
| a pre-#3086 handle resolves **once**, not per step | — (call counter) |
| an unresolvable legacy handle still composes a teardown | — (refusing would leak) |
| the address survives JSON storage | drop the struct tag |

All caught the intended test and only that test.

## Verification

`gofmt -l .` (no output) · `go build ./...` · `golangci-lint run --fast` · `scripts/lint-file-length.sh` · `go test ./session/ -run 'SSH|Sandbox|Cleanup|BackendField'`. The rest on CI, including `TestSSHBackendRoundTrip` and `TestSSHBackendArchiveRestore` — the specification that an existing `ssh.host` user does not break, and the strongest evidence the `HostKeyAlias` change is transparent.
