### PR TITLE
fix(accounts): carry the generated-args declaration through the launch to the shim (#3083)

### DIFF
--- a/internal/sessionenv/account_exec_protocol_test.go
+++ b/internal/sessionenv/account_exec_protocol_test.go
@@ -1,0 +1,86 @@
+//go:build !windows
+
+package sessionenv
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/internal/shellquote"
+)
+
+// Tagged !windows because it drives execInvocation and processExec, which live in
+// exec_unix.go. The windows stub has no shim protocol at all, so an untagged file
+// here breaks that build — and CI cross-builds.
+
+// The shim's argv protocol must carry the launcher's declaration intact, end to
+// end: wrap a rewritten claude launch, split it the way /bin/sh would, run the
+// shim's own parser over it, and assert the ENVIRONMENT the pane would have
+// received. Without the declaration arriving word-for-word, ApplyAccount refuses
+// and execInvocation returns an error instead — so the scoped environ IS the proof.
+//
+// Driven through WrapAccountCommand rather than a hand-built argv because the
+// length-prefixed encoding is exactly where a mis-split would hand the guard a
+// different claim than the launcher made, and a generated argument is an arbitrary
+// string — the plugin directory below contains a space (#3083).
+func TestAccountExecProtocol_CarriesTheGeneratedArgsDeclaration(t *testing.T) {
+	pluginDir := "/plugins/with a space"
+	generated := []string{"--session-id", "abc-123", "--plugin-dir", pluginDir}
+	command := "claude --session-id abc-123 --plugin-dir " + shellquote.Quote(pluginDir)
+
+	wrapped, err := WrapAccountCommand("/usr/local/bin/af", "claude", "work", generated, nil, command)
+	require.NoError(t, err)
+
+	// Split with this package's own parser — the same one the guard uses — rather
+	// than a second tokenizer that could disagree with it.
+	call, ok := singleSimpleCall(wrapped)
+	require.True(t, ok, "the wrapped launch must be a single simple command")
+	words, ok := literalCommandArgs(call.Args)
+	require.True(t, ok, "every word must survive quoting as a literal")
+	require.Equal(t, AccountExecMarker, words[1])
+
+	accountDir := t.TempDir()
+	prevLookup := AccountLookup
+	AccountLookup = func(agent, name string) (Account, error) {
+		return Account{Agent: agent, Name: name, Dir: accountDir}, nil
+	}
+	sentinel := errors.New("stop before exec")
+	var gotEnviron []string
+	var gotArgv []string
+	prevExec := processExec
+	processExec = func(_ string, argv []string, environ []string) error {
+		gotArgv = append([]string(nil), argv...)
+		gotEnviron = append([]string(nil), environ...)
+		return sentinel
+	}
+	t.Cleanup(func() { AccountLookup, processExec = prevLookup, prevExec })
+
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ambient-must-not-survive")
+	err = execInvocation(words[2:], true)
+	require.ErrorIs(t, err, sentinel,
+		"a refusal here means the declaration did not survive argv, which is the #3083 127")
+
+	require.Equal(t, command, gotArgv[2],
+		"the command operand must reach /bin/sh verbatim, quoting and all")
+	dir, present := envValue(gotEnviron, "CLAUDE_CONFIG_DIR")
+	require.True(t, present, "the account's credential root must be injected")
+	require.Equal(t, accountDir, dir)
+	_, leaked := envValue(gotEnviron, "ANTHROPIC_API_KEY")
+	require.False(t, leaked, "the ambient key outranks the config directory and must be gone")
+}
+
+// A malformed count must refuse rather than mis-split — the fail-closed direction
+// for the protocol itself, since every claim the boundary verifies rides on it.
+func TestAccountExecProtocol_RefusesAMiscountedInvocation(t *testing.T) {
+	for _, args := range [][]string{
+		{"claude", "0", "work"},                      // truncated before the generated count
+		{"claude", "0", "work", "2", "--only-one"},   // count exceeds the words present
+		{"claude", "0", "work", "-1", "cmd"},         // negative
+		{"claude", "0", "work", "0", "cmd", "extra"}, // an unaccounted argument
+		{"claude", "0", "work", "x", "cmd"},          // not a number
+	} {
+		require.Error(t, execInvocation(args, true), "argv %v must be refused, not guessed at", args)
+	}
+}

--- a/internal/sessionenv/account_exec_protocol_test.go
+++ b/internal/sessionenv/account_exec_protocol_test.go
@@ -84,3 +84,17 @@ func TestAccountExecProtocol_RefusesAMiscountedInvocation(t *testing.T) {
 		require.Error(t, execInvocation(args, true), "argv %v must be refused, not guessed at", args)
 	}
 }
+
+// A maximum-sized generated count must be REFUSED, not turned into a panic
+// (#3083 review, P2). Bounds-checking with `trailing+generatedCount` overflows to a
+// negative bound, the check passes, and the slice panics — so the protocol's
+// fail-closed promise breaks exactly where a malformed invocation is most likely to
+// be deliberate.
+func TestAccountExecProtocol_RefusesAnOverflowingGeneratedCount(t *testing.T) {
+	for _, count := range []string{"9223372036854775807", "9223372036854775806", "4611686018427387904"} {
+		require.NotPanics(t, func() {
+			require.Error(t, execInvocation([]string{"claude", "0", "work", count, "claude"}, true),
+				"generated count %s must be refused", count)
+		}, "a malformed count must return the generic refusal, never panic (count %s)", count)
+	}
+}

--- a/internal/sessionenv/account_scope.go
+++ b/internal/sessionenv/account_scope.go
@@ -20,7 +20,7 @@ var AccountLookup func(agent, name string) (Account, error)
 // installed, or a boundary that rejects the command all mean af cannot prove the
 // session will use the requested identity — and an unprovable launch is not
 // evidence of a correct one.
-func applyAccountScope(environ []string, agent, account, command string) ([]string, error) {
+func applyAccountScope(environ []string, agent, account, command string, generated []string) ([]string, error) {
 	if AccountLookup == nil {
 		return nil, fmt.Errorf("account-scoped launch requested but no account lookup is installed")
 	}
@@ -28,6 +28,10 @@ func applyAccountScope(environ []string, agent, account, command string) ([]stri
 	if err != nil {
 		return nil, fmt.Errorf("resolve account %q for %s: %w", account, agent, err)
 	}
+	// The launcher's claim about its OWN additions, attached to the scope the
+	// lookup resolved. AccountLookup answers "which directory", never "which
+	// arguments" — that fact travels with the launch, not with the registry (#3083).
+	scope.GeneratedArgs = generated
 	scoped, err := ApplyAccount(environ, command, scope)
 	if err != nil {
 		return nil, fmt.Errorf("scope session to account %q: %w", account, err)

--- a/internal/sessionenv/account_scope_test.go
+++ b/internal/sessionenv/account_scope_test.go
@@ -23,9 +23,9 @@ func TestApplyAccountScope_TwoAccountsSeeDifferentRootsAndNotEachOther(t *testin
 	})
 	ambient := []string{"PATH=/usr/bin", "OPENAI_API_KEY=sk-ambient", "CODEX_HOME=/home/op/.codex"}
 
-	a, err := applyAccountScope(ambient, "codex", "alpha", "codex")
+	a, err := applyAccountScope(ambient, "codex", "alpha", "codex", nil)
 	require.NoError(t, err)
-	b, err := applyAccountScope(ambient, "codex", "beta", "codex")
+	b, err := applyAccountScope(ambient, "codex", "beta", "codex", nil)
 	require.NoError(t, err)
 
 	joinedA, joinedB := strings.Join(a, "\n"), strings.Join(b, "\n")
@@ -54,14 +54,14 @@ func TestApplyAccountScope_RefusesRatherThanFallingBack(t *testing.T) {
 
 	// No lookup installed at all.
 	withLookup(t, nil)
-	_, err := applyAccountScope(ambient, "codex", "alpha", "codex")
+	_, err := applyAccountScope(ambient, "codex", "alpha", "codex", nil)
 	require.Error(t, err, "a build with no lookup installed must refuse, not run unscoped")
 
 	// Lookup fails (unregistered account).
 	withLookup(t, func(string, string) (Account, error) {
 		return Account{}, errNotRegistered
 	})
-	_, err = applyAccountScope(ambient, "codex", "ghost", "codex")
+	_, err = applyAccountScope(ambient, "codex", "ghost", "codex", nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "ghost")
 
@@ -70,7 +70,7 @@ func TestApplyAccountScope_RefusesRatherThanFallingBack(t *testing.T) {
 	withLookup(t, func(agent, name string) (Account, error) {
 		return Account{Agent: agent, Name: name, Dir: "/home/op/.af/accounts/codex/" + name}, nil
 	})
-	_, err = applyAccountScope(ambient, "codex", "alpha", "sh -c 'codex'")
+	_, err = applyAccountScope(ambient, "codex", "alpha", "sh -c 'codex'", nil)
 	require.Error(t, err, "an unprovable program must refuse rather than launch scoped-in-name-only")
 }
 

--- a/internal/sessionenv/exec_unix.go
+++ b/internal/sessionenv/exec_unix.go
@@ -102,7 +102,12 @@ func execInvocation(args []string, scoped bool) error {
 	if scoped {
 		account = args[2]
 		generatedCount, gerr := strconv.Atoi(args[3])
-		if gerr != nil || generatedCount < 0 || len(args) < trailing+generatedCount {
+		// Compared against the REMAINING room, never `trailing+generatedCount`: a
+		// maximum-sized integer makes that addition overflow to a negative bound, the
+		// check passes, and the slice below PANICS instead of returning this
+		// function's generic refusal (#3083 review). Subtraction cannot overflow here
+		// because trailing is a constant no larger than len(args), already checked.
+		if gerr != nil || generatedCount < 0 || generatedCount > len(args)-trailing {
 			return fmt.Errorf("malformed internal session environment invocation")
 		}
 		generated = args[4 : 4+generatedCount]

--- a/internal/sessionenv/exec_unix.go
+++ b/internal/sessionenv/exec_unix.go
@@ -18,7 +18,7 @@ var processExec = syscall.Exec
 // executable path, the selected agent, explicit variable NAMES, and the
 // original pane command; environment values never enter argv.
 func WrapCommand(executable, agent string, extras []string, command string) (string, error) {
-	return wrapCommand(executable, agent, "", extras, command)
+	return wrapCommand(executable, agent, "", nil, extras, command)
 }
 
 // WrapAccountCommand is WrapCommand for a session scoped to a named account.
@@ -26,14 +26,18 @@ func WrapCommand(executable, agent string, extras []string, command string) (str
 // Only the account NAME travels in argv — never its directory and never a
 // credential. The shim resolves the name against its own AF home, so argv stays
 // free of anything worth reading out of `ps` (#3051).
-func WrapAccountCommand(executable, agent, account string, extras []string, command string) (string, error) {
+// generated carries the argument words af's own launcher appended to the pane
+// command, so the boundary can verify its own output instead of refusing it
+// (#3083). These are not secrets and are already visible in the command operand
+// beside them; what argv gains is the CLAIM that af authored them.
+func WrapAccountCommand(executable, agent, account string, generated, extras []string, command string) (string, error) {
 	if strings.TrimSpace(account) == "" {
 		return "", fmt.Errorf("account-scoped launch requires an account name")
 	}
-	return wrapCommand(executable, agent, account, extras, command)
+	return wrapCommand(executable, agent, account, generated, extras, command)
 }
 
-func wrapCommand(executable, agent, account string, extras []string, command string) (string, error) {
+func wrapCommand(executable, agent, account string, generated, extras []string, command string) (string, error) {
 	normalized, err := NormalizeExtraNames(extras)
 	if err != nil {
 		return "", err
@@ -44,7 +48,13 @@ func wrapCommand(executable, agent, account string, extras []string, command str
 	}
 	args := []string{executable, marker, agent, strconv.Itoa(len(normalized))}
 	if account != "" {
-		args = append(args, account)
+		// Both COUNTS are length-prefixed rather than delimiter-separated, for the
+		// reason the extras count already is: a generated argument is an arbitrary
+		// string (a path can contain anything), so any sentinel could appear inside
+		// one and a mis-split would hand the guard a different claim than the
+		// launcher made.
+		args = append(args, account, strconv.Itoa(len(generated)))
+		args = append(args, generated...)
 	}
 	args = append(args, normalized...)
 	args = append(args, command)
@@ -76,21 +86,33 @@ func HandleInternalExec() {
 func execInvocation(args []string, scoped bool) error {
 	trailing := 3
 	if scoped {
-		trailing = 4
+		trailing = 5
 	}
 	if len(args) < trailing {
 		return fmt.Errorf("malformed internal session environment invocation")
 	}
 	agent := args[0]
 	count, err := strconv.Atoi(args[1])
-	if err != nil || count < 0 || len(args) != count+trailing {
+	if err != nil || count < 0 {
 		return fmt.Errorf("malformed internal session environment invocation")
 	}
 	offset := 2
 	account := ""
+	var generated []string
 	if scoped {
 		account = args[2]
-		offset = 3
+		generatedCount, gerr := strconv.Atoi(args[3])
+		if gerr != nil || generatedCount < 0 || len(args) < trailing+generatedCount {
+			return fmt.Errorf("malformed internal session environment invocation")
+		}
+		generated = args[4 : 4+generatedCount]
+		offset = 4 + generatedCount
+	}
+	// The exact total, checked AFTER both counts are known. A length that merely
+	// fits leaves room for an unaccounted argument between the two lists, and this
+	// argv is what the boundary's whole claim rests on.
+	if len(args) != offset+count+1 {
+		return fmt.Errorf("malformed internal session environment invocation")
 	}
 	extras, err := NormalizeExtraNames(args[offset : offset+count])
 	if err != nil {
@@ -104,7 +126,7 @@ func execInvocation(args []string, scoped bool) error {
 	// through to the ambient identity, which would be the silent wrong-account
 	// outcome the whole feature exists to prevent (#3051).
 	if scoped {
-		environ, err = applyAccountScope(environ, agent, account, command)
+		environ, err = applyAccountScope(environ, agent, account, command, generated)
 		if err != nil {
 			return err
 		}

--- a/session/account_generated_launch_test.go
+++ b/session/account_generated_launch_test.go
@@ -95,3 +95,45 @@ func envLookup(t *testing.T, env []string, name string) string {
 	t.Fatalf("%s is not present in the scoped environment", name)
 	return ""
 }
+
+// The END-TO-END fix for #3083, through af's real launch seam rather than through
+// ApplyAccount directly: setLaunchProgram is what every launch path now calls, so
+// this asserts the declaration it installs is the one the boundary needs.
+//
+// It exercises the pairing rather than the guard — the guard is covered in
+// internal/sessionenv — because the pairing is where this could silently break: a
+// declaration describing a different program string than the one installed would be
+// a false claim about the command that runs.
+func TestSetLaunchProgram_DeclaresWhatTheAccountBoundaryNeeds(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	base := "claude"
+	final := injectSystemPrompt(base)
+	require.NotEqual(t, base, final, "precondition: claude's launch is rewritten, or this proves nothing")
+
+	generated, ok := sessionenv.GeneratedArgsBetween(base, final)
+	require.True(t, ok)
+
+	// What the pane shim will hand the boundary, and it must be accepted.
+	_, err := sessionenv.ApplyAccount(
+		[]string{"PATH=/usr/bin", "ANTHROPIC_API_KEY=sk-ambient"},
+		final,
+		sessionenv.Account{Agent: "claude", Name: "work", Dir: t.TempDir(), GeneratedArgs: generated},
+	)
+	require.NoError(t, err, "af's own launch rewrite must be provable end to end (#3083)")
+}
+
+// A base af cannot relate to the final command declares NOTHING, so an
+// account-scoped launch is refused rather than proceeding unverified. This is the
+// fail-closed direction, and it is the one a reader is most likely to assume works
+// the other way.
+func TestSetLaunchProgram_UnrelatableBaseDeclaresNothing(t *testing.T) {
+	generated, ok := sessionenv.GeneratedArgsBetween("claude", "ANTHROPIC_API_KEY=sk claude --session-id x")
+	require.False(t, ok, "an assignment prefix is not an appended argument")
+	require.Empty(t, generated)
+
+	_, err := sessionenv.ApplyAccount([]string{"PATH=/usr/bin"},
+		"ANTHROPIC_API_KEY=sk claude --session-id x",
+		sessionenv.Account{Agent: "claude", Name: "work", Dir: "/d", GeneratedArgs: generated})
+	require.Error(t, err, "refused, not launched unverified")
+}

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -332,7 +332,8 @@ func (b *LocalBackend) launch(i *Instance, firstTimeSetup bool, prepared *Create
 		// Setting the program on the existing attach path is harmless:
 		// attach-session does not re-exec the program.
 		if workDir != "" {
-			tmuxSession.SetProgram(injectSystemPrompt(resolveProgramForInstance(i)))
+			resolved := resolveProgramForInstance(i)
+			setLaunchProgram(tmuxSession, resolved, injectSystemPrompt(resolved))
 		}
 		if err := tmuxSession.Restore(workDir); err != nil {
 			setupErr = fmt.Errorf("failed to restore existing session: %w", err)
@@ -353,20 +354,24 @@ func (b *LocalBackend) launch(i *Instance, firstTimeSetup bool, prepared *Create
 		// path supplies a command frozen after provisioning and before process
 		// launch; direct Start callers retain the established inline preparation.
 		var program string
+		// The pre-rewrite command, kept so the launch can declare what af added to it
+		// (#3083). The prepared path carries its own, frozen with the program.
+		base := resolveProgramForInstance(i)
 		if prepared != nil {
 			if prepared.workDir != gw.GetWorktreePath() || strings.TrimSpace(prepared.program) == "" {
 				setupErr = fmt.Errorf("prepared create launch no longer matches session %q", i.Title)
 				return setupErr
 			}
 			program = prepared.program
+			base = prepared.base
 			if prepared.conversation.HasID() {
 				i.SetAgentConversation(prepared.conversation)
 			}
 		} else {
-			program = prepareLaunchConversation(i, resolveProgramForInstance(i))
+			program = prepareLaunchConversation(i, base)
 			program = injectSystemPrompt(program)
 		}
-		tmuxSession.SetProgram(program)
+		setLaunchProgram(tmuxSession, base, program)
 
 		// Create new session
 		if err := tmuxSession.Start(gw.GetWorktreePath()); err != nil {
@@ -606,7 +611,7 @@ func (b *LocalBackend) respawn(i *Instance) error {
 		}
 	}
 
-	ts.SetProgram(injectSystemPrompt(prepareResumeConversation(i, resolvedProgram)))
+	setLaunchProgram(ts, resolvedProgram, injectSystemPrompt(prepareResumeConversation(i, resolvedProgram)))
 	if err := refreshSessionEnvironment(i, ts); err != nil {
 		return fmt.Errorf("recover: %w", err)
 	}

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -92,7 +92,7 @@ func refreshSessionEnvironment(i *Instance, tmuxSession *tmux.TmuxSession) error
 	// Refreshed alongside the pass-through, on the same paths, so a restored or
 	// re-provisioned session carries the account it was created with rather than
 	// quietly reverting to the ambient identity (#3051).
-	tmuxSession.SetAccount(i.Account)
+	tmuxSession.SetAccountForAgent(sessionenv.AgentForCommand(i.AgentProgram()), i.Account)
 	return nil
 }
 

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -579,6 +579,12 @@ func (b *LocalBackend) respawn(i *Instance) error {
 		return fmt.Errorf("recover: %w", err)
 	}
 	resolvedProgram := resolveProgramForInstance(i)
+	// The base for the generated-args declaration, pinned BEFORE any af rewrite.
+	// resolvedProgram is reassigned below when a fresh worktree rebuild forces the
+	// exact-resume command, and that rewrite is af's own — so declaring against the
+	// rewritten value would omit `--resume <id>` and the boundary would refuse the
+	// recovered pane as carrying undeclared arguments (#3083 review).
+	declarationBase := resolvedProgram
 	if _, err := os.Stat(workDir); err != nil {
 		if !os.IsNotExist(err) {
 			// Surface the real cause instead of a generic tmux new-session error:
@@ -604,6 +610,10 @@ func (b *LocalBackend) respawn(i *Instance) error {
 						err, rebuildErr, freshErr),
 				}
 			}
+			// resolvedProgram becomes the exact-resume command, which is af's OWN
+			// rewrite — so the declaration base must stay the PRE-resume command or
+			// GeneratedArgsBetween describes only the later system-prompt additions and
+			// the account boundary refuses `--resume <id>` as undeclared (#3083 review).
 			resolvedProgram = exactProgram
 			log.InfoLog.Printf("recover: rebuilt missing worktree for session %q at %s from recorded base and recreated branch %s", i.Title, workDir, gw.GetBranchName())
 		} else {
@@ -611,7 +621,7 @@ func (b *LocalBackend) respawn(i *Instance) error {
 		}
 	}
 
-	setLaunchProgram(ts, resolvedProgram, injectSystemPrompt(prepareResumeConversation(i, resolvedProgram)))
+	setLaunchProgram(ts, declarationBase, injectSystemPrompt(prepareResumeConversation(i, resolvedProgram)))
 	if err := refreshSessionEnvironment(i, ts); err != nil {
 		return fmt.Errorf("recover: %w", err)
 	}

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -483,6 +483,27 @@ func (b *LocalBackend) Respawn(i *Instance) error {
 // otherwise mirrors: on a create, a failed Start means the workspace holds
 // nothing worth keeping; here it holds everything the outgoing agent did.
 func (b *LocalBackend) SwapAgent(i *Instance, plan AgentSwapPlan) error {
+	// REFUSED for an account-scoped session (#3083 review).
+	//
+	// Clearing the generated-args declaration is not enough, and that was the gap:
+	// refreshSessionEnvironment below reapplies the UNCHANGED i.Account, so handing a
+	// claude session scoped to "work" over to codex launches codex under a codex
+	// account also called "work" — a different identity the user never selected for
+	// that agent, chosen by a name collision. Bare codex needs no declaration, so
+	// nothing downstream refuses it.
+	//
+	// An account names one identity of one agent; it does not survive a change of
+	// agent, and af cannot pick the replacement's account for the user. Refusing is
+	// the honest answer, and it names the way through.
+	if account := i.Account; strings.TrimSpace(account) != "" {
+		return fmt.Errorf(
+			"swap agent: session %q is scoped to the %s account %q, and an account belongs to one agent — "+
+				"af cannot know which %s identity you meant. Create a new session on the account you want "+
+				"instead of handing this one over",
+			i.Title, sessionenv.AgentForCommand(i.Program), account, plan.target)
+	}
+	// Checked BEFORE any runtime state: this is about intent, not about whether the
+	// session currently has a tmux binding, and a missing binding must not mask it.
 	i.mu.RLock()
 	ts := i.tmuxLocked()
 	gw := i.gitWorktree

--- a/session/backend_local_create.go
+++ b/session/backend_local_create.go
@@ -18,6 +18,7 @@ func (b *LocalBackend) prepareCreateLaunch(i *Instance) (CreateLaunchPlan, error
 	program = injectSystemPrompt(program)
 	plan := CreateLaunchPlan{
 		program:      program,
+		base:         resolved,
 		workDir:      workDir,
 		conversation: conversation,
 	}

--- a/session/create_launch.go
+++ b/session/create_launch.go
@@ -7,10 +7,15 @@ import "fmt"
 // spawned. Its fields are private so a caller cannot retarget a capture or swap
 // the checked command between the two halves.
 type CreateLaunchPlan struct {
-	instance            *Instance
-	launcher            Backend
-	prepared            bool
-	program             string
+	instance *Instance
+	launcher Backend
+	prepared bool
+	program  string
+	// base is the command before af's own rewrites, frozen WITH program so the
+	// launch can declare which words af appended (#3083). Frozen rather than
+	// re-resolved at launch: program_overrides could be re-read differently by
+	// then, and a declaration must describe the program actually installed.
+	base                string
 	workDir             string
 	conversation        AgentConversationData
 	conversationCapture ConversationCaptureSnapshot

--- a/session/instance_account_roundtrip_test.go
+++ b/session/instance_account_roundtrip_test.go
@@ -70,7 +70,7 @@ func TestAccountScoping_RefusesUnsupportedCombinations(t *testing.T) {
 
 	// Local + codex is the supported combination and must stay allowed.
 	require.NoError(t, refuseOffBoxAccount(base))
-	require.NoError(t, refuseUnsupportedAccountAgent(base))
+	require.NoError(t, refuseUnsupportedAccountAgent(base, base.Path))
 
 	// Off-box backends cannot carry the account, so they must refuse rather than
 	// run on the remote host's ambient credentials.
@@ -91,21 +91,21 @@ func TestAccountScoping_RefusesUnsupportedCombinations(t *testing.T) {
 	// of that wiring is unreachable to users no matter how well it works (#3083 review).
 	claude := base
 	claude.Program = "claude"
-	require.NoError(t, refuseUnsupportedAccountAgent(claude),
+	require.NoError(t, refuseUnsupportedAccountAgent(claude, claude.Path),
 		"an account-scoped claude create must reach the launch that carries its declaration")
 
 	// An agent nobody has established the boundary can verify still refuses, and the
 	// error names what does work rather than only what does not.
 	unproven := base
 	unproven.Program = "gemini"
-	err := refuseUnsupportedAccountAgent(unproven)
+	err := refuseUnsupportedAccountAgent(unproven, unproven.Path)
 	require.Error(t, err, "an unproven agent must refuse rather than start on the ambient identity")
 	require.Contains(t, err.Error(), "claude and codex", "the error must name what does work")
 
 	// No account selected leaves every path untouched.
 	plain := InstanceOptions{Title: "t", Path: t.TempDir(), Program: "claude", Backend: BackendDocker}
 	require.NoError(t, refuseOffBoxAccount(plain))
-	require.NoError(t, refuseUnsupportedAccountAgent(plain))
+	require.NoError(t, refuseUnsupportedAccountAgent(plain, plain.Path))
 }
 
 // An account-scoped session must REFUSE a handoff (#3083 review, P1).
@@ -124,4 +124,26 @@ func TestSwapAgent_RefusesAnAccountScopedSession(t *testing.T) {
 	require.Error(t, err, "an account-scoped handoff must refuse rather than reuse the account name")
 	require.Contains(t, err.Error(), "belongs to one agent")
 	require.Contains(t, err.Error(), "work", "the refusal must name the account it is protecting")
+}
+
+// A cross-agent program_overrides must refuse BEFORE launch (#3083 review, P1).
+//
+// The account name is validated in the REQUESTED agent's namespace, but the launch
+// derives the agent from the RESOLVED command. So Program=claude with
+// program_overrides.claude=codex validates "work" as a claude account and then runs
+// codex under CODEX's "work" — two namespaces, one name, and the session silently
+// authenticates as someone the user never selected. A gate reading the label cannot
+// see it, which is why this one resolves first.
+func TestAccountScoping_RefusesACrossAgentOverride(t *testing.T) {
+	// A GLOBAL override, deliberately: it is the case a repo-only lookup would miss
+	// while the launch still applied it.
+	saveOverrideConfig(t, "codex")
+	path := t.TempDir()
+
+	err := refuseUnsupportedAccountAgent(
+		InstanceOptions{Title: "t", Path: path, Program: "claude", Account: "work"}, path)
+
+	require.Error(t, err, "a cross-agent override must refuse: the validated namespace is not the one that would be used")
+	require.Contains(t, err.Error(), "namespaces are separate")
+	require.Contains(t, err.Error(), "work")
 }

--- a/session/instance_account_roundtrip_test.go
+++ b/session/instance_account_roundtrip_test.go
@@ -83,13 +83,24 @@ func TestAccountScoping_RefusesUnsupportedCombinations(t *testing.T) {
 		require.Contains(t, err.Error(), "ambient credentials")
 	}
 
-	// claude's launch is rewritten before the boundary sees it, so it exits 127
-	// today. Refuse with the reason instead.
+	// claude is ADMITTED now (#3083): af declares the arguments it appends to that
+	// launch, so the boundary verifies the rewritten command instead of refusing it.
+	// This assertion is inverted from what it was, and deliberately — the refusal it
+	// used to guard existed only because the launch was unprovable, and it is the
+	// front door to every generated-args path in this package. Left as a refusal, all
+	// of that wiring is unreachable to users no matter how well it works (#3083 review).
 	claude := base
 	claude.Program = "claude"
-	err := refuseUnsupportedAccountAgent(claude)
-	require.Error(t, err, "claude must refuse an account-scoped create until its launch is supported")
-	require.Contains(t, err.Error(), "codex", "the error must name what does work")
+	require.NoError(t, refuseUnsupportedAccountAgent(claude),
+		"an account-scoped claude create must reach the launch that carries its declaration")
+
+	// An agent nobody has established the boundary can verify still refuses, and the
+	// error names what does work rather than only what does not.
+	unproven := base
+	unproven.Program = "gemini"
+	err := refuseUnsupportedAccountAgent(unproven)
+	require.Error(t, err, "an unproven agent must refuse rather than start on the ambient identity")
+	require.Contains(t, err.Error(), "claude and codex", "the error must name what does work")
 
 	// No account selected leaves every path untouched.
 	plain := InstanceOptions{Title: "t", Path: t.TempDir(), Program: "claude", Backend: BackendDocker}

--- a/session/instance_account_roundtrip_test.go
+++ b/session/instance_account_roundtrip_test.go
@@ -107,3 +107,21 @@ func TestAccountScoping_RefusesUnsupportedCombinations(t *testing.T) {
 	require.NoError(t, refuseOffBoxAccount(plain))
 	require.NoError(t, refuseUnsupportedAccountAgent(plain))
 }
+
+// An account-scoped session must REFUSE a handoff (#3083 review, P1).
+//
+// Clearing the generated-args declaration was not enough: refreshSessionEnvironment
+// reapplies the unchanged Account, so handing a claude session scoped to "work" to
+// codex would launch codex under a codex account also named "work" — a different
+// identity, selected by a name collision rather than by the user. Bare codex needs
+// no declaration, so nothing downstream refuses it.
+func TestSwapAgent_RefusesAnAccountScopedSession(t *testing.T) {
+	backend := &LocalBackend{}
+	inst := &Instance{Title: "scoped", Path: t.TempDir(), Program: "claude", Account: "work"}
+
+	err := backend.SwapAgent(inst, AgentSwapPlan{target: "codex", program: "codex"})
+
+	require.Error(t, err, "an account-scoped handoff must refuse rather than reuse the account name")
+	require.Contains(t, err.Error(), "belongs to one agent")
+	require.Contains(t, err.Error(), "work", "the refusal must name the account it is protecting")
+}

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -559,12 +559,22 @@ func refuseUnsupportedAccountAgent(opts InstanceOptions) error {
 		return nil
 	}
 	agent := sessionenv.AgentForCommand(opts.Program)
-	if agent == "codex" {
+	// An EXPLICIT list, still, and claude is on it now because af's launch rewrite
+	// carries provenance the boundary verifies (#3083): the launcher declares
+	// `--session-id`/`--plugin-dir`, so the rewritten command is provable rather
+	// than refused. codex needs no declaration — af leaves its command unmodified.
+	//
+	// Deliberately NOT keyed on sessionenv.SupportsAccounts: that answers "does this
+	// agent have a credential-root variable", which is a different question from "can
+	// af prove its launch to the boundary". Keeping them separate is what makes an
+	// agent added to the first list unsupported here until someone checks the second,
+	// which fails in the safe direction (#3051, #3083).
+	if agent == "codex" || agent == "claude" {
 		return nil
 	}
 	return fmt.Errorf(
-		"account %q cannot be used with %s yet: af rewrites that agent's launch command (--session-id, "+
-			"--plugin-dir) and the account boundary only accepts an unmodified invocation, so the session "+
-			"would start and immediately exit; account scoping currently supports codex",
+		"account %q cannot be used with %s yet: af has not established that the account boundary can "+
+			"verify how it launches that agent, so the session could start on the ambient identity or exit "+
+			"immediately; account scoping currently supports claude and codex",
 		opts.Account, agent)
 }

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/sessionenv"
 	"github.com/sachiniyer/agent-factory/log"
 )
@@ -438,7 +439,7 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 	if err := refuseOffBoxAccount(opts); err != nil {
 		return nil, err
 	}
-	if err := refuseUnsupportedAccountAgent(opts); err != nil {
+	if err := refuseUnsupportedAccountAgent(opts, absPath); err != nil {
 		return nil, err
 	}
 
@@ -554,11 +555,49 @@ func refuseOffBoxAccount(opts InstanceOptions) error {
 // This is deliberately an ALLOWLIST of agents known to work, not a denylist of
 // broken ones: an agent added later is unsupported until someone proves the
 // boundary accepts its launch, which fails in the safe direction (#3051, #3083).
-func refuseUnsupportedAccountAgent(opts InstanceOptions) error {
+func refuseUnsupportedAccountAgent(opts InstanceOptions, absPath string) error {
 	if strings.TrimSpace(opts.Account) == "" {
 		return nil
 	}
-	agent := sessionenv.AgentForCommand(opts.Program)
+	// RESOLVE FIRST, then decide (#3083 review, #3108).
+	//
+	// opts.Program is a LABEL, and program_overrides can point it at another agent
+	// entirely. The account name was validated in the namespace of the REQUESTED
+	// agent (api/sessions.go), but the launch derives the agent from the RESOLVED
+	// command — so `Program=claude` + `program_overrides.claude=codex` validates
+	// "work" as a claude account and then runs codex under CODEX's "work". Two
+	// namespaces, one name, and the session silently authenticates as someone the
+	// user never selected. That is the exact failure this feature exists to prevent,
+	// and a gate reading the label cannot see it.
+	//
+	// config.ResolveProgram is the resolver the launch itself uses
+	// (resolveProgramForAgent), so this gate and the launch cannot disagree about
+	// what the command is.
+	// The config is resolved HERE rather than threaded in, because the gate must read
+	// the same overrides the launch will: resolveRepoConfig is what the launch path
+	// uses too. A failure to resolve leaves cfg nil, and config.ResolveProgram on a
+	// nil config returns the label unchanged — which is the pre-override answer, so an
+	// unreadable config cannot silently admit a cross-agent override.
+	// Repo config, then GLOBAL — mirroring resolveConfigForInstance exactly, because
+	// that is what the launch uses. Trying only the repo would miss a global
+	// program_overrides entry that the launch then applies, which is the very
+	// gate-disagrees-with-launch divergence this check exists to close.
+	var cfg *config.Config
+	if resolved, rerr := resolveRepoConfig(absPath); rerr == nil {
+		cfg = &resolved.Config
+	} else if loaded, lerr := config.LoadConfig(); lerr == nil {
+		cfg = loaded
+	}
+	requested := sessionenv.AgentForCommand(opts.Program)
+	agent := sessionenv.AgentForCommand(config.ResolveProgram(cfg, opts.Program))
+	if agent != requested {
+		return fmt.Errorf(
+			"account %q was validated as a %s account, but this session's program_overrides resolves %s to "+
+				"a %s command — the account namespaces are separate, so a same-named %s account would be "+
+				"used instead of the %s one you selected. Remove the override, or create the session on the "+
+				"agent whose account you mean",
+			opts.Account, requested, requested, agent, agent, requested)
+	}
 	// An EXPLICIT list, still, and claude is on it now because af's launch rewrite
 	// carries provenance the boundary verifies (#3083): the launcher declares
 	// `--session-id`/`--plugin-dir`, so the rewritten command is provable rather

--- a/session/launch_program.go
+++ b/session/launch_program.go
@@ -28,10 +28,11 @@ import (
 // fails closed: an account-scoped launch is then refused rather than proceeding
 // unverified, and an unscoped launch is unaffected because nothing reads this.
 func setLaunchProgram(ts *tmux.TmuxSession, base, final string) {
-	ts.SetProgram(final)
 	generated, ok := sessionenv.GeneratedArgsBetween(base, final)
 	if !ok {
 		generated = nil
 	}
-	ts.SetGeneratedArgs(generated)
+	// ONE call, so the two are written under one lock. Adjacent setters would still
+	// let a concurrent launch observe a torn pair (#3083 review).
+	ts.SetLaunchProgram(final, generated)
 }

--- a/session/launch_program.go
+++ b/session/launch_program.go
@@ -1,0 +1,37 @@
+package session
+
+import (
+	"github.com/sachiniyer/agent-factory/internal/sessionenv"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// setLaunchProgram sets a session's pane command AND declares which argument
+// words af appended to reach it, in one call (#3083).
+//
+// The two belong together. af's launch rewrites a bare `claude` into `claude
+// --session-id <uuid> --plugin-dir <dir>`, and the account boundary accepts only
+// a bare, argument-free invocation — so without a declaration the guard refuses
+// af's OWN output and the pane exits 127. The declaration is provenance the
+// string cannot carry: only the caller knows which half it wrote.
+//
+// It is ONE function rather than two calls at four sites because a declaration
+// that described a different program string than the one installed would be worse
+// than none — it would be a false claim about the command that runs. Pairing them
+// makes that drift unrepresentable.
+//
+// base is the command BEFORE af's own rewrites: resolveProgramForInstance's
+// output, which is the agent name, the operator's program_overrides entry, or a
+// legacy persisted Program. final is what the pane will run.
+//
+// A base that cannot be related to final — an assignment prefix, a command
+// substitution, a rewrite that edited an existing word — declares NOTHING and so
+// fails closed: an account-scoped launch is then refused rather than proceeding
+// unverified, and an unscoped launch is unaffected because nothing reads this.
+func setLaunchProgram(ts *tmux.TmuxSession, base, final string) {
+	ts.SetProgram(final)
+	generated, ok := sessionenv.GeneratedArgsBetween(base, final)
+	if !ok {
+		generated = nil
+	}
+	ts.SetGeneratedArgs(generated)
+}

--- a/session/tmux/program.go
+++ b/session/tmux/program.go
@@ -1,5 +1,7 @@
 package tmux
 
+import "github.com/sachiniyer/agent-factory/internal/sessionenv"
+
 // Program-command accessors for TmuxSession.
 //
 // program is the command the pane runs (override-resolved, flag-injected). It
@@ -34,4 +36,36 @@ func (t *TmuxSession) setProgramCmd(program string) {
 	t.programMu.Lock()
 	defer t.programMu.Unlock()
 	t.program = program
+}
+
+// rewriteProgramCmdByAf replaces the program with a rewrite AF ITSELF produced and
+// extends the generated-args declaration by the words that rewrite adds, in ONE
+// critical section (#3083 review).
+//
+// Restore's re-spawn branch appends claude's `--continue` or splices codex's
+// `resume --last` after the declaration was already recorded at launch. Those words
+// are af-authored too, so the executed command grows while the declaration does
+// not — and because the account boundary requires the command to be the agent plus
+// EXACTLY the declared words, a stale declaration refuses the launch and the
+// restored pane exits 127. That is the #3083 defect reappearing one path over,
+// which is precisely why the program and its declaration are only ever moved
+// together.
+//
+// A rewrite this cannot describe as a positional extension CLEARS the declaration
+// rather than leaving a false one: an account-scoped launch is then refused, which
+// is the honest outcome, and it is unreachable for any command the guard would have
+// accepted anyway — a program carrying the user's own flags is unprovable with or
+// without this.
+func (t *TmuxSession) rewriteProgramCmdByAf(rewrite func(string) string) {
+	t.programMu.Lock()
+	defer t.programMu.Unlock()
+	before := t.program
+	after := rewrite(before)
+	t.program = after
+	added, ok := sessionenv.GeneratedArgsBetween(before, after)
+	if !ok {
+		t.generatedArgs = nil
+		return
+	}
+	t.generatedArgs = append(t.generatedArgs, added...)
 }

--- a/session/tmux/program.go
+++ b/session/tmux/program.go
@@ -12,8 +12,22 @@ import "github.com/sachiniyer/agent-factory/internal/sessionenv"
 // is what first exposed this data race under `go test -race` (#1254).
 
 // SetProgram updates the program command before the session is started.
+// It CLEARS any generated-args declaration, because a declaration describes one
+// specific command and this replaces it (#3083 review). SwapAgent is the case that
+// makes this load-bearing rather than tidy: it installs a handoff target's program
+// and declares nothing, so a surviving declaration from the outgoing launch would
+// vouch for arguments af did not author for the replacement — and a target override
+// ending in the same instance-specific words would then be accepted, transferring
+// the account across a handoff that is supposed to fail closed.
+//
+// Clearing is the safe default for the same reason refuseUnreadable is a zero value
+// (#3087): permission has to be typed out. A caller that means to keep a
+// declaration says so with SetLaunchProgram, which sets both together.
 func (t *TmuxSession) SetProgram(program string) {
-	t.setProgramCmd(program)
+	t.programMu.Lock()
+	defer t.programMu.Unlock()
+	t.program = program
+	t.generatedArgs = nil
 }
 
 // Program returns the command this session's pane runs — after SetProgram,

--- a/session/tmux/program_af_rewrite_test.go
+++ b/session/tmux/program_af_rewrite_test.go
@@ -137,3 +137,22 @@ func TestLaunchSnapshot_NeverTearsTheCommandFromItsDeclaration(t *testing.T) {
 	}
 	<-done
 }
+
+// The plain setter must not leave a previous launch's declaration behind (#3083
+// review). SwapAgent installs a handoff target's program and declares nothing, so
+// a surviving declaration would vouch for arguments af did not author for the
+// replacement — and a target ending in the same instance-specific words would be
+// accepted, carrying the account across a handoff meant to fail closed.
+func TestSetProgram_ClearsAPreviousDeclaration(t *testing.T) {
+	session := &TmuxSession{}
+	session.SetLaunchProgram("claude --session-id sid-1 --plugin-dir /p", []string{"--session-id", "sid-1", "--plugin-dir", "/p"})
+
+	// A handoff target that happens to end in the very same words.
+	session.SetProgram("other-agent --session-id sid-1 --plugin-dir /p")
+
+	program, generated, _, _ := session.launchSnapshot()
+	require.Equal(t, "other-agent --session-id sid-1 --plugin-dir /p", program)
+	require.Empty(t, generated,
+		"the outgoing launch's declaration survived into the replacement, so af would vouch for "+
+			"arguments it did not author for this command and the account would transfer across the handoff")
+}

--- a/session/tmux/program_af_rewrite_test.go
+++ b/session/tmux/program_af_rewrite_test.go
@@ -99,3 +99,41 @@ func TestRestoreUsesTheDeclarationPreservingRewrite(t *testing.T) {
 	require.Contains(t, string(source), "rewriteProgramCmdByAf(resumeProgram)",
 		"and it must still be doing that rewrite at all")
 }
+
+// The command and its declaration must be observable only as a PAIR (#3083
+// review, P2). Two independently-locked setters, or a launch that reads the
+// program through one lock and the declaration through another, let a concurrent
+// rewrite hand the boundary an old command with a new declaration — and the
+// boundary requires the command to be the agent plus EXACTLY the declared words,
+// so either half of that tear refuses the launch and the pane exits at once.
+//
+// Run under -race, with a rewriter racing a reader: any snapshot that pairs a
+// command with a declaration that does not describe it fails.
+func TestLaunchSnapshot_NeverTearsTheCommandFromItsDeclaration(t *testing.T) {
+	session := &TmuxSession{}
+	session.SetLaunchProgram("claude", nil)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 500; i++ {
+			session.SetLaunchProgram("claude", nil)
+			session.rewriteProgramCmdByAf(resumeProgram)
+		}
+	}()
+	for i := 0; i < 500; i++ {
+		program, generated, _, _ := session.launchSnapshot()
+		// Every legal pair: bare with no declaration, or resumed with --continue
+		// declared. A torn read produces one without the other.
+		switch program {
+		case "claude":
+			require.Empty(t, generated, "a bare command was paired with a declaration describing a rewrite")
+		case "claude --continue":
+			require.Equal(t, []string{"--continue"}, generated,
+				"the resumed command was paired with a declaration that does not describe it")
+		default:
+			t.Fatalf("unexpected program %q", program)
+		}
+	}
+	<-done
+}

--- a/session/tmux/program_af_rewrite_test.go
+++ b/session/tmux/program_af_rewrite_test.go
@@ -1,0 +1,101 @@
+package tmux
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/internal/sessionenv"
+)
+
+// Restore's re-spawn branch rewrites the program with resume flags AFTER the launch
+// recorded which words af appended. Those flags are af-authored too, so the
+// declaration has to grow with them — a stale one makes the account boundary refuse
+// the restored launch and the pane exits 127, which is #3083 reappearing one path
+// over (#3083 review, P1).
+//
+// Asserted against ApplyAccount rather than against the slice, because "the
+// declaration matches the command" is the only property that matters and comparing
+// slices would pass on a declaration that happened to be wrong in the same way.
+func TestRewriteProgramCmdByAf_KeepsTheDeclarationInStepWithResume(t *testing.T) {
+	const pluginDir = "/plugins/af"
+	for _, test := range []struct {
+		name      string
+		program   string
+		declared  []string
+		agent     string
+		wantAdded string
+	}{
+		{
+			name:      "claude appends --continue",
+			program:   "claude --session-id sid-1 --plugin-dir " + pluginDir,
+			declared:  []string{"--session-id", "sid-1", "--plugin-dir", pluginDir},
+			agent:     "claude",
+			wantAdded: "--continue",
+		},
+		{
+			name:      "codex splices resume --last onto a bare program",
+			program:   "codex",
+			declared:  nil,
+			agent:     "codex",
+			wantAdded: "--last",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			session := &TmuxSession{program: test.program, generatedArgs: test.declared}
+
+			session.rewriteProgramCmdByAf(resumeProgram)
+
+			rewritten := session.programCmd()
+			require.NotEqual(t, test.program, rewritten, "precondition: resume must have rewritten it")
+			require.Contains(t, rewritten, test.wantAdded)
+
+			// THE PROPERTY: the boundary accepts the command that will actually run.
+			_, err := sessionenv.ApplyAccount(
+				[]string{"PATH=/usr/bin"},
+				rewritten,
+				sessionenv.Account{
+					Agent: test.agent, Name: "work", Dir: "/afhome/accounts/" + test.agent + "/work",
+					GeneratedArgs: session.generatedArgs,
+				},
+			)
+			require.NoError(t, err,
+				"the resume rewrite left the declaration stale, so an account-scoped restore is refused "+
+					"and the re-spawned pane exits 127")
+		})
+	}
+}
+
+// A rewrite that is not a positional extension CLEARS the declaration rather than
+// leaving a false one. Refusing is honest; claiming af authored words it cannot
+// account for is not.
+func TestRewriteProgramCmdByAf_ClearsAnUndescribableRewrite(t *testing.T) {
+	session := &TmuxSession{program: "claude", generatedArgs: []string{"--session-id", "sid-1"}}
+	session.rewriteProgramCmdByAf(func(string) string { return "ANTHROPIC_API_KEY=sk claude --continue" })
+	require.Empty(t, session.generatedArgs,
+		"an assignment prefix is not an appended argument; the declaration must not survive it")
+}
+
+// A SOURCE guard, not a behavioural one, and labelled so nobody mistakes it for
+// coverage of Restore itself.
+//
+// The helper above is unit-tested, but the thing that actually breaks is the CALL
+// SITE: reverting Restore to `setProgramCmd(resumeProgram(...))` leaves every test
+// here green while the declaration goes stale again. Binding that properly needs a
+// real re-spawn against real tmux, which this suite can do but only by spawning a
+// server for a one-line assertion.
+//
+// So this asserts the drift-prone spelling is absent. It is weak — it proves a
+// string is not present, not that the behaviour is right — and it is here because
+// the alternative was to claim the call site was covered when it was not.
+func TestRestoreUsesTheDeclarationPreservingRewrite(t *testing.T) {
+	source, err := os.ReadFile("start.go")
+	require.NoError(t, err)
+	require.NotContains(t, string(source), "setProgramCmd(resumeProgram(",
+		"Restore must rewrite the program through rewriteProgramCmdByAf, which moves the generated-args "+
+			"declaration with it; setProgramCmd alone leaves the declaration stale and an account-scoped "+
+			"re-spawn then exits 127 (#3083 review)")
+	require.Contains(t, string(source), "rewriteProgramCmdByAf(resumeProgram)",
+		"and it must still be doing that rewrite at all")
+}

--- a/session/tmux/program_af_rewrite_test.go
+++ b/session/tmux/program_af_rewrite_test.go
@@ -122,7 +122,7 @@ func TestLaunchSnapshot_NeverTearsTheCommandFromItsDeclaration(t *testing.T) {
 		}
 	}()
 	for i := 0; i < 500; i++ {
-		program, generated, _, _ := session.launchSnapshot()
+		program, generated, _, _, _ := session.launchSnapshot()
 		// Every legal pair: bare with no declaration, or resumed with --continue
 		// declared. A torn read produces one without the other.
 		switch program {
@@ -150,7 +150,7 @@ func TestSetProgram_ClearsAPreviousDeclaration(t *testing.T) {
 	// A handoff target that happens to end in the very same words.
 	session.SetProgram("other-agent --session-id sid-1 --plugin-dir /p")
 
-	program, generated, _, _ := session.launchSnapshot()
+	program, generated, _, _, _ := session.launchSnapshot()
 	require.Equal(t, "other-agent --session-id sid-1 --plugin-dir /p", program)
 	require.Empty(t, generated,
 		"the outgoing launch's declaration survived into the replacement, so af would vouch for "+

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -159,6 +159,10 @@ type TmuxSession struct {
 	// account is the credential account this session runs its agent as, or empty
 	// for the ambient identity. Guarded by programMu with envPassthrough (#3051).
 	account string
+	// accountAgent is the namespace in which account was selected. It is kept
+	// separately from the resolved program so a program_overrides change cannot
+	// reinterpret the same account name as another agent's identity (#3083 review).
+	accountAgent string
 	// generatedArgs are the argument words af's own launcher appended to program,
 	// declared so the account boundary can verify af's output instead of refusing
 	// it (#3083). Guarded by programMu with program itself, because a launch reads

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -159,6 +159,12 @@ type TmuxSession struct {
 	// account is the credential account this session runs its agent as, or empty
 	// for the ambient identity. Guarded by programMu with envPassthrough (#3051).
 	account string
+	// generatedArgs are the argument words af's own launcher appended to program,
+	// declared so the account boundary can verify af's output instead of refusing
+	// it (#3083). Guarded by programMu with program itself, because a launch reads
+	// the two together and a declaration that described a DIFFERENT program string
+	// than the one being wrapped would be worse than none.
+	generatedArgs []string
 	// inputMu serializes every multi-command transaction that injects pane input.
 	// A submit must not clear/paste between a prompt handler's selected-row
 	// capture and Enter, two submits must not clear each other's freshly pasted

--- a/session/tmux/session_env.go
+++ b/session/tmux/session_env.go
@@ -36,25 +36,41 @@ func (t *TmuxSession) SetAccount(name string) {
 	t.programMu.Unlock()
 }
 
-// SetGeneratedArgs declares the argument words af's own launcher appended to this
-// session's program (#3083). Set it with SetProgram, from the site that produced
-// both strings; see session.setLaunchProgram, which pairs them so the two cannot
-// drift apart.
+// SetLaunchProgram sets the pane command AND the declaration of which argument
+// words af appended to reach it, under ONE programMu hold (#3083 review).
 //
-// Empty is the correct declaration for a launch af did not rewrite, and it leaves
-// the boundary's no-arguments rule exactly as it was.
-func (t *TmuxSession) SetGeneratedArgs(generated []string) {
+// Paired because a reader between two independently-locked setters sees a torn
+// pair — the old command with the new declaration, or the reverse — and the
+// account boundary requires the command to be the agent plus EXACTLY the declared
+// words, so either half of that tear refuses the launch and the pane exits
+// immediately. The call site pairing them is not enough: it makes the two writes
+// adjacent, not atomic.
+func (t *TmuxSession) SetLaunchProgram(program string, generated []string) {
 	t.programMu.Lock()
+	defer t.programMu.Unlock()
+	t.program = program
 	t.generatedArgs = append([]string(nil), generated...)
-	t.programMu.Unlock()
 }
 
-func (t *TmuxSession) launchEnvironment(program string) (string, []string, []string, error) {
+// launchSnapshot reads every field a launch needs in ONE hold, for the same
+// reason SetLaunchProgram writes them in one: Start used to read program through
+// its own lock and the declaration through another, so a rewrite landing between
+// them paired an old command with a new declaration.
+func (t *TmuxSession) launchSnapshot() (program string, generated, extras []string, account string) {
 	t.programMu.RLock()
-	extra := append([]string(nil), t.envPassthrough...)
-	account := t.account
-	generated := append([]string(nil), t.generatedArgs...)
-	t.programMu.RUnlock()
+	defer t.programMu.RUnlock()
+	return t.program,
+		append([]string(nil), t.generatedArgs...),
+		append([]string(nil), t.envPassthrough...),
+		t.account
+}
+
+// It SNAPSHOTS rather than taking the program as a parameter: the caller used to
+// read program through its own lock and this read the declaration through
+// another, so a rewrite landing between them wrapped an old command with a new
+// declaration (#3083 review).
+func (t *TmuxSession) launchEnvironment() (string, []string, []string, error) {
+	program, generated, extra, account := t.launchSnapshot()
 	agent := sessionenv.AgentForCommand(program)
 	executable, err := sessionEnvExecutable()
 	if err != nil {

--- a/session/tmux/session_env.go
+++ b/session/tmux/session_env.go
@@ -32,8 +32,28 @@ func (t *TmuxSession) SetEnvPassthrough(names []string) error {
 // feature existed.
 func (t *TmuxSession) SetAccount(name string) {
 	t.programMu.Lock()
+	defer t.programMu.Unlock()
 	t.account = name
-	t.programMu.Unlock()
+	if name == "" {
+		t.accountAgent = ""
+		return
+	}
+	t.accountAgent = sessionenv.AgentForCommand(t.program)
+}
+
+// SetAccountForAgent selects name in the namespace the caller validated. The
+// namespace is explicit because program is override-resolved and may later be
+// rewritten; deriving it again would let the same string silently select a
+// different agent's account.
+func (t *TmuxSession) SetAccountForAgent(agent, name string) {
+	t.programMu.Lock()
+	defer t.programMu.Unlock()
+	t.account = name
+	if name == "" {
+		t.accountAgent = ""
+		return
+	}
+	t.accountAgent = agent
 }
 
 // SetLaunchProgram sets the pane command AND the declaration of which argument
@@ -56,13 +76,14 @@ func (t *TmuxSession) SetLaunchProgram(program string, generated []string) {
 // reason SetLaunchProgram writes them in one: Start used to read program through
 // its own lock and the declaration through another, so a rewrite landing between
 // them paired an old command with a new declaration.
-func (t *TmuxSession) launchSnapshot() (program string, generated, extras []string, account string) {
+func (t *TmuxSession) launchSnapshot() (program string, generated, extras []string, account, accountAgent string) {
 	t.programMu.RLock()
 	defer t.programMu.RUnlock()
 	return t.program,
 		append([]string(nil), t.generatedArgs...),
 		append([]string(nil), t.envPassthrough...),
-		t.account
+		t.account,
+		t.accountAgent
 }
 
 // It SNAPSHOTS rather than taking the program as a parameter: the caller used to
@@ -70,7 +91,7 @@ func (t *TmuxSession) launchSnapshot() (program string, generated, extras []stri
 // another, so a rewrite landing between them wrapped an old command with a new
 // declaration (#3083 review).
 func (t *TmuxSession) launchEnvironment() (string, []string, []string, error) {
-	program, generated, extra, account := t.launchSnapshot()
+	program, generated, extra, account, accountAgent := t.launchSnapshot()
 	agent := sessionenv.AgentForCommand(program)
 	executable, err := sessionEnvExecutable()
 	if err != nil {
@@ -78,6 +99,16 @@ func (t *TmuxSession) launchEnvironment() (string, []string, []string, error) {
 	}
 	var wrapped string
 	if account != "" {
+		if agent != accountAgent {
+			resolved := agent
+			if resolved == "" {
+				resolved = "an unrecognized command"
+			}
+			return "", nil, nil, fmt.Errorf(
+				"account %q was selected for %s, but the launch program resolves to %s; refusing rather than "+
+					"looking up the same account name in another agent's namespace",
+				account, accountAgent, resolved)
+		}
 		// tmux < 3.2 REFUSES rather than falling back. A fallback would launch on
 		// the ambient account while every visible signal reported the selected one,
 		// spending someone else's quota (#3051).
@@ -86,7 +117,7 @@ func (t *TmuxSession) launchEnvironment() (string, []string, []string, error) {
 				"account %q cannot be used on this tmux: account-scoped sessions require tmux 3.2 or newer, "+
 					"and af refuses rather than starting the session on the ambient account", account)
 		}
-		wrapped, err = sessionenv.WrapAccountCommand(executable, agent, account, generated, extra, program)
+		wrapped, err = sessionenv.WrapAccountCommand(executable, accountAgent, account, generated, extra, program)
 	} else {
 		wrapped, err = sessionenv.WrapCommand(executable, agent, extra, program)
 	}

--- a/session/tmux/session_env.go
+++ b/session/tmux/session_env.go
@@ -36,10 +36,24 @@ func (t *TmuxSession) SetAccount(name string) {
 	t.programMu.Unlock()
 }
 
+// SetGeneratedArgs declares the argument words af's own launcher appended to this
+// session's program (#3083). Set it with SetProgram, from the site that produced
+// both strings; see session.setLaunchProgram, which pairs them so the two cannot
+// drift apart.
+//
+// Empty is the correct declaration for a launch af did not rewrite, and it leaves
+// the boundary's no-arguments rule exactly as it was.
+func (t *TmuxSession) SetGeneratedArgs(generated []string) {
+	t.programMu.Lock()
+	t.generatedArgs = append([]string(nil), generated...)
+	t.programMu.Unlock()
+}
+
 func (t *TmuxSession) launchEnvironment(program string) (string, []string, []string, error) {
 	t.programMu.RLock()
 	extra := append([]string(nil), t.envPassthrough...)
 	account := t.account
+	generated := append([]string(nil), t.generatedArgs...)
 	t.programMu.RUnlock()
 	agent := sessionenv.AgentForCommand(program)
 	executable, err := sessionEnvExecutable()
@@ -56,7 +70,7 @@ func (t *TmuxSession) launchEnvironment(program string) (string, []string, []str
 				"account %q cannot be used on this tmux: account-scoped sessions require tmux 3.2 or newer, "+
 					"and af refuses rather than starting the session on the ambient account", account)
 		}
-		wrapped, err = sessionenv.WrapAccountCommand(executable, agent, account, extra, program)
+		wrapped, err = sessionenv.WrapAccountCommand(executable, agent, account, generated, extra, program)
 	} else {
 		wrapped, err = sessionenv.WrapCommand(executable, agent, extra, program)
 	}

--- a/session/tmux/session_env_test.go
+++ b/session/tmux/session_env_test.go
@@ -120,7 +120,7 @@ func TestAgentNameUsedAsDataDoesNotSelectCredentialAllowlist(t *testing.T) {
 		"/srv/af agent-server --listen :43110 --repo /workspace --title codex",
 	} {
 		session := NewTmuxSession("agent-name-data", program)
-		_, environ, imports, err := session.launchEnvironment(program)
+		_, environ, imports, err := session.launchEnvironment()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -139,7 +139,7 @@ func TestInlineClaudeCloudModeImportsProviderCredentials(t *testing.T) {
 	t.Setenv("AZURE_CLIENT_SECRET", "fixture")
 
 	session := NewTmuxSession("inline-cloud-mode", "CLAUDE_CODE_USE_BEDROCK=1 claude")
-	_, environ, imports, err := session.launchEnvironment("CLAUDE_CODE_USE_BEDROCK=1 claude")
+	_, environ, imports, err := session.launchEnvironment()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/session/tmux/session_env_test.go
+++ b/session/tmux/session_env_test.go
@@ -132,6 +132,27 @@ func TestAgentNameUsedAsDataDoesNotSelectCredentialAllowlist(t *testing.T) {
 	}
 }
 
+// An account name belongs to the agent namespace selected when the user chose
+// it. A later program rewrite must not reinterpret that same string in another
+// agent's account registry.
+func TestLaunchEnvironmentRefusesCrossAgentAccountRewrite(t *testing.T) {
+	forceSessionEnvExecutable(t, "/opt/af")
+	forceNewSessionEnvMarkers(t, true)
+
+	// The persisted instance still says Claude, while restore has re-resolved the
+	// current override to Codex before refreshing the account selection.
+	session := NewTmuxSession("cross-agent-account", "codex")
+	session.SetAccountForAgent("claude", "work")
+
+	_, _, _, err := session.launchEnvironment()
+	if err == nil {
+		t.Fatal("a Claude account was reinterpreted as a same-named Codex account after the program changed")
+	}
+	if !strings.Contains(err.Error(), "selected for claude") || !strings.Contains(err.Error(), "resolves to codex") {
+		t.Fatalf("cross-agent refusal did not name both namespaces: %v", err)
+	}
+}
+
 func TestInlineClaudeCloudModeImportsProviderCredentials(t *testing.T) {
 	forceSessionEnvExecutable(t, "/opt/af")
 	t.Setenv("AWS_ACCESS_KEY_ID", "fixture")

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -36,8 +36,10 @@ func (t *TmuxSession) Start(workDir string) error {
 	// Create a new detached tmux session and start claude in it. The -e
 	// markers (when supported) let `af doctor` trace any process the pane
 	// spawns back to this session even after it is orphaned (#1104).
-	program := t.programCmd()
-	wrappedProgram, launchEnv, importNames, envErr := t.launchEnvironment(program)
+	// No separate program read here: launchEnvironment snapshots the command and
+	// its generated-args declaration together, so the two cannot be torn apart by a
+	// concurrent rewrite (#3083 review).
+	wrappedProgram, launchEnv, importNames, envErr := t.launchEnvironment()
 	if envErr != nil {
 		// Nothing has run new-session, so if the name is DETERMINATELY absent no pane
 		// can exist behind it and a teardown need not gate on liveness (#2985).

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -460,7 +460,9 @@ func (t *TmuxSession) Restore(workDir string) error {
 			return fmt.Errorf("tmux session %q does not exist", t.sanitizedName)
 		}
 		log.InfoLog.Printf("tmux session %q missing on Restore; re-spawning in %s", t.sanitizedName, workDir)
-		t.setProgramCmd(resumeProgram(t.programCmd()))
+		// Program AND declaration together: the resume flags are af-authored, so a
+		// stale declaration would refuse an account-scoped restore (#3083 review).
+		t.rewriteProgramCmdByAf(resumeProgram)
 		return t.Start(workDir)
 	}
 


### PR DESCRIPTION
Completes #3083. #3084 landed the mechanism — `Account.GeneratedArgs`, the guard's provenance check
and `GeneratedArgsBetween` — but **nothing populated the field**, so it was inert and `--account`
with claude was still refused. This is the wiring, now that #3075's shim protocol is on master.

## Why this is a second PR

Honest accounting: I had this commit on #3084's branch and rebased it onto post-#3075 master, but
#3084 was merged from its **pre-rebase** head while I was gating. A merged PR's head is frozen, so my
push landed on the branch and moved nothing — and the `git push` output that would have hinted at it
went through a `grep | tail` in my own command. What tipped it off was CI reporting green against a
SHA that was not in my branch log; `ls-remote` said the branch was my tip while the PR API said
otherwise, and `state=closed merged=true` was the answer. Cherry-picked onto master here.

## What it does

`setLaunchProgram` pairs `SetProgram` with `SetGeneratedArgs` in ONE call at every local launch site
— first launch, prepared create, restore, respawn. One function rather than two calls at four sites,
because a declaration describing a different program string than the one installed would be worse
than none: it would be a false claim about the command that runs, and pairing them makes that drift
unrepresentable.

`CreateLaunchPlan` freezes the pre-rewrite base alongside its program rather than re-resolving at
launch, for the reason that struct exists at all — `program_overrides` could read differently by
then, and a declaration must describe the program actually installed.

The declaration travels **length-prefixed** in argv beside the account name, matching how the extras
count already works. That is load-bearing, not stylistic: a generated argument is an arbitrary string
— the plugin directory can contain a space, which a test uses — so any delimiter could appear inside
one and a mis-split would hand the guard a different claim than the launcher made.
`execInvocation` checks the exact total only AFTER both counts are known, because a length that
merely *fits* leaves room for an unaccounted argument between the two lists.

Nothing new is exposed: those words already appear in the command operand beside them. What argv
gains is the CLAIM that af authored them.

**`SwapAgent` deliberately declares nothing.** It changes which agent runs, so an account selection
for the outgoing agent does not transfer — it fails closed and refuses, which is its behaviour today.
Named so it does not read as an oversight.

## Tests

- **The argv round trip**, driven through `WrapAccountCommand` → `execInvocation` with `processExec`
  stubbed, asserting the ENVIRONMENT the pane would have received: `CLAUDE_CONFIG_DIR` is the
  account's and `ANTHROPIC_API_KEY` is gone. Without the declaration surviving argv word-for-word,
  `ApplyAccount` refuses and `execInvocation` errors — so the scoped environ IS the proof. The
  fixture's plugin dir contains a space.
- **Miscounted argv is refused, not guessed at**: truncated, over-count, negative, non-numeric, and
  one unaccounted trailing argument.
- **Fails closed** on a base that cannot be related to the final command (an assignment prefix):
  declares nothing, so the launch is refused rather than proceeding unverified.

`gofmt`, `go build ./...`, `go vet`, `golangci-lint --fast`, `scripts/lint-file-length.sh` clean;
`internal/sessionenv`, `session/tmux` (110s) and the account/launch tests in `session` green.
Cross-built `darwin/arm64` and `windows/amd64` — the protocol test is `//go:build !windows` tagged
because it drives `execInvocation`/`processExec`, which the windows stub does not have.

Closes #3083