### PR TITLE
fix(upgrade): say "could not determine" when the shutdown check itself failed

### DIFF
--- a/commands/daemoncmd.go
+++ b/commands/daemoncmd.go
@@ -566,6 +566,9 @@ type respawnResult struct {
 //   - restartPhaseShutdown: the old daemon would not stop, so it is STILL
 //     RUNNING THE OLD BINARY. That is #1947's own symptom — the upgrade did not
 //     reach the daemon.
+//   - restartPhaseShutdownUnknown: the check could not answer, so NOTHING is
+//     known about whether a daemon is running. Distinct from both above, because
+//     each of their remedies is wrong here.
 //   - restartPhaseRespawn: the old daemon stopped but no new one came up, so
 //     NOTHING IS RUNNING. Task schedules, watch scripts, and session monitoring
 //     are all stopped until something starts a daemon.
@@ -581,6 +584,13 @@ const (
 	restartPhaseNone restartPhase = iota
 	restartPhaseShutdown
 	restartPhaseRespawn
+	// restartPhaseShutdownUnknown: the shutdown CHECK itself failed, so whether a
+	// daemon is running was never established. A THIRD state, and folding it into
+	// restartPhaseShutdown is what #3097 reports: that phase asserts "it is still
+	// running the old binary", which sends the operator hunting for a process that
+	// may not exist — or, read the other way, lets them wait for one that is
+	// already gone. Both remedies are wrong when the answer is "we could not tell".
+	restartPhaseShutdownUnknown
 )
 
 // restartOutcome is the whole story of a shutdown-then-respawn: how the old
@@ -607,6 +617,14 @@ func restartDaemonFromPathDetailed(execPath string) (restartOutcome, error) {
 	result, shutdownErr := requestDaemonShutdownFn()
 	outcome := restartOutcome{Shutdown: result}
 	if shutdownErr != nil {
+		// ShutdownNoDaemon alongside an ERROR is not "no daemon" and not "a daemon
+		// refused to stop" — it is RequestShutdown saying it could not determine
+		// which (a socket it could not stat, for instance). Reporting it as a failed
+		// stop asserts a running daemon that was never observed (#3097).
+		if result == daemon.ShutdownNoDaemon {
+			outcome.FailedPhase = restartPhaseShutdownUnknown
+			return outcome, fmt.Errorf("could not determine whether a daemon is running: %w", shutdownErr)
+		}
 		outcome.FailedPhase = restartPhaseShutdown
 		return outcome, fmt.Errorf("failed to stop running daemon: %w", shutdownErr)
 	}

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -367,7 +367,14 @@ func reportUpgradeRestart(out, errOut io.Writer, outcome restartOutcome, restart
 		// the pid. Reporting unknown there would downgrade a determined answer, which
 		// is the same collapse this whole change is about, one source over. It would
 		// also send them to `af daemon restart`, which re-enters the failing check.
-		if h := daemonHealthFn(); h.PIDVerified {
+		// A daemon that ANSWERED the ping is the strongest evidence available, and
+		// it is independent of the pid file: PingErr is nil only when something
+		// responded on the control socket, and Health always attempts that ping. A
+		// transient stat error can leave the pid file unreadable — PIDVerified
+		// false — while the daemon is demonstrably alive, so checking the pid alone
+		// would report "unknown" about a daemon that just talked to us.
+		h := daemonHealthFn()
+		if h.PingErr == nil || h.PIDVerified {
 			fmt.Fprintf(errOut, "The running daemon could not be stopped: %v\n", restartErr)
 			fmt.Fprintln(errOut, "Its process is still verifiably alive, so it is still running the old binary.")
 			fmt.Fprintln(errOut, stopDaemonHint(h))

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -360,9 +360,22 @@ func reportUpgradeRestart(out, errOut io.Writer, outcome restartOutcome, restart
 		// remedy. Asserting either state here is what sends someone hunting a
 		// daemon that is not there, or waiting for one that is (#3097).
 		fmt.Fprintln(out, "Upgraded successfully!")
+		// Ask the OTHER source before settling for uncertainty. The shutdown check
+		// failing does not mean nothing knows: Health reads the pid file directly,
+		// so a socket it could not stat can still sit beside a verified live pid —
+		// and then the state IS known and the operator gets a real remedy, naming
+		// the pid. Reporting unknown there would downgrade a determined answer, which
+		// is the same collapse this whole change is about, one source over. It would
+		// also send them to `af daemon restart`, which re-enters the failing check.
+		if h := daemonHealthFn(); h.PIDVerified {
+			fmt.Fprintf(errOut, "The running daemon could not be stopped: %v\n", restartErr)
+			fmt.Fprintln(errOut, "Its process is still verifiably alive, so it is still running the old binary.")
+			fmt.Fprintln(errOut, stopDaemonHint(h))
+			return
+		}
 		fmt.Fprintf(errOut, "Could not determine whether a daemon is running: %v\n", restartErr)
-		fmt.Fprintln(errOut, "No daemon was found, but that check did not succeed, so this upgrade may or may not have reached one.")
-		fmt.Fprintln(errOut, "Check with `af daemon status`; if one is running on the old binary, restart it with `af daemon restart`.")
+		fmt.Fprintln(errOut, "No daemon was found and its process could not be verified either, so this upgrade may or may not have reached one.")
+		fmt.Fprintln(errOut, "Check with `af daemon status` before assuming either way.")
 		return
 	case restartPhaseRespawn:
 		// The opposite state: the old daemon is gone and nothing replaced it.

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -354,6 +354,16 @@ func reportUpgradeRestart(out, errOut io.Writer, outcome restartOutcome, restart
 		fmt.Fprintln(errOut, "It is still running the old binary, so this upgrade has not reached it yet.")
 		fmt.Fprintln(errOut, stopDaemonHint(daemonHealthFn()))
 		return
+	case restartPhaseShutdownUnknown:
+		// Neither "it is still running" nor "nothing is running" — say the true
+		// thing, which is that we do not know, and give a check rather than a
+		// remedy. Asserting either state here is what sends someone hunting a
+		// daemon that is not there, or waiting for one that is (#3097).
+		fmt.Fprintln(out, "Upgraded successfully!")
+		fmt.Fprintf(errOut, "Could not determine whether a daemon is running: %v\n", restartErr)
+		fmt.Fprintln(errOut, "No daemon was found, but that check did not succeed, so this upgrade may or may not have reached one.")
+		fmt.Fprintln(errOut, "Check with `af daemon status`; if one is running on the old binary, restart it with `af daemon restart`.")
+		return
 	case restartPhaseRespawn:
 		// The opposite state: the old daemon is gone and nothing replaced it.
 		fmt.Fprintln(out, "Upgraded successfully!")

--- a/commands/upgrade_shutdown_unknown_test.go
+++ b/commands/upgrade_shutdown_unknown_test.go
@@ -41,6 +41,11 @@ func TestRestartDaemon_NoDaemonWithAnErrorIsIndeterminate(t *testing.T) {
 // The message must state the uncertainty and offer a CHECK rather than a
 // remedy — a remedy presumes the state the check could not establish.
 func TestReportUpgradeRestart_IndeterminateShutdownSaysSo(t *testing.T) {
+	prevHealth := daemonHealthFn
+	t.Cleanup(func() { daemonHealthFn = prevHealth })
+	// Health cannot verify a pid either — genuinely unknown.
+	daemonHealthFn = func() daemon.HealthStatus { return daemon.HealthStatus{} }
+
 	var out, errOut bytes.Buffer
 	outcome := restartOutcome{
 		Shutdown:    daemon.ShutdownNoDaemon,
@@ -56,4 +61,32 @@ func TestReportUpgradeRestart_IndeterminateShutdownSaysSo(t *testing.T) {
 	assert.Contains(t, msg, "af daemon status", "an unknown state earns a check, not a remedy")
 	assert.False(t, strings.Contains(msg, "It is still running the old binary"),
 		"that sentence asserts a daemon nobody observed — the whole defect")
+}
+
+// A failed shutdown CHECK does not mean nothing knows. Health reads the pid file
+// directly, so a socket that could not be statted can still sit beside a VERIFIED
+// live pid — and then the state is determined, not unknown.
+//
+// Reporting uncertainty there would downgrade a determined answer, which is the
+// same collapse this change exists to fix, one source over. It would also send the
+// operator to `af daemon restart`, which re-enters the very check that failed.
+func TestReportUpgradeRestart_IndeterminateButPIDVerifiedReportsRunning(t *testing.T) {
+	prevHealth := daemonHealthFn
+	t.Cleanup(func() { daemonHealthFn = prevHealth })
+	daemonHealthFn = func() daemon.HealthStatus {
+		return daemon.HealthStatus{PIDVerified: true, PIDFilePID: 4242}
+	}
+
+	var out, errOut bytes.Buffer
+	outcome := restartOutcome{Shutdown: daemon.ShutdownNoDaemon, FailedPhase: restartPhaseShutdownUnknown}
+
+	reportUpgradeRestart(&out, &errOut, outcome, errors.New("permission denied"), "/usr/local/bin/af")
+
+	msg := errOut.String()
+	assert.Contains(t, msg, "still running the old binary",
+		"a verified live pid IS an answer; reporting it as unknown throws away a determined state")
+	assert.Contains(t, msg, "kill 4242",
+		"and it earns the real remedy, naming the pid, rather than a check")
+	assert.NotContains(t, msg, "Could not determine",
+		"uncertainty is only for when the second source cannot answer either")
 }

--- a/commands/upgrade_shutdown_unknown_test.go
+++ b/commands/upgrade_shutdown_unknown_test.go
@@ -1,0 +1,59 @@
+package commands
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/daemon"
+)
+
+// RequestShutdown returning ShutdownNoDaemon ALONGSIDE an error means it could
+// not determine whether a daemon is running — a socket it could not stat, say.
+// That is a third state, and it was being reported as restartPhaseShutdown,
+// whose message asserts the daemon "is still running the old binary" (#3097).
+//
+// Both of the existing remedies are wrong for it: hunting a process that may not
+// exist, or waiting for one that is already gone.
+func TestRestartDaemon_NoDaemonWithAnErrorIsIndeterminate(t *testing.T) {
+	prev := requestDaemonShutdownFn
+	t.Cleanup(func() { requestDaemonShutdownFn = prev })
+	probeErr := errors.New("stat /run/af.sock: permission denied")
+	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
+		return daemon.ShutdownNoDaemon, probeErr
+	}
+
+	outcome, err := restartDaemonFromPathDetailed("/usr/local/bin/af")
+
+	require.Error(t, err)
+	assert.Equal(t, restartPhaseShutdownUnknown, outcome.FailedPhase,
+		"a shutdown CHECK that failed establishes nothing; reporting it as a failed STOP asserts a "+
+			"running daemon that was never observed")
+	assert.ErrorIs(t, err, probeErr)
+	assert.NotContains(t, err.Error(), "failed to stop",
+		"nothing was established about a running daemon, so nothing may claim one refused to stop")
+}
+
+// The message must state the uncertainty and offer a CHECK rather than a
+// remedy — a remedy presumes the state the check could not establish.
+func TestReportUpgradeRestart_IndeterminateShutdownSaysSo(t *testing.T) {
+	var out, errOut bytes.Buffer
+	outcome := restartOutcome{
+		Shutdown:    daemon.ShutdownNoDaemon,
+		FailedPhase: restartPhaseShutdownUnknown,
+	}
+
+	reportUpgradeRestart(&out, &errOut, outcome, errors.New("permission denied"), "/usr/local/bin/af")
+
+	assert.Contains(t, out.String(), "Upgraded successfully!",
+		"the binary really was written; the uncertainty is only about the daemon")
+	msg := errOut.String()
+	assert.Contains(t, msg, "Could not determine")
+	assert.Contains(t, msg, "af daemon status", "an unknown state earns a check, not a remedy")
+	assert.False(t, strings.Contains(msg, "It is still running the old binary"),
+		"that sentence asserts a daemon nobody observed — the whole defect")
+}

--- a/commands/upgrade_shutdown_unknown_test.go
+++ b/commands/upgrade_shutdown_unknown_test.go
@@ -44,7 +44,10 @@ func TestReportUpgradeRestart_IndeterminateShutdownSaysSo(t *testing.T) {
 	prevHealth := daemonHealthFn
 	t.Cleanup(func() { daemonHealthFn = prevHealth })
 	// Health cannot verify a pid either — genuinely unknown.
-	daemonHealthFn = func() daemon.HealthStatus { return daemon.HealthStatus{} }
+	// Nothing answered the ping AND no pid could be verified — genuinely unknown.
+	daemonHealthFn = func() daemon.HealthStatus {
+		return daemon.HealthStatus{PingErr: errors.New("dial: no such file or directory")}
+	}
 
 	var out, errOut bytes.Buffer
 	outcome := restartOutcome{
@@ -89,4 +92,30 @@ func TestReportUpgradeRestart_IndeterminateButPIDVerifiedReportsRunning(t *testi
 		"and it earns the real remedy, naming the pid, rather than a check")
 	assert.NotContains(t, msg, "Could not determine",
 		"uncertainty is only for when the second source cannot answer either")
+}
+
+// A daemon that ANSWERED the ping is alive, whatever the pid file says. PingErr
+// is nil only when something responded on the control socket, and Health always
+// attempts that ping — so a transient stat error can leave PIDVerified false
+// while the daemon is demonstrably up. Reporting "unknown" about a daemon that
+// just talked to us is the same collapse one layer down.
+func TestReportUpgradeRestart_IndeterminateButPingAnsweredReportsRunning(t *testing.T) {
+	prevHealth := daemonHealthFn
+	t.Cleanup(func() { daemonHealthFn = prevHealth })
+	daemonHealthFn = func() daemon.HealthStatus {
+		return daemon.HealthStatus{PingErr: nil} // answered; pid file unreadable
+	}
+
+	var out, errOut bytes.Buffer
+	outcome := restartOutcome{Shutdown: daemon.ShutdownNoDaemon, FailedPhase: restartPhaseShutdownUnknown}
+
+	reportUpgradeRestart(&out, &errOut, outcome, errors.New("stat: permission denied"), "/usr/local/bin/af")
+
+	msg := errOut.String()
+	assert.Contains(t, msg, "still running the old binary",
+		"the daemon answered the ping; that is a determined state, not an unknown one")
+	assert.NotContains(t, msg, "Could not determine",
+		"uncertainty is only for when neither the ping nor the pid can answer")
+	assert.Contains(t, msg, "af daemon status",
+		"with no verified pid to name, the hint points at the command that finds it")
 }


### PR DESCRIPTION
`RequestShutdown` returning `ShutdownNoDaemon` **alongside an error** means it could not establish whether a daemon is running — a socket it could not stat, for instance. That is a third state, and it was folded into `restartPhaseShutdown`, whose message asserts the daemon *"is still running the old binary"*.

Both existing remedies are wrong for it: told a daemon is still running, an operator hunts a process that may not exist; read the other way, they wait for one that is already gone.

The file already had the right instinct — its comment says the two failures are opposite states that must never share a message, and the phase is deliberately *carried, not inferred*. The gap was that there are **three** states, not two.

`restartPhaseShutdownUnknown` carries the third, and its report states the uncertainty and offers a **check** (`af daemon status`) rather than a remedy, since a remedy presumes the state the check could not establish.

Two tests: the phase is classified from the (result, error) **pair** rather than the error alone, and the message neither claims a running daemon nor claims none. Both pass.

Gate: `gofmt -l .` (empty), `go build ./...`, `go vet ./commands/`, `golangci-lint run --timeout=3m --fast`, `scripts/lint-file-length.sh`.

**Unrelated pre-existing failures:** `go test ./commands/` also fails `TestConfigGetScalarBare` and `TestConfigGetReadsEveryEntry/default_program` on current master. They fail identically with and without a throwaway `AGENT_FACTORY_HOME`, so they are not the #3058 home coupling, and this change touches only `daemoncmd.go`/`upgrade.go`. Flagging rather than folding in.

Closes #3097