### PR TITLE
fix(upgradetxn): exit non-zero when a phase ends with the recovery job still armed

### DIFF
--- a/internal/upgradetxn/recovery_actor.go
+++ b/internal/upgradetxn/recovery_actor.go
@@ -114,12 +114,20 @@ func runRecoveryActorWith(
 	if errors.Is(err, ErrRecoveryJobDisableFailed) {
 		return err
 	}
+	// Checked BEFORE the terminal list, because a terminal-looking sentinel is not
+	// a statement that the work finished. A phase that ended before disarming the
+	// persistent job still owes that work, and exiting 0 there is what stopped
+	// systemd from retrying a transient ledger write until the next boot (#3098).
+	if errors.Is(err, ErrRecoveryJobStillArmed) {
+		return err
+	}
 	if errors.Is(err, ErrUpgradeAborted) ||
 		errors.Is(err, ErrUpgradeRolledBack) ||
 		errors.Is(err, ErrRollbackRecoveryFailed) {
-		// Each expected terminal result is returned by Supervisor only after
-		// the persistent job was disarmed. Exit 0 so the loaded unit's runtime
-		// Restart policy cannot undo that circuit breaker.
+		// Each expected terminal result reaching HERE was returned after the
+		// persistent job was disarmed — the still-armed cases are intercepted
+		// above. Exit 0 so the loaded unit's runtime Restart policy cannot undo
+		// that circuit breaker.
 		return nil
 	}
 	return err

--- a/internal/upgradetxn/recovery_actor_test.go
+++ b/internal/upgradetxn/recovery_actor_test.go
@@ -203,3 +203,56 @@ func TestRecoveryLease_ReleaseFailsOnAClosedHandle(t *testing.T) {
 	require.NoError(t, lease.file.Close())
 	require.Error(t, lease.Release(), "closing the handle must make Release fail")
 }
+
+// TestRecoveryActorRetriesWhenThePhaseEndedWithTheJobStillArmed is the #3098
+// regression, at the layer that decides the process exit code.
+//
+// ErrRollbackRecoveryFailed is returned BOTH after the recovery job was disarmed
+// (nothing is owed — exit 0 so Restart=on-failure cannot undo the circuit
+// breaker) and from a record-rejection failure reached BEFORE the disarm, where
+// the job is still enabled and a restart is exactly what should happen. The
+// actor read one value for two outcomes and exited 0 for both, so a transient
+// ledger write error waited for the next boot instead of the next second.
+func TestRecoveryActorRetriesWhenThePhaseEndedWithTheJobStillArmed(t *testing.T) {
+	txn, home, _ := prepareFixture(t)
+	invocation := RecoveryInvocation{HomeDir: home, TransactionID: txn.Journal().ID}
+
+	stillArmed := errors.Join(
+		ErrRollbackRecoveryFailed,
+		ErrRecoveryJobStillArmed,
+		errors.New("record the rolled-back candidate as rejected: disk full"),
+	)
+
+	err := runRecoveryActorWith(
+		context.Background(), invocation,
+		func(t *Transaction) (*RecoveryLease, error) {
+			return t.tryAcquireRecoveryAs(t.Journal().PreviousBinaryPath)
+		},
+		func(context.Context, *Transaction, *RecoveryLease) error { return stillArmed },
+	)
+
+	require.Error(t, err,
+		"the phase ended before the recovery job was disarmed, so the actor still owes that work; "+
+			"exiting 0 here is what stopped systemd from retrying it")
+	require.ErrorIs(t, err, ErrRecoveryJobStillArmed)
+}
+
+// The other half, and the reason the check is ordered before the terminal list:
+// a genuinely finished rollback failure — one that DID disarm the job — must
+// still exit 0, or the unit restart-loops against a circuit breaker that is
+// already in place (#2960).
+func TestRecoveryActorStillExitsZeroOnceTheJobIsDisarmed(t *testing.T) {
+	txn, home, _ := prepareFixture(t)
+	invocation := RecoveryInvocation{HomeDir: home, TransactionID: txn.Journal().ID}
+
+	err := runRecoveryActorWith(
+		context.Background(), invocation,
+		func(t *Transaction) (*RecoveryLease, error) {
+			return t.tryAcquireRecoveryAs(t.Journal().PreviousBinaryPath)
+		},
+		func(context.Context, *Transaction, *RecoveryLease) error { return ErrRollbackRecoveryFailed },
+	)
+
+	require.NoError(t, err,
+		"a terminal rollback failure reached AFTER the disarm must not restart-loop the unit")
+}

--- a/internal/upgradetxn/supervisor.go
+++ b/internal/upgradetxn/supervisor.go
@@ -26,6 +26,21 @@ var (
 	// and the active journal remain for explicit repair while the persistent job
 	// is disabled, so a corrupt snapshot cannot create a restart loop.
 	ErrRollbackRecoveryFailed = errors.New("automatic upgrade rollback failed; recovery artifacts retained")
+	// ErrRecoveryJobStillArmed marks a terminal-looking result that was reached
+	// BEFORE the persistent recovery job was disarmed, so the work is not finished
+	// and the actor must not exit 0 (#3098).
+	//
+	// ErrRollbackRecoveryFailed alone cannot answer this. It is returned both after
+	// a successful DisableRecoveryJob — the circuit breaker is in place, nothing is
+	// owed — and from the record-rejection failures below, where the job is still
+	// enabled and a retry is exactly what should happen. One value, two outcomes,
+	// and the actor was reading the wrong one: it exited 0 for both, so systemd's
+	// Restart=on-failure never fired and a transient write error waited for the
+	// next boot instead of the next second.
+	//
+	// The same shape as #3036's committed-mutation envelope: a caller cannot infer
+	// what completed from an error that does not say.
+	ErrRecoveryJobStillArmed = errors.New("recovery job was still armed when the phase ended")
 	// ErrRecoveryJobDisableFailed distinguishes a durable rollback circuit
 	// breaker from failure to disarm the service manager. A recovery actor may
 	// exit cleanly for the former, but must fail so the manager retries the
@@ -359,7 +374,9 @@ func (s Supervisor) Run(ctx context.Context, txn *Transaction, lease *RecoveryLe
 					journal.ExecutablePath, journal.CandidateSHA256, journal.ToVersion,
 					"the candidate was rolled back and the rollback did not complete",
 				); err != nil {
-					return errors.Join(ErrRollbackRecoveryFailed,
+					// Still armed: the disable below has NOT run, so a restart can
+					// re-enter this phase and retry the ledger write (#3098).
+					return errors.Join(ErrRollbackRecoveryFailed, ErrRecoveryJobStillArmed,
 						fmt.Errorf("record the rolled-back candidate as rejected: %w", err))
 				}
 			}
@@ -542,7 +559,9 @@ func (s Supervisor) finishFailedRollback(
 			journal.ExecutablePath, journal.CandidateSHA256, journal.ToVersion,
 			"the candidate was rolled back and the rollback did not complete",
 		); err != nil {
-			return errors.Join(ErrRollbackRecoveryFailed, cause,
+			// Same as the PhaseRollbackFailed arm: reached before the disable, so
+			// the job is still armed and this is retryable, not terminal (#3098).
+			return errors.Join(ErrRollbackRecoveryFailed, ErrRecoveryJobStillArmed, cause,
 				fmt.Errorf("record the rolled-back candidate as rejected: %w", err))
 		}
 	}

--- a/internal/upgradetxn/supervisor_test.go
+++ b/internal/upgradetxn/supervisor_test.go
@@ -601,3 +601,38 @@ func TestSupervisorRestartsPreviousBeforeLedgerBookkeeping(t *testing.T) {
 	require.False(t, runtime.jobDisabled, "cleanup must not run while the rejection is unrecorded")
 	require.NoError(t, takeover.Release())
 }
+
+// TestRollbackFailedRecordFailureLeavesTheJobArmedForRetry is the supervisor half
+// of #3098: the phase must SAY it ended with the recovery job still armed, and it
+// must not disarm it, so a restarted actor can re-enter and retry the ledger write.
+func TestRollbackFailedRecordFailureLeavesTheJobArmedForRetry(t *testing.T) {
+	txn, _, _ := prepareFixture(t)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+
+	txn.mu.Lock()
+	// CandidateInstalled reaches the record; an empty digest makes RecordRejectedCandidate
+	// fail deterministically ("cannot reject an upgrade candidate with no digest"),
+	// standing in for the transient disk error this exists to make retryable.
+	txn.journal.CandidateInstalled = true
+	txn.journal.CandidateSHA256 = ""
+	require.NoError(t, txn.persistPhaseLocked(PhaseRollbackFailed))
+	txn.mu.Unlock()
+
+	runtime := &fakeSupervisorRuntime{}
+	err = (Supervisor{Operations: runtime.operations()}).Run(context.Background(), txn, lease)
+
+	require.ErrorIs(t, err, ErrRollbackRecoveryFailed)
+	require.ErrorIs(t, err, ErrRecoveryJobStillArmed,
+		"the result must state that the job was never disarmed; without it the actor exits 0 and systemd never retries")
+	require.False(t, runtime.jobDisabled,
+		"disarming here would strand the candidate un-disqualified with nothing left to retry it")
+	require.NotContains(t, runtime.calls, "disable-recovery-job")
+
+	require.NoError(t, lease.Release())
+	// Deliberately no reload assertion here: the empty digest that makes the
+	// record fail also makes the journal fail its own load validation, and phase
+	// durability across a reload is already covered by
+	// TestRollbackFailedDisablesRecoveryLoopAndRetainsArtifacts. What this test
+	// owns is the OUTCOME the actor reads.
+}


### PR DESCRIPTION
`PhaseRollbackFailed` returned `ErrRollbackRecoveryFailed` for **two different
outcomes**, and the actor could not tell them apart:

| path | recovery job | correct exit |
|---|---|---|
| after `DisableRecoveryJob` succeeded | disarmed, nothing owed | **0** — so `Restart=on-failure` cannot undo the breaker (#2960) |
| `RecordRejectedCandidate` failed, reached **before** that disable | still enabled | **non-zero** — a restart is exactly what should happen |

The actor exited 0 for both, so systemd never retried and a transient ledger
write error waited for the next boot instead of the next second.

This is #3036's committed-outcome class in another subsystem: a caller cannot
infer what completed from a value that does not say. So it says it.
`ErrRecoveryJobStillArmed` is joined at **both** pre-disable record failures —
the `PhaseRollbackFailed` arm and `finishFailedRollback`, which had the identical
shape — and the actor checks it **before** the terminal list, because a
terminal-looking sentinel is not a statement that the work finished.

## One scoping decision, stated rather than guessed

Scoped to a NEGATIVE marker rather than requiring a positive "disarmed" one on
every terminal path. The positive form is the stronger shape — it makes the safe
outcome the lazy one, so forgetting yields "retry" rather than "exit 0" — but it
turns on auditing the abort and rolled-back paths for whether each is reached
post-disable, and getting that wrong restart-loops the unit against a breaker
that is already set. That is a worse failure than the one being fixed, so it is
recorded here instead of attempted blind.

## Both directions pinned

- `TestRecoveryActorRetriesWhenThePhaseEndedWithTheJobStillArmed` — still-armed
  must exit non-zero.
- `TestRecoveryActorStillExitsZeroOnceTheJobIsDisarmed` — a rollback failure
  reached AFTER the disarm must still exit 0. This is what stops the fix from
  becoming the #2960 restart loop.
- `TestRollbackFailedRecordFailureLeavesTheJobArmedForRetry` — the supervisor
  emits the marker and does NOT disarm.

Verified by mutation: deleting the actor's new check turns the first red.

Local gates: build, `go vet ./...`, gofmt, file-length, golangci-lint, and the
full `internal/upgradetxn` package.

Closes #3098

— Captain Claude
