### PR TITLE
fix(tui): surface a task-list reload failure instead of showing a stale list

### DIFF
--- a/app/home_tasks.go
+++ b/app/home_tasks.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -79,15 +80,28 @@ func (m *home) handleTaskCreate() tea.Cmd {
 		return m.handleError(fmt.Errorf("failed to save task: %v", addErr))
 	}
 	// Refresh sidebar and task pane
+	// A reload failure is NOT nothing: the save committed, so the list on screen is
+	// now stale, and returning nil tells the user it is current. They then read a
+	// list missing the task they just created and reasonably conclude the save
+	// failed — so they create it again (#3095). Surfaced the way
+	// saveContentPaneState already surfaces the same reload.
+	var reloadErr error
 	tasks, err := task.LoadTasksForCurrentRepo()
 	if err == nil {
 		m.store.SetTasks(tasks)
 		sp.SetTasks(tasks)
 		// Reflow so the new automation grows the rail's section (#1126).
 		m.relayout()
+	} else {
+		reloadErr = fmt.Errorf("the task was saved, but this list could not be reloaded, so it is showing the tasks from before — do not create it again: %w", err)
 	}
 	if addErr != nil {
-		return m.handleError(fmt.Errorf("task was saved, but the daemon could not refresh its schedules: %w", addErr))
+		return m.handleError(errors.Join(
+			fmt.Errorf("task was saved, but the daemon could not refresh its schedules: %w", addErr),
+			reloadErr))
+	}
+	if reloadErr != nil {
+		return m.handleError(reloadErr)
 	}
 	return nil
 }


### PR DESCRIPTION
Same class as #3097 (merged): a failed read reported as a definite state.

`handleTaskCreate` reloaded the task list after a successful save and **dropped the error**, then returned `nil`. The save committed, so the list on screen is stale — and returning `nil` tells the user it is current. They read a list missing the task they just created, reasonably conclude the save failed, and create it again. The reported symptom is duplicate tasks; the cause is the collapse.

## The fix is the neighbour's

`saveContentPaneState` (`app/content_persistence.go:142`) reloads *identically* and joins the failure into its returned error. This site now does the same — including when the daemon-refresh error is also present, so neither outcome is lost behind the other.

## The message names the consequence, not the operation

What the user has to decide is whether to retry, so it says the task **was** saved, that the list is showing the tasks from before, and not to create it again. "Failed to reload tasks" would be accurate and would not answer that question.

## Third site, deliberately unchanged

`home_model.go:547` logs and leaves the automations strip empty. That is construction time — there is no UI to render an error into yet — and it makes no success claim about a user action. The comment above it already records empty-not-errored as the intent, so changing it would contradict a decision rather than fix an oversight.

Gate: `gofmt -l .` (empty), `go build ./...`, `go vet ./app/`, `golangci-lint run --timeout=3m --fast`, `scripts/lint-file-length.sh`. `app/` tests are left to CI per the host policy — they drive real tmux beside the maintainer's live sessions.

Closes #3095