### PR TITLE
fix(git): retain a read descriptor so an unreadable copy can still be hard-linked (#3063)

### DIFF
--- a/session/git/worktree_copy_hardlink_stale_test.go
+++ b/session/git/worktree_copy_hardlink_stale_test.go
@@ -186,11 +186,11 @@ func TestSourceMatchesCopiedFile_RefusesWhenTheDestinationCannotBeRead(t *testin
 	srcIdentity, err := identityAt(root, "src")
 	require.NoError(t, err)
 
-	require.True(t, sourceMatchesCopiedFile(root, "src", root, "dst", dstIdentity, srcIdentity),
+	require.True(t, sourceMatchesCopiedFile(root, "src", root, "dst", dstIdentity, srcIdentity, nil),
 		"a readable destination with identical bytes must still link")
 
 	require.NoError(t, os.Chmod(filepath.Join(dir, "dst"), 0o000))
-	require.False(t, sourceMatchesCopiedFile(root, "src", root, "dst", dstIdentity, srcIdentity),
+	require.False(t, sourceMatchesCopiedFile(root, "src", root, "dst", dstIdentity, srcIdentity, nil),
 		"an unreadable destination cannot be attested, so it must not be linked against")
 
 	// Identity, not just content: a matching-content impostor at a different inode
@@ -199,7 +199,7 @@ func TestSourceMatchesCopiedFile_RefusesWhenTheDestinationCannotBeRead(t *testin
 	impostor, err := identityAt(root, "impostor")
 	require.NoError(t, err)
 	require.NotEqual(t, dstIdentity, impostor, "precondition: the impostor must be a different inode")
-	require.False(t, sourceMatchesCopiedFile(root, "src", root, "impostor", dstIdentity, srcIdentity),
+	require.False(t, sourceMatchesCopiedFile(root, "src", root, "impostor", dstIdentity, srcIdentity, nil),
 		"content equality on a substituted inode must not be accepted")
 
 	// And symmetrically on the SOURCE side. statAt and the open in the comparison
@@ -216,9 +216,9 @@ func TestSourceMatchesCopiedFile_RefusesWhenTheDestinationCannotBeRead(t *testin
 	src2, err := identityAt(root, "src2")
 	require.NoError(t, err)
 	require.NotEqual(t, srcIdentity, src2, "precondition: the swapped source must be a different inode")
-	require.True(t, sourceMatchesCopiedFile(root, "src2", root, "dst2", dst2, src2),
+	require.True(t, sourceMatchesCopiedFile(root, "src2", root, "dst2", dst2, src2, nil),
 		"control: matching bytes and BOTH identities correct must link")
-	require.False(t, sourceMatchesCopiedFile(root, "src2", root, "dst2", dst2, srcIdentity),
+	require.False(t, sourceMatchesCopiedFile(root, "src2", root, "dst2", dst2, srcIdentity, nil),
 		"a source inode that is not the one the walk inspected must be refused, "+
 			"even when its bytes match and the destination is readable")
 }

--- a/session/git/worktree_copy_link_budget_test.go
+++ b/session/git/worktree_copy_link_budget_test.go
@@ -1,0 +1,79 @@
+//go:build !windows
+
+package git
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// Retained hard-link readers must be bounded by the process's real descriptor
+// limit, not only by a constant that may sit above it. The copy still has to
+// retain readers (otherwise #3063 regresses), while leaving enough descriptors
+// for traversal, source/destination opens, and the daemon's unrelated work.
+func TestCopyTree_RetainedReadersHonorNoFileLimit(t *testing.T) {
+	var original unix.Rlimit
+	require.NoError(t, unix.Getrlimit(unix.RLIMIT_NOFILE, &original))
+	if original.Cur < 64 {
+		t.Skipf("RLIMIT_NOFILE=%d is too small for the bounded pressure fixture", original.Cur)
+	}
+	const limitedFDs = 64
+	if alreadyOpen := countOpenFileDescriptors(limitedFDs); alreadyOpen > 20 {
+		t.Skipf("test process already holds %d descriptors; cannot create a stable low-limit fixture", alreadyOpen)
+	}
+
+	src := filepath.Join(t.TempDir(), "src")
+	require.NoError(t, os.Mkdir(src, 0o755))
+	for index := range limitedFDs {
+		first := filepath.Join(src, fmt.Sprintf("a-%03d", index))
+		require.NoError(t, os.WriteFile(first, []byte("shared"), 0o600))
+		require.NoError(t, os.Link(first, filepath.Join(src, fmt.Sprintf("z-%03d", index))))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(src, "m-observe"), []byte("marker"), 0o600))
+	dest := filepath.Join(t.TempDir(), "dest")
+
+	originalHook := copyTreeAfterSourceInspect
+	defer func() { copyTreeAfterSourceInspect = originalHook }()
+	initialOpen := 0
+	openAtMarker := 0
+	copyTreeAfterSourceInspect = func(path string) error {
+		openNow := countOpenFileDescriptors(limitedFDs)
+		if initialOpen == 0 {
+			initialOpen = openNow
+		}
+		if filepath.Base(path) == "m-observe" {
+			openAtMarker = openNow
+		}
+		return nil
+	}
+
+	limited := original
+	limited.Cur = limitedFDs
+	require.NoError(t, unix.Setrlimit(unix.RLIMIT_NOFILE, &limited))
+	t.Cleanup(func() { _ = unix.Setrlimit(unix.RLIMIT_NOFILE, &original) })
+	err := copyTree(src, dest)
+	require.NoError(t, unix.Setrlimit(unix.RLIMIT_NOFILE, &original))
+
+	require.NoError(t, err)
+	require.Positive(t, initialOpen)
+	require.Greater(t, openAtMarker, initialOpen,
+		"the copy retained no readers, so unreadable hard-link groups would regress to the master behavior")
+	const minimumSpare = 12
+	require.GreaterOrEqual(t, limitedFDs-openAtMarker, minimumSpare,
+		"retained readers consumed the low RLIMIT before the copier's fixed cap activated")
+}
+
+func countOpenFileDescriptors(limit int) int {
+	count := 0
+	for fd := range limit {
+		if _, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0); err == nil {
+			count++
+		}
+	}
+	return count
+}

--- a/session/git/worktree_copy_link_budget_test.go
+++ b/session/git/worktree_copy_link_budget_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -66,6 +67,87 @@ func TestCopyTree_RetainedReadersHonorNoFileLimit(t *testing.T) {
 	const minimumSpare = 12
 	require.GreaterOrEqual(t, limitedFDs-openAtMarker, minimumSpare,
 		"retained readers consumed the low RLIMIT before the copier's fixed cap activated")
+}
+
+// Concurrent copies share one process descriptor table. A budget computed by
+// each copy from the same snapshot double-spends the spare slots, leaving no
+// room for the next source/destination open. The readers still need to be
+// retained (otherwise #3063 regresses), but their combined total must preserve
+// the process-wide reserve.
+func TestCopyTree_ConcurrentCopiesShareRetainedReaderCapacity(t *testing.T) {
+	var original unix.Rlimit
+	require.NoError(t, unix.Getrlimit(unix.RLIMIT_NOFILE, &original))
+	if original.Cur < 64 {
+		t.Skipf("RLIMIT_NOFILE=%d is too small for the concurrent pressure fixture", original.Cur)
+	}
+	const limitedFDs = 64
+	if alreadyOpen := countOpenFileDescriptors(limitedFDs); alreadyOpen > 20 {
+		t.Skipf("test process already holds %d descriptors; cannot create a stable low-limit fixture", alreadyOpen)
+	}
+
+	type copyPaths struct{ source, destination string }
+	copies := make([]copyPaths, 2)
+	for copyIndex := range copies {
+		source := filepath.Join(t.TempDir(), fmt.Sprintf("src-%d", copyIndex))
+		require.NoError(t, os.Mkdir(source, 0o755))
+		for linkIndex := range limitedFDs {
+			first := filepath.Join(source, fmt.Sprintf("a-%03d", linkIndex))
+			require.NoError(t, os.WriteFile(first, []byte("shared"), 0o600))
+			require.NoError(t, os.Link(first, filepath.Join(source, fmt.Sprintf("z-%03d", linkIndex))))
+		}
+		require.NoError(t, os.WriteFile(filepath.Join(source, "m-observe"), []byte("marker"), 0o600))
+		copies[copyIndex] = copyPaths{source: source, destination: filepath.Join(t.TempDir(), fmt.Sprintf("dest-%d", copyIndex))}
+	}
+
+	originalHook := copyTreeAfterSourceInspect
+	defer func() { copyTreeAfterSourceInspect = originalHook }()
+	var reachedFirst sync.WaitGroup
+	reachedFirst.Add(len(copies))
+	releaseFirst := make(chan struct{})
+	var observedMu sync.Mutex
+	maxOpenAtMarker := 0
+	copyTreeAfterSourceInspect = func(path string) error {
+		switch filepath.Base(path) {
+		case "a-000":
+			reachedFirst.Done()
+			<-releaseFirst
+		case "m-observe":
+			openNow := countOpenFileDescriptors(limitedFDs)
+			observedMu.Lock()
+			if openNow > maxOpenAtMarker {
+				maxOpenAtMarker = openNow
+			}
+			observedMu.Unlock()
+		}
+		return nil
+	}
+
+	limited := original
+	limited.Cur = limitedFDs
+	require.NoError(t, unix.Setrlimit(unix.RLIMIT_NOFILE, &limited))
+	t.Cleanup(func() { _ = unix.Setrlimit(unix.RLIMIT_NOFILE, &original) })
+
+	errors := make(chan error, len(copies))
+	for _, paths := range copies {
+		go func() { errors <- copyTree(paths.source, paths.destination) }()
+	}
+	reachedFirst.Wait()
+	openBeforeReaders := countOpenFileDescriptors(limitedFDs)
+	close(releaseFirst)
+	copyErrors := make([]error, 0, len(copies))
+	for range copies {
+		copyErrors = append(copyErrors, <-errors)
+	}
+	require.NoError(t, unix.Setrlimit(unix.RLIMIT_NOFILE, &original))
+	for _, copyErr := range copyErrors {
+		require.NoError(t, copyErr)
+	}
+
+	require.Greater(t, maxOpenAtMarker, openBeforeReaders,
+		"the concurrent copies retained no readers, so unreadable hard-link groups would regress to the master behavior")
+	const minimumSpare = 12
+	require.GreaterOrEqual(t, limitedFDs-maxOpenAtMarker, minimumSpare,
+		"concurrent copies consumed overlapping descriptor budgets")
 }
 
 func countOpenFileDescriptors(limit int) int {

--- a/session/git/worktree_copy_link_budget_test.go
+++ b/session/git/worktree_copy_link_budget_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -112,6 +113,20 @@ func TestCopyTree_ConcurrentCopiesShareRetainedReaderCapacity(t *testing.T) {
 			reachedFirst.Done()
 			<-releaseFirst
 		case "m-observe":
+			// Make the already-written copies unreadable before their second names
+			// are visited. Only a descriptor retained from the write can preserve
+			// those hard links now; master falls back to fresh copies instead.
+			for _, paths := range copies {
+				if !strings.HasPrefix(path, paths.source+string(os.PathSeparator)) {
+					continue
+				}
+				for linkIndex := range limitedFDs {
+					if err := os.Chmod(filepath.Join(paths.destination, fmt.Sprintf("a-%03d", linkIndex)), 0); err != nil {
+						return err
+					}
+				}
+				break
+			}
 			openNow := countOpenFileDescriptors(limitedFDs)
 			observedMu.Lock()
 			if openNow > maxOpenAtMarker {
@@ -148,6 +163,23 @@ func TestCopyTree_ConcurrentCopiesShareRetainedReaderCapacity(t *testing.T) {
 	const minimumSpare = 12
 	require.GreaterOrEqual(t, limitedFDs-maxOpenAtMarker, minimumSpare,
 		"concurrent copies consumed overlapping descriptor budgets")
+	preservedLinks := 0
+	for _, paths := range copies {
+		for linkIndex := range limitedFDs {
+			first := filepath.Join(paths.destination, fmt.Sprintf("a-%03d", linkIndex))
+			second := filepath.Join(paths.destination, fmt.Sprintf("z-%03d", linkIndex))
+			firstInfo, firstErr := os.Stat(first)
+			secondInfo, secondErr := os.Stat(second)
+			require.NoError(t, firstErr)
+			require.NoError(t, secondErr)
+			if os.SameFile(firstInfo, secondInfo) {
+				preservedLinks++
+			}
+			require.NoError(t, os.Chmod(first, 0o600))
+		}
+	}
+	require.Positive(t, preservedLinks,
+		"the copies retained no readers and lost every unreadable hard-link relationship")
 }
 
 func countOpenFileDescriptors(limit int) int {

--- a/session/git/worktree_copy_link_compare.go
+++ b/session/git/worktree_copy_link_compare.go
@@ -157,7 +157,8 @@ const retainedLinkReaderFDReserve = 16
 
 var retainedLinkReaderCapacity struct {
 	sync.Mutex
-	held int
+	held      int
+	available int
 }
 
 // retainedLinkReader owns both the duplicated descriptor and its process-wide
@@ -177,6 +178,12 @@ func (r *retainedLinkReader) Close() error {
 		r.closeErr = r.file.Close()
 		retainedLinkReaderCapacity.Lock()
 		retainedLinkReaderCapacity.held--
+		retainedLinkReaderCapacity.available++
+		if retainedLinkReaderCapacity.held == 0 {
+			// No reservation wave is active. Recompute against the live process
+			// table when the next copy asks, rather than carrying a stale snapshot.
+			retainedLinkReaderCapacity.available = 0
+		}
 		retainedLinkReaderCapacity.Unlock()
 	})
 	return r.closeErr
@@ -188,18 +195,25 @@ func (r *retainedLinkReader) Close() error {
 func retainLinkReader(fd int, path string) *retainedLinkReader {
 	retainedLinkReaderCapacity.Lock()
 	defer retainedLinkReaderCapacity.Unlock()
-	if retainedLinkReaderCapacity.held >= maxRetainedLinkReaders {
-		return nil
+	if retainedLinkReaderCapacity.held == 0 && retainedLinkReaderCapacity.available == 0 {
+		var limit unix.Rlimit
+		if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &limit); err != nil {
+			return nil
+		}
+		open, ok := openFileDescriptorCount(limit.Cur)
+		if !ok || limit.Cur <= uint64(open)+retainedLinkReaderFDReserve {
+			// An unknown or full table is not evidence that a slot is available.
+			// Falling back to a fresh copy can lose hard-link fidelity, but it never
+			// publishes unverified bytes and cannot exhaust the daemon for other work.
+			return nil
+		}
+		available := limit.Cur - uint64(open) - retainedLinkReaderFDReserve
+		if available > maxRetainedLinkReaders {
+			available = maxRetainedLinkReaders
+		}
+		retainedLinkReaderCapacity.available = int(available)
 	}
-	var limit unix.Rlimit
-	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &limit); err != nil {
-		return nil
-	}
-	open, ok := openFileDescriptorCount()
-	if !ok || limit.Cur <= uint64(open)+retainedLinkReaderFDReserve {
-		// An unknown or full table is not evidence that a slot is available.
-		// Falling back to a fresh copy can lose hard-link fidelity, but it never
-		// publishes unverified bytes and cannot exhaust the daemon for other work.
+	if retainedLinkReaderCapacity.available == 0 {
 		return nil
 	}
 	dupFD, err := unix.FcntlInt(uintptr(fd), unix.F_DUPFD_CLOEXEC, 0)
@@ -212,20 +226,34 @@ func retainLinkReader(fd int, path string) *retainedLinkReader {
 		return nil
 	}
 	retainedLinkReaderCapacity.held++
+	retainedLinkReaderCapacity.available--
 	return &retainedLinkReader{file: file}
 }
 
-// openFileDescriptorCount reads the process descriptor filesystem available on
-// Linux and macOS. The directory read can count its own transient descriptor;
-// that is deliberately conservative by one slot.
-func openFileDescriptorCount() (int, bool) {
+// openFileDescriptorCount first reads the process descriptor filesystem. Linux
+// exposes /proc/self/fd; some systems expose a readable /dev/fd. macOS exposes
+// /dev/fd but does not support enumerating it, so a low-limit portable fallback
+// probes each possible descriptor with F_GETFD instead. The scan is deliberately
+// capped: on a platform with neither descriptor filesystem nor a reasonably
+// small limit, retaining nothing is safer than an unbounded scan in the daemon.
+func openFileDescriptorCount(limit uint64) (int, bool) {
 	for _, path := range []string{"/dev/fd", "/proc/self/fd"} {
 		entries, err := os.ReadDir(path)
 		if err == nil {
 			return len(entries), true
 		}
 	}
-	return 0, false
+	const maxPortableFDScan = 64 * 1024
+	if limit > maxPortableFDScan {
+		return 0, false
+	}
+	open := 0
+	for fd := 0; uint64(fd) < limit; fd++ {
+		if _, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0); err == nil {
+			open++
+		}
+	}
+	return open, true
 }
 
 type copiedFileLink struct {

--- a/session/git/worktree_copy_link_compare.go
+++ b/session/git/worktree_copy_link_compare.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"sync"
 
 	"golang.org/x/sys/unix"
 )
@@ -144,8 +145,8 @@ func openAtForCompare(parent *os.File, name string) (*os.File, error) {
 }
 
 // maxRetainedLinkReaders caps the descriptors held for hard-link comparison even
-// when RLIMIT_NOFILE is very large. retainedLinkReaderBudget narrows it to the
-// process's actual spare capacity for each copy.
+// when RLIMIT_NOFILE is very large. The cap is process-wide: separate archive
+// restores share one descriptor table and cannot each spend the same capacity.
 const maxRetainedLinkReaders = 256
 
 // The copy needs descriptors after the retained-reader budget is chosen: two
@@ -154,27 +155,64 @@ const maxRetainedLinkReaders = 256
 // every slot RLIMIT_NOFILE currently exposes.
 const retainedLinkReaderFDReserve = 16
 
-func retainedLinkReaderBudget() int {
+var retainedLinkReaderCapacity struct {
+	sync.Mutex
+	held int
+}
+
+// retainedLinkReader owns both the duplicated descriptor and its process-wide
+// reservation. Keeping them in one value makes it impossible for a map
+// replacement or error cleanup to close the fd without returning the slot.
+type retainedLinkReader struct {
+	file     *os.File
+	once     sync.Once
+	closeErr error
+}
+
+func (r *retainedLinkReader) Close() error {
+	if r == nil {
+		return nil
+	}
+	r.once.Do(func() {
+		r.closeErr = r.file.Close()
+		retainedLinkReaderCapacity.Lock()
+		retainedLinkReaderCapacity.held--
+		retainedLinkReaderCapacity.Unlock()
+	})
+	return r.closeErr
+}
+
+// retainLinkReader duplicates fd only after atomically reserving room in the
+// process descriptor table. The measurement and dup stay under the same lock so
+// concurrent copies cannot both spend one observed spare slot.
+func retainLinkReader(fd int, path string) *retainedLinkReader {
+	retainedLinkReaderCapacity.Lock()
+	defer retainedLinkReaderCapacity.Unlock()
+	if retainedLinkReaderCapacity.held >= maxRetainedLinkReaders {
+		return nil
+	}
 	var limit unix.Rlimit
 	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &limit); err != nil {
-		return 0
+		return nil
 	}
 	open, ok := openFileDescriptorCount()
-	if !ok {
-		// An unknown table is not evidence that 256 slots are available. Falling
-		// back to reopen loses fidelity only for copies that later become unreadable;
-		// guessing can exhaust the daemon's descriptor table for every session.
-		return 0
+	if !ok || limit.Cur <= uint64(open)+retainedLinkReaderFDReserve {
+		// An unknown or full table is not evidence that a slot is available.
+		// Falling back to a fresh copy can lose hard-link fidelity, but it never
+		// publishes unverified bytes and cannot exhaust the daemon for other work.
+		return nil
 	}
-	usedAndReserved := uint64(open) + retainedLinkReaderFDReserve
-	if limit.Cur <= usedAndReserved {
-		return 0
+	dupFD, err := unix.FcntlInt(uintptr(fd), unix.F_DUPFD_CLOEXEC, 0)
+	if err != nil {
+		return nil
 	}
-	available := limit.Cur - usedAndReserved
-	if available > maxRetainedLinkReaders {
-		return maxRetainedLinkReaders
+	file := os.NewFile(uintptr(dupFD), path)
+	if file == nil {
+		_ = unix.Close(dupFD)
+		return nil
 	}
-	return int(available)
+	retainedLinkReaderCapacity.held++
+	return &retainedLinkReader{file: file}
 }
 
 // openFileDescriptorCount reads the process descriptor filesystem available on
@@ -198,7 +236,7 @@ type copiedFileLink struct {
 	// copier with mode 0004, and owner bits win — so the copier cannot reopen a file
 	// it owns, and every later link to that inode was copied separately instead
 	// (#3063). Owned by copyDirectoryContents, which closes them all.
-	reader *os.File
+	reader *retainedLinkReader
 }
 
 func linkCopiedFile(

--- a/session/git/worktree_copy_link_compare.go
+++ b/session/git/worktree_copy_link_compare.go
@@ -143,15 +143,52 @@ func openAtForCompare(parent *os.File, name string) (*os.File, error) {
 	return os.NewFile(uintptr(fd), name), nil
 }
 
-// maxRetainedLinkReaders caps the descriptors held for hard-link comparison.
-//
-// Chosen well under any default RLIMIT_NOFILE (1024 on most systems, and af also
-// holds tmux pipes, sockets and the walk's own directory descriptors), because
-// exceeding it does not fail loudly — it degrades hard-link fidelity on exactly
-// the large trees where the optimisation is worth most. A tree with more than this
-// many distinct shared inodes falls back to reopening for the remainder, which is
-// the behaviour before this change.
+// maxRetainedLinkReaders caps the descriptors held for hard-link comparison even
+// when RLIMIT_NOFILE is very large. retainedLinkReaderBudget narrows it to the
+// process's actual spare capacity for each copy.
 const maxRetainedLinkReaders = 256
+
+// The copy needs descriptors after the retained-reader budget is chosen: two
+// directory routes, a source and destination file, validation, and unrelated
+// daemon work can all overlap it. Keep an explicit reserve instead of consuming
+// every slot RLIMIT_NOFILE currently exposes.
+const retainedLinkReaderFDReserve = 16
+
+func retainedLinkReaderBudget() int {
+	var limit unix.Rlimit
+	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &limit); err != nil {
+		return 0
+	}
+	open, ok := openFileDescriptorCount()
+	if !ok {
+		// An unknown table is not evidence that 256 slots are available. Falling
+		// back to reopen loses fidelity only for copies that later become unreadable;
+		// guessing can exhaust the daemon's descriptor table for every session.
+		return 0
+	}
+	usedAndReserved := uint64(open) + retainedLinkReaderFDReserve
+	if limit.Cur <= usedAndReserved {
+		return 0
+	}
+	available := limit.Cur - usedAndReserved
+	if available > maxRetainedLinkReaders {
+		return maxRetainedLinkReaders
+	}
+	return int(available)
+}
+
+// openFileDescriptorCount reads the process descriptor filesystem available on
+// Linux and macOS. The directory read can count its own transient descriptor;
+// that is deliberately conservative by one slot.
+func openFileDescriptorCount() (int, bool) {
+	for _, path := range []string{"/dev/fd", "/proc/self/fd"} {
+		entries, err := os.ReadDir(path)
+		if err == nil {
+			return len(entries), true
+		}
+	}
+	return 0, false
+}
 
 type copiedFileLink struct {
 	path     string

--- a/session/git/worktree_copy_link_compare.go
+++ b/session/git/worktree_copy_link_compare.go
@@ -32,7 +32,11 @@ import (
 //
 // Both sides are opened relative to a directory descriptor, never by rebuilt
 // path, keeping the copier descriptor-anchored throughout.
-func sourceMatchesCopiedFile(source *os.File, name string, destinationRoot *os.File, copiedPath string, expected, expectedSource pathIdentity) bool {
+// retained is a descriptor on the copy kept from when it was written, or nil. When
+// present it is used INSTEAD of reopening, which is the whole of #3063: the copy's
+// own mode can deny the copier that owns it, and a descriptor older than the mode
+// is the only thing that still reads.
+func sourceMatchesCopiedFile(source *os.File, name string, destinationRoot *os.File, copiedPath string, expected, expectedSource pathIdentity, retained *os.File) bool {
 	current, err := openAtForCompare(source, name)
 	if err != nil {
 		return false
@@ -65,11 +69,15 @@ func sourceMatchesCopiedFile(source *os.File, name string, destinationRoot *os.F
 	// is #3063 and is a fidelity cost, not a correctness one. Hard-linking is an
 	// optimisation, and one that can publish bytes that were never at that path is
 	// not worth its saving.
-	copied, err := openAtForCompare(destinationRoot, copiedPath)
-	if err != nil {
-		return false
+	copied := retained
+	if copied == nil {
+		reopened, err := openAtForCompare(destinationRoot, copiedPath)
+		if err != nil {
+			return false
+		}
+		defer reopened.Close()
+		copied = reopened
 	}
-	defer copied.Close()
 	copiedIdentity, err := identityFromFile(copied)
 	if err != nil || !expected.same(copiedIdentity) {
 		return false
@@ -87,12 +95,18 @@ func sourceMatchesCopiedFile(source *os.File, name string, destinationRoot *os.F
 		return false
 	}
 
+	// Read the copy through a SectionReader, never sequentially off the descriptor
+	// itself. A retained descriptor is a dup of the one the bytes were written
+	// through, so its offset sits at EOF — and dup(2) SHARES that offset, so a
+	// sequential read would both start at the end and move the writer's position.
+	// A section reader uses pread and touches neither.
+	copiedReader := io.NewSectionReader(copied, 0, copiedInfo.Size())
 	const chunk = 64 * 1024
 	currentChunk := make([]byte, chunk)
 	copiedChunk := make([]byte, chunk)
 	for {
 		readCurrent, currentErr := io.ReadFull(current, currentChunk)
-		readCopied, copiedErr := io.ReadFull(copied, copiedChunk)
+		readCopied, copiedErr := io.ReadFull(copiedReader, copiedChunk)
 		if readCurrent != readCopied || !bytes.Equal(currentChunk[:readCurrent], copiedChunk[:readCopied]) {
 			return false
 		}

--- a/session/git/worktree_copy_link_compare.go
+++ b/session/git/worktree_copy_link_compare.go
@@ -5,6 +5,7 @@ package git
 import (
 	"bytes"
 	"io"
+	"math"
 	"os"
 
 	"golang.org/x/sys/unix"
@@ -95,12 +96,22 @@ func sourceMatchesCopiedFile(source *os.File, name string, destinationRoot *os.F
 		return false
 	}
 
-	// Read the copy through a SectionReader, never sequentially off the descriptor
-	// itself. A retained descriptor is a dup of the one the bytes were written
-	// through, so its offset sits at EOF — and dup(2) SHARES that offset, so a
-	// sequential read would both start at the end and move the writer's position.
-	// A section reader uses pread and touches neither.
-	copiedReader := io.NewSectionReader(copied, 0, copiedInfo.Size())
+	// Offset-based reads, and NOT capped at copiedInfo.Size() (#3063 review).
+	//
+	// Two separate reasons, and the second is a correctness bug rather than a
+	// nicety. pread is required because a retained descriptor is a dup of the one
+	// the bytes were written through: its offset sits at EOF, and dup(2) SHARES that
+	// offset, so a sequential read would start at the end and move the writer's
+	// position. But sizing a SectionReader from the earlier Stat imposes a STALE EOF:
+	// a same-UID process appending to the destination between that Stat and here
+	// makes the copy stop early, both sides appear to end together, and the function
+	// returns true — publishing destination bytes that were never at the source path,
+	// which is precisely the #3046 guarantee this must not break.
+	//
+	// math.MaxInt64 lets the section reader run to the inode's ACTUAL end, so a
+	// destination that grew reads longer than the source and the length check below
+	// refuses it.
+	copiedReader := io.NewSectionReader(copied, 0, math.MaxInt64)
 	const chunk = 64 * 1024
 	currentChunk := make([]byte, chunk)
 	copiedChunk := make([]byte, chunk)

--- a/session/git/worktree_copy_link_compare.go
+++ b/session/git/worktree_copy_link_compare.go
@@ -4,6 +4,7 @@ package git
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"math"
 	"os"
@@ -140,4 +141,53 @@ func openAtForCompare(parent *os.File, name string) (*os.File, error) {
 		return nil, err
 	}
 	return os.NewFile(uintptr(fd), name), nil
+}
+
+// maxRetainedLinkReaders caps the descriptors held for hard-link comparison.
+//
+// Chosen well under any default RLIMIT_NOFILE (1024 on most systems, and af also
+// holds tmux pipes, sockets and the walk's own directory descriptors), because
+// exceeding it does not fail loudly — it degrades hard-link fidelity on exactly
+// the large trees where the optimisation is worth most. A tree with more than this
+// many distinct shared inodes falls back to reopening for the remainder, which is
+// the behaviour before this change.
+const maxRetainedLinkReaders = 256
+
+type copiedFileLink struct {
+	path     string
+	identity pathIdentity
+	// reader is a descriptor on the copy, opened before its mode was narrowed, or
+	// nil. A root-owned 0004 file copied by a non-root user ends up owned by the
+	// copier with mode 0004, and owner bits win — so the copier cannot reopen a file
+	// it owns, and every later link to that inode was copied separately instead
+	// (#3063). Owned by copyDirectoryContents, which closes them all.
+	reader *os.File
+}
+
+func linkCopiedFile(
+	destination, destinationRoot *os.File,
+	first copiedFileLink,
+	name, destinationPath string,
+	sourceIdentity pathIdentity,
+) (copiedEntry, error) {
+	if err := unix.Linkat(int(destinationRoot.Fd()), first.path, int(destination.Fd()), name, 0); err != nil {
+		return copiedEntry{}, fmt.Errorf(
+			"cannot move worktree across filesystems: failed to reproduce the hard link at %s: %w", destinationPath, err)
+	}
+	// Named and identified before anything else can fail, exactly like every
+	// other node this copier creates — cleanup can only remove what the manifest
+	// describes, so the OBSERVED identity is recorded even on the refusal below.
+	destinationIdentity, err := identityAt(destination, name)
+	if err != nil {
+		return copiedEntry{name: name, source: sourceIdentity}, fmt.Errorf(
+			"cannot move worktree across filesystems: failed to identify hard link %s after creating it: %w",
+			destinationPath, err)
+	}
+	created := copiedEntry{name: name, source: sourceIdentity, destination: destinationIdentity}
+	if !first.identity.same(destinationIdentity) {
+		return created, fmt.Errorf(
+			"cannot move worktree across filesystems: hard link %s resolved to a different inode than the file it was linked from",
+			destinationPath)
+	}
+	return created, nil
 }

--- a/session/git/worktree_copy_link_unreadable_test.go
+++ b/session/git/worktree_copy_link_unreadable_test.go
@@ -88,3 +88,39 @@ func TestSourceMatchesCopiedFile_RetainedReaderStillRefusesChangedBytes(t *testi
 		"the retained descriptor reads the COPY; a source that no longer matches it must still refuse, "+
 			"or #3046's stale-content guarantee is lost through the new path")
 }
+
+// A destination LONGER than the source must not compare equal.
+//
+// NAMED for what it actually covers, after a mutation showed it does not cover
+// what I first claimed. It exercises the SIZE GUARD, which already worked: with
+// the copy at 15 bytes and the source at 6, `currentInfo.Size() != copiedInfo.Size()`
+// refuses before any byte is read, so it passes with or without the stale-EOF cap.
+//
+// The P1 that prompted the reader change is an append landing BETWEEN
+// `copied.Stat()` and the comparison, and that interleaving is not reachable from
+// outside the function — there is no seam to land a write in that window. The fix
+// (reading to the inode's real end instead of the size read a moment earlier) is
+// therefore NOT covered by a test, and saying so is better than leaving this one
+// looking like it is.
+func TestSourceMatchesCopiedFile_RefusesADestinationLongerThanTheSource(t *testing.T) {
+	dir := t.TempDir()
+	root, err := os.Open(dir)
+	require.NoError(t, err)
+	defer root.Close()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src"), []byte("SHARED"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "dst"), []byte("SHARED"), 0o600))
+	srcIdentity, err := identityAt(root, "src")
+	require.NoError(t, err)
+	dstIdentity, err := identityAt(root, "dst")
+	require.NoError(t, err)
+	require.True(t, sourceMatchesCopiedFile(root, "src", root, "dst", dstIdentity, srcIdentity, nil),
+		"precondition: identical bytes compare equal")
+
+	// The destination now holds MORE than the source. Same inode, same identity.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "dst"), []byte("SHARED-AND-MORE"), 0o600))
+
+	require.False(t, sourceMatchesCopiedFile(root, "src", root, "dst", dstIdentity, srcIdentity, nil),
+		"the copy is longer than the source, so linking to it would publish bytes that were never at "+
+			"this path; a reader capped at the earlier size reports a false match")
+}

--- a/session/git/worktree_copy_link_unreadable_test.go
+++ b/session/git/worktree_copy_link_unreadable_test.go
@@ -1,0 +1,90 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// #3063: the byte comparison must survive a copy whose OWN mode denies the copier.
+//
+// The reported shape needs two uids — a root-owned 0004 file read by a non-root
+// copier through its other bits, whose copy is then owned by the copier with no
+// owner-read, and owner bits win. That is not constructible in an unprivileged
+// single-uid test: at any mode where the copy is unreadable to me, the source is
+// too, and #3087's refuse-unreadable policy stops the copy before this code runs.
+// Measured, and the reason this tests the MECHANISM at its own seam rather than
+// through copyTree.
+//
+// What it pins is the exact property the end-to-end case needs: given a
+// destination that cannot be reopened, a descriptor retained from when it was
+// written still compares — so the later hard-link sighting links instead of
+// copying a second inode.
+func TestSourceMatchesCopiedFile_UsesTheRetainedReaderWhenTheCopyCannotBeReopened(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores mode bits, so an unreadable copy cannot be constructed")
+	}
+	dir := t.TempDir()
+	root, err := os.Open(dir)
+	require.NoError(t, err)
+	defer root.Close()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src"), []byte("SHARED"), 0o600))
+	copiedPath := filepath.Join(dir, "dst")
+	require.NoError(t, os.WriteFile(copiedPath, []byte("SHARED"), 0o600))
+
+	// The descriptor is taken while the file is still readable — exactly when the
+	// copier holds it, before preserveSourceMode narrows the mode.
+	retained, err := openAtForCompare(root, "dst")
+	require.NoError(t, err)
+	defer retained.Close()
+
+	srcIdentity, err := identityAt(root, "src")
+	require.NoError(t, err)
+	dstIdentity, err := identityAt(root, "dst")
+	require.NoError(t, err)
+
+	// Now the copy denies its owner, which is this process.
+	require.NoError(t, os.Chmod(copiedPath, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(copiedPath, 0o600) })
+	if _, err := openAtForCompare(root, "dst"); err == nil {
+		t.Skip("this user can reopen a 0000 file it owns; the #3063 window does not exist here")
+	}
+
+	require.False(t, sourceMatchesCopiedFile(root, "src", root, "dst", dstIdentity, srcIdentity, nil),
+		"precondition: without a retained descriptor this is the #3063 loss — the reopen fails and the "+
+			"caller copies a second inode instead of linking")
+	require.True(t, sourceMatchesCopiedFile(root, "src", root, "dst", dstIdentity, srcIdentity, retained),
+		"a descriptor retained from the write predates the mode narrowing, so the comparison still "+
+			"reads and the hard link is preserved (#3063)")
+}
+
+// The retained descriptor must not become a way to link MISMATCHED bytes: it is a
+// cheaper way to read the same file, not a reason to trust it. Same refusal as the
+// reopen path, which is what keeps #3046's guarantee intact.
+func TestSourceMatchesCopiedFile_RetainedReaderStillRefusesChangedBytes(t *testing.T) {
+	dir := t.TempDir()
+	root, err := os.Open(dir)
+	require.NoError(t, err)
+	defer root.Close()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src"), []byte("ORIGINAL"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "dst"), []byte("ORIGINAL"), 0o600))
+	retained, err := openAtForCompare(root, "dst")
+	require.NoError(t, err)
+	defer retained.Close()
+
+	srcIdentity, err := identityAt(root, "src")
+	require.NoError(t, err)
+	dstIdentity, err := identityAt(root, "dst")
+	require.NoError(t, err)
+	require.True(t, sourceMatchesCopiedFile(root, "src", root, "dst", dstIdentity, srcIdentity, retained))
+
+	// Rewritten in place, same size — the case a stamp misses and #3046 is about.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src"), []byte("REWRITTE"), 0o600))
+	require.False(t, sourceMatchesCopiedFile(root, "src", root, "dst", dstIdentity, srcIdentity, retained),
+		"the retained descriptor reads the COPY; a source that no longer matches it must still refuse, "+
+			"or #3046's stale-content guarantee is lost through the new path")
+}

--- a/session/git/worktree_copy_policy_test.go
+++ b/session/git/worktree_copy_policy_test.go
@@ -48,7 +48,7 @@ func TestCopyRegularFile_ClassifiesAnUnreadableSource(t *testing.T) {
 	defer destination.Close()
 
 	_, err = copyRegularFileAtWithIdentity(
-		source, destination, "locked", locked, filepath.Join(destinationDir, "locked"), nil, nil)
+		source, destination, "locked", locked, filepath.Join(destinationDir, "locked"), nil, nil, nil)
 	require.Error(t, err)
 
 	var unreadable *unreadableSourceError

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -241,6 +241,7 @@ func copyDirectoryContents(source, destination *os.File, sourcePath, destination
 	// A pointer is threaded to the level walker because the budget spans the WHOLE
 	// traversal, not one directory: shared inodes are found wherever their names are.
 	retainedReaders := 0
+	retainedReaderBudget := retainedLinkReaderBudget()
 	// The retained comparison descriptors die with the copy that opened them. Every
 	// exit from this function passes here, including the error returns below, so a
 	// failed copy cannot leak them either (#3063).
@@ -278,6 +279,7 @@ func copyDirectoryContents(source, destination *os.File, sourcePath, destination
 			links,
 			xattrs,
 			&retainedReaders,
+			retainedReaderBudget,
 		)
 		if err == nil {
 			// The level is complete, and nothing is ever written directly into
@@ -315,6 +317,7 @@ func copyDirectoryLevel(
 	links map[pathIdentity]copiedFileLink,
 	xattrs *xattrDestination,
 	retainedReaders *int,
+	retainedReaderBudget int,
 ) error {
 	names, err := source.Readdirnames(-1)
 	if err != nil {
@@ -389,7 +392,7 @@ func copyDirectoryLevel(
 				// (reopen, and fall back to a fresh copy if the mode denies it). Degrading
 				// to the old path is acceptable; degrading to it unpredictably at whatever
 				// point the fd table happens to fill is not.
-				if stat.Nlink > 1 && *retainedReaders < maxRetainedLinkReaders {
+				if stat.Nlink > 1 && *retainedReaders < retainedReaderBudget {
 					retain = func(fd int) {
 						// dup(2), not a reopen: the point is a descriptor that predates the
 						// mode narrowing, and a reopen would hit the very denial this avoids.

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -237,6 +237,16 @@ func copyDirectoryContents(source, destination *os.File, sourcePath, destination
 	// Source inode -> where its bytes first landed AND what inode they landed
 	// on. Scoped to one copy, so it can never name a path from another tree.
 	links := map[pathIdentity]copiedFileLink{}
+	// The retained comparison descriptors die with the copy that opened them. Every
+	// exit from this function passes here, including the error returns below, so a
+	// failed copy cannot leak them either (#3063).
+	defer func() {
+		for _, link := range links {
+			if link.reader != nil {
+				_ = link.reader.Close()
+			}
+		}
+	}()
 	// Same scoping as links above: whether this DESTINATION holds extended
 	// attributes is learned once per copy and never leaks into another one.
 	xattrs := &xattrDestination{}
@@ -351,15 +361,41 @@ func copyDirectoryLevel(
 			// archive holding bytes that never existed at that path. Hard-linking
 			// is an optimisation, and one that can corrupt content is not worth its
 			// saving (#3046).
-			if first, seen := links[inspected]; seen && sourceMatchesCopiedFile(source, name, destinationRoot, first.path, first.identity, inspected) {
+			if first, seen := links[inspected]; seen && sourceMatchesCopiedFile(source, name, destinationRoot, first.path, first.identity, inspected, first.reader) {
 				entry, err = linkCopiedFile(destination, destinationRoot, first, name, childDestinationPath, inspected)
 			} else {
-				entry, err = copyRegularFileAtWithIdentity(source, destination, name, childSourcePath, childDestinationPath, &inspected, xattrs)
-				if err == nil {
+				// Asked for only when the source was ALREADY seen with more than one
+				// link: those are the inodes a later sighting can hit, so the retained-fd
+				// count is bounded by genuinely shared inodes rather than by tree size and
+				// EMFILE does not become a new failure mode. An inode linked after this
+				// copy is still recorded (see above) and simply falls back to reopening,
+				// which is exactly today's behaviour.
+				var reader *os.File
+				var retain func(fd int)
+				if stat.Nlink > 1 {
+					retain = func(fd int) {
+						// dup(2), not a reopen: the point is a descriptor that predates the
+						// mode narrowing, and a reopen would hit the very denial this avoids.
+						// A dup failure is not fatal — the comparison falls back to reopening.
+						dupFD, dupErr := unix.Dup(fd)
+						if dupErr != nil {
+							return
+						}
+						reader = os.NewFile(uintptr(dupFD), childDestinationPath)
+					}
+				}
+				entry, err = copyRegularFileAtWithIdentity(
+					source, destination, name, childSourcePath, childDestinationPath, &inspected, xattrs, retain)
+				switch {
+				case err == nil:
 					links[inspected] = copiedFileLink{
 						path:     filepath.Join(relativeDirectory, name),
 						identity: entry.destination,
+						reader:   reader,
 					}
+				case reader != nil:
+					// Nothing will record it, so nothing else can close it.
+					_ = reader.Close()
 				}
 			}
 		default:
@@ -399,6 +435,12 @@ func relativeRoutePath(components []copiedEntry) string {
 type copiedFileLink struct {
 	path     string
 	identity pathIdentity
+	// reader is a descriptor on the copy, opened before its mode was narrowed, or
+	// nil. A root-owned 0004 file copied by a non-root user ends up owned by the
+	// copier with mode 0004, and owner bits win — so the copier cannot reopen a file
+	// it owns, and every later link to that inode was copied separately instead
+	// (#3063). Owned by copyDirectoryContents, which closes them all.
+	reader *os.File
 }
 
 func linkCopiedFile(
@@ -808,7 +850,7 @@ func copyFile(src, dst string) error {
 }
 
 func copyRegularFileAt(source, destination *os.File, name, sourcePath, destinationPath string) error {
-	_, err := copyRegularFileAtWithIdentity(source, destination, name, sourcePath, destinationPath, nil, &xattrDestination{})
+	_, err := copyRegularFileAtWithIdentity(source, destination, name, sourcePath, destinationPath, nil, &xattrDestination{}, nil)
 	return err
 }
 
@@ -817,6 +859,7 @@ func copyRegularFileAtWithIdentity(
 	name, sourcePath, destinationPath string,
 	inspected *pathIdentity,
 	support *xattrDestination,
+	retainCopiedFD func(fd int),
 ) (copiedEntry, error) {
 	fd, err := unix.Openat(
 		int(source.Fd()), name,
@@ -851,7 +894,12 @@ func copyRegularFileAtWithIdentity(
 	}
 	outFD, err := unix.Openat(
 		int(destination.Fd()), filepath.Base(destinationPath),
-		unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC,
+		// O_RDWR, not O_WRONLY: a descriptor retained past the mode narrowing below is
+		// how a later hard-link sighting compares this copy's bytes without reopening a
+		// path its own mode may deny (#3063). It works for the reason the mode comment
+		// below already gives — an open descriptor keeps the access it was opened with
+		// regardless of the new mode — applied to reading.
+		unix.O_RDWR|unix.O_CREAT|unix.O_EXCL|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC,
 		workingFileMode(info.Mode()),
 	)
 	if err != nil {
@@ -905,6 +953,13 @@ func copyRegularFileAtWithIdentity(
 	); err != nil {
 		_ = out.Close()
 		return created, err
+	}
+	// SUCCESS ONLY, and before the close: the caller dups this descriptor to compare
+	// against later (#3063). A callback rather than a returned file keeps every error
+	// path above unchanged — each still closes `out` and returns without a descriptor
+	// the caller would have to remember to release.
+	if retainCopiedFD != nil {
+		retainCopiedFD(outFD)
 	}
 	if err := out.Close(); err != nil {
 		return created, err

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -466,54 +466,6 @@ func relativeRoutePath(components []copiedEntry) string {
 // against, and the destination inode that path resolved to at the time. Both are
 // needed — the path to make the link, the identity to prove the link landed on
 // the right inode.
-// maxRetainedLinkReaders caps the descriptors held for hard-link comparison.
-//
-// Chosen well under any default RLIMIT_NOFILE (1024 on most systems, and af also
-// holds tmux pipes, sockets and the walk's own directory descriptors), because
-// exceeding it does not fail loudly — it degrades hard-link fidelity on exactly
-// the large trees where the optimisation is worth most. A tree with more than this
-// many distinct shared inodes falls back to reopening for the remainder, which is
-// the behaviour before this change.
-const maxRetainedLinkReaders = 256
-
-type copiedFileLink struct {
-	path     string
-	identity pathIdentity
-	// reader is a descriptor on the copy, opened before its mode was narrowed, or
-	// nil. A root-owned 0004 file copied by a non-root user ends up owned by the
-	// copier with mode 0004, and owner bits win — so the copier cannot reopen a file
-	// it owns, and every later link to that inode was copied separately instead
-	// (#3063). Owned by copyDirectoryContents, which closes them all.
-	reader *os.File
-}
-
-func linkCopiedFile(
-	destination, destinationRoot *os.File,
-	first copiedFileLink,
-	name, destinationPath string,
-	sourceIdentity pathIdentity,
-) (copiedEntry, error) {
-	if err := unix.Linkat(int(destinationRoot.Fd()), first.path, int(destination.Fd()), name, 0); err != nil {
-		return copiedEntry{}, fmt.Errorf(
-			"cannot move worktree across filesystems: failed to reproduce the hard link at %s: %w", destinationPath, err)
-	}
-	// Named and identified before anything else can fail, exactly like every
-	// other node this copier creates — cleanup can only remove what the manifest
-	// describes, so the OBSERVED identity is recorded even on the refusal below.
-	destinationIdentity, err := identityAt(destination, name)
-	if err != nil {
-		return copiedEntry{name: name, source: sourceIdentity}, fmt.Errorf(
-			"cannot move worktree across filesystems: failed to identify hard link %s after creating it: %w",
-			destinationPath, err)
-	}
-	created := copiedEntry{name: name, source: sourceIdentity, destination: destinationIdentity}
-	if !first.identity.same(destinationIdentity) {
-		return created, fmt.Errorf(
-			"cannot move worktree across filesystems: hard link %s resolved to a different inode than the file it was linked from",
-			destinationPath)
-	}
-	return created, nil
-}
 
 func copyDirectoryEntry(
 	source, destination *os.File,

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -237,6 +237,10 @@ func copyDirectoryContents(source, destination *os.File, sourcePath, destination
 	// Source inode -> where its bytes first landed AND what inode they landed
 	// on. Scoped to one copy, so it can never name a path from another tree.
 	links := map[pathIdentity]copiedFileLink{}
+	// How many comparison descriptors are currently held, against the cap above.
+	// A pointer is threaded to the level walker because the budget spans the WHOLE
+	// traversal, not one directory: shared inodes are found wherever their names are.
+	retainedReaders := 0
 	// The retained comparison descriptors die with the copy that opened them. Every
 	// exit from this function passes here, including the error returns below, so a
 	// failed copy cannot leak them either (#3063).
@@ -273,6 +277,7 @@ func copyDirectoryContents(source, destination *os.File, sourcePath, destination
 			relativeRoutePath(components),
 			links,
 			xattrs,
+			&retainedReaders,
 		)
 		if err == nil {
 			// The level is complete, and nothing is ever written directly into
@@ -309,6 +314,7 @@ func copyDirectoryLevel(
 	relativeDirectory string,
 	links map[pathIdentity]copiedFileLink,
 	xattrs *xattrDestination,
+	retainedReaders *int,
 ) error {
 	names, err := source.Readdirnames(-1)
 	if err != nil {
@@ -372,22 +378,49 @@ func copyDirectoryLevel(
 				// which is exactly today's behaviour.
 				var reader *os.File
 				var retain func(fd int)
-				if stat.Nlink > 1 {
+				// BOUNDED (#3063 review). A valid static tree can hold more distinct
+				// hard-linked inodes than the process has spare descriptors, and an
+				// unbounded cache does not merely waste them: once dup starts failing, the
+				// later groups get a nil reader, cannot be reopened, and are copied as
+				// separate inodes — reintroducing the exact fidelity loss this change
+				// exists to remove, silently and only on big trees.
+				//
+				// Past the budget af simply does not retain, which is today's behaviour
+				// (reopen, and fall back to a fresh copy if the mode denies it). Degrading
+				// to the old path is acceptable; degrading to it unpredictably at whatever
+				// point the fd table happens to fill is not.
+				if stat.Nlink > 1 && *retainedReaders < maxRetainedLinkReaders {
 					retain = func(fd int) {
 						// dup(2), not a reopen: the point is a descriptor that predates the
 						// mode narrowing, and a reopen would hit the very denial this avoids.
 						// A dup failure is not fatal — the comparison falls back to reopening.
-						dupFD, dupErr := unix.Dup(fd)
+						// F_DUPFD_CLOEXEC, never unix.Dup: dup(2) CLEARS FD_CLOEXEC on the new
+						// descriptor even though the original was opened O_CLOEXEC (#3063
+						// review). The daemon forks hooks and session processes while a copy is
+						// running, and any of them would inherit an O_RDWR handle to a staging
+						// inode — able to read or modify archived content past the preserved
+						// mode and past this function's own close. Setting the flag after the
+						// dup would leave that window open between the two calls.
+						dupFD, dupErr := unix.FcntlInt(uintptr(fd), unix.F_DUPFD_CLOEXEC, 0)
 						if dupErr != nil {
 							return
 						}
 						reader = os.NewFile(uintptr(dupFD), childDestinationPath)
+						*retainedReaders++
 					}
 				}
 				entry, err = copyRegularFileAtWithIdentity(
 					source, destination, name, childSourcePath, childDestinationPath, &inspected, xattrs, retain)
 				switch {
 				case err == nil:
+					// The entry being REPLACED owns a descriptor, and overwriting the map
+					// value would strand it: the deferred cleanup only sees the final value,
+					// so an inode rewritten between sightings would leak one descriptor per
+					// fallback and exhaust the table before any finalizer ran (#3063 review).
+					if previous, seen := links[inspected]; seen && previous.reader != nil {
+						_ = previous.reader.Close()
+						*retainedReaders--
+					}
 					links[inspected] = copiedFileLink{
 						path:     filepath.Join(relativeDirectory, name),
 						identity: entry.destination,
@@ -396,6 +429,7 @@ func copyDirectoryLevel(
 				case reader != nil:
 					// Nothing will record it, so nothing else can close it.
 					_ = reader.Close()
+					*retainedReaders--
 				}
 			}
 		default:
@@ -432,6 +466,16 @@ func relativeRoutePath(components []copiedEntry) string {
 // against, and the destination inode that path resolved to at the time. Both are
 // needed — the path to make the link, the identity to prove the link landed on
 // the right inode.
+// maxRetainedLinkReaders caps the descriptors held for hard-link comparison.
+//
+// Chosen well under any default RLIMIT_NOFILE (1024 on most systems, and af also
+// holds tmux pipes, sockets and the walk's own directory descriptors), because
+// exceeding it does not fail loudly — it degrades hard-link fidelity on exactly
+// the large trees where the optimisation is worth most. A tree with more than this
+// many distinct shared inodes falls back to reopening for the remainder, which is
+// the behaviour before this change.
+const maxRetainedLinkReaders = 256
+
 type copiedFileLink struct {
 	path     string
 	identity pathIdentity

--- a/session/git/worktree_copy_tree.go
+++ b/session/git/worktree_copy_tree.go
@@ -237,11 +237,6 @@ func copyDirectoryContents(source, destination *os.File, sourcePath, destination
 	// Source inode -> where its bytes first landed AND what inode they landed
 	// on. Scoped to one copy, so it can never name a path from another tree.
 	links := map[pathIdentity]copiedFileLink{}
-	// How many comparison descriptors are currently held, against the cap above.
-	// A pointer is threaded to the level walker because the budget spans the WHOLE
-	// traversal, not one directory: shared inodes are found wherever their names are.
-	retainedReaders := 0
-	retainedReaderBudget := retainedLinkReaderBudget()
 	// The retained comparison descriptors die with the copy that opened them. Every
 	// exit from this function passes here, including the error returns below, so a
 	// failed copy cannot leak them either (#3063).
@@ -278,8 +273,6 @@ func copyDirectoryContents(source, destination *os.File, sourcePath, destination
 			relativeRoutePath(components),
 			links,
 			xattrs,
-			&retainedReaders,
-			retainedReaderBudget,
 		)
 		if err == nil {
 			// The level is complete, and nothing is ever written directly into
@@ -316,8 +309,6 @@ func copyDirectoryLevel(
 	relativeDirectory string,
 	links map[pathIdentity]copiedFileLink,
 	xattrs *xattrDestination,
-	retainedReaders *int,
-	retainedReaderBudget int,
 ) error {
 	names, err := source.Readdirnames(-1)
 	if err != nil {
@@ -370,7 +361,12 @@ func copyDirectoryLevel(
 			// archive holding bytes that never existed at that path. Hard-linking
 			// is an optimisation, and one that can corrupt content is not worth its
 			// saving (#3046).
-			if first, seen := links[inspected]; seen && sourceMatchesCopiedFile(source, name, destinationRoot, first.path, first.identity, inspected, first.reader) {
+			first, seen := links[inspected]
+			var retained *os.File
+			if seen && first.reader != nil {
+				retained = first.reader.file
+			}
+			if seen && sourceMatchesCopiedFile(source, name, destinationRoot, first.path, first.identity, inspected, retained) {
 				entry, err = linkCopiedFile(destination, destinationRoot, first, name, childDestinationPath, inspected)
 			} else {
 				// Asked for only when the source was ALREADY seen with more than one
@@ -379,9 +375,9 @@ func copyDirectoryLevel(
 				// EMFILE does not become a new failure mode. An inode linked after this
 				// copy is still recorded (see above) and simply falls back to reopening,
 				// which is exactly today's behaviour.
-				var reader *os.File
+				var reader *retainedLinkReader
 				var retain func(fd int)
-				// BOUNDED (#3063 review). A valid static tree can hold more distinct
+				// PROCESS-WIDE BOUNDED (#3063 review). A valid static tree can hold more distinct
 				// hard-linked inodes than the process has spare descriptors, and an
 				// unbounded cache does not merely waste them: once dup starts failing, the
 				// later groups get a nil reader, cannot be reopened, and are copied as
@@ -392,7 +388,7 @@ func copyDirectoryLevel(
 				// (reopen, and fall back to a fresh copy if the mode denies it). Degrading
 				// to the old path is acceptable; degrading to it unpredictably at whatever
 				// point the fd table happens to fill is not.
-				if stat.Nlink > 1 && *retainedReaders < retainedReaderBudget {
+				if stat.Nlink > 1 {
 					retain = func(fd int) {
 						// dup(2), not a reopen: the point is a descriptor that predates the
 						// mode narrowing, and a reopen would hit the very denial this avoids.
@@ -404,12 +400,7 @@ func copyDirectoryLevel(
 						// inode — able to read or modify archived content past the preserved
 						// mode and past this function's own close. Setting the flag after the
 						// dup would leave that window open between the two calls.
-						dupFD, dupErr := unix.FcntlInt(uintptr(fd), unix.F_DUPFD_CLOEXEC, 0)
-						if dupErr != nil {
-							return
-						}
-						reader = os.NewFile(uintptr(dupFD), childDestinationPath)
-						*retainedReaders++
+						reader = retainLinkReader(fd, childDestinationPath)
 					}
 				}
 				entry, err = copyRegularFileAtWithIdentity(
@@ -422,7 +413,6 @@ func copyDirectoryLevel(
 					// fallback and exhaust the table before any finalizer ran (#3063 review).
 					if previous, seen := links[inspected]; seen && previous.reader != nil {
 						_ = previous.reader.Close()
-						*retainedReaders--
 					}
 					links[inspected] = copiedFileLink{
 						path:     filepath.Join(relativeDirectory, name),
@@ -432,7 +422,6 @@ func copyDirectoryLevel(
 				case reader != nil:
 					// Nothing will record it, so nothing else can close it.
 					_ = reader.Close()
-					*retainedReaders--
 				}
 			}
 		default:


### PR DESCRIPTION
Re-checked against master `42652140` first, with #3087 now merged: it added `worktree_copy_policy.go`
and touched `worktree_archive.go`/`worktree_copy_tree.go`, and `worktree_copy_link_compare.go` is
untouched. #3087 classifies an unreadable **SOURCE**; this is the **DESTINATION**. The gap is
unchanged, so this is the fix rather than a close.

## The defect

`sourceMatchesCopiedFile` reopens the destination to compare bytes. When the copier read the source
through its group/other bits — a root-owned `0004` file archived by a non-root user — the copy is
owned by the COPIER with that same mode, and **owner bits take precedence**, so the copier cannot
reopen a file it owns. The comparison fails and every later hard link to that inode is written as a
separate inode.

Correct bytes throughout; what is lost is hard-link preservation. Disk, not integrity — which is why
this was filed rather than fixed inline, and why the fix must not put CPU on every archive.

## The fix, as the issue predicted

Retain a read descriptor from the copy instead of reopening later.

- The destination is opened **`O_RDWR`** rather than `O_WRONLY`. It works for the reason the mode
  comment one line below already gives — an open descriptor keeps the access it was opened with
  regardless of the new mode — applied to reading.
- The descriptor is a **`dup` taken on the success path before `out.Close()`**, via a callback. That
  keeps every existing error path byte-identical: each still closes `out` and returns without handing
  back a descriptor a caller would have to remember to release.
- **Requested only for inodes already seen with `nlink > 1`**, so the retained-fd count is bounded by
  genuinely shared inodes rather than by tree size and EMFILE does not become a new failure mode on a
  large worktree. An inode hard-linked AFTER its copy is still recorded — the map deliberately records
  every regular inode, and that comment explains why — and simply falls back to reopening, which is
  today's behaviour.
- **Comparison reads through `io.NewSectionReader`, never sequentially.** A dup SHARES the original's
  file offset, which sits at EOF after the write, so a sequential read would both start at the end and
  move the writer's position. pread touches neither.
- `copyDirectoryContents` owns the lifetime and closes them in a `defer`, so the error returns cannot
  leak them either.

Correctness is unchanged in both directions: a byte mismatch still refuses, and a descriptor that
could not be retained still falls back to a fresh copy. Hard-linking is an optimisation, and this
makes it available more often without making it authoritative.

## Tests, and an honest limit on the fixture

The reported shape needs **two uids** — a root-owned source read through its other bits, whose copy
the non-root copier then cannot reopen. That is not constructible in an unprivileged single-uid test:
at any mode where the copy is unreadable to me the SOURCE is too, and #3087's refuse-unreadable policy
stops the copy before this code runs. I measured that — my first fixture failed with "af has no
permission to read …" — so the tests pin the mechanism at its own seam rather than pretending to drive
the end-to-end case.

- **The retained descriptor reads what a reopen cannot.** The same test asserts the `nil`-reader call
  returns false first, so the pre-fix loss and the fixed behaviour are one red/green pair rather than
  two tests that could drift apart.
- **A retained descriptor still refuses changed bytes**, including a same-size in-place rewrite. It is
  a cheaper way to read the same file, not a reason to trust it — without this, #3046's stale-content
  guarantee could be lost through the new path.

Both skip rather than lie where the window does not exist (running as root, or a filesystem that lets
an owner reopen a `0000` file).

`gofmt`, `go build ./...`, `go vet`, `golangci-lint --fast`, `scripts/lint-file-length.sh` clean; the
full `session/git` suite green (22.8s); cross-built `darwin/arm64`.

Closes #3063