### PR TITLE
fix(ssh): validate ssh.identity_file at choose time too

### DIFF
--- a/session/backend_preconditions.go
+++ b/session/backend_preconditions.go
@@ -27,8 +27,9 @@ import (
 //
 //	local  — nothing; it is always usable.
 //	docker — docker.image set, the `docker` CLI on PATH, an `origin` to clone from.
-//	ssh    — ssh.host set, the `ssh` CLI on PATH, an `origin` to clone from. (Host
-//	         reachability is a network fact this must not dial for.)
+//	ssh    — ssh.host set, the `ssh` CLI on PATH, a readable ssh.identity_file if
+//	         one is configured, an `origin` to clone from. (Host reachability is a
+//	         network fact this must not dial for.)
 //	hook   — remote_hooks set AND valid AND its commands actually runnable.
 //
 // What is deliberately NOT checked, because it cannot be without doing the work:
@@ -129,6 +130,15 @@ func BackendUnusableReason(kind BackendKind, cfg *config.ResolvedConfig, repoRoo
 		// whose every provision fails. Same shape as the docker check above.
 		if _, err := lookPath("ssh"); err != nil {
 			return sshCLIMissingError(err)
+		}
+		// A picker is a promise, and ssh.identity_file is a LOCAL, side-effect-free
+		// fact — so a repo whose key path is a typo must not be told the backend is
+		// usable and then fail deterministically at create (#3092). Same validator
+		// the runtime runs, so choose time and create time cannot disagree.
+		if cfg != nil && cfg.SSH != nil {
+			if err := verifySSHIdentityFile(*cfg.SSH); err != nil {
+				return err
+			}
 		}
 		if originRemoteURL(repoRoot) == "" {
 			return missingOriginError(BackendSSH, repoRoot)

--- a/session/ssh_version_floor_test.go
+++ b/session/ssh_version_floor_test.go
@@ -232,3 +232,27 @@ func TestUnpinnedCleanupRecordDialsTheName(t *testing.T) {
 	assert.Equal(t, "'h.example.com'", fields[len(fields)-1])
 	assert.NotContains(t, sb.provisioner.sshCmd, "HostKeyAlias")
 }
+
+// A picker is a promise. ssh.identity_file is a local, side-effect-free fact, so
+// a repo whose key path is a typo must be told at CHOOSE time rather than being
+// offered a backend whose every create fails deterministically (#3092).
+func TestBackendUnusableReasonSSHValidatesTheIdentityFile(t *testing.T) {
+	repo := repoWithOriginForTest(t)
+	restore := SetLookPathForTest(func(name string) (string, error) { return "/usr/bin/" + name, nil })
+	defer restore()
+
+	missing := filepath.Join(t.TempDir(), "typo_id_ed25519")
+	err := BackendUnusableReason(BackendSSH,
+		&config.ResolvedConfig{SSH: &config.SSHConfig{Host: "h.example.com", IdentityFile: missing}}, repo)
+	require.Error(t, err, "the picker must not offer a backend whose every create fails on this path")
+	assert.Contains(t, err.Error(), missing)
+
+	// A readable key, and no key at all, both stay usable — so this moved only the
+	// case that was already broken.
+	good := filepath.Join(t.TempDir(), "id_ed25519")
+	require.NoError(t, os.WriteFile(good, []byte("k"), 0o600))
+	assert.NoError(t, BackendUnusableReason(BackendSSH,
+		&config.ResolvedConfig{SSH: &config.SSHConfig{Host: "h.example.com", IdentityFile: good}}, repo))
+	assert.NoError(t, BackendUnusableReason(BackendSSH,
+		&config.ResolvedConfig{SSH: &config.SSHConfig{Host: "h.example.com"}}, repo))
+}


### PR DESCRIPTION
Follow-up to #3100, which merged while this was in flight — review finding [3739641835](https://github.com/sachiniyer/agent-factory/pull/3100#discussion_r3739641835) on that PR, answered but not carried by it.

`BackendUnusableReason`'s SSH branch checked the `ssh` binary and `origin` but never the key path, so a repo whose `ssh.identity_file` is a typo was **advertised as usable** by `ListBackends`/the TUI picker and then failed deterministically at create.

That is the same shape as the `lookPath("ssh")` precondition beside it, and the same rule `backend_preconditions.go` states about itself:

> a picker is a promise. Every backend offered as usable says "choose this and it will work". So availability is a CHECKED fact, never an assumed one.

The key path is a **local, side-effect-free** fact, so it satisfies that function's no-side-effects contract — and it calls the **same validator the runtime runs** (`verifySSHIdentityFile`), so choose time and create time cannot drift apart. Drift is exactly what made the `lookPath` gap worth closing beside it.

The create-time check stays: a picker answers *before* a create, not instead of one.

## Test

`TestBackendUnusableReasonSSHValidatesTheIdentityFile` asserts the refusal names the offending path, and that **a readable key and no key at all both stay usable** — so this moves only the case that was already broken. Watched failing with the call removed.

`gofmt -l .` · `go build ./...` · `golangci-lint run --fast` · `scripts/lint-file-length.sh` · `go test ./session/ -run 'SSH|Sandbox|Cleanup|Backend'`.