### PR TITLE
fix(reset): bound the worktree removal so a stalled filesystem cannot wedge it

### DIFF
--- a/session/git/worktree_remove.go
+++ b/session/git/worktree_remove.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -100,9 +99,21 @@ func RemoveWorktreeDir(repoRoot, worktreePath string) (bool, error) {
 		// allowance for the factory reset (it matched for Cleanup, which folds stderr via
 		// runGitCommandContext) and leaving the os.RemoveAll fallback below unreachable.
 		// Fold stderr into the error so both callers see the same evidence (#2531 review).
-		if out, runErr := exec.Command("git", "-C", repoRoot, "worktree", "remove", "-f", worktreePath).CombinedOutput(); runErr != nil {
+		// BOUNDED (#3096). This recursive unlink is the one local git command that
+		// genuinely stalls forever, which Cleanup has known since #1917 — and this
+		// path, the factory reset's only removal path, ran it unbounded. `af reset`
+		// could therefore wedge with no completion time and no message.
+		if out, runErr := runBoundedWorktreeGit(repoRoot, true, "worktree", "remove", "-f", worktreePath); runErr != nil {
 			err := fmt.Errorf("git worktree remove failed: %s (%w)", strings.TrimSpace(string(out)), runErr)
 			log.ErrorLog.Printf("failed to remove worktree %s: %v", worktreePath, err)
+
+			// A STALL is not an answer. On a deadline nothing is known about the
+			// registration, so stop here rather than let the ownership gate below decide
+			// from a probe that is about to stall the same way — and report what could
+			// not be removed, which is the whole point of bounding a destructive path.
+			if errors.Is(runErr, ErrWorktreeRemovalTimedOut) {
+				return false, worktreeStalledError(worktreePath, err)
+			}
 
 			// Ownership check, restored from Cleanup (#2110). The reset's fallback
 			// used to delete unconditionally, which is how a LOCKED worktree — a
@@ -135,7 +146,10 @@ func RemoveWorktreeDir(repoRoot, worktreePath string) (bool, error) {
 
 	// Prune stale metadata so a subsequent `git branch -D` for this session's
 	// branch isn't blocked by a lingering worktree registration.
-	if err := exec.Command("git", "-C", repoRoot, "worktree", "prune").Run(); err != nil {
+	// Bounded like the remove above: prune walks the same admin files a stalled
+	// mount can block on. Best-effort either way — the VERIFY below is what decides
+	// the outcome, and it does not trust prune's exit code.
+	if _, err := runBoundedWorktreeGit(repoRoot, true, "worktree", "prune"); err != nil {
 		log.ErrorLog.Printf("failed to prune worktrees for %s: %v", repoRoot, err)
 	}
 
@@ -206,7 +220,14 @@ func repoRegistersNothing(repoRoot string) bool {
 // GitWorktree.isWorktreeRegistered, for callers (the factory reset) that hold
 // only two paths; both read the answer through worktreeListed.
 func worktreeRegisteredIn(repoRoot, worktreePath string) (bool, error) {
-	out, err := exec.Command("git", "-C", repoRoot, "worktree", "list", "--porcelain").Output()
+	// Bounded (#3096), and the SUBTLEST of the three. This is the verification read
+	// on the error path, so an unbounded stall here hangs a reset that has already
+	// decided something went wrong — and a bound that let a stalled probe answer
+	// "not registered" would be worse still, converting a hang into silent data
+	// loss: mayDeleteWorktreeDir would then treat git's own worktree as ours to
+	// delete. A failed read is not an empty result, so the error is RETURNED and
+	// every caller checks it before trusting the boolean.
+	out, err := runBoundedWorktreeGit(repoRoot, false, "worktree", "list", "--porcelain")
 	if err != nil {
 		return false, err
 	}

--- a/session/git/worktree_remove_bounded.go
+++ b/session/git/worktree_remove_bounded.go
@@ -1,0 +1,120 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+// Bounding the factory reset's worktree removal (#3096).
+//
+// WHY THIS EXISTS SEPARATELY FROM runGitLocalCommand. Cleanup() already runs the
+// same three git operations under localGitTimeout, and has since #1917, which
+// documented the reason: `git worktree remove -f` recursively unlinks a tree and
+// blocks indefinitely on a hung network mount or a D-state process holding a file
+// in it. RemoveWorktreeDir performs the identical operations and did not, because
+// runGitLocalCommand is a method on *GitWorktree and the reset path holds only two
+// paths. The asymmetry was the whole bug: the codebase's own hardening proved the
+// stall is real, and the reset path was the one that could not use it.
+//
+// So `af reset` could wedge with no bounded completion time and no message — and
+// Ctrl-C, the only escape, leaves the reset half-applied. An operation that never
+// returns is worse than one that fails clearly.
+//
+// WHAT A BOUND CANNOT DO, named because it matters on the destructive path: the
+// deadline works by SIGKILLing git, so it rescues stalls where git is killable. A
+// process wedged in an uninterruptible (D-state) syscall against a dead mount
+// ignores SIGKILL, and no in-process deadline fixes that. What the bound
+// guarantees is that af RETURNS and REPORTS, not that the removal succeeds.
+
+// ErrWorktreeRemovalTimedOut marks a worktree operation that made no progress
+// before its deadline. It is deliberately reported ALONGSIDE
+// ErrWorktreeStillRegistered rather than instead of it: a timeout leaves the
+// registration UNKNOWN, and unknown must behave like "still registered" so the
+// caller retains the session record and a re-run has something to revisit. The
+// distinct sentinel exists so the message can say "stalled" rather than blaming a
+// lock it never observed.
+var ErrWorktreeRemovalTimedOut = errors.New("git worktree operation timed out")
+
+// runBoundedWorktreeGit runs one local git command for the reset path under
+// localGitTimeout, killing the whole process group on the deadline.
+//
+// combined folds stderr into the returned bytes. `worktree remove` needs that —
+// mayDeleteWorktreeDir classifies on git's "validation failed:" message, which git
+// writes to stderr, and a stdout-only read silently disabled the #726
+// corrupted-pointer allowance once already (#2531). The porcelain probe wants
+// stdout alone, so a warning on stderr cannot be parsed as a worktree entry.
+func runBoundedWorktreeGit(repoRoot string, combined bool, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), localGitTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", repoRoot}, args...)...)
+	// The environment is INHERITED rather than filtered. Cleanup's runner filters
+	// because it carries a session's hook passthrough; this path has no session and
+	// no secrets to scope, and a filtered env here would change what git resolves
+	// (PATH, HOME, GIT_* overrides) — a behaviour change beyond the bug being fixed.
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	// Own process group, so the deadline tears down git AND anything it spawned.
+	// exec.CommandContext's default Cancel SIGKILLs only the direct child, which on
+	// a stalled unlink leaves the work still running against the dead mount.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				return os.ErrProcessDone
+			}
+			return err
+		}
+		return nil
+	}
+	// Bound the post-exit wait too: a child inheriting the capture pipes would
+	// otherwise block the read on pipe EOF even after the deadline killed git.
+	cmd.WaitDelay = gitWaitDelay
+
+	var out []byte
+	var err error
+	if combined {
+		out, err = cmd.CombinedOutput()
+	} else {
+		out, err = cmd.Output()
+	}
+	if cmd.Process != nil {
+		// Reap a straggler on EVERY path, not just the timeout: the group is led by
+		// git, which has already exited, so this is ESRCH (ignored) in the common case.
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	if errors.Is(err, exec.ErrWaitDelay) {
+		// git itself exited cleanly — a non-zero exit surfaces as *exec.ExitError, not
+		// this — and only a straggler held the pipe past gitWaitDelay. The output is
+		// already complete, so this is not a failure (#676 precedent).
+		err = nil
+	}
+	// The err != nil guard matters: without it, the ErrWaitDelay mapping above would
+	// surface as a FALSE timeout on a command that in fact succeeded (#914).
+	if err != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return out, fmt.Errorf("%w: git %s made no progress in %s — a stalled filesystem or a process "+
+			"holding a file in the tree; git was killed rather than waited on: %w",
+			ErrWorktreeRemovalTimedOut, strings.Join(args, " "), localGitTimeout, ctx.Err())
+	}
+	return out, err
+}
+
+// worktreeStalledError is the failure a reset reports for a worktree it could not
+// finish removing because git stopped making progress.
+//
+// It wraps ErrWorktreeStillRegistered so the caller RETAINS the session record —
+// a timeout leaves the registration unknown, and dropping the record on an answer
+// nobody got would orphan a possibly-registered worktree and its branch with
+// nothing left to plan a re-run from (#2531). The rest of the reset continues:
+// commands/reset.go collects this per worktree rather than aborting, so one
+// stalled mount cannot strand every other session's cleanup.
+func worktreeStalledError(worktreePath string, cause error) error {
+	return fmt.Errorf("%w: %w: %s could not be removed and its registration is unknown, so it was left "+
+		"in place and its session record kept; check the filesystem it lives on (a hung network mount, or "+
+		"a process stuck in an uninterruptible read) and re-run `af reset`",
+		ErrWorktreeStillRegistered, cause, worktreePath)
+}

--- a/session/git/worktree_remove_bounded.go
+++ b/session/git/worktree_remove_bounded.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 	"syscall"
+	"time"
 )
 
 // Bounding the factory reset's worktree removal (#3096).
@@ -25,11 +26,27 @@ import (
 // Ctrl-C, the only escape, leaves the reset half-applied. An operation that never
 // returns is worse than one that fails clearly.
 //
-// WHAT A BOUND CANNOT DO, named because it matters on the destructive path: the
-// deadline works by SIGKILLing git, so it rescues stalls where git is killable. A
-// process wedged in an uninterruptible (D-state) syscall against a dead mount
-// ignores SIGKILL, and no in-process deadline fixes that. What the bound
-// guarantees is that af RETURNS and REPORTS, not that the removal succeeds.
+// A CONTEXT DEADLINE IS NOT ENOUGH, and this is the part that is easy to get
+// wrong — the first cut of this fix did. exec.Cmd.Wait blocks on
+// c.Process.Wait() BEFORE it ever consults the context or WaitDelay
+// (os/exec/exec.go: `state, err := c.Process.Wait()` is the first statement).
+// waitpid does not return until the process actually exits. So against the very
+// case this issue names — git wedged in an uninterruptible D-state syscall on a
+// dead mount, where SIGKILL is delivered but stays PENDING — the deadline fires,
+// Cancel signals, WaitDelay elapses, and Output() still blocks forever.
+//
+// Measured: with Cancel made a no-op, Output() returned only because Go's own
+// WaitDelay fallback kill SUCCEEDED on a killable child. A child that cannot be
+// reaped has nothing to make Wait return.
+//
+// So the wait is SUPERVISED: the command runs on its own goroutine and the caller
+// selects against a grace period beyond the deadline. If even that expires, af
+// ABANDONS the process and returns. That leaks one goroutine and one unreaped
+// git — unavoidable when the kernel will not let go — and it is strictly better
+// than an unresponsive CLI on a destructive path, which is the whole issue.
+//
+// What is guaranteed, precisely: af RETURNS and REPORTS what it could not remove.
+// Not that the removal succeeded, and not that the process died.
 
 // ErrWorktreeRemovalTimedOut marks a worktree operation that made no progress
 // before its deadline. It is deliberately reported ALONGSIDE
@@ -75,12 +92,12 @@ func runBoundedWorktreeGit(repoRoot string, combined bool, args ...string) ([]by
 	// otherwise block the read on pipe EOF even after the deadline killed git.
 	cmd.WaitDelay = gitWaitDelay
 
-	var out []byte
-	var err error
-	if combined {
-		out, err = cmd.CombinedOutput()
-	} else {
-		out, err = cmd.Output()
+	out, err, reaped := awaitCommandFn(cmd, combined, localGitTimeout+waitAbandonGrace)
+	if !reaped {
+		return nil, fmt.Errorf("%w: git %s could not be killed after %s — it is most likely wedged in an "+
+			"uninterruptible syscall on a stalled filesystem, where SIGKILL stays pending and the process "+
+			"cannot be reaped. af gave up waiting and left it running rather than hanging",
+			ErrWorktreeRemovalTimedOut, strings.Join(args, " "), localGitTimeout+waitAbandonGrace)
 	}
 	if cmd.Process != nil {
 		// Reap a straggler on EVERY path, not just the timeout: the group is led by
@@ -101,6 +118,49 @@ func runBoundedWorktreeGit(repoRoot string, combined bool, args ...string) ([]by
 			ErrWorktreeRemovalTimedOut, strings.Join(args, " "), localGitTimeout, ctx.Err())
 	}
 	return out, err
+}
+
+// waitAbandonGrace is how long past the command's own deadline af waits for the
+// process to actually die before abandoning it. It must EXCEED gitWaitDelay so
+// the ordinary timeout path — which reaps properly and produces the better
+// message — always wins when the process is killable at all. A package var so
+// tests can shrink it.
+var waitAbandonGrace = 15 * time.Second
+
+// awaitCommandFn is the supervision seam. A killable child ALWAYS takes the
+// ordinary deadline path, by design — which means the abandon branch cannot be
+// reached with a real process, and a test that only exercised awaitCommand
+// directly would pass while nothing called it. Production leaves this alone.
+var awaitCommandFn = awaitCommand
+
+// awaitCommand runs cmd and returns its output, or reports that it could not be
+// reaped within limit. reaped=false means the caller must not touch cmd's state:
+// the goroutine still owns it.
+//
+// The channel is BUFFERED so the abandoned goroutine can finish writing and exit
+// if the process ever does die, rather than blocking forever on a receiver that
+// has already gone.
+func awaitCommand(cmd *exec.Cmd, combined bool, limit time.Duration) (out []byte, err error, reaped bool) {
+	type result struct {
+		out []byte
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		var r result
+		if combined {
+			r.out, r.err = cmd.CombinedOutput()
+		} else {
+			r.out, r.err = cmd.Output()
+		}
+		done <- r
+	}()
+	select {
+	case r := <-done:
+		return r.out, r.err, true
+	case <-time.After(limit):
+		return nil, nil, false
+	}
 }
 
 // worktreeStalledError is the failure a reset reports for a worktree it could not

--- a/session/git/worktree_remove_wedge_test.go
+++ b/session/git/worktree_remove_wedge_test.go
@@ -1,0 +1,164 @@
+package git
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The factory reset's removal path, bounded (#3096).
+//
+// The asymmetry this closes is the whole report: Cleanup() has run these exact
+// git operations under localGitTimeout since #1917 — which documented that
+// `git worktree remove -f` genuinely stalls forever on a hung mount — while
+// RemoveWorktreeDir, the reset's ONLY removal path, ran them unbounded. The
+// codebase's own hardening proved the stall is real; the reset could not use it.
+//
+// These mirror the #1917 wedge tests deliberately, because the property is the
+// same one: on a destructive path, RETURNING AND REPORTING is the guarantee, not
+// succeeding. Ctrl-C is not an escape when it leaves a reset half-applied.
+
+// stallingGitFor puts a `git` earlier on PATH that hangs on the given
+// subcommand and delegates everything else to the real one. Targeting a SINGLE
+// subcommand is what lets these tests separate the three call sites — a blanket
+// stall cannot tell "the remove hung" from "the verification probe hung", and
+// those two have different correct answers.
+//
+// The sleep runs in a CHILD, matching stallingGitOnPath: killing only the direct
+// git leaves the child holding the inherited capture pipe, so passing requires
+// the process-group kill AND the WaitDelay, not just exec.CommandContext.
+func stallingGitFor(t *testing.T, subcommand string) {
+	t.Helper()
+	real, err := findRealGit()
+	require.NoError(t, err)
+	dir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"for a in \"$@\"; do\n" +
+		"  if [ \"$a\" = \"" + subcommand + "\" ]; then sleep 300 & wait; fi\n" +
+		"done\n" +
+		"exec " + real + " \"$@\"\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "git"), []byte(script), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func findRealGit() (string, error) {
+	return exec.LookPath("git")
+}
+
+// THE CORE REGRESSION. Unbounded, this call never returns and `af reset` wedges
+// with no completion time and no message.
+func TestRemoveWorktreeDirDoesNotWedgeOnStalledGit(t *testing.T) {
+	sandboxHome(t)
+	repoRoot := createGitRepo(t)
+	runGit(t, repoRoot, "commit", "--allow-empty", "-m", "initial")
+
+	worktreePath := filepath.Join(t.TempDir(), "wt")
+	require.NoError(t, os.MkdirAll(worktreePath, 0o755))
+
+	stallingGitFor(t, "remove")
+	shortenLocalTimeout(t, 200*time.Millisecond)
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() { _, err := RemoveWorktreeDir(repoRoot, worktreePath); done <- err }()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "a stalled removal must surface an error, never silent success")
+		assert.Less(t, time.Since(start), 30*time.Second,
+			"git must be killed at its deadline, not waited on until the stall clears")
+
+		// RETAIN, not drop. A timeout leaves the registration UNKNOWN, and dropping
+		// the session record on an answer nobody got would orphan a possibly-registered
+		// worktree and its branch with nothing left to plan a re-run from (#2531).
+		assert.True(t, errors.Is(err, ErrWorktreeStillRegistered),
+			"a stall must classify as still-registered so reset keeps the record, got %v", err)
+		assert.True(t, errors.Is(err, ErrWorktreeRemovalTimedOut),
+			"and must be distinguishable from a real lock, so the message does not blame one it never saw")
+		assert.Contains(t, err.Error(), worktreePath, "the operator must be told WHICH worktree could not be removed")
+
+		// The directory survives. A stall is not permission to delete: git may still
+		// own the path, and the whole ownership rule exists to keep a locked or
+		// undetermined worktree's directory in place.
+		assert.DirExists(t, worktreePath,
+			"a timeout is not an ownership verdict — deleting here is exactly the data loss the gate prevents")
+	case <-time.After(60 * time.Second):
+		t.Fatal("RemoveWorktreeDir HUNG on a stalled git (#3096): `af reset` becomes unresponsive with no " +
+			"bounded completion time, and Ctrl-C leaves the reset half-applied")
+	}
+}
+
+// THE SUBTLE ONE. `worktree list --porcelain` is the verification read, and a
+// bound that let a stalled probe answer "not registered" would convert a hang
+// into SILENT DATA LOSS: mayDeleteWorktreeDir would then treat git's own
+// worktree as af's to delete. A failed read is not an empty result.
+func TestStalledRegistrationProbeIsNotAnAbsence(t *testing.T) {
+	sandboxHome(t)
+	repoRoot := createGitRepo(t)
+	runGit(t, repoRoot, "commit", "--allow-empty", "-m", "initial")
+
+	worktreePath := filepath.Join(t.TempDir(), "wt")
+	require.NoError(t, os.MkdirAll(worktreePath, 0o755))
+
+	stallingGitFor(t, "list")
+	shortenLocalTimeout(t, 200*time.Millisecond)
+
+	// Bounded by a select, so an UNBOUNDED probe fails RED instead of hanging the
+	// suite until the whole run is killed. A test that hangs reports nothing, which
+	// is the same failure this change is about one level up.
+	type probe struct {
+		registered bool
+		err        error
+	}
+	got := make(chan probe, 1)
+	go func() {
+		reg, err := worktreeRegisteredIn(repoRoot, worktreePath)
+		got <- probe{reg, err}
+	}()
+	var registered bool
+	var err error
+	select {
+	case p := <-got:
+		registered, err = p.registered, p.err
+	case <-time.After(30 * time.Second):
+		t.Fatal("worktreeRegisteredIn HUNG on a stalled `git worktree list` (#3096): this is the " +
+			"verification read on the ERROR path, so an unbounded stall wedges a reset that has " +
+			"already decided something went wrong")
+	}
+
+	require.Error(t, err, "a probe that could not be asked must ERROR, never answer")
+	assert.False(t, registered,
+		"the boolean is meaningless on error, which is why every caller checks err first")
+	assert.True(t, errors.Is(err, ErrWorktreeRemovalTimedOut), "and the error must say it stalled, got %v", err)
+
+	// The gate must refuse on that error rather than read it as "not ours".
+	assert.False(t, mayDeleteWorktreeDir(registered, err == nil, errors.New("git worktree remove failed")),
+		"a probe that could not be asked must never resolve to 'not registered, delete it'")
+}
+
+// The bound must not change the ordinary path: a healthy repo still removes and
+// deregisters, so this fix costs nothing when nothing is stalled.
+func TestRemoveWorktreeDirStillRemovesWhenGitIsHealthy(t *testing.T) {
+	sandboxHome(t)
+	repoRoot := createGitRepo(t)
+	runGit(t, repoRoot, "commit", "--allow-empty", "-m", "initial")
+
+	worktreePath := filepath.Join(t.TempDir(), "wt")
+	runGit(t, repoRoot, "worktree", "add", "-b", "af-3096-healthy", worktreePath)
+	require.DirExists(t, worktreePath)
+
+	removed, err := RemoveWorktreeDir(repoRoot, worktreePath)
+
+	require.NoError(t, err)
+	assert.True(t, removed)
+	assert.NoDirExists(t, worktreePath)
+	stillThere, probeErr := worktreeRegisteredIn(repoRoot, worktreePath)
+	require.NoError(t, probeErr)
+	assert.False(t, stillThere, "the registration must be gone, or the branch delete that follows is blocked")
+}

--- a/session/git/worktree_remove_wedge_test.go
+++ b/session/git/worktree_remove_wedge_test.go
@@ -162,3 +162,84 @@ func TestRemoveWorktreeDirStillRemovesWhenGitIsHealthy(t *testing.T) {
 	require.NoError(t, probeErr)
 	assert.False(t, stillThere, "the registration must be gone, or the branch delete that follows is blocked")
 }
+
+// A DEADLINE ALONE DOES NOT BOUND THIS, which is the trap the first cut of the
+// fix fell into. exec.Cmd.Wait blocks on c.Process.Wait() before it consults the
+// context or WaitDelay, and waitpid does not return until the process exits — so
+// against the issue's own motivating case (git wedged in an uninterruptible
+// syscall on a dead mount, SIGKILL delivered but pending) the deadline fires and
+// Output() still blocks forever.
+//
+// Tested at the supervision boundary rather than by simulating D-state, which is
+// not creatable portably from userspace: `run` here simply never returns, which
+// is exactly what an unreapable child produces.
+func TestAwaitCommandAbandonsAChildItCannotReap(t *testing.T) {
+	blocked := make(chan struct{})
+	t.Cleanup(func() { close(blocked) })
+
+	// A command whose wait never completes, standing in for waitpid on a process
+	// that cannot be reaped.
+	cmd := exec.Command("sh", "-c", "sleep 300")
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() { _ = cmd.Process.Kill(); _, _ = cmd.Process.Wait() })
+
+	start := time.Now()
+	done := make(chan bool, 1)
+	go func() {
+		// Wait on a process nothing is going to kill, with a short abandon limit.
+		_, _, reaped := awaitCommand(exec.Command("sh", "-c", "sleep 300"), false, 300*time.Millisecond)
+		done <- reaped
+	}()
+
+	select {
+	case reaped := <-done:
+		assert.False(t, reaped, "a child that has not exited must be reported as UNREAPED, not waited on")
+		assert.Less(t, time.Since(start), 20*time.Second,
+			"the caller must return at its abandon limit rather than block on waitpid")
+	case <-time.After(30 * time.Second):
+		t.Fatal("awaitCommand BLOCKED on a child that never exits (#3096): Cmd.Wait waits on waitpid " +
+			"BEFORE consulting the context or WaitDelay, so a deadline alone cannot make it return — " +
+			"which is exactly the D-state case this issue is about")
+	}
+}
+
+// And the ordinary path still wins: a killable stall must produce the proper
+// timeout error, reaped and diagnosed, never the abandon message. The abandon
+// grace exceeds gitWaitDelay precisely so this ordering holds.
+func TestKillableStallTakesTheOrdinaryTimeoutPath(t *testing.T) {
+	sandboxHome(t)
+	repoRoot := createGitRepo(t)
+	runGit(t, repoRoot, "commit", "--allow-empty", "-m", "initial")
+
+	stallingGitFor(t, "list")
+	shortenLocalTimeout(t, 200*time.Millisecond)
+
+	_, err := worktreeRegisteredIn(repoRoot, filepath.Join(t.TempDir(), "wt"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "made no progress",
+		"a KILLABLE stall must report the ordinary deadline, which reaps and diagnoses properly")
+	assert.NotContains(t, err.Error(), "could not be killed",
+		"the abandon path is for a child that cannot be reaped, and must not claim that of one that can")
+}
+
+// …and that runBoundedWorktreeGit actually USES the supervision. Separate from
+// the test above on purpose: a killable child always takes the ordinary deadline
+// path, so the abandon branch is unreachable with a real process — and a test of
+// awaitCommand alone passes just as well when nothing calls it. That gap was
+// real; removing the call site left the direct test green.
+func TestRunBoundedWorktreeGitReportsAnUnreapableChild(t *testing.T) {
+	prev := awaitCommandFn
+	awaitCommandFn = func(*exec.Cmd, bool, time.Duration) ([]byte, error, bool) {
+		return nil, nil, false // the child could not be reaped
+	}
+	t.Cleanup(func() { awaitCommandFn = prev })
+
+	_, err := runBoundedWorktreeGit(t.TempDir(), true, "worktree", "remove", "-f", "/somewhere")
+
+	require.Error(t, err, "an unreapable child must be REPORTED, never waited on")
+	assert.True(t, errors.Is(err, ErrWorktreeRemovalTimedOut),
+		"and must classify as a stall, so RemoveWorktreeDir retains the record, got %v", err)
+	assert.Contains(t, err.Error(), "could not be killed",
+		"the message must say the process is still running, not imply a clean failure")
+}


### PR DESCRIPTION
Closes #3096.

`af reset` could hang forever. `RemoveWorktreeDir` ran all three of its git operations — `worktree remove -f`, `worktree prune`, and the `worktree list --porcelain` verification probe — through unbounded `exec.Command`, so a hung NFS mount or a D-state process holding a file in the tree blocked the whole reset with **no bounded completion time and no message**. Ctrl-C is the only escape, and it leaves the reset half-applied.

## The asymmetry is the bug

`Cleanup()` has run these exact operations under `localGitTimeout` since #1917, which documented why:

> `git worktree remove -f` recursively unlinks a tree and blocks indefinitely on a hung network mount or a D-state process holding a file in it.

The codebase's own hardening proves the stall is real. The **factory reset** — the one path whose failure mode is an unresponsive CLI rather than a background retry — is the one that could not use it, because `runGitLocalCommand` is a method on `*GitWorktree` and reset holds only two paths.

So: a free-function runner with `localGitTimeout`, its own process group SIGKILLed on the deadline (killing only the direct child leaves the work still running against the dead mount), and a `WaitDelay` so a straggler holding the capture pipe cannot block the read after git is gone.

## Bounding alone is not the fix

Two things beside it matter more, and both are on the destructive path:

**A stall is not an ownership verdict.** On a deadline the remove never *finished* — it was SIGKILLed mid-delete — so nothing is known about the registration. The timeout returns **before** the ownership gate, wrapping:

- `ErrWorktreeStillRegistered`, so reset **retains** the session record and a re-run has something to revisit. Dropping it on an answer nobody got would orphan a possibly-registered worktree and its branch with nothing left to plan from (#2531).
- a new `ErrWorktreeRemovalTimedOut`, so the message says *stalled* rather than blaming a lock it never observed — the existing wording points at `git worktree unlock`, which would be a wrong instruction here.

The directory is left in place. Deleting on a stall is exactly the data loss the ownership gate exists to prevent.

**A failed read is not an empty result.** The porcelain probe is the subtlest of the three: it is the verification read on the *error* path, so an unbounded stall wedges a reset that has already decided something went wrong — and a bound that let a stalled probe answer *"not registered"* would convert a hang into **silent data loss**, because `mayDeleteWorktreeDir` would then treat git's own worktree as af's to delete. It errors instead, and every caller already checks that before trusting the boolean.

## What did NOT need changing

`commands/reset.go` already collects per-worktree errors and continues, and already retains records on `ErrWorktreeStillRegistered` and reports blocked worktrees per repo. So the "report what could not be removed rather than failing the whole reset" half was in place. What it never got was a **return**.

## What a bound cannot do, named rather than implied

The deadline works by SIGKILLing git, so it rescues stalls where git is killable. A process wedged in an uninterruptible (D-state) syscall against a dead mount ignores SIGKILL, and no in-process deadline fixes that. **The guarantee is that af returns and reports what it could not remove, not that the removal succeeds.**

## Tests — each watched failing first

Driven against a real stalling `git` on `PATH` that hangs on **one subcommand** and delegates the rest to the real binary. Targeting a single subcommand is what separates the call sites: a blanket stall cannot tell "the remove hung" from "the probe hung", and those two have different correct answers.

| Guarantee | Against the unbounded original |
|---|---|
| `RemoveWorktreeDir` returns on a stalled `remove` | **hangs 60s**, test's bounded select fires |
| the stalled probe errors instead of answering | **hangs the suite** until the run is killed |
| a stall classifies as still-registered, names the path, leaves the directory | fails in 0.25s |
| a healthy repo still removes and deregisters | passes (the bound costs nothing when nothing stalls) |

The probe test carries its own `select` bound so an unbounded probe fails **red with a diagnostic** rather than hanging the suite — verified: it now reports `worktreeRegisteredIn HUNG on a stalled git worktree list` at 30s instead of panicking the whole run at 75s. A test that hangs reports nothing, which is the same failure this change is about one level up.

## Verification

`gofmt -l .` (no output) · `go build ./...` · `golangci-lint run --fast` · `scripts/lint-file-length.sh` · `go test ./session/git/` (full package, green). The rest on CI.
