### PR TITLE
fix(reset): reap processes when tmux vanishes during capture

### DIFF
--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -613,8 +613,9 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 	// reap synchronously at the end because `af reset` is a short-lived CLI
 	// process — a goroutine would die with it before the sweep ran.
 	leakedBySession := make(map[string][]proctree.Process, len(matches))
+	captureErrBySession := make(map[string]error, len(matches))
 	for _, match := range matches {
-		leakedBySession[match] = SessionProcessTrees(cmdExec, match)
+		leakedBySession[match], captureErrBySession[match] = captureSessionProcessTrees(cmdExec, match)
 	}
 
 	// Only sessions that are actually gone get their captured trees reaped —
@@ -663,7 +664,27 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 	// Sweep concurrently: the grace waits overlap instead of serializing,
 	// and the whole reset still blocks until every sweep finishes.
 	var wg sync.WaitGroup
+	vanishedSweepErrs := make(chan error, len(killed))
 	for _, match := range killed {
+		captureErr := captureErrBySession[match]
+		if errors.Is(captureErr, ErrSessionVanishedBeforeCapture) {
+			wg.Add(1)
+			go func(match string, captureErr error) {
+				defer wg.Done()
+				// Ownership was proved immediately before this capture, but the
+				// session then vanished and took its pane ancestry with it. Re-check
+				// the pre-marker candidates by their immutable AF_SESSION/AF_HOME
+				// markers instead of collapsing the failed capture into "no leaks".
+				if reapErr := reapVanishedSessionProcesses(match, ownHome, preMarkerProcesses[match],
+					preMarkerCaptureErrs[match]); reapErr != nil {
+					vanishedSweepErrs <- fmt.Errorf("tmux session %s vanished during process capture, but its process cleanup is incomplete: %w",
+						match, errors.Join(captureErr, reapErr))
+					return
+				}
+				log.InfoLog.Printf("tmux session %s vanished during process capture; marked orphan process sweep completed", match)
+			}(match, captureErr)
+			continue
+		}
 		leaked := leakedBySession[match]
 		if len(leaked) == 0 {
 			continue
@@ -677,7 +698,12 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 		}(match, leaked)
 	}
 	wg.Wait()
-	return killErr
+	close(vanishedSweepErrs)
+	var vanishedSweepErr error
+	for sweepErr := range vanishedSweepErrs {
+		vanishedSweepErr = errors.Join(vanishedSweepErr, sweepErr)
+	}
+	return errors.Join(killErr, vanishedSweepErr)
 }
 
 func reapVanishedSessionProcesses(match, ownHome string, candidates []proctree.Process, captureErr error) error {

--- a/session/tmux/reap_test.go
+++ b/session/tmux/reap_test.go
@@ -178,6 +178,24 @@ func TestCleanupSessionsReapsMarkedProcessWhenSessionVanishesDuringOwnership(t *
 		"AF_SESSION/AF_HOME-marked helper survived after its tmux session vanished")
 }
 
+// TestCleanupSessionsReapsMarkedProcessWhenSessionVanishesDuringCapture
+// covers the marker-to-capture race. Ownership was proved while the session
+// existed, but losing the session before the destructive capture must not turn
+// the already captured process evidence into an empty set.
+func TestCleanupSessionsReapsMarkedProcessWhenSessionVanishesDuringCapture(t *testing.T) {
+	testguard.IsolateTmux(t)
+	shrinkReapWaits(t)
+
+	const name = "af_vanished_during_capture"
+	home := t.TempDir()
+	marked := spawnMarkedSessionWithEscapee(t, name, home)
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	require.NoError(t, CleanupSessions(vanishOnSecondPaneCaptureExecutor(t, name)))
+	require.False(t, proctree.AliveSame(marked),
+		"AF_SESSION/AF_HOME-marked helper survived after tmux vanished during process capture")
+}
+
 // A pane can launch a helper after the pre-marker process snapshot and before
 // marker lookup loses the session. The post-absence refresh must find that
 // newly marked process rather than treating the older snapshot as final.
@@ -340,6 +358,25 @@ func vanishOnMarkerExecutorWith(t *testing.T, name string, beforeKill func()) cm
 				}
 				out, err := exec.Command("tmux", "kill-session", "-t", exactTarget(name)).CombinedOutput()
 				require.NoError(t, err, "kill session before marker lookup: %s", out)
+			}
+			return realExec.Output(command)
+		},
+	}
+}
+
+func vanishOnSecondPaneCaptureExecutor(t *testing.T, name string) cmd.Executor {
+	t.Helper()
+	realExec := cmd.MakeExecutor()
+	paneCaptures := 0
+	return cmd_test.MockCmdExec{
+		RunFunc: realExec.Run,
+		OutputFunc: func(command *exec.Cmd) ([]byte, error) {
+			if len(command.Args) > 1 && command.Args[1] == "list-panes" {
+				paneCaptures++
+				if paneCaptures == 2 {
+					out, err := exec.Command("tmux", "kill-session", "-t", exactTarget(name)).CombinedOutput()
+					require.NoError(t, err, "kill session before second pane capture: %s", out)
+				}
 			}
 			return realExec.Output(command)
 		},


### PR DESCRIPTION
## Summary

- retain the evidence-bearing error from the post-ownership pane-process capture
- when tmux reports that the owned session vanished in that race window, re-check and reap the pre-captured candidates by exact AF_SESSION/AF_HOME markers
- keep reset fail-closed if the ownership-scoped orphan sweep cannot establish cleanup

## Testing

- regression observed failing on master: `go test ./session/tmux -run '^TestCleanupSessionsReapsMarkedProcessWhenSessionVanishesDuringCapture$' -count=1` (marked helper survived)
- regression passes after the fix
- `go test ./session/tmux -count=1`
- `gofmt -l .`
- `go build ./...`
- `golangci-lint run --timeout=3m --fast`
- `scripts/lint-file-length.sh`

Closes #3093