### PR TITLE
fix(web selftest): settle startup resync before #1813

### DIFF
--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -15279,6 +15279,7 @@ function startStream(tok) {
 }
 function stopStream() {
   resyncRequestGeneration += 1;
+  root?.removeAttribute("data-af-resync-settled");
   if (resyncTimer !== null) {
     window.clearTimeout(resyncTimer);
     resyncTimer = null;
@@ -15352,6 +15353,7 @@ function requestResync() {
         return;
       }
       applySessions(sessions);
+      root?.setAttribute("data-af-resync-settled", "");
     }).catch(() => {
     });
   }, 150);

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "0a939ac5cbe0";
+const VERSION = "bc2567cd7602";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/initial-resync.ts
+++ b/web/selftest/initial-resync.ts
@@ -1,0 +1,34 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Opens a fresh SPA page only after both startup Snapshots have settled:
+ *
+ *  1. the seed Snapshot used to authenticate and populate the rail; and
+ *  2. the events socket's first-open resync, which closes the seed-to-subscribe gap.
+ *
+ * The second response is registered before `open` starts, so a fast loopback daemon
+ * cannot win the observation race. `finished()` waits for the body on the wire; the
+ * no-op evaluation then crosses a browser task boundary, after the fetch promise's
+ * body/applySessions microtasks have drained.
+ */
+export async function openAfterInitialResync(page: Page, open: () => Promise<void>): Promise<void> {
+  let successfulSnapshots = 0;
+  const initialResync = page.waitForResponse((response) => {
+    let path: string;
+    try {
+      path = new URL(response.url()).pathname;
+    } catch {
+      return false;
+    }
+    if (path !== "/v1/Snapshot" || response.request().method() !== "POST" || response.status() !== 200) {
+      return false;
+    }
+    successfulSnapshots += 1;
+    return successfulSnapshots === 2;
+  });
+
+  await open();
+  const response = await initialResync;
+  await response.finished();
+  await page.evaluate(() => undefined);
+}

--- a/web/selftest/initial-resync.ts
+++ b/web/selftest/initial-resync.ts
@@ -1,34 +1,13 @@
 import type { Page } from "@playwright/test";
 
 /**
- * Opens a fresh SPA page only after both startup Snapshots have settled:
- *
- *  1. the seed Snapshot used to authenticate and populate the rail; and
- *  2. the events socket's first-open resync, which closes the seed-to-subscribe gap.
- *
- * The second response is registered before `open` starts, so a fast loopback daemon
- * cannot win the observation race. `finished()` waits for the body on the wire; the
- * no-op evaluation then crosses a browser task boundary, after the fetch promise's
- * body/applySessions microtasks have drained.
+ * Opens a fresh SPA page only after the events socket's first-open resync has been
+ * accepted and applied. A response count is insufficient: an event crossing an
+ * in-flight Snapshot makes the application discard it and schedule another fenced
+ * request. The marker is persistent, so waiting after `open` cannot miss a fast
+ * resync that settled while the seed Snapshot was rendering the rail.
  */
 export async function openAfterInitialResync(page: Page, open: () => Promise<void>): Promise<void> {
-  let successfulSnapshots = 0;
-  const initialResync = page.waitForResponse((response) => {
-    let path: string;
-    try {
-      path = new URL(response.url()).pathname;
-    } catch {
-      return false;
-    }
-    if (path !== "/v1/Snapshot" || response.request().method() !== "POST" || response.status() !== 200) {
-      return false;
-    }
-    successfulSnapshots += 1;
-    return successfulSnapshots === 2;
-  });
-
   await open();
-  const response = await initialResync;
-  await response.finished();
-  await page.evaluate(() => undefined);
+  await page.locator("#app[data-af-resync-settled]").waitFor({ state: "attached" });
 }

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -48,6 +48,7 @@ import {
   test,
 } from "@playwright/test";
 import { decode, Op } from "../src/frame.js";
+import { openAfterInitialResync } from "./initial-resync.js";
 
 const SESSION_A = process.env.AF_WEB_SESSION_A ?? "probe-a";
 const SESSION_B = process.env.AF_WEB_SESSION_B ?? "probe-b";
@@ -8742,7 +8743,13 @@ test("#1813: a close+recreate of the same name mid-edit renames NOTHING — neve
     const cdp = await ctx.newCDPSession(win);
     await cdp.send("Network.enable");
 
-    await openTokenless(win);
+    // Wait for BOTH startup Snapshots before manufacturing the outage. openTokenless
+    // proves the seed Snapshot rendered the rail, but the event socket's first-open
+    // resync is debounced separately. If that older request is still pending, it can
+    // sample the real deleted-only roster between tab-delete and tab-create, repaint
+    // the bar, and make the fused-reconnect assertion fail even though the reconnect
+    // Snapshot itself carries the intended same-name replacement (#3081).
+    await openAfterInitialResync(win, () => openTokenless(win));
     await row(win, SESSION_ORDER).click();
     await expect(win.locator(".af-tabbar .af-tab")).toHaveCount(4, { timeout: 15_000 });
     // A tab of this test's OWN, appended LAST: a recreate appends, so closing and
@@ -8814,23 +8821,33 @@ test("#1813: a close+recreate of the same name mid-edit renames NOTHING — neve
       timeout: 30_000,
     });
     await cdp.send("Network.setBlockedURLs", { urls: [] });
-    await resync;
+    const resyncResponse = await resync;
+    const resyncEnvelope = (await resyncResponse.json()) as {
+      data?: {
+        instances?: { title?: string; tabs?: { id?: string; name?: string }[] }[];
+      } | null;
+    };
+    const replacementID = resyncEnvelope.data?.instances
+      ?.find((instance) => instance.title === SESSION_ORDER)
+      ?.tabs?.find((tab) => tab.name === VICTIM)?.id;
+    expect(replacementID, "the reconnect Snapshot must carry the recreated tab's stable id").toMatch(/\S/);
+    expect(replacementID, "the daemon must never reuse the closed tab's identity").not.toBe(editedPaneID);
     // waitForResponse resolves at the response headers, before the app necessarily
     // reads the body and applies it. Poll the pane's production identity instead: it
     // changes only when the reconnect Snapshot has reached store.set → split reconcile,
     // so Enter below cannot race a stale client cache under a loaded test box (#2387).
+    // Compare with the replacement's EXACT id, not merely `id !== editedPaneID`: a
+    // deleted-only intermediate roster clamps this last-slot pane onto its neighbour,
+    // whose different id would otherwise satisfy the wait while proving the wrong bind.
     await expect
       .poll(
-        async () => {
-          const id = await editedPane.getAttribute("data-tab-id");
-          return id !== null && id !== "" && id !== editedPaneID;
-        },
+        async () => await editedPane.getAttribute("data-tab-id"),
         {
           message: "the reconnect Snapshot must bind the pane to the replacement tab id",
           timeout: 15_000,
         },
       )
-      .toBe(true);
+      .toBe(replacementID);
 
     // The bar held still across all of it — the precondition the bug needs, asserted
     // rather than assumed: had the roster change repainted, the input would be gone and

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -8743,12 +8743,12 @@ test("#1813: a close+recreate of the same name mid-edit renames NOTHING — neve
     const cdp = await ctx.newCDPSession(win);
     await cdp.send("Network.enable");
 
-    // Wait for BOTH startup Snapshots before manufacturing the outage. openTokenless
-    // proves the seed Snapshot rendered the rail, but the event socket's first-open
-    // resync is debounced separately. If that older request is still pending, it can
-    // sample the real deleted-only roster between tab-delete and tab-create, repaint
-    // the bar, and make the fused-reconnect assertion fail even though the reconnect
-    // Snapshot itself carries the intended same-name replacement (#3081).
+    // Wait for the startup resync CHAIN to be accepted before manufacturing the
+    // outage. openTokenless proves the seed Snapshot rendered the rail, but the event
+    // socket's first-open resync is debounced separately, and a crossing event can
+    // fence that response out and schedule another. If any older request is pending,
+    // it can sample the real deleted-only roster between tab-delete and tab-create,
+    // repaint the bar, and fail this fused-reconnect assertion (#3081).
     await openAfterInitialResync(win, () => openTokenless(win));
     await row(win, SESSION_ORDER).click();
     await expect(win.locator(".af-tabbar .af-tab")).toHaveCount(4, { timeout: 15_000 });

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -1700,6 +1700,7 @@ function stopStream(): void {
   // prevents a request that has not started; a response from the previous stream
   // must not land in a newly-connected (possibly differently-authorized) app.
   resyncRequestGeneration += 1;
+  root?.removeAttribute("data-af-resync-settled");
   if (resyncTimer !== null) {
     window.clearTimeout(resyncTimer);
     resyncTimer = null;
@@ -1826,6 +1827,12 @@ function requestResync(): void {
           return;
         }
         applySessions(sessions);
+        // A successful HTTP response is not necessarily authoritative: either fence
+        // above can discard it and schedule a replacement. Stamp the stable app root
+        // only after the winning response reaches the store, giving black-box clients
+        // an application-level settlement signal instead of a network-timing guess
+        // (#3081). stopStream clears it before a new stream owns the connection.
+        root?.setAttribute("data-af-resync-settled", "");
       })
       .catch(() => {
         // Transport/auth failure: the events stream owns reconnection; a later

--- a/web/src/initial_resync.test.ts
+++ b/web/src/initial_resync.test.ts
@@ -1,0 +1,60 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import type { Page, Response } from "@playwright/test";
+import { openAfterInitialResync } from "../selftest/initial-resync.js";
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function response(path: string, method = "POST", status = 200): Response {
+  return {
+    url: () => `http://af.test${path}`,
+    request: () => ({ method: () => method }),
+    status: () => status,
+    finished: async () => null,
+  } as unknown as Response;
+}
+
+test("#3081 setup stays closed until the event stream's first resync is consumed", async () => {
+  let matches!: (candidate: Response) => boolean | Promise<boolean>;
+  let evaluateCalls = 0;
+  const matched = deferred<Response>();
+  const page = {
+    waitForResponse: (predicate: (candidate: Response) => boolean | Promise<boolean>) => {
+      matches = predicate;
+      return matched.promise;
+    },
+    evaluate: async () => {
+      evaluateCalls += 1;
+    },
+  } as unknown as Page;
+  const opened = deferred<void>();
+  let settled = false;
+  const opening = openAfterInitialResync(page, () => opened.promise).then(() => {
+    settled = true;
+  });
+
+  await Promise.resolve();
+  opened.resolve(undefined);
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.equal(settled, false, "the seed Snapshot alone must not open the mutation window");
+  assert.equal(await matches(response("/v1/Snapshot", "GET")), false, "only the real POST is counted");
+  assert.equal(await matches(response("/v1/Snapshot", "POST", 503)), false, "a failed resync closes no gap");
+  assert.equal(await matches(response("/v1/ListTasks")), false, "another RPC is not a Snapshot");
+  assert.equal(await matches(response("/v1/Snapshot")), false, "the seed Snapshot is response one");
+  const initialResync = response("/v1/Snapshot");
+  assert.equal(await matches(initialResync), true, "the event stream's first-open resync is response two");
+  matched.resolve(initialResync);
+  await opening;
+
+  assert.equal(settled, true);
+  assert.equal(evaluateCalls, 1, "one browser turn lets the resync body reach applySessions");
+});

--- a/web/src/initial_resync.test.ts
+++ b/web/src/initial_resync.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import type { Page, Response } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { openAfterInitialResync } from "../selftest/initial-resync.js";
 
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
@@ -12,26 +12,13 @@ function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
   return { promise, resolve };
 }
 
-function response(path: string, method = "POST", status = 200): Response {
-  return {
-    url: () => `http://af.test${path}`,
-    request: () => ({ method: () => method }),
-    status: () => status,
-    finished: async () => null,
-  } as unknown as Response;
-}
-
-test("#3081 setup stays closed until the event stream's first resync is consumed", async () => {
-  let matches!: (candidate: Response) => boolean | Promise<boolean>;
-  let evaluateCalls = 0;
-  const matched = deferred<Response>();
+test("#3081 setup stays closed until the event stream's resync is accepted", async () => {
+  let settledSelector = "";
+  const accepted = deferred<void>();
   const page = {
-    waitForResponse: (predicate: (candidate: Response) => boolean | Promise<boolean>) => {
-      matches = predicate;
-      return matched.promise;
-    },
-    evaluate: async () => {
-      evaluateCalls += 1;
+    locator: (selector: string) => {
+      settledSelector = selector;
+      return { waitFor: () => accepted.promise };
     },
   } as unknown as Page;
   const opened = deferred<void>();
@@ -45,16 +32,14 @@ test("#3081 setup stays closed until the event stream's first resync is consumed
   await Promise.resolve();
   await Promise.resolve();
 
-  assert.equal(settled, false, "the seed Snapshot alone must not open the mutation window");
-  assert.equal(await matches(response("/v1/Snapshot", "GET")), false, "only the real POST is counted");
-  assert.equal(await matches(response("/v1/Snapshot", "POST", 503)), false, "a failed resync closes no gap");
-  assert.equal(await matches(response("/v1/ListTasks")), false, "another RPC is not a Snapshot");
-  assert.equal(await matches(response("/v1/Snapshot")), false, "the seed Snapshot is response one");
-  const initialResync = response("/v1/Snapshot");
-  assert.equal(await matches(initialResync), true, "the event stream's first-open resync is response two");
-  matched.resolve(initialResync);
+  // `open` may have observed any number of successful HTTP responses. None can
+  // release the helper until the application says a fenced response reached its
+  // store; an event-crossed response is deliberately discarded before that marker.
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(settled, false, "a successful but discarded Snapshot must not open the mutation window");
+  accepted.resolve(undefined);
   await opening;
 
   assert.equal(settled, true);
-  assert.equal(evaluateCalls, 1, "one browser turn lets the resync body reach applySessions");
+  assert.equal(settledSelector, "#app[data-af-resync-settled]", "the test waits on the app acceptance marker");
 });


### PR DESCRIPTION
## Summary

- wait for the application to accept and apply the complete startup resync chain before opening the #1813 close-and-recreate mutation window
- stamp accepted resync settlement only after the event/request fences and clear it when the stream stops
- prove the reconnect Snapshot binds the pane to the exact recreated tab identity

The flake was a test setup race: the event socket first-open resync is debounced after the seed Snapshot renders. Under load, that older request could sample the legitimate deleted-only roster between close and recreate and repaint the tab bar. A successful response may itself be fenced out by a crossing event, so the barrier now waits for application-level settlement rather than a response count. The previous identity check could also accept the adjacent tab after pane clamping because it only required an ID different from the closed tab.

## Testing

- RED: `node --import tsx --test src/initial_resync.test.ts` failed with the prior open-only behavior: `the seed Snapshot alone must not open the mutation window`
- RED review regression: the response-count helper failed `a successful but discarded Snapshot must not open the mutation window`
- GREEN: `node --import tsx --test src/initial_resync.test.ts`
- `make web-test` (562 tests passed)
- `make web-build` (regenerated `web/dist/af-web.js` and the service-worker cache stamp)
- `gofmt -l .`
- `go build ./...`
- `golangci-lint run --timeout=3m --fast`
- `scripts/lint-file-length.sh`

Closes #3081