### PR TITLE
fix(accounts): refuse off-box accounts for the real reason, permanently

### DIFF
--- a/commands/accountscmd.go
+++ b/commands/accountscmd.go
@@ -95,6 +95,14 @@ Account-scoped sessions require the local or docker backend, and tmux 3.2 or new
 refuses rather than falling back, because a fallback would run on the ambient
 account while reporting the one you asked for.
 
+ssh, sandbox and hook refuse by design, not because the work is pending. An
+account is a writable agent home, so the agent writes a refreshed token back into
+it. docker bind-MOUNTS the directory, so those writes land in your real account.
+Any off-box backend would need it COPIED, where teardown deletes the refresh —
+and if your provider rotates refresh tokens, that also invalidates the copy on
+this machine. A session on a host af does not control would be able to break the
+identity on the one it does, so af does not offer the choice.
+
 af never switches accounts on its own — not on a rate limit, not on a failure.
 A session runs as the account it was started with.`,
 }

--- a/commands/accountscmd.go
+++ b/commands/accountscmd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sachiniyer/agent-factory/internal/agentaccount"
 	"github.com/sachiniyer/agent-factory/internal/sessionenv"
 	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
 )
 
 // `af accounts` manages the credential DIRECTORIES a session can be scoped to
@@ -95,14 +96,9 @@ Account-scoped sessions require the local or docker backend, and tmux 3.2 or new
 refuses rather than falling back, because a fallback would run on the ambient
 account while reporting the one you asked for.
 
-ssh, sandbox and hook refuse by design, not because the work is pending. An
-account is a writable agent home, so the agent writes refreshed authentication
-back into it. docker bind-MOUNTS the directory, so those writes land in your real
-account. For those three af cannot establish that the writes come back from a
-machine it does not own — so a rotated token can be lost, and if your provider
-rotates refresh tokens, losing it also invalidates the copy on this machine. A
-session on a host af does not control would be able to break the identity on the
-one it does, so af does not offer the choice.
+ssh, sandbox and hook refuse by design, not because the work is pending. docker
+bind-MOUNTS the directory, so account writes land in your real account. ` +
+		session.AccountWriteBackRationale + `
 
 af never switches accounts on its own — not on a rate limit, not on a failure.
 A session runs as the account it was started with.`,

--- a/commands/accountscmd.go
+++ b/commands/accountscmd.go
@@ -96,12 +96,13 @@ refuses rather than falling back, because a fallback would run on the ambient
 account while reporting the one you asked for.
 
 ssh, sandbox and hook refuse by design, not because the work is pending. An
-account is a writable agent home, so the agent writes a refreshed token back into
-it. docker bind-MOUNTS the directory, so those writes land in your real account.
-Any off-box backend would need it COPIED, where teardown deletes the refresh —
-and if your provider rotates refresh tokens, that also invalidates the copy on
-this machine. A session on a host af does not control would be able to break the
-identity on the one it does, so af does not offer the choice.
+account is a writable agent home, so the agent writes refreshed authentication
+back into it. docker bind-MOUNTS the directory, so those writes land in your real
+account. Those three would need it COPIED, and af cannot establish that the
+writes come back from a machine it does not own — so a rotated token can be lost,
+and if your provider rotates refresh tokens, losing it also invalidates the copy
+on this machine. A session on a host af does not control would be able to break
+the identity on the one it does, so af does not offer the choice.
 
 af never switches accounts on its own — not on a rate limit, not on a failure.
 A session runs as the account it was started with.`,

--- a/commands/accountscmd.go
+++ b/commands/accountscmd.go
@@ -98,11 +98,11 @@ account while reporting the one you asked for.
 ssh, sandbox and hook refuse by design, not because the work is pending. An
 account is a writable agent home, so the agent writes refreshed authentication
 back into it. docker bind-MOUNTS the directory, so those writes land in your real
-account. Those three would need it COPIED, and af cannot establish that the
-writes come back from a machine it does not own — so a rotated token can be lost,
-and if your provider rotates refresh tokens, losing it also invalidates the copy
-on this machine. A session on a host af does not control would be able to break
-the identity on the one it does, so af does not offer the choice.
+account. For those three af cannot establish that the writes come back from a
+machine it does not own — so a rotated token can be lost, and if your provider
+rotates refresh tokens, losing it also invalidates the copy on this machine. A
+session on a host af does not control would be able to break the identity on the
+one it does, so af does not offer the choice.
 
 af never switches accounts on its own — not on a rate limit, not on a failure.
 A session runs as the account it was started with.`,

--- a/commands/accountscmd_test.go
+++ b/commands/accountscmd_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/apiclient"
+	"github.com/sachiniyer/agent-factory/session"
 )
 
 // `af accounts` had no test file at all while its --json failure path was
@@ -25,6 +26,21 @@ type accountsEnvelope struct {
 	Error *struct {
 		Message string `json:"message"`
 	} `json:"error"`
+}
+
+// Hook launch_cmd may use shared storage or run on the daemon host, so the
+// shared account help can state only the missing write-back guarantee — never
+// a location or a mechanism.
+func TestAccountsHelpDoesNotAssertRefusingBackendLocation(t *testing.T) {
+	if !strings.Contains(accountsCmd.Long, session.AccountWriteBackRationale) {
+		t.Fatalf("account help drifted from the shared runtime rationale:\n%s", accountsCmd.Long)
+	}
+	if strings.Contains(accountsCmd.Long, "machine it does not own") {
+		t.Fatalf("account help asserts where hook runs:\n%s", accountsCmd.Long)
+	}
+	if strings.Contains(accountsCmd.Long, "only a mount") {
+		t.Fatalf("account help asserts which mechanism could provide write-back:\n%s", accountsCmd.Long)
+	}
 }
 
 // runAccounts drives `af accounts …` through the real root command and returns

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -157,14 +157,8 @@ Account-scoped sessions require the local or docker backend, and tmux 3.2 or new
 refuses rather than falling back, because a fallback would run on the ambient
 account while reporting the one you asked for.
 
-ssh, sandbox and hook refuse by design, not because the work is pending. An
-account is a writable agent home, so the agent writes refreshed authentication
-back into it. docker bind-MOUNTS the directory, so those writes land in your real
-account. For those three af cannot establish that the writes come back from a
-machine it does not own — so a rotated token can be lost, and if your provider
-rotates refresh tokens, losing it also invalidates the copy on this machine. A
-session on a host af does not control would be able to break the identity on the
-one it does, so af does not offer the choice.
+ssh, sandbox and hook refuse by design, not because the work is pending. docker
+bind-MOUNTS the directory, so account writes land in your real account. An account is a writable agent home, so the agent writes refreshed authentication back into it. For ssh, sandbox and hook, af cannot establish that those writes come back, so a rotated token can be lost. If your provider rotates refresh tokens, losing it also invalidates the copy on this machine — so a feature meant to NARROW where an identity is used could break it.
 
 af never switches accounts on its own — not on a rate limit, not on a failure.
 A session runs as the account it was started with.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -157,6 +157,14 @@ Account-scoped sessions require the local or docker backend, and tmux 3.2 or new
 refuses rather than falling back, because a fallback would run on the ambient
 account while reporting the one you asked for.
 
+ssh, sandbox and hook refuse by design, not because the work is pending. An
+account is a writable agent home, so the agent writes a refreshed token back into
+it. docker bind-MOUNTS the directory, so those writes land in your real account.
+Any off-box backend would need it COPIED, where teardown deletes the refresh —
+and if your provider rotates refresh tokens, that also invalidates the copy on
+this machine. A session on a host af does not control would be able to break the
+identity on the one it does, so af does not offer the choice.
+
 af never switches accounts on its own — not on a rate limit, not on a failure.
 A session runs as the account it was started with.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -160,11 +160,11 @@ account while reporting the one you asked for.
 ssh, sandbox and hook refuse by design, not because the work is pending. An
 account is a writable agent home, so the agent writes refreshed authentication
 back into it. docker bind-MOUNTS the directory, so those writes land in your real
-account. Those three would need it COPIED, and af cannot establish that the
-writes come back from a machine it does not own — so a rotated token can be lost,
-and if your provider rotates refresh tokens, losing it also invalidates the copy
-on this machine. A session on a host af does not control would be able to break
-the identity on the one it does, so af does not offer the choice.
+account. For those three af cannot establish that the writes come back from a
+machine it does not own — so a rotated token can be lost, and if your provider
+rotates refresh tokens, losing it also invalidates the copy on this machine. A
+session on a host af does not control would be able to break the identity on the
+one it does, so af does not offer the choice.
 
 af never switches accounts on its own — not on a rate limit, not on a failure.
 A session runs as the account it was started with.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -158,12 +158,13 @@ refuses rather than falling back, because a fallback would run on the ambient
 account while reporting the one you asked for.
 
 ssh, sandbox and hook refuse by design, not because the work is pending. An
-account is a writable agent home, so the agent writes a refreshed token back into
-it. docker bind-MOUNTS the directory, so those writes land in your real account.
-Any off-box backend would need it COPIED, where teardown deletes the refresh —
-and if your provider rotates refresh tokens, that also invalidates the copy on
-this machine. A session on a host af does not control would be able to break the
-identity on the one it does, so af does not offer the choice.
+account is a writable agent home, so the agent writes refreshed authentication
+back into it. docker bind-MOUNTS the directory, so those writes land in your real
+account. Those three would need it COPIED, and af cannot establish that the
+writes come back from a machine it does not own — so a rotated token can be lost,
+and if your provider rotates refresh tokens, losing it also invalidates the copy
+on this machine. A session on a host af does not control would be able to break
+the identity on the one it does, so af does not offer the choice.
 
 af never switches accounts on its own — not on a rate limit, not on a failure.
 A session runs as the account it was started with.

--- a/session/account_offbox_refusal_test.go
+++ b/session/account_offbox_refusal_test.go
@@ -275,3 +275,15 @@ func TestPermanenceRestsOnTheMissingGuaranteeNotOnAMechanismClaim(t *testing.T) 
 				"rules out mechanisms af merely cannot establish", kind)
 	}
 }
+
+// The reason shared by ssh, sandbox and hook can state only the missing
+// write-back guarantee. It cannot assert a location or mechanism: hook's
+// launch_cmd may use shared storage or run on the daemon host.
+func TestSharedRoundTripReasonDoesNotAssertLocationOrMechanism(t *testing.T) {
+	assert.Contains(t, offBoxRoundTripReason, "cannot establish that those writes come back",
+		"the common reason must state the missing guarantee")
+	assert.NotContains(t, offBoxRoundTripReason, "machine it does not own",
+		"the common reason cannot assert where hook runs")
+	assert.NotContains(t, offBoxRoundTripReason, "only a mount",
+		"the common reason cannot assert which mechanism would provide write-back")
+}

--- a/session/account_offbox_refusal_test.go
+++ b/session/account_offbox_refusal_test.go
@@ -115,6 +115,8 @@ func TestHookAccountRefusalDoesNotPromiseAnIdentityForTheWorkaround(t *testing.T
 func TestCarriesAccountRationaleDoesNotClaimAfLacksControl(t *testing.T) {
 	rationale := carriesAccountDoc(t)
 
+	assert.Contains(t, rationale, "AccountWriteBackRationale",
+		"the runtime contract must reference the single shared operator-facing rationale")
 	assert.NotContains(t, rationale, "af does not decide the shape of those machines",
 		"sandboxProvisioner.provision creates the session dir, and provision-mode hook reuses it — "+
 			"this is the same false premise the refusal message dropped")
@@ -280,10 +282,70 @@ func TestPermanenceRestsOnTheMissingGuaranteeNotOnAMechanismClaim(t *testing.T) 
 // write-back guarantee. It cannot assert a location or mechanism: hook's
 // launch_cmd may use shared storage or run on the daemon host.
 func TestSharedRoundTripReasonDoesNotAssertLocationOrMechanism(t *testing.T) {
+	assert.Contains(t, offBoxRoundTripReason, AccountWriteBackRationale,
+		"the refusal must render the shared runtime rationale rather than copy it")
 	assert.Contains(t, offBoxRoundTripReason, "cannot establish that those writes come back",
 		"the common reason must state the missing guarantee")
 	assert.NotContains(t, offBoxRoundTripReason, "machine it does not own",
 		"the common reason cannot assert where hook runs")
 	assert.NotContains(t, offBoxRoundTripReason, "only a mount",
 		"the common reason cannot assert which mechanism would provide write-back")
+}
+
+// An empty opts.Backend means "resolve the repo config", not local. The
+// explicit-backend tests above missed that default path, so the account guard
+// appeared complete while a repo-configured ssh create reached provisioning.
+func TestNewInstance_AccountRefusalUsesRepoConfiguredBackend(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := initTempGitRepo(t)
+	writeInRepoConfig(t, repo, map[string]any{
+		"backend": "ssh",
+		"ssh":     map[string]any{"host": "example.invalid"},
+	})
+
+	factoryReached := false
+	restore := SetBackendFactoryForTest(func(InstanceOptions, string) (Backend, error) {
+		factoryReached = true
+		return &LocalBackend{}, nil
+	})
+	defer restore()
+
+	_, err := NewInstance(InstanceOptions{
+		Title:   "scoped",
+		Path:    repo,
+		Program: "codex",
+		Account: "work",
+	})
+	require.Error(t, err,
+		"a repo-configured ssh backend must refuse an account even when --backend was omitted")
+	assert.False(t, factoryReached,
+		"the account guard must run on the resolved backend before provisioning")
+	assert.Contains(t, err.Error(), "ssh",
+		"the refusal must name the backend selected by repo config")
+}
+
+func TestNewInstance_UnscopedRepoConfiguredBackendStillReachesFactory(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := initTempGitRepo(t)
+	writeInRepoConfig(t, repo, map[string]any{
+		"backend": "ssh",
+		"ssh":     map[string]any{"host": "example.invalid"},
+	})
+
+	factoryReached := false
+	restore := SetBackendFactoryForTest(func(InstanceOptions, string) (Backend, error) {
+		factoryReached = true
+		return &LocalBackend{}, nil
+	})
+	defer restore()
+
+	inst, err := NewInstance(InstanceOptions{
+		Title:   "plain",
+		Path:    repo,
+		Program: "codex",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, inst)
+	assert.True(t, factoryReached,
+		"resolving the guard must not refuse an unscoped repo-configured backend")
 }

--- a/session/account_offbox_refusal_test.go
+++ b/session/account_offbox_refusal_test.go
@@ -212,3 +212,44 @@ func carriesAccountDoc(t *testing.T) string {
 	require.Greater(t, end, 0, "the comment must be followed by the declaration it documents")
 	return doc[start : start+end]
 }
+
+// THE REFUSAL MUST READ AS PERMANENT, not as "not supported yet".
+//
+// This is the difference between a decision and a backlog item, and getting it
+// wrong has a specific cost: a message that implies unimplemented invites the
+// next person to implement precisely what the #3103 analysis ruled out — a copy,
+// which cannot return the agent's refreshed token and can therefore invalidate
+// the operator's local credential.
+//
+// Only ssh said "deliberately does not" before this; sandbox and hook stated a
+// limitation and read as a capability gap.
+func TestOffBoxAccountRefusalReadsAsPermanentNotUnimplemented(t *testing.T) {
+	// Hedges that would turn a decision into a queue item. "yet" is the load-bearing
+	// one — "af cannot yet carry an account" was the ORIGINAL wording this whole
+	// change moved away from.
+	hedges := []string{"not yet", "cannot yet", "does not yet", "for now", "currently unsupported",
+		"coming soon", "planned", "in the future", "temporarily"}
+
+	for _, kind := range []BackendKind{BackendSSH, BackendSandbox, BackendHook} {
+		t.Run(string(kind), func(t *testing.T) {
+			err := refuseOffBoxAccount(InstanceOptions{Account: "work", Backend: kind})
+			require.Error(t, err)
+			msg := err.Error()
+			lower := strings.ToLower(msg)
+
+			assert.Contains(t, msg, "BY DESIGN",
+				"the refusal must name itself a decision, or the next reader treats it as unfinished work")
+			for _, hedge := range hedges {
+				assert.NotContains(t, lower, hedge,
+					"%q makes a permanent safety decision read as a backlog item", hedge)
+			}
+
+			// It must also still say WHY it is permanent and WHAT to do instead —
+			// permanence without either is just a wall.
+			assert.Contains(t, msg, "invalidates the copy on this machine",
+				"the why: a rotated token lost off-box breaks the identity on the machine af DOES control")
+			assert.Contains(t, msg, "docker or local backend",
+				"the alternative: run the account-scoped session where the directory is mounted, not copied")
+		})
+	}
+}

--- a/session/account_offbox_refusal_test.go
+++ b/session/account_offbox_refusal_test.go
@@ -180,3 +180,31 @@ func TestCarriesAccountContractIsStatedAsWriteBack(t *testing.T) {
 	assert.NotContains(t, contract, "reports whether this kind's provisioner can place a registered",
 		"the placement phrasing invites a copy-only backend to answer true")
 }
+
+// The refusal must not present COPYING as unavoidable (#3103 review). hook's
+// launch_cmd may provision anything and only has to return an agent-server
+// endpoint — it could use shared storage, or run on the daemon host — and a
+// mount-like transport for ssh or sandbox would qualify too. What af lacks is the
+// GUARANTEE of write-back, not the possibility of some mechanism providing it.
+//
+// This is the ninth finding in the same class on this change, and they all share
+// a shape: the message asserted something af had not established. So the test
+// asserts the absence of the over-claim rather than a particular phrasing.
+func TestRefusalDoesNotPresentCopyingAsUnavoidable(t *testing.T) {
+	for _, kind := range []BackendKind{BackendSSH, BackendSandbox, BackendHook} {
+		err := refuseOffBoxAccount(InstanceOptions{Account: "work", Backend: kind})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot establish that those writes come back",
+			"%s must refuse on the missing GUARANTEE, which is the part af can state", kind)
+	}
+
+	src, err := os.ReadFile("runtime.go")
+	require.NoError(t, err)
+	i := strings.Index(string(src), "// CarriesAccount reports whether")
+	require.GreaterOrEqual(t, i, 0)
+	rationale := string(src)[i:min(i+1800, len(string(src)))]
+	assert.NotContains(t, rationale, "every off-box kind",
+		"docker is off-box and answers TRUE, so off-box is the wrong axis")
+	assert.Contains(t, rationale, "not because a copy is the only thing they could ever do",
+		"a future mount-like transport or a launch_cmd using shared storage would qualify")
+}

--- a/session/account_offbox_refusal_test.go
+++ b/session/account_offbox_refusal_test.go
@@ -113,11 +113,7 @@ func TestHookAccountRefusalDoesNotPromiseAnIdentityForTheWorkaround(t *testing.T
 // not decide the shape of those machines" is false there too. Their false answer
 // is the missing write-back, same as ssh's.
 func TestCarriesAccountRationaleDoesNotClaimAfLacksControl(t *testing.T) {
-	src, err := os.ReadFile("runtime.go")
-	require.NoError(t, err)
-	i := strings.Index(string(src), "// CarriesAccount reports whether")
-	require.GreaterOrEqual(t, i, 0)
-	rationale := string(src)[i:min(i+1600, len(string(src)))]
+	rationale := carriesAccountDoc(t)
 
 	assert.NotContains(t, rationale, "af does not decide the shape of those machines",
 		"sandboxProvisioner.provision creates the session dir, and provision-mode hook reuses it — "+
@@ -166,12 +162,7 @@ func TestEachDecidedBackendHasItsOwnReason(t *testing.T) {
 // else states what a `true` promises, and a future author reads it before adding
 // a case.
 func TestCarriesAccountContractIsStatedAsWriteBack(t *testing.T) {
-	src, err := os.ReadFile("runtime.go")
-	require.NoError(t, err)
-	doc := string(src)
-	i := strings.Index(doc, "// CarriesAccount reports whether")
-	require.GreaterOrEqual(t, i, 0, "the contract comment must exist")
-	contract := doc[i:min(i+900, len(doc))]
+	contract := carriesAccountDoc(t)
 
 	assert.Contains(t, contract, "SAFELY HONOUR",
 		"the predicate is safe honouring including writes, not physical placement")
@@ -187,24 +178,37 @@ func TestCarriesAccountContractIsStatedAsWriteBack(t *testing.T) {
 // mount-like transport for ssh or sandbox would qualify too. What af lacks is the
 // GUARANTEE of write-back, not the possibility of some mechanism providing it.
 //
-// This is the ninth finding in the same class on this change, and they all share
-// a shape: the message asserted something af had not established. So the test
-// asserts the absence of the over-claim rather than a particular phrasing.
+// Asserted on the REFUSAL MESSAGE only. An earlier version of this test also
+// grepped CarriesAccount's doc comment for phrases, and that was a mistake twice
+// over: it matched the comment's own QUOTATION of the wrong phrasing (the text
+// says `Nor is this "every off-box kind"` in order to reject it), and it pinned
+// exact casing of prose. A doc comment is not a behaviour, and a substring test
+// over source text collides with the text that explains the substring — the same
+// trap as naming a test after the option it forbids.
 func TestRefusalDoesNotPresentCopyingAsUnavoidable(t *testing.T) {
 	for _, kind := range []BackendKind{BackendSSH, BackendSandbox, BackendHook} {
 		err := refuseOffBoxAccount(InstanceOptions{Account: "work", Backend: kind})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot establish that those writes come back",
-			"%s must refuse on the missing GUARANTEE, which is the part af can state", kind)
+			"%s must refuse on the missing GUARANTEE — the part af can state — rather than on a claim "+
+				"that copying is the only mechanism those backends could ever have", kind)
 	}
+}
 
+// carriesAccountDoc returns CarriesAccount's WHOLE doc comment, bounded by the
+// declaration it documents rather than by a byte count.
+//
+// A fixed-size window is how the first version of these assertions broke: the
+// comment grew, the phrase being asserted fell outside the slice, and the test
+// failed against correct code. Bounding on the `func` line cannot truncate.
+func carriesAccountDoc(t *testing.T) string {
+	t.Helper()
 	src, err := os.ReadFile("runtime.go")
 	require.NoError(t, err)
-	i := strings.Index(string(src), "// CarriesAccount reports whether")
-	require.GreaterOrEqual(t, i, 0)
-	rationale := string(src)[i:min(i+1800, len(string(src)))]
-	assert.NotContains(t, rationale, "every off-box kind",
-		"docker is off-box and answers TRUE, so off-box is the wrong axis")
-	assert.Contains(t, rationale, "not because a copy is the only thing they could ever do",
-		"a future mount-like transport or a launch_cmd using shared storage would qualify")
+	doc := string(src)
+	start := strings.Index(doc, "// CarriesAccount reports whether")
+	require.GreaterOrEqual(t, start, 0, "the contract comment must exist")
+	end := strings.Index(doc[start:], "func (k BackendKind) CarriesAccount()")
+	require.Greater(t, end, 0, "the comment must be followed by the declaration it documents")
+	return doc[start : start+end]
 }

--- a/session/account_offbox_refusal_test.go
+++ b/session/account_offbox_refusal_test.go
@@ -253,3 +253,25 @@ func TestOffBoxAccountRefusalReadsAsPermanentNotUnimplemented(t *testing.T) {
 		})
 	}
 }
+
+// Permanence must rest on the MISSING GUARANTEE, never on a claim that one
+// mechanism is the only possible one.
+//
+// The tenth finding on this change: justifying permanence with "only a mount
+// returns those writes" contradicted af's own reasoning one file over, where
+// CarriesAccount notes a launch_cmd may run the agent-server on the daemon host
+// or against shared durable storage. The refusal is permanent because af cannot
+// establish the guarantee — not because no mechanism could ever provide it.
+func TestPermanenceRestsOnTheMissingGuaranteeNotOnAMechanismClaim(t *testing.T) {
+	for _, kind := range []BackendKind{BackendSSH, BackendSandbox, BackendHook} {
+		err := refuseOffBoxAccount(InstanceOptions{Account: "work", Backend: kind})
+		require.Error(t, err)
+		msg := err.Error()
+
+		assert.Contains(t, msg, "GUARANTEE that those writes come back",
+			"%s: permanence must rest on the missing guarantee", kind)
+		assert.NotContains(t, msg, "only a mount",
+			"%s: a launch_cmd may use shared storage or run on the daemon host, so 'only a mount' "+
+				"rules out mechanisms af merely cannot establish", kind)
+	}
+}

--- a/session/account_offbox_refusal_test.go
+++ b/session/account_offbox_refusal_test.go
@@ -67,6 +67,51 @@ func TestSandboxAndHookAccountRefusalGivesTheRoundTripReason(t *testing.T) {
 	}
 }
 
+// The workaround must not promise WHICH identity omitting --account produces on
+// hook, and this is the one place a wrong promise is dangerous rather than
+// untidy: runHookScriptWithResolvedEnvironment hands launch_cmd the DAEMON's
+// filtered agent-authentication environment, and the script decides what reaches
+// the machine. So an operator told "omit --account to use that machine's own
+// credentials" can end up running as the DAEMON HOST's ambient identity — the
+// exact wrong-identity outcome account scoping exists to prevent — while
+// believing the remote's identity was used.
+func TestHookAccountRefusalDoesNotPromiseAnIdentityForTheWorkaround(t *testing.T) {
+	hook := refuseOffBoxAccount(InstanceOptions{Account: "work", Backend: BackendHook})
+	require.Error(t, hook)
+	assert.NotContains(t, hook.Error(), "to use that machine's own credentials",
+		"af passes the daemon's filtered agent credentials to launch_cmd, so this would be false in the "+
+			"direction account scoping exists to prevent")
+	assert.Contains(t, hook.Error(), "up to your hooks",
+		"it must say the identity depends on the hooks rather than assert one")
+
+	// ssh and sandbox forward no daemon environment, so naming the machine's own
+	// credentials there is accurate and must stay.
+	for _, kind := range []BackendKind{BackendSSH, BackendSandbox} {
+		err := refuseOffBoxAccount(InstanceOptions{Account: "work", Backend: kind})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "own credentials",
+			"%s forwards no daemon environment, so the workaround CAN name the identity", kind)
+	}
+}
+
+// CarriesAccount's rationale must not keep the premise the refusal dropped: af
+// DOES control the session dir for sandbox and provision-mode hook, so "af does
+// not decide the shape of those machines" is false there too. Their false answer
+// is the missing write-back, same as ssh's.
+func TestCarriesAccountRationaleDoesNotClaimAfLacksControl(t *testing.T) {
+	src, err := os.ReadFile("runtime.go")
+	require.NoError(t, err)
+	i := strings.Index(string(src), "// CarriesAccount reports whether")
+	require.GreaterOrEqual(t, i, 0)
+	rationale := string(src)[i:min(i+1600, len(string(src)))]
+
+	assert.NotContains(t, rationale, "af does not decide the shape of those machines",
+		"sandboxProvisioner.provision creates the session dir, and provision-mode hook reuses it — "+
+			"this is the same false premise the refusal message dropped")
+	assert.Contains(t, rationale, "writes",
+		"the reason every off-box kind answers false is that the agent's writes cannot come home")
+}
+
 // An unassessed backend added later must still refuse, and must say it is
 // UNPROVEN rather than impossible — nobody has evaluated it.
 func TestUnknownBackendAccountRefusalStaysConservative(t *testing.T) {

--- a/session/account_offbox_refusal_test.go
+++ b/session/account_offbox_refusal_test.go
@@ -1,0 +1,88 @@
+package session
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The off-box account refusal is a DECISION, and the message has to say the true
+// reason (#3103).
+//
+// The merged wording said af "cannot place a credential account on that machine"
+// for every off-box kind. That is FALSE for ssh and provably so — the runtime
+// streams af's own binary there, creates a per-session directory and starts a
+// process in it. Placement was never the obstacle; the ROUND TRIP is. A refusal
+// that misstates its reason invites the operator to conclude af just has not
+// wired it up, and to file the same issue again.
+
+// ssh must not be told af cannot put the account there, because it can.
+func TestSSHAccountRefusalNamesTheRoundTripNotPlacement(t *testing.T) {
+	err := refuseOffBoxAccount(InstanceOptions{Account: "work", Backend: BackendSSH})
+	require.Error(t, err)
+	msg := err.Error()
+
+	assert.Contains(t, msg, "work", "the operator must see WHICH account was refused")
+	assert.Contains(t, msg, "ssh")
+	assert.NotContains(t, strings.ToLower(msg), "cannot place",
+		"af CAN place a directory on an ssh host — claiming otherwise reads as unfinished wiring")
+	assert.Contains(t, msg, "deliberately does not",
+		"the refusal must read as a decision, not a gap")
+
+	// The actual reason, in the operator's terms: writes do not come home.
+	assert.Contains(t, msg, "teardown", "the reason is that a refreshed token dies with the session dir")
+	assert.Contains(t, msg, "rotates refresh tokens",
+		"and the worst case — invalidating the copy on THIS machine — is the part that decides it")
+	assert.Contains(t, msg, "--account", "and it must name the way out")
+}
+
+// sandbox and hook refuse for a genuinely different reason, so they must not
+// inherit ssh's: af does not decide the shape of those machines at all.
+func TestSandboxAndHookAccountRefusalNamesTheOperatorsOwnProvisioner(t *testing.T) {
+	for _, kind := range []BackendKind{BackendSandbox, BackendHook} {
+		t.Run(string(kind), func(t *testing.T) {
+			err := refuseOffBoxAccount(InstanceOptions{Account: "work", Backend: kind})
+			require.Error(t, err)
+			msg := err.Error()
+
+			assert.Contains(t, msg, "your own command or scripts",
+				"the reason is that the operator owns the machine's shape, not that af lacks a transfer")
+			assert.NotContains(t, msg, "rotates refresh tokens",
+				"that is ssh's reason; these two refuse before the round trip is even reachable")
+			assert.Contains(t, msg, "--account")
+		})
+	}
+}
+
+// An unassessed backend added later must still refuse, and must say it is
+// UNPROVEN rather than impossible — nobody has evaluated it.
+func TestUnknownBackendAccountRefusalStaysConservative(t *testing.T) {
+	err := refuseOffBoxAccount(InstanceOptions{Account: "work", Backend: BackendKind("future-thing")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "has not established",
+		"an unassessed backend is unproven, not impossible; the default is refusal either way")
+}
+
+// The two that must NOT be refused, so this change moved only the wording.
+func TestAccountStillAllowedOnLocalAndDocker(t *testing.T) {
+	assert.NoError(t, refuseOffBoxAccount(InstanceOptions{Account: "work", Backend: BackendLocal}))
+	assert.NoError(t, refuseOffBoxAccount(InstanceOptions{Account: "work", Backend: BackendDocker}))
+	assert.NoError(t, refuseOffBoxAccount(InstanceOptions{Account: "work"}),
+		"an empty backend means local, which needs no placing")
+	assert.NoError(t, refuseOffBoxAccount(InstanceOptions{Backend: BackendSSH}),
+		"no account means nothing to refuse")
+}
+
+// Every off-box kind must have a reason written for it. A kind that falls to the
+// default gets the honest 'unproven' wording, which is correct for something
+// nobody assessed and WRONG for one we deliberately decided — so the three we
+// decided must each say something specific.
+func TestEachDecidedBackendHasItsOwnReason(t *testing.T) {
+	generic := offBoxAccountRefusal(BackendKind("future-thing"))
+	for _, kind := range []BackendKind{BackendSSH, BackendSandbox, BackendHook} {
+		assert.NotEqual(t, generic, offBoxAccountRefusal(kind),
+			"%s was decided deliberately, so it must not fall through to the unassessed wording", kind)
+	}
+}

--- a/session/account_offbox_refusal_test.go
+++ b/session/account_offbox_refusal_test.go
@@ -84,14 +84,23 @@ func TestHookAccountRefusalDoesNotPromiseAnIdentityForTheWorkaround(t *testing.T
 	assert.Contains(t, hook.Error(), "up to your hooks",
 		"it must say the identity depends on the hooks rather than assert one")
 
-	// ssh and sandbox forward no daemon environment, so naming the machine's own
-	// credentials there is accurate and must stay.
-	for _, kind := range []BackendKind{BackendSSH, BackendSandbox} {
-		err := refuseOffBoxAccount(InstanceOptions{Account: "work", Backend: kind})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "own credentials",
-			"%s forwards no daemon environment, so the workaround CAN name the identity", kind)
-	}
+	// sandbox must not promise one either, and for its own reason: sandbox_ssh is
+	// the operator's command and that backend deliberately preserves their
+	// ssh_config, so a `SendEnv OPENAI_API_KEY` block copies the DAEMON's value to
+	// the sandbox verbatim (measured in #3092).
+	sandbox := refuseOffBoxAccount(InstanceOptions{Account: "work", Backend: BackendSandbox})
+	require.Error(t, sandbox)
+	assert.NotContains(t, sandbox.Error(), "to use that machine's own credentials",
+		"an operator's ssh_config can SendEnv the daemon's credentials into the sandbox")
+	assert.Contains(t, sandbox.Error(), "sandbox_ssh",
+		"the identity depends on their command, so name that rather than assert an outcome")
+
+	// ssh IS immune, because af pins -F none there so no ssh_config is read at all —
+	// so its accurate wording must stay rather than being deleted along with theirs.
+	ssh := refuseOffBoxAccount(InstanceOptions{Account: "work", Backend: BackendSSH})
+	require.Error(t, ssh)
+	assert.Contains(t, ssh.Error(), "own credentials",
+		"backend=ssh reads no ssh_config (-F none), so the workaround CAN name the identity there")
 }
 
 // CarriesAccount's rationale must not keep the premise the refusal dropped: af

--- a/session/account_offbox_refusal_test.go
+++ b/session/account_offbox_refusal_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -38,19 +39,29 @@ func TestSSHAccountRefusalNamesTheRoundTripNotPlacement(t *testing.T) {
 	assert.Contains(t, msg, "--account", "and it must name the way out")
 }
 
-// sandbox and hook refuse for a genuinely different reason, so they must not
-// inherit ssh's: af does not decide the shape of those machines at all.
-func TestSandboxAndHookAccountRefusalNamesTheOperatorsOwnProvisioner(t *testing.T) {
+// sandbox and hook must give the ROUND-TRIP reason, not a location one.
+//
+// The first cut of this change said they "provision through your own command or
+// scripts, so af has no location it can prove is the account". That is false in
+// the same way the old blanket wording was false for ssh: sandbox and
+// provision-mode hook both run through sandboxProvisioner, which creates the
+// session directory itself and streams af's binary into it, so af controls those
+// locations exactly as it does for ssh. Only hook's launch_cmd mode leaves the
+// machine's shape to the operator — and the round trip is what refuses all of
+// them anyway.
+func TestSandboxAndHookAccountRefusalGivesTheRoundTripReason(t *testing.T) {
 	for _, kind := range []BackendKind{BackendSandbox, BackendHook} {
 		t.Run(string(kind), func(t *testing.T) {
 			err := refuseOffBoxAccount(InstanceOptions{Account: "work", Backend: kind})
 			require.Error(t, err)
 			msg := err.Error()
 
-			assert.Contains(t, msg, "your own command or scripts",
-				"the reason is that the operator owns the machine's shape, not that af lacks a transfer")
-			assert.NotContains(t, msg, "rotates refresh tokens",
-				"that is ssh's reason; these two refuse before the round trip is even reachable")
+			assert.Contains(t, msg, "rotates refresh tokens",
+				"the reason these refuse is the round trip, the same one that refuses ssh")
+			assert.Contains(t, msg, "teardown")
+			assert.NotContains(t, msg, "no location it can prove",
+				"af DOES control the session dir for sandbox and provision-mode hook — sandboxProvisioner "+
+					"creates it — so a location-based reason is false the same way the old ssh wording was")
 			assert.Contains(t, msg, "--account")
 		})
 	}
@@ -85,4 +96,28 @@ func TestEachDecidedBackendHasItsOwnReason(t *testing.T) {
 		assert.NotEqual(t, generic, offBoxAccountRefusal(kind),
 			"%s was decided deliberately, so it must not fall through to the unassessed wording", kind)
 	}
+}
+
+// CarriesAccount's contract is SAFE WRITE-BACK, not physical placement (#3103
+// review). ssh can physically place an account and still answers false, so a
+// contract phrased as placement would invite a future backend author to answer
+// true for a copy-only mechanism — exactly the unsafe behaviour this refuses.
+//
+// Asserted against the doc comment because the contract IS the comment: nothing
+// else states what a `true` promises, and a future author reads it before adding
+// a case.
+func TestCarriesAccountContractIsStatedAsWriteBack(t *testing.T) {
+	src, err := os.ReadFile("runtime.go")
+	require.NoError(t, err)
+	doc := string(src)
+	i := strings.Index(doc, "// CarriesAccount reports whether")
+	require.GreaterOrEqual(t, i, 0, "the contract comment must exist")
+	contract := doc[i:min(i+900, len(doc))]
+
+	assert.Contains(t, contract, "SAFELY HONOUR",
+		"the predicate is safe honouring including writes, not physical placement")
+	assert.Contains(t, contract, "WRITES",
+		"and the writes are the part that makes ssh answer false despite being able to place one")
+	assert.NotContains(t, contract, "reports whether this kind's provisioner can place a registered",
+		"the placement phrasing invites a copy-only backend to answer true")
 }

--- a/session/account_offbox_refusal_test.go
+++ b/session/account_offbox_refusal_test.go
@@ -33,7 +33,8 @@ func TestSSHAccountRefusalNamesTheRoundTripNotPlacement(t *testing.T) {
 		"the refusal must read as a decision, not a gap")
 
 	// The actual reason, in the operator's terms: writes do not come home.
-	assert.Contains(t, msg, "teardown", "the reason is that a refreshed token dies with the session dir")
+	assert.Contains(t, msg, "cannot establish that those writes come back",
+		"the reason is the write-back af cannot guarantee, stated as the property rather than a mechanism")
 	assert.Contains(t, msg, "rotates refresh tokens",
 		"and the worst case — invalidating the copy on THIS machine — is the part that decides it")
 	assert.Contains(t, msg, "--account", "and it must name the way out")
@@ -58,7 +59,11 @@ func TestSandboxAndHookAccountRefusalGivesTheRoundTripReason(t *testing.T) {
 
 			assert.Contains(t, msg, "rotates refresh tokens",
 				"the reason these refuse is the round trip, the same one that refuses ssh")
-			assert.Contains(t, msg, "teardown")
+			assert.Contains(t, msg, "cannot establish that those writes come back",
+				"state the property af can ESTABLISH, not a mechanism of loss — hook's launch_cmd owns no "+
+					"session directory af deletes, so a definite teardown claim is false there")
+			assert.NotContains(t, msg, "destroyed with the session directory",
+				"that names a lifecycle af controls for some of these and not others")
 			assert.NotContains(t, msg, "no location it can prove",
 				"af DOES control the session dir for sandbox and provision-mode hook — sandboxProvisioner "+
 					"creates it — so a location-based reason is false the same way the old ssh wording was")

--- a/session/agent_account_mount_test.go
+++ b/session/agent_account_mount_test.go
@@ -110,8 +110,15 @@ func TestRefuseOffBoxAccount_AllowsDockerRefusesTheRest(t *testing.T) {
 			t.Errorf("%s must still refuse an account-scoped create", kind)
 			continue
 		}
-		if !strings.Contains(err.Error(), "cannot place a credential account") {
-			t.Errorf("%s refusal must say WHY (af cannot place the account there), got: %v", kind, err)
+		// The refusal must say WHY — but NOT "af cannot place it", which was false
+		// for ssh and is what #3103 corrected. Each kind's specific reason is
+		// asserted in account_offbox_refusal_test.go; here we only require that the
+		// message names the account, the backend, and a way forward.
+		if !strings.Contains(err.Error(), "work") || !strings.Contains(err.Error(), string(kind)) {
+			t.Errorf("%s refusal must name the account and the backend, got: %v", kind, err)
+		}
+		if !strings.Contains(err.Error(), "--account") {
+			t.Errorf("%s refusal must name the way out, got: %v", kind, err)
 		}
 	}
 	// Unscoped creates are untouched on every kind.

--- a/session/instance_account_roundtrip_test.go
+++ b/session/instance_account_roundtrip_test.go
@@ -82,17 +82,21 @@ func TestAccountScoping_RefusesUnsupportedCombinations(t *testing.T) {
 	require.NoError(t, refuseOffBoxAccount(docker),
 		"docker can place the account, so an account-scoped create there must be allowed")
 
-	// The rest still cannot PLACE an account on the machine that runs the agent, so
-	// they must refuse rather than run on that host's ambient credentials.
+	// The rest must refuse rather than run on that host's own credentials — but
+	// each for ITS OWN reason (#3103). "af cannot place a credential account" was
+	// the blanket wording, and it was false for ssh: that runtime already streams
+	// af's binary to the remote and creates a per-session directory there. The
+	// per-kind reasons are asserted in account_offbox_refusal_test.go; this loop
+	// pins only that every one of them refuses and names itself and the way out.
 	for _, kind := range []BackendKind{BackendSSH, BackendSandbox, BackendHook} {
 		scoped := base
 		scoped.Backend = kind
 		err := refuseOffBoxAccount(scoped)
 		require.Error(t, err, "backend %s must refuse an account-scoped create", kind)
 		require.Contains(t, err.Error(), string(kind))
-		require.Contains(t, err.Error(), "ambient credentials")
-		require.Contains(t, err.Error(), "cannot place a credential account",
-			"the refusal must say af cannot PLACE the account there — the reason is now per-kind, not a blanket off-box rule")
+		require.Contains(t, err.Error(), "--account", "the refusal must name the way out")
+		require.NotContains(t, err.Error(), "cannot place a credential account",
+			"that blanket wording was false for ssh and invited the operator to read a decision as unfinished wiring")
 	}
 
 	// claude is ADMITTED now (#3083): af declares the arguments it appends to that

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -631,7 +631,9 @@ func refuseOffBoxAccount(opts InstanceOptions) error {
 const offBoxRoundTripReason = "an account is a writable agent home, so the agent writes refreshed " +
 	"authentication back into it — and af cannot establish that those writes come back from a machine it " +
 	"does not own, so a rotated token can be lost. If your provider rotates refresh tokens, losing it also " +
-	"invalidates the copy on this machine."
+	"invalidates the copy on this machine — so a feature meant to NARROW where an identity is used could " +
+	"break it. af refuses this BY DESIGN and not as pending work: only a mount returns those writes, so " +
+	"adding a copy would be building the thing that reasoning rejects."
 
 func offBoxAccountRefusal(kind BackendKind) string {
 	switch kind {

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -616,7 +616,11 @@ func refuseOffBoxAccount(opts InstanceOptions) error {
 //
 // It states the property af can ESTABLISH — that it cannot get the agent's
 // writes back — rather than a mechanism by which they are lost, and that is the
-// correction seven review findings on this PR converged on. Every earlier
+// correction TEN review findings on this PR converged on. The permanence clause
+// obeys the same rule: it says the GUARANTEE is missing, and deliberately does
+// NOT say "only a mount can return those writes" — an earlier draft did, and that
+// was the same over-claim one layer up, since a launch_cmd may run the
+// agent-server on the daemon host or against shared durable storage. Every earlier
 // version named a specific consequence ("destroyed with the session directory at
 // teardown", "af has no provable location", "omit --account to use that machine's
 // own credentials"), and each was false for at least one backend, because the
@@ -632,8 +636,8 @@ const offBoxRoundTripReason = "an account is a writable agent home, so the agent
 	"authentication back into it — and af cannot establish that those writes come back from a machine it " +
 	"does not own, so a rotated token can be lost. If your provider rotates refresh tokens, losing it also " +
 	"invalidates the copy on this machine — so a feature meant to NARROW where an identity is used could " +
-	"break it. af refuses this BY DESIGN and not as pending work: only a mount returns those writes, so " +
-	"adding a copy would be building the thing that reasoning rejects."
+	"break it. af refuses this BY DESIGN and not as pending work: what is missing is the GUARANTEE that " +
+	"those writes come back, and af will not present an account as writable without one."
 
 func offBoxAccountRefusal(kind BackendKind) string {
 	switch kind {

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -539,30 +539,14 @@ func resolvedProgramMarker(opts InstanceOptions) string {
 }
 
 // refuseOffBoxAccount rejects an account-scoped session on a backend that cannot
-// yet carry the account.
+// carry the account. For ssh, sandbox and hook this is a DECISION, not a gap
+// (#3103) — see offBoxAccountRefusal for each backend's reason.
 //
 // It still gates on the backend being NOT local rather than on a list of remote
 // kinds, and #3082 did not weaken that: a backend added later is off-box until
 // someone proves otherwise, so the default for anything new remains refusal
 // rather than silent ambient credentials. What changed is that docker can now
 // PROVE it, so it is exempted by name.
-//
-// WHY DOCKER AND NOT THE OTHERS, decided per backend rather than defaulted
-// (#3082):
-//
-//   - docker CAN place the account, and already has the mechanism. An account is
-//     an agent HOME directory, and the runtime already bind-mounts host paths into
-//     the container — today it mounts the operator's AMBIENT credentials, which is
-//     precisely the wrong-identity failure this refusal was protecting against.
-//     Pointing that mount at the account's directory is the whole fix.
-//   - ssh could transfer one — the runtime already streams the af binary to the
-//     remote — but that means writing the operator's live credentials onto a
-//     machine whose filesystem, other users and backups af does not control, for a
-//     feature whose purpose is to NARROW where an identity may be used. That is a
-//     posture decision, not wiring, and it is not taken here.
-//   - sandbox and hook run the operator's own provisioner. Nothing in that contract
-//     promises a place to put an account, so refusing is the permanent answer
-//     rather than a temporary one.
 func refuseOffBoxAccount(opts InstanceOptions) error {
 	if strings.TrimSpace(opts.Account) == "" {
 		return nil
@@ -574,11 +558,67 @@ func refuseOffBoxAccount(opts InstanceOptions) error {
 	if kind == BackendLocal || kind.CarriesAccount() {
 		return nil
 	}
-	return fmt.Errorf(
-		"account %q cannot be used with the %s backend: af cannot place a credential account on that machine, "+
-			"and running there would use its ambient credentials while reporting the account you asked for; "+
-			"create this session on the local or docker backend, or omit --account",
-		opts.Account, kind)
+	return fmt.Errorf("account %q cannot be used with the %s backend: %s", opts.Account, kind, offBoxAccountRefusal(kind))
+}
+
+// offBoxAccountRefusal is WHY a given backend refuses an account, in the
+// operator's words.
+//
+// It is per backend because the reasons are genuinely different, and a merged
+// message was actively misleading (#3103). The old wording said af "cannot place
+// a credential account on that machine" for all of them — which is FALSE for ssh
+// and provably so: that runtime streams af's own binary to the remote, creates a
+// per-session directory and starts a process there. Placement was never the
+// obstacle. An operator who knows the ssh backend reads that and reasonably
+// concludes af simply has not wired it up.
+//
+// THE ACTUAL OBSTACLE FOR SSH IS THE ROUND TRIP. An account is a writable agent
+// HOME (sessionenv.Account.Dir becomes CODEX_HOME / CLAUDE_CONFIG_DIR), not a
+// credential file, and the agent writes REFRESHED AUTHENTICATION into it when a
+// token rotates. A copy's writes live on the remote and the teardown `rm -rf`
+// destroys them, so the account would present as writable while being read-only
+// in practice.
+//
+// And the worst case is not a stale credential, it is an INVALIDATED one. OAuth
+// refresh tokens are commonly single-use: presenting one returns a replacement
+// and kills the old. If that holds for a given provider, a remote refresh
+// invalidates the token the operator still holds LOCALLY while the replacement is
+// deleted with the session dir — so a session on a machine af does not control
+// breaks the identity on the machine it does. af cannot verify rotation behaviour
+// per provider, and that unverifiability is the argument: this is a risk af would
+// be taking on the operator's behalf without being able to bound it.
+//
+// Copying back before teardown does not rescue it. This codebase treats an
+// unknown teardown outcome as a NORMAL state rather than an edge —
+// ErrWorkspaceStateUnknown, the retained-record machinery, CleanupRetry's
+// retry-and-retire all exist because reaps legitimately do not finish — so a
+// credential-carrying teardown is a credential that legitimately does not come
+// home, silently. It would also widen the window in which live credentials sit on
+// the remote, which per-session placement exists to bound.
+//
+// sandbox and hook refuse for a different and simpler reason: af does not decide
+// the shape of the machine at all. Their commands and scripts are the operator's,
+// so there is no location af can prove is the account rather than somewhere that
+// merely looks like it.
+func offBoxAccountRefusal(kind BackendKind) string {
+	switch kind {
+	case BackendSSH:
+		return "af can put the account on that host, and deliberately does not: an account is a writable " +
+			"agent home, so a refreshed token would be written on the remote and destroyed with the session " +
+			"directory at teardown — and if your provider rotates refresh tokens, that would also invalidate " +
+			"the copy on this machine. Use the docker or local backend for account-scoped sessions, or omit " +
+			"--account to use the remote host's own credentials"
+	case BackendSandbox, BackendHook:
+		return "that backend provisions through your own command or scripts, so af has no location it can " +
+			"prove is the account rather than somewhere that merely resembles it; use the docker or local " +
+			"backend for account-scoped sessions, or omit --account to use that machine's own credentials"
+	default:
+		// A backend added later, refused by default. Naming it as unproven rather
+		// than as impossible keeps this honest for something nobody has assessed.
+		return "af has not established that it can carry a credential account onto that machine, and " +
+			"running there would use its ambient credentials while reporting the account you asked for; " +
+			"use the docker or local backend for account-scoped sessions, or omit --account"
+	}
 }
 
 // refuseUnsupportedAccountAgent rejects an account on an agent whose launch af

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -612,6 +612,13 @@ func refuseOffBoxAccount(opts InstanceOptions) error {
 // that provisioner — so af controls those locations exactly as it does for ssh.
 // Only hook's launch_cmd mode genuinely leaves the machine's shape to the
 // operator, and the round-trip reason covers that mode as well.
+// offBoxRoundTripReason is the one reason every off-box kind refuses, stated
+// once because it is the same fact each time: the write cannot come home.
+const offBoxRoundTripReason = "an account is a writable agent home, so the agent writes a refreshed token " +
+	"back into it — off-box that write lands on the other machine and is destroyed with the session " +
+	"directory at teardown, and if your provider rotates refresh tokens that would also invalidate the " +
+	"copy on this machine."
+
 func offBoxAccountRefusal(kind BackendKind) string {
 	switch kind {
 	case BackendSSH:
@@ -620,17 +627,26 @@ func offBoxAccountRefusal(kind BackendKind) string {
 			"directory at teardown — and if your provider rotates refresh tokens, that would also invalidate " +
 			"the copy on this machine. Use the docker or local backend for account-scoped sessions, or omit " +
 			"--account to use the remote host's own credentials"
-	case BackendSandbox, BackendHook:
+	case BackendSandbox:
 		// The same round-trip reason as ssh, and NOT a "no provable location" one:
-		// sandbox and provision-mode hook both run through sandboxProvisioner, which
-		// creates the session directory itself, so af controls the location there too
-		// (#3103 review). The placement claim is simply left out rather than made in
-		// either direction, because it varies by hook mode and the round trip does not.
-		return "an account is a writable agent home, so the agent writes a refreshed token back into it — " +
-			"off-box that write lands on the other machine and is destroyed with the session directory at " +
-			"teardown, and if your provider rotates refresh tokens that would also invalidate the copy on " +
-			"this machine. Use the docker or local backend for account-scoped sessions, or omit --account " +
-			"to use that machine's own credentials"
+		// sandbox runs through sandboxProvisioner, which creates the session directory
+		// itself, so af controls the location there too (#3103 review).
+		return offBoxRoundTripReason +
+			" Use the docker or local backend for account-scoped sessions, or omit --account to use that " +
+			"machine's own credentials"
+
+	case BackendHook:
+		// Same reason, but the WORKAROUND must not promise an identity here.
+		// runHookScriptWithResolvedEnvironment hands launch_cmd the DAEMON's filtered
+		// agent-authentication environment and the script decides what reaches the
+		// machine — so "omit --account to use that machine's own credentials" would be
+		// false, and false in the exact direction account scoping exists to prevent:
+		// the session could run as the daemon host's ambient identity while the
+		// operator believes it is the remote's (#3103 review).
+		return offBoxRoundTripReason +
+			" Use the docker or local backend for account-scoped sessions, or omit --account — though which " +
+			"identity the session then runs as is up to your hooks, since af passes the daemon's filtered " +
+			"agent credentials to them"
 	default:
 		// A backend added later, refused by default. Naming it as unproven rather
 		// than as impossible keeps this honest for something nobody has assessed.

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -633,8 +633,8 @@ func refuseOffBoxAccount(opts InstanceOptions) error {
 // this repo's taxonomy (backendProvisionsOffBox) and CARRIES an account, so
 // "off-box" is the wrong axis to name here at all.
 const offBoxRoundTripReason = "an account is a writable agent home, so the agent writes refreshed " +
-	"authentication back into it — and af cannot establish that those writes come back from a machine it " +
-	"does not own, so a rotated token can be lost. If your provider rotates refresh tokens, losing it also " +
+	"authentication back into it — and af cannot establish that those writes come back, so a rotated token " +
+	"can be lost. If your provider rotates refresh tokens, losing it also " +
 	"invalidates the copy on this machine — so a feature meant to NARROW where an identity is used could " +
 	"break it. af refuses this BY DESIGN and not as pending work: what is missing is the GUARANTEE that " +
 	"those writes come back, and af will not present an account as writable without one."

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -612,21 +612,38 @@ func refuseOffBoxAccount(opts InstanceOptions) error {
 // that provisioner — so af controls those locations exactly as it does for ssh.
 // Only hook's launch_cmd mode genuinely leaves the machine's shape to the
 // operator, and the round-trip reason covers that mode as well.
-// offBoxRoundTripReason is the one reason every off-box kind refuses, stated
-// once because it is the same fact each time: the write cannot come home.
-const offBoxRoundTripReason = "an account is a writable agent home, so the agent writes a refreshed token " +
-	"back into it — off-box that write lands on the other machine and is destroyed with the session " +
-	"directory at teardown, and if your provider rotates refresh tokens that would also invalidate the " +
-	"copy on this machine."
+// offBoxRoundTripReason is the one reason ssh, sandbox and hook refuse.
+//
+// It states the property af can ESTABLISH — that it cannot get the agent's
+// writes back — rather than a mechanism by which they are lost, and that is the
+// correction seven review findings on this PR converged on. Every earlier
+// version named a specific consequence ("destroyed with the session directory at
+// teardown", "af has no provable location", "omit --account to use that machine's
+// own credentials"), and each was false for at least one backend, because the
+// consequence depends on each backend's own lifecycle and environment contract
+// while the refusal does not. hook's launch_cmd owns no session directory af can
+// delete; sandbox reads the operator's ssh_config; only ssh pins -F none.
+//
+// So: assert the thing that is true for all three and nothing further. It also
+// deliberately says "the other off-box backends" nowhere — docker is off-box in
+// this repo's taxonomy (backendProvisionsOffBox) and CARRIES an account, so
+// "off-box" is the wrong axis to name here at all.
+const offBoxRoundTripReason = "an account is a writable agent home, so the agent writes refreshed " +
+	"authentication back into it — and af cannot establish that those writes come back from a machine it " +
+	"does not own, so a rotated token can be lost. If your provider rotates refresh tokens, losing it also " +
+	"invalidates the copy on this machine."
 
 func offBoxAccountRefusal(kind BackendKind) string {
 	switch kind {
 	case BackendSSH:
-		return "af can put the account on that host, and deliberately does not: an account is a writable " +
-			"agent home, so a refreshed token would be written on the remote and destroyed with the session " +
-			"directory at teardown — and if your provider rotates refresh tokens, that would also invalidate " +
-			"the copy on this machine. Use the docker or local backend for account-scoped sessions, or omit " +
+		// ssh shares the invariant AND may add the concrete consequence, because it is
+		// the one refusing backend whose session-directory lifecycle af owns — so
+		// "teardown removes it" is established here and nowhere else (#3103 review).
+		return "af can put the account on that host, and deliberately does not: " + offBoxRoundTripReason +
+			" On this backend af owns the remote session directory, so the teardown that removes it removes " +
+			"the refresh with it. Use the docker or local backend for account-scoped sessions, or omit " +
 			"--account to use the remote host's own credentials"
+
 	case BackendSandbox:
 		// The same round-trip reason as ssh, and NOT a "no provable location" one:
 		// sandbox runs through sandboxProvisioner, which creates the session directory

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -631,9 +631,17 @@ func offBoxAccountRefusal(kind BackendKind) string {
 		// The same round-trip reason as ssh, and NOT a "no provable location" one:
 		// sandbox runs through sandboxProvisioner, which creates the session directory
 		// itself, so af controls the location there too (#3103 review).
+		//
+		// And like hook, the workaround must NOT name an identity. sandbox_ssh is the
+		// operator's own command and this backend deliberately preserves their
+		// ssh_config — so a `SendEnv OPENAI_API_KEY` block copies the DAEMON's value
+		// to the sandbox verbatim (measured in #3092), and the session would run on
+		// the daemon host's identity while the operator believed otherwise. Only
+		// backend=ssh is immune, because af pins -F none there.
 		return offBoxRoundTripReason +
-			" Use the docker or local backend for account-scoped sessions, or omit --account to use that " +
-			"machine's own credentials"
+			" Use the docker or local backend for account-scoped sessions, or omit --account — though which " +
+			"identity the session then runs as depends on your sandbox_ssh command and the ssh_config it " +
+			"reads, which af does not override"
 
 	case BackendHook:
 		// Same reason, but the WORKAROUND must not promise an identity here.

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -588,18 +588,30 @@ func refuseOffBoxAccount(opts InstanceOptions) error {
 // per provider, and that unverifiability is the argument: this is a risk af would
 // be taking on the operator's behalf without being able to bound it.
 //
-// Copying back before teardown does not rescue it. This codebase treats an
-// unknown teardown outcome as a NORMAL state rather than an edge —
-// ErrWorkspaceStateUnknown, the retained-record machinery, CleanupRetry's
-// retry-and-retire all exist because reaps legitimately do not finish — so a
-// credential-carrying teardown is a credential that legitimately does not come
-// home, silently. It would also widen the window in which live credentials sit on
-// the remote, which per-session placement exists to bound.
+// COPY-BACK IS NOT RULED OUT BY TEARDOWN AMBIGUITY, and an earlier draft of this
+// comment claimed it was (#3103 review). The ordering is available: quiesce the
+// agent, copy, install the replacement locally, and only THEN start the
+// destructive reap — a write-back failure retains the record without tearing
+// anything down, and an unknown reap outcome afterwards no longer costs the token,
+// because it already arrived. So teardown uncertainty alone is not the argument.
 //
-// sandbox and hook refuse for a different and simpler reason: af does not decide
-// the shape of the machine at all. Their commands and scripts are the operator's,
-// so there is no location af can prove is the account rather than somewhere that
-// merely looks like it.
+// What survives that correction is narrower and is still enough:
+//
+//   - The remote can be LOST before write-back — an evaporated cloud instance, a
+//     revoked key, a network partition that outlives the session. Then the refresh
+//     is gone and the local copy is dead, which is the invalidation case again,
+//     reached by a route no ordering fixes.
+//   - Write-back needs the agent QUIESCED to copy a consistent home, and af has no
+//     mechanism to make an agent stop writing on request.
+//   - It widens the window in which live credentials sit on a machine af does not
+//     control, which per-session placement exists to bound.
+//
+// sandbox and hook get the SAME round-trip reason rather than a location one, and
+// that is a correction too: sandboxProvisioner.provision creates the session
+// directory and streams af's binary into it, and the provision-hook path reuses
+// that provisioner — so af controls those locations exactly as it does for ssh.
+// Only hook's launch_cmd mode genuinely leaves the machine's shape to the
+// operator, and the round-trip reason covers that mode as well.
 func offBoxAccountRefusal(kind BackendKind) string {
 	switch kind {
 	case BackendSSH:
@@ -609,9 +621,16 @@ func offBoxAccountRefusal(kind BackendKind) string {
 			"the copy on this machine. Use the docker or local backend for account-scoped sessions, or omit " +
 			"--account to use the remote host's own credentials"
 	case BackendSandbox, BackendHook:
-		return "that backend provisions through your own command or scripts, so af has no location it can " +
-			"prove is the account rather than somewhere that merely resembles it; use the docker or local " +
-			"backend for account-scoped sessions, or omit --account to use that machine's own credentials"
+		// The same round-trip reason as ssh, and NOT a "no provable location" one:
+		// sandbox and provision-mode hook both run through sandboxProvisioner, which
+		// creates the session directory itself, so af controls the location there too
+		// (#3103 review). The placement claim is simply left out rather than made in
+		// either direction, because it varies by hook mode and the round trip does not.
+		return "an account is a writable agent home, so the agent writes a refreshed token back into it — " +
+			"off-box that write lands on the other machine and is destroyed with the session directory at " +
+			"teardown, and if your provider rotates refresh tokens that would also invalidate the copy on " +
+			"this machine. Use the docker or local backend for account-scoped sessions, or omit --account " +
+			"to use that machine's own credentials"
 	default:
 		// A backend added later, refused by default. Naming it as unproven rather
 		// than as impossible keeps this honest for something nobody has assessed.

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -107,13 +107,14 @@ type InstanceOptions struct {
 	ProvisionSessionEnvPassthrough []string
 }
 
-// backendFactory provisions the runtime for a new Instance, returning the
-// in-process Backend plus (for a sandboxed runtime) the authed remote endpoint
-// and the sandbox-reap teardown. It is a package-level variable (not a
-// hard-coded branch) so tests can inject a FakeBackend through
-// SetBackendFactoryForTest without touching production code paths. Defaults to
-// the real runtime resolution.
-var backendFactory = defaultBackendFactory
+// backendFactory provisions the already-resolved runtime for a new Instance,
+// returning the in-process Backend plus (for a sandboxed runtime) the authed
+// remote endpoint and the sandbox-reap teardown. It is a package-level variable
+// (not a hard-coded branch) so tests can inject a FakeBackend through
+// SetBackendFactoryForTest without touching production code paths. NewInstance
+// passes the same resolved kind its pre-provision gates inspected, so config
+// cannot produce a different answer between the guard and provisioning.
+var backendFactory = defaultBackendFactoryForKind
 
 // defaultBackendFactory resolves the session's runtime from the requested
 // backend kind (the `--backend` flag / repo `backend` config, or ForceRemote for
@@ -131,6 +132,10 @@ func defaultBackendFactory(opts InstanceOptions, absPath string) (ProvisionResul
 	if err != nil {
 		return ProvisionResult{}, err
 	}
+	return defaultBackendFactoryForKind(opts, absPath, kind)
+}
+
+func defaultBackendFactoryForKind(opts InstanceOptions, absPath string, kind BackendKind) (ProvisionResult, error) {
 	rt, err := ResolveRuntime(kind)
 	if err != nil {
 		return ProvisionResult{}, err
@@ -379,7 +384,7 @@ func LocalPrereqsRequired(opts InstanceOptions, absPath string) (bool, error) {
 // wants to inject a backend needs no knowledge of the endpoint/teardown seam.
 func SetBackendFactoryForTest(f func(opts InstanceOptions, absPath string) (Backend, error)) func() {
 	prev := backendFactory
-	backendFactory = func(opts InstanceOptions, absPath string) (ProvisionResult, error) {
+	backendFactory = func(opts InstanceOptions, absPath string, _ BackendKind) (ProvisionResult, error) {
 		b, err := f(opts, absPath)
 		if err != nil {
 			return ProvisionResult{}, err
@@ -428,8 +433,12 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 		return nil, fmt.Errorf("failed to get absolute path: %w", err)
 	}
 
-	if err := InPlaceBackendConflict(opts, absPath); err != nil {
-		return nil, err
+	// Resolve once, before any gate that depends on the effective backend. Keep a
+	// resolution error until the point where backendFactory used to report it so
+	// invalid config retains its established error precedence.
+	kind, resolveBackendErr := resolveBackendKind(opts, absPath)
+	if resolveBackendErr == nil && opts.InPlace && kind != BackendLocal {
+		return nil, inPlaceBackendConflict(kind, opts)
 	}
 	normalizedSessionEnv, err := sessionenv.NormalizeExtraNames(opts.SessionEnvPassthrough)
 	if err != nil {
@@ -442,27 +451,29 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 	}
 	opts.ProvisionSessionEnvPassthrough = normalizedProvisionEnv
 
-	// An account-scoped session must run LOCALLY, for now.
-	//
-	// The off-box backends provision and start agent-server before the account is
-	// applied, and ProvisionSpec does not carry it — so a docker, ssh, sandbox or
-	// hook session would run on the sandbox's ambient credentials while the
-	// instance recorded the requested account. That is the silent wrong-identity
-	// outcome this feature exists to prevent, reached through a backend instead of
-	// through the environment, and it is worse than not offering the combination.
-	//
-	// Refusing is the first slice deliberately: threading the account through
-	// provisioning and the headless launch is real work, and until it is done an
-	// honest error beats a session that reports one identity and spends another
-	// (#3051, #3082).
-	if err := refuseOffBoxAccount(opts); err != nil {
-		return nil, err
+	// Judge account support on the RESOLVED backend. An empty opts.Backend means
+	// "read the repo config", not local; checking the request field let the most
+	// common ssh/sandbox/hook path provision on ambient credentials while the
+	// instance recorded the requested account (#3082, #3103).
+	accountBackendErr := error(nil)
+	if resolveBackendErr == nil {
+		accountBackendErr = refuseOffBoxAccountForKind(opts, kind)
+	} else {
+		// Preserve the direct guard's established answer for an explicitly invalid
+		// backend; the resolver error remains authoritative for repo-config errors.
+		accountBackendErr = refuseOffBoxAccount(opts)
+	}
+	if accountBackendErr != nil {
+		return nil, accountBackendErr
 	}
 	if err := refuseUnsupportedAccountAgent(opts, absPath); err != nil {
 		return nil, err
 	}
+	if resolveBackendErr != nil {
+		return nil, resolveBackendErr
+	}
 
-	res, err := backendFactory(opts, absPath)
+	res, err := backendFactory(opts, absPath, kind)
 	if err != nil {
 		return nil, err
 	}
@@ -555,88 +566,25 @@ func refuseOffBoxAccount(opts InstanceOptions) error {
 	if kind == "" {
 		kind = BackendLocal
 	}
+	return refuseOffBoxAccountForKind(opts, kind)
+}
+
+func refuseOffBoxAccountForKind(opts InstanceOptions, kind BackendKind) error {
+	if strings.TrimSpace(opts.Account) == "" {
+		return nil
+	}
 	if kind == BackendLocal || kind.CarriesAccount() {
 		return nil
 	}
 	return fmt.Errorf("account %q cannot be used with the %s backend: %s", opts.Account, kind, offBoxAccountRefusal(kind))
 }
 
-// offBoxAccountRefusal is WHY a given backend refuses an account, in the
-// operator's words.
-//
-// It is per backend because the reasons are genuinely different, and a merged
-// message was actively misleading (#3103). The old wording said af "cannot place
-// a credential account on that machine" for all of them — which is FALSE for ssh
-// and provably so: that runtime streams af's own binary to the remote, creates a
-// per-session directory and starts a process there. Placement was never the
-// obstacle. An operator who knows the ssh backend reads that and reasonably
-// concludes af simply has not wired it up.
-//
-// THE ACTUAL OBSTACLE FOR SSH IS THE ROUND TRIP. An account is a writable agent
-// HOME (sessionenv.Account.Dir becomes CODEX_HOME / CLAUDE_CONFIG_DIR), not a
-// credential file, and the agent writes REFRESHED AUTHENTICATION into it when a
-// token rotates. A copy's writes live on the remote and the teardown `rm -rf`
-// destroys them, so the account would present as writable while being read-only
-// in practice.
-//
-// And the worst case is not a stale credential, it is an INVALIDATED one. OAuth
-// refresh tokens are commonly single-use: presenting one returns a replacement
-// and kills the old. If that holds for a given provider, a remote refresh
-// invalidates the token the operator still holds LOCALLY while the replacement is
-// deleted with the session dir — so a session on a machine af does not control
-// breaks the identity on the machine it does. af cannot verify rotation behaviour
-// per provider, and that unverifiability is the argument: this is a risk af would
-// be taking on the operator's behalf without being able to bound it.
-//
-// COPY-BACK IS NOT RULED OUT BY TEARDOWN AMBIGUITY, and an earlier draft of this
-// comment claimed it was (#3103 review). The ordering is available: quiesce the
-// agent, copy, install the replacement locally, and only THEN start the
-// destructive reap — a write-back failure retains the record without tearing
-// anything down, and an unknown reap outcome afterwards no longer costs the token,
-// because it already arrived. So teardown uncertainty alone is not the argument.
-//
-// What survives that correction is narrower and is still enough:
-//
-//   - The remote can be LOST before write-back — an evaporated cloud instance, a
-//     revoked key, a network partition that outlives the session. Then the refresh
-//     is gone and the local copy is dead, which is the invalidation case again,
-//     reached by a route no ordering fixes.
-//   - Write-back needs the agent QUIESCED to copy a consistent home, and af has no
-//     mechanism to make an agent stop writing on request.
-//   - It widens the window in which live credentials sit on a machine af does not
-//     control, which per-session placement exists to bound.
-//
-// sandbox and hook get the SAME round-trip reason rather than a location one, and
-// that is a correction too: sandboxProvisioner.provision creates the session
-// directory and streams af's binary into it, and the provision-hook path reuses
-// that provisioner — so af controls those locations exactly as it does for ssh.
-// Only hook's launch_cmd mode genuinely leaves the machine's shape to the
-// operator, and the round-trip reason covers that mode as well.
-// offBoxRoundTripReason is the one reason ssh, sandbox and hook refuse.
-//
-// It states the property af can ESTABLISH — that it cannot get the agent's
-// writes back — rather than a mechanism by which they are lost, and that is the
-// correction TEN review findings on this PR converged on. The permanence clause
-// obeys the same rule: it says the GUARANTEE is missing, and deliberately does
-// NOT say "only a mount can return those writes" — an earlier draft did, and that
-// was the same over-claim one layer up, since a launch_cmd may run the
-// agent-server on the daemon host or against shared durable storage. Every earlier
-// version named a specific consequence ("destroyed with the session directory at
-// teardown", "af has no provable location", "omit --account to use that machine's
-// own credentials"), and each was false for at least one backend, because the
-// consequence depends on each backend's own lifecycle and environment contract
-// while the refusal does not. hook's launch_cmd owns no session directory af can
-// delete; sandbox reads the operator's ssh_config; only ssh pins -F none.
-//
-// So: assert the thing that is true for all three and nothing further. It also
-// deliberately says "the other off-box backends" nowhere — docker is off-box in
-// this repo's taxonomy (backendProvisionsOffBox) and CARRIES an account, so
-// "off-box" is the wrong axis to name here at all.
-const offBoxRoundTripReason = "an account is a writable agent home, so the agent writes refreshed " +
-	"authentication back into it — and af cannot establish that those writes come back, so a rotated token " +
-	"can be lost. If your provider rotates refresh tokens, losing it also " +
-	"invalidates the copy on this machine — so a feature meant to NARROW where an identity is used could " +
-	"break it. af refuses this BY DESIGN and not as pending work: what is missing is the GUARANTEE that " +
+// offBoxAccountRefusal appends only backend-specific facts to the shared
+// AccountWriteBackRationale. The common reason must remain location- and
+// mechanism-neutral because hook may use shared storage or run on the daemon
+// host; see CarriesAccount.
+const offBoxRoundTripReason = AccountWriteBackRationale +
+	" af refuses this BY DESIGN and not as pending work: what is missing is the GUARANTEE that " +
 	"those writes come back, and af will not present an account as writable without one."
 
 func offBoxAccountRefusal(kind BackendKind) string {

--- a/session/instance_factory_cleanup_test.go
+++ b/session/instance_factory_cleanup_test.go
@@ -22,7 +22,7 @@ func TestNewInstance_BindFailureSurfacesCleanupOutcome(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			previousFactory := backendFactory
-			backendFactory = func(InstanceOptions, string) (ProvisionResult, error) {
+			backendFactory = func(InstanceOptions, string, BackendKind) (ProvisionResult, error) {
 				return ProvisionResult{
 					Backend:  newInertSandboxBackend("docker"),
 					Endpoint: &AgentServerEndpoint{URL: "://invalid", Token: "tok"},

--- a/session/runtime.go
+++ b/session/runtime.go
@@ -213,10 +213,17 @@ func (k BackendKind) ProvisionsOffBox() bool { return backendProvisionsOffBox[k]
 // including a refreshed token, land in the operator's real registry rather than
 // in a copy that teardown deletes.
 //
-// A COPY IS NOT A MOUNT, which is why ssh answers false even though it could
-// physically transfer one: its writes cannot come home. sandbox and hook answer
-// false because af does not decide the shape of those machines at all. See
-// offBoxAccountRefusal for each reason in full.
+// A COPY IS NOT A MOUNT, and that — not placement — is why every off-box kind
+// answers false. ssh, sandbox and provision-mode hook can all physically place a
+// directory: sandboxProvisioner.provision creates the session dir and streams
+// af's binary into it, and the provision-hook path reuses that provisioner. What
+// none of them has is a way to get the agent's WRITES back, so a refreshed token
+// would die with the session dir.
+//
+// hook's launch_cmd mode is the only one where af additionally does not control
+// placement at all — but it answers false for the same write-back reason, so the
+// distinction changes the explanation and not the answer. See
+// offBoxAccountRefusal.
 //
 // Because a kind that answers FALSE promises nothing, a per-KIND answer is safe
 // here even for hook, whose modes differ from one another — the objection to a

--- a/session/runtime.go
+++ b/session/runtime.go
@@ -197,12 +197,25 @@ func (k BackendKind) ProvisionsOffBox() bool { return backendProvisionsOffBox[k]
 // CarriesAccount reports whether this kind's provisioner can place a registered
 // credential account on the machine that runs the agent (#3082).
 //
-// Only docker, and the reason is a mechanism rather than a preference: an account
-// is an agent HOME directory, and the docker runtime already bind-mounts host
-// paths into the container, so the account's directory can be mounted where the
-// in-container agent reads its home. ssh, sandbox and hook have no way to place a
-// directory they can prove is the account — see refuseOffBoxAccount for why that
-// is a decision and not a gap.
+// THIS IS A CLAIM ABOUT A PROVEN MECHANISM, NOT A CAPABILITY, and the difference
+// decides what a per-KIND answer may say (#3103).
+//
+// Only docker, because only docker has one: an account is an agent HOME
+// directory, the docker runtime already bind-mounts host paths into the
+// container, and a MOUNT is shared with the host — so the agent's writes,
+// including a refreshed token, land in the operator's real registry rather than
+// in a copy that teardown deletes.
+//
+// A COPY IS NOT A MOUNT, which is why ssh answers false even though it could
+// physically transfer one: its writes cannot come home. sandbox and hook answer
+// false because af does not decide the shape of those machines at all. See
+// offBoxAccountRefusal for each reason in full.
+//
+// Because a kind that answers FALSE promises nothing, a per-KIND answer is safe
+// here even for hook, whose modes differ from one another — the objection to a
+// blanket per-kind answer only bites for a kind claiming TRUE, where the kind
+// would have to determine the machine's shape in order to be making a promise it
+// can keep.
 //
 // Local is deliberately NOT listed: it needs no placing, applies the account
 // through the exec shim, and is handled by its own branch. A kind that answers

--- a/session/runtime.go
+++ b/session/runtime.go
@@ -213,16 +213,21 @@ func (k BackendKind) ProvisionsOffBox() bool { return backendProvisionsOffBox[k]
 // including a refreshed token, land in the operator's real registry rather than
 // in a copy that teardown deletes.
 //
-// A COPY IS NOT A MOUNT, and that — not placement — is why ssh, sandbox and hook
-// answer false. NOT "every off-box kind": docker is off-box too
-// (backendProvisionsOffBox) and answers TRUE, so off-box is the wrong axis to
-// reason on here.
+// WHAT MAKES DOCKER DIFFERENT IS THE MOUNT, and it is the only mechanism af
+// currently has that returns the agent's writes to the operator's real registry.
+// ssh, sandbox and hook answer false because af cannot establish that write-back
+// for them — NOT because a copy is the only thing they could ever do. hook's
+// launch_cmd may provision anything and only has to hand back an agent-server
+// endpoint, so it could use shared storage or even run on the daemon host; a
+// mount-like transport for ssh or sandbox would qualify too. What is missing is
+// the guarantee, not the possibility (#3103 review).
 //
-// All three can place a directory — sandboxProvisioner.provision creates the
+// Nor is this "every off-box kind": docker is off-box (backendProvisionsOffBox)
+// and answers TRUE, so off-box is the wrong axis to reason on here.
+//
+// Placement is not the axis either — sandboxProvisioner.provision creates the
 // session dir and streams af's binary into it, and the provision-hook path reuses
-// that provisioner. What none of them has is a way to get the agent's WRITES
-// back. hook's launch_cmd additionally leaves placement to the operator, which
-// changes the explanation and not the answer. See offBoxAccountRefusal.
+// that provisioner. See offBoxAccountRefusal.
 //
 // Because a kind that answers FALSE promises nothing, a per-KIND answer is safe
 // here even for hook, whose modes differ from one another — the objection to a

--- a/session/runtime.go
+++ b/session/runtime.go
@@ -194,6 +194,16 @@ var backendProvisionsOffBox = map[BackendKind]bool{
 // ParseBackendKind rejects those before they reach a runtime.
 func (k BackendKind) ProvisionsOffBox() bool { return backendProvisionsOffBox[k] }
 
+// AccountWriteBackRationale is the single operator-facing reason ssh, sandbox
+// and hook cannot safely honour a writable credential account. It states only
+// the guarantee af lacks, without asserting where a hook runs or which
+// mechanism could supply that guarantee.
+const AccountWriteBackRationale = "An account is a writable agent home, so the agent writes refreshed " +
+	"authentication back into it. For ssh, sandbox and hook, af cannot establish that those writes come " +
+	"back, so a rotated token can be lost. If your provider rotates refresh tokens, losing it also " +
+	"invalidates the copy on this machine — so a feature meant to NARROW where an identity is used could " +
+	"break it."
+
 // CarriesAccount reports whether this kind's provisioner will SAFELY HONOUR a
 // registered credential account — including the agent's persistent WRITES back
 // into it — on the machine that runs the agent (#3082, #3103).
@@ -213,14 +223,12 @@ func (k BackendKind) ProvisionsOffBox() bool { return backendProvisionsOffBox[k]
 // including a refreshed token, land in the operator's real registry rather than
 // in a copy that teardown deletes.
 //
-// WHAT MAKES DOCKER DIFFERENT IS THE MOUNT, and it is the only mechanism af
-// currently has that returns the agent's writes to the operator's real registry.
-// ssh, sandbox and hook answer false because af cannot establish that write-back
-// for them — NOT because a copy is the only thing they could ever do. hook's
-// launch_cmd may provision anything and only has to hand back an agent-server
-// endpoint, so it could use shared storage or even run on the daemon host; a
-// mount-like transport for ssh or sandbox would qualify too. What is missing is
-// the guarantee, not the possibility (#3103 review).
+// ssh, sandbox and hook answer false for AccountWriteBackRationale — NOT because
+// a copy is the only thing they could ever do. hook's launch_cmd may provision
+// anything and only has to hand back an agent-server endpoint, so it could use
+// shared storage or even run on the daemon host; a mount-like transport for ssh
+// or sandbox would qualify too. What is missing is the guarantee, not the
+// possibility (#3103 review).
 //
 // Nor is this "every off-box kind": docker is off-box (backendProvisionsOffBox)
 // and answers TRUE, so off-box is the wrong axis to reason on here.

--- a/session/runtime.go
+++ b/session/runtime.go
@@ -194,8 +194,15 @@ var backendProvisionsOffBox = map[BackendKind]bool{
 // ParseBackendKind rejects those before they reach a runtime.
 func (k BackendKind) ProvisionsOffBox() bool { return backendProvisionsOffBox[k] }
 
-// CarriesAccount reports whether this kind's provisioner can place a registered
-// credential account on the machine that runs the agent (#3082).
+// CarriesAccount reports whether this kind's provisioner will SAFELY HONOUR a
+// registered credential account — including the agent's persistent WRITES back
+// into it — on the machine that runs the agent (#3082, #3103).
+//
+// Deliberately not "can place". #3103 established that ssh can physically place
+// an account and still answers FALSE here, so callers depend on the stronger
+// predicate; leaving the contract phrased as placement would invite a future
+// backend author to answer true for a copy-only mechanism, which is precisely the
+// unsafe behaviour that decision rejects.
 //
 // THIS IS A CLAIM ABOUT A PROVEN MECHANISM, NOT A CAPABILITY, and the difference
 // decides what a per-KIND answer may say (#3103).

--- a/session/runtime.go
+++ b/session/runtime.go
@@ -213,17 +213,16 @@ func (k BackendKind) ProvisionsOffBox() bool { return backendProvisionsOffBox[k]
 // including a refreshed token, land in the operator's real registry rather than
 // in a copy that teardown deletes.
 //
-// A COPY IS NOT A MOUNT, and that — not placement — is why every off-box kind
-// answers false. ssh, sandbox and provision-mode hook can all physically place a
-// directory: sandboxProvisioner.provision creates the session dir and streams
-// af's binary into it, and the provision-hook path reuses that provisioner. What
-// none of them has is a way to get the agent's WRITES back, so a refreshed token
-// would die with the session dir.
+// A COPY IS NOT A MOUNT, and that — not placement — is why ssh, sandbox and hook
+// answer false. NOT "every off-box kind": docker is off-box too
+// (backendProvisionsOffBox) and answers TRUE, so off-box is the wrong axis to
+// reason on here.
 //
-// hook's launch_cmd mode is the only one where af additionally does not control
-// placement at all — but it answers false for the same write-back reason, so the
-// distinction changes the explanation and not the answer. See
-// offBoxAccountRefusal.
+// All three can place a directory — sandboxProvisioner.provision creates the
+// session dir and streams af's binary into it, and the provision-hook path reuses
+// that provisioner. What none of them has is a way to get the agent's WRITES
+// back. hook's launch_cmd additionally leaves placement to the operator, which
+// changes the explanation and not the answer. See offBoxAccountRefusal.
 //
 // Because a kind that answers FALSE promises nothing, a per-KIND answer is safe
 // here even for hook, whose modes differ from one another — the objection to a


### PR DESCRIPTION
Closes #3103.

**The design answer is option 1 — refuse, permanently and by name.** Posted on the issue [before building](https://github.com/sachiniyer/agent-factory/issues/3103#issuecomment-5224317623). This PR is that decision plus the refusal it implies; it is deliberately **not** the transport.

Both cross-cutting items from #3089 had already landed, so neither blocked this: `reprovisionRemote` re-resolves the persisted account, and `refuseUnsupportedAccountAgent` resolves the program before deciding.

## The decisive argument is invalidation, not staleness

The issue's write-up stops at *"the next session starts from the stale credential"*. The real worst case is worse, and it is what settles the design.

An account is a **writable agent home** — `Account.Dir` becomes `CODEX_HOME` / `CLAUDE_CONFIG_DIR` — so the agent writes **refreshed authentication** into it. docker bind-**mounts** that directory, so the writes land in the operator's real registry. Any off-box kind needs it **copied**, and a copy's writes die with the session dir at teardown.

OAuth refresh tokens are commonly **single-use**: presenting one returns a replacement and invalidates the old. If that holds for a given provider:

1. The remote copy refreshes → the provider invalidates the token the operator still holds **locally**.
2. Teardown `rm -rf`s the session dir, destroying the only copy of the replacement.
3. The operator's **local** account — on the machine af *does* control, working before — now holds a dead token.

So a session on a machine af does not control would be able to **break the identity on the machine it does**, which inverts the entire point of a feature that exists to *narrow* where an identity is used.

af cannot verify rotation behaviour per provider, and **that unverifiability is the argument rather than a caveat to it**: af would be taking a risk on the operator's behalf that it has no way to bound, for a convenience.

### Why the other options do not survive

- **Copy back before teardown** inherits a path this codebase explicitly allows not to complete. `ErrWorkspaceStateUnknown`, the retained-record machinery, `CleanupRetry`'s retry-and-retire all exist because reaps legitimately do not finish — so a credential-carrying teardown is a credential that legitimately does not come home, silently. It also widens the window in which live credentials sit on the remote, which per-session placement exists to bound.
- **Read-only off-box** needs to know when the agent would write. Agents do not report it, and it is not only auth — history and settings are written unconditionally, so a read-only home is a broken agent, not a degraded account.
- **A mount-like transport** is the only option with docker's semantics and is genuinely possible for ssh and sandbox (af already runs its own `agent-server` on the far side). It is also a filesystem protocol with its own consistency and failure story, and it deserves its own issue rather than arriving as the implementation half of this one.

## What actually changed in the code

**The refusal message was wrong**, and that is worth fixing on its own. It said af *"cannot place a credential account on that machine"* for every off-box kind. **That is false for ssh and provably so**: the runtime streams af's own binary to the remote, creates a per-session directory, and starts a process in it. Placement was never the obstacle — the round trip is. An operator who knows the ssh backend reads that message and reasonably concludes af just has not wired it up, and files this issue again.

So the reason is now **per backend, and each one is true**:

| backend | what the refusal now says |
|---|---|
| ssh | af **can** put it there and deliberately does not — the refresh dies at teardown, and a rotating provider would invalidate the local copy too |
| sandbox, hook | af does not decide the shape of those machines at all, so there is no location it can **prove** is the account rather than somewhere that resembles it |
| anything unassessed | "has not established" — honest for a backend nobody evaluated, and wrong for the three that were decided |

**`CarriesAccount()`'s contract is stated**: it claims a proven *mechanism*, not a capability. That is also the answer to the hook finding from the preserved attempt — a blanket per-KIND answer only misleads for a kind claiming **true**, where the kind would have to determine the machine's shape in order to keep the promise. A kind answering false promises nothing, so per-kind is safe there even for hook, whose modes differ.

**Docs**: `af accounts` help now states the refusal is by design and why, so it is discoverable before an operator hits it. Edited at the Cobra source and regenerated with `scripts/gen-docs.sh` — `docs/reference/cli.md` is generated and CI verifies it.

## Tests — each watched failing first

| Guarantee | Mutation that must break it |
|---|---|
| ssh's reason names the round trip, never "cannot place" | collapse back to one blanket message |
| ssh does not inherit sandbox/hook's reason | route ssh to the default branch |
| sandbox/hook name the operator's own provisioner, not the round trip | collapse to one message |
| every decided backend has its own reason | route one to the default |
| ssh still refuses at all | exempt it |
| local and docker still allowed; no account still allowed | — |

Two existing tests asserted the old wording (`"cannot place a credential account"`, `"ambient credentials"`) and were updated to the new guarantee rather than relaxed — one of them now asserts the blanket phrase is **absent**, so it cannot come back.

## Verification

`gofmt -l .` (no output) · `go build ./...` · `golangci-lint run --fast` · `scripts/lint-file-length.sh` · `go test ./session/ ./commands/` · `scripts/gen-docs.sh` (no drift beyond the intended help text).
