### PR TITLE
test(integration): wait out daemon warmup in Codex readiness checks

### DIFF
--- a/integration/codex_ready_retry_test.go
+++ b/integration/codex_ready_retry_test.go
@@ -1,0 +1,50 @@
+package integration_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestRunAFUntilDaemonAdmitsRetriesWarmupRefusal(t *testing.T) {
+	t.Parallel()
+
+	const daemonStarting = "agent-factory daemon is starting (restoring sessions); retry shortly"
+	calls := 0
+	out, err := runAFUntilDaemonAdmits(context.Background(), 0, func() (string, error) {
+		calls++
+		if calls == 1 {
+			return "", errors.New(daemonStarting)
+		}
+		return "created", nil
+	})
+	if err != nil {
+		t.Fatalf("runAFUntilDaemonAdmits: %v", err)
+	}
+	if out != "created" {
+		t.Fatalf("output = %q, want created", out)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+}
+
+func TestRunAFUntilDaemonAdmitsDoesNotRetryOtherFailures(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("agent readiness failed")
+	calls := 0
+	out, err := runAFUntilDaemonAdmits(context.Background(), 0, func() (string, error) {
+		calls++
+		return "pane diagnostics", wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+	if out != "pane diagnostics" {
+		t.Fatalf("output = %q, want pane diagnostics", out)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+}

--- a/integration/codex_ready_test.go
+++ b/integration/codex_ready_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
@@ -25,6 +26,55 @@ import (
 // gets reported as a readiness regression (#2879), which is the bug these tests
 // had — so the distinction is a sentinel rather than a comment.
 var errHangGuardExpired = errors.New("hang guard expired before the CLI answered")
+
+func runAFUntilDaemonAdmits(ctx context.Context, retryDelay time.Duration, run func() (string, error)) (string, error) {
+	for {
+		out, err := run()
+		if !daemon.IsDaemonStartingErr(err) {
+			return out, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return out, err
+		case <-time.After(retryDelay):
+		}
+	}
+}
+
+func runAFWithin(limit time.Duration, bin, repo, home string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), limit)
+	defer cancel()
+
+	// Capture stdout separately from stderr: the CLI writes the session JSON
+	// to stdout but a "wrote logs to …" line to stderr, so CombinedOutput
+	// would corrupt the JSON parse.
+	run := func() (string, error) {
+		cmd := exec.CommandContext(ctx, bin, args...)
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(), "AGENT_FACTORY_HOME="+home, "TERM=xterm")
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+		if err != nil {
+			return stdout.String(), fmt.Errorf("%w; stderr=%s", err, stderr.String())
+		}
+		return stdout.String(), nil
+	}
+
+	// #3111's fourth and fifth sightings ended before a session existed: the
+	// first CLI call started a fresh daemon, its bounded internal admission retry
+	// expired while restore was still running, and CreateSession was refused.
+	// The refusal happens before any create work, so retry only that documented
+	// condition. The readiness verdict and launch-marker assertions below remain
+	// untouched and still get exactly one successfully admitted create.
+	out, err := runAFUntilDaemonAdmits(ctx, 100*time.Millisecond, run)
+	if ctx.Err() == context.DeadlineExceeded {
+		return out, fmt.Errorf("%w after %s; last error=%v", errHangGuardExpired, limit, err)
+	}
+	return out, err
+}
 
 // TestCLICreateCodexSessionBecomesReady is the regression test for
 // sachiniyer/agent-factory#714. Before isReadyContent became agent-aware, a
@@ -102,30 +152,9 @@ func TestCLICreateCodexSessionBecomesReady(t *testing.T) {
 	writeFile(t, filepath.Join(home, config.ConfigFileName), string(raw), 0644)
 
 	bin := buildBinary(t)
-	// Capture stdout separately from stderr: the CLI writes the session JSON
-	// to stdout but a "wrote logs to …" line to stderr, so CombinedOutput
-	// would corrupt the JSON parse.
-	runAFWithin := func(limit time.Duration, args ...string) (string, error) {
-		ctx, cancel := context.WithTimeout(context.Background(), limit)
-		defer cancel()
-		cmd := exec.CommandContext(ctx, bin, args...)
-		cmd.Dir = repo
-		cmd.Env = append(os.Environ(), "AGENT_FACTORY_HOME="+home, "TERM=xterm")
-		var stdout, stderr bytes.Buffer
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-		err := cmd.Run()
-		if ctx.Err() == context.DeadlineExceeded {
-			return stdout.String(), fmt.Errorf("%w after %s; stderr=%s", errHangGuardExpired, limit, stderr.String())
-		}
-		if err != nil {
-			return stdout.String(), fmt.Errorf("%w; stderr=%s", err, stderr.String())
-		}
-		return stdout.String(), nil
-	}
 
 	t.Cleanup(func() {
-		_, _ = runAFWithin(30*time.Second, "sessions", "kill", "codex-ready")
+		_, _ = runAFWithin(30*time.Second, bin, repo, home, "sessions", "kill", "codex-ready")
 		killDaemonFromHome(home)
 	})
 
@@ -137,7 +166,7 @@ func TestCLICreateCodexSessionBecomesReady(t *testing.T) {
 	// this test had.
 	const createHangGuard = 4 * time.Minute
 
-	out, err := runAFWithin(createHangGuard, "sessions", "--repo", repo, "create", "--name", "codex-ready", "--program", tmux.ProgramCodex)
+	out, err := runAFWithin(createHangGuard, bin, repo, home, "sessions", "--repo", repo, "create", "--name", "codex-ready", "--program", tmux.ProgramCodex)
 
 	// Read the count BEFORE judging the error, so the three outcomes stay
 	// distinguishable (#2879).
@@ -252,27 +281,9 @@ func TestCLICreateCodexWaitsPastTrustPrompt(t *testing.T) {
 	writeFile(t, filepath.Join(home, config.ConfigFileName), string(raw), 0644)
 
 	bin := buildBinary(t)
-	runAFWithin := func(limit time.Duration, args ...string) (string, error) {
-		ctx, cancel := context.WithTimeout(context.Background(), limit)
-		defer cancel()
-		cmd := exec.CommandContext(ctx, bin, args...)
-		cmd.Dir = repo
-		cmd.Env = append(os.Environ(), "AGENT_FACTORY_HOME="+home, "TERM=xterm")
-		var stdout, stderr bytes.Buffer
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-		err := cmd.Run()
-		if ctx.Err() == context.DeadlineExceeded {
-			return stdout.String(), fmt.Errorf("%w after %s; stderr=%s", errHangGuardExpired, limit, stderr.String())
-		}
-		if err != nil {
-			return stdout.String(), fmt.Errorf("%w; stderr=%s", err, stderr.String())
-		}
-		return stdout.String(), nil
-	}
 
 	t.Cleanup(func() {
-		_, _ = runAFWithin(30*time.Second, "sessions", "kill", "codex-trust")
+		_, _ = runAFWithin(30*time.Second, bin, repo, home, "sessions", "kill", "codex-trust")
 		killDaemonFromHome(home)
 	})
 
@@ -304,7 +315,7 @@ func TestCLICreateCodexWaitsPastTrustPrompt(t *testing.T) {
 	//
 	// If you are about to add a timing assertion back here, add a case there
 	// instead.
-	out, err := runAFWithin(createHangGuard, "sessions", "--repo", repo, "create", "--name", "codex-trust", "--program", tmux.ProgramCodex)
+	out, err := runAFWithin(createHangGuard, bin, repo, home, "sessions", "--repo", repo, "create", "--name", "codex-trust", "--program", tmux.ProgramCodex)
 	if errors.Is(err, errHangGuardExpired) {
 		t.Fatalf("the create never returned within the %s hang guard, so af rendered no verdict — "+
 			"a hang or environment failure: %v\n%s", createHangGuard, err, out)


### PR DESCRIPTION
## Cause established from the failing runs

Both the fourth and fifth sightings failed before Codex readiness was involved:

- [run 31235860733, attempt 1](https://github.com/sachiniyer/agent-factory/actions/runs/31235860733/attempts/1) returned `agent-factory daemon is starting (restoring sessions); retry shortly`
- [run 31237159081, attempt 1](https://github.com/sachiniyer/agent-factory/actions/runs/31237159081/attempts/1) returned the same refusal
- both reported zero durable fake-Codex launch markers

So af did not report ready before the session accepted input: it never launched the agent or created a pane. The failing pane contained nothing because no pane existed. The first CLI call started a fresh daemon, but the daemon was still restoring after the CLI internal five-second admission retry expired.

## Fix

The Codex integration harness now retries only `daemon.IsDaemonStartingErr`, under its existing four-minute hang guard. That refusal is emitted before any create work, so reissuing it cannot duplicate a session. Readiness errors and every other failure still return immediately; the launch-marker and readiness assertions are unchanged.

The duplicated CLI runner used by both Codex tests is also consolidated so the sibling cold-start path cannot retain the same race.

## Verification

- New regression test observed failing before the fix: the one-shot helper returned the daemon-starting refusal instead of making the second admitted call
- `go test ./integration -run '^TestRunAFUntilDaemonAdmits' -count=1`
- `gofmt -l .`
- `go build ./...`
- `golangci-lint run --timeout=3m --fast`
- `scripts/lint-file-length.sh`

No daemon package tests, full-suite host test, deadcode analysis, or container build was run locally; CI owns the full matrix.

Closes #3111
