### PR TITLE
ci: make Auto Gate recovery observable

### DIFF
--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -26,6 +26,7 @@ async function evaluate({ github, context, core, prNumber, setOutputs = true }) 
     return finish(core, setOutputs, {
       prNumber: prNumber ? String(prNumber) : "",
       shouldMerge: false,
+      isOpen: false,
       docsChanged: false,
       reasons: [`auto-gate evaluation error: ${message}`],
       notes: [],
@@ -40,6 +41,7 @@ async function evaluatePullRequest({ github, context, core, prNumber, setOutputs
     return finish(core, setOutputs, {
       prNumber: "",
       shouldMerge: false,
+      isOpen: false,
       docsChanged: false,
       reasons: ["No open pull request found for this event."],
       notes: [],
@@ -124,6 +126,7 @@ async function evaluatePullRequest({ github, context, core, prNumber, setOutputs
   return finish(core, setOutputs, {
     prNumber: String(pr.number),
     shouldMerge: reasons.length === 0,
+    isOpen: pr.state === "OPEN" && !pr.merged,
     headSha: pr.headRefOid,
     docsChanged,
     reasons,
@@ -135,6 +138,10 @@ async function reportDecision({ github, context, core, result, manual = false })
   if (!result?.headSha || !result.prNumber) {
     core.info("Auto Gate decision was not reported because no pull-request head was resolved.");
     return { state: "unreported", priorDecision: false };
+  }
+  if (result.isOpen === false) {
+    core.notice(`Leaving the existing Auto Gate decision unchanged for closed PR #${result.prNumber}.`);
+    return { state: "closed", priorDecision: false };
   }
 
   const { owner, repo } = context.repo;
@@ -337,9 +344,13 @@ async function listPullRequestFiles({ github, context, number }) {
 
 async function evaluateRequiredChecks({ github, context, branch, sha, core }) {
   const required = await getRequiredCheckSpecs({ github, context, branch, core });
-  const specs = required.specs;
+  const specs = required.specs.filter((spec) => spec.context !== AUTO_GATE_DECISION_CHECK);
   const notes = [];
   const reasons = [...required.errors];
+
+  if (specs.length !== required.specs.length) {
+    notes.push("Auto Gate decision is enforced after this prerequisite evaluation");
+  }
 
   if (specs.length === 0) {
     notes.push("No required status checks configured for branch");

--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -259,6 +259,25 @@ async function findPullRequestNumber({ github, context, core, pullAssociationCac
     payload.action === "edited" &&
     payload.changes?.base?.ref?.from === "master" &&
     payload.pull_request?.base?.ref !== "master";
+  const synchronizedPullRequest =
+    context.eventName === "pull_request" &&
+    payload.action === "synchronize" &&
+    payload.before;
+
+  if (synchronizedPullRequest) {
+    const previousHeadPulls = await listOpenMasterPullRequestsForCommit({
+      github,
+      context,
+      sha: payload.before,
+      pullAssociationCache,
+    });
+    if (previousHeadPulls.length > 0) {
+      core.info(
+        `Head moved from ${payload.before}; reevaluating surviving PR #${previousHeadPulls[0].number}.`,
+      );
+      return previousHeadPulls[0].number;
+    }
+  }
 
   if (payload.pull_request?.number && !closedPullRequest && !removedFromMaster) {
     return payload.pull_request.number;

--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -254,8 +254,13 @@ async function findPullRequestNumber({ github, context, core, pullAssociationCac
   const payload = context.payload;
   const closedPullRequest =
     context.eventName === "pull_request" && payload.action === "closed";
+  const removedFromMaster =
+    context.eventName === "pull_request" &&
+    payload.action === "edited" &&
+    payload.changes?.base?.ref?.from === "master" &&
+    payload.pull_request?.base?.ref !== "master";
 
-  if (payload.pull_request?.number && !closedPullRequest) {
+  if (payload.pull_request?.number && !closedPullRequest && !removedFromMaster) {
     return payload.pull_request.number;
   }
 

--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -252,8 +252,10 @@ async function merge({ github, context, core, prNumber }) {
 
 async function findPullRequestNumber({ github, context, core, pullAssociationCache }) {
   const payload = context.payload;
+  const closedPullRequest =
+    context.eventName === "pull_request" && payload.action === "closed";
 
-  if (payload.pull_request?.number) {
+  if (payload.pull_request?.number && !closedPullRequest) {
     return payload.pull_request.number;
   }
 
@@ -267,7 +269,7 @@ async function findPullRequestNumber({ github, context, core, pullAssociationCac
     return checkSuitePr.number;
   }
 
-  const sha = payload.check_suite?.head_sha || payload.sha;
+  const sha = payload.check_suite?.head_sha || payload.pull_request?.head?.sha || payload.sha;
   if (!sha) {
     core.info(`Event ${context.eventName} did not include a PR or SHA to evaluate.`);
     return null;

--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -35,7 +35,10 @@ async function evaluate({ github, context, core, prNumber, setOutputs = true }) 
 }
 
 async function evaluatePullRequest({ github, context, core, prNumber, setOutputs = true }) {
-  const number = prNumber || (await findPullRequestNumber({ github, context, core }));
+  const pullAssociationCache = new Map();
+  const number =
+    prNumber ||
+    (await findPullRequestNumber({ github, context, core, pullAssociationCache }));
 
   if (!number) {
     return finish(core, setOutputs, {
@@ -78,6 +81,21 @@ async function evaluatePullRequest({ github, context, core, prNumber, setOutputs
     reasons.push(`mergeability is blocked (${pr.mergeable}/${pr.mergeStateStatus})`);
   } else if (pr.mergeable !== "MERGEABLE") {
     reasons.push(`mergeability is still ${pr.mergeable}`);
+  }
+
+  const associatedPulls = await listOpenMasterPullRequestsForCommit({
+    github,
+    context,
+    sha: pr.headRefOid,
+    pullAssociationCache,
+  });
+  const otherPulls = associatedPulls.filter((pull) => pull.number !== pr.number);
+  if (otherPulls.length > 0) {
+    reasons.push(
+      `head commit ${pr.headRefOid} is shared with open master ` +
+        `PRs ${otherPulls.map((pull) => `#${pull.number}`).join(", ")}; ` +
+        "Auto Gate decisions are commit-scoped",
+    );
   }
 
   const files = await listPullRequestFiles({ github, context, number: pr.number });
@@ -232,7 +250,7 @@ async function merge({ github, context, core, prNumber }) {
   }
 }
 
-async function findPullRequestNumber({ github, context, core }) {
+async function findPullRequestNumber({ github, context, core, pullAssociationCache }) {
   const payload = context.payload;
 
   if (payload.pull_request?.number) {
@@ -255,6 +273,29 @@ async function findPullRequestNumber({ github, context, core }) {
     return null;
   }
 
+  const openMasterPulls = await listOpenMasterPullRequestsForCommit({
+    github,
+    context,
+    sha,
+    pullAssociationCache,
+  });
+  if (openMasterPulls.length > 1) {
+    core.warning(`Found multiple open master PRs for ${sha}; evaluating PR #${openMasterPulls[0].number}.`);
+  }
+
+  return openMasterPulls[0]?.number || null;
+}
+
+async function listOpenMasterPullRequestsForCommit({
+  github,
+  context,
+  sha,
+  pullAssociationCache,
+}) {
+  if (pullAssociationCache?.has(sha)) {
+    return pullAssociationCache.get(sha);
+  }
+
   const { owner, repo } = context.repo;
   const pulls = await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {
     owner,
@@ -262,13 +303,11 @@ async function findPullRequestNumber({ github, context, core }) {
     commit_sha: sha,
     per_page: 100,
   });
-
-  const openMasterPulls = pulls.filter((pr) => pr.state === "open" && pr.base?.ref === "master");
-  if (openMasterPulls.length > 1) {
-    core.warning(`Found multiple open master PRs for ${sha}; evaluating PR #${openMasterPulls[0].number}.`);
-  }
-
-  return openMasterPulls[0]?.number || null;
+  const openMasterPulls = pulls.filter(
+    (pull) => pull.state === "open" && pull.base?.ref === "master",
+  );
+  pullAssociationCache?.set(sha, openMasterPulls);
+  return openMasterPulls;
 }
 
 async function getPullRequest({ github, context, number }) {

--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -344,7 +344,11 @@ async function listPullRequestFiles({ github, context, number }) {
 
 async function evaluateRequiredChecks({ github, context, branch, sha, core }) {
   const required = await getRequiredCheckSpecs({ github, context, branch, core });
-  const specs = required.specs.filter((spec) => spec.context !== AUTO_GATE_DECISION_CHECK);
+  const specs = required.specs.filter(
+    (spec) =>
+      spec.context !== AUTO_GATE_DECISION_CHECK ||
+      spec.sourceAppId !== GITHUB_ACTIONS_APP_ID,
+  );
   const notes = [];
   const reasons = [...required.errors];
 

--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -304,7 +304,10 @@ async function listOpenMasterPullRequestsForCommit({
     per_page: 100,
   });
   const openMasterPulls = pulls.filter(
-    (pull) => pull.state === "open" && pull.base?.ref === "master",
+    (pull) =>
+      pull.state === "open" &&
+      pull.base?.ref === "master" &&
+      pull.head?.sha === sha,
   );
   pullAssociationCache?.set(sha, openMasterPulls);
   return openMasterPulls;

--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -189,25 +189,48 @@ async function reportDecision({ github, context, core, result, manual = false })
       summary: result.summary,
     },
   };
-  if (priorDecision) {
-    await github.rest.checks.update({
-      owner,
-      repo,
-      check_run_id: priorDecision.id,
-      ...decision,
-    });
-  } else {
-    await github.rest.checks.create({
-      owner,
-      repo,
-      head_sha: result.headSha,
-      name: identity.checkName,
-      external_id: identity.externalId,
-      ...decision,
-    });
+  try {
+    if (priorDecision) {
+      await github.rest.checks.update({
+        owner,
+        repo,
+        check_run_id: priorDecision.id,
+        ...decision,
+      });
+    } else {
+      await github.rest.checks.create({
+        owner,
+        repo,
+        head_sha: result.headSha,
+        name: identity.checkName,
+        external_id: identity.externalId,
+        ...decision,
+      });
+    }
+  } catch (error) {
+    // pull_request-family events from forks can receive a read-only GITHUB_TOKEN
+    // even though this workflow requests checks: write. Leave absence observable
+    // and recoverable by a base-repository workflow_dispatch; other write errors
+    // remain fatal so a repository permission regression cannot pass silently.
+    if (!isReadOnlyForkCheckError(error, context)) {
+      throw error;
+    }
+    core.warning(
+      `Auto Gate could not publish the decision for fork PR #${result.prNumber} with its ` +
+        "read-only token; run workflow_dispatch from the base repository to recover it.",
+    );
+    return { state: "read-only", priorDecision: Boolean(priorDecision) };
   }
   core.notice(`${title} for PR #${result.prNumber}.`);
   return { state, priorDecision: Boolean(priorDecision) };
+}
+
+function isReadOnlyForkCheckError(error, context) {
+  return (
+    error?.status === 403 &&
+    /Resource not accessible by integration/i.test(error.message || "") &&
+    context.payload.pull_request?.head?.repo?.fork === true
+  );
 }
 
 function decisionIdentity(prNumber, headSha) {
@@ -319,7 +342,7 @@ async function resolveTargets({ github, context, core, prNumber }) {
       continue;
     }
     targets.push({
-      prNumber: String(pr.number),
+      prNumber: Number(pr.number),
       headSha: pr.headRefOid,
       decisionKey: decisionIdentity(pr.number, pr.headRefOid).key,
     });

--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -1,6 +1,8 @@
 const ALLOWED_AUTHORS = new Set(["sachiniyer", "app-detail-app", "app-detail-app[bot]"]);
 const TUI_PATH_PREFIXES = ["app/", "ui/", "session/tmux/"];
 const DOCS_DEPLOY_PATHS = ["docs/", "mkdocs.yml"];
+const AUTO_GATE_DECISION_CHECK = "Auto Gate decision";
+const GITHUB_ACTIONS_APP_ID = 15368;
 const CODEX_REVIEWER = "chatgpt-codex-connector[bot]";
 const CODEX_REVIEW_RE = /\bCodex Review\b/i;
 const CODEX_RATE_LIMIT_RE = /reached your Codex usage limits for code reviews/i;
@@ -127,6 +129,62 @@ async function evaluatePullRequest({ github, context, core, prNumber, setOutputs
     reasons,
     notes,
   });
+}
+
+async function reportDecision({ github, context, core, result, manual = false }) {
+  if (!result?.headSha || !result.prNumber) {
+    core.info("Auto Gate decision was not reported because no pull-request head was resolved.");
+    return { state: "unreported", priorDecision: false };
+  }
+
+  const { owner, repo } = context.repo;
+  const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+    owner,
+    repo,
+    ref: result.headSha,
+    per_page: 100,
+  });
+  const priorDecision = checkRuns
+    .filter(
+      (run) =>
+        run.name === AUTO_GATE_DECISION_CHECK && run.app?.id === GITHUB_ACTIONS_APP_ID,
+    )
+    .sort((left, right) => latestRunTime(right) - latestRunTime(left))[0];
+  const state =
+    manual && !priorDecision ? "never-ran" : result.shouldMerge ? "pass" : "waiting";
+  const title =
+    state === "never-ran"
+      ? `NEVER_RAN: no prior decision; recovery ${result.shouldMerge ? "passed" : "is waiting"}`
+      : result.shouldMerge
+        ? "PASS: Auto Gate requirements are satisfied"
+        : "WAITING: Auto Gate requirements are not yet satisfied";
+
+  const decision = {
+    status: "completed",
+    conclusion: result.shouldMerge ? "success" : "failure",
+    output: {
+      title,
+      summary: result.summary,
+    },
+  };
+  if (priorDecision) {
+    await github.rest.checks.update({
+      owner,
+      repo,
+      check_run_id: priorDecision.id,
+      ...decision,
+    });
+  } else {
+    await github.rest.checks.create({
+      owner,
+      repo,
+      head_sha: result.headSha,
+      name: AUTO_GATE_DECISION_CHECK,
+      ...decision,
+    });
+  }
+  core.notice(`${title} for PR #${result.prNumber}.`);
+  return { state, priorDecision: Boolean(priorDecision) };
 }
 
 async function merge({ github, context, core, prNumber }) {
@@ -649,6 +707,7 @@ function formatError(error) {
 module.exports = {
   evaluate,
   merge,
+  reportDecision,
   __test: {
     evaluateCodex,
     evaluateRequiredChecks,

--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -344,16 +344,30 @@ async function listPullRequestFiles({ github, context, number }) {
 
 async function evaluateRequiredChecks({ github, context, branch, sha, core }) {
   const required = await getRequiredCheckSpecs({ github, context, branch, core });
+  const hasOwnedDecisionSpec = required.specs.some(
+    (spec) =>
+      spec.context === AUTO_GATE_DECISION_CHECK &&
+      spec.sourceAppId === GITHUB_ACTIONS_APP_ID,
+  );
+  const hasAmbiguousDecisionSpec = required.specs.some(
+    (spec) => spec.context === AUTO_GATE_DECISION_CHECK && !spec.sourceAppId,
+  );
   const specs = required.specs.filter(
     (spec) =>
       spec.context !== AUTO_GATE_DECISION_CHECK ||
-      spec.sourceAppId !== GITHUB_ACTIONS_APP_ID,
+      (spec.sourceAppId && spec.sourceAppId !== GITHUB_ACTIONS_APP_ID),
   );
   const notes = [];
   const reasons = [...required.errors];
 
-  if (specs.length !== required.specs.length) {
+  if (hasOwnedDecisionSpec) {
     notes.push("Auto Gate decision is enforced after this prerequisite evaluation");
+  }
+  if (hasAmbiguousDecisionSpec && !hasOwnedDecisionSpec) {
+    reasons.push(
+      `required check ${AUTO_GATE_DECISION_CHECK} without a source app is ambiguous; ` +
+        `it must be bound to GitHub Actions app ${GITHUB_ACTIONS_APP_ID}`,
+    );
   }
 
   if (specs.length === 0) {

--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -1,6 +1,10 @@
 const ALLOWED_AUTHORS = new Set(["sachiniyer", "app-detail-app", "app-detail-app[bot]"]);
 const TUI_PATH_PREFIXES = ["app/", "ui/", "session/tmux/"];
 const DOCS_DEPLOY_PATHS = ["docs/", "mkdocs.yml"];
+// GitHub check runs live on commits, but the gate evidence is PR-scoped. The
+// full (PR, head) pair is therefore part of every decision identifier. These
+// checks are observability records; a future required-check policy needs a
+// separate static aggregate because rulesets cannot require dynamic names.
 const AUTO_GATE_DECISION_CHECK = "Auto Gate decision";
 const GITHUB_ACTIONS_APP_ID = 15368;
 const CODEX_REVIEWER = "chatgpt-codex-connector[bot]";
@@ -35,10 +39,7 @@ async function evaluate({ github, context, core, prNumber, setOutputs = true }) 
 }
 
 async function evaluatePullRequest({ github, context, core, prNumber, setOutputs = true }) {
-  const pullAssociationCache = new Map();
-  const number =
-    prNumber ||
-    (await findPullRequestNumber({ github, context, core, pullAssociationCache }));
+  const number = prNumber || (await findPullRequestNumber({ github, context, core }));
 
   if (!number) {
     return finish(core, setOutputs, {
@@ -81,21 +82,6 @@ async function evaluatePullRequest({ github, context, core, prNumber, setOutputs
     reasons.push(`mergeability is blocked (${pr.mergeable}/${pr.mergeStateStatus})`);
   } else if (pr.mergeable !== "MERGEABLE") {
     reasons.push(`mergeability is still ${pr.mergeable}`);
-  }
-
-  const associatedPulls = await listOpenMasterPullRequestsForCommit({
-    github,
-    context,
-    sha: pr.headRefOid,
-    pullAssociationCache,
-  });
-  const otherPulls = associatedPulls.filter((pull) => pull.number !== pr.number);
-  if (otherPulls.length > 0) {
-    reasons.push(
-      `head commit ${pr.headRefOid} is shared with open master ` +
-        `PRs ${otherPulls.map((pull) => `#${pull.number}`).join(", ")}; ` +
-        "Auto Gate decisions are commit-scoped",
-    );
   }
 
   const files = await listPullRequestFiles({ github, context, number: pr.number });
@@ -170,6 +156,7 @@ async function reportDecision({ github, context, core, result, manual = false })
     return { state: "ineligible", priorDecision: false };
   }
 
+  const identity = decisionIdentity(result.prNumber, result.headSha);
   const { owner, repo } = context.repo;
   const checkRuns = await github.paginate(github.rest.checks.listForRef, {
     owner,
@@ -180,7 +167,9 @@ async function reportDecision({ github, context, core, result, manual = false })
   const priorDecision = checkRuns
     .filter(
       (run) =>
-        run.name === AUTO_GATE_DECISION_CHECK && run.app?.id === GITHUB_ACTIONS_APP_ID,
+        run.name === identity.checkName &&
+        run.external_id === identity.externalId &&
+        run.app?.id === GITHUB_ACTIONS_APP_ID,
     )
     .sort((left, right) => latestRunTime(right) - latestRunTime(left))[0];
   const state =
@@ -212,12 +201,29 @@ async function reportDecision({ github, context, core, result, manual = false })
       owner,
       repo,
       head_sha: result.headSha,
-      name: AUTO_GATE_DECISION_CHECK,
+      name: identity.checkName,
+      external_id: identity.externalId,
       ...decision,
     });
   }
   core.notice(`${title} for PR #${result.prNumber}.`);
   return { state, priorDecision: Boolean(priorDecision) };
+}
+
+function decisionIdentity(prNumber, headSha) {
+  const number = Number(prNumber);
+  const sha = String(headSha || "").toLowerCase();
+  if (!Number.isSafeInteger(number) || number <= 0) {
+    throw new Error(`Invalid PR number for Auto Gate decision: ${prNumber}`);
+  }
+  if (!/^[0-9a-f]{40}$/.test(sha)) {
+    throw new Error(`Invalid head SHA for Auto Gate decision: ${headSha}`);
+  }
+  return {
+    checkName: `${AUTO_GATE_DECISION_CHECK} / PR #${number} / ${sha}`,
+    externalId: `auto-gate:pr:${number}:head:${sha}`,
+    key: `pr-${number}-head-${sha}`,
+  };
 }
 
 async function merge({ github, context, core, prNumber, expectedHeadSha }) {
@@ -265,135 +271,69 @@ async function merge({ github, context, core, prNumber, expectedHeadSha }) {
 }
 
 async function resolveTargets({ github, context, core, prNumber }) {
-  const pullAssociationCache = new Map();
   const numbers = [];
+  const payload = context.payload;
 
   if (prNumber) {
     numbers.push(prNumber);
+  } else if (payload.pull_request?.number) {
+    numbers.push(payload.pull_request.number);
+  } else if (payload.issue?.pull_request && payload.issue.number) {
+    numbers.push(payload.issue.number);
   } else {
-    const synchronizedPullRequest =
-      context.eventName === "pull_request" &&
-      context.payload.action === "synchronize" &&
-      context.payload.before;
-    if (synchronizedPullRequest) {
-      if (context.payload.pull_request?.number) {
-        numbers.push(context.payload.pull_request.number);
-      }
-      const previousHeadPulls = await listOpenMasterPullRequestsForCommit({
-        github,
-        context,
-        sha: context.payload.before,
-        pullAssociationCache,
-      });
-      numbers.push(...previousHeadPulls.map((pull) => pull.number));
+    const sha = payload.check_suite?.head_sha || payload.sha;
+    if (sha) {
+      const { owner, repo } = context.repo;
+      const pulls = await github.paginate(
+        github.rest.repos.listPullRequestsAssociatedWithCommit,
+        {
+          owner,
+          repo,
+          commit_sha: sha,
+          per_page: 100,
+        },
+      );
+      numbers.push(
+        ...pulls
+          .filter(
+            (pull) =>
+              pull.state === "open" &&
+              pull.base?.ref === "master" &&
+              pull.head?.sha === sha,
+          )
+          .map((pull) => pull.number),
+      );
     } else {
-      const number = await findPullRequestNumber({
-        github,
-        context,
-        core,
-        pullAssociationCache,
-      });
-      if (number) {
-        numbers.push(number);
-      }
+      core.info(`Event ${context.eventName} did not identify a PR/head pair to evaluate.`);
     }
   }
 
+  const sourceSha = payload.check_suite?.head_sha || payload.sha;
   const targets = [];
-  for (const number of [...new Set(numbers)]) {
+  for (const number of [...new Set(numbers.filter(Boolean))]) {
     const pr = await getPullRequest({ github, context, number });
-    targets.push({ prNumber: String(pr.number), headSha: pr.headRefOid });
+    if (
+      sourceSha &&
+      (pr.state !== "OPEN" || pr.merged || pr.baseRefName !== "master" || pr.headRefOid !== sourceSha)
+    ) {
+      continue;
+    }
+    targets.push({
+      prNumber: String(pr.number),
+      headSha: pr.headRefOid,
+      decisionKey: decisionIdentity(pr.number, pr.headRefOid).key,
+    });
   }
   return targets;
 }
 
-async function findPullRequestNumber({ github, context, core, pullAssociationCache }) {
-  const payload = context.payload;
-  const closedPullRequest =
-    context.eventName === "pull_request" && payload.action === "closed";
-  const removedFromMaster =
-    context.eventName === "pull_request" &&
-    payload.action === "edited" &&
-    payload.changes?.base?.ref?.from === "master" &&
-    payload.pull_request?.base?.ref !== "master";
-  const synchronizedPullRequest =
-    context.eventName === "pull_request" &&
-    payload.action === "synchronize" &&
-    payload.before;
-
-  if (synchronizedPullRequest) {
-    const previousHeadPulls = await listOpenMasterPullRequestsForCommit({
-      github,
-      context,
-      sha: payload.before,
-      pullAssociationCache,
-    });
-    if (previousHeadPulls.length > 0) {
-      core.info(
-        `Head moved from ${payload.before}; reevaluating surviving PR #${previousHeadPulls[0].number}.`,
-      );
-      return previousHeadPulls[0].number;
-    }
-  }
-
-  if (payload.pull_request?.number && !closedPullRequest && !removedFromMaster) {
-    return payload.pull_request.number;
-  }
-
-  if (payload.issue?.pull_request && payload.issue.number) {
-    return payload.issue.number;
-  }
-
-  const checkSuitePrs = payload.check_suite?.pull_requests || [];
-  const checkSuitePr = checkSuitePrs.find((pr) => pr.base?.ref === "master") || checkSuitePrs[0];
-  if (checkSuitePr?.number) {
-    return checkSuitePr.number;
-  }
-
-  const sha = payload.check_suite?.head_sha || payload.pull_request?.head?.sha || payload.sha;
-  if (!sha) {
-    core.info(`Event ${context.eventName} did not include a PR or SHA to evaluate.`);
-    return null;
-  }
-
-  const openMasterPulls = await listOpenMasterPullRequestsForCommit({
+async function findPullRequestNumber({ github, context, core }) {
+  const targets = await resolveTargets({
     github,
     context,
-    sha,
-    pullAssociationCache,
+    core,
   });
-  if (openMasterPulls.length > 1) {
-    core.warning(`Found multiple open master PRs for ${sha}; evaluating PR #${openMasterPulls[0].number}.`);
-  }
-
-  return openMasterPulls[0]?.number || null;
-}
-
-async function listOpenMasterPullRequestsForCommit({
-  github,
-  context,
-  sha,
-  pullAssociationCache,
-}) {
-  if (pullAssociationCache?.has(sha)) {
-    return pullAssociationCache.get(sha);
-  }
-
-  const { owner, repo } = context.repo;
-  const pulls = await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {
-    owner,
-    repo,
-    commit_sha: sha,
-    per_page: 100,
-  });
-  const openMasterPulls = pulls.filter(
-    (pull) =>
-      pull.state === "open" &&
-      pull.base?.ref === "master" &&
-      pull.head?.sha === sha,
-  );
-  pullAssociationCache?.set(sha, openMasterPulls);
-  return openMasterPulls;
+  return targets[0]?.prNumber || null;
 }
 
 async function getPullRequest({ github, context, number }) {
@@ -469,30 +409,21 @@ async function listPullRequestFiles({ github, context, number }) {
 
 async function evaluateRequiredChecks({ github, context, branch, sha, core }) {
   const required = await getRequiredCheckSpecs({ github, context, branch, core });
-  const hasOwnedDecisionSpec = required.specs.some(
+  const syntheticDecisionSpecs = required.specs.filter(
     (spec) =>
-      spec.context === AUTO_GATE_DECISION_CHECK &&
-      spec.sourceAppId === GITHUB_ACTIONS_APP_ID,
-  );
-  const hasAmbiguousDecisionSpec = required.specs.some(
-    (spec) => spec.context === AUTO_GATE_DECISION_CHECK && !spec.sourceAppId,
+      isSyntheticDecisionContext(spec.context) &&
+      (!spec.sourceAppId || spec.sourceAppId === GITHUB_ACTIONS_APP_ID),
   );
   const specs = required.specs.filter(
     (spec) =>
-      spec.context !== AUTO_GATE_DECISION_CHECK ||
+      !isSyntheticDecisionContext(spec.context) ||
       (spec.sourceAppId && spec.sourceAppId !== GITHUB_ACTIONS_APP_ID),
   );
   const notes = [];
   const reasons = [...required.errors];
 
-  if (hasOwnedDecisionSpec) {
-    notes.push("Auto Gate decision is enforced after this prerequisite evaluation");
-  }
-  if (hasAmbiguousDecisionSpec && !hasOwnedDecisionSpec) {
-    reasons.push(
-      `required check ${AUTO_GATE_DECISION_CHECK} without a source app is ambiguous; ` +
-        `it must be bound to GitHub Actions app ${GITHUB_ACTIONS_APP_ID}`,
-    );
+  if (syntheticDecisionSpecs.length > 0) {
+    notes.push("Synthetic Auto Gate decisions are excluded from their own prerequisites");
   }
 
   if (specs.length === 0) {
@@ -530,6 +461,13 @@ async function evaluateRequiredChecks({ github, context, branch, sha, core }) {
   }
 
   return { ok: reasons.length === 0, reasons, notes };
+}
+
+function isSyntheticDecisionContext(contextName) {
+  return (
+    contextName === AUTO_GATE_DECISION_CHECK ||
+    /^Auto Gate decision \/ PR #\d+ \/ [0-9a-f]{40}$/.test(contextName)
+  );
 }
 
 async function getRequiredCheckSpecs({ github, context, branch, core }) {

--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -145,6 +145,7 @@ async function evaluatePullRequest({ github, context, core, prNumber, setOutputs
     prNumber: String(pr.number),
     shouldMerge: reasons.length === 0,
     isOpen: pr.state === "OPEN" && !pr.merged,
+    baseRefName: pr.baseRefName,
     headSha: pr.headRefOid,
     docsChanged,
     reasons,
@@ -160,6 +161,13 @@ async function reportDecision({ github, context, core, result, manual = false })
   if (result.isOpen === false) {
     core.notice(`Leaving the existing Auto Gate decision unchanged for closed PR #${result.prNumber}.`);
     return { state: "closed", priorDecision: false };
+  }
+  if (result.baseRefName && result.baseRefName !== "master") {
+    core.notice(
+      `Auto Gate decision was not reported for PR #${result.prNumber} because its base is ` +
+        `${result.baseRefName}, not master.`,
+    );
+    return { state: "ineligible", priorDecision: false };
   }
 
   const { owner, repo } = context.repo;
@@ -212,7 +220,7 @@ async function reportDecision({ github, context, core, result, manual = false })
   return { state, priorDecision: Boolean(priorDecision) };
 }
 
-async function merge({ github, context, core, prNumber }) {
+async function merge({ github, context, core, prNumber, expectedHeadSha }) {
   if (!Number.isInteger(prNumber) || prNumber <= 0) {
     throw new Error(`Invalid PR number for merge: ${prNumber}`);
   }
@@ -223,6 +231,12 @@ async function merge({ github, context, core, prNumber }) {
   }
   if (!gate.headSha) {
     throw new Error(`Refusing to merge PR #${prNumber}; evaluated head SHA is missing`);
+  }
+  if (expectedHeadSha && gate.headSha !== expectedHeadSha) {
+    throw new Error(
+      `Refusing to merge PR #${prNumber}; serialized head ${expectedHeadSha} ` +
+        `does not match evaluated head ${gate.headSha}`,
+    );
   }
 
   const { owner, repo } = context.repo;
@@ -248,6 +262,49 @@ async function merge({ github, context, core, prNumber }) {
     });
     core.notice(`Dispatched Docs workflow for PR #${prNumber} docs-path merge.`);
   }
+}
+
+async function resolveTargets({ github, context, core, prNumber }) {
+  const pullAssociationCache = new Map();
+  const numbers = [];
+
+  if (prNumber) {
+    numbers.push(prNumber);
+  } else {
+    const synchronizedPullRequest =
+      context.eventName === "pull_request" &&
+      context.payload.action === "synchronize" &&
+      context.payload.before;
+    if (synchronizedPullRequest) {
+      if (context.payload.pull_request?.number) {
+        numbers.push(context.payload.pull_request.number);
+      }
+      const previousHeadPulls = await listOpenMasterPullRequestsForCommit({
+        github,
+        context,
+        sha: context.payload.before,
+        pullAssociationCache,
+      });
+      numbers.push(...previousHeadPulls.map((pull) => pull.number));
+    } else {
+      const number = await findPullRequestNumber({
+        github,
+        context,
+        core,
+        pullAssociationCache,
+      });
+      if (number) {
+        numbers.push(number);
+      }
+    }
+  }
+
+  const targets = [];
+  for (const number of [...new Set(numbers)]) {
+    const pr = await getPullRequest({ github, context, number });
+    targets.push({ prNumber: String(pr.number), headSha: pr.headRefOid });
+  }
+  return targets;
 }
 
 async function findPullRequestNumber({ github, context, core, pullAssociationCache }) {
@@ -805,6 +862,7 @@ module.exports = {
   evaluate,
   merge,
   reportDecision,
+  resolveTargets,
   __test: {
     evaluateCodex,
     evaluateRequiredChecks,

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -14,6 +14,7 @@ test("Auto Gate can be recovered manually by PR number", () => {
   const workflow = fs.readFileSync(AUTO_GATE_WORKFLOW, "utf8");
 
   assert.match(workflow, /workflow_dispatch:\s+inputs:\s+pr_number:/);
+  assert.match(workflow, /pull_request:\s+types: \[labeled, unlabeled\]/);
   assert.match(workflow, /pr_number:\s+[\s\S]*?required: true[\s\S]*?type: number/);
   assert.match(
     workflow,
@@ -34,9 +35,11 @@ test("Auto Gate can be recovered manually by PR number", () => {
     workflow,
     /context\.eventName === "workflow_dispatch" && !result\.headSha/,
   );
+  assert.match(workflow, /evaluationFailed = result\.reasons\.some/);
+  assert.match(workflow, /evaluationFailed \|\|/);
   assert.match(
     workflow,
-    /if \(context\.eventName === "workflow_dispatch"\) \{\s+throw error;/,
+    /if \(error\.failWorkflow \|\| context\.eventName === "workflow_dispatch"\) \{\s+throw error;/,
   );
 });
 
@@ -90,6 +93,32 @@ test("an evaluated but blocked gate reports WAITING rather than NEVER_RAN", asyn
   assert.match(github.updatedChecks[0].output.title, /^WAITING:/);
 });
 
+test("a queued evaluation cannot overwrite PASS after the PR merges", async () => {
+  const github = fakeGateGithub({
+    checkRuns: [
+      ...happyCheckRuns(),
+      checkRun({ id: 321, name: "Auto Gate decision", conclusion: "success" }),
+    ],
+  });
+
+  const report = await autoGate.reportDecision({
+    github,
+    context: fakeContext(),
+    core: fakeCore(),
+    result: {
+      prNumber: "1465",
+      headSha: HEAD_SHA,
+      isOpen: false,
+      shouldMerge: false,
+      summary: "BLOCKED: PR is already merged, not open",
+    },
+  });
+
+  assert.equal(report.state, "closed");
+  assert.equal(github.createdChecks.length, 0);
+  assert.equal(github.updatedChecks.length, 0);
+});
+
 test("required check matching respects the required source app", () => {
   const spec = { context: "Build", sourceAppId: ACTIONS_APP_ID };
   const checkRuns = [
@@ -123,6 +152,22 @@ test("an absent required check blocks the gate", async () => {
 
   assert.equal(result.shouldMerge, false);
   assert.match(result.reasons.join("\n"), /required check Lint.*missing/);
+});
+
+test("the synthetic decision check is not its own prerequisite", async () => {
+  const result = await evaluateGate({
+    checkRuns: [
+      ...happyCheckRuns(),
+      checkRun({ name: "Auto Gate decision", conclusion: "failure" }),
+    ],
+    requiredChecks: [
+      { context: "Lint", integration_id: ACTIONS_APP_ID },
+      { context: "Build", integration_id: ACTIONS_APP_ID },
+      { context: "Auto Gate decision", integration_id: ACTIONS_APP_ID },
+    ],
+  });
+
+  assert.equal(result.shouldMerge, true, result.reasons.join("\n"));
 });
 
 test("terminal non-success conclusions never verify a required check", () => {

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -523,6 +523,33 @@ test("the happy path squash-merges the exact evaluated head", async () => {
   assert.equal(github.mergedWith.merge_method, "squash");
 });
 
+test("merge reevaluates fresh instead of trusting a stale PASS decision", async () => {
+  const github = fakeGateGithub({
+    checkRuns: [
+      ...happyCheckRuns(),
+      checkRun({
+        name: decisionName(1465, HEAD_SHA),
+        externalId: decisionExternalId(1465, HEAD_SHA),
+        conclusion: "success",
+      }),
+    ],
+    reviewComments: [codexFinding({ id: 10, line: 32 })],
+  });
+
+  await assert.rejects(
+    autoGate.merge({
+      github,
+      context: fakeContext(),
+      core: fakeCore(),
+      prNumber: 1465,
+    }),
+    /gate no longer passes.*unresolved live Codex inline finding/,
+  );
+
+  assert.equal(github.reviewCommentReads, 1, "merge must read current finding state");
+  assert.equal(github.mergedWith, null);
+});
+
 test("merge refuses a head that escaped its serialized decision lane", async () => {
   const github = fakeGateGithub();
 
@@ -696,6 +723,7 @@ function fakeGateGithub({
 
   const github = {
     mergedWith: null,
+    reviewCommentReads: 0,
     createdChecks: [],
     updatedChecks: [],
     rest: {
@@ -729,7 +757,12 @@ function fakeGateGithub({
         },
       };
     },
-    paginate: async (fn) => responses.get(fn) || [],
+    paginate: async (fn) => {
+      if (fn === listReviewComments) {
+        github.reviewCommentReads += 1;
+      }
+      return responses.get(fn) || [];
+    },
     request: async (route) => {
       if (route.includes("/rules/branches/")) {
         return {

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -22,12 +22,14 @@ test("Auto Gate can be recovered manually by PR number", () => {
   assert.match(workflow, /pr_number:\s+[\s\S]*?required: true[\s\S]*?type: number/);
   assert.match(
     workflow,
-    /head_sha: \$\{\{ steps\.evaluate\.outputs\.head_sha \}\}/,
+    /targets: \$\{\{ steps\.evaluate\.outputs\.targets \}\}/,
   );
   assert.match(
     workflow,
-    /concurrency:\s+group: auto-gate-\$\{\{ needs\.auto-gate\.outputs\.head_sha \}\}\s+cancel-in-progress: false/,
+    /concurrency:\s+group: auto-gate-\$\{\{ matrix\.target\.head_sha \}\}\s+cancel-in-progress: false/,
   );
+  assert.match(workflow, /strategy:\s+fail-fast: false\s+matrix:\s+target:/);
+  assert.match(workflow, /EXPECTED_HEAD_SHA: \$\{\{ matrix\.target\.head_sha \}\}/);
   assert.match(workflow, /PR_NUMBER: \$\{\{ inputs\.pr_number \|\| '' \}\}/);
   assert.match(workflow, /prNumber: explicitPrNumber/);
   assert.match(
@@ -39,16 +41,11 @@ test("Auto Gate can be recovered manually by PR number", () => {
     workflow,
     /if \(typeof autoGate\.reportDecision === "function"\)/,
   );
-  assert.match(
-    workflow,
-    /context\.eventName === "workflow_dispatch" && !result\.headSha/,
-  );
+  assert.match(workflow, /typeof autoGate\.resolveTargets === "function"/);
+  assert.match(workflow, /context\.eventName === "workflow_dispatch" && targets\.length === 0/);
   assert.match(workflow, /evaluationFailed = result\.reasons\.some/);
-  assert.match(workflow, /evaluationFailed \|\|/);
-  assert.match(
-    workflow,
-    /if \(error\.failWorkflow \|\| context\.eventName === "workflow_dispatch"\) \{\s+throw error;/,
-  );
+  assert.match(workflow, /core\.setOutput\("targets", "\[\]"\)/);
+  assert.match(workflow, /core\.setOutput\("targets", "\[\]"\);\s+throw error;/);
 });
 
 test("manual recovery reports a previously absent gate distinctly", async () => {
@@ -123,6 +120,28 @@ test("a queued evaluation cannot overwrite PASS after the PR merges", async () =
   });
 
   assert.equal(report.state, "closed");
+  assert.equal(github.createdChecks.length, 0);
+  assert.equal(github.updatedChecks.length, 0);
+});
+
+test("a non-master PR event cannot overwrite a master decision on the same commit", async () => {
+  const github = fakeGateGithub({ checkRuns: happyCheckRuns() });
+
+  const report = await autoGate.reportDecision({
+    github,
+    context: fakeContext(),
+    core: fakeCore(),
+    result: {
+      prNumber: "1465",
+      headSha: HEAD_SHA,
+      baseRefName: "release",
+      isOpen: true,
+      shouldMerge: false,
+      summary: "BLOCKED: base branch is release, not master",
+    },
+  });
+
+  assert.equal(report.state, "ineligible");
   assert.equal(github.createdChecks.length, 0);
   assert.equal(github.updatedChecks.length, 0);
 });
@@ -528,6 +547,37 @@ test("synchronizing away from a shared head reevaluates the previous-head surviv
   assert.equal(result.shouldMerge, true, result.reasons.join("\n"));
 });
 
+test("synchronizing away from a shared head targets both affected decisions", async () => {
+  const targets = await autoGate.resolveTargets({
+    github: fakeGateGithub({
+      associatedPullRequests: [
+        { number: 2048, state: "open", base: { ref: "master" }, head: { sha: HEAD_SHA } },
+      ],
+      pullRequestsByNumber: {
+        1465: { headRefOid: OTHER_SHA },
+        2048: { headRefOid: HEAD_SHA },
+      },
+    }),
+    context: fakeContext({
+      action: "synchronize",
+      before: HEAD_SHA,
+      after: OTHER_SHA,
+      pull_request: {
+        number: 1465,
+        state: "open",
+        base: { ref: "master" },
+        head: { sha: OTHER_SHA },
+      },
+    }),
+    core: fakeCore(),
+  });
+
+  assert.deepEqual(targets, [
+    { prNumber: "1465", headSha: OTHER_SHA },
+    { prNumber: "2048", headSha: HEAD_SHA },
+  ]);
+});
+
 test("the happy path squash-merges the exact evaluated head", async () => {
   const github = fakeGateGithub();
 
@@ -540,6 +590,22 @@ test("the happy path squash-merges the exact evaluated head", async () => {
 
   assert.equal(github.mergedWith.sha, HEAD_SHA);
   assert.equal(github.mergedWith.merge_method, "squash");
+});
+
+test("merge refuses a head that escaped its serialized decision lane", async () => {
+  const github = fakeGateGithub();
+
+  await assert.rejects(
+    autoGate.merge({
+      github,
+      context: fakeContext(),
+      core: fakeCore(),
+      prNumber: 1465,
+      expectedHeadSha: OTHER_SHA,
+    }),
+    /serialized head.*does not match evaluated head/,
+  );
+  assert.equal(github.mergedWith, null);
 });
 
 test("draft and closed pull requests cannot merge", async () => {
@@ -666,6 +732,7 @@ function fakeGateGithub({
     { context: "Lint", integration_id: ACTIONS_APP_ID },
     { context: "Build", integration_id: ACTIONS_APP_ID },
   ],
+  pullRequestsByNumber = {},
 } = {}) {
   const listFiles = function listFiles() {};
   const listForRef = function listForRef() {};
@@ -707,27 +774,30 @@ function fakeGateGithub({
       repos: { listCommitStatusesForRef, listPullRequestsAssociatedWithCommit },
       pulls: { listFiles, listReviews, listReviewComments, merge },
     },
-    graphql: async (_query, variables) => ({
-      repository: {
-        pullRequest: {
-          number: variables.number,
-          title: "Gate test",
-          url: "https://example.invalid/pr/1465",
-          baseRefName: "master",
-          headRefOid: headSha,
-          isDraft,
-          state,
-          merged,
-          mergeable,
-          mergeStateStatus,
-          author: { login: "sachiniyer" },
-          labels: { nodes: [] },
-          commits: {
-            nodes: [{ commit: { committedDate: headCommittedDate } }],
+    graphql: async (_query, variables) => {
+      const pullRequestOverride = pullRequestsByNumber[variables.number] || {};
+      return {
+        repository: {
+          pullRequest: {
+            number: variables.number,
+            title: "Gate test",
+            url: "https://example.invalid/pr/1465",
+            baseRefName: "master",
+            headRefOid: pullRequestOverride.headRefOid || headSha,
+            isDraft,
+            state,
+            merged,
+            mergeable,
+            mergeStateStatus,
+            author: { login: "sachiniyer" },
+            labels: { nodes: [] },
+            commits: {
+              nodes: [{ commit: { committedDate: headCommittedDate } }],
+            },
           },
         },
-      },
-    }),
+      };
+    },
     paginate: async (fn) => responses.get(fn) || [],
     request: async (route) => {
       if (route.includes("/rules/branches/")) {

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -157,13 +157,24 @@ test("an absent required check blocks the gate", async () => {
 test("a head shared by multiple open master PRs blocks the commit-scoped decision", async () => {
   const result = await evaluateGate({
     associatedPullRequests: [
-      { number: 1465, state: "open", base: { ref: "master" } },
-      { number: 2048, state: "open", base: { ref: "master" } },
+      { number: 1465, state: "open", base: { ref: "master" }, head: { sha: HEAD_SHA } },
+      { number: 2048, state: "open", base: { ref: "master" }, head: { sha: HEAD_SHA } },
     ],
   });
 
   assert.equal(result.shouldMerge, false);
   assert.match(result.reasons.join("\n"), /head commit.*shared.*#2048.*commit-scoped/);
+});
+
+test("an associated PR with a newer head does not trigger the shared-head guard", async () => {
+  const result = await evaluateGate({
+    associatedPullRequests: [
+      { number: 1465, state: "open", base: { ref: "master" }, head: { sha: HEAD_SHA } },
+      { number: 2048, state: "open", base: { ref: "master" }, head: { sha: OTHER_SHA } },
+    ],
+  });
+
+  assert.equal(result.shouldMerge, true, result.reasons.join("\n"));
 });
 
 test("the synthetic decision check is not its own prerequisite", async () => {
@@ -566,7 +577,7 @@ function fakeGateGithub({
   reviewComments = [],
   files = [],
   associatedPullRequests = [
-    { number: 1465, state: "open", base: { ref: "master" } },
+    { number: 1465, state: "open", base: { ref: "master" }, head: { sha: headSha } },
   ],
   requiredChecks = [
     { context: "Lint", integration_id: ACTIONS_APP_ID },

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -190,6 +190,39 @@ test("a same-named decision check from another app remains required", async () =
   );
 });
 
+test("a source-less decision requirement fails with an actionable configuration error", async () => {
+  const result = await evaluateGate({
+    requiredChecks: [
+      { context: "Lint", integration_id: ACTIONS_APP_ID },
+      { context: "Build", integration_id: ACTIONS_APP_ID },
+      { context: "Auto Gate decision" },
+    ],
+  });
+
+  assert.equal(result.shouldMerge, false);
+  assert.match(
+    result.reasons.join("\n"),
+    /Auto Gate decision.*must be bound to GitHub Actions app 15368/,
+  );
+});
+
+test("a source-less legacy duplicate does not deadlock an app-bound decision requirement", async () => {
+  const result = await evaluateGate({
+    checkRuns: [
+      ...happyCheckRuns(),
+      checkRun({ name: "Auto Gate decision", conclusion: "failure" }),
+    ],
+    requiredChecks: [
+      { context: "Lint", integration_id: ACTIONS_APP_ID },
+      { context: "Build", integration_id: ACTIONS_APP_ID },
+      { context: "Auto Gate decision" },
+      { context: "Auto Gate decision", integration_id: ACTIONS_APP_ID },
+    ],
+  });
+
+  assert.equal(result.shouldMerge, true, result.reasons.join("\n"));
+});
+
 test("terminal non-success conclusions never verify a required check", () => {
   const spec = { context: "Lint", sourceAppId: ACTIONS_APP_ID };
 

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -18,8 +18,7 @@ test("Auto Gate can be recovered manually by PR number", () => {
     workflow,
     /pull_request:\s+types: \[opened, reopened, closed, synchronize, edited, converted_to_draft, ready_for_review, labeled, unlabeled\]/,
   );
-  assert.match(workflow, /github\.event\.action == 'closed'/);
-  assert.match(workflow, /github\.event\.action == 'converted_to_draft'/);
+  assert.match(workflow, /github\.event_name == 'pull_request'/);
   assert.match(workflow, /pr_number:\s+[\s\S]*?required: true[\s\S]*?type: number/);
   assert.match(
     workflow,
@@ -463,6 +462,31 @@ test("closing a shared-head PR reevaluates the surviving open PR", async () => {
         number: 1465,
         state: "closed",
         base: { ref: "master" },
+        head: { sha: HEAD_SHA },
+      },
+    }),
+    core: fakeCore(),
+    setOutputs: false,
+  });
+
+  assert.equal(result.prNumber, "2048");
+  assert.equal(result.shouldMerge, true, result.reasons.join("\n"));
+});
+
+test("moving a shared-head PR off master reevaluates the surviving master PR", async () => {
+  const result = await autoGate.evaluate({
+    github: fakeGateGithub({
+      associatedPullRequests: [
+        { number: 2048, state: "open", base: { ref: "master" }, head: { sha: HEAD_SHA } },
+      ],
+    }),
+    context: fakeContext({
+      action: "edited",
+      changes: { base: { ref: { from: "master" } } },
+      pull_request: {
+        number: 1465,
+        state: "open",
+        base: { ref: "release" },
         head: { sha: HEAD_SHA },
       },
     }),

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -22,7 +22,11 @@ test("Auto Gate can be recovered manually by PR number", () => {
   assert.match(workflow, /pr_number:\s+[\s\S]*?required: true[\s\S]*?type: number/);
   assert.match(
     workflow,
-    /concurrency:\s+group: auto-gate-\$\{\{ needs\.auto-gate\.outputs\.pr_number \}\}\s+cancel-in-progress: false/,
+    /head_sha: \$\{\{ steps\.evaluate\.outputs\.head_sha \}\}/,
+  );
+  assert.match(
+    workflow,
+    /concurrency:\s+group: auto-gate-\$\{\{ needs\.auto-gate\.outputs\.head_sha \}\}\s+cancel-in-progress: false/,
   );
   assert.match(workflow, /PR_NUMBER: \$\{\{ inputs\.pr_number \|\| '' \}\}/);
   assert.match(workflow, /prNumber: explicitPrNumber/);
@@ -488,6 +492,32 @@ test("moving a shared-head PR off master reevaluates the surviving master PR", a
         state: "open",
         base: { ref: "release" },
         head: { sha: HEAD_SHA },
+      },
+    }),
+    core: fakeCore(),
+    setOutputs: false,
+  });
+
+  assert.equal(result.prNumber, "2048");
+  assert.equal(result.shouldMerge, true, result.reasons.join("\n"));
+});
+
+test("synchronizing away from a shared head reevaluates the previous-head survivor", async () => {
+  const result = await autoGate.evaluate({
+    github: fakeGateGithub({
+      associatedPullRequests: [
+        { number: 2048, state: "open", base: { ref: "master" }, head: { sha: HEAD_SHA } },
+      ],
+    }),
+    context: fakeContext({
+      action: "synchronize",
+      before: HEAD_SHA,
+      after: OTHER_SHA,
+      pull_request: {
+        number: 1465,
+        state: "open",
+        base: { ref: "master" },
+        head: { sha: OTHER_SHA },
       },
     }),
     core: fakeCore(),

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -154,6 +154,18 @@ test("an absent required check blocks the gate", async () => {
   assert.match(result.reasons.join("\n"), /required check Lint.*missing/);
 });
 
+test("a head shared by multiple open master PRs blocks the commit-scoped decision", async () => {
+  const result = await evaluateGate({
+    associatedPullRequests: [
+      { number: 1465, state: "open", base: { ref: "master" } },
+      { number: 2048, state: "open", base: { ref: "master" } },
+    ],
+  });
+
+  assert.equal(result.shouldMerge, false);
+  assert.match(result.reasons.join("\n"), /head commit.*shared.*#2048.*commit-scoped/);
+});
+
 test("the synthetic decision check is not its own prerequisite", async () => {
   const result = await evaluateGate({
     checkRuns: [
@@ -553,6 +565,9 @@ function fakeGateGithub({
   reviews = [],
   reviewComments = [],
   files = [],
+  associatedPullRequests = [
+    { number: 1465, state: "open", base: { ref: "master" } },
+  ],
   requiredChecks = [
     { context: "Lint", integration_id: ACTIONS_APP_ID },
     { context: "Build", integration_id: ACTIONS_APP_ID },
@@ -564,6 +579,7 @@ function fakeGateGithub({
   const listComments = function listComments() {};
   const listReviews = function listReviews() {};
   const listReviewComments = function listReviewComments() {};
+  const listPullRequestsAssociatedWithCommit = function listPullRequestsAssociatedWithCommit() {};
   const merge = async function merge(options) {
     github.mergedWith = options;
     return { data: { sha: "merge-sha" } };
@@ -583,6 +599,7 @@ function fakeGateGithub({
     [listComments, issueComments],
     [listReviews, reviews],
     [listReviewComments, reviewComments],
+    [listPullRequestsAssociatedWithCommit, associatedPullRequests],
   ]);
 
   const github = {
@@ -593,7 +610,7 @@ function fakeGateGithub({
       actions: { createWorkflowDispatch: async () => {} },
       checks: { create: createCheck, listForRef, update: updateCheck },
       issues: { listComments },
-      repos: { listCommitStatusesForRef },
+      repos: { listCommitStatusesForRef, listPullRequestsAssociatedWithCommit },
       pulls: { listFiles, listReviews, listReviewComments, merge },
     },
     graphql: async () => ({

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -12,13 +12,13 @@ const AUTO_GATE_WORKFLOW = path.join(__dirname, "..", "workflows", "auto-gate.ym
 
 test("Auto Gate can be recovered manually by PR number", () => {
   const workflow = fs.readFileSync(AUTO_GATE_WORKFLOW, "utf8");
+  const helper = fs.readFileSync(path.join(__dirname, "auto-gate.js"), "utf8");
 
   assert.match(workflow, /workflow_dispatch:\s+inputs:\s+pr_number:/);
   assert.match(
     workflow,
     /pull_request:\s+types: \[opened, reopened, closed, synchronize, edited, converted_to_draft, ready_for_review, labeled, unlabeled\]/,
   );
-  assert.match(workflow, /github\.event_name == 'pull_request'/);
   assert.match(workflow, /pr_number:\s+[\s\S]*?required: true[\s\S]*?type: number/);
   assert.match(
     workflow,
@@ -26,8 +26,9 @@ test("Auto Gate can be recovered manually by PR number", () => {
   );
   assert.match(
     workflow,
-    /concurrency:\s+group: auto-gate-\$\{\{ matrix\.target\.head_sha \}\}\s+cancel-in-progress: false/,
+    /concurrency:\s+group: auto-gate-\$\{\{ matrix\.target\.decision_key \}\}\s+cancel-in-progress: false/,
   );
+  assert.match(workflow, /decision_key: target\.decisionKey/);
   assert.match(workflow, /strategy:\s+fail-fast: false\s+matrix:\s+target:/);
   assert.match(workflow, /EXPECTED_HEAD_SHA: \$\{\{ matrix\.target\.head_sha \}\}/);
   assert.match(workflow, /PR_NUMBER: \$\{\{ inputs\.pr_number \|\| '' \}\}/);
@@ -46,6 +47,7 @@ test("Auto Gate can be recovered manually by PR number", () => {
   assert.match(workflow, /evaluationFailed = result\.reasons\.some/);
   assert.match(workflow, /core\.setOutput\("targets", "\[\]"\)/);
   assert.match(workflow, /core\.setOutput\("targets", "\[\]"\);\s+throw error;/);
+  assert.doesNotMatch(helper, /payload\.action|context\.payload\.action/);
 });
 
 test("manual recovery reports a previously absent gate distinctly", async () => {
@@ -74,7 +76,12 @@ test("an evaluated but blocked gate reports WAITING rather than NEVER_RAN", asyn
   const github = fakeGateGithub({
     checkRuns: [
       ...happyCheckRuns(),
-      checkRun({ id: 321, name: "Auto Gate decision", conclusion: "failure" }),
+      checkRun({
+        id: 321,
+        name: decisionName(1465, HEAD_SHA),
+        externalId: decisionExternalId(1465, HEAD_SHA),
+        conclusion: "failure",
+      }),
     ],
   });
   const result = {
@@ -96,6 +103,63 @@ test("an evaluated but blocked gate reports WAITING rather than NEVER_RAN", asyn
   assert.equal(github.createdChecks.length, 0);
   assert.equal(github.updatedChecks[0].check_run_id, 321);
   assert.match(github.updatedChecks[0].output.title, /^WAITING:/);
+});
+
+test("a PR cannot read another PR's decision when both share one head", async () => {
+  const github = fakeGateGithub({
+    associatedPullRequests: [
+      { number: 1465, state: "open", base: { ref: "master" }, head: { sha: HEAD_SHA } },
+      { number: 2048, state: "open", base: { ref: "master" }, head: { sha: HEAD_SHA } },
+    ],
+    pullRequestsByNumber: {
+      1465: { headRefOid: HEAD_SHA },
+      2048: { headRefOid: HEAD_SHA },
+    },
+    checkRuns: [
+      ...happyCheckRuns(),
+      {
+        ...checkRun({
+          id: 321,
+          name: decisionName(1465, HEAD_SHA),
+          externalId: decisionExternalId(1465, HEAD_SHA),
+          conclusion: "success",
+        }),
+        output: { title: "PASS: PR #1465 requirements are satisfied" },
+      },
+    ],
+  });
+
+  const targets = await autoGate.resolveTargets({
+    github,
+    context: fakeContext({ sha: HEAD_SHA }),
+    core: fakeCore(),
+  });
+  assert.deepEqual(targets, [
+    { prNumber: "1465", headSha: HEAD_SHA, decisionKey: decisionKey(1465, HEAD_SHA) },
+    { prNumber: "2048", headSha: HEAD_SHA, decisionKey: decisionKey(2048, HEAD_SHA) },
+  ]);
+
+  await autoGate.reportDecision({
+    github,
+    context: fakeContext(),
+    core: fakeCore(),
+    result: {
+      prNumber: "2048",
+      headSha: HEAD_SHA,
+      baseRefName: "master",
+      isOpen: true,
+      shouldMerge: false,
+      summary: "BLOCKED: 1 unresolved live Codex inline finding",
+    },
+  });
+
+  assert.equal(github.updatedChecks.length, 0);
+  assert.equal(github.createdChecks.length, 1);
+  assert.equal(
+    github.createdChecks[0].name,
+    decisionName(2048, HEAD_SHA),
+  );
+  assert.equal(github.createdChecks[0].external_id, decisionExternalId(2048, HEAD_SHA));
 });
 
 test("a queued evaluation cannot overwrite PASS after the PR merges", async () => {
@@ -181,39 +245,16 @@ test("an absent required check blocks the gate", async () => {
   assert.match(result.reasons.join("\n"), /required check Lint.*missing/);
 });
 
-test("a head shared by multiple open master PRs blocks the commit-scoped decision", async () => {
-  const result = await evaluateGate({
-    associatedPullRequests: [
-      { number: 1465, state: "open", base: { ref: "master" }, head: { sha: HEAD_SHA } },
-      { number: 2048, state: "open", base: { ref: "master" }, head: { sha: HEAD_SHA } },
-    ],
-  });
-
-  assert.equal(result.shouldMerge, false);
-  assert.match(result.reasons.join("\n"), /head commit.*shared.*#2048.*commit-scoped/);
-});
-
-test("an associated PR with a newer head does not trigger the shared-head guard", async () => {
-  const result = await evaluateGate({
-    associatedPullRequests: [
-      { number: 1465, state: "open", base: { ref: "master" }, head: { sha: HEAD_SHA } },
-      { number: 2048, state: "open", base: { ref: "master" }, head: { sha: OTHER_SHA } },
-    ],
-  });
-
-  assert.equal(result.shouldMerge, true, result.reasons.join("\n"));
-});
-
 test("the synthetic decision check is not its own prerequisite", async () => {
   const result = await evaluateGate({
     checkRuns: [
       ...happyCheckRuns(),
-      checkRun({ name: "Auto Gate decision", conclusion: "failure" }),
+      checkRun({ name: decisionName(1465, HEAD_SHA), conclusion: "failure" }),
     ],
     requiredChecks: [
       { context: "Lint", integration_id: ACTIONS_APP_ID },
       { context: "Build", integration_id: ACTIONS_APP_ID },
-      { context: "Auto Gate decision", integration_id: ACTIONS_APP_ID },
+      { context: decisionName(1465, HEAD_SHA), integration_id: ACTIONS_APP_ID },
     ],
   });
 
@@ -240,7 +281,7 @@ test("a same-named decision check from another app remains required", async () =
   );
 });
 
-test("a source-less decision requirement fails with an actionable configuration error", async () => {
+test("a source-less synthetic decision is not its own prerequisite", async () => {
   const result = await evaluateGate({
     requiredChecks: [
       { context: "Lint", integration_id: ACTIONS_APP_ID },
@@ -249,11 +290,7 @@ test("a source-less decision requirement fails with an actionable configuration 
     ],
   });
 
-  assert.equal(result.shouldMerge, false);
-  assert.match(
-    result.reasons.join("\n"),
-    /Auto Gate decision.*must be bound to GitHub Actions app 15368/,
-  );
+  assert.equal(result.shouldMerge, true, result.reasons.join("\n"));
 });
 
 test("a source-less legacy duplicate does not deadlock an app-bound decision requirement", async () => {
@@ -470,112 +507,6 @@ test("issue-comment events resolve their pull request number", async () => {
 
   assert.equal(result.prNumber, "1465");
   assert.equal(result.shouldMerge, true);
-});
-
-test("closing a shared-head PR reevaluates the surviving open PR", async () => {
-  const result = await autoGate.evaluate({
-    github: fakeGateGithub({
-      associatedPullRequests: [
-        { number: 2048, state: "open", base: { ref: "master" }, head: { sha: HEAD_SHA } },
-      ],
-    }),
-    context: fakeContext({
-      action: "closed",
-      pull_request: {
-        number: 1465,
-        state: "closed",
-        base: { ref: "master" },
-        head: { sha: HEAD_SHA },
-      },
-    }),
-    core: fakeCore(),
-    setOutputs: false,
-  });
-
-  assert.equal(result.prNumber, "2048");
-  assert.equal(result.shouldMerge, true, result.reasons.join("\n"));
-});
-
-test("moving a shared-head PR off master reevaluates the surviving master PR", async () => {
-  const result = await autoGate.evaluate({
-    github: fakeGateGithub({
-      associatedPullRequests: [
-        { number: 2048, state: "open", base: { ref: "master" }, head: { sha: HEAD_SHA } },
-      ],
-    }),
-    context: fakeContext({
-      action: "edited",
-      changes: { base: { ref: { from: "master" } } },
-      pull_request: {
-        number: 1465,
-        state: "open",
-        base: { ref: "release" },
-        head: { sha: HEAD_SHA },
-      },
-    }),
-    core: fakeCore(),
-    setOutputs: false,
-  });
-
-  assert.equal(result.prNumber, "2048");
-  assert.equal(result.shouldMerge, true, result.reasons.join("\n"));
-});
-
-test("synchronizing away from a shared head reevaluates the previous-head survivor", async () => {
-  const result = await autoGate.evaluate({
-    github: fakeGateGithub({
-      associatedPullRequests: [
-        { number: 2048, state: "open", base: { ref: "master" }, head: { sha: HEAD_SHA } },
-      ],
-    }),
-    context: fakeContext({
-      action: "synchronize",
-      before: HEAD_SHA,
-      after: OTHER_SHA,
-      pull_request: {
-        number: 1465,
-        state: "open",
-        base: { ref: "master" },
-        head: { sha: OTHER_SHA },
-      },
-    }),
-    core: fakeCore(),
-    setOutputs: false,
-  });
-
-  assert.equal(result.prNumber, "2048");
-  assert.equal(result.shouldMerge, true, result.reasons.join("\n"));
-});
-
-test("synchronizing away from a shared head targets both affected decisions", async () => {
-  const targets = await autoGate.resolveTargets({
-    github: fakeGateGithub({
-      associatedPullRequests: [
-        { number: 2048, state: "open", base: { ref: "master" }, head: { sha: HEAD_SHA } },
-      ],
-      pullRequestsByNumber: {
-        1465: { headRefOid: OTHER_SHA },
-        2048: { headRefOid: HEAD_SHA },
-      },
-    }),
-    context: fakeContext({
-      action: "synchronize",
-      before: HEAD_SHA,
-      after: OTHER_SHA,
-      pull_request: {
-        number: 1465,
-        state: "open",
-        base: { ref: "master" },
-        head: { sha: OTHER_SHA },
-      },
-    }),
-    core: fakeCore(),
-  });
-
-  assert.deepEqual(targets, [
-    { prNumber: "1465", headSha: OTHER_SHA },
-    { prNumber: "2048", headSha: HEAD_SHA },
-  ]);
 });
 
 test("the happy path squash-merges the exact evaluated head", async () => {
@@ -865,10 +796,12 @@ function checkRun({
   conclusion,
   appId = ACTIONS_APP_ID,
   appSlug = "github-actions",
+  externalId = null,
 }) {
   return {
     id,
     name,
+    external_id: externalId,
     app: { id: appId, slug: appSlug },
     status,
     conclusion,
@@ -876,6 +809,18 @@ function checkRun({
     started_at: "2026-07-09T01:06:00Z",
     completed_at: status === "completed" ? "2026-07-09T01:10:00Z" : null,
   };
+}
+
+function decisionName(prNumber, headSha) {
+  return `Auto Gate decision / PR #${prNumber} / ${headSha}`;
+}
+
+function decisionExternalId(prNumber, headSha) {
+  return `auto-gate:pr:${prNumber}:head:${headSha}`;
+}
+
+function decisionKey(prNumber, headSha) {
+  return `pr-${prNumber}-head-${headSha}`;
 }
 
 function codexVerdict(sha, timestamp = "2026-07-09T01:20:00Z") {

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -14,7 +14,12 @@ test("Auto Gate can be recovered manually by PR number", () => {
   const workflow = fs.readFileSync(AUTO_GATE_WORKFLOW, "utf8");
 
   assert.match(workflow, /workflow_dispatch:\s+inputs:\s+pr_number:/);
-  assert.match(workflow, /pull_request:\s+types: \[labeled, unlabeled\]/);
+  assert.match(
+    workflow,
+    /pull_request:\s+types: \[opened, reopened, closed, synchronize, edited, converted_to_draft, ready_for_review, labeled, unlabeled\]/,
+  );
+  assert.match(workflow, /github\.event\.action == 'closed'/);
+  assert.match(workflow, /github\.event\.action == 'converted_to_draft'/);
   assert.match(workflow, /pr_number:\s+[\s\S]*?required: true[\s\S]*?type: number/);
   assert.match(
     workflow,
@@ -445,6 +450,30 @@ test("issue-comment events resolve their pull request number", async () => {
   assert.equal(result.shouldMerge, true);
 });
 
+test("closing a shared-head PR reevaluates the surviving open PR", async () => {
+  const result = await autoGate.evaluate({
+    github: fakeGateGithub({
+      associatedPullRequests: [
+        { number: 2048, state: "open", base: { ref: "master" }, head: { sha: HEAD_SHA } },
+      ],
+    }),
+    context: fakeContext({
+      action: "closed",
+      pull_request: {
+        number: 1465,
+        state: "closed",
+        base: { ref: "master" },
+        head: { sha: HEAD_SHA },
+      },
+    }),
+    core: fakeCore(),
+    setOutputs: false,
+  });
+
+  assert.equal(result.prNumber, "2048");
+  assert.equal(result.shouldMerge, true, result.reasons.join("\n"));
+});
+
 test("the happy path squash-merges the exact evaluated head", async () => {
   const github = fakeGateGithub();
 
@@ -624,10 +653,10 @@ function fakeGateGithub({
       repos: { listCommitStatusesForRef, listPullRequestsAssociatedWithCommit },
       pulls: { listFiles, listReviews, listReviewComments, merge },
     },
-    graphql: async () => ({
+    graphql: async (_query, variables) => ({
       repository: {
         pullRequest: {
-          number: 1465,
+          number: variables.number,
           title: "Gate test",
           url: "https://example.invalid/pr/1465",
           baseRefName: "master",

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -170,6 +170,26 @@ test("the synthetic decision check is not its own prerequisite", async () => {
   assert.equal(result.shouldMerge, true, result.reasons.join("\n"));
 });
 
+test("a same-named decision check from another app remains required", async () => {
+  const result = await evaluateGate({
+    checkRuns: [
+      ...happyCheckRuns(),
+      checkRun({ name: "Auto Gate decision", conclusion: "failure" }),
+    ],
+    requiredChecks: [
+      { context: "Lint", integration_id: ACTIONS_APP_ID },
+      { context: "Build", integration_id: ACTIONS_APP_ID },
+      { context: "Auto Gate decision", integration_id: 999 },
+    ],
+  });
+
+  assert.equal(result.shouldMerge, false);
+  assert.match(
+    result.reasons.join("\n"),
+    /required check Auto Gate decision \(app 999\).*missing/,
+  );
+});
+
 test("terminal non-success conclusions never verify a required check", () => {
   const spec = { context: "Lint", sourceAppId: ACTIONS_APP_ID };
 

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -28,6 +28,10 @@ test("Auto Gate can be recovered manually by PR number", () => {
   assert.match(workflow, /const result = await autoGate\.evaluate\(/);
   assert.match(
     workflow,
+    /if \(typeof autoGate\.reportDecision === "function"\)/,
+  );
+  assert.match(
+    workflow,
     /context\.eventName === "workflow_dispatch" && !result\.headSha/,
   );
   assert.match(

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -105,6 +105,50 @@ test("an evaluated but blocked gate reports WAITING rather than NEVER_RAN", asyn
   assert.match(github.updatedChecks[0].output.title, /^WAITING:/);
 });
 
+test("a read-only fork token leaves the decision unreported without failing the gate", async () => {
+  const error = new Error("Resource not accessible by integration");
+  error.status = 403;
+  const github = fakeGateGithub({ checkRuns: happyCheckRuns(), checkWriteError: error });
+  const warnings = [];
+  const core = { ...fakeCore(), warning: (message) => warnings.push(message) };
+
+  const report = await autoGate.reportDecision({
+    github,
+    context: fakeContext({ pull_request: { head: { repo: { fork: true } } } }),
+    core,
+    result: {
+      prNumber: 1465,
+      headSha: HEAD_SHA,
+      baseRefName: "master",
+      isOpen: true,
+      shouldMerge: false,
+      summary: "BLOCKED: author is not an allowed maintainer/app",
+    },
+  });
+
+  assert.equal(report.state, "read-only");
+  assert.equal(github.createdChecks.length, 0);
+  assert.match(warnings.join("\n"), /could not publish.*read-only token/i);
+
+  const baseGithub = fakeGateGithub({ checkRuns: happyCheckRuns(), checkWriteError: error });
+  await assert.rejects(
+    autoGate.reportDecision({
+      github: baseGithub,
+      context: fakeContext(),
+      core: fakeCore(),
+      result: {
+        prNumber: 1465,
+        headSha: HEAD_SHA,
+        baseRefName: "master",
+        isOpen: true,
+        shouldMerge: false,
+        summary: "BLOCKED: waiting",
+      },
+    }),
+    /Resource not accessible by integration/,
+  );
+});
+
 test("a PR cannot read another PR's decision when both share one head", async () => {
   const github = fakeGateGithub({
     associatedPullRequests: [
@@ -135,8 +179,8 @@ test("a PR cannot read another PR's decision when both share one head", async ()
     core: fakeCore(),
   });
   assert.deepEqual(targets, [
-    { prNumber: "1465", headSha: HEAD_SHA, decisionKey: decisionKey(1465, HEAD_SHA) },
-    { prNumber: "2048", headSha: HEAD_SHA, decisionKey: decisionKey(2048, HEAD_SHA) },
+    { prNumber: 1465, headSha: HEAD_SHA, decisionKey: decisionKey(1465, HEAD_SHA) },
+    { prNumber: 2048, headSha: HEAD_SHA, decisionKey: decisionKey(2048, HEAD_SHA) },
   ]);
 
   await autoGate.reportDecision({
@@ -160,6 +204,24 @@ test("a PR cannot read another PR's decision when both share one head", async ()
     decisionName(2048, HEAD_SHA),
   );
   assert.equal(github.createdChecks[0].external_id, decisionExternalId(2048, HEAD_SHA));
+});
+
+test("the queued legacy evaluator keeps resolved PR numbers numeric", async () => {
+  const github = fakeGateGithub();
+  const graphql = github.graphql;
+  github.graphql = async (query, variables) => {
+    assert.equal(typeof variables.number, "number");
+    return graphql(query, variables);
+  };
+
+  const result = await autoGate.evaluate({
+    github,
+    context: fakeContext({ sha: HEAD_SHA }),
+    core: fakeCore(),
+    setOutputs: false,
+  });
+
+  assert.equal(result.shouldMerge, true, result.reasons.join("\n"));
 });
 
 test("a queued evaluation cannot overwrite PASS after the PR merges", async () => {
@@ -691,6 +753,7 @@ function fakeGateGithub({
     { context: "Build", integration_id: ACTIONS_APP_ID },
   ],
   pullRequestsByNumber = {},
+  checkWriteError = null,
 } = {}) {
   const listFiles = function listFiles() {};
   const listForRef = function listForRef() {};
@@ -704,10 +767,16 @@ function fakeGateGithub({
     return { data: { sha: "merge-sha" } };
   };
   const createCheck = async function createCheck(options) {
+    if (checkWriteError) {
+      throw checkWriteError;
+    }
     github.createdChecks.push(options);
     return { data: options };
   };
   const updateCheck = async function updateCheck(options) {
+    if (checkWriteError) {
+      throw checkWriteError;
+    }
     github.updatedChecks.push(options);
     return { data: options };
   };

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -1,4 +1,6 @@
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 const test = require("node:test");
 const autoGate = require("./auto-gate.js");
 const { __test } = autoGate;
@@ -6,6 +8,74 @@ const { __test } = autoGate;
 const HEAD_SHA = "0a5393dd71ddbbf66486d31939728f9947c843bb";
 const OTHER_SHA = "da0a05ea3b9036a12f67a3b3877d16dd0dac893d";
 const ACTIONS_APP_ID = 15368;
+const AUTO_GATE_WORKFLOW = path.join(__dirname, "..", "workflows", "auto-gate.yml");
+
+test("Auto Gate can be recovered manually by PR number", () => {
+  const workflow = fs.readFileSync(AUTO_GATE_WORKFLOW, "utf8");
+
+  assert.match(workflow, /workflow_dispatch:\s+inputs:\s+pr_number:/);
+  assert.match(workflow, /pr_number:\s+[\s\S]*?required: true[\s\S]*?type: number/);
+  assert.match(
+    workflow,
+    /github\.event_name == 'workflow_dispatch' && github\.run_id/,
+  );
+  assert.match(workflow, /PR_NUMBER: \$\{\{ inputs\.pr_number \|\| '' \}\}/);
+  assert.match(workflow, /prNumber: explicitPrNumber/);
+  assert.match(
+    workflow,
+    /- name: Report gate decision[\s\S]*?continue-on-error: true[\s\S]*?github-token: \$\{\{ github\.token \}\}/,
+  );
+});
+
+test("manual recovery reports a previously absent gate distinctly", async () => {
+  const github = fakeGateGithub({ checkRuns: happyCheckRuns() });
+  const result = {
+    prNumber: "1465",
+    headSha: HEAD_SHA,
+    shouldMerge: false,
+    summary: "BLOCKED: waiting on review",
+  };
+
+  const report = await autoGate.reportDecision({
+    github,
+    context: fakeContext(),
+    core: fakeCore(),
+    result,
+    manual: true,
+  });
+
+  assert.equal(report.state, "never-ran");
+  assert.equal(github.createdChecks[0].conclusion, "failure");
+  assert.match(github.createdChecks[0].output.title, /^NEVER_RAN:/);
+});
+
+test("an evaluated but blocked gate reports WAITING rather than NEVER_RAN", async () => {
+  const github = fakeGateGithub({
+    checkRuns: [
+      ...happyCheckRuns(),
+      checkRun({ id: 321, name: "Auto Gate decision", conclusion: "failure" }),
+    ],
+  });
+  const result = {
+    prNumber: "1465",
+    headSha: HEAD_SHA,
+    shouldMerge: false,
+    summary: "BLOCKED: waiting on review",
+  };
+
+  const report = await autoGate.reportDecision({
+    github,
+    context: fakeContext(),
+    core: fakeCore(),
+    result,
+    manual: false,
+  });
+
+  assert.equal(report.state, "waiting");
+  assert.equal(github.createdChecks.length, 0);
+  assert.equal(github.updatedChecks[0].check_run_id, 321);
+  assert.match(github.updatedChecks[0].output.title, /^WAITING:/);
+});
 
 test("required check matching respects the required source app", () => {
   const spec = { context: "Build", sourceAppId: ACTIONS_APP_ID };
@@ -387,6 +457,14 @@ function fakeGateGithub({
     github.mergedWith = options;
     return { data: { sha: "merge-sha" } };
   };
+  const createCheck = async function createCheck(options) {
+    github.createdChecks.push(options);
+    return { data: options };
+  };
+  const updateCheck = async function updateCheck(options) {
+    github.updatedChecks.push(options);
+    return { data: options };
+  };
   const responses = new Map([
     [listFiles, files.map((filename) => ({ filename }))],
     [listForRef, checkRuns],
@@ -398,9 +476,11 @@ function fakeGateGithub({
 
   const github = {
     mergedWith: null,
+    createdChecks: [],
+    updatedChecks: [],
     rest: {
       actions: { createWorkflowDispatch: async () => {} },
-      checks: { listForRef },
+      checks: { create: createCheck, listForRef, update: updateCheck },
       issues: { listComments },
       repos: { listCommitStatusesForRef },
       pulls: { listFiles, listReviews, listReviewComments, merge },
@@ -487,6 +567,7 @@ function requiredSuccessRuns() {
 }
 
 function checkRun({
+  id = 100,
   name,
   status = "completed",
   conclusion,
@@ -494,6 +575,7 @@ function checkRun({
   appSlug = "github-actions",
 }) {
   return {
+    id,
     name,
     app: { id: appId, slug: appSlug },
     status,

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -17,13 +17,22 @@ test("Auto Gate can be recovered manually by PR number", () => {
   assert.match(workflow, /pr_number:\s+[\s\S]*?required: true[\s\S]*?type: number/);
   assert.match(
     workflow,
-    /github\.event_name == 'workflow_dispatch' && github\.run_id/,
+    /concurrency:\s+group: auto-gate-\$\{\{ needs\.auto-gate\.outputs\.pr_number \}\}\s+cancel-in-progress: false/,
   );
   assert.match(workflow, /PR_NUMBER: \$\{\{ inputs\.pr_number \|\| '' \}\}/);
   assert.match(workflow, /prNumber: explicitPrNumber/);
   assert.match(
     workflow,
-    /- name: Report gate decision[\s\S]*?continue-on-error: true[\s\S]*?github-token: \$\{\{ github\.token \}\}/,
+    /- name: Report gate decision[\s\S]*?github-token: \$\{\{ github\.token \}\}/,
+  );
+  assert.match(workflow, /const result = await autoGate\.evaluate\(/);
+  assert.match(
+    workflow,
+    /context\.eventName === "workflow_dispatch" && !result\.headSha/,
+  );
+  assert.match(
+    workflow,
+    /if \(context\.eventName === "workflow_dispatch"\) \{\s+throw error;/,
   );
 });
 

--- a/.github/workflows/auto-gate.yml
+++ b/.github/workflows/auto-gate.yml
@@ -9,7 +9,7 @@ on:
   pull_request_review_comment:
     types: [created, edited, deleted]
   pull_request:
-    types: [labeled, unlabeled]
+    types: [opened, reopened, closed, synchronize, edited, converted_to_draft, ready_for_review, labeled, unlabeled]
   status:
   workflow_dispatch:
     inputs:
@@ -34,8 +34,8 @@ jobs:
       pr_number: ${{ steps.evaluate.outputs.pr_number }}
     # Late review comments on a merged/closed PR keep re-triggering the gate
     # against a stale head (#1876). Drafts are never merge-eligible, so review
-    # traffic on a held-open draft is pure evaluation waste (#1907) — the helper
-    # blocks them anyway, this just skips before the checkout and API calls.
+    # traffic on a held-open draft is pure evaluation waste (#1907), but the
+    # converted_to_draft transition must invalidate a persisted PASS.
     # check_suite/status events resolve the PR by head SHA and already filter to
     # open PRs. issue_comment events are limited to comments on open PRs here.
     # The helper's own state/draft checks remain the backstop for every event.
@@ -43,6 +43,8 @@ jobs:
       (github.event_name != 'issue_comment' ||
        (github.event.issue.pull_request != null && github.event.issue.state == 'open')) &&
       (github.event.pull_request == null ||
+       github.event.action == 'closed' ||
+       github.event.action == 'converted_to_draft' ||
        (github.event.pull_request.state == 'open' && github.event.pull_request.draft != true))
     steps:
       - name: Check out gate logic

--- a/.github/workflows/auto-gate.yml
+++ b/.github/workflows/auto-gate.yml
@@ -34,8 +34,8 @@ jobs:
       pr_number: ${{ steps.evaluate.outputs.pr_number }}
     # Late review comments on a merged/closed PR keep re-triggering the gate
     # against a stale head (#1876). Drafts are never merge-eligible, so review
-    # traffic on a held-open draft is pure evaluation waste (#1907), but the
-    # converted_to_draft transition must invalidate a persisted PASS.
+    # review traffic on a held-open draft is pure evaluation waste (#1907), but
+    # every subscribed pull_request state transition must reach the helper.
     # check_suite/status events resolve the PR by head SHA and already filter to
     # open PRs. issue_comment events are limited to comments on open PRs here.
     # The helper's own state/draft checks remain the backstop for every event.
@@ -43,8 +43,7 @@ jobs:
       (github.event_name != 'issue_comment' ||
        (github.event.issue.pull_request != null && github.event.issue.state == 'open')) &&
       (github.event.pull_request == null ||
-       github.event.action == 'closed' ||
-       github.event.action == 'converted_to_draft' ||
+       github.event_name == 'pull_request' ||
        (github.event.pull_request.state == 'open' && github.event.pull_request.draft != true))
     steps:
       - name: Check out gate logic

--- a/.github/workflows/auto-gate.yml
+++ b/.github/workflows/auto-gate.yml
@@ -32,19 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       targets: ${{ steps.evaluate.outputs.targets }}
-    # Late review comments on a merged/closed PR keep re-triggering the gate
-    # against a stale head (#1876). Drafts are never merge-eligible, so review
-    # review traffic on a held-open draft is pure evaluation waste (#1907), but
-    # every subscribed pull_request state transition must reach the helper.
-    # check_suite/status events resolve the PR by head SHA and already filter to
-    # open PRs. issue_comment events are limited to comments on open PRs here.
-    # The helper's own state/draft checks remain the backstop for every event.
-    if: >-
-      (github.event_name != 'issue_comment' ||
-       (github.event.issue.pull_request != null && github.event.issue.state == 'open')) &&
-      (github.event.pull_request == null ||
-       github.event_name == 'pull_request' ||
-       (github.event.pull_request.state == 'open' && github.event.pull_request.draft != true))
+    # One resolver handles every subscribed input change. It does not branch on
+    # activity type: PR/review/comment events identify a PR, while check/status
+    # events identify every exact (PR, head) pair associated with their SHA.
     steps:
       - name: Check out gate logic
         uses: actions/checkout@v6
@@ -109,7 +99,11 @@ jobs:
                   throw failure;
                 }
                 targets = result.headSha
-                  ? [{ prNumber: result.prNumber, headSha: result.headSha }]
+                  ? [{
+                      prNumber: result.prNumber,
+                      headSha: result.headSha,
+                      decisionKey: `pr-${result.prNumber}-head-${result.headSha}`,
+                    }]
                   : [];
               }
               core.setOutput(
@@ -118,6 +112,7 @@ jobs:
                   targets.map((target) => ({
                     pr_number: target.prNumber,
                     head_sha: target.headSha,
+                    decision_key: target.decisionKey,
                   })),
                 ),
               );
@@ -146,10 +141,10 @@ jobs:
       fail-fast: false
       matrix:
         target: ${{ fromJSON(needs.auto-gate.outputs.targets) }}
-    # Decision checks are commit-scoped, so every PR/event sharing a head must
-    # enter one reporting and destructive lane.
+    # Decision identity is the pair, never the commit alone. Two PRs may point
+    # at the same commit without sharing a check or serialization lane.
     concurrency:
-      group: auto-gate-${{ matrix.target.head_sha }}
+      group: auto-gate-${{ matrix.target.decision_key }}
       cancel-in-progress: false
     steps:
       - name: Check out gate logic

--- a/.github/workflows/auto-gate.yml
+++ b/.github/workflows/auto-gate.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       pr_number: ${{ steps.evaluate.outputs.pr_number }}
+      head_sha: ${{ steps.evaluate.outputs.head_sha }}
     # Late review comments on a merged/closed PR keep re-triggering the gate
     # against a stale head (#1876). Drafts are never merge-eligible, so review
     # review traffic on a held-open draft is pure evaluation waste (#1907), but
@@ -122,12 +123,15 @@ jobs:
   apply-gate:
     name: Apply auto-merge gate
     needs: auto-gate
-    if: needs.auto-gate.result == 'success' && needs.auto-gate.outputs.pr_number != ''
+    if: >-
+      needs.auto-gate.result == 'success' &&
+      needs.auto-gate.outputs.pr_number != '' &&
+      needs.auto-gate.outputs.head_sha != ''
     runs-on: ubuntu-latest
-    # Every event resolves the PR before entering this lane. That gives status,
-    # review, comment, and manual events one stable destructive/reporting key.
+    # Decision checks are commit-scoped, so every PR/event sharing a head must
+    # enter one reporting and destructive lane.
     concurrency:
-      group: auto-gate-${{ needs.auto-gate.outputs.pr_number }}
+      group: auto-gate-${{ needs.auto-gate.outputs.head_sha }}
       cancel-in-progress: false
     steps:
       - name: Check out gate logic

--- a/.github/workflows/auto-gate.yml
+++ b/.github/workflows/auto-gate.yml
@@ -9,7 +9,7 @@ on:
   pull_request_review_comment:
     types: [created, edited, deleted]
   pull_request:
-    types: [labeled]
+    types: [labeled, unlabeled]
   status:
   workflow_dispatch:
     inputs:
@@ -92,8 +92,16 @@ jobs:
                 core,
                 prNumber: explicitPrNumber,
               });
-              if (context.eventName === "workflow_dispatch" && !result.headSha) {
-                throw new Error(result.summary);
+              const evaluationFailed = result.reasons.some((reason) =>
+                reason.startsWith("auto-gate evaluation error:"),
+              );
+              if (
+                evaluationFailed ||
+                (context.eventName === "workflow_dispatch" && !result.headSha)
+              ) {
+                const failure = new Error(result.summary);
+                failure.failWorkflow = true;
+                throw failure;
               }
             } catch (error) {
               const message = error && error.message ? error.message : String(error);
@@ -105,7 +113,7 @@ jobs:
               core.setOutput("head_sha", "");
               core.setOutput("docs_changed", "false");
               core.setOutput("summary", summary);
-              if (context.eventName === "workflow_dispatch") {
+              if (error.failWorkflow || context.eventName === "workflow_dispatch") {
                 throw error;
               }
             }

--- a/.github/workflows/auto-gate.yml
+++ b/.github/workflows/auto-gate.yml
@@ -26,16 +26,12 @@ permissions:
   statuses: read
   issues: write
 
-concurrency:
-  # Manual recovery must not be displaced by an event burst. Event-driven runs
-  # still coalesce by PR/SHA, with the newest pending evaluation retained.
-  group: auto-gate-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event.pull_request.number || github.event.issue.number || github.event.check_suite.pull_requests[0].number || github.event.check_suite.head_sha || github.event.sha || github.run_id }}
-  cancel-in-progress: false
-
 jobs:
   auto-gate:
     name: Evaluate auto-merge gate
     runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.evaluate.outputs.pr_number }}
     # Late review comments on a merged/closed PR keep re-triggering the gate
     # against a stale head (#1876). Drafts are never merge-eligible, so review
     # traffic on a held-open draft is pure evaluation waste (#1907) — the helper
@@ -74,6 +70,9 @@ jobs:
               core.setOutput("head_sha", "");
               core.setOutput("docs_changed", "false");
               core.setOutput("summary", summary);
+              if (context.eventName === "workflow_dispatch") {
+                throw new Error(summary);
+              }
               return;
             }
 
@@ -87,12 +86,15 @@ jobs:
               ) {
                 throw new Error(`Invalid PR number: ${rawPrNumber}`);
               }
-              await autoGate.evaluate({
+              const result = await autoGate.evaluate({
                 github,
                 context,
                 core,
                 prNumber: explicitPrNumber,
               });
+              if (context.eventName === "workflow_dispatch" && !result.headSha) {
+                throw new Error(result.summary);
+              }
             } catch (error) {
               const message = error && error.message ? error.message : String(error);
               const summary = `BLOCKED: auto-gate evaluation error: ${message}`;
@@ -103,17 +105,32 @@ jobs:
               core.setOutput("head_sha", "");
               core.setOutput("docs_changed", "false");
               core.setOutput("summary", summary);
+              if (context.eventName === "workflow_dispatch") {
+                throw error;
+              }
             }
 
+  apply-gate:
+    name: Apply auto-merge gate
+    needs: auto-gate
+    if: needs.auto-gate.result == 'success' && needs.auto-gate.outputs.pr_number != ''
+    runs-on: ubuntu-latest
+    # Every event resolves the PR before entering this lane. That gives status,
+    # review, comment, and manual events one stable destructive/reporting key.
+    concurrency:
+      group: auto-gate-${{ needs.auto-gate.outputs.pr_number }}
+      cancel-in-progress: false
+    steps:
+      - name: Check out gate logic
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
       - name: Report gate decision
-        if: steps.evaluate.outputs.head_sha != ''
-        continue-on-error: true
+        id: decision
         uses: actions/github-script@v8
         env:
-          PR_NUMBER: ${{ steps.evaluate.outputs.pr_number }}
-          HEAD_SHA: ${{ steps.evaluate.outputs.head_sha }}
-          SHOULD_MERGE: ${{ steps.evaluate.outputs.should_merge }}
-          SUMMARY: ${{ steps.evaluate.outputs.summary }}
+          PR_NUMBER: ${{ needs.auto-gate.outputs.pr_number }}
         with:
           # Check runs require an App installation token. Keep this separate
           # from the optional maintainer token used by the existing merge path.
@@ -122,35 +139,39 @@ jobs:
             const path = require("path");
             const helperPath = path.join(process.env.GITHUB_WORKSPACE, ".github/scripts/auto-gate.js");
             const autoGate = require(helperPath);
+            const result = await autoGate.evaluate({
+              github,
+              context,
+              core,
+              prNumber: Number(process.env.PR_NUMBER),
+            });
+            if (!result.headSha) {
+              throw new Error(result.summary);
+            }
             await autoGate.reportDecision({
               github,
               context,
               core,
-              result: {
-                prNumber: process.env.PR_NUMBER,
-                headSha: process.env.HEAD_SHA,
-                shouldMerge: process.env.SHOULD_MERGE === "true",
-                summary: process.env.SUMMARY,
-              },
+              result,
               manual: context.eventName === "workflow_dispatch",
             });
 
       - name: Report disabled merge
-        if: steps.evaluate.outputs.should_merge == 'true' && vars.AUTO_GATE_ENABLED != 'true'
+        if: steps.decision.outputs.should_merge == 'true' && vars.AUTO_GATE_ENABLED != 'true'
         env:
-          PR_NUMBER: ${{ steps.evaluate.outputs.pr_number }}
-          DOCS_CHANGED: ${{ steps.evaluate.outputs.docs_changed }}
-          SUMMARY: ${{ steps.evaluate.outputs.summary }}
+          PR_NUMBER: ${{ needs.auto-gate.outputs.pr_number }}
+          DOCS_CHANGED: ${{ steps.decision.outputs.docs_changed }}
+          SUMMARY: ${{ steps.decision.outputs.summary }}
         run: |
           echo "::notice::AUTO_GATE_ENABLED is not true; would squash-merge PR #${PR_NUMBER}."
           echo "::notice::Docs workflow dispatch after merge: ${DOCS_CHANGED}."
           printf '%s\n' "$SUMMARY"
 
       - name: Squash merge PR
-        if: steps.evaluate.outputs.should_merge == 'true' && vars.AUTO_GATE_ENABLED == 'true'
+        if: steps.decision.outputs.should_merge == 'true' && vars.AUTO_GATE_ENABLED == 'true'
         uses: actions/github-script@v8
         env:
-          PR_NUMBER: ${{ steps.evaluate.outputs.pr_number }}
+          PR_NUMBER: ${{ needs.auto-gate.outputs.pr_number }}
         with:
           github-token: ${{ secrets.AUTO_GATE_TOKEN || github.token }}
           script: |

--- a/.github/workflows/auto-gate.yml
+++ b/.github/workflows/auto-gate.yml
@@ -31,8 +31,7 @@ jobs:
     name: Evaluate auto-merge gate
     runs-on: ubuntu-latest
     outputs:
-      pr_number: ${{ steps.evaluate.outputs.pr_number }}
-      head_sha: ${{ steps.evaluate.outputs.head_sha }}
+      targets: ${{ steps.evaluate.outputs.targets }}
     # Late review comments on a merged/closed PR keep re-triggering the gate
     # against a stale head (#1876). Drafts are never merge-eligible, so review
     # review traffic on a held-open draft is pure evaluation waste (#1907), but
@@ -67,11 +66,7 @@ jobs:
             if (!fs.existsSync(helperPath)) {
               const summary = "BLOCKED: auto-gate helper is not present on the default branch yet.";
               core.notice(summary);
-              core.setOutput("pr_number", "");
-              core.setOutput("should_merge", "false");
-              core.setOutput("head_sha", "");
-              core.setOutput("docs_changed", "false");
-              core.setOutput("summary", summary);
+              core.setOutput("targets", "[]");
               if (context.eventName === "workflow_dispatch") {
                 throw new Error(summary);
               }
@@ -88,20 +83,46 @@ jobs:
               ) {
                 throw new Error(`Invalid PR number: ${rawPrNumber}`);
               }
-              const result = await autoGate.evaluate({
-                github,
-                context,
-                core,
-                prNumber: explicitPrNumber,
-              });
-              const evaluationFailed = result.reasons.some((reason) =>
-                reason.startsWith("auto-gate evaluation error:"),
+              let targets;
+              if (typeof autoGate.resolveTargets === "function") {
+                targets = await autoGate.resolveTargets({
+                  github,
+                  context,
+                  core,
+                  prNumber: explicitPrNumber,
+                });
+              } else {
+                // The workflow file takes effect before its default-branch helper
+                // on the landing run. Preserve one-target behavior for that run.
+                const result = await autoGate.evaluate({
+                  github,
+                  context,
+                  core,
+                  prNumber: explicitPrNumber,
+                });
+                const evaluationFailed = result.reasons.some((reason) =>
+                  reason.startsWith("auto-gate evaluation error:"),
+                );
+                if (evaluationFailed) {
+                  const failure = new Error(result.summary);
+                  failure.failWorkflow = true;
+                  throw failure;
+                }
+                targets = result.headSha
+                  ? [{ prNumber: result.prNumber, headSha: result.headSha }]
+                  : [];
+              }
+              core.setOutput(
+                "targets",
+                JSON.stringify(
+                  targets.map((target) => ({
+                    pr_number: target.prNumber,
+                    head_sha: target.headSha,
+                  })),
+                ),
               );
-              if (
-                evaluationFailed ||
-                (context.eventName === "workflow_dispatch" && !result.headSha)
-              ) {
-                const failure = new Error(result.summary);
+              if (context.eventName === "workflow_dispatch" && targets.length === 0) {
+                const failure = new Error("No pull-request head was resolved for manual recovery.");
                 failure.failWorkflow = true;
                 throw failure;
               }
@@ -110,14 +131,8 @@ jobs:
               const summary = `BLOCKED: auto-gate evaluation error: ${message}`;
               core.warning(error && error.stack ? error.stack : message);
               core.notice(summary);
-              core.setOutput("pr_number", "");
-              core.setOutput("should_merge", "false");
-              core.setOutput("head_sha", "");
-              core.setOutput("docs_changed", "false");
-              core.setOutput("summary", summary);
-              if (error.failWorkflow || context.eventName === "workflow_dispatch") {
-                throw error;
-              }
+              core.setOutput("targets", "[]");
+              throw error;
             }
 
   apply-gate:
@@ -125,13 +140,16 @@ jobs:
     needs: auto-gate
     if: >-
       needs.auto-gate.result == 'success' &&
-      needs.auto-gate.outputs.pr_number != '' &&
-      needs.auto-gate.outputs.head_sha != ''
+      needs.auto-gate.outputs.targets != '[]'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.auto-gate.outputs.targets) }}
     # Decision checks are commit-scoped, so every PR/event sharing a head must
     # enter one reporting and destructive lane.
     concurrency:
-      group: auto-gate-${{ needs.auto-gate.outputs.head_sha }}
+      group: auto-gate-${{ matrix.target.head_sha }}
       cancel-in-progress: false
     steps:
       - name: Check out gate logic
@@ -143,7 +161,8 @@ jobs:
         id: decision
         uses: actions/github-script@v8
         env:
-          PR_NUMBER: ${{ needs.auto-gate.outputs.pr_number }}
+          PR_NUMBER: ${{ matrix.target.pr_number }}
+          EXPECTED_HEAD_SHA: ${{ matrix.target.head_sha }}
         with:
           # Check runs require an App installation token. Keep this separate
           # from the optional maintainer token used by the existing merge path.
@@ -157,10 +176,26 @@ jobs:
               context,
               core,
               prNumber: Number(process.env.PR_NUMBER),
+              setOutputs: false,
             });
             if (!result.headSha) {
               throw new Error(result.summary);
             }
+            if (result.headSha !== process.env.EXPECTED_HEAD_SHA) {
+              core.notice(
+                `Skipping stale target for PR #${process.env.PR_NUMBER}: serialized head ` +
+                  `${process.env.EXPECTED_HEAD_SHA}, current head ${result.headSha}.`,
+              );
+              core.setOutput("should_merge", "false");
+              core.setOutput("docs_changed", "false");
+              core.setOutput("summary", "BLOCKED: pull-request head changed before serialized evaluation");
+              return;
+            }
+            core.setOutput("pr_number", result.prNumber);
+            core.setOutput("should_merge", result.shouldMerge ? "true" : "false");
+            core.setOutput("head_sha", result.headSha);
+            core.setOutput("docs_changed", result.docsChanged ? "true" : "false");
+            core.setOutput("summary", result.summary);
             if (typeof autoGate.reportDecision === "function") {
               await autoGate.reportDecision({
                 github,
@@ -176,7 +211,7 @@ jobs:
       - name: Report disabled merge
         if: steps.decision.outputs.should_merge == 'true' && vars.AUTO_GATE_ENABLED != 'true'
         env:
-          PR_NUMBER: ${{ needs.auto-gate.outputs.pr_number }}
+          PR_NUMBER: ${{ matrix.target.pr_number }}
           DOCS_CHANGED: ${{ steps.decision.outputs.docs_changed }}
           SUMMARY: ${{ steps.decision.outputs.summary }}
         run: |
@@ -188,7 +223,8 @@ jobs:
         if: steps.decision.outputs.should_merge == 'true' && vars.AUTO_GATE_ENABLED == 'true'
         uses: actions/github-script@v8
         env:
-          PR_NUMBER: ${{ needs.auto-gate.outputs.pr_number }}
+          PR_NUMBER: ${{ matrix.target.pr_number }}
+          EXPECTED_HEAD_SHA: ${{ matrix.target.head_sha }}
         with:
           github-token: ${{ secrets.AUTO_GATE_TOKEN || github.token }}
           script: |
@@ -200,4 +236,5 @@ jobs:
               context,
               core,
               prNumber: Number(process.env.PR_NUMBER),
+              expectedHeadSha: process.env.EXPECTED_HEAD_SHA,
             });

--- a/.github/workflows/auto-gate.yml
+++ b/.github/workflows/auto-gate.yml
@@ -11,17 +11,25 @@ on:
   pull_request:
     types: [labeled]
   status:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to evaluate
+        required: true
+        type: number
 
 permissions:
   contents: write
   pull-requests: write
   actions: write
-  checks: read
+  checks: write
   statuses: read
   issues: write
 
 concurrency:
-  group: auto-gate-${{ github.event.pull_request.number || github.event.issue.number || github.event.check_suite.pull_requests[0].number || github.event.check_suite.head_sha || github.event.sha || github.run_id }}
+  # Manual recovery must not be displaced by an event burst. Event-driven runs
+  # still coalesce by PR/SHA, with the newest pending evaluation retained.
+  group: auto-gate-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event.pull_request.number || github.event.issue.number || github.event.check_suite.pull_requests[0].number || github.event.check_suite.head_sha || github.event.sha || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -49,6 +57,8 @@ jobs:
       - name: Evaluate gate
         id: evaluate
         uses: actions/github-script@v8
+        env:
+          PR_NUMBER: ${{ inputs.pr_number || '' }}
         with:
           github-token: ${{ secrets.AUTO_GATE_TOKEN || github.token }}
           script: |
@@ -61,6 +71,7 @@ jobs:
               core.notice(summary);
               core.setOutput("pr_number", "");
               core.setOutput("should_merge", "false");
+              core.setOutput("head_sha", "");
               core.setOutput("docs_changed", "false");
               core.setOutput("summary", summary);
               return;
@@ -68,7 +79,20 @@ jobs:
 
             try {
               const autoGate = require(helperPath);
-              await autoGate.evaluate({ github, context, core });
+              const rawPrNumber = process.env.PR_NUMBER.trim();
+              const explicitPrNumber = rawPrNumber ? Number(rawPrNumber) : undefined;
+              if (
+                rawPrNumber &&
+                (!Number.isSafeInteger(explicitPrNumber) || explicitPrNumber <= 0)
+              ) {
+                throw new Error(`Invalid PR number: ${rawPrNumber}`);
+              }
+              await autoGate.evaluate({
+                github,
+                context,
+                core,
+                prNumber: explicitPrNumber,
+              });
             } catch (error) {
               const message = error && error.message ? error.message : String(error);
               const summary = `BLOCKED: auto-gate evaluation error: ${message}`;
@@ -76,9 +100,40 @@ jobs:
               core.notice(summary);
               core.setOutput("pr_number", "");
               core.setOutput("should_merge", "false");
+              core.setOutput("head_sha", "");
               core.setOutput("docs_changed", "false");
               core.setOutput("summary", summary);
             }
+
+      - name: Report gate decision
+        if: steps.evaluate.outputs.head_sha != ''
+        continue-on-error: true
+        uses: actions/github-script@v8
+        env:
+          PR_NUMBER: ${{ steps.evaluate.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.evaluate.outputs.head_sha }}
+          SHOULD_MERGE: ${{ steps.evaluate.outputs.should_merge }}
+          SUMMARY: ${{ steps.evaluate.outputs.summary }}
+        with:
+          # Check runs require an App installation token. Keep this separate
+          # from the optional maintainer token used by the existing merge path.
+          github-token: ${{ github.token }}
+          script: |
+            const path = require("path");
+            const helperPath = path.join(process.env.GITHUB_WORKSPACE, ".github/scripts/auto-gate.js");
+            const autoGate = require(helperPath);
+            await autoGate.reportDecision({
+              github,
+              context,
+              core,
+              result: {
+                prNumber: process.env.PR_NUMBER,
+                headSha: process.env.HEAD_SHA,
+                shouldMerge: process.env.SHOULD_MERGE === "true",
+                summary: process.env.SUMMARY,
+              },
+              manual: context.eventName === "workflow_dispatch",
+            });
 
       - name: Report disabled merge
         if: steps.evaluate.outputs.should_merge == 'true' && vars.AUTO_GATE_ENABLED != 'true'

--- a/.github/workflows/auto-gate.yml
+++ b/.github/workflows/auto-gate.yml
@@ -1,6 +1,12 @@
 name: Auto Gate
 
 on:
+  # These events cover every input read by evaluate(): required checks,
+  # reviews/findings, labels, base, draft/state, and head. Repository-ruleset
+  # changes and mergeability changes caused only by master advancing are not
+  # evented here. workflow_dispatch repairs stale observational state, and this
+  # is safe for Auto Gate because merge() always performs a fresh full
+  # evaluation immediately before its destructive write.
   check_suite:
     types: [completed]
   issue_comment:

--- a/.github/workflows/auto-gate.yml
+++ b/.github/workflows/auto-gate.yml
@@ -148,13 +148,17 @@ jobs:
             if (!result.headSha) {
               throw new Error(result.summary);
             }
-            await autoGate.reportDecision({
-              github,
-              context,
-              core,
-              result,
-              manual: context.eventName === "workflow_dispatch",
-            });
+            if (typeof autoGate.reportDecision === "function") {
+              await autoGate.reportDecision({
+                github,
+                context,
+                core,
+                result,
+                manual: context.eventName === "workflow_dispatch",
+              });
+            } else {
+              core.notice("Decision reporting activates after this workflow lands on master.");
+            }
 
       - name: Report disabled merge
         if: steps.decision.outputs.should_merge == 'true' && vars.AUTO_GATE_ENABLED != 'true'


### PR DESCRIPTION
## Summary

- add workflow_dispatch recovery by PR number and report NEVER_RAN, WAITING, or PASS
- make every decision identity the composite (pr_number, head_sha): check name, Checks API external_id, matrix target, concurrency key, and merge-time expected head
- replace shared-head association/event repair branches with one target resolver used by every subscribed input event
- resolve SHA events to every open master PR whose exact current head matches that SHA, so two PRs sharing a commit receive independent decisions
- exclude both GitHub Actions-owned and source-less synthetic decision contexts from the gate's own prerequisites while preserving an explicitly other-app requirement
- re-evaluate inside the serialized pair lane and again before merge; stale observational PASS cannot authorize a destructive write

## Why this replaces the event patch series

GitHub stores check runs on a commit, but labels, draft/base state, Codex reviews, and findings belong to a PR. A static check name therefore allowed a decision computed for (PR A, H) to be read or overwritten as the decision for (PR B, H).

The decision check is now named:

    Auto Gate decision / PR #<number> / <full head SHA>

and carries the matching external_id and serialization key. No decision lookup is possible without both values. The shared-head blocker, old-head survivor recovery, base-removal recovery, and dual-head synchronization branches were removed because they no longer protect a shared object.

Every subscribed event now enters one resolver. PR/review/comment events identify their PR; check/status events identify all exact current (PR, head) pairs for the SHA. The helper does not branch on activity type.

## Events and remaining limits

The subscriptions cover the inputs the gate reads: check suites/statuses; issue comments and review bodies/comments including edits/deletions; PR head, base, draft/state, and label changes. Assignment, milestone, lock, review-request, and auto-merge-setting events are intentionally omitted because the evaluator does not read them.

GitHub does not emit a PR event for repository-ruleset changes or every mergeability change caused by master advancing. Those can leave an observational decision stale until the next event or manual dispatch. This limit is documented beside the subscription list, and a direct regression test proves the destructive merge helper ignores stale PASS and performs a fresh full evaluation before writing.

## Relationship to #3099

#3119 remains a prerequisite, not the exclusive-merge solution. Live run https://github.com/sachiniyer/agent-factory/actions/runs/31240534387 proved the workflow installation token does not receive the github-actions[bot] User ruleset bypass, so the experimental blocking ruleset remains disabled.

The maintainer selected #3099 option 2: no elevated merge identity. Composite decision names are deliberately dynamic and therefore are not the fixed-name enforcement context. A follow-up PR will add the static aggregate check after this identity/recovery layer lands. It must name every coupled same-head PR and what it is waiting on in the failure output, explain that coupling in the check summary, and document a recovery path that works with the built-in token and no bypass. This PR deliberately does not add that policy mechanism.

## Regression proof

The invariant fixture failed against prior head 6bc6b433: PR B at the same SHA updated PR A's PASS check (one update, zero independent checks). On the composite implementation, the SHA resolver returns both targets and PR B creates its own WAITING check with a different name and external_id.

A separate destructive-path fixture starts with a stale successful decision, adds a current unresolved finding, attempts the merge, and proves the helper rereads the finding and refuses to merge.

The prerequisite regressions also prove both an Actions-owned composite decision and a source-less synthetic decision are excluded from their own prerequisite set. This was not #3119's live cause: #3115's trace evaluated only Build and Lint as required and passed the full gate before its 405 ruleset failure.

The docs arbitrary-SHA security finding applied only to the abandoned post-merge-dispatch implementation. Current master has no commit_sha input and this narrowed PR does not modify docs.yml, so the thread records it as moot because the described code is gone, not fixed.

All 39 focused Auto Gate tests pass.

## Local checks

- node --test .github/scripts/auto-gate.test.js
- actionlint .github/workflows/auto-gate.yml
- gofmt -l . (empty)
- go build ./...
- golangci-lint run --timeout=3m --fast
- scripts/lint-file-length.sh

Closes #3119
Refs #3099
