### PR TITLE
fix(ssh): pin every transport step to one resolved host with a ProxyCommand

### DIFF
--- a/commands/sshrelaycmd.go
+++ b/commands/sshrelaycmd.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sachiniyer/agent-factory/internal/sshrelay"
+)
+
+// sshRelayCmd is the ProxyCommand af composes into its own ssh invocations so
+// every step of a remote session dials one resolved address (#3086). Hidden: it
+// is af talking to af, never something an operator runs — the same convention as
+// hook-guard-tmux.
+//
+// STDOUT IS THE SSH TRANSPORT STREAM while this runs, which shapes every choice
+// below:
+//
+//   - The command's output writer is pointed at STDERR, so cobra itself can never
+//     reach stdout — not a usage dump, not a help screen, not an error. Only the
+//     explicit os.Stdout handed to sshrelay.Run carries bytes.
+//   - SilenceUsage, so a malformed invocation prints one line rather than a usage
+//     block. (The root command's PersistentPreRun sets this too; stating it here
+//     keeps the guarantee local to the command that depends on it.)
+//   - RunE does NO af startup work: no config load, no log.Initialize, no
+//     ensureDaemonForTasks. The root command's PersistentPreRun only sets
+//     SilenceUsage, and every other side effect lives in the bare-`af` RunE this
+//     path never enters — so a relay cannot start a daemon or migrate a config.
+//     TestSSHRelayWritesNothingButRelayedBytesToStdout runs the REAL binary and
+//     asserts the byte stream, which is what makes that a checked property rather
+//     than a claim about the call graph.
+//
+// The port is a separate argument from the address rather than one `host:port`
+// string, so an IPv6 literal is bracketed by net.JoinHostPort inside the relay
+// instead of by a caller that might forget.
+var sshRelayCmd = &cobra.Command{
+	Use:          sshrelay.Subcommand + " <address> <port>",
+	Short:        "Internal: relay stdio to a pinned TCP address for af's own ssh ProxyCommand",
+	Hidden:       true,
+	Args:         cobra.ExactArgs(2),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return sshrelay.Run(args[0], args[1], cmd.InOrStdin(), os.Stdout)
+	},
+}
+
+func init() {
+	// Everything cobra prints for this command goes to stderr. OutOrStdout() is
+	// what the help and usage writers consult, and its default is os.Stdout.
+	sshRelayCmd.SetOut(os.Stderr)
+	rootCmd.AddCommand(sshRelayCmd)
+}

--- a/commands/sshrelaycmd_test.go
+++ b/commands/sshrelaycmd_test.go
@@ -1,0 +1,226 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/internal/sshrelay"
+)
+
+// `af ssh-relay` is the ProxyCommand af hands to its own ssh invocations (#3086),
+// which makes its stdout THE SSH TRANSPORT STREAM.
+//
+// That is the property these tests exist for, and it is a property of the whole
+// PROGRAM rather than of sshrelay.Run: a log line from an init(), a cobra usage
+// dump, a migration notice, a daemon-autostart banner — any of them corrupts the
+// protocol, and none is visible from the function under test. So these drive the
+// REAL binary and compare bytes.
+
+// TestSSHRelayWritesNothingButRelayedBytesToStdout is the one that would catch a
+// stray Println anywhere in af's startup.
+func TestSSHRelayWritesNothingButRelayedBytesToStdout(t *testing.T) {
+	// Deliberately BINARY, not a greeting: ssh's transport is framed binary, and a
+	// payload of printable text could hide a stray newline written beside it.
+	payload := make([]byte, 0, 4096)
+	for i := 0; i < 4096; i++ {
+		payload = append(payload, byte(i%251))
+	}
+	addr := serveOnce(t, func(conn net.Conn) {
+		_, _ = conn.Write(payload)
+		_ = conn.Close()
+	})
+
+	stdout, stderr, err := runRelay(t, nil, addr)
+	require.NoError(t, err, "stderr: %s", stderr)
+	assert.True(t, bytes.Equal(payload, stdout),
+		"stdout must carry the relayed bytes and NOTHING else — it is the ssh transport stream, so one extra "+
+			"byte corrupts the session rather than merely being noisy (got %d bytes, want %d)",
+		len(stdout), len(payload))
+}
+
+// The other direction, and the half-close that makes it terminate. af streams its
+// own binary to the remote over ssh's stdin, and the remote `cat` finishes only
+// when it sees EOF.
+func TestSSHRelayForwardsStdinAndHalfClosesOnEOF(t *testing.T) {
+	payload := bytes.Repeat([]byte("stream-me\n"), 5000)
+	addr := serveOnce(t, func(conn net.Conn) {
+		// Reads until EOF, which only arrives if the relay shuts down its write half
+		// rather than holding the connection open or closing it outright.
+		got, _ := io.ReadAll(conn)
+		_, _ = fmt.Fprintf(conn, "%d", len(got))
+		_ = conn.Close()
+	})
+
+	stdout, stderr, err := runRelay(t, payload, addr)
+	require.NoError(t, err, "stderr: %s", stderr)
+	assert.Equal(t, strconv.Itoa(len(payload)), string(stdout),
+		"the far side must receive every byte AND then see EOF; a relay that never half-closes hangs here "+
+			"instead, and one that closes the whole connection loses this reply")
+}
+
+// A relay that cannot dial must say so where diagnostics belong, and must leave
+// the transport stream untouched.
+func TestSSHRelayReportsADialFailureOnStderrOnly(t *testing.T) {
+	// A port nothing is listening on: bind one and release it.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	dead := ln.Addr().String()
+	require.NoError(t, ln.Close())
+
+	stdout, stderr, err := runRelay(t, nil, dead)
+	require.Error(t, err, "a relay that cannot reach the pinned address must fail rather than exit 0 on an "+
+		"empty stream, which ssh would read as a closed connection")
+	assert.Empty(t, stdout, "not one byte on the transport stream, even on the failure path")
+	assert.Contains(t, string(stderr), dead, "the operator needs to see WHICH address could not be reached")
+}
+
+// Two arguments, not one host:port string — so an IPv6 literal is bracketed by
+// net.JoinHostPort inside the relay rather than by a caller who might forget.
+func TestSSHRelayBracketsAnIPv6Literal(t *testing.T) {
+	ln, err := net.Listen("tcp", "[::1]:0")
+	if err != nil {
+		t.Skipf("no IPv6 loopback on this host: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	go func() {
+		conn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			return
+		}
+		_, _ = conn.Write([]byte("V6_OK"))
+		_ = conn.Close()
+	}()
+	t.Cleanup(func() { _ = ln.Close() })
+
+	stdout, stderr, err := runRelayArgs(t, nil, "::1", strconv.Itoa(port))
+	require.NoError(t, err, "stderr: %s", stderr)
+	assert.Equal(t, "V6_OK", string(stdout))
+}
+
+// A malformed invocation must not put a usage block on the transport stream. This
+// is why the command points cobra's output writer at stderr.
+func TestSSHRelayKeepsCobraOutputOffStdout(t *testing.T) {
+	for _, args := range [][]string{
+		{sshrelay.Subcommand},
+		{sshrelay.Subcommand, "127.0.0.1"},
+		{sshrelay.Subcommand, "127.0.0.1", "22", "extra"},
+		{sshrelay.Subcommand, "--help"},
+	} {
+		stdout, stderr, _ := runAF(t, nil, args...)
+		assert.Empty(t, stdout,
+			"`af %s` wrote to stdout; cobra's usage and help writers default to os.Stdout, and this command's "+
+				"stdout is the ssh transport stream", strings.Join(args, " "))
+		assert.NotEmpty(t, stderr, "the diagnostic still has to go somewhere")
+	}
+}
+
+// The command is af talking to af, so it stays out of `af --help`.
+func TestSSHRelayIsHidden(t *testing.T) {
+	stdout, _, err := runAF(t, nil, "--help")
+	require.NoError(t, err)
+	assert.NotContains(t, string(stdout), sshrelay.Subcommand,
+		"the relay is an internal seam, not a command an operator runs")
+}
+
+// serveOnce accepts exactly one connection, hands it to handle, and returns the
+// address to dial.
+func serveOnce(t *testing.T, handle func(net.Conn)) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		conn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			return
+		}
+		handle(conn)
+	}()
+	return ln.Addr().String()
+}
+
+func runRelay(t *testing.T, stdin []byte, addr string) (stdout, stderr []byte, err error) {
+	t.Helper()
+	host, port, splitErr := net.SplitHostPort(addr)
+	require.NoError(t, splitErr)
+	return runRelayArgs(t, stdin, host, port)
+}
+
+func runRelayArgs(t *testing.T, stdin []byte, host, port string) (stdout, stderr []byte, err error) {
+	t.Helper()
+	return runAF(t, stdin, sshrelay.Subcommand, host, port)
+}
+
+// runAF invokes the REAL af binary. Nothing short of that can decide the question
+// these tests ask, which is what the whole program writes to fd 1.
+func runAF(t *testing.T, stdin []byte, args ...string) (stdout, stderr []byte, err error) {
+	t.Helper()
+	cmd := exec.Command(afTestBinary(t), args...)
+	// A throwaway AF home, so a relay can neither read nor disturb the real one.
+	cmd.Env = append(os.Environ(), "AGENT_FACTORY_HOME="+t.TempDir(), "HOME="+t.TempDir())
+	if stdin != nil {
+		cmd.Stdin = bytes.NewReader(stdin)
+	}
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	// A relay that never exits is a wedged provision step, so bound it here rather
+	// than letting the suite hang.
+	done := make(chan error, 1)
+	require.NoError(t, cmd.Start())
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err = <-done:
+	case <-time.After(60 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatalf("af %s did not exit; a relay must terminate when the remote closes", strings.Join(args, " "))
+	}
+	return outBuf.Bytes(), errBuf.Bytes(), err
+}
+
+// afTestBinary builds af once per test binary run.
+var (
+	afBuildOnce sync.Once
+	afBuildPath string
+	afBuildErr  error
+)
+
+func afTestBinary(t *testing.T) string {
+	t.Helper()
+	afBuildOnce.Do(func() {
+		if _, err := exec.LookPath("go"); err != nil {
+			afBuildErr = fmt.Errorf("no go toolchain: %w", err)
+			return
+		}
+		dir, err := os.MkdirTemp("", "af-relay-cmd")
+		if err != nil {
+			afBuildErr = err
+			return
+		}
+		out := filepath.Join(dir, "af")
+		build := exec.Command("go", "build", "-o", out, "github.com/sachiniyer/agent-factory")
+		build.Dir = ".."
+		if combined, buildErr := build.CombinedOutput(); buildErr != nil {
+			afBuildErr = fmt.Errorf("building af: %w: %s", buildErr, combined)
+			return
+		}
+		afBuildPath = out
+	})
+	if afBuildErr != nil {
+		t.Skipf("cannot build the af binary under test (%v)", afBuildErr)
+	}
+	return afBuildPath
+}

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -357,8 +357,8 @@ back (see [Archive & restore](#archive-restore)).
 
 > **A `ssh.host` with several addresses stays on one machine.** af runs a separate
 > `ssh` for each step — the setup commands, the port-forward, and the cleanup — so
-> a name answering with more than one address (a round-robin record, a load
-> balancer, a dual-stack host) could once put the workspace on one machine while
+> a name answering with more than one address (a round-robin record, several A
+> records, a dual-stack host) could once put the workspace on one machine while
 > the agent-server or the cleanup landed on another. Nothing looked wrong: every
 > step succeeded against a valid host, and the cleanup then removed the wrong
 > machine's directory and reported success while the real one leaked.
@@ -367,6 +367,24 @@ back (see [Archive & restore](#archive-restore)).
 > step dials that one address. The address is recorded with the session, so the
 > cleanup reaches the same machine even after the daemon restarts.
 >
+> **This fixes DNS multiplicity, and only DNS multiplicity.** Read the next
+> paragraph before assuming it covers you.
+
+> **Still a known limitation: a load-balancer VIP is not pinned, and can still
+> split a session.** If `ssh.host` resolves to an address that is a **virtual IP in
+> front of several machines** — an L4/TCP load balancer, an AWS NLB, a
+> keepalived/IPVS pair, a Kubernetes service — then pinning the address changes
+> nothing, because *the address is not a machine identity*. The balancer picks a
+> backend **per TCP connection**, and af opens a separate connection for every
+> provision command, for the tunnel, and for the cleanup. Those can still land on
+> different machines, and the failure is the same one described above: the cleanup
+> removes the wrong machine's directory, reports success, and the real workspace
+> leaks.
+>
+> af cannot detect this — a VIP looks exactly like an ordinary address — so there is
+> no warning to go on. The workaround is the same as before: **point `ssh.host` at
+> one machine**, not at the balancer. Tracked in #3086, which stays open for it.
+
 > **Your host key configuration is unaffected**, which is the part worth knowing:
 > `ssh` is still given the **name** as its destination, so `known_hosts` is matched
 > and host **certificate** principals are checked exactly as before. The pin
@@ -374,6 +392,16 @@ back (see [Archive & restore](#archive-restore)).
 > itself — nothing new to install. An earlier attempt pinned the address as ssh's
 > destination and had to restore the name with `HostKeyAlias`; that rejected host
 > certificates on every non-default port, and was reverted (#3086).
+>
+> One genuine, if small, reduction comes with it: **`CheckHostIP` is switched off**.
+> OpenSSH disables it whenever a `ProxyCommand` is in use, and it defaulted to *on*
+> for OpenSSH 7.6–8.4 (upstream turned the default off in 8.5). On those clients a
+> pinned session no longer records or cross-checks the host key against the
+> **address** in `known_hosts`, only against the **name**. Verification against the
+> name — the guarantee that matters, and the one certificates rely on — is
+> unchanged, and af resolving the address itself and reusing that one address for
+> every step covers the drift `CheckHostIP` was watching for. It is a trade, not a
+> free win: ssh's IP cross-check for af's single-resolution guarantee.
 >
 > **What this changes for an existing `ssh.host`, deliberately:** a session is tied
 > to the machine it was created on for its whole life. Before, if that machine went

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -422,15 +422,26 @@ back (see [Archive & restore](#archive-restore)).
 > cannot look up still works. The pin is an improvement on connecting by name, so
 > when it cannot be applied af falls back rather than failing the session.
 >
-> **If your resolver and `ssh`'s disagree, af notices and gives up the pin.** af
-> resolves with Go's built-in resolver, which reads `/etc/hosts` and DNS; `ssh`
-> resolves with `getaddrinfo`, which follows `nsswitch.conf`. With a source Go does
-> not implement — LDAP, `sssd`, mDNS — both can succeed and return *different*
-> addresses, and af would then have pinned somewhere `ssh` would never have gone.
-> That fails host-key verification rather than connecting to the wrong host, so
-> nothing unverified is ever trusted; af retries **once without the pin**, which is
-> what it did before this existed, and logs that the session is unpinned. You do not
-> need to change anything — the note is here so the log line makes sense.
+> **Which resolver picks the address, and when it matters.** af resolves with Go's
+> built-in resolver, which reads `/etc/hosts` and DNS. `ssh` resolves with
+> `getaddrinfo`, which follows `nsswitch.conf` and so can also use LDAP, `sssd` or
+> mDNS. Once af pins, `ssh` does no resolving at all — the connection is made for
+> it — so every step of a session goes to the same place regardless.
+>
+> The one place this can bite is a `known_hosts` entry recorded **earlier**, by a
+> plain `ssh` or an older session, against whichever machine `getaddrinfo` picked.
+> If your resolvers select different machines *and* those machines have different
+> host keys, the pinned one presents a key that entry does not match and the session
+> fails to start, naming the host. Nothing runs on the wrong machine — verification
+> refuses it before authenticating. Point `ssh.host` at one machine if you hit this.
+>
+> **`accept-new` pins only once it knows the host.** On the very first connection to
+> a host there is no entry to check against, so `accept-new` would simply record
+> whatever key the pinned machine presented — and if that were the wrong machine,
+> the session would run there silently and the name would stay bound to it. af
+> therefore does not pin that first connection, and pins normally afterwards.
+> `insecure` verifies nothing, so it is never pinned. Both cases are logged, and
+> both keep the multi-address exposure this section describes.
 
 **Host-key verification is strict by default** (secure by default — an unverified
 host could MITM the connection and capture the bearer token). The operator can

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -375,8 +375,24 @@ back (see [Archive & restore](#archive-restore)).
 > destination and had to restore the name with `HostKeyAlias`; that rejected host
 > certificates on every non-default port, and was reverted (#3086).
 >
-> If af cannot resolve the name at create time it says so in the log and connects
-> by name, exactly as it did before — a host af cannot look up still works.
+> **What this changes for an existing `ssh.host`, deliberately:** a session is tied
+> to the machine it was created on for its whole life. Before, if that machine went
+> away mid-session, the next step would resolve the name again and might reach a
+> different one and appear to keep working — which is the bug, not a feature: the
+> workspace it needed was on the first machine. Now that step fails against the
+> machine holding the workspace, which is the honest answer. Choosing a machine
+> still tries each address the name answers with, so a host with one dead address
+> and one live one is picked correctly at create time.
+>
+> Nothing else about connecting changes: same `known_hosts` matching, same
+> certificate principals, same keys, same `ssh_config`-is-not-read rule, and no new
+> software to install. There is nothing to migrate — existing sessions created
+> before this keep working and are cleaned up by name exactly as they were.
+>
+> If af cannot resolve the name at create time, or cannot run itself as the relay,
+> it says so in the log and connects by name, exactly as it did before — a host af
+> cannot look up still works. The pin is an improvement on connecting by name, so
+> when it cannot be applied af falls back rather than failing the session.
 
 **Host-key verification is strict by default** (secure by default — an unverified
 host could MITM the connection and capture the bearer token). The operator can

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -355,20 +355,28 @@ back (see [Archive & restore](#archive-restore)).
 > yourself, and there your `ssh_config` and `known_hosts` are the whole authority.
 > See the sandbox section below.
 
-> **Known limitation: a `ssh.host` with several addresses can split a session.**
-> af runs a separate `ssh` for each step — the setup commands, the port-forward,
-> and the cleanup — and each one resolves the name independently. If the name
-> answers with more than one address (a round-robin record, a load balancer, a
-> dual-stack host), the workspace can end up on one machine while the agent-server
-> or the cleanup lands on another. Nothing looks wrong: every step succeeds against
-> a valid host, and the cleanup then removes the wrong machine's directory and
-> reports success while the real one leaks.
+> **A `ssh.host` with several addresses stays on one machine.** af runs a separate
+> `ssh` for each step — the setup commands, the port-forward, and the cleanup — so
+> a name answering with more than one address (a round-robin record, a load
+> balancer, a dual-stack host) could once put the workspace on one machine while
+> the agent-server or the cleanup landed on another. Nothing looked wrong: every
+> step succeeded against a valid host, and the cleanup then removed the wrong
+> machine's directory and reported success while the real one leaked.
 >
-> Point `ssh.host` at a single machine — a literal address, or a name with one
-> address — if that is a risk for your setup. Tracking issue: #3086. A previous fix
-> pinned one resolved address, but it had to identify the host by address, which
-> broke host **certificates** and removed ssh's own try-each-address fallback · it
-> was reverted rather than kept with those costs.
+> af now resolves `ssh.host` **once**, when the session is created, and every later
+> step dials that one address. The address is recorded with the session, so the
+> cleanup reaches the same machine even after the daemon restarts.
+>
+> **Your host key configuration is unaffected**, which is the part worth knowing:
+> `ssh` is still given the **name** as its destination, so `known_hosts` is matched
+> and host **certificate** principals are checked exactly as before. The pin
+> applies only to the TCP connection, through a `ProxyCommand` that runs `af`
+> itself — nothing new to install. An earlier attempt pinned the address as ssh's
+> destination and had to restore the name with `HostKeyAlias`; that rejected host
+> certificates on every non-default port, and was reverted (#3086).
+>
+> If af cannot resolve the name at create time it says so in the log and connects
+> by name, exactly as it did before — a host af cannot look up still works.
 
 **Host-key verification is strict by default** (secure by default — an unverified
 host could MITM the connection and capture the bearer token). The operator can
@@ -443,6 +451,47 @@ case commits real work, **archives** it (branch pushed to `origin`, remote
 sandbox reaped), then **restores** it (a fresh remote clones the branch back, the
 commit is present, the session is drivable) — the identical push/pull-branch
 flow, over ssh. It skips cleanly where Docker is unavailable.
+
+---
+
+## Sandbox backend
+
+`backend = "sandbox"` reaches the target through **your own** ssh invocation. The
+global `sandbox_ssh` key holds a free-form command line — whatever already works
+in your terminal, including a jump host, a `ProxyCommand`, a bastion, or any flag
+`backend = "ssh"` does not model — and af runs the same provision, tunnel, and
+cleanup steps over it. Your `ssh_config`, `known_hosts`, and host-key posture are
+the whole authority here; af adds none of its own. It is global-only and
+operator-owned, because af **executes** it on the daemon host (see
+[Configuration](configuration.md)).
+
+> **Known limitation: af cannot pin a `sandbox_ssh` target to one machine.**
+> af runs a separate invocation of your command for each step — the setup
+> commands, the port-forward, and the cleanup. If it reaches a name with several
+> addresses (a round-robin record, a load balancer, a dual-stack host), each
+> invocation resolves independently, so the workspace can end up on one machine
+> while the agent-server or the cleanup lands on another. Nothing looks wrong:
+> every step succeeds against a valid host, and the cleanup then removes the wrong
+> machine's directory and reports success while the real one leaks.
+>
+> `backend = "ssh"` no longer has this problem because af composes that command
+> and knows which token is the host. `sandbox_ssh` is **your** command, and af
+> cannot know which of its words is a hostname — an argument to `-o`, a jump-host
+> spec, a wrapper's own flag, or the target — so there is nothing it can safely
+> substitute. Guessing would silently rewrite the command you asked for.
+>
+> Two workarounds, both under your control:
+>
+> - **Point the command at a single machine** — a literal address, or a name with
+>   one address. This is the simplest fix and needs no other change.
+> - **Pin it yourself**, the same way af does for `backend = "ssh"`: keep the name
+>   as ssh's destination so `known_hosts` and certificate principals still match,
+>   and put the address in a `ProxyCommand` — for example
+>   `ssh -o ProxyCommand='nc 198.51.100.8 22' build-box.example.com`. Do not pin by
+>   making the address the destination: that forces a `HostKeyAlias`, and no alias
+>   value satisfies both a plain `[name]:port` entry and a certificate principal.
+>
+> Tracked in #3086, which is deliberately left open for this half.
 
 ---
 

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -421,6 +421,16 @@ back (see [Archive & restore](#archive-restore)).
 > it says so in the log and connects by name, exactly as it did before — a host af
 > cannot look up still works. The pin is an improvement on connecting by name, so
 > when it cannot be applied af falls back rather than failing the session.
+>
+> **If your resolver and `ssh`'s disagree, af notices and gives up the pin.** af
+> resolves with Go's built-in resolver, which reads `/etc/hosts` and DNS; `ssh`
+> resolves with `getaddrinfo`, which follows `nsswitch.conf`. With a source Go does
+> not implement — LDAP, `sssd`, mDNS — both can succeed and return *different*
+> addresses, and af would then have pinned somewhere `ssh` would never have gone.
+> That fails host-key verification rather than connecting to the wrong host, so
+> nothing unverified is ever trusted; af retries **once without the pin**, which is
+> what it did before this existed, and logs that the session is unpinned. You do not
+> need to change anything — the note is here so the log line makes sense.
 
 **Host-key verification is strict by default** (secure by default — an unverified
 host could MITM the connection and capture the bearer token). The operator can

--- a/integration/backend_archive_test.go
+++ b/integration/backend_archive_test.go
@@ -184,6 +184,10 @@ func TestSSHBackendArchiveRestore(t *testing.T) {
 	afBin := buildStaticBinary(t)
 	restore := session.SetSSHSelfBinaryForTest(afBin)
 	defer restore()
+	// And the binary af runs locally as its ssh ProxyCommand (#3086) — see the
+	// companion note in backend_ssh_test.go.
+	restoreRelay := session.SetSSHRelayBinaryForTest(afBin)
+	defer restoreRelay()
 	image := buildSSHDRoundTripImage(t)
 
 	repo := setupGitRepo(t)

--- a/integration/backend_ssh_test.go
+++ b/integration/backend_ssh_test.go
@@ -54,6 +54,13 @@ func TestSSHBackendRoundTrip(t *testing.T) {
 	afBin := buildStaticBinary(t)
 	restore := session.SetSSHSelfBinaryForTest(afBin)
 	defer restore()
+	// The SAME reason, for the binary af runs LOCALLY as its ssh ProxyCommand
+	// (#3086): the pin dials through `af ssh-relay`, and the test binary has no
+	// such subcommand — so without this the proxy never connects and every step
+	// dies on its 30s deadline. Production resolves both from os.Executable, which
+	// is af; a test has to say so.
+	restoreRelay := session.SetSSHRelayBinaryForTest(afBin)
+	defer restoreRelay()
 
 	image := buildSSHDRoundTripImage(t)
 

--- a/internal/sshrelay/sshrelay.go
+++ b/internal/sshrelay/sshrelay.go
@@ -1,0 +1,108 @@
+// Package sshrelay is the stdio↔TCP relay af hands to ssh(1) as a
+// ProxyCommand, so every step of a remote session dials ONE resolved address
+// (#3086).
+//
+// WHY A PROXYCOMMAND AND NOT AN ssh OPTION. A multi-address `ssh.host` can split
+// a session across machines: the workspace is created on host A while the clone,
+// the tunnel or the reap runs on host B, and the reap then removes B's directory,
+// reports success and leaves A's agent-server and workspace leaking silently. The
+// two previous attempts at fixing that both lost, and their measurements bound
+// what is left:
+//
+//   - Pinning the ADDRESS as ssh's destination forces `-o HostKeyAlias`, and no
+//     alias value is correct — a plain known_hosts entry on a non-default port is
+//     keyed `[name]:port` while a certificate principal is the bare `name`, and
+//     HostKeyAlias is one string (#3090, reverted by #3100).
+//   - A `ControlMaster` multiplex keeps the name, but a master is a PROCESS, and
+//     `restoreRuntimeCleanup` composes a teardown from PERSISTED data in a FRESH
+//     daemon, where no master exists and none can be adopted.
+//
+// A ProxyCommand pins BELOW ssh's naming layer. ssh's destination stays the NAME,
+// so ssh itself computes the known_hosts key and the certificate principal
+// exactly as it does today, and only the TCP dial is pinned. Measured against
+// OpenSSH_9.6p1 and a real sshd whose host key is certified for the principal
+// `pinned.invalid` on port 2299:
+//
+//	ProxyCommand pinning                -> cert ACCEPTED
+//	HostKeyAlias=[pinned.invalid]:2299  -> Host key verification failed
+//
+// Same sshd, same certificate. And because the pinned address travels in the
+// persisted cleanup handle rather than in a live process, a reap after a daemon
+// restart composes the same command.
+//
+// WHY af's OWN BINARY AND NOT nc/socat. An external binary is the same failure
+// class as an ssh option that is too new: it is a dependency af cannot guarantee,
+// and its absence breaks the whole backend rather than degrading. af is by
+// definition present, because af is the process composing the command.
+package sshrelay
+
+import (
+	"fmt"
+	"io"
+	"net"
+)
+
+// Subcommand is the hidden `af` subcommand that runs the relay.
+//
+// It lives HERE, in a leaf package, rather than in commands/: session composes
+// the ProxyCommand and commands registers the cobra command, session cannot
+// import commands (the import already runs the other way), and a duplicated
+// string literal in two packages is the drift class this repo keeps paying for —
+// a "mirrors the other one" comment is unenforced and false the moment either
+// side is edited (#2097). One constant cannot disagree with itself.
+const Subcommand = "ssh-relay"
+
+// closeWriter is *net.TCPConn's half-close. Named as an interface so the relay
+// can be driven over a pipe pair in a test without a real socket.
+type closeWriter interface{ CloseWrite() error }
+
+// Run dials host:port and shuttles bytes between that connection and in/out
+// until the remote closes.
+//
+// OUT IS THE SSH TRANSPORT STREAM. Every byte written to it is protocol, so a
+// single stray one — a log line, a banner, a usage dump, a fmt.Println — corrupts
+// the session rather than merely being noisy. Nothing in this function or in the
+// command that calls it may write to stdout except the copy below; diagnostics go
+// to stderr, and the error returned here is rendered there by the caller.
+//
+// HALF-CLOSE IS LOAD-BEARING, not tidiness. af streams its own `af` binary to the
+// remote over ssh's stdin (`cat > af`), and the remote `cat` finishes only when it
+// sees EOF. Closing the whole connection at that point would also tear down the
+// reply direction before the remote's answer arrived, and NOT closing the write
+// half at all hangs the copy forever — so the write half is shut down on stdin
+// EOF while reading continues.
+func Run(host, port string, in io.Reader, out io.Writer) error {
+	// JoinHostPort, never fmt.Sprintf("%s:%s"): an IPv6 literal needs brackets,
+	// and af pins literal addresses by construction — including the scoped
+	// `fe80::1%eth0` form, which JoinHostPort renders as `[fe80::1%eth0]:22` and
+	// net.Dial parses back.
+	addr := net.JoinHostPort(host, port)
+
+	// No dial deadline, deliberately. ssh applies none of its own to a
+	// ProxyCommand, so imposing one here would make af stricter than the plain
+	// `ssh` this replaces and could fail a slow link that works by hand. Every
+	// caller already bounds it from outside: the provision steps run under a
+	// context deadline whose cancel SIGKILLs the whole process group (this relay
+	// included), and the long-lived tunnel child is bounded by the readiness probe
+	// that fails the provision and kills the same group.
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("af %s: dialling the pinned address %s failed: %w", Subcommand, addr, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// stdin → remote. NOT waited on: once the remote has closed, a read on stdin
+	// can block forever (ssh may hold the pipe open), and a relay that will not
+	// exit wedges the step that spawned it.
+	go func() {
+		_, _ = io.Copy(conn, in)
+		if cw, ok := conn.(closeWriter); ok {
+			_ = cw.CloseWrite()
+		}
+	}()
+
+	// remote → stdout. This returning IS the exit condition: it means the far side
+	// closed, which is exactly when ssh expects its proxy to go away.
+	_, err = io.Copy(out, conn)
+	return err
+}

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -397,7 +397,7 @@
         "pointer": "commands/docs_gen.go:29 (hidden); commands/docs_gen.go:61 (--plugin-root); commands/agentservercmd.go:34; commands/legacy_tmuxguardcmd.go"
       },
       "verdict": "deliberate",
-      "notes": "af gen-docs is Hidden:true (CI docs generation). af agent-server is daemon-consumed plumbing — its own Long says it 'exists to be consumed by a daemon rather than opened by a person' — and af --daemon is a hidden flag. af hook-guard-tmux is also hidden: #2608 retains the removed command name only as an exit-0 compatibility tombstone for already-running pre-#2563 Codex hooks; it performs no guard or user operation. None are user capabilities. af gen-docs --plugin-root (#2172) regenerates the committed per-agent plugin artifacts from the canonical af usage text; like the rest of gen-docs it is build tooling, run by scripts/gen-docs.sh and the CI drift gate. The TUI and web will deliberately never expose these internals — regenerating a repo's committed build artifacts and legacy hook compatibility are not things either surface should offer — so this is a recorded decision, not a parity gap to re-report."
+      "notes": "af gen-docs is Hidden:true (CI docs generation). af agent-server is daemon-consumed plumbing — its own Long says it 'exists to be consumed by a daemon rather than opened by a person' — and af --daemon is a hidden flag. af hook-guard-tmux is also hidden: #2608 retains the removed command name only as an exit-0 compatibility tombstone for already-running pre-#2563 Codex hooks; it performs no guard or user operation. af ssh-relay is hidden for the same class of reason (#3086): it is the stdio\u2194TCP relay af composes into its OWN ssh invocations as a ProxyCommand, so every step of a remote session dials the one address the session was pinned to. Its stdout IS the ssh transport stream while it runs, so it is af talking to af and not something a person invokes \u2014 running it by hand does nothing useful. None are user capabilities. af gen-docs --plugin-root (#2172) regenerates the committed per-agent plugin artifacts from the canonical af usage text; like the rest of gen-docs it is build tooling, run by scripts/gen-docs.sh and the CI drift gate. The TUI and web will deliberately never expose these internals — regenerating a repo's committed build artifacts and legacy hook compatibility are not things either surface should offer — so this is a recorded decision, not a parity gap to re-report."
     },
     {
       "id": "project.add",
@@ -1464,6 +1464,7 @@
       "af sessions tabs reorder": "session.tab.reorder",
       "af sessions watch": "session.watch",
       "af sessions whoami": "session.whoami",
+      "af ssh-relay": "meta.internal",
       "af tasks add": "task.add",
       "af tasks get": "task.get",
       "af tasks list": "task.list",
@@ -1746,6 +1747,7 @@
       "af sessions watch --interval": "session.watch",
       "af sessions watch --timeout": "session.watch",
       "af sessions whoami --help": "meta.discovery",
+      "af ssh-relay --help": "meta.internal",
       "af tasks --help": "meta.discovery",
       "af tasks --json": "cli.json-envelope",
       "af tasks --repo": "project.switch",

--- a/session/backend_ssh.go
+++ b/session/backend_ssh.go
@@ -156,7 +156,26 @@ func (sshRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 	if err := verifySSHIdentityFile(sshCfg); err != nil {
 		return ProvisionResult{}, err
 	}
-	sshCmd, err := sshCommandForConfig(sshCfg, cfg.SSHHostKeyVerification)
+	// ONE resolution, here, feeding EVERY later step. Each provision command, the
+	// `ssh -L` tunnel and the reap are separate ssh invocations that would each
+	// resolve `ssh.host` independently, so a name with several addresses could put
+	// the workspace on one machine and the agent-server, tunnel or reap on another —
+	// and the reap would then remove the wrong directory, report success, and leave
+	// the real workspace leaking with nothing pointing at it (#3086). Pinning it
+	// into the composed command means all of them ride the same address, because
+	// they all ride this one string.
+	//
+	// An empty result means af could not settle on an address and this session
+	// behaves exactly as it did before the pin — see resolvePinnedSSHDialAddress.
+	pinHost, pinPort, err := resolveSSHHostPort(sshCfg.Host, sshCfg.Port)
+	if err != nil {
+		return ProvisionResult{}, err
+	}
+	if pinPort == 0 {
+		pinPort = sshDefaultPort
+	}
+	dialAddr := resolvePinnedSSHDialAddress(pinHost, pinPort)
+	sshCmd, err := sshCommandPinnedTo(sshCfg, cfg.SSHHostKeyVerification, dialAddr)
 	if err != nil {
 		return ProvisionResult{}, err
 	}
@@ -177,9 +196,14 @@ func (sshRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 		remoteAgentBackend: remoteAgentBackend{reap: res.Teardown},
 		provisioner:        p,
 		cleanup: &SSHRuntimeCleanupData{
-			Config:              sshCfg,
-			SessionDir:          p.sessionDir,
-			RemotePID:           p.remotePID,
+			Config:     sshCfg,
+			SessionDir: p.sessionDir,
+			RemotePID:  p.remotePID,
+			// The one fact no re-resolution can recover: which machine this
+			// session's workspace is actually on. A reap after a daemon restart
+			// composes its command from this, in a fresh process, which is the
+			// constraint that ruled out a ControlMaster multiplex (#3086).
+			DialAddress:         dialAddr,
 			HostKeyVerification: cfg.SSHHostKeyVerification,
 		},
 	}

--- a/session/backend_ssh.go
+++ b/session/backend_ssh.go
@@ -174,7 +174,7 @@ func (sshRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 	if pinPort == 0 {
 		pinPort = sshDefaultPort
 	}
-	dialAddr := resolvePinnedSSHDialAddress(pinHost, pinPort)
+	dialAddr := pinForProvision(pinHost, pinPort)
 	sshCmd, err := sshCommandPinnedTo(sshCfg, cfg.SSHHostKeyVerification, dialAddr)
 	if err != nil {
 		return ProvisionResult{}, err

--- a/session/backend_ssh.go
+++ b/session/backend_ssh.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
 )
 
 // The SSH remote-machine runtime (#1592 Phase 4 PR5) — the first-class remote
@@ -184,8 +185,34 @@ func (sshRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 	if err := prepareSSHHostKeyStore(sshCfg, cfg.SSHHostKeyVerification); err != nil {
 		return ProvisionResult{}, err
 	}
-	p := newSSHSandboxProvisioner(spec, sshCmd, afBin, config.ResolveProgram(&cfg.Config, spec.Program))
+	program := config.ResolveProgram(&cfg.Config, spec.Program)
+	p := newSSHSandboxProvisioner(spec, sshCmd, afBin, program)
 	res, err := p.provision()
+	// THE PIN IS NON-FATAL. af resolves with Go's pure resolver and ssh resolves
+	// with getaddrinfo, so an nsswitch source Go does not implement (LDAP, sssd,
+	// mDNS) can make both succeed with DIFFERENT addresses — and af would then have
+	// pinned somewhere ssh would never have gone. That fails CLOSED on host-key
+	// verification, so nothing wrong is trusted; what it costs is the whole backend,
+	// for exactly the users whose resolver disagrees. One unpinned retry gives them
+	// back the behaviour af had before it pinned anything.
+	//
+	// Guarded on an EMPTY session dir, which proves the failed attempt created no
+	// remote state: re-provisioning over something already created is the leak this
+	// issue exists to prevent. See shouldRetryProvisionUnpinned.
+	if err != nil && shouldRetryProvisionUnpinned(dialAddr, p.sessionDir, err) {
+		log.WarningLog.Printf("backend=ssh: the pinned connection to %s failed host-key verification, which "+
+			"usually means af resolved %q differently from ssh (af uses Go's resolver, ssh uses getaddrinfo/NSS); "+
+			"retrying once WITHOUT the pin, so this session is not protected against a multi-address host "+
+			"splitting it across machines (#3086)", dialAddr, sshCfg.Host)
+		_ = p.reap() // a no-op while sessionDir is empty; called so nothing is assumed
+		dialAddr = ""
+		unpinned, cmdErr := sshCommandPinnedTo(sshCfg, cfg.SSHHostKeyVerification, "")
+		if cmdErr != nil {
+			return ProvisionResult{}, cmdErr
+		}
+		p = newSSHSandboxProvisioner(spec, unpinned, afBin, program)
+		res, err = p.provision()
+	}
 	if err != nil {
 		// Best-effort reap whatever the failed provision left behind. Preserve any
 		// cleanup failure in the returned error: no Instance exists yet to own a

--- a/session/backend_ssh.go
+++ b/session/backend_ssh.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
-	"github.com/sachiniyer/agent-factory/log"
 )
 
 // The SSH remote-machine runtime (#1592 Phase 4 PR5) — the first-class remote
@@ -175,7 +174,7 @@ func (sshRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 	if pinPort == 0 {
 		pinPort = sshDefaultPort
 	}
-	dialAddr := pinForProvision(pinHost, pinPort)
+	dialAddr := pinForProvision(sshCfg, pinHost, pinPort, cfg.SSHHostKeyVerification)
 	sshCmd, err := sshCommandPinnedTo(sshCfg, cfg.SSHHostKeyVerification, dialAddr)
 	if err != nil {
 		return ProvisionResult{}, err
@@ -188,31 +187,6 @@ func (sshRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 	program := config.ResolveProgram(&cfg.Config, spec.Program)
 	p := newSSHSandboxProvisioner(spec, sshCmd, afBin, program)
 	res, err := p.provision()
-	// THE PIN IS NON-FATAL. af resolves with Go's pure resolver and ssh resolves
-	// with getaddrinfo, so an nsswitch source Go does not implement (LDAP, sssd,
-	// mDNS) can make both succeed with DIFFERENT addresses — and af would then have
-	// pinned somewhere ssh would never have gone. That fails CLOSED on host-key
-	// verification, so nothing wrong is trusted; what it costs is the whole backend,
-	// for exactly the users whose resolver disagrees. One unpinned retry gives them
-	// back the behaviour af had before it pinned anything.
-	//
-	// Guarded on an EMPTY session dir, which proves the failed attempt created no
-	// remote state: re-provisioning over something already created is the leak this
-	// issue exists to prevent. See shouldRetryProvisionUnpinned.
-	if err != nil && shouldRetryProvisionUnpinned(dialAddr, p.sessionDir, err) {
-		log.WarningLog.Printf("backend=ssh: the pinned connection to %s failed host-key verification, which "+
-			"usually means af resolved %q differently from ssh (af uses Go's resolver, ssh uses getaddrinfo/NSS); "+
-			"retrying once WITHOUT the pin, so this session is not protected against a multi-address host "+
-			"splitting it across machines (#3086)", dialAddr, sshCfg.Host)
-		_ = p.reap() // a no-op while sessionDir is empty; called so nothing is assumed
-		dialAddr = ""
-		unpinned, cmdErr := sshCommandPinnedTo(sshCfg, cfg.SSHHostKeyVerification, "")
-		if cmdErr != nil {
-			return ProvisionResult{}, cmdErr
-		}
-		p = newSSHSandboxProvisioner(spec, unpinned, afBin, program)
-		res, err = p.provision()
-	}
 	if err != nil {
 		// Best-effort reap whatever the failed provision left behind. Preserve any
 		// cleanup failure in the returned error: no Instance exists yet to own a

--- a/session/backend_ssh_hostkey_test.go
+++ b/session/backend_ssh_hostkey_test.go
@@ -22,7 +22,7 @@ import (
 
 func sshCmdFor(t *testing.T, cfg config.SSHConfig, posture string) string {
 	t.Helper()
-	cmd, err := sshCommandForConfig(cfg, posture)
+	cmd, err := sshCommandPinnedTo(cfg, posture, "")
 	require.NoError(t, err)
 	return cmd
 }

--- a/session/runtime_cleanup.go
+++ b/session/runtime_cleanup.go
@@ -240,7 +240,8 @@ func restoreRuntimeCleanup(title, backendType string, data *RuntimeCleanupData) 
 		// The accept-new store is prepared inside each ATTEMPT, never here: this
 		// function composes a closure while persisted instances are being loaded,
 		// and a transiently unwritable AF home must not be captured as a permanently
-		// dead cleanup. sshCommandForConfig above is pure for the same reason.
+		// dead cleanup. sshCommandPinnedTo above touches no filesystem state for the
+		// same reason.
 		teardown := sshTeardownWithStore(p.reap, legacyCfg, data.SSH.HostKeyVerification)
 		if strings.TrimSpace(data.SSH.HostKeyVerification) == "" {
 			// The ONLY way an empty posture reaches here is a record written before

--- a/session/runtime_cleanup.go
+++ b/session/runtime_cleanup.go
@@ -53,18 +53,22 @@ type SSHRuntimeCleanupData struct {
 	Config     config.SSHConfig `json:"config"`
 	SessionDir string           `json:"session_dir"`
 	RemotePID  string           `json:"remote_pid,omitempty"`
-	// DialAddress is the literal address a session was provisioned on, recorded
-	// ONLY by the short-lived pinning in #3090 and never written again (#3092
-	// reverted it, because dialling an address forces a HostKeyAlias and no alias
-	// value satisfies both a plain [host]:port entry and a certificate principal).
+	// DialAddress is the literal address this session was provisioned on: the one
+	// thing the record knows and no re-resolution can recover. Without it, reaping a
+	// multi-address name could reach a DIFFERENT machine, find nothing, report
+	// success and retire the only tombstone — a permanent, silent leak (#3086).
 	//
-	// It is still DECODED, and still honoured on teardown. Dropping the field would
-	// silently discard the one thing such a record knows and nothing else does: the
-	// exact machine its workspace is on. Re-resolving a multi-address name could
-	// then reap a DIFFERENT machine, find nothing, report success and retire the
-	// only tombstone — a permanent leak. Honouring it can at worst fail
-	// verification for a certificate host on a non-default port, which RETAINS and
-	// retries. Retained-and-retried beats silently-wrong-and-retired.
+	// HOW IT IS APPLIED CHANGED, WHAT IT MEANS DID NOT. #3090 wrote this field and
+	// dialled it as ssh's destination, which forced a `-o HostKeyAlias` and rejected
+	// host certificates on every non-default port; #3100 reverted the writing but
+	// kept honouring it. It is now applied as a `-o ProxyCommand` that pins only the
+	// TCP dial while ssh's destination stays the configured NAME, so the certificate
+	// conflict is gone and there is nothing left to accept as a cost.
+	//
+	// So a record from EITHER era reads the same way, and both reap correctly under
+	// the current mechanism. An empty value — a record written before #3090, or
+	// between #3100 and this change, or one whose provision could not settle on an
+	// address — dials the name, exactly as it always did.
 	DialAddress         string `json:"dial_address,omitempty"`
 	HostKeyVerification string `json:"host_key_verification,omitempty"`
 }
@@ -222,9 +226,11 @@ func restoreRuntimeCleanup(title, backendType string, data *RuntimeCleanupData) 
 		// ssh.* settings, not a command — and refusing to reap it because the
 		// transport changed underneath would leak the workspace it exists to
 		// remove (the #3044 lesson).
-		// A handle written by #3090 carries the address its session actually ran on.
-		// Reach THAT machine rather than re-resolving the name — see DialAddress.
-		sshCmd, cmdErr := sshCommandForPinnedRecord(legacyCfg, data.SSH.HostKeyVerification, data.SSH.DialAddress)
+		// A handle carrying a dial address knows the machine its session actually ran
+		// on. Reach THAT machine rather than re-resolving the name — see DialAddress.
+		// An empty one composes the ordinary name-based command, so a record from
+		// before any of this reaps exactly as it always did.
+		sshCmd, cmdErr := sshCommandPinnedTo(legacyCfg, data.SSH.HostKeyVerification, data.SSH.DialAddress)
 		if cmdErr != nil {
 			return nil, nil, fmt.Errorf("ssh cleanup handle has an unusable address: %w", cmdErr)
 		}

--- a/session/ssh_command.go
+++ b/session/ssh_command.go
@@ -188,7 +188,7 @@ func sshCommandPinnedTo(cfg config.SSHConfig, posture, dialAddr string) (string,
 		// name, and one string cannot be both.
 		//
 		// So the connection stays NAME-based: ssh resolves it, which is what keeps
-		// certificates valid — and when af pins a session to one machine it does so
+		// certificates valid — and when af pins a session to one address it does so
 		// with the ProxyCommand below, which leaves this destination alone.
 	}
 	// The pin, when there is one. A ProxyCommand replaces ssh's TCP connect, so the
@@ -354,7 +354,7 @@ func sshPinnedProxyCommand(dialAddr string, port int) (string, error) {
 	relay, err := sshRelayBinary()
 	if err != nil {
 		return "", fmt.Errorf("backend=ssh: cannot locate the af binary to relay this session's pinned "+
-			"connection to %s (af runs itself as ssh's ProxyCommand so every step reaches the one machine "+
+			"connection to %s (af runs itself as ssh's ProxyCommand so every step dials the one address "+
 			"the session was provisioned on): %w", dialAddr, err)
 	}
 	inner := shellQuoteSandbox(relay) +

--- a/session/ssh_command.go
+++ b/session/ssh_command.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/sshrelay"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
@@ -68,11 +69,18 @@ const sshNoConfigFile = "none"
 // sshCommandForConfig builds the ssh invocation for a repo's ssh.* settings and
 // the operator's host-key posture.
 //
-// It is PURE: it composes a string and touches nothing. Callers that need the
-// accept-new store to exist on disk call prepareSSHHostKeyStore separately, at
-// the point they are about to run the command — restoreRuntimeCleanup composes a
-// teardown during storage load and must not do I/O there (a transiently
-// unwritable AF home would otherwise be captured as a permanently dead closure).
+// IT TOUCHES NO FILESYSTEM STATE, which is what lets restoreRuntimeCleanup call
+// it while persisted handles are loading. Callers that need the accept-new store
+// to exist on disk call prepareSSHHostKeyStore separately, at the point they are
+// about to run the command — a teardown composed during storage load must not do
+// I/O there, or a transiently unwritable AF home is captured as a permanently
+// dead closure.
+//
+// A PINNED command reads one thing: os.Executable, for the relay path (see
+// sshPinnedProxyCommand). That is deliberately inside the boundary above rather
+// than an exception to it — it names the running binary, not a path under AF home,
+// so there is no transient failure for a closure to capture. Reading it fresh on
+// every composition is also what keeps a teardown correct across an upgrade.
 //
 // WHAT IS PRESERVED, option by option:
 //
@@ -93,9 +101,29 @@ const sshNoConfigFile = "none"
 // dialed a pinned literal address and restored the name with `-o HostKeyAlias`
 // (#3086); that rejected host certificates on every non-default port and removed
 // ssh's own multi-address fallback, and no alias value fixes both — see the block
-// on the NO HostKeyAlias line below. The one exception is a teardown for a record
-// that was already provisioned under that pinning, in sshCommandForPinnedRecord.
+// on the NO HostKeyAlias line below. Pinning to one machine is done BELOW the
+// naming layer instead, with a ProxyCommand — see sshCommandPinnedTo.
 func sshCommandForConfig(cfg config.SSHConfig, posture string) (string, error) {
+	return sshCommandPinnedTo(cfg, posture, "")
+}
+
+// sshCommandPinnedTo is sshCommandForConfig with the TCP dial pinned to one
+// address, which is how a session stops splitting across a multi-address host
+// (#3086).
+//
+// The destination stays the configured NAME whether or not an address is pinned —
+// the pin travels in `-o ProxyCommand`, which decides only where the socket goes.
+// So ssh computes the known_hosts key and the certificate principal from the name
+// exactly as it does unpinned, and constraint 2 of #3086 ("do not identify the
+// host by address") is satisfied by construction rather than by correction. See
+// internal/sshrelay for the measurement against a real certified sshd.
+//
+// AN EMPTY dialAddr COMPOSES THE ORDINARY NAME-BASED COMMAND, which is what every
+// caller that has no address wants: a persisted cleanup handle written before any
+// of this, and a create whose one-off resolution could not settle on an address.
+// A teardown that refused there would leak the workspace it exists to remove (the
+// #3044 lesson).
+func sshCommandPinnedTo(cfg config.SSHConfig, posture, dialAddr string) (string, error) {
 	host, port, err := resolveSSHHostPort(cfg.Host, cfg.Port)
 	if err != nil {
 		return "", err
@@ -165,10 +193,18 @@ func sshCommandForConfig(cfg config.SSHConfig, posture string) (string, error) {
 		// verbatim. Plain entries want the bracketed form, certificates want the bare
 		// name, and one string cannot be both.
 		//
-		// So the connection stays NAME-based: ssh resolves it, which also keeps the
-		// dialer's try-each-address fallback that pinning removed. The split-session
-		// risk is real and unfixed — #3086 tracks it, with this result recorded so the
-		// approach is not tried again.
+		// So the connection stays NAME-based: ssh resolves it, which is what keeps
+		// certificates valid — and when af pins a session to one machine it does so
+		// with the ProxyCommand below, which leaves this destination alone.
+	}
+	// The pin, when there is one. A ProxyCommand replaces only ssh's TCP connect,
+	// so everything above — including how the host is IDENTIFIED — is untouched.
+	if pinned := strings.TrimSpace(dialAddr); pinned != "" {
+		proxy, proxyErr := sshPinnedProxyCommand(pinned, port)
+		if proxyErr != nil {
+			return "", proxyErr
+		}
+		parts = append(parts, "-o", proxy)
 	}
 	if identity := strings.TrimSpace(cfg.IdentityFile); identity != "" {
 		// Composition stays FILESYSTEM-PURE — the readability check lives in
@@ -258,50 +294,63 @@ func verifySSHIdentityFile(cfg config.SSHConfig) error {
 	return f.Close()
 }
 
-// sshCommandForPinnedRecord composes a TEARDOWN command for a persisted handle
-// that recorded a literal dial address (#3090), which #3092 stopped writing.
+// sshPinnedProxyCommand builds the `-o ProxyCommand=…` that makes ssh's TCP
+// connect land on ONE address while ssh's destination stays the configured name.
 //
-// Such a record knows something no re-resolution can recover: the exact machine
-// its workspace is on. So it dials that address, and restores the name as the
-// host-key lookup key with HostKeyAlias — the pairing #3090 measured, and the one
-// #3092 removed from the CREATE path because no alias value satisfies both a
-// plain [host]:port entry and a certificate principal.
+// The relay is af's OWN binary. `nc`/`socat` would be the same failure class as an
+// ssh option that is too new — a dependency af cannot guarantee, whose absence
+// breaks the whole backend rather than degrading — while af is present by
+// definition, since af is the process composing this command. It is resolved
+// fresh rather than persisted, so a daemon that restarted into an upgraded binary
+// names the one it is actually running.
 //
-// That conflict is accepted HERE and nowhere else, because the failure modes are
-// not symmetric. A certificate host on a non-default port fails verification, so
-// the reap fails and the record is RETAINED and retried — visible, recoverable.
-// Re-resolving a multi-address name instead can reach a different machine, remove
-// nothing, report success and retire the only tombstone — silent, permanent.
+// A FAILURE HERE IS RETURNED, not swallowed, and that is the opposite of the
+// empty-dialAddr case above. Reaching this function means a session IS pinned to a
+// machine — on the teardown path, a record that knows the exact host its workspace
+// is on. Quietly composing a name-based command there could reap a DIFFERENT
+// machine, find nothing, report success and retire the only tombstone: silent and
+// permanent. The error instead reaches restoreRuntimeCleanup, which classifies the
+// handle as unavailable, so the record is RETAINED and retried. Retained-and-
+// retried beats silently-wrong-and-retired.
 //
-// An empty address (every record written before #3090 and after #3092) takes the
-// ordinary name-based command, unchanged.
-func sshCommandForPinnedRecord(cfg config.SSHConfig, posture, dialAddr string) (string, error) {
-	base, err := sshCommandForConfig(cfg, posture)
+// TWO LAYERS OF QUOTING, because the string passes through two shells, and NEITHER
+// is optional:
+//
+//   - ssh runs a ProxyCommand as `/bin/sh -c <value>`, so the relay path is
+//     shell-quoted INSIDE the value — an AF home with a space would otherwise
+//     split into a command and a stray argument.
+//   - af runs the whole ssh invocation as `sh -c '<sshCmd> "$@"'`, so the value is
+//     shell-quoted AGAIN for that outer shell, which is what keeps it one argv
+//     element on the way to ssh.
+//
+// AND A THIRD ESCAPE THAT IS NOT QUOTING AT ALL. ssh percent-expands a
+// ProxyCommand before running it, so a literal `%` in the relay path or in a
+// zoned IPv6 address (`fe80::1%eth0`) is read as a token. Measured on
+// OpenSSH_9.6p1: an unescaped `%d` aborts with `vdollar_percent_expand: unknown
+// key %d` and the connection never starts, while `%%` yields a literal `%`. The
+// `%%` case is in percent_expand at the 7.6 floor, so the escape costs no version.
+//
+// NO `%h`/`%p` TOKENS, deliberately: they expand to the values ssh is dialling,
+// which is the name — and the entire point is that the socket goes somewhere the
+// name does not necessarily lead.
+func sshPinnedProxyCommand(dialAddr string, port int) (string, error) {
+	relay, err := sshRelayBinary()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("backend=ssh: cannot locate the af binary to relay this session's pinned "+
+			"connection to %s (af runs itself as ssh's ProxyCommand so every step reaches the one machine "+
+			"the session was provisioned on): %w", dialAddr, err)
 	}
-	pinned := strings.TrimSpace(dialAddr)
-	if pinned == "" {
-		return base, nil
-	}
-	host, port, err := resolveSSHHostPort(cfg.Host, cfg.Port)
-	if err != nil {
-		return "", err
-	}
-	if port == 0 {
-		port = sshDefaultPort
-	}
-	// The destination is the LAST token of the composed command; swap it for the
-	// recorded address and add the alias that keeps known_hosts keyed by name.
-	suffix := " " + shellQuoteSandbox(host)
-	if !strings.HasSuffix(base, suffix) {
-		// The composer changed shape underneath this; dial by name rather than
-		// guess, since a wrong destination on a teardown is the whole hazard.
-		return base, nil
-	}
-	return strings.TrimSuffix(base, suffix) +
-		" -o HostKeyAlias=" + shellQuoteSandbox(knownHostsLookupName(host, port)) +
-		" " + shellQuoteSandbox(pinned), nil
+	inner := shellQuoteSandbox(relay) +
+		" " + sshrelay.Subcommand +
+		" " + shellQuoteSandbox(dialAddr) +
+		" " + strconv.Itoa(port)
+	return "ProxyCommand=" + shellQuoteSandbox(escapeSSHPercent(inner)), nil
+}
+
+// escapeSSHPercent doubles every `%` so ssh's percent expansion yields the literal
+// string back. See sshPinnedProxyCommand for the measurement.
+func escapeSSHPercent(s string) string {
+	return strings.ReplaceAll(s, "%", "%%")
 }
 
 // sshHostKeyOptions maps ssh_host_key_verification onto the ssh binary's own

--- a/session/ssh_command.go
+++ b/session/ssh_command.go
@@ -66,8 +66,16 @@ import (
 // DECIDES, not by which ssh client runs.
 const sshNoConfigFile = "none"
 
-// sshCommandForConfig builds the ssh invocation for a repo's ssh.* settings and
-// the operator's host-key posture.
+// sshCommandPinnedTo builds the ssh invocation for a repo's ssh.* settings and the
+// operator's host-key posture, with the TCP dial pinned to one resolved address.
+//
+// THE ONE COMPOSER. Both the create path and the persisted-handle restore path
+// build through here, because a divergence between those two is how a legacy
+// handle stops being reapable (#3044) — and it is why an empty dialAddr composes
+// the ordinary name-based command rather than being a separate function. Every
+// caller with no address to pin wants exactly that: a cleanup handle written
+// before any of this, and a create whose one-off resolution could not settle. A
+// teardown that refused there would leak the workspace it exists to remove.
 //
 // IT TOUCHES NO FILESYSTEM STATE, which is what lets restoreRuntimeCleanup call
 // it while persisted handles are loading. Callers that need the accept-new store
@@ -97,32 +105,18 @@ const sshNoConfigFile = "none"
 //     SEPARATE create-path step for the same reason prepareSSHHostKeyStore is.
 //   - Host keys: the configured posture, mapped below.
 //
-// THE TARGET IS THE CONFIGURED NAME, never an address af resolved first. #3061
-// dialed a pinned literal address and restored the name with `-o HostKeyAlias`
-// (#3086); that rejected host certificates on every non-default port and removed
-// ssh's own multi-address fallback, and no alias value fixes both — see the block
-// on the NO HostKeyAlias line below. Pinning to one machine is done BELOW the
-// naming layer instead, with a ProxyCommand — see sshCommandPinnedTo.
-func sshCommandForConfig(cfg config.SSHConfig, posture string) (string, error) {
-	return sshCommandPinnedTo(cfg, posture, "")
-}
-
-// sshCommandPinnedTo is sshCommandForConfig with the TCP dial pinned to one
-// address, which is how a session stops splitting across a multi-address host
-// (#3086).
+// THE TARGET IS THE CONFIGURED NAME, never an address af resolved first, PINNED OR
+// NOT. #3061 dialed a pinned literal address and restored the name with `-o
+// HostKeyAlias` (#3086); that rejected host certificates on every non-default port
+// and removed ssh's own multi-address fallback, and no alias value fixes both —
+// see the block on the NO HostKeyAlias line below.
 //
-// The destination stays the configured NAME whether or not an address is pinned —
-// the pin travels in `-o ProxyCommand`, which decides only where the socket goes.
-// So ssh computes the known_hosts key and the certificate principal from the name
-// exactly as it does unpinned, and constraint 2 of #3086 ("do not identify the
-// host by address") is satisfied by construction rather than by correction. See
-// internal/sshrelay for the measurement against a real certified sshd.
-//
-// AN EMPTY dialAddr COMPOSES THE ORDINARY NAME-BASED COMMAND, which is what every
-// caller that has no address wants: a persisted cleanup handle written before any
-// of this, and a create whose one-off resolution could not settle on an address.
-// A teardown that refused there would leak the workspace it exists to remove (the
-// #3044 lesson).
+// So the pin goes BELOW ssh's naming layer, in `-o ProxyCommand`, which decides
+// only where the socket goes. ssh computes the known_hosts key and the certificate
+// principal from the name exactly as it does unpinned, and constraint 2 of #3086
+// ("do not identify the host by address") is satisfied by construction rather than
+// by correction. See internal/sshrelay for the measurement against a real
+// certified sshd, and sshPinnedProxyCommand for what the option carries.
 func sshCommandPinnedTo(cfg config.SSHConfig, posture, dialAddr string) (string, error) {
 	host, port, err := resolveSSHHostPort(cfg.Host, cfg.Port)
 	if err != nil {

--- a/session/ssh_command.go
+++ b/session/ssh_command.go
@@ -191,8 +191,31 @@ func sshCommandPinnedTo(cfg config.SSHConfig, posture, dialAddr string) (string,
 		// certificates valid — and when af pins a session to one machine it does so
 		// with the ProxyCommand below, which leaves this destination alone.
 	}
-	// The pin, when there is one. A ProxyCommand replaces only ssh's TCP connect,
-	// so everything above — including how the host is IDENTIFIED — is untouched.
+	// The pin, when there is one. A ProxyCommand replaces ssh's TCP connect, so the
+	// destination above stays the NAME and the known_hosts key and certificate
+	// principal are computed from it exactly as they are unpinned.
+	//
+	// IT IS NOT ENTIRELY FREE, and an earlier version of this comment claimed it was
+	// ("how the host is IDENTIFIED is untouched"), which was false. OpenSSH turns
+	// CheckHostIP OFF whenever a ProxyCommand is set — sshconnect.c, unconditionally:
+	//
+	//	if (options.check_host_ip && (local ||
+	//	    strcmp(hostname, ip) == 0 || options.proxy_command != NULL))
+	//		options.check_host_ip = 0;
+	//
+	// and it DEFAULTED ON for 7.6-8.4, which is exactly the range this backend's
+	// floor commits to (readconf.c sets it to 1 at V_7_6_P1/V_8_2_P1/V_8_4_P1 and to
+	// 0 from V_8_5_P1, where upstream turned the default off). So on those clients a
+	// pinned session loses the secondary check of the host key against the ADDRESS.
+	//
+	// ACCEPTED DELIBERATELY, and stated as a trade rather than a nil cost. What
+	// CheckHostIP watches for is the address behind a name drifting between
+	// connections — which is the very thing af now settles once and reuses for every
+	// step, so the guarantee is replaced rather than dropped. Verification against
+	// the NAME, which is what certificates rest on, is untouched. ProxyUseFdpass
+	// does NOT recover it and was checked rather than assumed: it clears the version
+	// bar (present at V_7_6_P1) but is reached only INSIDE the branch where
+	// proxy_command is set, and the disable above keys on precisely that.
 	if pinned := strings.TrimSpace(dialAddr); pinned != "" {
 		proxy, proxyErr := sshPinnedProxyCommand(pinned, port)
 		if proxyErr != nil {

--- a/session/ssh_dial_pin.go
+++ b/session/ssh_dial_pin.go
@@ -1,0 +1,92 @@
+package session
+
+import (
+	"net"
+	"os"
+	"strconv"
+
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// Resolving `ssh.host` to ONE address, once, so every later step of the session
+// reaches the same machine (#3086).
+//
+// See internal/sshrelay for why the address is applied as a ProxyCommand rather
+// than as ssh's destination, and what the two previous attempts measured.
+
+// sshRelayBinary resolves the `af` binary af runs LOCALLY as its ProxyCommand
+// relay.
+//
+// SEPARATE FROM sshSelfBinary ON PURPOSE, even though production sets both from
+// os.Executable. They are different roles: sshSelfBinary is the binary STREAMED
+// ONTO THE REMOTE and must match the remote's architecture, this one is EXECUTED
+// ON THE DAEMON HOST and must match the daemon's. One variable serving both would
+// break the relay the first time someone points the remote one at a
+// cross-compiled build.
+//
+// It is resolved FRESH on every composition and never persisted. A daemon that
+// restarted into an upgraded binary composes a teardown naming the binary it is
+// actually running, which a path recorded at create time would not.
+var sshRelayBinary = os.Executable
+
+// SetSSHRelayBinaryForTest overrides the local relay binary and returns a restore
+// function.
+func SetSSHRelayBinaryForTest(path string) func() {
+	prev := sshRelayBinary
+	sshRelayBinary = func() (string, error) { return path, nil }
+	return func() { sshRelayBinary = prev }
+}
+
+// resolvePinnedSSHDialAddress picks the ONE address this session will use, by
+// dialling the configured name once and reporting where the connection actually
+// landed.
+//
+// IT DIALS RATHER THAN LOOKING UP, and that is the whole point. A plain
+// LookupIPAddr plus "take the first" would pin an address nothing has proved is
+// reachable, which is precisely the regression #3090 shipped: pinning removed
+// net.Dialer's try-each-consecutive-address behaviour, so a dual-stack host with a
+// black-holed IPv6 route failed every provision where plain `ssh` falls through to
+// IPv4. net.Dialer already implements that fallback — including RFC 6555 fast
+// fallback across families — so dialling once and reading RemoteAddr yields an
+// address that DEMONSTRABLY answered, and keeps the behaviour pinning had
+// removed. The connection is closed immediately; it never authenticates.
+//
+// AN EMPTY RETURN IS NOT AN ERROR, it is "carry on exactly as before". A failure
+// here means af could not determine an address, and the honest response is to
+// compose the same name-based command af has always composed rather than to
+// refuse. Two reasons, both learned the hard way:
+//
+//   - Refusing would make a probe af added a hard precondition for the whole
+//     backend. `-F none` means ssh does a plain TCP connect to the same host and
+//     port, so the two agree in every ordinary case — but Go's pure resolver
+//     (CGO_ENABLED=0) does not consult nsswitch modules that getaddrinfo does, so
+//     a name served only by mDNS or an LDAP module resolves for ssh and not for
+//     af. Turning that into a dead backend is #3092's mistake with a new cause.
+//   - The next thing af does is connect anyway. When the host is genuinely
+//     unreachable, ssh's own error names the cause far better than a probe can.
+//
+// So the pin is an IMPROVEMENT over dialling by name, and where it cannot be
+// computed af degrades to what it did before rather than to nothing.
+func resolvePinnedSSHDialAddress(host string, port int) string {
+	conn, err := net.Dial("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	if err != nil {
+		log.WarningLog.Printf("backend=ssh: could not resolve %q to a single address to pin this session to "+
+			"(%v); every step will resolve the name independently, so a host with several addresses could still "+
+			"split this session across machines (#3086)", host, err)
+		return ""
+	}
+	defer func() { _ = conn.Close() }()
+
+	addr, ok := conn.RemoteAddr().(*net.TCPAddr)
+	if !ok || addr.IP == nil {
+		return ""
+	}
+	// The zone is part of the identity of a link-local address: fe80::1 on eth0 is
+	// not fe80::1 on eth1, and TCPAddr.IP.String() drops it. Both net.Dial and
+	// net.JoinHostPort round-trip the `%zone` form, and the composer escapes the
+	// `%` for ssh's own percent expansion — see sshPinnedProxyCommand.
+	if addr.Zone != "" {
+		return addr.IP.String() + "%" + addr.Zone
+	}
+	return addr.IP.String()
+}

--- a/session/ssh_dial_pin.go
+++ b/session/ssh_dial_pin.go
@@ -37,6 +37,22 @@ func SetSSHRelayBinaryForTest(path string) func() {
 	return func() { sshRelayBinary = prev }
 }
 
+// sshDialProbeTimeout bounds the one dial resolvePinnedSSHDialAddress performs.
+//
+// IT IS THE ONE PART OF THIS PIN THAT RUNS IN-PROCESS, which is why it needs a
+// deadline at all when the relay's own dial deliberately has none. The relay is a
+// child in a process group its caller SIGKILLs on the step's deadline, so matching
+// ssh's no-timeout behaviour is safe there. This runs inside sshRuntime.Provision,
+// which carries no context — so an unbounded dial to an address that silently
+// drops packets would hold a session create for the kernel's SYN-retry window
+// (~130s on Linux), where an unpinned create fails at the first ssh step's own 30s
+// deadline. Giving up here costs only the pin: the composer falls back to the
+// name-based command and that step reports the real error.
+//
+// A var so a test can prove the bound is APPLIED without spending it —
+// TestTheDialProbeIsBounded shrinks it and separately asserts the shipped value.
+var sshDialProbeTimeout = sshDialTimeout
+
 // resolvePinnedSSHDialAddress picks the ONE address this session will use, by
 // dialling the configured name once and reporting where the connection actually
 // landed.
@@ -68,7 +84,16 @@ func SetSSHRelayBinaryForTest(path string) func() {
 // So the pin is an IMPROVEMENT over dialling by name, and where it cannot be
 // computed af degrades to what it did before rather than to nothing.
 func resolvePinnedSSHDialAddress(host string, port int) string {
-	conn, err := net.Dial("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	// BOUNDED, unlike the relay's own dial, and the difference is where each one
+	// runs. The relay is a child in a process group the caller SIGKILLs on its
+	// deadline, so ssh's own no-timeout behaviour is safe there. This probe runs
+	// IN-PROCESS, inside a Provision that carries no context — so an unbounded dial
+	// to a black-holed address would block the create for the kernel's SYN-retry
+	// window (~130s on Linux) where the first ssh step would have failed at its own
+	// 30s deadline. Timing out here just means no pin, which composes the ordinary
+	// name-based command and lets that step report the real error.
+	dialer := net.Dialer{Timeout: sshDialProbeTimeout}
+	conn, err := dialer.Dial("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if err != nil {
 		log.WarningLog.Printf("backend=ssh: could not resolve %q to a single address to pin this session to "+
 			"(%v); every step will resolve the name independently, so a host with several addresses could still "+

--- a/session/ssh_dial_pin.go
+++ b/session/ssh_dial_pin.go
@@ -1,10 +1,15 @@
 package session
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/sachiniyer/agent-factory/log"
 )
@@ -90,6 +95,75 @@ func pinForProvision(host string, port int) string {
 	return dialAddr
 }
 
+// AF'S RESOLVER IS NOT NECESSARILY SSH'S, and this is the escape hatch for when
+// they disagree.
+//
+// af resolves with Go's PURE resolver — af ships CGO_ENABLED=0 — which reads
+// /etc/hosts and DNS and nothing else. ssh resolves with getaddrinfo, which
+// follows nsswitch.conf. Under `hosts: ldap dns`, or sssd, or mDNS, both can
+// succeed and return DIFFERENT addresses, so af can pin somewhere ssh would never
+// have gone. The dial probe cannot detect this: it succeeded, so the fallback for
+// an unresolvable name never engages.
+//
+// THE SEVERITY IS AVAILABILITY, NOT SECURITY, and that is what decides the fix.
+// ssh's destination is still the NAME, so a pin that lands on a different machine
+// fails CLOSED on host-key verification rather than silently using the wrong host.
+// Nothing is trusted that should not be. What happens instead is that a backend
+// which worked before af pinned anything now fails every create — the #3092 shape,
+// where a class of users loses the whole backend.
+//
+// So the pin is made NON-FATAL rather than merely documented. A create whose
+// PINNED command failed host-key verification retries ONCE unpinned, which is
+// exactly what af did before this change, and records no pinned address so the
+// teardown matches. Documenting alone would leave those users with a dead backend
+// and a manual diagnosis; this recovers automatically and says so in the log.
+//
+// TWO GUARDS, both necessary:
+//
+//   - sessionDir must be EMPTY. It is set by the first provision step, so an empty
+//     one proves no remote state exists yet and re-provisioning cannot orphan a
+//     workspace. Re-provisioning after anything was created is precisely the leak
+//     #3086 exists to prevent, so this is a hard precondition rather than an
+//     optimisation.
+//   - A CHANGED host key is excluded. `REMOTE HOST IDENTIFICATION HAS CHANGED` is a
+//     security signal that deserves to surface immediately; retrying would only
+//     delay it, since the unpinned attempt verifies the same name against the same
+//     store and fails the same way.
+func shouldRetryProvisionUnpinned(dialAddr, sessionDir string, err error) bool {
+	if strings.TrimSpace(dialAddr) == "" {
+		return false // never pinned; there is nothing to retry differently
+	}
+	if sessionDir != "" {
+		return false // remote state exists — see the guard note above
+	}
+	return sshHostKeyVerificationFailed(err)
+}
+
+// sshHostKeyVerificationFailed reports ssh's own pre-authentication refusal.
+//
+// The marker is ssh's, not af's: OpenSSH prints `Host key verification failed.`
+// from a fatal() in sshconnect.c and does not localise its diagnostics, so the
+// string is stable across the releases this backend supports. It arrives on
+// STDERR, which for the non-combined steps lands in exec.ExitError.Stderr rather
+// than in the error's own text — so both are searched.
+//
+// It is also, usefully, a PRE-AUTH failure: no remote command has run, which is
+// the same fact sessionDir being empty records independently.
+func sshHostKeyVerificationFailed(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := err.Error()
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		text += "\n" + string(exitErr.Stderr)
+	}
+	if strings.Contains(text, "REMOTE HOST IDENTIFICATION HAS CHANGED") {
+		return false
+	}
+	return strings.Contains(text, "Host key verification failed")
+}
+
 // verifySSHRelayBinary reports whether af can actually run itself as the
 // ProxyCommand relay.
 //
@@ -123,8 +197,21 @@ func verifySSHRelayBinary() error {
 	if !info.Mode().IsRegular() {
 		return fmt.Errorf("%s is not a regular file (mode %s)", path, info.Mode())
 	}
-	if info.Mode().Perm()&0o111 == 0 {
-		return fmt.Errorf("%s is not executable (mode %s)", path, info.Mode())
+	// EFFECTIVE executability, not "some execute bit is set somewhere".
+	//
+	// An earlier version tested `Perm()&0o111 != 0`, which asks whether ANY class
+	// may execute the file — so a root-owned 0700 replacement of the daemon binary
+	// passed while every ProxyCommand then failed with EACCES. That is worse than no
+	// check at all: the guard exists to fall back to the name-based command, and a
+	// guard that says yes when exec will say no converts the intended fallback into
+	// an unusable backend.
+	//
+	// faccessat(X_OK) asks the kernel the question that actually matters, with
+	// AT_EACCESS so it answers for the EFFECTIVE identity the exec will run under.
+	// Hand-rolled uid/gid arithmetic would have to reimplement supplementary groups,
+	// ACLs and capabilities to get the same answer.
+	if err := unix.Faccessat(unix.AT_FDCWD, path, unix.X_OK, unix.AT_EACCESS); err != nil {
+		return fmt.Errorf("%s is not executable by this user (mode %s): %w", path, info.Mode(), err)
 	}
 	return nil
 }

--- a/session/ssh_dial_pin.go
+++ b/session/ssh_dial_pin.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"time"
 
 	"golang.org/x/sys/unix"
@@ -191,8 +192,48 @@ func acceptNewStoreKnowsHost(cfg config.SSHConfig) bool {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), sshKnownHostsLookupTimeout)
 	defer cancel()
-	// -F searches, and exits non-zero when the host is absent.
-	return exec.CommandContext(ctx, bin, "-F", knownHostsLookupName(host, port), "-f", store).Run() == nil
+	// -F searches and exits non-zero when the host is absent — but a ZERO EXIT IS
+	// NOT THE ANSWER, which is the whole point of reading its output below.
+	out, err := exec.CommandContext(ctx, bin, "-F", knownHostsLookupName(host, port), "-f", store).Output()
+	if err != nil {
+		return false
+	}
+	return hasConcreteHostKey(out)
+}
+
+// hasConcreteHostKey reports whether `ssh-keygen -F` matched an actual host key
+// rather than only a marker line.
+//
+// EXIT STATUS ALONE IS WRONG HERE, and measured to be so. `ssh-keygen -F` exits 0
+// when the host matches a `@cert-authority` or `@revoked` line, and neither makes
+// an unrelated server key a CHANGED key — so accept-new still accepts it. Measured
+// against OpenSSH_9.6p1 and a real sshd presenting a raw host key, with a
+// known_hosts holding only a matching @cert-authority entry:
+//
+//	Warning: Permanently added '[pinned.invalid]:2299' (ED25519) to the list of known hosts.
+//	ACCEPTED_UNRELATED_RAW_KEY
+//
+// The key was accepted and appended. Trusting the exit status would therefore have
+// pinned exactly the case this check exists to exclude — a wrong machine accepted
+// silently — while looking like it had verified something.
+//
+// The output distinguishes them unambiguously (also measured): a comment line
+// starts with `#`, a marker line starts with `@cert-authority`/`@revoked`, and a
+// concrete entry starts with the host pattern (`[host]:port …`) or, in a hashed
+// store, with `|1|…`. So a line that is neither a comment nor a marker is a real
+// key.
+//
+// A @cert-authority line ALONGSIDE a concrete key still counts, which is correct:
+// the concrete key is what a mismatched machine would be measured against.
+func hasConcreteHostKey(keygenOutput []byte) bool {
+	for _, line := range strings.Split(string(keygenOutput), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "@") {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 // sshKnownHostsLookupTimeout bounds the one `ssh-keygen -F`. It reads a local file,

--- a/session/ssh_dial_pin.go
+++ b/session/ssh_dial_pin.go
@@ -10,7 +10,17 @@ import (
 )
 
 // Resolving `ssh.host` to ONE address, once, so every later step of the session
-// reaches the same machine (#3086).
+// dials that same address (#3086).
+//
+// THAT IS AN ADDRESS, NOT A MACHINE, and the distinction is load-bearing rather
+// than pedantic. It closes DNS multiplicity — a round-robin record, several A
+// records, a dual-stack host — where each step resolving independently could reach
+// a different box. It does NOT close load-balancer multiplicity: an L4 VIP picks a
+// backend PER TCP CONNECTION, and af opens a separate connection for every
+// provision command, for the tunnel, and for the reap, so those can still land on
+// different machines. af cannot tell a VIP from an ordinary address, so there is
+// nothing to detect and nothing to warn about; docs/backends.md documents it as a
+// live limitation with the same workaround, and #3086 stays open for it.
 //
 // See internal/sshrelay for why the address is applied as a ProxyCommand rather
 // than as ssh's destination, and what the two previous attempts measured.

--- a/session/ssh_dial_pin.go
+++ b/session/ssh_dial_pin.go
@@ -1,16 +1,17 @@
 package session
 
 import (
-	"errors"
+	"context"
 	"fmt"
 	"net"
 	"os"
 	"os/exec"
 	"strconv"
-	"strings"
+	"time"
 
 	"golang.org/x/sys/unix"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
@@ -81,7 +82,17 @@ var sshDialProbeTimeout = sshDialTimeout
 //
 // It lives here, as one function, so that decision is testable without a repo, a
 // config and a real sshd — see TestAnUnusableRelayBinaryFallsBackToDiallingTheName.
-func pinForProvision(host string, port int) string {
+func pinForProvision(cfg config.SSHConfig, host string, port int, posture string) string {
+	// FIRST, because it is a precondition rather than a preference, and checked
+	// before the probe so a session that cannot be pinned costs no dial at all.
+	if !sshPinIsCheckable(cfg, posture) {
+		log.InfoLog.Printf("backend=ssh: not pinning this session's address under ssh_host_key_verification=%q, "+
+			"because ssh would not refuse a host key it has not been told to expect — so a pin landing on a "+
+			"machine this host's known_hosts entry was not recorded against would be accepted silently. A host "+
+			"with several addresses can therefore still split this session across machines (#3086); point "+
+			"ssh.host at one machine, or use the default strict posture", posture)
+		return ""
+	}
 	dialAddr := resolvePinnedSSHDialAddress(host, port)
 	if dialAddr == "" {
 		return ""
@@ -95,74 +106,99 @@ func pinForProvision(host string, port int) string {
 	return dialAddr
 }
 
-// AF'S RESOLVER IS NOT NECESSARILY SSH'S, and this is the escape hatch for when
-// they disagree.
+// sshPinIsCheckable reports whether ssh will check the machine af pinned against
+// a host key it ALREADY trusts. It is the precondition for pinning at all.
 //
-// af resolves with Go's PURE resolver — af ships CGO_ENABLED=0 — which reads
-// /etc/hosts and DNS and nothing else. ssh resolves with getaddrinfo, which
-// follows nsswitch.conf. Under `hosts: ldap dns`, or sssd, or mDNS, both can
-// succeed and return DIFFERENT addresses, so af can pin somewhere ssh would never
-// have gone. The dial probe cannot detect this: it succeeded, so the fallback for
-// an unresolvable name never engages.
+// FIRST, THE THING THAT NARROWS THIS. With a ProxyCommand, ssh does not resolve
+// the name — measured in ssh.c, where the resolution site is guarded by
+// `if (addrs == NULL && options.proxy_command == NULL)`, and the only other site
+// is gated on CanonicalizeHostname, which `-F none` leaves off. The relay makes
+// the connection. So there is no live "af's resolver vs ssh's resolver"
+// disagreement during a session: every step goes where af pinned, consistently,
+// which is exactly what #3086 asked for.
 //
-// THE SEVERITY IS AVAILABILITY, NOT SECURITY, and that is what decides the fix.
-// ssh's destination is still the NAME, so a pin that lands on a different machine
-// fails CLOSED on host-key verification rather than silently using the wrong host.
-// Nothing is trusted that should not be. What happens instead is that a backend
-// which worked before af pinned anything now fails every create — the #3092 shape,
-// where a class of users loses the whole backend.
+// What remains is narrower and static: a known_hosts entry recorded EARLIER — by a
+// plain `ssh`, or a previous af session — may have been written against whichever
+// machine getaddrinfo/NSS selected, while af pins one Go's resolver selected. If
+// those differ, the pinned machine presents a key the entry does not match.
 //
-// So the pin is made NON-FATAL rather than merely documented. A create whose
-// PINNED command failed host-key verification retries ONCE unpinned, which is
-// exactly what af did before this change, and records no pinned address so the
-// teardown matches. Documenting alone would leave those users with a dead backend
-// and a manual diagnosis; this recovers automatically and says so in the log.
+// WHY THAT DECIDES WHERE AF MAY PIN. Under `strict`, ssh refuses any key it has
+// not been told to expect, so a mismatch is LOUD: the create fails before
+// authenticating, names the host, and nothing runs anywhere. Under `accept-new`
+// with an entry already present, a mismatch is loud in the same way, because
+// accept-new still refuses a CHANGED key. But under `accept-new` with NO entry for
+// the name, there is no signal at all: ssh adds whatever key the pinned machine
+// presents, the session provisions THERE, and the name is now bound to that
+// machine's key — silent, and durable, since the intended host then looks changed
+// forever. `insecure` verifies nothing, so it has no signal either.
 //
-// TWO GUARDS, both necessary:
+// So af pins only where a wrong pin would be refused. That is a precondition, not
+// a preference: it is what makes "a wrong pin fails closed" true by construction
+// rather than a claim that happens to hold for one posture.
 //
-//   - sessionDir must be EMPTY. It is set by the first provision step, so an empty
-//     one proves no remote state exists yet and re-provisioning cannot orphan a
-//     workspace. Re-provisioning after anything was created is precisely the leak
-//     #3086 exists to prevent, so this is a hard precondition rather than an
-//     optimisation.
-//   - A CHANGED host key is excluded. `REMOTE HOST IDENTIFICATION HAS CHANGED` is a
-//     security signal that deserves to surface immediately; retrying would only
-//     delay it, since the unpinned attempt verifies the same name against the same
-//     store and fails the same way.
-func shouldRetryProvisionUnpinned(dialAddr, sessionDir string, err error) bool {
-	if strings.TrimSpace(dialAddr) == "" {
-		return false // never pinned; there is nothing to retry differently
+// AN EARLIER ATTEMPT INFERRED THIS FROM AN ERROR instead — retry unpinned when the
+// create failed host-key verification — and it could not work. The error channel is
+// overloaded (a changed key means both "wrong machine" and "genuine key change")
+// and sometimes silent (accept-new with no entry produces no error at all, which is
+// precisely the case with the worst consequence). It was deleted rather than given
+// a third condition.
+func sshPinIsCheckable(cfg config.SSHConfig, posture string) bool {
+	switch posture {
+	case config.SSHHostKeyInsecure:
+		return false
+	case config.SSHHostKeyAcceptNew:
+		return acceptNewStoreKnowsHost(cfg)
+	default:
+		// strict, and any unrecognised value — sshHostKeyOptions fails safe to strict,
+		// and TestPinningFollowsTheVerifyingPostureExactly asserts the two agree rather
+		// than a comment claiming they do.
+		return true
 	}
-	if sessionDir != "" {
-		return false // remote state exists — see the guard note above
-	}
-	return sshHostKeyVerificationFailed(err)
 }
 
-// sshHostKeyVerificationFailed reports ssh's own pre-authentication refusal.
+// acceptNewStoreKnowsHost reports whether the accept-new store already holds a key
+// for this host, which is what turns a wrong pin from silent into refused.
 //
-// The marker is ssh's, not af's: OpenSSH prints `Host key verification failed.`
-// from a fatal() in sshconnect.c and does not localise its diagnostics, so the
-// string is stable across the releases this backend supports. It arrives on
-// STDERR, which for the non-combined steps lands in exec.ExitError.Stderr rather
-// than in the error's own text — so both are searched.
+// It asks `ssh-keygen -F`, and does not parse known_hosts itself, because the file
+// may be HASHED — Debian and Ubuntu ship HashKnownHosts=yes — and a hand-rolled
+// parser would have to reproduce the HMAC-SHA1 keying, plus @cert-authority,
+// @revoked and wildcard lines, to reach the same answer. Measured: `ssh-keygen -F`
+// resolves plain and hashed entries alike and distinguishes the `[host]:port` key
+// form that a non-default port requires.
 //
-// It is also, usefully, a PRE-AUTH failure: no remote command has run, which is
-// the same fact sessionDir being empty records independently.
-func sshHostKeyVerificationFailed(err error) bool {
-	if err == nil {
+// ANY DOUBT MEANS NO PIN. A missing ssh-keygen, an unreadable store, a non-zero
+// exit: all answer "not known", so af declines to pin rather than pinning without
+// the check that makes it safe. ssh-keygen ships beside ssh on Debian/Ubuntu but is
+// a separate package on Alpine, so its absence is a real case and must degrade
+// rather than break — the same rule the relay binary follows.
+func acceptNewStoreKnowsHost(cfg config.SSHConfig) bool {
+	host, port, err := resolveSSHHostPort(cfg.Host, cfg.Port)
+	if err != nil {
 		return false
 	}
-	text := err.Error()
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		text += "\n" + string(exitErr.Stderr)
+	if port == 0 {
+		port = sshDefaultPort
 	}
-	if strings.Contains(text, "REMOTE HOST IDENTIFICATION HAS CHANGED") {
+	store, err := acceptNewKnownHostsPathFor(cfg)
+	if err != nil {
 		return false
 	}
-	return strings.Contains(text, "Host key verification failed")
+	bin, err := lookPath("ssh-keygen")
+	if err != nil {
+		log.InfoLog.Printf("backend=ssh: ssh-keygen is not on PATH, so af cannot tell whether %q is already in "+
+			"the accept-new host-key store; not pinning this session's address (#3086)", host)
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), sshKnownHostsLookupTimeout)
+	defer cancel()
+	// -F searches, and exits non-zero when the host is absent.
+	return exec.CommandContext(ctx, bin, "-F", knownHostsLookupName(host, port), "-f", store).Run() == nil
 }
+
+// sshKnownHostsLookupTimeout bounds the one `ssh-keygen -F`. It reads a local file,
+// so this is a stuck-filesystem guard rather than a network one — but it runs
+// in-process during a create, which carries no context of its own.
+const sshKnownHostsLookupTimeout = 10 * time.Second
 
 // verifySSHRelayBinary reports whether af can actually run itself as the
 // ProxyCommand relay.

--- a/session/ssh_dial_pin.go
+++ b/session/ssh_dial_pin.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"strconv"
@@ -52,6 +53,71 @@ func SetSSHRelayBinaryForTest(path string) func() {
 // A var so a test can prove the bound is APPLIED without spending it —
 // TestTheDialProbeIsBounded shrinks it and separately asserts the shipped value.
 var sshDialProbeTimeout = sshDialTimeout
+
+// pinForProvision is the CREATE path's whole pin decision: the address to pin
+// this session to, or "" to connect by name exactly as af always has.
+//
+// Both ways of answering "" are fail-soft on purpose, and both are the same
+// lesson. A pin is an IMPROVEMENT on dialling by name; when af cannot compute one,
+// the session must still be created the way it was before rather than not at all.
+// #3092 is what the other choice looks like in production — a mechanism that
+// failed totally instead of partially, and took backend=ssh away from every Ubuntu
+// 20.04 and Debian 11 user until it was reverted.
+//
+// It lives here, as one function, so that decision is testable without a repo, a
+// config and a real sshd — see TestAnUnusableRelayBinaryFallsBackToDiallingTheName.
+func pinForProvision(host string, port int) string {
+	dialAddr := resolvePinnedSSHDialAddress(host, port)
+	if dialAddr == "" {
+		return ""
+	}
+	if err := verifySSHRelayBinary(); err != nil {
+		log.WarningLog.Printf("backend=ssh: not pinning this session to %s because af cannot run itself as "+
+			"ssh's ProxyCommand relay (%v); connecting by name instead, so a host with several addresses "+
+			"could still split this session across machines (#3086)", dialAddr, err)
+		return ""
+	}
+	return dialAddr
+}
+
+// verifySSHRelayBinary reports whether af can actually run itself as the
+// ProxyCommand relay.
+//
+// IT EXISTS SO A BROKEN PIN COSTS THE PIN, NOT THE BACKEND. A ProxyCommand that
+// cannot exec does not degrade: ssh has no transport at all, so every step dies on
+// its deadline with a timeout that names neither the relay nor the cause. That is
+// the shape of #3092 — a mechanism whose failure mode was total rather than
+// partial, discovered by users rather than by CI — and the lesson is not "avoid
+// that one option", it is that anything af adds to this command must fall back to
+// what worked before.
+//
+// So the CREATE path checks first and simply does not pin when the answer is no.
+// The TEARDOWN path deliberately does NOT get this treatment: there, a record
+// already knows which machine holds its workspace, so composing a name-based
+// command instead could reap a different one and retire the tombstone. It errors
+// and is retried. Fail-soft on the way in, fail-loud on the way out.
+//
+// os.Executable is reliable here in the case that actually happens — Go trims
+// Linux's " (deleted)" suffix, so a daemon whose binary was REPLACED in place by
+// an upgrade still names a path that exists and is the new af. A binary deleted
+// outright is what this catches.
+func verifySSHRelayBinary() error {
+	path, err := sshRelayBinary()
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s is not a regular file (mode %s)", path, info.Mode())
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		return fmt.Errorf("%s is not executable (mode %s)", path, info.Mode())
+	}
+	return nil
+}
 
 // resolvePinnedSSHDialAddress picks the ONE address this session will use, by
 // dialling the configured name once and reporting where the connection actually

--- a/session/ssh_hostport_test.go
+++ b/session/ssh_hostport_test.go
@@ -51,7 +51,7 @@ func TestSSHAndHookResolveTheSameAddressIdentically(t *testing.T) {
 			// asserted where it now lives — which is itself the convergence: there is
 			// no second resolver left to disagree.
 			t.Setenv("HOME", t.TempDir())
-			sshCmd, sshErr := sshCommandForConfig(config.SSHConfig{Host: tc.address, Port: tc.port}, config.SSHHostKeyInsecure)
+			sshCmd, sshErr := sshCommandPinnedTo(config.SSHConfig{Host: tc.address, Port: tc.port}, config.SSHHostKeyInsecure, "")
 			require.NoError(t, sshErr)
 			sshHost := tc.wantHost
 
@@ -85,7 +85,7 @@ func TestConflictingPortsAreRefusedByBothBackends(t *testing.T) {
 	assert.Contains(t, hookErr.Error(), "3333", "the error must name BOTH values so it is obvious which to delete")
 
 	t.Setenv("HOME", t.TempDir())
-	_, sshErr := sshCommandForConfig(config.SSHConfig{Host: address, Port: port}, config.SSHHostKeyInsecure)
+	_, sshErr := sshCommandPinnedTo(config.SSHConfig{Host: address, Port: port}, config.SSHHostKeyInsecure, "")
 	require.Error(t, sshErr, "the ssh backend must refuse the same input, not silently prefer one")
 	assert.Contains(t, sshErr.Error(), "2222")
 	assert.Contains(t, sshErr.Error(), "3333")
@@ -137,7 +137,7 @@ func TestLegacyConflictingCleanupHandleCanStillReap(t *testing.T) {
 // filesystem or the network.
 func TestSSHAddressConflictIsDiagnosedBeforeAnythingLocal(t *testing.T) {
 	t.Setenv("HOME", t.TempDir()) // no keys, no known_hosts: a local check would fail too
-	_, err := sshCommandForConfig(config.SSHConfig{Host: "10.0.0.7:2222", Port: 3333}, config.SSHHostKeyStrict)
+	_, err := sshCommandPinnedTo(config.SSHConfig{Host: "10.0.0.7:2222", Port: 3333}, config.SSHHostKeyStrict, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "2222", "the ADDRESS conflict must win over any local prerequisite failure")
 	assert.Contains(t, err.Error(), "3333")

--- a/session/ssh_legacy_tombstone.go
+++ b/session/ssh_legacy_tombstone.go
@@ -41,7 +41,7 @@ import (
 // store. That reads like a widening, and the "host merely DOWN" case is the one
 // worth checking — but it cannot fire here, for a reason worth stating:
 //
-//	posture "" restores as STRICT, and sshCommandForConfig pins
+//	posture "" restores as STRICT, and sshCommandPinnedTo pins
 //	StrictHostKeyChecking=yes against that one store, with
 //	GlobalKnownHostsFile=/dev/null and KnownHostsCommand=none. So reaching the
 //	remote at all REQUIRES the host to be in that file. A down-but-known host
@@ -123,7 +123,7 @@ func knownHostsLookupName(host string, port int) string {
 // all — is inconclusive on purpose.
 //
 // The store path comes from strictKnownHostsPathFor, the same resolver
-// sshCommandForConfig hands to UserKnownHostsFile, so this lookup cannot disagree
+// sshCommandPinnedTo hands to UserKnownHostsFile, so this lookup cannot disagree
 // with the file the composed command actually reads.
 //
 // AND THE NAME CANNOT DISAGREE EITHER, because the composed command carries

--- a/session/ssh_proxycommand_pin_test.go
+++ b/session/ssh_proxycommand_pin_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -357,25 +358,103 @@ func TestTheDialProbeIsBounded(t *testing.T) {
 
 	// Now prove the deadline is APPLIED. A probe with no timeout at all would
 	// ignore this and hang, so the short value tests the mechanism rather than
-	// standing in for it — and it costs 300ms instead of the full 20s.
+	// standing in for it — and it costs milliseconds instead of the full 20s.
 	prev := sshDialProbeTimeout
 	sshDialProbeTimeout = 300 * time.Millisecond
 	defer func() { sshDialProbeTimeout = prev }()
 
-	done := make(chan string, 1)
-	start := time.Now()
-	go func() { done <- resolvePinnedSSHDialAddress("198.51.100.9", 22) }()
+	// NEITHER CASE MAY BE A REFUSED CONNECTION. ECONNREFUSED returns instantly
+	// whether or not a deadline exists, so a test built on one passes against an
+	// unbounded probe — it would assert nothing. Both cases below STALL.
 
-	select {
-	case pinned := <-done:
-		assert.Empty(t, pinned, "an unreachable address yields no pin")
+	// A stalled RESOLVER, which is deterministic and entirely in-process: the DNS
+	// server reads the query and never answers. Go's Dialer deadline covers name
+	// resolution as well as the connect, so this is the half a black-holed address
+	// cannot reach. Without a deadline Go's own resolver still gives up eventually
+	// (~2 attempts x 5s), which is why the assertion is "promptly", not "at all".
+	t.Run("a stalled resolver", func(t *testing.T) {
+		useStallingResolver(t)
+		start := time.Now()
+		assert.Empty(t, mustReturnWithin(t, 60*time.Second, func() string {
+			return resolvePinnedSSHDialAddress("stalled.test", 22)
+		}))
+		assert.Less(t, time.Since(start), 3*time.Second,
+			"the probe must give up on ITS OWN deadline; without one it waits out the resolver's retries")
+	})
+
+	// A black-holed ADDRESS: TEST-NET-2 (RFC 5737) is reserved for documentation and
+	// routed nowhere, so a SYN to it goes unanswered. Not every network agrees —
+	// some return an ICMP unreachable, which arrives instantly — so the precondition
+	// is checked and the case SKIPS rather than passing vacuously.
+	t.Run("a black-holed address", func(t *testing.T) {
+		const blackhole = "198.51.100.9:22"
+		probe, err := net.DialTimeout("tcp", blackhole, 750*time.Millisecond)
+		if probe != nil {
+			_ = probe.Close()
+		}
+		if err == nil || !errors.Is(err, os.ErrDeadlineExceeded) {
+			var netErr net.Error
+			if !errors.As(err, &netErr) || !netErr.Timeout() {
+				t.Skipf("%s is not black-holed on this network (%v); a refused address returns instantly "+
+					"and would make this assertion vacuous", blackhole, err)
+			}
+		}
+		start := time.Now()
+		assert.Empty(t, mustReturnWithin(t, 60*time.Second, func() string {
+			return resolvePinnedSSHDialAddress("198.51.100.9", 22)
+		}))
 		assert.Less(t, time.Since(start), 20*time.Second,
-			"the probe must give up on ITS OWN deadline rather than the kernel's")
-	case <-time.After(60 * time.Second):
-		t.Fatal("resolvePinnedSSHDialAddress ignored its deadline: an unbounded probe blocks a session create " +
-			"for the kernel's SYN-retry window, where an unpinned create fails at the first step's 30s " +
-			"deadline. It runs in-process, so unlike the relay there is no process group for a caller to kill")
+			"the probe must give up on ITS OWN deadline rather than the kernel's SYN-retry window")
+	})
+}
+
+// mustReturnWithin fails loudly instead of hanging the suite, because "blocks a
+// session create forever" is the defect under test and a timed-out `go test` would
+// report it as an unrelated package timeout.
+func mustReturnWithin(t *testing.T, limit time.Duration, fn func() string) string {
+	t.Helper()
+	done := make(chan string, 1)
+	go func() { done <- fn() }()
+	select {
+	case v := <-done:
+		return v
+	case <-time.After(limit):
+		t.Fatal("resolvePinnedSSHDialAddress ignored its deadline: an unbounded probe blocks a session create, " +
+			"where an unpinned create fails at the first ssh step's own 30s deadline. It runs IN-PROCESS, so " +
+			"unlike the relay there is no process group for a caller to kill")
+		return ""
 	}
+}
+
+// useStallingResolver points the process resolver at a DNS server that reads every
+// query and answers none — the "stalled resolver" half of the probe's deadline,
+// which no choice of address can exercise.
+func useStallingResolver(t *testing.T) {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() {
+		buf := make([]byte, 512)
+		for {
+			if _, _, readErr := pc.ReadFrom(buf); readErr != nil {
+				return
+			}
+			// Deliberately no reply.
+		}
+	}()
+
+	prevResolver := net.DefaultResolver
+	net.DefaultResolver = &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, "udp", pc.LocalAddr().String())
+		},
+	}
+	t.Cleanup(func() {
+		net.DefaultResolver = prevResolver
+		_ = pc.Close()
+	})
 }
 
 // proxyCommandValue extracts the ProxyCommand value from a composed command as

--- a/session/ssh_proxycommand_pin_test.go
+++ b/session/ssh_proxycommand_pin_test.go
@@ -1,0 +1,511 @@
+package session
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/sshrelay"
+)
+
+// #3086: every ssh transport step must reach ONE machine.
+//
+// The property under test is not "the string contains ProxyCommand" — it is that
+// a target which GENUINELY resolves to two reachable addresses puts every step on
+// one of them, and that its reap targets that same one after a daemon restart.
+// So the fixture below is a real round-robin name over a real resolver, with a
+// CONTROL that proves the fixture can actually split. A test that asserted only
+// the composed string would pass just as happily against a pin that resolves to
+// nothing.
+
+// TestPinnedSSHDialAddressKeepsEveryStepOnOneMachine is the issue's acceptance
+// criterion, driven through the mechanism.
+//
+// Two listeners on two loopback addresses stand in for two machines behind one
+// name, and the name's DNS answers ROTATE — which is what a round-robin record,
+// a load balancer, or a multi-A-record host does, and is why af cannot simply
+// trust that consecutive resolutions agree.
+func TestPinnedSSHDialAddressKeepsEveryStepOnOneMachine(t *testing.T) {
+	machineA, machineB, port := twoMachinesBehindOneName(t)
+	const name = "pinned-multi.test"
+	useRotatingResolver(t, "127.0.0.1", "127.0.0.2")
+
+	// THE CONTROL, and it is not decoration: it proves the fixture reproduces the
+	// bug. Without it, "every pinned dial landed on one machine" would be equally
+	// true of a fixture where only one machine was ever reachable, and the test
+	// would assert nothing at all.
+	hosts, err := net.LookupHost(name)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"127.0.0.1", "127.0.0.2"}, hosts,
+		"the target must GENUINELY resolve to two addresses — that is the condition #3086 is about")
+	for i := 0; i < 6; i++ {
+		// The GREETING is read, not just the connection opened, and that is what
+		// makes the counters below trustworthy rather than racy. net.Dial returns as
+		// soon as the handshake completes, which can be BEFORE the listener's Accept
+		// has run and incremented its counter — so a control dial's increment could
+		// land after the reset() below and be miscounted as a pinned one. The
+		// greeting is written after the increment, so receiving it orders the two.
+		// Measured: without this the test failed 7 times in 25.
+		require.NoError(t, greetingFrom(net.JoinHostPort(name, strconv.Itoa(port))),
+			"both stand-in machines must be reachable by name")
+	}
+	require.NotZero(t, machineA.count(), "fixture is vacuous: machine A never saw a name-based dial")
+	require.NotZero(t, machineB.count(), "fixture is vacuous: machine B never saw a name-based dial — "+
+		"the name must resolve to two REACHABLE addresses and unpinned dials must be able to reach either, "+
+		"or this test proves nothing")
+
+	// Resolve ONCE, the way provisioning does.
+	pinned := resolvePinnedSSHDialAddress(name, port)
+	require.Contains(t, []string{"127.0.0.1", "127.0.0.2"}, pinned,
+		"the pin must be one of the addresses the name actually answers with")
+	chosen, other := machineA, machineB
+	if pinned == "127.0.0.2" {
+		chosen, other = machineB, machineA
+	}
+
+	// FLUSH BOTH ACCEPT LOOPS BEFORE ZEROING THE COUNTERS. The probe above opens a
+	// real connection and closes it without reading, so unlike the control dials
+	// there is nothing to order its listener's increment against — and an increment
+	// that lands after reset() is counted as a pinned dial, which is precisely the
+	// off-by-one that made this test fail 6 times in 30 with the counter reading 7.
+	// Each listener accepts sequentially, so a connection whose greeting has been
+	// received was accepted after everything already queued: receiving one from each
+	// machine proves both loops are past the probe.
+	for _, m := range []*standInMachine{machineA, machineB} {
+		require.NoError(t, greetingFrom(net.JoinHostPort(m.addr, strconv.Itoa(port))))
+	}
+	machineA.reset()
+	machineB.reset()
+
+	// EVERY step of a session — each provision command, the `ssh -L` tunnel, and
+	// the reap — is a separate ssh invocation that dials through this relay. Run it
+	// the number of times a session would and prove they all land together.
+	for i := 0; i < 6; i++ {
+		require.NoError(t, relayOnce(pinned, port), "relay dial %d", i)
+	}
+	assert.Equal(t, 6, chosen.count(), "every pinned dial must reach the machine the session was pinned to")
+	assert.Zero(t, other.count(),
+		"a pinned session reached a SECOND machine — that is #3086 exactly: the workspace lands on one host "+
+			"while the clone, the tunnel or the reap lands on another, and the reap then removes the wrong "+
+			"directory and reports success while the real workspace leaks")
+
+	// And the reap composed from the PERSISTED handle, in what is effectively a
+	// fresh daemon, must target that same machine. This is the constraint that
+	// ruled out a ControlMaster multiplex: a live master cannot survive a restart,
+	// a recorded address can.
+	backend, _, err := restoreRuntimeCleanup("pinned", "ssh", &RuntimeCleanupData{SSH: &SSHRuntimeCleanupData{
+		Config:              config.SSHConfig{Host: name, Port: port},
+		SessionDir:          "/home/af/.af-sessions/x.AbCdEf",
+		DialAddress:         pinned,
+		HostKeyVerification: config.SSHHostKeyInsecure,
+	}})
+	require.NoError(t, err)
+	sb, ok := backend.(*sshBackend)
+	require.True(t, ok)
+	assert.Contains(t, proxyCommandValue(t, sb.provisioner.sshCmd),
+		sshrelay.Subcommand+" '"+pinned+"' "+strconv.Itoa(port),
+		"the restored teardown must dial the machine the session actually ran on")
+}
+
+// "Every step" is a structural claim, so it is pinned structurally.
+//
+// The leak in #3086 is not that one command dialled the wrong host — it is that
+// the provision commands, the `ssh -L` tunnel and the reap are SEPARATE ssh
+// invocations that could each land somewhere different. They cannot, for exactly
+// one reason: all three are built from the single sshCmd string the pin lives in.
+// A refactor that gave the tunnel or the reap its own composition would reopen the
+// bug while every string assertion above still passed.
+func TestEveryTransportStepRidesTheOnePinnedCommand(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defer SetSSHRelayBinaryForTest("/opt/af/af")()
+
+	pinnedCmd, err := sshCommandPinnedTo(
+		config.SSHConfig{Host: "many.example.com", Port: 2222}, config.SSHHostKeyInsecure, "198.51.100.8")
+	require.NoError(t, err)
+	p := newSSHSandboxProvisioner(ProvisionSpec{Title: "pinned"}, pinnedCmd, "", "")
+
+	// Every provision step AND the reap run through Run → buildRunCommand.
+	built := p.buildRunCommand(context.Background(), "echo probe", nil)
+	assert.Contains(t, strings.Join(built.Args, " "), sshrelay.Subcommand,
+		"the provision steps and the reap must run over the pinned command, not a freshly composed one")
+
+	// The tunnel is the third invocation, and it is composed inside startTunnel —
+	// which dials, so it cannot be called here. Asserted against the SOURCE, the way
+	// the ExitOnForwardFailure guarantee next door is: what matters is that it
+	// extends p.sshCmd rather than building its own.
+	src, err := os.ReadFile("backend_sandbox.go")
+	require.NoError(t, err)
+	assert.Contains(t, string(src), `p.sshCmd+`+"`"+` -o ExitOnForwardFailure=yes -N -L "$1"`+"`",
+		"startTunnel must extend the ONE pinned command; a tunnel that composed its own ssh invocation would "+
+			"re-resolve the name and could forward to a different machine than the workspace is on (#3086)")
+}
+
+// The destination stays the NAME whether or not a session is pinned — that is the
+// whole reason this approach survives where #3090 did not. ssh computes the
+// known_hosts key and the certificate principal from the destination, and only
+// ssh, given the name, computes both correctly.
+func TestPinnedCommandKeepsTheNameAsSSHsDestination(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defer SetSSHRelayBinaryForTest("/opt/af/af")()
+
+	cmd, err := sshCommandPinnedTo(
+		config.SSHConfig{Host: "many.example.com", Port: 2222}, config.SSHHostKeyStrict, "198.51.100.8")
+	require.NoError(t, err)
+
+	fields := strings.Fields(cmd)
+	assert.Equal(t, "'many.example.com'", fields[len(fields)-1],
+		"ssh's destination must remain the configured NAME: it is what keeps a host certificate valid, and "+
+			"pinning the address instead is what #3090 had to revert")
+	assert.NotContains(t, cmd, "HostKeyAlias",
+		"no alias is needed when the destination is already the name — and no alias VALUE is correct, since a "+
+			"plain known_hosts entry on a non-default port wants [name]:port while a certificate principal "+
+			"wants the bare name")
+	assert.Contains(t, cmd, "-o ProxyCommand='"+"'\\''/opt/af/af'\\''"+" "+sshrelay.Subcommand+" '\\''198.51.100.8'\\'' 2222'",
+		"the pin belongs in the ProxyCommand, which decides only where the socket goes")
+}
+
+// An unpinned command must be exactly what it always was. A session af could not
+// resolve, and a handle written before any of this, both take this path.
+func TestUnpinnedCommandCarriesNoProxyCommand(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	cmd, err := sshCommandPinnedTo(config.SSHConfig{Host: "h.example.com", Port: 2222}, config.SSHHostKeyStrict, "")
+	require.NoError(t, err)
+	// "-o ProxyCommand", not the bare word, for the reason
+	// TestSSHCommandOmitsThePost85HostKeyHelperOption records: t.TempDir() embeds
+	// the TEST NAME, that path is interpolated into UserKnownHostsFile, and a test
+	// with the option in its name therefore matches its own directory and fails
+	// against correct code. Measured — this assertion was red before it was
+	// narrowed.
+	assert.NotContains(t, cmd, "-o ProxyCommand",
+		"with no address to pin, af must compose the ordinary name-based command rather than a relay to nowhere")
+	assert.Equal(t, "'h.example.com'", strings.Fields(cmd)[len(strings.Fields(cmd))-1])
+}
+
+// The ProxyCommand crosses TWO shells and one percent expansion, and every one of
+// them can corrupt it silently.
+func TestPinnedProxyCommandSurvivesQuotingAndPercentExpansion(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// A relay path with BOTH hazards: a space (which the shell splits) and a `%`
+	// (which ssh percent-expands). Measured on OpenSSH_9.6p1: an unescaped `%d`
+	// aborts the connection with `vdollar_percent_expand: unknown key %d`.
+	defer SetSSHRelayBinaryForTest("/opt/af home/pct%dir/af")()
+	cmd, err := sshCommandPinnedTo(config.SSHConfig{Host: "h.example.com"}, config.SSHHostKeyStrict, "198.51.100.8")
+	require.NoError(t, err)
+
+	assert.Contains(t, cmd, "pct%%dir",
+		"a literal %% in the relay path must be doubled, or ssh reads it as a token and refuses to connect")
+	assert.NotContains(t, cmd, "%h", "the address is fixed; %%h/%%p would expand to what ssh is dialling, "+
+		"which is the name — the exact thing the pin exists to bypass")
+
+	// The value af emits, unwrapped one shell at a time, must still name the relay
+	// as a single argument. This is the assertion that fails if either quoting
+	// layer is dropped.
+	value := proxyCommandValue(t, cmd)
+	assert.Equal(t, `'/opt/af home/pct%%dir/af' `+sshrelay.Subcommand+` '198.51.100.8' 22`, value)
+	assert.Equal(t, `'/opt/af home/pct%dir/af' `+sshrelay.Subcommand+` '198.51.100.8' 22`,
+		strings.ReplaceAll(value, "%%", "%"),
+		"after ssh's percent expansion the relay path must still be one quoted argument")
+}
+
+// A zoned IPv6 link-local address is two hazards at once: the zone is part of the
+// address's identity, and its separator is the character ssh expands.
+func TestPinnedProxyCommandCarriesAZonedIPv6Address(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	defer SetSSHRelayBinaryForTest("/opt/af/af")()
+
+	cmd, err := sshCommandPinnedTo(config.SSHConfig{Host: "h.example.com"}, config.SSHHostKeyStrict, "fe80::1%eth0")
+	require.NoError(t, err)
+	assert.Contains(t, proxyCommandValue(t, cmd), "'fe80::1%%eth0'",
+		"fe80::1 on eth0 is not fe80::1 on eth1, so the zone travels with the address — escaped, because "+
+			"ssh would otherwise expand %%e")
+
+	// And the relay brackets it back into a dialable address rather than leaving
+	// the caller to remember.
+	assert.Equal(t, "[fe80::1%eth0]:22", net.JoinHostPort("fe80::1%eth0", "22"))
+}
+
+// A pin af cannot compose must not quietly become a name-based command. Reaching
+// that code means the session IS on a known machine; dialling the name instead
+// could reap a different one, report success and retire the only tombstone.
+func TestUncomposablePinRetainsTheRecordRatherThanDiallingTheName(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	prev := sshRelayBinary
+	sshRelayBinary = func() (string, error) { return "", fmt.Errorf("no /proc/self/exe") }
+	defer func() { sshRelayBinary = prev }()
+
+	_, _, err := restoreRuntimeCleanup("pinned", "ssh", &RuntimeCleanupData{SSH: &SSHRuntimeCleanupData{
+		Config:              config.SSHConfig{Host: "many.example.com", Port: 2222},
+		SessionDir:          "/home/af/.af-sessions/x.AbCdEf",
+		DialAddress:         "198.51.100.8",
+		HostKeyVerification: config.SSHHostKeyStrict,
+	}})
+	require.Error(t, err, "restoreRuntimeCleanup must report the handle as unavailable, which RETAINS and "+
+		"retries it — silently reaping by name could remove a different machine's directory and retire the "+
+		"tombstone for good")
+
+	// The same failure must NOT block a handle with nothing to pin: that one has
+	// always dialled the name, and refusing it would leak the workspace it exists
+	// to remove.
+	_, _, err = restoreRuntimeCleanup("ordinary", "ssh", &RuntimeCleanupData{SSH: &SSHRuntimeCleanupData{
+		Config:              config.SSHConfig{Host: "h.example.com", Port: 2222},
+		SessionDir:          "/home/af/.af-sessions/x.AbCdEf",
+		HostKeyVerification: config.SSHHostKeyStrict,
+	}})
+	require.NoError(t, err)
+}
+
+// An address af could not settle on degrades to today's behaviour rather than to
+// a dead backend — #3092's lesson, with a new cause.
+func TestUnresolvableHostFallsBackToDiallingTheName(t *testing.T) {
+	assert.Empty(t, resolvePinnedSSHDialAddress("no-such-host.invalid", 22),
+		"a probe that cannot answer must report no pin, so the composer emits the name-based command af has "+
+			"always emitted")
+}
+
+// proxyCommandValue extracts the ProxyCommand value from a composed command as
+// the outer `sh -c` would hand it to ssh: unwrapped one layer, still carrying the
+// inner quoting and the doubled percents ssh has yet to expand.
+func proxyCommandValue(t *testing.T, cmd string) string {
+	t.Helper()
+	const marker = "-o ProxyCommand='"
+	i := strings.Index(cmd, marker)
+	require.GreaterOrEqual(t, i, 0, "no ProxyCommand in %q", cmd)
+	rest := cmd[i+len(marker):]
+	// shellQuoteSandbox spells an embedded quote '\'' — undo that, then stop at the
+	// closing quote.
+	rest = strings.ReplaceAll(rest, `'\''`, "\x00")
+	end := strings.Index(rest, "'")
+	require.GreaterOrEqual(t, end, 0, "unterminated ProxyCommand in %q", cmd)
+	return strings.ReplaceAll(rest[:end], "\x00", "'")
+}
+
+// relayOnce drives the production relay for one connection and reads the far
+// side's greeting back, so a dial that connects but relays nothing still fails —
+// and so the listener's counter is settled before the caller looks at it.
+func relayOnce(host string, port int) error {
+	var out strings.Builder
+	if err := sshrelay.Run(host, strconv.Itoa(port), strings.NewReader(""), &out); err != nil {
+		return err
+	}
+	if out.String() == "" {
+		return fmt.Errorf("relay connected but returned no bytes")
+	}
+	return nil
+}
+
+// greetingFrom opens a plain connection and waits for the stand-in machine to
+// announce itself, which is the point at which that machine has certainly counted
+// the connection.
+func greetingFrom(addr string) error {
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		return err
+	}
+	buf := make([]byte, 64)
+	if _, err := conn.Read(buf); err != nil {
+		return err
+	}
+	return nil
+}
+
+// standInMachine is one of the two hosts behind the round-robin name. It greets
+// every connection so a relayed dial can be told apart from a bare TCP connect.
+type standInMachine struct {
+	addr string
+	ln   net.Listener
+	mu   sync.Mutex
+	n    int
+}
+
+func (m *standInMachine) count() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.n
+}
+
+func (m *standInMachine) reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.n = 0
+}
+
+func (m *standInMachine) serve() {
+	for {
+		conn, err := m.ln.Accept()
+		if err != nil {
+			return
+		}
+		m.mu.Lock()
+		m.n++
+		m.mu.Unlock()
+		go func() {
+			_, _ = conn.Write([]byte("on " + m.addr + "\n"))
+			_ = conn.Close()
+		}()
+	}
+}
+
+// twoMachinesBehindOneName binds two loopback addresses to the SAME port, which
+// is what makes them addressable as one name. 127.0.0.0/8 is entirely local on
+// Linux, so no privileges and no external interface are involved.
+func twoMachinesBehindOneName(t *testing.T) (*standInMachine, *standInMachine, int) {
+	t.Helper()
+	for attempt := 0; attempt < 8; attempt++ {
+		lnB, err := net.Listen("tcp", "127.0.0.2:0")
+		if err != nil {
+			t.Skipf("this platform cannot bind a second loopback address (%v); the multi-address property "+
+				"needs two REACHABLE addresses and asserting it against one would prove nothing", err)
+		}
+		port := lnB.Addr().(*net.TCPAddr).Port
+		lnA, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(port))
+		if err != nil {
+			// The port is free on .2 but taken on .1; try another.
+			_ = lnB.Close()
+			continue
+		}
+		a := &standInMachine{addr: "127.0.0.1", ln: lnA}
+		b := &standInMachine{addr: "127.0.0.2", ln: lnB}
+		t.Cleanup(func() { _ = lnA.Close(); _ = lnB.Close() })
+		go a.serve()
+		go b.serve()
+		return a, b, port
+	}
+	t.Skip("could not find a port free on both loopback addresses")
+	return nil, nil, 0
+}
+
+// useRotatingResolver points the process resolver at an in-process DNS server
+// that answers with the given addresses in a DIFFERENT ORDER each time.
+//
+// Rotation is the point, not a flourish: a name whose answers are stable would
+// make consecutive unpinned dials agree by luck, and the control above would stop
+// distinguishing a working pin from no pin at all. Round-robin DNS and load
+// balancers genuinely rotate, which is exactly why af cannot assume two
+// resolutions of one name reach the same machine.
+//
+// `localhost` is deliberately NOT used for this: on Debian and Ubuntu it maps to
+// 127.0.0.1 alone (::1 is ip6-localhost), so a localhost-based fixture would be
+// single-address and this test would pass while proving nothing.
+func useRotatingResolver(t *testing.T, addrs ...string) {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	var turn int
+	go func() {
+		buf := make([]byte, 512)
+		for {
+			n, from, readErr := pc.ReadFrom(buf)
+			if readErr != nil {
+				return
+			}
+			rotated := make([]string, 0, len(addrs))
+			for i := range addrs {
+				rotated = append(rotated, addrs[(i+turn)%len(addrs)])
+			}
+			reply, answeredA := dnsReply(buf[:n], rotated)
+			// ROTATE PER LOOKUP, NOT PER QUERY. Go resolves a name by sending the A
+			// and AAAA queries CONCURRENTLY, so a counter advanced on every packet
+			// depends on which of the two happens to arrive first — measured: the
+			// order came back constant for four straight lookups, then a dial landed
+			// on the other machine out of nowhere. Advancing only on the query whose
+			// answer this fixture actually varies makes each lookup see the next
+			// rotation, deterministically.
+			if answeredA {
+				turn++
+			}
+			if reply != nil {
+				_, _ = pc.WriteTo(reply, from)
+			}
+		}
+	}()
+
+	prev := net.DefaultResolver
+	net.DefaultResolver = &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, "udp", pc.LocalAddr().String())
+		},
+	}
+	t.Cleanup(func() {
+		net.DefaultResolver = prev
+		_ = pc.Close()
+	})
+}
+
+// dnsMinHeader is the fixed-size prefix of a DNS message: id, flags, and the four
+// section counts.
+const dnsMinHeader = 12
+
+// dnsReply answers an A query with the given addresses and an AAAA query with an
+// empty NOERROR, which is what stops Go's parallel A/AAAA lookup from failing.
+//
+// It answers whatever name is asked. The resolver is redirected here for one test
+// only, and matching on the name would make the fixture depend on resolv.conf's
+// ndots and search list — settings that vary per machine and per container, and
+// that decide only whether Go asks for `n.test` or `n.test.some.search.domain`
+// first.
+func dnsReply(query []byte, addrs []string) (reply []byte, answeredA bool) {
+	if len(query) < dnsMinHeader {
+		return nil, false
+	}
+	// Walk the QNAME labels to find where the question ends.
+	i := dnsMinHeader
+	for i < len(query) && query[i] != 0 {
+		i += int(query[i]) + 1
+	}
+	if i+5 > len(query) {
+		return nil, false
+	}
+	qEnd := i + 5 // the zero label byte, then QTYPE and QCLASS
+	qType := binary.BigEndian.Uint16(query[i+1 : i+3])
+
+	reply = make([]byte, qEnd)
+	copy(reply, query[:qEnd])
+	binary.BigEndian.PutUint16(reply[2:4], 0x8180) // response, recursion available
+	binary.BigEndian.PutUint16(reply[4:6], 1)      // one question, echoed back
+
+	// Anything that is not an A query gets NOERROR with no answers. For AAAA that
+	// is what settles the other half of Go's parallel lookup instead of leaving it
+	// to time out.
+	const typeA = 1
+	if qType != typeA {
+		return reply, false
+	}
+	answers := 0
+	for _, a := range addrs {
+		ip := net.ParseIP(a).To4()
+		if ip == nil {
+			continue
+		}
+		rr := make([]byte, 0, 16)
+		rr = append(rr, 0xC0, 0x0C) // a pointer to the question's name
+		rr = binary.BigEndian.AppendUint16(rr, typeA)
+		rr = binary.BigEndian.AppendUint16(rr, 1) // class IN
+		rr = binary.BigEndian.AppendUint32(rr, 0) // TTL 0: never cached anywhere
+		rr = binary.BigEndian.AppendUint16(rr, 4)
+		rr = append(rr, ip...)
+		reply = append(reply, rr...)
+		answers++
+	}
+	binary.BigEndian.PutUint16(reply[6:8], uint16(answers))
+	return reply, true
+}

--- a/session/ssh_proxycommand_pin_test.go
+++ b/session/ssh_proxycommand_pin_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -273,6 +274,71 @@ func TestUnresolvableHostFallsBackToDiallingTheName(t *testing.T) {
 	assert.Empty(t, resolvePinnedSSHDialAddress("no-such-host.invalid", 22),
 		"a probe that cannot answer must report no pin, so the composer emits the name-based command af has "+
 			"always emitted")
+}
+
+// A pin af cannot RUN must cost the pin, not the session.
+//
+// This is the failure #3118 hit in CI before it shipped, and it is worth stating
+// precisely because it is the exact shape of #3092. A ProxyCommand that cannot
+// exec does not degrade — ssh gets no transport at all, so every step dies on its
+// 30s deadline with a timeout naming neither the relay nor the cause. An unpinned
+// session in the same situation would simply have worked. So the create path
+// checks first and declines to pin.
+//
+// The reverse asymmetry is asserted by
+// TestUncomposablePinRetainsTheRecordRatherThanDiallingTheName: on TEARDOWN the
+// same condition must fail LOUD, because a record already knows which machine
+// holds its workspace and reaping a different one retires the tombstone for good.
+func TestAnUnusableRelayBinaryFallsBackToDiallingTheName(t *testing.T) {
+	// A listener that certainly answers, so the ONLY thing under test is the relay
+	// check — not whether the address resolved.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = ln.Close() }()
+	go func() {
+		for {
+			conn, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	// A usable relay pins.
+	usable := filepath.Join(t.TempDir(), "af")
+	require.NoError(t, os.WriteFile(usable, []byte("#!/bin/sh\n"), 0o755))
+	restore := SetSSHRelayBinaryForTest(usable)
+	assert.Equal(t, "127.0.0.1", pinForProvision("127.0.0.1", port),
+		"an executable relay must pin, or this test proves nothing about the cases below")
+	restore()
+
+	dir := t.TempDir()
+	notThere := filepath.Join(dir, "deleted-af")
+	notExecutable := filepath.Join(dir, "not-executable")
+	require.NoError(t, os.WriteFile(notExecutable, []byte("#!/bin/sh\n"), 0o644))
+
+	for name, path := range map[string]string{
+		// os.Executable trims Linux's " (deleted)" suffix, so a daemon whose binary
+		// was replaced in place still names a real file. One deleted outright does not.
+		"a binary that is gone":   notThere,
+		"a binary that is not +x": notExecutable,
+		"a directory, not a file": dir,
+	} {
+		t.Run(name, func(t *testing.T) {
+			defer SetSSHRelayBinaryForTest(path)()
+			assert.Empty(t, pinForProvision("127.0.0.1", port),
+				"%s must cost the PIN, not the whole session: a ProxyCommand that cannot exec leaves ssh with "+
+					"no transport, so every step times out where an unpinned session would have connected", name)
+		})
+	}
+
+	// And a relay af cannot even name at all.
+	prev := sshRelayBinary
+	sshRelayBinary = func() (string, error) { return "", fmt.Errorf("no /proc/self/exe") }
+	defer func() { sshRelayBinary = prev }()
+	assert.Empty(t, pinForProvision("127.0.0.1", port))
 }
 
 // The probe is BOUNDED, because it is the one part of this that runs in-process.

--- a/session/ssh_proxycommand_pin_test.go
+++ b/session/ssh_proxycommand_pin_test.go
@@ -335,6 +335,27 @@ func TestAnUnusableRelayBinaryFallsBackToDiallingTheName(t *testing.T) {
 		})
 	}
 
+	// THE CASE A PERMISSION-BIT TEST MISSES. Mode 0o011 has execute bits set — for
+	// group and other — so "is any execute bit set?" says yes, while the kernel says
+	// EACCES because the OWNER class applies to the owner and it has none. That is
+	// the same shape as the root-owned 0700 binary the review named, constructible
+	// without root, and it is why the check asks faccessat(X_OK) instead of reading
+	// Mode().Perm().
+	t.Run("executable for another class but not for us", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("root bypasses the permission check (CAP_DAC_OVERRIDE), so this case cannot be built here")
+		}
+		wrongClass := filepath.Join(t.TempDir(), "af")
+		require.NoError(t, os.WriteFile(wrongClass, []byte("#!/bin/sh\n"), 0o644))
+		require.NoError(t, os.Chmod(wrongClass, 0o011))
+		require.NotZero(t, 0o011&0o111, "the fixture must have SOME execute bit, or it proves nothing")
+
+		defer SetSSHRelayBinaryForTest(wrongClass)()
+		assert.Empty(t, pinForProvision("127.0.0.1", port),
+			"a binary this user cannot execute must cost the pin: accepting it turns the intended name-based "+
+				"fallback into an unusable backend, since every ProxyCommand then fails with EACCES")
+	})
+
 	// And a relay af cannot even name at all.
 	prev := sshRelayBinary
 	sshRelayBinary = func() (string, error) { return "", fmt.Errorf("no /proc/self/exe") }

--- a/session/ssh_proxycommand_pin_test.go
+++ b/session/ssh_proxycommand_pin_test.go
@@ -275,6 +275,43 @@ func TestUnresolvableHostFallsBackToDiallingTheName(t *testing.T) {
 			"always emitted")
 }
 
+// The probe is BOUNDED, because it is the one part of this that runs in-process.
+//
+// sshRuntime.Provision carries no context, so an unbounded dial to an address that
+// silently drops packets would hold a session create for the kernel's SYN-retry
+// window — well past the 30s deadline the first ssh step would have failed at.
+// 198.51.100.0/24 is TEST-NET-2 (RFC 5737): reserved for documentation, routed
+// nowhere, so a connect to it hangs rather than being refused, which is exactly
+// the shape this bounds.
+func TestTheDialProbeIsBounded(t *testing.T) {
+	// The SHIPPED value, asserted separately from the behaviour, so shrinking the
+	// timeout below cannot quietly become the only thing this test checks.
+	assert.Equal(t, sshDialTimeout, sshDialProbeTimeout,
+		"the probe must ship with a real deadline, not a test's")
+
+	// Now prove the deadline is APPLIED. A probe with no timeout at all would
+	// ignore this and hang, so the short value tests the mechanism rather than
+	// standing in for it — and it costs 300ms instead of the full 20s.
+	prev := sshDialProbeTimeout
+	sshDialProbeTimeout = 300 * time.Millisecond
+	defer func() { sshDialProbeTimeout = prev }()
+
+	done := make(chan string, 1)
+	start := time.Now()
+	go func() { done <- resolvePinnedSSHDialAddress("198.51.100.9", 22) }()
+
+	select {
+	case pinned := <-done:
+		assert.Empty(t, pinned, "an unreachable address yields no pin")
+		assert.Less(t, time.Since(start), 20*time.Second,
+			"the probe must give up on ITS OWN deadline rather than the kernel's")
+	case <-time.After(60 * time.Second):
+		t.Fatal("resolvePinnedSSHDialAddress ignored its deadline: an unbounded probe blocks a session create " +
+			"for the kernel's SYN-retry window, where an unpinned create fails at the first step's 30s " +
+			"deadline. It runs in-process, so unlike the relay there is no process group for a caller to kill")
+	}
+}
+
 // proxyCommandValue extracts the ProxyCommand value from a composed command as
 // the outer `sh -c` would hand it to ssh: unwrapped one layer, still carrying the
 // inner quoting and the doubled percents ssh has yet to expand.

--- a/session/ssh_proxycommand_pin_test.go
+++ b/session/ssh_proxycommand_pin_test.go
@@ -424,6 +424,15 @@ func TestPinningFollowsTheVerifyingPostureExactly(t *testing.T) {
 	require.NoError(t, os.WriteFile(empty, nil, 0o600))
 	emptyCfg := config.SSHConfig{Host: "127.0.0.1", Port: port, KnownHosts: empty}
 
+	// A store that MENTIONS the host but holds no concrete key. `ssh-keygen -F`
+	// exits 0 on it, so this case is what separates reading its output from
+	// trusting its exit status — and without it, a regression to the exit status
+	// passes every other case here.
+	markerOnly := filepath.Join(t.TempDir(), "marker_only_known_hosts")
+	require.NoError(t, os.WriteFile(markerOnly,
+		[]byte(fmt.Sprintf("@cert-authority [127.0.0.1]:%d %s\n", port, strings.TrimSpace(string(pub)))), 0o600))
+	markerCfg := config.SSHConfig{Host: "127.0.0.1", Port: port, KnownHosts: markerOnly}
+
 	cases := []struct {
 		name    string
 		cfg     config.SSHConfig
@@ -442,6 +451,10 @@ func TestPinningFollowsTheVerifyingPostureExactly(t *testing.T) {
 		// Once the host is known, accept-new refuses a CHANGED key, so a wrong pin is
 		// loud and pinning is sound again.
 		{"accept-new with the host known", seededCfg, config.SSHHostKeyAcceptNew, true},
+		// A @cert-authority line matches the host and makes `ssh-keygen -F` exit 0,
+		// but it does NOT make an unrelated raw key a CHANGED key — measured, accept-new
+		// accepted and appended one. So this must not pin.
+		{"accept-new with only a marker line", markerCfg, config.SSHHostKeyAcceptNew, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -468,6 +481,70 @@ func TestPinningFollowsTheVerifyingPostureExactly(t *testing.T) {
 			default:
 				t.Fatalf("unexpected StrictHostKeyChecking=%s; the pin rule must be extended to cover it", strictOpt)
 			}
+		})
+	}
+}
+
+// A MARKER IS NOT A KEY, and `ssh-keygen -F` exits 0 for both.
+//
+// `@cert-authority` and `@revoked` lines match a host, so a zero exit says "this
+// file mentions the host" — not "a wrong machine would be refused". Measured
+// against OpenSSH_9.6p1 and a real sshd presenting a raw host key, with a store
+// holding only a matching @cert-authority entry, accept-new ACCEPTED the unrelated
+// key and appended it. Trusting the exit status would therefore have pinned
+// precisely the silent case the check exists to exclude.
+//
+// The fixtures are built with real ssh-keygen output rather than hand-written
+// strings, so the parsing is checked against what the tool actually emits —
+// including the hashed form, where a concrete entry begins `|1|…` instead of with
+// the host pattern.
+func TestOnlyAConcreteHostKeyCountsAsKnown(t *testing.T) {
+	if _, err := exec.LookPath("ssh-keygen"); err != nil {
+		t.Skipf("ssh-keygen unavailable: %v", err)
+	}
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "k")
+	out, genErr := exec.Command("ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", keyPath).CombinedOutput()
+	require.NoError(t, genErr, "%s", out)
+	pubBytes, readErr := os.ReadFile(keyPath + ".pub")
+	require.NoError(t, readErr)
+	pub := strings.TrimSpace(string(pubBytes))
+	const host = "[h.example]:2222"
+
+	write := func(name string, lines ...string) string {
+		path := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600))
+		return path
+	}
+	hashed := write("hashed", host+" "+pub)
+	hashOut, hashErr := exec.Command("ssh-keygen", "-q", "-H", "-f", hashed).CombinedOutput()
+	require.NoError(t, hashErr, "%s", hashOut)
+	require.NoError(t, os.Remove(hashed+".old"))
+
+	for name, tc := range map[string]struct {
+		store string
+		want  bool
+	}{
+		"a plain key":               {write("plain", host+" "+pub), true},
+		"a hashed key":              {hashed, true},
+		"@cert-authority ONLY":      {write("ca", "@cert-authority "+host+" "+pub), false},
+		"@revoked ONLY":             {write("rev", "@revoked "+host+" "+pub), false},
+		"@cert-authority AND a key": {write("both", "@cert-authority "+host+" "+pub, host+" "+pub), true},
+		"a different host entirely": {write("other", "[nope.example]:2222 "+pub), false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			keygen := exec.Command("ssh-keygen", "-F", host, "-f", tc.store)
+			stdout, runErr := keygen.Output()
+			if !tc.want && runErr != nil {
+				// A genuine miss: ssh-keygen exits non-zero and af declines to pin.
+				assert.False(t, hasConcreteHostKey(stdout))
+				return
+			}
+			require.NoError(t, runErr, "ssh-keygen -F should have MATCHED for %q", name)
+			assert.Equal(t, tc.want, hasConcreteHostKey(stdout),
+				"%s: ssh-keygen exited 0, but a zero exit only means the file MENTIONS the host. Only a "+
+					"concrete key makes a wrong machine's key a CHANGED key; a marker line leaves accept-new "+
+					"free to accept an unrelated key and append it (measured). Output was:\n%s", name, stdout)
 		})
 	}
 }

--- a/session/ssh_proxycommand_pin_test.go
+++ b/session/ssh_proxycommand_pin_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -311,7 +312,7 @@ func TestAnUnusableRelayBinaryFallsBackToDiallingTheName(t *testing.T) {
 	usable := filepath.Join(t.TempDir(), "af")
 	require.NoError(t, os.WriteFile(usable, []byte("#!/bin/sh\n"), 0o755))
 	restore := SetSSHRelayBinaryForTest(usable)
-	assert.Equal(t, "127.0.0.1", pinForProvision("127.0.0.1", port),
+	assert.Equal(t, "127.0.0.1", pinForProvision(config.SSHConfig{Host: "127.0.0.1"}, "127.0.0.1", port, config.SSHHostKeyStrict),
 		"an executable relay must pin, or this test proves nothing about the cases below")
 	restore()
 
@@ -329,7 +330,7 @@ func TestAnUnusableRelayBinaryFallsBackToDiallingTheName(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			defer SetSSHRelayBinaryForTest(path)()
-			assert.Empty(t, pinForProvision("127.0.0.1", port),
+			assert.Empty(t, pinForProvision(config.SSHConfig{Host: "127.0.0.1"}, "127.0.0.1", port, config.SSHHostKeyStrict),
 				"%s must cost the PIN, not the whole session: a ProxyCommand that cannot exec leaves ssh with "+
 					"no transport, so every step times out where an unpinned session would have connected", name)
 		})
@@ -351,7 +352,7 @@ func TestAnUnusableRelayBinaryFallsBackToDiallingTheName(t *testing.T) {
 		require.NotZero(t, 0o011&0o111, "the fixture must have SOME execute bit, or it proves nothing")
 
 		defer SetSSHRelayBinaryForTest(wrongClass)()
-		assert.Empty(t, pinForProvision("127.0.0.1", port),
+		assert.Empty(t, pinForProvision(config.SSHConfig{Host: "127.0.0.1"}, "127.0.0.1", port, config.SSHHostKeyStrict),
 			"a binary this user cannot execute must cost the pin: accepting it turns the intended name-based "+
 				"fallback into an unusable backend, since every ProxyCommand then fails with EACCES")
 	})
@@ -360,7 +361,115 @@ func TestAnUnusableRelayBinaryFallsBackToDiallingTheName(t *testing.T) {
 	prev := sshRelayBinary
 	sshRelayBinary = func() (string, error) { return "", fmt.Errorf("no /proc/self/exe") }
 	defer func() { sshRelayBinary = prev }()
-	assert.Empty(t, pinForProvision("127.0.0.1", port))
+	assert.Empty(t, pinForProvision(config.SSHConfig{Host: "127.0.0.1"}, "127.0.0.1", port, config.SSHHostKeyStrict))
+}
+
+// af pins ONLY where ssh would REFUSE a machine whose key it does not already
+// trust.
+//
+// With a ProxyCommand ssh does not resolve the name at all — the relay connects —
+// so there is no live resolver disagreement during a session; every step goes where
+// af pinned. What remains is that a known_hosts entry recorded EARLIER may have
+// been written against whichever machine getaddrinfo/NSS selected, while af pins
+// one Go's resolver selected.
+//
+// Under `strict`, and under `accept-new` once the host is in the store, that
+// mismatch is refused: loud, pre-auth, nothing runs anywhere. Under `accept-new`
+// with NO entry it is SILENT — ssh adds the pinned machine's key, the session
+// provisions there, and the name is bound to that machine from then on. `insecure`
+// verifies nothing at all.
+//
+// So this is a precondition rather than a preference, and it is what makes "a wrong
+// pin fails closed" true by construction. #3086 stays open for the exposure it
+// leaves behind.
+func TestPinningFollowsTheVerifyingPostureExactly(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = ln.Close() }()
+	go func() {
+		for {
+			conn, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	usable := filepath.Join(t.TempDir(), "af")
+	require.NoError(t, os.WriteFile(usable, []byte("#!/bin/sh\n"), 0o755))
+	defer SetSSHRelayBinaryForTest(usable)()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	// An accept-new store that already holds this host, written in the HASHED form
+	// Debian and Ubuntu produce by default — so the lookup is exercised against the
+	// shape a hand-rolled parser would get wrong, not just the easy one.
+	seeded := filepath.Join(t.TempDir(), "known_hosts")
+	keyPath := filepath.Join(t.TempDir(), "k")
+	if out, genErr := exec.Command("ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", keyPath).CombinedOutput(); genErr != nil {
+		t.Skipf("ssh-keygen unavailable, so the store lookup cannot be exercised: %v: %s", genErr, out)
+	}
+	pub, readErr := os.ReadFile(keyPath + ".pub")
+	require.NoError(t, readErr)
+	require.NoError(t, os.WriteFile(seeded,
+		[]byte(fmt.Sprintf("[127.0.0.1]:%d %s\n", port, strings.TrimSpace(string(pub)))), 0o600))
+	hashOut, hashErr := exec.Command("ssh-keygen", "-q", "-H", "-f", seeded).CombinedOutput()
+	require.NoError(t, hashErr, "%s", hashOut)
+	require.NoError(t, os.Remove(seeded+".old"))
+	seededCfg := config.SSHConfig{Host: "127.0.0.1", Port: port, KnownHosts: seeded}
+
+	empty := filepath.Join(t.TempDir(), "empty_known_hosts")
+	require.NoError(t, os.WriteFile(empty, nil, 0o600))
+	emptyCfg := config.SSHConfig{Host: "127.0.0.1", Port: port, KnownHosts: empty}
+
+	cases := []struct {
+		name    string
+		cfg     config.SSHConfig
+		posture string
+		wantPin bool
+	}{
+		{"strict", emptyCfg, config.SSHHostKeyStrict, true},
+		// config defaults the posture to strict at parse time; an empty value must not
+		// silently relax, and sshHostKeyOptions fails safe the same way.
+		{"empty posture is strict", emptyCfg, "", true},
+		{"unknown posture is strict", emptyCfg, "unknown-future-posture", true},
+		{"insecure never pins", seededCfg, config.SSHHostKeyInsecure, false},
+		// The case with no verification signal at all: ssh would ADD the pinned
+		// machine's key and provision there, silently and durably.
+		{"accept-new with no entry", emptyCfg, config.SSHHostKeyAcceptNew, false},
+		// Once the host is known, accept-new refuses a CHANGED key, so a wrong pin is
+		// loud and pinning is sound again.
+		{"accept-new with the host known", seededCfg, config.SSHHostKeyAcceptNew, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pinForProvision(tc.cfg, "127.0.0.1", port, tc.posture) != ""
+			assert.Equal(t, tc.wantPin, got,
+				"%s: af may pin only where ssh would REFUSE a machine whose key it does not already trust — "+
+					"that refusal is the only thing standing between a wrong pin and a session silently "+
+					"provisioned on the wrong machine", tc.name)
+
+			// AND THE POSTURE MAPPINGS MUST AGREE. sshHostKeyOptions decides what ssh is
+			// actually told; sshPinIsCheckable decides whether af pins. A comment claiming
+			// they agree would be false the moment either moved, so the relationship is
+			// asserted: strict pins, insecure never does, accept-new follows its store.
+			_, strictOpt, optErr := sshHostKeyOptions(tc.cfg, tc.posture, "127.0.0.1")
+			require.NoError(t, optErr)
+			switch strictOpt {
+			case "yes":
+				assert.True(t, sshPinIsCheckable(tc.cfg, tc.posture), "StrictHostKeyChecking=yes refuses an unknown key")
+			case "no":
+				assert.False(t, sshPinIsCheckable(tc.cfg, tc.posture), "StrictHostKeyChecking=no verifies nothing")
+			case "accept-new":
+				assert.Equal(t, tc.wantPin, sshPinIsCheckable(tc.cfg, tc.posture),
+					"accept-new pins exactly when the store already knows the host")
+			default:
+				t.Fatalf("unexpected StrictHostKeyChecking=%s; the pin rule must be extended to cover it", strictOpt)
+			}
+		})
+	}
 }
 
 // The probe is BOUNDED, because it is the one part of this that runs in-process.

--- a/session/ssh_proxycommand_sshd_test.go
+++ b/session/ssh_proxycommand_sshd_test.go
@@ -1,0 +1,350 @@
+package session
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// The #3086 pin against a REAL sshd, because the thing that killed the previous
+// attempt is not expressible as a string assertion.
+//
+// #3090 pinned by making the resolved address ssh's destination and restoring the
+// name with `-o HostKeyAlias`. That is correct-looking and wrong: OpenSSH uses the
+// alias as BOTH the known_hosts lookup key AND the certificate principal, and on a
+// non-default port those need different values — `[name]:port` for a plain entry,
+// the bare `name` for a certificate. Only a live sshd holding a real host
+// certificate can tell the two apart, which is why these tests start one.
+//
+// EVERY TEST HERE USES A `.invalid` HOST NAME, and that is load-bearing rather
+// than cosmetic. RFC 6761 guarantees `.invalid` never resolves, so a connection
+// that succeeds PROVES the ProxyCommand carried it — there is no address behind
+// the name for ssh to fall back to. A resolvable fixture could pass with the pin
+// doing nothing at all.
+
+// TestPinnedSessionValidatesAHostCertificateOnANonDefaultPort is the #3090
+// regression, with its old mechanism reproduced beside its fix.
+func TestPinnedSessionValidatesAHostCertificateOnANonDefaultPort(t *testing.T) {
+	lab := startSSHLab(t)
+	defer SetSSHRelayBinaryForTest(afRelayBinary(t))()
+
+	// known_hosts holds ONLY the CA line, so nothing but certificate validation can
+	// satisfy this connection.
+	knownHosts := lab.writeKnownHosts(t, "@cert-authority pinned.invalid "+lab.caPub)
+	cfg := lab.sshConfig(knownHosts)
+
+	pinnedCmd, err := sshCommandPinnedTo(cfg, config.SSHHostKeyStrict, "127.0.0.1")
+	require.NoError(t, err)
+	out, err := runOverTransport(pinnedCmd, "echo CERT_ACCEPTED")
+	require.NoError(t, err, "a pinned session must still validate a host certificate.\nssh said:\n%s", out)
+	assert.Contains(t, out, "CERT_ACCEPTED")
+
+	// THE CONTROL: the mechanism #3090 shipped, reproduced verbatim against the same
+	// sshd and the same certificate. It must FAIL — if it did not, this test would
+	// not be pinning anything, because the fix and the bug would be
+	// indistinguishable here.
+	legacyCmd := hostKeyAliasPinnedCommand(t, cfg, config.SSHHostKeyStrict, "127.0.0.1")
+	legacyOut, legacyErr := runOverTransport(legacyCmd, "echo SHOULD_NOT_HAPPEN")
+	require.Error(t, legacyErr,
+		"the HostKeyAlias mechanism #3090 shipped must still fail against a certified host on a non-default "+
+			"port — that is the regression this approach exists to avoid, and a control that passes means the "+
+			"fixture is not exercising certificates at all.\nssh said:\n%s", legacyOut)
+	assert.Contains(t, legacyOut, "Host key verification failed",
+		"and it must fail for the RECORDED reason (the alias is used as the certificate principal), not for "+
+			"some unrelated setup problem")
+}
+
+// The other half of the bind #3090 could not satisfy: a PLAIN known_hosts entry on
+// a non-default port, which OpenSSH keys as `[host]:port`. One mechanism now
+// serves both shapes, because ssh computes the key from its own destination.
+func TestPinnedSessionMatchesAPlainKnownHostsEntryOnANonDefaultPort(t *testing.T) {
+	lab := startSSHLab(t)
+	defer SetSSHRelayBinaryForTest(afRelayBinary(t))()
+
+	entry := fmt.Sprintf("[pinned.invalid]:%d %s", lab.port, lab.hostPub)
+	cfg := lab.sshConfig(lab.writeKnownHosts(t, entry))
+
+	pinnedCmd, err := sshCommandPinnedTo(cfg, config.SSHHostKeyStrict, "127.0.0.1")
+	require.NoError(t, err)
+	out, err := runOverTransport(pinnedCmd, "echo PLAIN_ENTRY_OK")
+	require.NoError(t, err, "ssh said:\n%s", out)
+	assert.Contains(t, out, "PLAIN_ENTRY_OK")
+
+	// And the key is looked up under the NAME, not the pinned address: an entry for
+	// a different name must not satisfy it, however the socket got there.
+	wrong := lab.sshConfig(lab.writeKnownHosts(t, fmt.Sprintf("[other.invalid]:%d %s", lab.port, lab.hostPub)))
+	wrongCmd, err := sshCommandPinnedTo(wrong, config.SSHHostKeyStrict, "127.0.0.1")
+	require.NoError(t, err)
+	wrongOut, wrongErr := runOverTransport(wrongCmd, "echo SHOULD_NOT_HAPPEN")
+	require.Error(t, wrongErr, "ssh said:\n%s", wrongOut)
+	assert.Contains(t, wrongOut, "pinned.invalid",
+		"the host must still be IDENTIFIED by the configured name — that is the constraint that ruled out "+
+			"every address-based pin")
+}
+
+// The provision path streams af's own binary over ssh's stdin, and the remote
+// `cat` finishes only on EOF. A relay that closed the whole connection there would
+// lose the reply, and one that never closed the write half would hang forever.
+func TestPinnedSessionStreamsStdinAndSeesEOF(t *testing.T) {
+	lab := startSSHLab(t)
+	defer SetSSHRelayBinaryForTest(afRelayBinary(t))()
+
+	cfg := lab.sshConfig(lab.writeKnownHosts(t,
+		fmt.Sprintf("[pinned.invalid]:%d %s", lab.port, lab.hostPub)))
+	pinnedCmd, err := sshCommandPinnedTo(cfg, config.SSHHostKeyStrict, "127.0.0.1")
+	require.NoError(t, err)
+
+	// Big enough to cross many relay buffers, so a half-close bug shows up as a
+	// short file rather than passing by luck on a payload that fits in one write.
+	payload := strings.Repeat("af-binary-stand-in-0123456789\n", 40000)
+	dst := filepath.Join(t.TempDir(), "streamed")
+	p := newSSHSandboxProvisioner(ProvisionSpec{Title: "stream"}, pinnedCmd, "", "")
+	out, err := p.Run(60*time.Second, "cat > "+shellQuoteSandbox(dst)+" && wc -c < "+shellQuoteSandbox(dst),
+		strings.NewReader(payload), false)
+	require.NoError(t, err, "ssh said:\n%s", out)
+	assert.Equal(t, strconv.Itoa(len(payload)), strings.TrimSpace(string(out)),
+		"the whole stream must reach the far side and the remote command must then see EOF")
+}
+
+// hostKeyAliasPinnedCommand reproduces the mechanism #3090 shipped and #3100
+// reverted: dial the resolved address as ssh's DESTINATION, and restore the name
+// as the host-key lookup key with an alias.
+//
+// It lives in the test rather than in production because it is the CONTROL, not a
+// code path — the fix's whole claim is that this shape is unnecessary, and a claim
+// with no failing counterpart is untested.
+func hostKeyAliasPinnedCommand(t *testing.T, cfg config.SSHConfig, posture, dialAddr string) string {
+	t.Helper()
+	base, err := sshCommandForConfig(cfg, posture)
+	require.NoError(t, err)
+	host, port, err := resolveSSHHostPort(cfg.Host, cfg.Port)
+	require.NoError(t, err)
+	if port == 0 {
+		port = sshDefaultPort
+	}
+	suffix := " " + shellQuoteSandbox(host)
+	require.True(t, strings.HasSuffix(base, suffix))
+	return strings.TrimSuffix(base, suffix) +
+		" -o HostKeyAlias=" + shellQuoteSandbox(knownHostsLookupName(host, port)) +
+		" " + shellQuoteSandbox(dialAddr)
+}
+
+// runOverTransport runs one command through the production transport — the same
+// `sh -c '<sshCmd> "$@"'` composition every provision step and the reap use, so
+// the two shells and the percent expansion are all exercised for real.
+func runOverTransport(sshCmd, script string) (string, error) {
+	p := newSSHSandboxProvisioner(ProvisionSpec{Title: "probe"}, sshCmd, "", "")
+	out, err := p.Run(45*time.Second, script, nil, true)
+	return string(out), err
+}
+
+// sshLab is a throwaway sshd on a high loopback port, with its own host key, its
+// own CA, and its own client key. It never touches the system sshd, the operator's
+// ~/.ssh, or any port but the one it bound.
+type sshLab struct {
+	dir     string
+	port    int
+	hostPub string
+	caPub   string
+	keyPath string
+	user    string
+}
+
+func (l *sshLab) sshConfig(knownHosts string) config.SSHConfig {
+	return config.SSHConfig{
+		Host:         "pinned.invalid",
+		Port:         l.port,
+		User:         l.user,
+		IdentityFile: l.keyPath,
+		KnownHosts:   knownHosts,
+	}
+}
+
+func (l *sshLab) writeKnownHosts(t *testing.T, lines ...string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "known_hosts")
+	require.NoError(t, os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600))
+	return path
+}
+
+func startSSHLab(t *testing.T) *sshLab {
+	t.Helper()
+	sshdBin := lookSSHD(t)
+	for _, tool := range []string{"ssh", "ssh-keygen"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s is not installed; the certificate bind this test exists for cannot be checked without "+
+				"a real OpenSSH client and server", tool)
+		}
+	}
+	me, err := user.Current()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	require.NoError(t, os.Chmod(dir, 0o700))
+	keygen := func(name, comment string, args ...string) {
+		full := append([]string{"-q", "-t", "ed25519", "-N", "", "-C", comment, "-f", filepath.Join(dir, name)}, args...)
+		out, genErr := exec.Command("ssh-keygen", full...).CombinedOutput()
+		require.NoError(t, genErr, "ssh-keygen %v: %s", full, out)
+	}
+	keygen("host_key", "host")
+	keygen("client_key", "client")
+	keygen("ca_key", "ca")
+
+	// A host CERTIFICATE for the bare principal `pinned.invalid` — the value ssh
+	// derives from its own destination, and the one `HostKeyAlias=[name]:port`
+	// cannot produce.
+	signOut, err := exec.Command("ssh-keygen", "-q", "-s", filepath.Join(dir, "ca_key"),
+		"-I", "af-test-hostcert", "-h", "-n", "pinned.invalid", "-V", "-5m:+52w",
+		filepath.Join(dir, "host_key.pub")).CombinedOutput()
+	require.NoError(t, err, "signing the host certificate: %s", signOut)
+
+	read := func(name string) string {
+		b, readErr := os.ReadFile(filepath.Join(dir, name))
+		require.NoError(t, readErr)
+		return strings.TrimSpace(string(b))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "authorized_keys"),
+		[]byte(read("client_key.pub")+"\n"), 0o600))
+
+	port := freeLoopbackPort(t)
+	sshdConfig := filepath.Join(dir, "sshd_config")
+	require.NoError(t, os.WriteFile(sshdConfig, []byte(strings.Join([]string{
+		"Port " + strconv.Itoa(port),
+		// LOOPBACK ONLY. This sshd accepts the invoking user's key, so it must not be
+		// reachable from anywhere but this machine.
+		"ListenAddress 127.0.0.1",
+		"HostKey " + filepath.Join(dir, "host_key"),
+		"HostCertificate " + filepath.Join(dir, "host_key-cert.pub"),
+		"AuthorizedKeysFile " + filepath.Join(dir, "authorized_keys"),
+		"PidFile " + filepath.Join(dir, "sshd.pid"),
+		// t.TempDir() is under a world-searchable /tmp, which StrictModes rejects.
+		"StrictModes no",
+		"UsePAM no",
+		"PasswordAuthentication no",
+		"KbdInteractiveAuthentication no",
+		"PermitRootLogin no",
+	}, "\n")+"\n"), 0o600))
+
+	logPath := filepath.Join(dir, "sshd.log")
+	// No -D: sshd daemonizes and writes its pid file, which is what the cleanup
+	// below kills. -e would send logs to a stderr that goes away with the fork.
+	start := exec.Command(sshdBin, "-f", sshdConfig, "-E", logPath)
+	if out, startErr := start.CombinedOutput(); startErr != nil {
+		logs, _ := os.ReadFile(logPath)
+		t.Skipf("cannot start a private sshd (%v): %s\n%s", startErr, out, logs)
+	}
+	t.Cleanup(func() {
+		pid, readErr := os.ReadFile(filepath.Join(dir, "sshd.pid"))
+		if readErr != nil {
+			return
+		}
+		// Signal by the pid IT recorded, so nothing else on this box is touched.
+		if n, convErr := strconv.Atoi(strings.TrimSpace(string(pid))); convErr == nil {
+			if proc, findErr := os.FindProcess(n); findErr == nil {
+				_ = proc.Kill()
+				_, _ = proc.Wait()
+			}
+		}
+	})
+	waitForListener(t, port)
+
+	return &sshLab{
+		dir:     dir,
+		port:    port,
+		hostPub: read("host_key.pub"),
+		caPub:   read("ca_key.pub"),
+		keyPath: filepath.Join(dir, "client_key"),
+		user:    me.Username,
+	}
+}
+
+func lookSSHD(t *testing.T) string {
+	t.Helper()
+	if path, err := exec.LookPath("sshd"); err == nil {
+		return path
+	}
+	// sshd usually lives in an sbin a non-root PATH omits.
+	for _, candidate := range []string{"/usr/sbin/sshd", "/usr/local/sbin/sshd", "/sbin/sshd", "/opt/homebrew/sbin/sshd"} {
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+	t.Skip("no sshd on this host; the certificate bind #3090 tripped over cannot be checked without a real server")
+	return ""
+}
+
+func freeLoopbackPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+	return port
+}
+
+func waitForListener(t *testing.T, port int) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if conn, err := net.Dial("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port))); err == nil {
+			_ = conn.Close()
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Skip("the private sshd never started listening; skipping rather than reporting a false failure")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// afRelayBinary builds the real `af` once per test binary and returns its path.
+//
+// THE REAL BINARY, not a stand-in script: the ProxyCommand is af invoking itself,
+// and the property that matters most — that nothing but relayed bytes reaches
+// stdout — is a property of the whole program's startup, not of sshrelay.Run in
+// isolation. A shell stand-in would test the composition and none of that.
+var (
+	afRelayOnce sync.Once
+	afRelayPath string
+	afRelayErr  error
+)
+
+func afRelayBinary(t *testing.T) string {
+	t.Helper()
+	afRelayOnce.Do(func() {
+		if _, err := exec.LookPath("go"); err != nil {
+			afRelayErr = fmt.Errorf("no go toolchain to build af with: %w", err)
+			return
+		}
+		dir, err := os.MkdirTemp("", "af-relay-bin")
+		if err != nil {
+			afRelayErr = err
+			return
+		}
+		out := filepath.Join(dir, "af")
+		build := exec.Command("go", "build", "-o", out, "github.com/sachiniyer/agent-factory")
+		build.Dir = ".."
+		if combined, buildErr := build.CombinedOutput(); buildErr != nil {
+			afRelayErr = fmt.Errorf("building af: %w: %s", buildErr, combined)
+			return
+		}
+		afRelayPath = out
+	})
+	if afRelayErr != nil {
+		t.Skipf("cannot build the af binary the ProxyCommand runs (%v)", afRelayErr)
+	}
+	return afRelayPath
+}

--- a/session/ssh_proxycommand_sshd_test.go
+++ b/session/ssh_proxycommand_sshd_test.go
@@ -119,68 +119,6 @@ func TestPinnedSessionStreamsStdinAndSeesEOF(t *testing.T) {
 		"the whole stream must reach the far side and the remote command must then see EOF")
 }
 
-// The pin's escape hatch, against REAL ssh output rather than an invented string.
-//
-// af resolves with Go's pure resolver and ssh resolves with getaddrinfo, so an
-// nsswitch source Go does not implement (LDAP, sssd, mDNS) can make both succeed
-// with DIFFERENT addresses — and af would have pinned somewhere ssh would never
-// have gone. That fails CLOSED on host-key verification, so it is an availability
-// bug rather than a security one: nothing wrong is trusted, but the backend stops
-// working for exactly those users. The recovery is one unpinned retry, and this is
-// the detector it turns on.
-//
-// Both branches are driven through the real transport, because the whole point is
-// that the marker is OpenSSH's wording and not af's guess about it.
-func TestHostKeyFailureIsDetectedFromRealSSHOutput(t *testing.T) {
-	lab := startSSHLab(t)
-	defer SetSSHRelayBinaryForTest(afRelayBinary(t))()
-
-	t.Run("an unknown host key retries", func(t *testing.T) {
-		// known_hosts holds an entry for a DIFFERENT name, so this host is unknown.
-		cfg := lab.sshConfig(lab.writeKnownHosts(t,
-			fmt.Sprintf("[other.invalid]:%d %s", lab.port, lab.hostPub)))
-		cmd, err := sshCommandPinnedTo(cfg, config.SSHHostKeyStrict, "127.0.0.1")
-		require.NoError(t, err)
-
-		p := newSSHSandboxProvisioner(ProvisionSpec{Title: "unknown"}, cmd, "", "")
-		// combined=false, which is what the FIRST provision step uses — so ssh's
-		// diagnostic lands in exec.ExitError.Stderr rather than in the error text,
-		// and a detector reading only err.Error() would miss it.
-		_, runErr := p.Run(30*time.Second, "echo SHOULD_NOT_HAPPEN", nil, false)
-		require.Error(t, runErr)
-		assert.True(t, sshHostKeyVerificationFailed(runErr),
-			"OpenSSH's own `Host key verification failed.` must be recognised through the real error chain; "+
-				"got %v", runErr)
-		assert.True(t, shouldRetryProvisionUnpinned("127.0.0.1", "", runErr),
-			"a pinned attempt that never created a session dir must be retryable unpinned")
-	})
-
-	t.Run("a CHANGED host key does not retry", func(t *testing.T) {
-		// A different key under the RIGHT name: ssh reports the identification as
-		// changed, which is a security signal that must surface immediately rather
-		// than be delayed by a retry that would fail the same way.
-		other := filepath.Join(t.TempDir(), "impostor")
-		out, genErr := exec.Command("ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-C", "impostor",
-			"-f", other).CombinedOutput()
-		require.NoError(t, genErr, "%s", out)
-		impostor, readErr := os.ReadFile(other + ".pub")
-		require.NoError(t, readErr)
-
-		cfg := lab.sshConfig(lab.writeKnownHosts(t,
-			fmt.Sprintf("[pinned.invalid]:%d %s", lab.port, strings.TrimSpace(string(impostor)))))
-		cmd, err := sshCommandPinnedTo(cfg, config.SSHHostKeyStrict, "127.0.0.1")
-		require.NoError(t, err)
-
-		p := newSSHSandboxProvisioner(ProvisionSpec{Title: "changed"}, cmd, "", "")
-		_, runErr := p.Run(30*time.Second, "echo SHOULD_NOT_HAPPEN", nil, false)
-		require.Error(t, runErr)
-		assert.False(t, sshHostKeyVerificationFailed(runErr),
-			"a CHANGED identification must NOT be treated as the retryable case: it is a security signal, and "+
-				"the unpinned attempt verifies the same name against the same store and fails identically")
-		assert.False(t, shouldRetryProvisionUnpinned("127.0.0.1", "", runErr))
-	})
-}
-
 // hostKeyAliasPinnedCommand reproduces the mechanism #3090 shipped and #3100
 // reverted: dial the resolved address as ssh's DESTINATION, and restore the name
 // as the host-key lookup key with an alias.

--- a/session/ssh_proxycommand_sshd_test.go
+++ b/session/ssh_proxycommand_sshd_test.go
@@ -128,7 +128,7 @@ func TestPinnedSessionStreamsStdinAndSeesEOF(t *testing.T) {
 // with no failing counterpart is untested.
 func hostKeyAliasPinnedCommand(t *testing.T, cfg config.SSHConfig, posture, dialAddr string) string {
 	t.Helper()
-	base, err := sshCommandForConfig(cfg, posture)
+	base, err := sshCommandPinnedTo(cfg, posture, "")
 	require.NoError(t, err)
 	host, port, err := resolveSSHHostPort(cfg.Host, cfg.Port)
 	require.NoError(t, err)

--- a/session/ssh_proxycommand_sshd_test.go
+++ b/session/ssh_proxycommand_sshd_test.go
@@ -119,6 +119,68 @@ func TestPinnedSessionStreamsStdinAndSeesEOF(t *testing.T) {
 		"the whole stream must reach the far side and the remote command must then see EOF")
 }
 
+// The pin's escape hatch, against REAL ssh output rather than an invented string.
+//
+// af resolves with Go's pure resolver and ssh resolves with getaddrinfo, so an
+// nsswitch source Go does not implement (LDAP, sssd, mDNS) can make both succeed
+// with DIFFERENT addresses — and af would have pinned somewhere ssh would never
+// have gone. That fails CLOSED on host-key verification, so it is an availability
+// bug rather than a security one: nothing wrong is trusted, but the backend stops
+// working for exactly those users. The recovery is one unpinned retry, and this is
+// the detector it turns on.
+//
+// Both branches are driven through the real transport, because the whole point is
+// that the marker is OpenSSH's wording and not af's guess about it.
+func TestHostKeyFailureIsDetectedFromRealSSHOutput(t *testing.T) {
+	lab := startSSHLab(t)
+	defer SetSSHRelayBinaryForTest(afRelayBinary(t))()
+
+	t.Run("an unknown host key retries", func(t *testing.T) {
+		// known_hosts holds an entry for a DIFFERENT name, so this host is unknown.
+		cfg := lab.sshConfig(lab.writeKnownHosts(t,
+			fmt.Sprintf("[other.invalid]:%d %s", lab.port, lab.hostPub)))
+		cmd, err := sshCommandPinnedTo(cfg, config.SSHHostKeyStrict, "127.0.0.1")
+		require.NoError(t, err)
+
+		p := newSSHSandboxProvisioner(ProvisionSpec{Title: "unknown"}, cmd, "", "")
+		// combined=false, which is what the FIRST provision step uses — so ssh's
+		// diagnostic lands in exec.ExitError.Stderr rather than in the error text,
+		// and a detector reading only err.Error() would miss it.
+		_, runErr := p.Run(30*time.Second, "echo SHOULD_NOT_HAPPEN", nil, false)
+		require.Error(t, runErr)
+		assert.True(t, sshHostKeyVerificationFailed(runErr),
+			"OpenSSH's own `Host key verification failed.` must be recognised through the real error chain; "+
+				"got %v", runErr)
+		assert.True(t, shouldRetryProvisionUnpinned("127.0.0.1", "", runErr),
+			"a pinned attempt that never created a session dir must be retryable unpinned")
+	})
+
+	t.Run("a CHANGED host key does not retry", func(t *testing.T) {
+		// A different key under the RIGHT name: ssh reports the identification as
+		// changed, which is a security signal that must surface immediately rather
+		// than be delayed by a retry that would fail the same way.
+		other := filepath.Join(t.TempDir(), "impostor")
+		out, genErr := exec.Command("ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-C", "impostor",
+			"-f", other).CombinedOutput()
+		require.NoError(t, genErr, "%s", out)
+		impostor, readErr := os.ReadFile(other + ".pub")
+		require.NoError(t, readErr)
+
+		cfg := lab.sshConfig(lab.writeKnownHosts(t,
+			fmt.Sprintf("[pinned.invalid]:%d %s", lab.port, strings.TrimSpace(string(impostor)))))
+		cmd, err := sshCommandPinnedTo(cfg, config.SSHHostKeyStrict, "127.0.0.1")
+		require.NoError(t, err)
+
+		p := newSSHSandboxProvisioner(ProvisionSpec{Title: "changed"}, cmd, "", "")
+		_, runErr := p.Run(30*time.Second, "echo SHOULD_NOT_HAPPEN", nil, false)
+		require.Error(t, runErr)
+		assert.False(t, sshHostKeyVerificationFailed(runErr),
+			"a CHANGED identification must NOT be treated as the retryable case: it is a security signal, and "+
+				"the unpinned attempt verifies the same name against the same store and fails identically")
+		assert.False(t, shouldRetryProvisionUnpinned("127.0.0.1", "", runErr))
+	})
+}
+
 // hostKeyAliasPinnedCommand reproduces the mechanism #3090 shipped and #3100
 // reverted: dial the resolved address as ssh's DESTINATION, and restore the name
 // as the host-key lookup key with an alias.

--- a/session/ssh_version_floor_test.go
+++ b/session/ssh_version_floor_test.go
@@ -43,24 +43,35 @@ func TestSSHCommandEmitsOnlyLongEstablishedOptions(t *testing.T) {
 		"GlobalKnownHostsFile":  "1.2",
 		"BatchMode":             "1.2",
 		"ExitOnForwardFailure":  "4.4",
+		// #3086's pin. Priced by reading readconf.c at the earliest release-era tag
+		// that has it (V_1_2_2_P1), where `proxycommand` sits in the same keyword
+		// table as `user` and `batchmode` — the options already priced 1.2 above.
+		// The `%%` escape the value relies on is in percent_expand at the 7.6 floor.
+		"ProxyCommand": "1.2",
 	}
 
 	for _, posture := range []string{
 		config.SSHHostKeyStrict, config.SSHHostKeyAcceptNew, config.SSHHostKeyInsecure, "unknown-future",
 	} {
-		cmd := sshCmdFor(t, config.SSHConfig{Host: "h.example.com", Port: 2222}, posture)
-		fields := strings.Fields(cmd)
-		for i, f := range fields {
-			if f != "-o" || i+1 >= len(fields) {
-				continue
+		// BOTH shapes. A pinned session emits an option an unpinned one does not, so
+		// checking only the unpinned command would leave the allowlist blind at
+		// exactly the place the newest option lives.
+		for _, dialAddr := range []string{"", "198.51.100.8"} {
+			cmd, err := sshCommandPinnedTo(config.SSHConfig{Host: "h.example.com", Port: 2222}, posture, dialAddr)
+			require.NoError(t, err)
+			fields := strings.Fields(cmd)
+			for i, f := range fields {
+				if f != "-o" || i+1 >= len(fields) {
+					continue
+				}
+				name, _, _ := strings.Cut(strings.Trim(fields[i+1], "'"), "=")
+				_, ok := allowed[name]
+				assert.True(t, ok,
+					"posture %q (pin %q) emits -o %s=…, which is not in the priced allowlist. Every option costs a "+
+						"MINIMUM OpenSSH VERSION: `KnownHostsCommand` (8.5) made backend=ssh unusable on Ubuntu 20.04 "+
+						"and Debian 11 because an unrecognised -o aborts option parsing rather than warning (#3092). "+
+						"Add it here with the release that introduced it, or drop it.", posture, dialAddr, name)
 			}
-			name, _, _ := strings.Cut(strings.Trim(fields[i+1], "'"), "=")
-			_, ok := allowed[name]
-			assert.True(t, ok,
-				"posture %q emits -o %s=…, which is not in the priced allowlist. Every option costs a MINIMUM "+
-					"OpenSSH VERSION: `KnownHostsCommand` (8.5) made backend=ssh unusable on Ubuntu 20.04 and "+
-					"Debian 11 because an unrecognised -o aborts option parsing rather than warning (#3092). "+
-					"Add it here with the release that introduced it, or drop it.", posture, name)
 		}
 	}
 }
@@ -184,12 +195,19 @@ func TestSSHCommandCompositionIgnoresAnUnreadableIdentity(t *testing.T) {
 	assert.Contains(t, cmd, "-i '"+missing+"'")
 }
 
-// A cleanup record written by the short-lived #3090 pinning knows the exact
-// machine its workspace is on. Dropping that would let a multi-address name
-// re-resolve to a DIFFERENT machine, remove nothing, report success and retire
-// the only tombstone — a permanent leak. So it is still decoded and honoured.
+// A cleanup record that carries a dial address knows the exact machine its
+// workspace is on. Dropping that would let a multi-address name re-resolve to a
+// DIFFERENT machine, remove nothing, report success and retire the only
+// tombstone — a permanent leak. So it is still decoded and honoured.
+//
+// Records exist from two eras and this covers both: #3090 wrote the field and
+// dialled it as ssh's DESTINATION (with the HostKeyAlias that rejected host
+// certificates), and #3086 writes it again but applies it as a ProxyCommand. Both
+// decode to the same field and both must now reap through the current mechanism —
+// there is no second code path for the older shape.
 func TestPinnedCleanupRecordStillDialsItsRecordedAddress(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	defer SetSSHRelayBinaryForTest("/opt/af/af")()
 
 	raw, err := json.Marshal(&RuntimeCleanupData{SSH: &SSHRuntimeCleanupData{
 		Config:              config.SSHConfig{Host: "many.example.com", Port: 2222},
@@ -207,15 +225,19 @@ func TestPinnedCleanupRecordStillDialsItsRecordedAddress(t *testing.T) {
 	sb, ok := backend.(*sshBackend)
 	require.True(t, ok)
 
-	fields := strings.Fields(sb.provisioner.sshCmd)
-	assert.Equal(t, "'198.51.100.8'", fields[len(fields)-1],
+	assert.Contains(t, proxyCommandValue(t, sb.provisioner.sshCmd), "ssh-relay '198.51.100.8' 2222",
 		"the teardown must reach the machine the session actually ran on")
-	assert.Contains(t, sb.provisioner.sshCmd, "HostKeyAlias='[many.example.com]:2222'",
-		"and keep known_hosts keyed by name, which is what dialling an address requires")
+	fields := strings.Fields(sb.provisioner.sshCmd)
+	assert.Equal(t, "'many.example.com'", fields[len(fields)-1],
+		"and reach it WITHOUT making the address ssh's destination: that is what forced a HostKeyAlias, and "+
+			"no alias value satisfies both a plain [name]:port entry and a certificate principal (#3090)")
+	assert.NotContains(t, sb.provisioner.sshCmd, "HostKeyAlias")
 }
 
-// Every other record — before #3090 and after #3092 — dials the name, with no
-// alias, because that is what keeps certificates and dialer fallback working.
+// Every record with nothing to pin — written before #3090, between #3100 and
+// #3086, or by a provision whose one-off resolution could not settle — dials the
+// name exactly as it always has. A teardown that refused would leak the workspace
+// it exists to remove.
 func TestUnpinnedCleanupRecordDialsTheName(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
@@ -231,6 +253,7 @@ func TestUnpinnedCleanupRecordDialsTheName(t *testing.T) {
 	fields := strings.Fields(sb.provisioner.sshCmd)
 	assert.Equal(t, "'h.example.com'", fields[len(fields)-1])
 	assert.NotContains(t, sb.provisioner.sshCmd, "HostKeyAlias")
+	assert.NotContains(t, sb.provisioner.sshCmd, "-o ProxyCommand")
 }
 
 // A picker is a promise. ssh.identity_file is a local, side-effect-free fact, so

--- a/session/ssh_version_floor_test.go
+++ b/session/ssh_version_floor_test.go
@@ -186,8 +186,8 @@ func TestSSHCommandCompositionIgnoresAnUnreadableIdentity(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	missing := filepath.Join(t.TempDir(), "gone_id_ed25519")
 
-	cmd, err := sshCommandForConfig(
-		config.SSHConfig{Host: "h.example.com", IdentityFile: missing}, config.SSHHostKeyStrict)
+	cmd, err := sshCommandPinnedTo(
+		config.SSHConfig{Host: "h.example.com", IdentityFile: missing}, config.SSHHostKeyStrict, "")
 
 	require.NoError(t, err,
 		"restoreRuntimeCleanup composes while loading persisted handles; refusing here would capture a "+


### PR DESCRIPTION
`backend = "ssh"` runs a **separate `ssh` for each step** — every provision command, the `ssh -L` tunnel, and the reap — and each one resolved `ssh.host` independently. A name answering with more than one address could put the workspace on one machine while the agent-server, tunnel or reap landed on another. Nothing errored: the reap removed the wrong machine's directory, reported success, and retired the only tombstone, leaving the real workspace and agent-server leaking with nothing pointing at them.

This resolves the name **once** at provision, records the address in the cleanup handle's existing `DialAddress` field, and pins every later step to it with `-o ProxyCommand`.

## Why this shape, when the last two lost

Starting from the three constraints recorded on #3086 rather than re-deriving them.

**The pin sits below ssh's naming layer.** ssh's destination stays the configured **name**, so ssh computes the `known_hosts` key and the certificate principal exactly as it does unpinned; only the TCP dial is pinned. Constraint 2 is satisfied by construction rather than by correction.

Measured on OpenSSH_9.6p1 against a real sshd whose host key is certified for the principal `pinned.invalid` on a non-default port:

| mechanism | outcome |
|---|---|
| `ProxyCommand` pinning | **cert ACCEPTED** |
| `HostKeyAlias=[pinned.invalid]:2299` (what #3090 emitted) | **`Host key verification failed`** |

Same sshd, same certificate. That control is a **test**, not a claim in a commit message — `hostKeyAliasPinnedCommand` in `ssh_proxycommand_sshd_test.go` reproduces the reverted mechanism and asserts it still fails. A fix whose bug has no failing counterpart is untested.

**`ProxyCommand` costs no version.** Priced **1.2** in `ssh_version_floor_test.go`'s allowlist, verified rather than guessed: at the earliest release-era tag of `openssh-portable` that carries `readconf.c` (`V_1_2_2_P1`), `proxycommand` sits in the same keyword table as `user` and `batchmode` — the options already priced 1.2. The floor stays 7.6.

**The address travels in persisted data, not a live process.** `restoreRuntimeCleanup` composes the same pinned command in a fresh daemon, which is the constraint that ruled out a `ControlMaster` multiplex.

## Two hazards the issue did not name

Both measured on OpenSSH_9.6p1, both handled:

- **ssh percent-expands a `ProxyCommand` value.** An unescaped `%` in the AF path aborts the connection before it starts — `vdollar_percent_expand: unknown key %d` — so every `%` is doubled. `%%` is in `percent_expand` at the 7.6 floor, so the escape costs nothing. This also carries a zoned IPv6 address (`fe80::1%eth0`), where the zone is part of the address's identity.
- **The value crosses two shells.** ssh runs a `ProxyCommand` as `/bin/sh -c`, and af runs the whole invocation as `sh -c '<sshCmd> "$@"'` — so it carries two quoting layers, and an AF home with a space survives both.

No `%h`/`%p` tokens: they expand to what ssh is dialling, which is the name — the exact thing the pin exists to bypass.

## The relay

A hidden `af ssh-relay <address> <port>` subcommand, not `nc`/`socat`. An external binary is the same failure class as an option that is too new — a dependency af cannot guarantee, whose absence breaks the whole backend rather than degrading — while af is present by definition, because af is the process composing the command. The path is resolved fresh, never persisted, so a daemon that restarted into an upgraded binary names the one it is running.

Its **stdout is the ssh transport stream**, so one stray byte corrupts the session. That is tested against the **real binary**, because it is a property of the whole program's startup rather than of the relay function: cobra's output writer is pointed at stderr (its help writer defaults to stdout — confirmed by mutation), and the tests compare 4 KB of binary payload byte-for-byte. Half-close is driven end-to-end through a real sshd with a 1.2 MB stdin stream, since af streams its own binary that way and the remote `cat` finishes only on EOF.

## Resolution keeps the fallback address-pinning removed

The probe **dials** rather than looking up, so the pinned address is one that demonstrably answered — which preserves `net.Dialer`'s try-each-consecutive-address behaviour that #3090 silently removed (the dual-stack host with a black-holed IPv6 route).

When it cannot settle on an address, af logs and composes the name-based command it always did. Turning a probe into a hard precondition for the backend would be #3092's mistake with a new cause: Go's pure resolver (`CGO_ENABLED=0`) does not consult the nsswitch modules `getaddrinfo` does, so a name served only by mDNS resolves for ssh and not for af. The pin is an improvement over dialling by name; where it cannot be computed, af degrades to what it did before rather than to nothing.

An **uncomposable** pin is the opposite case and is returned as an error, not swallowed: reaching it means the session *is* on a known machine, so the record is retained and retried rather than reaped by name. Retained-and-retried beats silently-wrong-and-retired.

## Tests, and what each would catch

- **`TestPinnedSSHDialAddressKeepsEveryStepOnOneMachine`** — the acceptance criterion, driven through the mechanism. Two loopback addresses on one port stand in for two machines, behind an in-process **round-robin DNS** name whose answers rotate. It carries a **control**: the name must resolve to both *and* unpinned dials must reach both, or the fixture proves nothing. `localhost` was rejected for this — on Debian/Ubuntu it maps to `127.0.0.1` alone, so a localhost fixture would be single-address and pass while testing nothing.
- **`TestEveryTransportStepRidesTheOnePinnedCommand`** — "every step" is a structural claim, pinned structurally. The three invocations cannot diverge for exactly one reason: all are built from the single `sshCmd` string. A refactor giving the tunnel its own composition would reopen the bug while every string assertion still passed.
- **Real sshd** (skips cleanly without one; high loopback port, own keys, own CA, killed by the pid it recorded) — host certificate on a non-default port, plain `[name]:port` entry, wrong-name entry rejected, stdin stream + EOF.
- **`TestSSHRelay*`** — stdout purity, stdin forwarding and half-close, dial failure on stderr only, IPv6 bracketing, cobra output kept off stdout, hidden from `af --help`.

Every one was mutation-probed. Dropping the pin makes the certificate test fail with `ssh: Could not resolve hostname pinned.invalid` — the fixtures use `.invalid` deliberately, so a **success proves the ProxyCommand carried the connection**; there is no address behind the name to fall back to. A single stray `Println` fails the stdout test at 4105 bytes against 4096.

Two test bugs of my own were found by measurement, not by luck, and both are recorded where they happened: the DNS rotation was parity-locked because Go issues the A and AAAA queries concurrently and the counter advanced on both; and the connection counters raced the listener's accept loop (7 failures in 25, then 6 in 30). 40 consecutive runs clean, and clean under `-race`.

## What this does NOT fix, stated plainly

Two limits, both from review, both now in `docs/backends.md` rather than only here.

**A load-balancer VIP is not pinned.** If `ssh.host` resolves to a virtual IP in front of several machines — an L4/TCP balancer, an AWS NLB, keepalived/IPVS, a Kubernetes service — pinning the address changes nothing, because *the address is not a machine identity*. The balancer picks a backend **per TCP connection**, and af opens one per provision command, one for the tunnel, and one for the reap. Those can still land on different machines, and the leak is identical. af cannot detect this, since a VIP looks exactly like an ordinary address. Same workaround: point `ssh.host` at one machine. This fixes **DNS multiplicity and only DNS multiplicity**.

**`CheckHostIP` is switched off, and that is a real if small reduction.** OpenSSH disables it whenever a `ProxyCommand` is set — `sshconnect.c`, unconditionally — and `readconf.c` defaults it to `1` at `V_7_6_P1`/`V_8_2_P1`/`V_8_4_P1` and to `0` from `V_8_5_P1`, so the loss lands exactly on the floor range this backend commits to. Accepted deliberately and framed as a trade, not a free win: pinning swaps ssh's IP cross-check for af's own single-resolution guarantee, and verification against the **name** — what certificates rest on — is untouched. `ProxyUseFdpass` was checked rather than assumed and does not recover it: it clears the version bar but is reached only inside the branch where `proxy_command` is set, which is what the disable keys on.

## `backend = "sandbox"` is deliberately not pinned

`sandbox_ssh` is the operator's free-form command and af cannot know which of its words is a hostname — an argument to `-o`, a jump-host spec, a wrapper's own flag, or the target. Guessing would silently rewrite the command they asked for. `docs/backends.md` gains a Sandbox section documenting this with two workarounds (point the command at one machine, or pin it yourself the same way — keeping the name as the destination), which also fixes a dangling "see the sandbox section below" reference that pointed at a section that did not exist.

**#3086 stays open** for both the sandbox half and the load-balancer case above — referenced without a closing keyword on purpose.

## Gates

`gofmt -l .` · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `scripts/lint-file-length.sh` · `scripts/gen-docs.sh` (no drift — the hidden command correctly stays out of the generated CLI reference) · `go test ./session/ -run 'SSH|Sandbox|Cleanup'` · `go test ./commands/ -run 'TestSSHRelay'`. No daemon/app tests, no container suites, no local `deadcode`.

Refs #3086

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
