### PR TITLE
test(session): probe background child after capture teardown

### DIFF
--- a/session/backend_hook_reap_test.go
+++ b/session/backend_hook_reap_test.go
@@ -1,7 +1,6 @@
 package session
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -912,27 +911,37 @@ exit 0
 
 // TestHookLaunchDoesNotKillBackgroundedChildren is the mechanism behind the test
 // above, pinned separately so a regression names its own cause: the capture must
-// not kill a process launch_cmd deliberately backgrounded. A heartbeat file is the
-// liveness probe — it keeps ticking only while the child lives, so requiring the
-// mtime to keep advancing after the script exits proves the capture left the child
-// alone.
+// not kill a process launch_cmd deliberately backgrounded. The child installs a
+// signal handler before launch_cmd exits; after the capture has returned, the test
+// signals that exact PID and requires its acknowledgement. That proves the child
+// is alive at the teardown boundary, rather than merely proving it ran earlier.
 //
-// The test also OWNS that child's lifetime (the t.Cleanup reap below): a
-// backgrounded writer left running races t.TempDir()'s os.RemoveAll and fails the
-// test in cleanup with an ENOTEMPTY — the actual flake this file hit on CI, which
-// looks like a passing body followed by "TempDir RemoveAll cleanup: ... directory
-// not empty".
+// The test also OWNS that child's lifetime (the t.Cleanup reap below), so a green
+// run cannot leave the shell behind. Cleanup runs before t.TempDir removal because
+// the child's signal handler writes its acknowledgement there.
 func TestHookLaunchDoesNotKillBackgroundedChildren(t *testing.T) {
 	shrinkHookTimeouts(t, 5*time.Second, 5*time.Second)
 	dir := t.TempDir()
-	hb := filepath.Join(dir, "heartbeat")
+	pidFile := filepath.Join(dir, "child.pid")
+	readyFile := filepath.Join(dir, "child.ready")
+	ackFile := filepath.Join(dir, "child.ack")
 
 	h := hookState{dir: dir, launch: filepath.Join(dir, "launch.sh"), delete: filepath.Join(dir, "delete.sh")}
+	// The child deliberately inherits the captured stderr, as a real tunnel does.
+	// stdout stays endpoint-only; writing the chatter there would make this a
+	// failed launch and correctly send the child through failure-path reaping.
 	writeHookScript(t, h.launch, fmt.Sprintf(`
-( for i in $(seq 1 1000); do echo "still here"; echo tick >> %s; sleep 0.05; done ) &
+(
+  trap 'echo alive > %s' USR1
+  : > %s
+  while true; do echo "still here" >&2; sleep 0.05; done
+) &
+child_pid=$!
+echo "$child_pid" > %s
+while [[ ! -e %s ]]; do sleep 0.01; done
 echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
 exit 0
-`, shellsuggest.Arg(hb)))
+`, shellsuggest.Arg(ackFile), shellsuggest.Arg(readyFile), shellsuggest.Arg(pidFile), shellsuggest.Arg(readyFile)))
 	writeHookScript(t, h.delete, "true")
 
 	p := newHookProvisioner(h, "background child")
@@ -950,46 +959,34 @@ exit 0
 		}
 	})
 	_, err := p.provisionOrReap()
-	require.NoError(t, err)
+	pidData, readErr := os.ReadFile(pidFile)
+	require.NoError(t, readErr, "launch_cmd must record the exact background child it started")
+	var childPID int
+	_, scanErr := fmt.Sscan(strings.TrimSpace(string(pidData)), &childPID)
+	require.NoError(t, scanErr, "launch_cmd wrote an invalid child pid %q", pidData)
+	childStateErr := syscall.Kill(childPID, 0)
+	childPgid, childPgidErr := syscall.Getpgid(childPID)
+	require.NoError(t, err, "launch failed; child pid %d liveness after teardown: %v; process group: %v",
+		childPID, childStateErr, childPgidErr)
 
-	// provisionOrReap has returned, so launch_cmd itself is already gone and what
-	// follows measures only the BACKGROUNDED child.
-	//
-	// Counting TICKS, not mtime advances, and waiting on the count rather than
-	// inside a fixed window (#2879). The previous shape had two independent ways to
-	// fail on a healthy box, and neither had anything to do with the contract:
-	//
-	//   - It required three mtime ADVANCES within a fixed three seconds. mtime
-	//     granularity is a filesystem property, not a liveness property: on a
-	//     one-second-granularity filesystem three distinct advances need ~3s of
-	//     wall time all by themselves, which is the whole budget. This box reports
-	//     nanoseconds and never saw it; a macOS runner can.
-	//   - A loaded box stretches the child's `sleep 0.05` loop, so the same fixed
-	//     window buys fewer ticks exactly when the machine is busy.
-	//
-	// The child appends one "tick" per iteration, so the count is monotonic, has no
-	// granularity, and answers the actual question: did this child keep running
-	// AFTER the capture? Baselined at this instant, so ticks written before
-	// provisionOrReap returned cannot be mistaken for survival — a killed child
-	// contributes exactly zero more, no matter how slow the box is.
-	ticks := func() int {
-		data, readErr := os.ReadFile(hb)
-		if readErr != nil {
-			return 0
-		}
-		return bytes.Count(data, []byte("tick"))
-	}
-	baseline := ticks()
-
-	// The ceiling is a FAILURE deadline, not an expectation: this is normally
-	// satisfied in a few hundred milliseconds. It stays well inside the writer's own
-	// ~50s lifetime (1000 iterations x 0.05s) so a slow start cannot turn into a
-	// failure of this assertion instead.
-	const wantTicks = 3
+	// provisionOrReap has returned, so launch_cmd and the entire output-capture
+	// teardown are already gone. Probe the background child only now: kill(0)
+	// establishes that the PID still exists at the boundary, and the subsequent
+	// signal acknowledgement proves it is a running process that accepts work, not
+	// a stale heartbeat written before teardown or a zombie process-table entry.
+	require.NoError(t, childStateErr,
+		"the process launch_cmd backgrounded was dead when output capture returned")
+	require.NoError(t, childPgidErr,
+		"the process launch_cmd backgrounded had no process group after output capture returned")
+	require.Equal(t, p.launchPgid, childPgid,
+		"the recorded PID no longer belongs to launch_cmd's process group")
+	require.NoError(t, syscall.Kill(childPID, syscall.SIGUSR1),
+		"the process launch_cmd backgrounded died before accepting a post-capture probe")
 	require.Eventually(t, func() bool {
-		return ticks() >= baseline+wantTicks
-	}, 30*time.Second, 10*time.Millisecond,
-		"the process launch_cmd backgrounded stopped ticking — the output capture killed a child that was not ours to kill")
+		_, statErr := os.Stat(ackFile)
+		return statErr == nil
+	}, 5*time.Second, 10*time.Millisecond,
+		"the live background child never acknowledged the post-capture probe")
 }
 
 // TestHookLaunchIsBounded proves the launch bound fires at all. It is the


### PR DESCRIPTION
## What actually failed

Run 31242558802 did not reach the tick assertion. After 20 ms, `provisionOrReap` rejected the launch because the background child had appended `still here` to stdout beside the endpoint record.

That test fixture predated the endpoint-only stdout contract and still raced the parser: if af read its regular output file before the first child write, the launch succeeded; if the child won, the launch correctly failed and failure-path cleanup killed its process group.

## Fix

- Keep stdout exclusively for the endpoint and make the background child inherit/write stderr, matching a real tunnel and the documented hook contract.
- Synchronize launch exit on the child installing a signal handler.
- Record the exact child PID.
- Only after `provisionOrReap` and capture teardown return, require that PID to exist, require it still belongs to the launch process group, send `SIGUSR1`, and require the child acknowledgment.

This checks the contract directly: the child is alive and accepts new work after teardown. No tick written before teardown can satisfy it, and no duration bound was widened.

## Product verdict and fail-first evidence

With the new PID probe in place but the old stdout-writing fixture retained, the test failed deterministically against master behavior:

```
launch_cmd ... printed something other than its endpoint on stdout
launch failed; child pid 1215236 liveness after teardown: no such process
```

So the observed death was real, but it followed a failed launch and was the intended cleanup behavior. Once the child chatter moved to stderr, the unchanged product success path passed 30/30.

A mutation that reaped the launch group on successful provision made the replacement assertion fail immediately with:

```
the process launch_cmd backgrounded was dead when output capture returned: no such process
```

That preserves the #2850 regression signal.

## Local checks

- `gofmt -l .`
- `go build ./...`
- `golangci-lint run --timeout=3m --fast`
- `scripts/lint-file-length.sh`
- `go test ./session`
- exact test 30 consecutive runs

Closes #3120