### PR TITLE
fix(accounts): admit the resolved launch command

### DIFF
--- a/config/config_types.go
+++ b/config/config_types.go
@@ -535,6 +535,12 @@ func ResolveProgram(cfg *Config, agent string) string {
 	return agent
 }
 
+// DetectedClaudePermissionsFlag is the argument af appends to the Claude
+// command it auto-detects for the built-in program override. Launch admission
+// uses the same constant to declare exactly this af-authored word without
+// trusting any additional arguments that came from an operator's shell alias.
+const DetectedClaudePermissionsFlag = "--dangerously-skip-permissions"
+
 // DefaultConfig returns the default configuration. The auto-detected claude
 // command (e.g. "/home/user/.local/bin/claude") is stored in
 // ProgramOverrides["claude"] together with --dangerously-skip-permissions
@@ -576,7 +582,7 @@ func DefaultConfig() *Config {
 		// the alias-provided argument suffix (#569, #2323).
 		command := shellQuoteDetectedCommand(claudePath)
 		cfg.ProgramOverrides = map[string]string{
-			tmux.ProgramClaude: command + " --dangerously-skip-permissions",
+			tmux.ProgramClaude: command + " " + DetectedClaudePermissionsFlag,
 		}
 	} else if err != nil {
 		log.ErrorLog.Printf("failed to get claude command: %v", err)

--- a/internal/sessionenv/account.go
+++ b/internal/sessionenv/account.go
@@ -56,8 +56,19 @@ type Account struct {
 	// Only an EXACT match is honoured — never a basename — so a repository file
 	// that merely shares the name is still refused (#2983 review).
 	TrustedWrapper string
-	// GeneratedArgs are the argument words af's OWN launcher appended to this
-	// session's program, in order, unquoted.
+	// TrustedExecutable is the exact agent executable af selected for this
+	// launch, or empty when PATH must resolve the bare agent name.
+	//
+	// A path-qualified executable is otherwise unprovable: ./claude may be a
+	// repository file that receives the selected credential root. The one safe
+	// exception is an exact path from af's built-in auto-detected program
+	// override. Like TrustedWrapper, this is provenance supplied by the launcher,
+	// never inferred from a basename.
+	TrustedExecutable string
+	// GeneratedArgs are the argument words af authored for this session's
+	// program, in order, unquoted. Usually those are launch-time additions; for
+	// af's built-in detected Claude command they also include the detected
+	// override's built-in arguments (#3108).
 	//
 	// This is the same shape of claim as TrustedWrapper, for the same reason. The
 	// local launch rewrites a bare `claude` into `claude --session-id <uuid>
@@ -75,8 +86,8 @@ type Account struct {
 	// repository can write into program_overrides matches them, and a flag af did
 	// not generate is still refused however harmless it looks.
 	//
-	// Empty means af appended nothing, which is every non-claude agent today and
-	// the only behaviour before this field existed.
+	// Empty means af authored no arguments, which is every non-claude agent today
+	// and the only behaviour before this field existed.
 	GeneratedArgs []string
 }
 
@@ -222,26 +233,8 @@ func ApplyAccount(env []string, command string, account Account) ([]string, erro
 	// never fires while the shell expands it to a non-empty string and Claude
 	// authenticates through ~/.aws instead. Refusing any command-local assignment
 	// to a selector removes the need to evaluate it (#2983 review).
-	refused := accountScopedNames(account.Agent, configVar)
-	for _, selector := range GuardedSelectors() {
-		refused[selector] = struct{}{}
-	}
-	proof := commandProof{
-		agent:          account.Agent,
-		trustedWrapper: account.TrustedWrapper,
-		generated:      account.GeneratedArgs,
-		names:          refused,
-	}
-	if overrides, provable := commandOverridesName(command, proof); overrides || !provable {
-		if !provable {
-			return nil, fmt.Errorf(
-				"account %q cannot scope agent %q: its program could not be proven to be a direct %s invocation free of "+
-					"identity assignments, and an unverifiable program is not evidence that the account would be used",
-				account.Name, account.Agent, account.Agent)
-		}
-		return nil, fmt.Errorf(
-			"account %q cannot scope agent %q: its program sets an identity variable itself, which overrides the account directory",
-			account.Name, account.Agent)
+	if err := ValidateAccountCommand(command, account); err != nil {
+		return nil, err
 	}
 
 	denied := accountScopedNames(account.Agent, configVar)

--- a/internal/sessionenv/account_command.go
+++ b/internal/sessionenv/account_command.go
@@ -34,15 +34,15 @@ import (
 // as UNPROVABLE. New syntax then arrives as a refusal to scope rather than as a
 // silent bypass, which is the direction this repo can afford to be wrong in.
 // commandProof is what the CALLER knows and the string cannot say: which agent
-// this account scopes, which af binary generated the handoff, and which argument
-// words af's own launcher appended. Grouped because all three are provenance
-// supplied from outside, and a five-argument recursion invited passing them in
-// the wrong order.
+// this account scopes, which af binary generated a handoff, which exact detected
+// agent executable af selected, and which argument words af authored. Grouped
+// because all are provenance supplied from outside, and a positional recursion
+// invited passing them in the wrong order.
 type commandProof struct {
-	agent          string
-	trustedWrapper string
-	generated      []string
-	names          map[string]struct{}
+	agent             string
+	trustedWrapper    string
+	trustedExecutable string
+	generated         []string
 }
 
 func commandOverridesName(command string, proof commandProof) (overrides, provable bool) {
@@ -144,7 +144,7 @@ func callOverridesName(call *syntax.CallExpr, proof commandProof, depth int) (ov
 		return false, false
 	}
 	if len(words) == 1 {
-		if executable, ok := literalShellWord(words[0]); ok && executableIsAgent(executable, proof.agent) {
+		if executable, ok := literalShellWord(words[0]); ok && executableIsAgent(executable, proof.agent, proof.trustedExecutable) {
 			return false, true
 		}
 	}
@@ -262,7 +262,7 @@ func envOverridesName(args []*syntax.Word, proof commandProof) (overrides, prova
 			return false, false
 		}
 	}
-	if executableIsAgent(literals[invocation.CommandIndex], proof.agent) {
+	if executableIsAgent(literals[invocation.CommandIndex], proof.agent, proof.trustedExecutable) {
 		return false, true
 	}
 	return false, false
@@ -279,9 +279,12 @@ func envOverridesName(args []*syntax.Word, proof commandProof) (overrides, prova
 // override (`account.Agent` claude, command `codex`) would otherwise be called
 // provable, after which the injected CLAUDE_CONFIG_DIR means nothing to codex and
 // it authenticates from its own default home (#2983 review).
-func executableIsAgent(executable, agent string) bool {
+func executableIsAgent(executable, agent, trustedExecutable string) bool {
 	if executable == "" || agent == "" {
 		return false
+	}
+	if trustedExecutable != "" && executable == trustedExecutable {
+		return true
 	}
 	// A BARE name only. `./codex` shares a basename with the real CLI and is an
 	// arbitrary repository-provided file: the shell would hand it the selected

--- a/internal/sessionenv/account_exec_protocol_test.go
+++ b/internal/sessionenv/account_exec_protocol_test.go
@@ -27,10 +27,12 @@ import (
 // string — the plugin directory below contains a space (#3083).
 func TestAccountExecProtocol_CarriesTheGeneratedArgsDeclaration(t *testing.T) {
 	pluginDir := "/plugins/with a space"
+	trustedExecutable := "/opt/af detected/claude"
 	generated := []string{"--session-id", "abc-123", "--plugin-dir", pluginDir}
-	command := "claude --session-id abc-123 --plugin-dir " + shellquote.Quote(pluginDir)
+	command := shellquote.Quote(trustedExecutable) + " --session-id abc-123 --plugin-dir " + shellquote.Quote(pluginDir)
 
-	wrapped, err := WrapAccountCommand("/usr/local/bin/af", "claude", "work", generated, nil, command)
+	wrapped, err := WrapAccountCommand("/usr/local/bin/af", "claude", "work",
+		AccountLaunchProof{TrustedExecutable: trustedExecutable, GeneratedArgs: generated}, nil, command)
 	require.NoError(t, err)
 
 	// Split with this package's own parser — the same one the guard uses — rather
@@ -75,11 +77,11 @@ func TestAccountExecProtocol_CarriesTheGeneratedArgsDeclaration(t *testing.T) {
 // for the protocol itself, since every claim the boundary verifies rides on it.
 func TestAccountExecProtocol_RefusesAMiscountedInvocation(t *testing.T) {
 	for _, args := range [][]string{
-		{"claude", "0", "work"},                      // truncated before the generated count
-		{"claude", "0", "work", "2", "--only-one"},   // count exceeds the words present
-		{"claude", "0", "work", "-1", "cmd"},         // negative
-		{"claude", "0", "work", "0", "cmd", "extra"}, // an unaccounted argument
-		{"claude", "0", "work", "x", "cmd"},          // not a number
+		{"claude", "0", "work"},                        // truncated before proof fields
+		{"claude", "0", "work", "", "2", "--only-one"}, // count exceeds the words present
+		{"claude", "0", "work", "", "-1", "cmd"},       // negative
+		{"claude", "0", "work", "", "0", "cmd", "extra"},
+		{"claude", "0", "work", "", "x", "cmd"}, // not a number
 	} {
 		require.Error(t, execInvocation(args, true), "argv %v must be refused, not guessed at", args)
 	}
@@ -93,7 +95,7 @@ func TestAccountExecProtocol_RefusesAMiscountedInvocation(t *testing.T) {
 func TestAccountExecProtocol_RefusesAnOverflowingGeneratedCount(t *testing.T) {
 	for _, count := range []string{"9223372036854775807", "9223372036854775806", "4611686018427387904"} {
 		require.NotPanics(t, func() {
-			require.Error(t, execInvocation([]string{"claude", "0", "work", count, "claude"}, true),
+			require.Error(t, execInvocation([]string{"claude", "0", "work", "", count, "claude"}, true),
 				"generated count %s must be refused", count)
 		}, "a malformed count must return the generic refusal, never panic (count %s)", count)
 	}

--- a/internal/sessionenv/account_generated_args_test.go
+++ b/internal/sessionenv/account_generated_args_test.go
@@ -293,3 +293,31 @@ func TestGenerateAccountLaunchProof_TrustsOnlyTheBuiltInBase(t *testing.T) {
 	require.ErrorContains(t, err, "--model")
 	require.ErrorContains(t, err, "sonnet")
 }
+
+func TestGenerateAccountLaunchProof_DoesNotTrustRelativeDetectedExecutable(t *testing.T) {
+	base := "./bin/claude --dangerously-skip-permissions"
+	final := base + " --session-id " + genSessionID
+
+	proof, ok := GenerateAccountLaunchProof(base, final, []string{"--dangerously-skip-permissions"})
+	require.True(t, ok)
+	require.Empty(t, proof.TrustedExecutable,
+		"a relative executable is resolved again from the pane workdir and cannot inherit detection from the daemon cwd")
+	require.Equal(t, []string{"--dangerously-skip-permissions", "--session-id", genSessionID}, proof.GeneratedArgs,
+		"rejecting executable provenance must not lose the independently known af-authored words")
+	err := ValidateAccountCommand(final, Account{
+		Agent: "claude", Name: "work", TrustedExecutable: proof.TrustedExecutable,
+		GeneratedArgs: proof.GeneratedArgs,
+	})
+	require.Error(t, err, "the relative executable must fail closed before receiving the account directory")
+
+	bareBase := "claude --dangerously-skip-permissions"
+	bareFinal := bareBase + " --session-id " + genSessionID
+	bareProof, ok := GenerateAccountLaunchProof(bareBase, bareFinal, []string{"--dangerously-skip-permissions"})
+	require.True(t, ok)
+	require.Empty(t, bareProof.TrustedExecutable,
+		"the ordinary bare-name rule proves claude without manufacturing path provenance")
+	require.NoError(t, ValidateAccountCommand(bareFinal, Account{
+		Agent: "claude", Name: "work", TrustedExecutable: bareProof.TrustedExecutable,
+		GeneratedArgs: bareProof.GeneratedArgs,
+	}), "a bare agent name with only af-authored arguments remains safe")
+}

--- a/internal/sessionenv/account_generated_args_test.go
+++ b/internal/sessionenv/account_generated_args_test.go
@@ -251,3 +251,45 @@ func TestGeneratedArgsBetween_NoRewriteDeclaresNothing(t *testing.T) {
 	require.True(t, ok)
 	require.Empty(t, generated)
 }
+
+func TestGenerateAccountLaunchProof_TrustsOnlyTheBuiltInBase(t *testing.T) {
+	const executable = "/opt/af-detected/claude"
+	base := executable + " --dangerously-skip-permissions"
+	final := base + " --session-id " + genSessionID
+
+	builtIn, ok := GenerateAccountLaunchProof(base, final, []string{"--dangerously-skip-permissions"})
+	require.True(t, ok)
+	require.Equal(t, executable, builtIn.TrustedExecutable)
+	require.Equal(t, []string{"--dangerously-skip-permissions", "--session-id", genSessionID}, builtIn.GeneratedArgs)
+	require.NoError(t, ValidateAccountCommand(final, Account{
+		Agent:             "claude",
+		Name:              "work",
+		TrustedExecutable: builtIn.TrustedExecutable,
+		GeneratedArgs:     builtIn.GeneratedArgs,
+	}))
+
+	aliasBase := executable + " --settings /operator/auth.json --dangerously-skip-permissions"
+	aliasFinal := aliasBase + " --session-id " + genSessionID
+	aliasProof, ok := GenerateAccountLaunchProof(aliasBase, aliasFinal,
+		[]string{"--dangerously-skip-permissions"})
+	require.True(t, ok)
+	err := ValidateAccountCommand(aliasFinal, Account{
+		Agent: "claude", Name: "work", TrustedExecutable: aliasProof.TrustedExecutable,
+		GeneratedArgs: aliasProof.GeneratedArgs,
+	})
+	require.ErrorContains(t, err, "--settings",
+		"arguments from the detected shell alias are operator-authored, not af-authored")
+	require.ErrorContains(t, err, "/operator/auth.json")
+
+	userOverride, ok := GenerateAccountLaunchProof("claude --model sonnet",
+		"claude --model sonnet --session-id "+genSessionID, nil)
+	require.True(t, ok)
+	require.Empty(t, userOverride.TrustedExecutable)
+	require.Equal(t, []string{"--session-id", genSessionID}, userOverride.GeneratedArgs,
+		"a user override's arguments must not be laundered into af-authored provenance")
+	err = ValidateAccountCommand("claude --model sonnet --session-id "+genSessionID, Account{
+		Agent: "claude", Name: "work", GeneratedArgs: userOverride.GeneratedArgs,
+	})
+	require.ErrorContains(t, err, "--model")
+	require.ErrorContains(t, err, "sonnet")
+}

--- a/internal/sessionenv/account_launch_proof.go
+++ b/internal/sessionenv/account_launch_proof.go
@@ -1,0 +1,134 @@
+package sessionenv
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// AccountLaunchProof carries the facts only af's launcher can know about a
+// command: the exact agent executable it selected and the exact argument words
+// it authored. Neither is inferred from command spelling at the credential
+// boundary.
+type AccountLaunchProof struct {
+	TrustedExecutable string
+	GeneratedArgs     []string
+}
+
+// GenerateAccountLaunchProof describes the change from base to final. A nil
+// trustedBaseArgs means only words appended after base are af-authored. A
+// non-nil slice also trusts the exact base executable and the named trailing
+// base words. Any other base arguments stay undeclared.
+func GenerateAccountLaunchProof(base, final string, trustedBaseArgs []string) (AccountLaunchProof, bool) {
+	added, ok := GeneratedArgsBetween(base, final)
+	if !ok {
+		return AccountLaunchProof{}, false
+	}
+	proof := AccountLaunchProof{GeneratedArgs: added}
+	if trustedBaseArgs == nil {
+		return proof, true
+	}
+
+	call, ok := singleSimpleCall(base)
+	if !ok || !callIsLiteral(call) || len(call.Assigns) > 0 {
+		return AccountLaunchProof{}, false
+	}
+	words, ok := literalCommandArgs(call.Args)
+	if !ok || len(words) == 0 {
+		return AccountLaunchProof{}, false
+	}
+	if len(words) < len(trustedBaseArgs)+1 {
+		return AccountLaunchProof{}, false
+	}
+	baseSuffix := words[len(words)-len(trustedBaseArgs):]
+	for idx, want := range trustedBaseArgs {
+		if baseSuffix[idx] != want {
+			return AccountLaunchProof{}, false
+		}
+	}
+	proof.TrustedExecutable = words[0]
+	proof.GeneratedArgs = append(append([]string(nil), trustedBaseArgs...), added...)
+	return proof, true
+}
+
+// ValidateAccountCommand applies the command-shape half of the account
+// boundary before launch.
+func ValidateAccountCommand(command string, account Account) error {
+	proof := commandProof{
+		agent:             account.Agent,
+		trustedWrapper:    account.TrustedWrapper,
+		trustedExecutable: account.TrustedExecutable,
+		generated:         account.GeneratedArgs,
+	}
+	overrides, provable := commandOverridesName(command, proof)
+	if overrides {
+		return fmt.Errorf(
+			"account %q cannot scope agent %q: its program sets an identity variable itself, which overrides the account directory",
+			account.Name, account.Agent)
+	}
+	if provable {
+		return nil
+	}
+	if args, ok := undeclaredAccountArguments(command, proof); ok {
+		return fmt.Errorf(
+			"account %q cannot scope agent %q: its resolved program contains undeclared arguments %s; "+
+				"only arguments af authored for this launch can accompany an account-scoped agent, so this program could not be proven safe",
+			account.Name, account.Agent, quoteArguments(args))
+	}
+	return fmt.Errorf(
+		"account %q cannot scope agent %q: its program could not be proven to be a direct %s invocation free of "+
+			"identity assignments, and an unverifiable program is not evidence that the account would be used",
+		account.Name, account.Agent, account.Agent)
+}
+
+func undeclaredAccountArguments(command string, proof commandProof) ([]string, bool) {
+	call, ok := singleSimpleCall(command)
+	if !ok || len(call.Assigns) > 0 || !callIsLiteral(call) {
+		return nil, false
+	}
+	words := call.Args
+	if len(words) > 0 && wordEquals(words[0], "exec") {
+		words = words[1:]
+		if len(words) > 0 && wordEquals(words[0], "--") {
+			words = words[1:]
+		}
+	}
+	stripped, ok := stripDeclaredSuffixForDiagnostics(words, proof.generated)
+	if !ok || len(stripped) < 2 {
+		return nil, false
+	}
+	args, ok := literalCommandArgs(stripped[1:])
+	return args, ok
+}
+
+// stripDeclaredSuffixForDiagnostics is deliberately weaker than
+// stripGeneratedArgs: it may leave user arguments in front of af's exact
+// declared suffix so the refusal can name them. It is never an admission check;
+// commandOverridesName has already refused the command through the strict
+// executable-plus-exactly-generated rule before this runs.
+func stripDeclaredSuffixForDiagnostics(words []*syntax.Word, generated []string) ([]*syntax.Word, bool) {
+	if len(generated) == 0 {
+		return words, true
+	}
+	if len(words) < len(generated)+1 {
+		return nil, false
+	}
+	start := len(words) - len(generated)
+	for idx, want := range generated {
+		got, ok := literalShellWord(words[start+idx])
+		if !ok || got != want {
+			return nil, false
+		}
+	}
+	return words[:start], true
+}
+
+func quoteArguments(args []string) string {
+	quoted := make([]string, len(args))
+	for idx, arg := range args {
+		quoted[idx] = strconv.Quote(arg)
+	}
+	return strings.Join(quoted, " ")
+}

--- a/internal/sessionenv/account_launch_proof.go
+++ b/internal/sessionenv/account_launch_proof.go
@@ -3,6 +3,7 @@ package sessionenv
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -41,8 +42,10 @@ func IsAccountCommandValidationError(err error) bool {
 
 // GenerateAccountLaunchProof describes the change from base to final. A nil
 // trustedBaseArgs means only words appended after base are af-authored. A
-// non-nil slice also trusts the exact base executable and the named trailing
-// base words. Any other base arguments stay undeclared.
+// non-nil slice also trusts an absolute base executable and the named trailing
+// base words. Relative executable spellings are resolved again from the pane's
+// workdir, so their arguments can be declared but their identity cannot. Any
+// other base arguments stay undeclared.
 func GenerateAccountLaunchProof(base, final string, trustedBaseArgs []string) (AccountLaunchProof, bool) {
 	added, ok := GeneratedArgsBetween(base, final)
 	if !ok {
@@ -70,8 +73,10 @@ func GenerateAccountLaunchProof(base, final string, trustedBaseArgs []string) (A
 			return AccountLaunchProof{}, false
 		}
 	}
-	proof.TrustedExecutable = words[0]
 	proof.GeneratedArgs = append(append([]string(nil), trustedBaseArgs...), added...)
+	if filepath.IsAbs(words[0]) {
+		proof.TrustedExecutable = words[0]
+	}
 	return proof, true
 }
 

--- a/internal/sessionenv/account_launch_proof.go
+++ b/internal/sessionenv/account_launch_proof.go
@@ -1,6 +1,7 @@
 package sessionenv
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -15,6 +16,27 @@ import (
 type AccountLaunchProof struct {
 	TrustedExecutable string
 	GeneratedArgs     []string
+}
+
+type accountCommandValidationError struct {
+	message string
+}
+
+func (e *accountCommandValidationError) Error() string {
+	return e.message
+}
+
+func accountCommandValidationErrorf(format string, args ...any) error {
+	return &accountCommandValidationError{message: fmt.Sprintf(format, args...)}
+}
+
+// IsAccountCommandValidationError reports whether err came from the
+// command-shape half of the account boundary. Provisioners use this to add
+// runtime-specific context without changing the priority of earlier account
+// refusals such as cloud authentication mode.
+func IsAccountCommandValidationError(err error) bool {
+	var target *accountCommandValidationError
+	return errors.As(err, &target)
 }
 
 // GenerateAccountLaunchProof describes the change from base to final. A nil
@@ -64,7 +86,7 @@ func ValidateAccountCommand(command string, account Account) error {
 	}
 	overrides, provable := commandOverridesName(command, proof)
 	if overrides {
-		return fmt.Errorf(
+		return accountCommandValidationErrorf(
 			"account %q cannot scope agent %q: its program sets an identity variable itself, which overrides the account directory",
 			account.Name, account.Agent)
 	}
@@ -72,12 +94,12 @@ func ValidateAccountCommand(command string, account Account) error {
 		return nil
 	}
 	if args, ok := undeclaredAccountArguments(command, proof); ok {
-		return fmt.Errorf(
+		return accountCommandValidationErrorf(
 			"account %q cannot scope agent %q: its resolved program contains undeclared arguments %s; "+
 				"only arguments af authored for this launch can accompany an account-scoped agent, so this program could not be proven safe",
 			account.Name, account.Agent, quoteArguments(args))
 	}
-	return fmt.Errorf(
+	return accountCommandValidationErrorf(
 		"account %q cannot scope agent %q: its program could not be proven to be a direct %s invocation free of "+
 			"identity assignments, and an unverifiable program is not evidence that the account would be used",
 		account.Name, account.Agent, account.Agent)

--- a/internal/sessionenv/account_scope.go
+++ b/internal/sessionenv/account_scope.go
@@ -20,7 +20,7 @@ var AccountLookup func(agent, name string) (Account, error)
 // installed, or a boundary that rejects the command all mean af cannot prove the
 // session will use the requested identity — and an unprovable launch is not
 // evidence of a correct one.
-func applyAccountScope(environ []string, agent, account, command string, generated []string) ([]string, error) {
+func applyAccountScope(environ []string, agent, account, command string, proof AccountLaunchProof) ([]string, error) {
 	if AccountLookup == nil {
 		return nil, fmt.Errorf("account-scoped launch requested but no account lookup is installed")
 	}
@@ -28,10 +28,11 @@ func applyAccountScope(environ []string, agent, account, command string, generat
 	if err != nil {
 		return nil, fmt.Errorf("resolve account %q for %s: %w", account, agent, err)
 	}
-	// The launcher's claim about its OWN additions, attached to the scope the
+	// The launcher's claim about its OWN executable/arguments, attached to the scope the
 	// lookup resolved. AccountLookup answers "which directory", never "which
-	// arguments" — that fact travels with the launch, not with the registry (#3083).
-	scope.GeneratedArgs = generated
+	// command" — those facts travel with the launch, not with the registry (#3083, #3108).
+	scope.TrustedExecutable = proof.TrustedExecutable
+	scope.GeneratedArgs = proof.GeneratedArgs
 	scoped, err := ApplyAccount(environ, command, scope)
 	if err != nil {
 		return nil, fmt.Errorf("scope session to account %q: %w", account, err)

--- a/internal/sessionenv/account_scope_test.go
+++ b/internal/sessionenv/account_scope_test.go
@@ -23,9 +23,9 @@ func TestApplyAccountScope_TwoAccountsSeeDifferentRootsAndNotEachOther(t *testin
 	})
 	ambient := []string{"PATH=/usr/bin", "OPENAI_API_KEY=sk-ambient", "CODEX_HOME=/home/op/.codex"}
 
-	a, err := applyAccountScope(ambient, "codex", "alpha", "codex", nil)
+	a, err := applyAccountScope(ambient, "codex", "alpha", "codex", AccountLaunchProof{})
 	require.NoError(t, err)
-	b, err := applyAccountScope(ambient, "codex", "beta", "codex", nil)
+	b, err := applyAccountScope(ambient, "codex", "beta", "codex", AccountLaunchProof{})
 	require.NoError(t, err)
 
 	joinedA, joinedB := strings.Join(a, "\n"), strings.Join(b, "\n")
@@ -54,14 +54,14 @@ func TestApplyAccountScope_RefusesRatherThanFallingBack(t *testing.T) {
 
 	// No lookup installed at all.
 	withLookup(t, nil)
-	_, err := applyAccountScope(ambient, "codex", "alpha", "codex", nil)
+	_, err := applyAccountScope(ambient, "codex", "alpha", "codex", AccountLaunchProof{})
 	require.Error(t, err, "a build with no lookup installed must refuse, not run unscoped")
 
 	// Lookup fails (unregistered account).
 	withLookup(t, func(string, string) (Account, error) {
 		return Account{}, errNotRegistered
 	})
-	_, err = applyAccountScope(ambient, "codex", "ghost", "codex", nil)
+	_, err = applyAccountScope(ambient, "codex", "ghost", "codex", AccountLaunchProof{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "ghost")
 
@@ -70,7 +70,7 @@ func TestApplyAccountScope_RefusesRatherThanFallingBack(t *testing.T) {
 	withLookup(t, func(agent, name string) (Account, error) {
 		return Account{Agent: agent, Name: name, Dir: "/home/op/.af/accounts/codex/" + name}, nil
 	})
-	_, err = applyAccountScope(ambient, "codex", "alpha", "sh -c 'codex'", nil)
+	_, err = applyAccountScope(ambient, "codex", "alpha", "sh -c 'codex'", AccountLaunchProof{})
 	require.Error(t, err, "an unprovable program must refuse rather than launch scoped-in-name-only")
 }
 

--- a/internal/sessionenv/exec_unix.go
+++ b/internal/sessionenv/exec_unix.go
@@ -18,7 +18,7 @@ var processExec = syscall.Exec
 // executable path, the selected agent, explicit variable NAMES, and the
 // original pane command; environment values never enter argv.
 func WrapCommand(executable, agent string, extras []string, command string) (string, error) {
-	return wrapCommand(executable, agent, "", nil, extras, command)
+	return wrapCommand(executable, agent, "", AccountLaunchProof{}, extras, command)
 }
 
 // WrapAccountCommand is WrapCommand for a session scoped to a named account.
@@ -26,18 +26,18 @@ func WrapCommand(executable, agent string, extras []string, command string) (str
 // Only the account NAME travels in argv — never its directory and never a
 // credential. The shim resolves the name against its own AF home, so argv stays
 // free of anything worth reading out of `ps` (#3051).
-// generated carries the argument words af's own launcher appended to the pane
-// command, so the boundary can verify its own output instead of refusing it
-// (#3083). These are not secrets and are already visible in the command operand
-// beside them; what argv gains is the CLAIM that af authored them.
-func WrapAccountCommand(executable, agent, account string, generated, extras []string, command string) (string, error) {
+// proof carries the exact executable and argument words af authored for the pane
+// command, so the boundary can verify its own output instead of refusing it.
+// These are not secrets and are already visible in the command operand beside
+// them; what argv gains is the CLAIM that af authored them (#3083, #3108).
+func WrapAccountCommand(executable, agent, account string, proof AccountLaunchProof, extras []string, command string) (string, error) {
 	if strings.TrimSpace(account) == "" {
 		return "", fmt.Errorf("account-scoped launch requires an account name")
 	}
-	return wrapCommand(executable, agent, account, generated, extras, command)
+	return wrapCommand(executable, agent, account, proof, extras, command)
 }
 
-func wrapCommand(executable, agent, account string, generated, extras []string, command string) (string, error) {
+func wrapCommand(executable, agent, account string, proof AccountLaunchProof, extras []string, command string) (string, error) {
 	normalized, err := NormalizeExtraNames(extras)
 	if err != nil {
 		return "", err
@@ -53,8 +53,8 @@ func wrapCommand(executable, agent, account string, generated, extras []string, 
 		// string (a path can contain anything), so any sentinel could appear inside
 		// one and a mis-split would hand the guard a different claim than the
 		// launcher made.
-		args = append(args, account, strconv.Itoa(len(generated)))
-		args = append(args, generated...)
+		args = append(args, account, proof.TrustedExecutable, strconv.Itoa(len(proof.GeneratedArgs)))
+		args = append(args, proof.GeneratedArgs...)
 	}
 	args = append(args, normalized...)
 	args = append(args, command)
@@ -86,7 +86,7 @@ func HandleInternalExec() {
 func execInvocation(args []string, scoped bool) error {
 	trailing := 3
 	if scoped {
-		trailing = 5
+		trailing = 6
 	}
 	if len(args) < trailing {
 		return fmt.Errorf("malformed internal session environment invocation")
@@ -98,10 +98,11 @@ func execInvocation(args []string, scoped bool) error {
 	}
 	offset := 2
 	account := ""
-	var generated []string
+	proof := AccountLaunchProof{}
 	if scoped {
 		account = args[2]
-		generatedCount, gerr := strconv.Atoi(args[3])
+		proof.TrustedExecutable = args[3]
+		generatedCount, gerr := strconv.Atoi(args[4])
 		// Compared against the REMAINING room, never `trailing+generatedCount`: a
 		// maximum-sized integer makes that addition overflow to a negative bound, the
 		// check passes, and the slice below PANICS instead of returning this
@@ -110,8 +111,8 @@ func execInvocation(args []string, scoped bool) error {
 		if gerr != nil || generatedCount < 0 || generatedCount > len(args)-trailing {
 			return fmt.Errorf("malformed internal session environment invocation")
 		}
-		generated = args[4 : 4+generatedCount]
-		offset = 4 + generatedCount
+		proof.GeneratedArgs = args[5 : 5+generatedCount]
+		offset = 5 + generatedCount
 	}
 	// The exact total, checked AFTER both counts are known. A length that merely
 	// fits leaves room for an unaccounted argument between the two lists, and this
@@ -131,7 +132,7 @@ func execInvocation(args []string, scoped bool) error {
 	// through to the ambient identity, which would be the silent wrong-account
 	// outcome the whole feature exists to prevent (#3051).
 	if scoped {
-		environ, err = applyAccountScope(environ, agent, account, command, generated)
+		environ, err = applyAccountScope(environ, agent, account, command, proof)
 		if err != nil {
 			return err
 		}

--- a/internal/sessionenv/exec_windows.go
+++ b/internal/sessionenv/exec_windows.go
@@ -8,4 +8,8 @@ func WrapCommand(string, string, []string, string) (string, error) {
 	return "", fmt.Errorf("tmux session environments are unsupported on windows")
 }
 
+func WrapAccountCommand(string, string, string, AccountLaunchProof, []string, string) (string, error) {
+	return "", fmt.Errorf("tmux session environments are unsupported on windows")
+}
+
 func HandleInternalExec() {}

--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -224,12 +224,22 @@ func (dockerRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 		}
 		proof := accountLaunchProof(resolvedProgram, resolvedProgram,
 			builtInProgramOverride(cfg, spec.Program, resolvedProgram))
-		spec.Account.TrustedExecutable = proof.TrustedExecutable
+		// The built-in proof is established in the host namespace. Docker may not
+		// contain that path (or may contain a different file there), so never grant
+		// its executable identity across the container boundary. A bare agent name
+		// remains independently provable; a host-qualified path fails closed below.
+		hostExecutable := proof.TrustedExecutable
+		spec.Account.TrustedExecutable = ""
 		spec.Account.GeneratedArgs = proof.GeneratedArgs
 		// Reuse the local shim's authoritative validation for cloud modes and
 		// command-local identity assignments. The returned host environment is not
 		// installed in Docker; accountMountAndEnv builds the container boundary.
 		if _, aerr := sessionenv.ApplyAccount(os.Environ(), resolvedProgram, spec.Account); aerr != nil {
+			if hostExecutable != "" && sessionenv.IsAccountCommandValidationError(aerr) {
+				return ProvisionResult{}, fmt.Errorf(
+					"backend=docker: resolved program names host executable %q, whose identity cannot be established inside the container: %w",
+					hostExecutable, aerr)
+			}
 			return ProvisionResult{}, fmt.Errorf("backend=docker: %w", aerr)
 		}
 		if aerr := validateAccountDockerRunArgs(runArgs, spec.Account.Agent); aerr != nil {

--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -222,6 +222,10 @@ func (dockerRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 		if err := refuseAccountAgentDrift(spec.Account.Name, spec.Account.Agent, resolvedProgram); err != nil {
 			return ProvisionResult{}, fmt.Errorf("backend=docker: %w", err)
 		}
+		proof := accountLaunchProof(resolvedProgram, resolvedProgram,
+			builtInProgramOverride(cfg, spec.Program, resolvedProgram))
+		spec.Account.TrustedExecutable = proof.TrustedExecutable
+		spec.Account.GeneratedArgs = proof.GeneratedArgs
 		// Reuse the local shim's authoritative validation for cloud modes and
 		// command-local identity assignments. The returned host environment is not
 		// installed in Docker; accountMountAndEnv builds the container boundary.

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -14,57 +14,6 @@ import (
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
-// resolveProgramForInstance returns the actual tmux command for an instance.
-// Resolution chain: agent enum -> cfg.ProgramOverrides[agent] (if set) ->
-// bare agent name. The overrides come from the repo-resolved config (global
-// program_overrides merged with the repo's .agent-factory/config.json) when
-// the instance path belongs to a git repo; outside a repo, or when repo
-// resolution fails, the global config alone applies. A nil cfg (e.g. tests
-// that don't materialize a config) falls back to the raw Program string so
-// legacy free-form values still reach tmux verbatim.
-func resolveProgramForInstance(i *Instance) string {
-	i.mu.RLock()
-	agent := i.Program
-	alreadyResolved := agent != "" && agent == i.preResolvedProgram
-	i.mu.RUnlock()
-	if alreadyResolved {
-		return agent
-	}
-	return resolveProgramForAgent(i, agent)
-}
-
-// resolveProgramForAgent is the target-explicit form used by handoff preflight.
-// It resolves configuration before Instance.Program is rewritten, so an invalid
-// incoming override can be rejected while the outgoing process is still alive.
-func resolveProgramForAgent(i *Instance, agent string) string {
-	cfg := resolveConfigForInstance(i)
-	// Read the enum through the accessor, not the bare field: a handoff (#2013)
-	// rewrites Program in place while the instance is live and shared, so this
-	// is a genuinely concurrent read now. Every other reader of the field
-	// (ToInstanceData, ReconcileTabsFromData) already holds the instance lock.
-	return config.ResolveProgram(cfg, agent)
-}
-
-func resolveConfigForInstance(i *Instance) *config.Config {
-	var cfg *config.Config
-	if repo, err := config.RepoFromPath(i.Path); err == nil {
-		if resolved, rerr := config.ResolveConfig(repo.Root); rerr == nil {
-			cfg = &resolved.Config
-		} else {
-			log.WarningLog.Printf("failed to resolve repo config when resolving program for %q: %v", i.Title, rerr)
-		}
-	}
-	if cfg == nil {
-		loaded, err := config.LoadConfig()
-		if err != nil {
-			log.WarningLog.Printf("failed to load config when resolving program for %q: %v", i.Title, err)
-			loaded = nil
-		}
-		cfg = loaded
-	}
-	return cfg
-}
-
 func configuredSessionEnvPassthrough(explicit []string) []string {
 	names := append([]string(nil), explicit...)
 	if cfg, err := config.LoadConfig(); err == nil && cfg != nil {
@@ -332,8 +281,10 @@ func (b *LocalBackend) launch(i *Instance, firstTimeSetup bool, prepared *Create
 		// Setting the program on the existing attach path is harmless:
 		// attach-session does not re-exec the program.
 		if workDir != "" {
-			resolved := resolveProgramForInstance(i)
-			setLaunchProgram(tmuxSession, resolved, injectSystemPrompt(resolved))
+			resolution := resolveLaunchProgramForInstance(i)
+			program := injectSystemPrompt(resolution.command)
+			setLaunchProgram(tmuxSession, program,
+				accountLaunchProof(resolution.command, program, resolution.trustBase))
 		}
 		if err := tmuxSession.Restore(workDir); err != nil {
 			setupErr = fmt.Errorf("failed to restore existing session: %w", err)
@@ -354,24 +305,27 @@ func (b *LocalBackend) launch(i *Instance, firstTimeSetup bool, prepared *Create
 		// path supplies a command frozen after provisioning and before process
 		// launch; direct Start callers retain the established inline preparation.
 		var program string
-		// The pre-rewrite command, kept so the launch can declare what af added to it
-		// (#3083). The prepared path carries its own, frozen with the program.
-		base := resolveProgramForInstance(i)
+		var proof sessionenv.AccountLaunchProof
 		if prepared != nil {
 			if prepared.workDir != gw.GetWorktreePath() || strings.TrimSpace(prepared.program) == "" {
 				setupErr = fmt.Errorf("prepared create launch no longer matches session %q", i.Title)
 				return setupErr
 			}
 			program = prepared.program
-			base = prepared.base
+			proof = prepared.accountProof
 			if prepared.conversation.HasID() {
 				i.SetAgentConversation(prepared.conversation)
 			}
 		} else {
+			// The pre-rewrite command is resolved once and kept with the proof it
+			// produces. A prepared create carries both from its earlier freeze.
+			resolution := resolveLaunchProgramForInstance(i)
+			base := resolution.command
 			program = prepareLaunchConversation(i, base)
 			program = injectSystemPrompt(program)
+			proof = accountLaunchProof(base, program, resolution.trustBase)
 		}
-		setLaunchProgram(tmuxSession, base, program)
+		setLaunchProgram(tmuxSession, program, proof)
 
 		// Create new session
 		if err := tmuxSession.Start(gw.GetWorktreePath()); err != nil {
@@ -599,7 +553,8 @@ func (b *LocalBackend) respawn(i *Instance) error {
 	if err := refreshWorktreeEnvironment(i, gw); err != nil {
 		return fmt.Errorf("recover: %w", err)
 	}
-	resolvedProgram := resolveProgramForInstance(i)
+	resolution := resolveLaunchProgramForInstance(i)
+	resolvedProgram := resolution.command
 	// The base for the generated-args declaration, pinned BEFORE any af rewrite.
 	// resolvedProgram is reassigned below when a fresh worktree rebuild forces the
 	// exact-resume command, and that rewrite is af's own — so declaring against the
@@ -642,7 +597,9 @@ func (b *LocalBackend) respawn(i *Instance) error {
 		}
 	}
 
-	setLaunchProgram(ts, declarationBase, injectSystemPrompt(prepareResumeConversation(i, resolvedProgram)))
+	program := injectSystemPrompt(prepareResumeConversation(i, resolvedProgram))
+	setLaunchProgram(ts, program,
+		accountLaunchProof(declarationBase, program, resolution.trustBase))
 	if err := refreshSessionEnvironment(i, ts); err != nil {
 		return fmt.Errorf("recover: %w", err)
 	}

--- a/session/backend_local_create.go
+++ b/session/backend_local_create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sachiniyer/agent-factory/internal/sessionenv"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
@@ -13,12 +14,29 @@ func (b *LocalBackend) prepareCreateLaunch(i *Instance) (CreateLaunchPlan, error
 		return CreateLaunchPlan{}, fmt.Errorf("cannot prepare session %q: local provisioning produced no launch directory", i.Title)
 	}
 
-	resolved := resolveProgramForInstance(i)
+	resolution := resolveLaunchProgramForInstance(i)
+	resolved := resolution.command
 	program, conversation := planCreateConversation(i, resolved)
 	program = injectSystemPrompt(program)
+	proof := accountLaunchProof(resolved, program, resolution.trustBase)
+	if account := strings.TrimSpace(i.Account); account != "" {
+		accountAgent := sessionenv.AgentForCommand(i.AgentProgram())
+		if err := refuseAccountAgentDrift(account, accountAgent, program); err != nil {
+			return CreateLaunchPlan{}, fmt.Errorf("cannot create account-scoped session: %w", err)
+		}
+		err := sessionenv.ValidateAccountCommand(program, sessionenv.Account{
+			Agent:             accountAgent,
+			Name:              account,
+			TrustedExecutable: proof.TrustedExecutable,
+			GeneratedArgs:     proof.GeneratedArgs,
+		})
+		if err != nil {
+			return CreateLaunchPlan{}, fmt.Errorf("cannot create account-scoped session: %w", err)
+		}
+	}
 	plan := CreateLaunchPlan{
 		program:      program,
-		base:         resolved,
+		accountProof: proof,
 		workDir:      workDir,
 		conversation: conversation,
 	}

--- a/session/backend_local_create_test.go
+++ b/session/backend_local_create_test.go
@@ -124,6 +124,69 @@ func TestPrepareCreateLaunchUsesProvisionedLinkedWorktreeCwd(t *testing.T) {
 	require.Equal(t, filepath.Join(plan.workDir, "relative-store"), plan.conversationCapture.codexHome)
 }
 
+// #3108: account admission must judge the command the create will actually
+// launch, not the bare agent label the request carried. The old NewInstance
+// gate saw only Program="claude", while prepareCreateLaunch later applied this
+// repo override; it admitted a session the pane boundary could only reject with
+// exit 127. An explicit Program containing these arguments exercises the path
+// the old gate already handled and would not reproduce the defect.
+func TestPrepareCreateLaunchRefusesRepoOverrideArgumentsByName(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoRoot := initInPlaceRepo(t, "account-override-args")
+	writeInRepoConfig(t, repoRoot, map[string]any{
+		"program_overrides": map[string]string{
+			tmux.ProgramClaude: "claude --model sonnet",
+		},
+	})
+
+	inst, err := NewInstance(InstanceOptions{
+		Title:   "account-override-args",
+		Path:    repoRoot,
+		Program: tmux.ProgramClaude,
+		Account: "work",
+		InPlace: true,
+	})
+	require.NoError(t, err, "the request stays bare; the repo override is resolved downstream")
+
+	_, err = inst.PrepareCreateLaunch()
+	require.Error(t, err, "a create whose resolved command cannot honor the account must be refused before pane launch")
+	require.ErrorContains(t, err, "--model")
+	require.ErrorContains(t, err, "sonnet")
+}
+
+// The refusal above must not turn the ordinary first-run Claude command into a
+// universal account refusal. af itself detects this executable and adds
+// --dangerously-skip-permissions in the built-in config layer, so both facts
+// carry provenance; a user-authored override with the same shape does not.
+func TestPrepareCreateLaunchAcceptsBuiltInDetectedClaudeCommand(t *testing.T) {
+	afHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", afHome)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("SHELL", "/bin/sh")
+	binDir := t.TempDir()
+	claudePath := filepath.Join(binDir, "claude")
+	require.NoError(t, os.WriteFile(claudePath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	// Leave the AF home empty: LoadConfig's real first-run path materializes the
+	// detected override. Its source metadata must still distinguish that generated
+	// default from an override the operator or repository supplied.
+
+	repoRoot := initInPlaceRepo(t, "account-built-in-command")
+	inst, err := NewInstance(InstanceOptions{
+		Title:   "account-built-in-command",
+		Path:    repoRoot,
+		Program: tmux.ProgramClaude,
+		Account: "work",
+		InPlace: true,
+	})
+	require.NoError(t, err)
+
+	plan, err := inst.PrepareCreateLaunch()
+	require.NoError(t, err, "af's own detected executable and arguments must remain usable with --account")
+	require.Equal(t, claudePath, plan.accountProof.TrustedExecutable)
+	require.Contains(t, plan.accountProof.GeneratedArgs, "--dangerously-skip-permissions")
+}
+
 func TestPreparedCreateLaunchConsumesFrozenCommand(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	t.Setenv("CODEX_HOME", t.TempDir())

--- a/session/create_launch.go
+++ b/session/create_launch.go
@@ -1,6 +1,10 @@
 package session
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/sachiniyer/agent-factory/internal/sessionenv"
+)
 
 // CreateLaunchPlan freezes the provider-local facts that must be decided after
 // provisioning fixes the final workspace path but before the agent process is
@@ -11,11 +15,11 @@ type CreateLaunchPlan struct {
 	launcher Backend
 	prepared bool
 	program  string
-	// base is the command before af's own rewrites, frozen WITH program so the
-	// launch can declare which words af appended (#3083). Frozen rather than
-	// re-resolved at launch: program_overrides could be re-read differently by
-	// then, and a declaration must describe the program actually installed.
-	base                string
+	// accountProof is frozen WITH program so the launch declares only the
+	// executable/arguments af authored (#3083, #3108). Re-resolving at launch
+	// could read a different override and make the proof describe a command other
+	// than the one installed.
+	accountProof        sessionenv.AccountLaunchProof
 	workDir             string
 	conversation        AgentConversationData
 	conversationCapture ConversationCaptureSnapshot

--- a/session/docker_account_findings_test.go
+++ b/session/docker_account_findings_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -114,6 +115,28 @@ func TestDockerAccount_RefusesCloudAuthenticationMode(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "CLAUDE_CODE_USE_BEDROCK")
 	require.False(t, dockerCalled, "cloud-mode refusal must happen before provisioning")
+}
+
+func TestDockerAccount_RefusesHostDetectedExecutableProvenance(t *testing.T) {
+	binDir := t.TempDir()
+	claudePath := filepath.Join(binDir, "claude")
+	require.NoError(t, os.WriteFile(claudePath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+"/usr/bin:/bin")
+	t.Setenv("SHELL", "/bin/bash")
+	t.Setenv("HOME", t.TempDir())
+
+	f := newDockerAccountFixture(t, "", "claude", nil)
+	dockerCalled := false
+	t.Cleanup(SetDockerExecForTest(func(_ context.Context, _ []string, args ...string) ([]byte, error) {
+		dockerCalled = true
+		return fakeLocalDockerResponse(args)
+	}))
+
+	_, err := createDockerAccountSession(f, "claude", nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), claudePath)
+	require.False(t, dockerCalled,
+		"a host-qualified executable must be refused before its provenance crosses into Docker")
 }
 
 func TestDockerAccount_RejectsIdentityRunArgs(t *testing.T) {

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -635,18 +635,16 @@ func offBoxAccountRefusal(kind BackendKind) string {
 	}
 }
 
-// refuseUnsupportedAccountAgent rejects an account on an agent whose launch af
-// rewrites before the boundary sees it.
+// refuseUnsupportedAccountAgent rejects a cross-agent override or an agent whose
+// launch/account contract af has not established. It deliberately does NOT judge
+// command shape here: program_overrides can be re-read before launch, and only
+// prepareCreateLaunch has the frozen resolved command plus af's generated-argument
+// declaration. That final admission names any undeclared arguments before the pane
+// starts (#3108).
 //
-// claude is the case today. The local launch appends --session-id and usually
-// --plugin-dir, and the boundary's command guard accepts only a bare,
-// argument-free invocation — so the pane exits 127 with a generic message. A
-// clear refusal at create time is strictly better than a session that starts and
-// dies for a reason nothing explains.
-//
-// This is deliberately an ALLOWLIST of agents known to work, not a denylist of
-// broken ones: an agent added later is unsupported until someone proves the
-// boundary accepts its launch, which fails in the safe direction (#3051, #3083).
+// This remains an ALLOWLIST, not a denylist: an agent added later is unsupported
+// until someone proves the boundary accepts its launch, which fails in the safe
+// direction (#3051, #3083).
 func refuseUnsupportedAccountAgent(opts InstanceOptions, absPath string) error {
 	if strings.TrimSpace(opts.Account) == "" {
 		return nil

--- a/session/launch_program.go
+++ b/session/launch_program.go
@@ -1,12 +1,15 @@
 package session
 
 import (
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/sessionenv"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
-// setLaunchProgram sets a session's pane command AND declares which argument
-// words af appended to reach it, in one call (#3083).
+// accountLaunchProof describes af's contribution to a pane command. Ordinary
+// overrides declare only launch-time additions; an exact match for af's
+// built-in detected command also declares its executable and built-in arguments
+// (#3083, #3108).
 //
 // The two belong together. af's launch rewrites a bare `claude` into `claude
 // --session-id <uuid> --plugin-dir <dir>`, and the account boundary accepts only
@@ -19,20 +22,32 @@ import (
 // than none — it would be a false claim about the command that runs. Pairing them
 // makes that drift unrepresentable.
 //
-// base is the command BEFORE af's own rewrites: resolveProgramForInstance's
-// output, which is the agent name, the operator's program_overrides entry, or a
-// legacy persisted Program. final is what the pane will run.
+// base is the command BEFORE af's own launch rewrites. final is what the pane
+// will run. trustBase is true only when base exactly matches the built-in
+// detected override from the same resolved config snapshot.
 //
 // A base that cannot be related to final — an assignment prefix, a command
 // substitution, a rewrite that edited an existing word — declares NOTHING and so
 // fails closed: an account-scoped launch is then refused rather than proceeding
 // unverified, and an unscoped launch is unaffected because nothing reads this.
-func setLaunchProgram(ts *tmux.TmuxSession, base, final string) {
-	generated, ok := sessionenv.GeneratedArgsBetween(base, final)
-	if !ok {
-		generated = nil
+func accountLaunchProof(base, final string, trustBase bool) sessionenv.AccountLaunchProof {
+	var trustedBaseArgs []string
+	if trustBase {
+		// DefaultConfig appends this exact word. GetClaudeCommand may return an
+		// alias carrying OTHER words; those remain user-authored and undeclared,
+		// so an alias such as `claude --settings ...` is still refused rather than
+		// laundered through the built-in executable proof.
+		trustedBaseArgs = []string{config.DetectedClaudePermissionsFlag}
 	}
+	proof, ok := sessionenv.GenerateAccountLaunchProof(base, final, trustedBaseArgs)
+	if !ok {
+		return sessionenv.AccountLaunchProof{}
+	}
+	return proof
+}
+
+func setLaunchProgram(ts *tmux.TmuxSession, final string, proof sessionenv.AccountLaunchProof) {
 	// ONE call, so the two are written under one lock. Adjacent setters would still
 	// let a concurrent launch observe a torn pair (#3083 review).
-	ts.SetLaunchProgram(final, generated)
+	ts.SetLaunchProgram(final, proof)
 }

--- a/session/program_resolution.go
+++ b/session/program_resolution.go
@@ -1,0 +1,124 @@
+package session
+
+import (
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// resolveProgramForInstance returns the actual tmux command for an instance.
+// Resolution chain: agent enum -> cfg.ProgramOverrides[agent] (if set) -> bare
+// agent name. Repo-resolved config wins when the path belongs to a repository;
+// otherwise the global config applies. A nil cfg preserves legacy free-form
+// Program values verbatim.
+func resolveProgramForInstance(i *Instance) string {
+	i.mu.RLock()
+	agent := i.Program
+	alreadyResolved := agent != "" && agent == i.preResolvedProgram
+	i.mu.RUnlock()
+	if alreadyResolved {
+		return agent
+	}
+	return resolveProgramForAgent(i, agent)
+}
+
+type launchProgramResolution struct {
+	command   string
+	trustBase bool
+}
+
+// resolveLaunchProgramForInstance resolves a create/restore command and the
+// provenance needed by the account boundary in one config snapshot. Only a
+// command that exactly matches the same resolution's built-in detected override
+// can receive executable provenance; any differing global, repo, or personal
+// override remains operator/repository-authored and undeclared (#3108).
+func resolveLaunchProgramForInstance(i *Instance) launchProgramResolution {
+	i.mu.RLock()
+	agent := i.Program
+	alreadyResolved := agent != "" && agent == i.preResolvedProgram
+	i.mu.RUnlock()
+	if alreadyResolved {
+		return launchProgramResolution{command: agent}
+	}
+
+	resolved := resolveResolvedConfigForInstance(i)
+	command := agent
+	if resolved != nil {
+		command = config.ResolveProgram(&resolved.Config, agent)
+	}
+	return launchProgramResolution{
+		command:   command,
+		trustBase: builtInProgramOverride(resolved, agent, command),
+	}
+}
+
+func resolveResolvedConfigForInstance(i *Instance) *config.ResolvedConfig {
+	if repo, err := config.RepoFromPath(i.Path); err == nil {
+		if resolved, rerr := config.ResolveConfig(repo.Root); rerr == nil {
+			return resolved
+		} else {
+			log.WarningLog.Printf("failed to resolve repo config when resolving program for %q: %v", i.Title, rerr)
+		}
+	}
+	resolved, err := config.ResolveGlobalConfig()
+	if err != nil {
+		log.WarningLog.Printf("failed to load config when resolving program for %q: %v", i.Title, err)
+		return nil
+	}
+	return resolved
+}
+
+func builtInProgramOverride(resolved *config.ResolvedConfig, agent, command string) bool {
+	if resolved == nil || agent == "" || config.ResolveProgram(&resolved.Config, agent) != command {
+		return false
+	}
+	value, ok := resolved.ResolvedValuePath("program_overrides." + agent)
+	if !ok {
+		return false
+	}
+	// First-run materialization writes DefaultConfig to config.toml, so the
+	// effective leaf is reported as global even though its exact value came from
+	// af's detected built-in. Compare against the built-in candidate from the same
+	// resolution instead of trusting the winner's location. A user/repo value is
+	// admitted only when it is byte-for-byte the command af independently detected
+	// for this process; a different path or argument remains undeclared.
+	for _, candidate := range value.Candidates {
+		if candidate.Layer != config.SourceBuiltIn.String() || !candidate.Present {
+			continue
+		}
+		builtIn, stringValue := candidate.Value.(string)
+		return stringValue && builtIn == command
+	}
+	return false
+}
+
+// resolveProgramForAgent is the target-explicit form used by handoff preflight.
+// It resolves configuration before Instance.Program is rewritten, so an invalid
+// incoming override can be rejected while the outgoing process is still alive.
+func resolveProgramForAgent(i *Instance, agent string) string {
+	cfg := resolveConfigForInstance(i)
+	// Read the enum through the accessor, not the bare field: a handoff (#2013)
+	// rewrites Program in place while the instance is live and shared, so this
+	// is a genuinely concurrent read now. Every other reader of the field
+	// (ToInstanceData, ReconcileTabsFromData) already holds the instance lock.
+	return config.ResolveProgram(cfg, agent)
+}
+
+func resolveConfigForInstance(i *Instance) *config.Config {
+	var cfg *config.Config
+	if repo, err := config.RepoFromPath(i.Path); err == nil {
+		if resolved, rerr := config.ResolveConfig(repo.Root); rerr == nil {
+			cfg = &resolved.Config
+		} else {
+			log.WarningLog.Printf("failed to resolve repo config when resolving program for %q: %v", i.Title, rerr)
+		}
+	}
+	if cfg == nil {
+		loaded, err := config.LoadConfig()
+		if err != nil {
+			log.WarningLog.Printf("failed to load config when resolving program for %q: %v", i.Title, err)
+			loaded = nil
+		}
+		cfg = loaded
+	}
+	return cfg
+}

--- a/session/tmux/program.go
+++ b/session/tmux/program.go
@@ -28,6 +28,7 @@ func (t *TmuxSession) SetProgram(program string) {
 	defer t.programMu.Unlock()
 	t.program = program
 	t.generatedArgs = nil
+	t.trustedExecutable = ""
 }
 
 // Program returns the command this session's pane runs — after SetProgram,
@@ -79,6 +80,7 @@ func (t *TmuxSession) rewriteProgramCmdByAf(rewrite func(string) string) {
 	added, ok := sessionenv.GeneratedArgsBetween(before, after)
 	if !ok {
 		t.generatedArgs = nil
+		t.trustedExecutable = ""
 		return
 	}
 	t.generatedArgs = append(t.generatedArgs, added...)

--- a/session/tmux/program_af_rewrite_test.go
+++ b/session/tmux/program_af_rewrite_test.go
@@ -111,26 +111,59 @@ func TestRestoreUsesTheDeclarationPreservingRewrite(t *testing.T) {
 // command with a declaration that does not describe it fails.
 func TestLaunchSnapshot_NeverTearsTheCommandFromItsDeclaration(t *testing.T) {
 	session := &TmuxSession{}
-	session.SetLaunchProgram("claude", nil)
+	session.SetLaunchProgram("claude", sessionenv.AccountLaunchProof{})
 
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		for i := 0; i < 500; i++ {
-			session.SetLaunchProgram("claude", nil)
+			session.SetLaunchProgram("claude", sessionenv.AccountLaunchProof{})
 			session.rewriteProgramCmdByAf(resumeProgram)
 		}
 	}()
 	for i := 0; i < 500; i++ {
-		program, generated, _, _, _ := session.launchSnapshot()
+		program, proof, _, _, _ := session.launchSnapshot()
 		// Every legal pair: bare with no declaration, or resumed with --continue
 		// declared. A torn read produces one without the other.
 		switch program {
 		case "claude":
-			require.Empty(t, generated, "a bare command was paired with a declaration describing a rewrite")
+			require.Empty(t, proof.GeneratedArgs, "a bare command was paired with a declaration describing a rewrite")
 		case "claude --continue":
-			require.Equal(t, []string{"--continue"}, generated,
+			require.Equal(t, []string{"--continue"}, proof.GeneratedArgs,
 				"the resumed command was paired with a declaration that does not describe it")
+		default:
+			t.Fatalf("unexpected program %q", program)
+		}
+	}
+	<-done
+}
+
+func TestLaunchSnapshot_NeverTearsTrustedExecutableFromCommand(t *testing.T) {
+	const trusted = "/opt/af-detected/claude"
+	session := &TmuxSession{}
+	detectedProof := sessionenv.AccountLaunchProof{
+		TrustedExecutable: trusted,
+		GeneratedArgs:     []string{"--dangerously-skip-permissions"},
+	}
+	session.SetLaunchProgram("claude", sessionenv.AccountLaunchProof{})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 500; i++ {
+			session.SetLaunchProgram("claude", sessionenv.AccountLaunchProof{})
+			session.SetLaunchProgram(trusted+" --dangerously-skip-permissions", detectedProof)
+		}
+	}()
+	for i := 0; i < 500; i++ {
+		program, proof, _, _, _ := session.launchSnapshot()
+		switch program {
+		case "claude":
+			require.Empty(t, proof.TrustedExecutable)
+			require.Empty(t, proof.GeneratedArgs)
+		case trusted + " --dangerously-skip-permissions":
+			require.Equal(t, detectedProof, proof,
+				"a trusted path is provenance for one exact command and must snapshot atomically with it")
 		default:
 			t.Fatalf("unexpected program %q", program)
 		}
@@ -145,14 +178,19 @@ func TestLaunchSnapshot_NeverTearsTheCommandFromItsDeclaration(t *testing.T) {
 // accepted, carrying the account across a handoff meant to fail closed.
 func TestSetProgram_ClearsAPreviousDeclaration(t *testing.T) {
 	session := &TmuxSession{}
-	session.SetLaunchProgram("claude --session-id sid-1 --plugin-dir /p", []string{"--session-id", "sid-1", "--plugin-dir", "/p"})
+	session.SetLaunchProgram("claude --session-id sid-1 --plugin-dir /p", sessionenv.AccountLaunchProof{
+		TrustedExecutable: "/opt/af-detected/claude",
+		GeneratedArgs:     []string{"--session-id", "sid-1", "--plugin-dir", "/p"},
+	})
 
 	// A handoff target that happens to end in the very same words.
 	session.SetProgram("other-agent --session-id sid-1 --plugin-dir /p")
 
-	program, generated, _, _, _ := session.launchSnapshot()
+	program, proof, _, _, _ := session.launchSnapshot()
 	require.Equal(t, "other-agent --session-id sid-1 --plugin-dir /p", program)
-	require.Empty(t, generated,
+	require.Empty(t, proof.GeneratedArgs,
 		"the outgoing launch's declaration survived into the replacement, so af would vouch for "+
 			"arguments it did not author for this command and the account would transfer across the handoff")
+	require.Empty(t, proof.TrustedExecutable,
+		"an exact executable path is part of the old launch's proof and must not survive replacement")
 }

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -163,12 +163,16 @@ type TmuxSession struct {
 	// separately from the resolved program so a program_overrides change cannot
 	// reinterpret the same account name as another agent's identity (#3083 review).
 	accountAgent string
-	// generatedArgs are the argument words af's own launcher appended to program,
-	// declared so the account boundary can verify af's output instead of refusing
-	// it (#3083). Guarded by programMu with program itself, because a launch reads
+	// generatedArgs are the argument words af authored for program, declared so
+	// the account boundary can verify af's output instead of refusing it (#3083,
+	// #3108). Guarded by programMu with program itself, because a launch reads
 	// the two together and a declaration that described a DIFFERENT program string
 	// than the one being wrapped would be worse than none.
 	generatedArgs []string
+	// trustedExecutable is the exact path af's built-in program detection chose
+	// for an account-scoped launch. Empty keeps the ordinary bare-name rule.
+	// Guarded and snapshotted with program/generatedArgs: all three are one proof.
+	trustedExecutable string
 	// inputMu serializes every multi-command transaction that injects pane input.
 	// A submit must not clear/paste between a prompt handler's selected-row
 	// capture and Enter, two submits must not clear each other's freshly pasted

--- a/session/tmux/session_env.go
+++ b/session/tmux/session_env.go
@@ -56,8 +56,8 @@ func (t *TmuxSession) SetAccountForAgent(agent, name string) {
 	t.accountAgent = agent
 }
 
-// SetLaunchProgram sets the pane command AND the declaration of which argument
-// words af appended to reach it, under ONE programMu hold (#3083 review).
+// SetLaunchProgram sets the pane command AND af's executable/argument proof
+// under ONE programMu hold (#3083 review, #3108).
 //
 // Paired because a reader between two independently-locked setters sees a torn
 // pair — the old command with the new declaration, or the reverse — and the
@@ -65,22 +65,25 @@ func (t *TmuxSession) SetAccountForAgent(agent, name string) {
 // words, so either half of that tear refuses the launch and the pane exits
 // immediately. The call site pairing them is not enough: it makes the two writes
 // adjacent, not atomic.
-func (t *TmuxSession) SetLaunchProgram(program string, generated []string) {
+func (t *TmuxSession) SetLaunchProgram(program string, proof sessionenv.AccountLaunchProof) {
 	t.programMu.Lock()
 	defer t.programMu.Unlock()
 	t.program = program
-	t.generatedArgs = append([]string(nil), generated...)
+	t.generatedArgs = append([]string(nil), proof.GeneratedArgs...)
+	t.trustedExecutable = proof.TrustedExecutable
 }
 
 // launchSnapshot reads every field a launch needs in ONE hold, for the same
 // reason SetLaunchProgram writes them in one: Start used to read program through
 // its own lock and the declaration through another, so a rewrite landing between
 // them paired an old command with a new declaration.
-func (t *TmuxSession) launchSnapshot() (program string, generated, extras []string, account, accountAgent string) {
+func (t *TmuxSession) launchSnapshot() (program string, proof sessionenv.AccountLaunchProof, extras []string, account, accountAgent string) {
 	t.programMu.RLock()
 	defer t.programMu.RUnlock()
-	return t.program,
-		append([]string(nil), t.generatedArgs...),
+	return t.program, sessionenv.AccountLaunchProof{
+			TrustedExecutable: t.trustedExecutable,
+			GeneratedArgs:     append([]string(nil), t.generatedArgs...),
+		},
 		append([]string(nil), t.envPassthrough...),
 		t.account,
 		t.accountAgent
@@ -91,7 +94,7 @@ func (t *TmuxSession) launchSnapshot() (program string, generated, extras []stri
 // another, so a rewrite landing between them wrapped an old command with a new
 // declaration (#3083 review).
 func (t *TmuxSession) launchEnvironment() (string, []string, []string, error) {
-	program, generated, extra, account, accountAgent := t.launchSnapshot()
+	program, proof, extra, account, accountAgent := t.launchSnapshot()
 	agent := sessionenv.AgentForCommand(program)
 	executable, err := sessionEnvExecutable()
 	if err != nil {
@@ -117,7 +120,7 @@ func (t *TmuxSession) launchEnvironment() (string, []string, []string, error) {
 				"account %q cannot be used on this tmux: account-scoped sessions require tmux 3.2 or newer, "+
 					"and af refuses rather than starting the session on the ambient account", account)
 		}
-		wrapped, err = sessionenv.WrapAccountCommand(executable, accountAgent, account, generated, extra, program)
+		wrapped, err = sessionenv.WrapAccountCommand(executable, accountAgent, account, proof, extra, program)
 	} else {
 		wrapped, err = sessionenv.WrapCommand(executable, agent, extra, program)
 	}


### PR DESCRIPTION
## Summary

- judge account command shape in `prepareCreateLaunch`, against the exact resolved command and the launch proof frozen with it
- refuse repo/user arguments before pane launch and name the undeclared words in the error
- carry exact provenance for af's first-run detected Claude executable and its own `--dangerously-skip-permissions` argument through tmux and the shim
- keep shell-alias and other user-authored arguments undeclared; apply the same proof to Docker's pre-provision account validation

This differs from #3114's resolve-earlier fix because the correct decision does not exist at `NewInstance`: Claude's generated `--session-id`/`--plugin-dir` declaration and the final command are only paired when the create launch is frozen. The prepared plan now carries that exact command/proof pair to launch, so it is not resolved a second time.

## Admission-gate audit

I checked the other create-path gates for request-vs-resolved drift:

- local prerequisites, runtime namespace, in-place conflict, and off-box account admission all use the shared effective-backend resolver
- program preflight receives the repo-resolved config
- account lookup intentionally uses the requested agent namespace, followed by cross-agent validation against the resolved command
- Docker resolves again at its provision boundary but revalidates account-agent drift against that final command, so a changed resolution refuses rather than admitting the wrong identity

I found no third admission gate that reads a request value and then admits a differently resolved downstream value, so there is no follow-up issue to file.

## Verification

The new repo-override regression test failed on master because `PrepareCreateLaunch` returned no error for `claude --model sonnet`. It passes after this change and asserts both offending arguments are named. A paired first-run test proves af's detected Claude command remains usable, while an alias carrying additional user arguments is still refused.

- `gofmt -l .`
- `go build ./...`
- `golangci-lint run --timeout=3m --fast`
- `scripts/lint-file-length.sh`
- `go test ./config/ -count=1`
- `go test ./internal/sessionenv/ -count=1`
- `go test ./session/ -count=1`
- `go test ./session/tmux/ -count=1`

Closes #3108
