### PR TITLE
config: clarify unset list values

### DIFF
--- a/commands/configcmd.go
+++ b/commands/configcmd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -88,6 +89,12 @@ var (
 type configEntry struct {
 	Key   string `json:"key"`
 	Value any    `json:"value"`
+
+	// configured is presentation-only provenance. JSON callers keep receiving
+	// the effective typed value above; human `config list` uses this bit to tell
+	// a missing value (the compiled default applies) from an explicitly
+	// configured empty value.
+	configured bool
 }
 
 // globalConfigReadOrder preserves the historical `af config list` order. It is
@@ -141,7 +148,7 @@ func loadGlobalConfigEntries() ([]configEntry, error) {
 		if !ok {
 			return nil, fmt.Errorf("global config read order contains unknown manifest key %q", key)
 		}
-		entries = append(entries, configEntry{Key: key, Value: value.Value})
+		entries = append(entries, configEntryFromResolvedValue(value))
 	}
 	return entries, nil
 }
@@ -164,6 +171,51 @@ func formatConfigValue(v any) string {
 		}
 		return string(b)
 	}
+}
+
+// formatConfigListValue makes absence visible without hiding an explicit
+// empty value. Empty built-in values are not configured anywhere, so the human
+// list labels them consistently. An explicit empty string/list/table/null is
+// rendered literally, preserving the distinction between "use the default"
+// and "I configured the empty/off value". `config get` and JSON output keep
+// their existing script-facing representations.
+func formatConfigListValue(entry configEntry) string {
+	if !isEmptyConfigValue(entry.Value) {
+		return formatConfigValue(entry.Value)
+	}
+	if !entry.configured {
+		return "(unset)"
+	}
+	return formatConfigExplanationValue(entry.Value)
+}
+
+func isEmptyConfigValue(value any) bool {
+	if value == nil {
+		return true
+	}
+	if text, ok := value.(string); ok {
+		return text == ""
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Map, reflect.Slice:
+		return reflected.Len() == 0
+	case reflect.Pointer:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}
+
+func configEntryFromResolvedValue(value config.ResolvedValue) configEntry {
+	entry := configEntry{Key: value.Key, Value: value.Value}
+	for _, candidate := range value.Candidates {
+		if candidate.Layer != config.SourceBuiltIn.String() && candidate.Allowed && candidate.Present {
+			entry.configured = true
+			break
+		}
+	}
+	return entry
 }
 
 var configCmd = &cobra.Command{
@@ -274,7 +326,9 @@ legacy, checked-in, and personal layers participate; outside git, the command
 falls back to global defaults. Pass --repo <repository-path> to inspect another
 project. --project remains accepted as a deprecated alias. --explain prints
 every source candidate and the reason it won, was shadowed, was absent, or is
-disallowed for that key.`,
+disallowed for that key. Human output renders an empty built-in value as
+"(unset)"; an explicitly configured empty value remains visible as "", [], {},
+or null. JSON output preserves the typed effective values.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)
@@ -310,7 +364,7 @@ disallowed for that key.`,
 			}
 			tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
 			for _, entry := range entries {
-				fmt.Fprintf(tw, "%s\t%s\n", entry.Key, formatConfigValue(entry.Value))
+				fmt.Fprintf(tw, "%s\t%s\n", entry.Key, formatConfigListValue(entry))
 			}
 			return tw.Flush()
 		}
@@ -324,7 +378,7 @@ disallowed for that key.`,
 		}
 		tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
 		for _, e := range entries {
-			fmt.Fprintf(tw, "%s\t%s\n", e.Key, formatConfigValue(e.Value))
+			fmt.Fprintf(tw, "%s\t%s\n", e.Key, formatConfigListValue(e))
 		}
 		return tw.Flush()
 	},

--- a/commands/configcmd.go
+++ b/commands/configcmd.go
@@ -209,8 +209,17 @@ func isEmptyConfigValue(value any) bool {
 
 func configEntryFromResolvedValue(value config.ResolvedValue) configEntry {
 	entry := configEntry{Key: value.Key, Value: value.Value}
+	if value.Winner != nil && value.Winner.Layer != config.SourceBuiltIn.String() {
+		entry.configured = true
+		return entry
+	}
+
+	// Empty composites have no leaf origin or winner. Their candidate result
+	// still distinguishes an intentionally empty/replacing value from a
+	// nonempty value that validation discarded as "ignored".
 	for _, candidate := range value.Candidates {
-		if candidate.Layer != config.SourceBuiltIn.String() && candidate.Allowed && candidate.Present {
+		if candidate.Layer != config.SourceBuiltIn.String() && candidate.Allowed && candidate.Present &&
+			(candidate.Result == "empty" || candidate.Result == "replaced") {
 			entry.configured = true
 			break
 		}

--- a/commands/configcmd_test.go
+++ b/commands/configcmd_test.go
@@ -197,6 +197,15 @@ func TestConfigListDistinguishesUnsetFromConfiguredEmpty(t *testing.T) {
 	if got := getOut.String(); got != "\n" {
 		t.Fatalf("config get changed its empty-value output to %q", got)
 	}
+
+	configPath := filepath.Join(os.Getenv("AGENT_FACTORY_HOME"), config.TomlConfigFileName)
+	invalidPattern := "schema_version = 1\n[limit_patterns]\nclaude = '('\n"
+	if err := os.WriteFile(configPath, []byte(invalidPattern), 0644); err != nil {
+		t.Fatalf("write config with ignored pattern: %v", err)
+	}
+	if got := valueFor(list(), "limit_patterns"); got != "(unset)" {
+		t.Fatalf("ignored nonempty limit_patterns = %q, want (unset)", got)
+	}
 }
 
 // configEntriesInternalKeys are the toml-tagged config.Config fields that are

--- a/commands/configcmd_test.go
+++ b/commands/configcmd_test.go
@@ -111,6 +111,94 @@ func TestFormatConfigValue(t *testing.T) {
 	}
 }
 
+func TestFormatConfigListValue(t *testing.T) {
+	cases := []struct {
+		name       string
+		value      any
+		configured bool
+		want       string
+	}{
+		{"unset string", "", false, "(unset)"},
+		{"unset nil list", []string(nil), false, "(unset)"},
+		{"unset empty map", map[string]string{}, false, "(unset)"},
+		{"configured empty string", "", true, `""`},
+		{"configured nil list", []string(nil), true, "null"},
+		{"configured empty list", []string{}, true, "[]"},
+		{"configured empty map", map[string]string{}, true, "{}"},
+		{"false is a value", false, false, "false"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			entry := configEntry{Value: c.value, configured: c.configured}
+			if got := formatConfigListValue(entry); got != c.want {
+				t.Fatalf("formatConfigListValue(%#v) = %q, want %q", entry, got, c.want)
+			}
+		})
+	}
+}
+
+func TestConfigListDistinguishesUnsetFromConfiguredEmpty(t *testing.T) {
+	tempAFHome(t)
+
+	list := func() string {
+		t.Helper()
+		var out bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&out)
+		if err := configListCmd.RunE(cmd, nil); err != nil {
+			t.Fatalf("config list: %v", err)
+		}
+		return out.String()
+	}
+	valueFor := func(output, key string) string {
+		t.Helper()
+		for line := range strings.SplitSeq(output, "\n") {
+			if strings.HasPrefix(line, key) {
+				return strings.TrimSpace(strings.TrimPrefix(line, key))
+			}
+		}
+		t.Fatalf("config list does not contain %q:\n%s", key, output)
+		return ""
+	}
+
+	initial := list()
+	for _, key := range []string{
+		"session_env_passthrough",
+		"preview_listen_addr",
+		"cors_allowed_origins",
+		"on_archive_command",
+		"vscode_server_binary",
+		"root_agents",
+		"sandbox_ssh",
+		"limit_patterns",
+		"keys",
+	} {
+		if got := valueFor(initial, key); got != "(unset)" {
+			t.Errorf("default %s = %q, want (unset)", key, got)
+		}
+	}
+	if got := valueFor(initial, "require_token"); got != "false" {
+		t.Errorf("require_token = %q, want false", got)
+	}
+
+	if _, err := config.SetGlobalConfigValue("on_archive_command", ""); err != nil {
+		t.Fatalf("set explicit empty on_archive_command: %v", err)
+	}
+	if got := valueFor(list(), "on_archive_command"); got != `""` {
+		t.Fatalf("configured empty on_archive_command = %q, want explicit empty string", got)
+	}
+
+	var getOut bytes.Buffer
+	getCmd := &cobra.Command{}
+	getCmd.SetOut(&getOut)
+	if err := configGetCmd.RunE(getCmd, []string{"on_archive_command"}); err != nil {
+		t.Fatalf("config get on_archive_command: %v", err)
+	}
+	if got := getOut.String(); got != "\n" {
+		t.Fatalf("config get changed its empty-value output to %q", got)
+	}
+}
+
 // configEntriesInternalKeys are the toml-tagged config.Config fields that are
 // deliberately NOT readable through `af config get/list`. Every entry needs a
 // reason: this is the only escape hatch from the reflective coverage check, so
@@ -560,13 +648,21 @@ func TestConfigListJSONEnvelope(t *testing.T) {
 	if env.Error != nil {
 		t.Fatalf("envelope error should be null, got %v", env.Error)
 	}
-	var haveDefaultProgram bool
+	var haveDefaultProgram, haveEmptyString, haveNilList bool
 	for _, e := range env.Data {
-		if e.Key == "default_program" {
+		switch e.Key {
+		case "default_program":
 			haveDefaultProgram = true
+		case "preview_listen_addr":
+			haveEmptyString = e.Value == ""
+		case "session_env_passthrough":
+			haveNilList = e.Value == nil
 		}
 	}
 	if !haveDefaultProgram {
 		t.Fatalf("config list --json missing default_program: %s", out.String())
+	}
+	if !haveEmptyString || !haveNilList {
+		t.Fatalf("config list --json changed typed empty values: %s", out.String())
 	}
 }

--- a/commands/configexplain.go
+++ b/commands/configexplain.go
@@ -139,7 +139,7 @@ func rootAgentAwareResolution(resolved *config.ResolvedConfig, projectSelector s
 func configEntriesFromResolution(values []config.ResolvedValue) []configEntry {
 	entries := make([]configEntry, 0, len(values))
 	for _, value := range values {
-		entries = append(entries, configEntry{Key: value.Key, Value: value.Value})
+		entries = append(entries, configEntryFromResolvedValue(value))
 	}
 	return entries
 }

--- a/commands/configexplain_test.go
+++ b/commands/configexplain_test.go
@@ -291,6 +291,21 @@ func TestConfigListProjectIncludesRepoOnlyKeysButBareListDoesNot(t *testing.T) {
 	assert.Contains(t, projectOutput, "post_worktree_commands")
 }
 
+func TestConfigListProjectDistinguishesUnsetFromExplicitEmpty(t *testing.T) {
+	_, repoRoot := setupConfigExplainCommandTest(t, "schema_version = 1\ndefault_program = \"codex\"\n")
+	setConfigListReadFlags(t, repoRoot, false, false)
+
+	output, err := runConfigListForTest(t)
+	require.NoError(t, err)
+	assert.Regexp(t, `(?m)^docker\s+\(unset\)$`, output)
+	assert.Regexp(t, `(?m)^post_worktree_commands\s+\(unset\)$`, output)
+
+	writeCommandTestInRepoConfig(t, repoRoot, "post_worktree_commands = []\n")
+	output, err = runConfigListForTest(t)
+	require.NoError(t, err)
+	assert.Regexp(t, `(?m)^post_worktree_commands\s+\[\]$`, output)
+}
+
 func TestConfigGetProjectReportsLocalForAbsentBackend(t *testing.T) {
 	_, repoRoot := setupConfigExplainCommandTest(t, "schema_version = 1\ndefault_program = \"codex\"\n")
 	setConfigGetReadFlags(t, repoRoot, false, false)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -633,7 +633,9 @@ legacy, checked-in, and personal layers participate; outside git, the command
 falls back to global defaults. Pass --repo <repository-path> to inspect another
 project. --project remains accepted as a deprecated alias. --explain prints
 every source candidate and the reason it won, was shadowed, was absent, or is
-disallowed for that key.
+disallowed for that key. Human output renders an empty built-in value as
+"(unset)"; an explicitly configured empty value remains visible as "", [], {},
+or null. JSON output preserves the typed effective values.
 
 ```
 af config list [flags]


### PR DESCRIPTION
## Summary
- render empty built-in values as `(unset)` in human `af config list` output
- keep explicitly configured empty strings, lists, maps, and legacy JSON nulls visible as literals
- preserve the existing `config get`, `--explain`, and typed `--json` contracts
- document the presentation rule in the generated CLI reference

## Compatibility
This changes presentation only. No config key, spelling, parser, stored value, JSON type, or write path changes. Repository-effective lists use the same provenance-aware rule as global lists.

## Failing-first evidence
Before the renderer change, `go test ./commands -run '^TestConfigListDistinguishesUnsetFromConfiguredEmpty$' -count=1` failed on the master implementation: unset lists/tables rendered `null`, unset strings rendered blank, and an explicitly configured empty string was indistinguishable from the built-in default. The same test passes after the change.

## Verification
- `go test ./commands`
- `gofmt -l .` (empty)
- `go build ./...`
- `golangci-lint run --timeout=3m --fast`
- `scripts/lint-file-length.sh`
- `scripts/gen-docs.sh`

Closes #3124
