### PR TITLE
fix(daemon): kill a ghost's pending tab-cleanup tmux sessions before deleting its worktree

### DIFF
--- a/daemon/ghost_pending_tab_test.go
+++ b/daemon/ghost_pending_tab_test.go
@@ -1,0 +1,68 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// A ghost's tmux enumeration must include PENDING TAB CLEANUP handles, or kill
+// deletes the worktree around a session it never attempted to stop (#3137).
+//
+// PendingTabCleanup exists precisely because a tab's removal from Tabs is
+// already durable while its teardown is not confirmed (#2669) — so these are the
+// names most likely to still have a live process, and they were the only ones
+// ghostTmuxNames did not enumerate.
+//
+// The ghostBlind guard does not cover the gap: CheckWorktreeOccupants runs only
+// when a tmux kill was blind, so if every ENUMERATED session dies cleanly the
+// guard never runs, and the un-enumerated pending handle keeps running while git
+// deletes the directory underneath it.
+func TestGhostTmuxNames_IncludesPendingTabCleanupHandles(t *testing.T) {
+	data := &session.InstanceData{
+		TmuxName: "af_agent",
+		Tabs: []session.TabData{
+			{TmuxName: "af_agent"},
+			{TmuxName: "af_shell"},
+		},
+		PendingTabCleanup: []session.TabCleanupData{
+			{TmuxName: "af_pending"},
+		},
+	}
+
+	names := ghostTmuxNames(data)
+
+	require.Contains(t, names, "af_pending",
+		"a pending cleanup handle is a tmux session with a live process and no other record of it; "+
+			"omitting it means kill deletes the worktree while that process is still writing into it")
+	require.Contains(t, names, "af_agent")
+	require.Contains(t, names, "af_shell")
+
+	// Dedupe must still hold across the three sources.
+	seen := map[string]int{}
+	for _, name := range names {
+		seen[name]++
+	}
+	for name, count := range seen {
+		require.Equal(t, 1, count, "name %q enumerated %d times", name, count)
+	}
+}
+
+// A pending handle that duplicates a live tab must not be enumerated twice, and
+// an empty handle must be ignored — the same contract the other two sources have.
+func TestGhostTmuxNames_PendingHandlesDedupeAndSkipEmpty(t *testing.T) {
+	data := &session.InstanceData{
+		TmuxName: "af_agent",
+		Tabs:     []session.TabData{{TmuxName: "af_agent"}},
+		PendingTabCleanup: []session.TabCleanupData{
+			{TmuxName: "af_agent"},
+			{TmuxName: ""},
+			{TmuxName: "af_ghost"},
+		},
+	}
+
+	names := ghostTmuxNames(data)
+	require.Equal(t, []string{"af_agent", "af_ghost"}, names)
+}

--- a/daemon/killbound.go
+++ b/daemon/killbound.go
@@ -248,12 +248,11 @@ func killWatchdogTabCount(instance *session.Instance, data *session.InstanceData
 		// Asked of the SAME function the ghost teardown iterates, rather than
 		// reconstructed from the same fields. ghostCleanup loops over
 		// ghostTmuxNames(data), which collects the session's own tmux session plus
-		// each tab's, DEDUPLICATES them, and does not reap PendingTabCleanup — and
-		// every one of those three properties has to hold here too. Rebuilding the
-		// set by hand got the last two wrong: pending handles bought ~54s apiece for
-		// work this path never does, and a post-#953 record stores the agent's name
-		// in both data.TmuxName and data.Tabs[0].TmuxName, so it was counted twice.
-		// Calling the real thing cannot drift from it.
+		// each live tab's and each pending-cleanup handle's, then DEDUPLICATES them.
+		// Every property has to hold here too: the watchdog must budget every tmux
+		// kill ghostCleanup will actually attempt, without double-charging a
+		// post-#953 agent name stored in both data.TmuxName and data.Tabs[0]. Calling
+		// the real enumerator keeps the budget from drifting from the teardown.
 		return len(ghostTmuxNames(data))
 	}
 	return 0

--- a/daemon/killbound_test.go
+++ b/daemon/killbound_test.go
@@ -30,24 +30,24 @@ func TestKillWatchdogTabCount_SurvivesAGhostInstance(t *testing.T) {
 		require.Equal(t, 2, killWatchdogTabCount(nil, data),
 			"only tmux-bearing tabs are torn down per-tab; a ghost names them by TmuxName")
 
-		// Pending handles are NOT budgeted on the ghost path: ghostTmuxNames collects
-		// data.TmuxName and data.Tabs only, so ghostCleanup never reaps them, and each
-		// one would buy ~54s of delay for work this path does not do.
+		// Pending handles are real teardown work on the ghost path: they can still
+		// own a live process in this worktree, so each distinct handle must buy the
+		// same bounded-kill budget as a live tab.
 		data.PendingTabCleanup = []session.TabCleanupData{{TabID: "t9", TmuxName: "af_x__stuck"}}
-		require.Equal(t, 2, killWatchdogTabCount(nil, data),
-			"a ghost budgets only what ghostCleanup actually tears down")
+		require.Equal(t, 3, killWatchdogTabCount(nil, data),
+			"a ghost budgets every tmux session ghostCleanup actually tears down")
 
 		// A post-#953 record stores the agent's tmux name in BOTH data.TmuxName and
 		// data.Tabs[0].TmuxName. ghostTmuxNames deduplicates them, so the budget must
 		// not count the agent twice — nine real sessions budgeted as ten postpones
 		// the wedge diagnostics by ~54s.
 		data.TmuxName = "af_x"
-		require.Equal(t, 2, killWatchdogTabCount(nil, data),
+		require.Equal(t, 3, killWatchdogTabCount(nil, data),
 			"the agent's name appears twice in the record but is ONE tmux session")
 
 		// A genuinely distinct session does add to it.
 		data.Tabs = append(data.Tabs, session.TabData{Name: "shell-3", TmuxName: "af_x__shell3"})
-		require.Equal(t, 3, killWatchdogTabCount(nil, data))
+		require.Equal(t, 4, killWatchdogTabCount(nil, data))
 	})
 }
 

--- a/daemon/manager_persist.go
+++ b/daemon/manager_persist.go
@@ -365,16 +365,16 @@ var ghostCleanupWorktree = func(data *session.InstanceData, title string) (git.C
 }
 
 // ghostTmuxNames returns the deduped, ordered set of tmux session names a ghost
-// record owns: the legacy agent-tab name (data.TmuxName) first, then each tab's
-// name in persisted order. Empty names are skipped. A post-#953 record repeats
-// the agent tab in BOTH data.TmuxName and data.Tabs, so the dedupe collapses that
-// to a single kill; a pre-#953 record has no Tabs and yields just data.TmuxName,
-// keeping the legacy path byte-identical.
+// record owns: the legacy agent-tab name (data.TmuxName) first, then each live
+// tab's name, then each pending-cleanup handle's name, all in persisted order.
+// Empty names are skipped. A post-#953 record repeats the agent tab in BOTH
+// data.TmuxName and data.Tabs, so the dedupe collapses that to a single kill; a
+// pre-#953 record has no Tabs and yields just data.TmuxName, keeping the legacy
+// path byte-identical.
 func ghostTmuxNames(data *session.InstanceData) []string {
-	// Pre-sized to len(data.Tabs), NOT len(data.Tabs)+1. The legacy name is
-	// already one of the tabs on any post-#953 record, so the +1 was slack in the
-	// common case, and the one add that can exceed this cap (a pre-#953 record,
-	// which has no Tabs at all) grows the slice itself.
+	// Pre-sized to len(data.Tabs), without allocation-size arithmetic. The legacy
+	// name is already one of the tabs on any post-#953 record, and the uncommon
+	// pending handles can grow the slice themselves.
 	//
 	// The arithmetic tripped CodeQL's go/allocation-size-overflow (high) on
 	// `len(...)+1` inside make(). That was a FALSE POSITIVE — data.Tabs is a

--- a/daemon/manager_persist.go
+++ b/daemon/manager_persist.go
@@ -401,6 +401,20 @@ func ghostTmuxNames(data *session.InstanceData) []string {
 	for _, tab := range data.Tabs {
 		add(tab.TmuxName)
 	}
+	// PENDING CLEANUP HANDLES too. These are tabs whose removal from Tabs is
+	// already durable while their teardown was never confirmed (#2669), so they
+	// are the names MOST likely to still have a live process — and they were the
+	// only ones this did not enumerate. Omitting them meant kill deleted the
+	// worktree around a session it had never attempted to stop (#3137).
+	//
+	// The ghostBlind guard does not cover the gap. CheckWorktreeOccupants runs
+	// only when a tmux kill came back blind, so if every enumerated session dies
+	// cleanly the guard never runs at all, and an un-enumerated handle keeps
+	// writing into a directory git is deleting. Enumerating it is what makes the
+	// kill attempt happen, and a blind result there is what arms the guard.
+	for _, pending := range data.PendingTabCleanup {
+		add(pending.TmuxName)
+	}
 	return names
 }
 


### PR DESCRIPTION
## Verified before fixing

**Still reproduces on master.** `ghostTmuxNames` is unchanged in the relevant way, and `daemon/manager_persist.go` references `PendingTabCleanup` **zero** times.

**Reachable, not a theorem.** `ToInstanceData` populates the field from `i.pendingTabCleanup`, and `session/teardown.go` documents a `reapsPendingTabCleanup` property per teardown mode — so this is live modelled state that the codebase already reasons about.

## The bug

`ghostCleanup` kills tmux by iterating `ghostTmuxNames`, which enumerated `data.TmuxName` and `data.Tabs[*]` but not `data.PendingTabCleanup[*]`. Those sessions were never attempted, and the worktree was then deleted around them — a live agent writing into a directory git is recursively removing, which is the reap-before-delete rule this repo has been bitten by before (#802).

Pending handles are the **worst** omission rather than an edge case: the field exists precisely because a tab's removal from `Tabs` is already durable while its teardown was *not* confirmed (#2669), so these are the names most likely to still have a live process.

## Why the fix is at the enumeration, not the guard

The `ghostBlind` / `CheckWorktreeOccupants` guard does not cover this. It runs only when a tmux kill came back **blind** — so if every enumerated session died cleanly, `ghostBlind` stayed false, the guard never ran, and the un-enumerated handle survived untouched.

Enumerating the handle is what makes the kill *attempt* happen, and a blind result on that attempt is what arms the guard. Fixing the guard instead would have left the session unattempted.

## Test

Watched failing on master for the right reason: the enumeration returned `["af_agent","af_shell"]` with the pending handle absent. A second case pins the dedupe and empty-name contract across all three sources, so the new source cannot double-enumerate a name that is also a live tab.

Daemon tests are left to CI per repo policy — this host runs the maintainer's live daemon and sessions.

Closes #3137

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Verification evidence

- **Fail-first CI proof:** test-only head `f8e95f596f82a7f26e4798b6b78c3da7e53501e3` failed [`Test`](https://github.com/sachiniyer/agent-factory/actions/runs/31286160240/job/93175325520) on both new regressions for the right reason: `ghostTmuxNames` returned `["af_agent","af_shell"]` without `af_pending`, and `["af_agent"]` without `af_ghost`.
- **Final-head local gates:** `gofmt -l .` empty; `go build ./...`; `golangci-lint run --timeout=3m --fast`; `scripts/lint-file-length.sh`. No daemon tests were run on the host.
- **Review fix:** updated the watchdog count regression and adjacent helper/watchdog contracts so pending handles are both reaped and budgeted, while duplicate names remain single-counted.