### PR TITLE
fix(cli): fail closed on Git scope resolution errors

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -71,6 +71,21 @@ func repoFromFlag() (*config.RepoContext, error) {
 	return repo, nil
 }
 
+// optionalCurrentRepo resolves the cwd's project when one exists. Only the
+// positively identified outside-Git condition means "no project context";
+// treating any other discovery failure as absence would silently widen scoped
+// reads and mutations to every project (#3134).
+func optionalCurrentRepo() (*config.RepoContext, error) {
+	repo, err := config.CurrentRepo()
+	if err == nil {
+		return repo, nil
+	}
+	if errors.Is(err, config.ErrNotGitRepository) {
+		return nil, nil
+	}
+	return nil, fmt.Errorf("resolve current repository: %w", err)
+}
+
 // resolveRepoID resolves a repo ID from flags, cwd, or returns "" for all-repo mode.
 //
 // This ALWAYS consults the cwd, including when --daemon-url is set. That looks
@@ -95,8 +110,11 @@ func resolveRepoID() (string, error) {
 		return repo.ID, nil
 	}
 	// Try cwd
-	repo, err := config.CurrentRepo()
+	repo, err := optionalCurrentRepo()
 	if err != nil {
+		return "", err
+	}
+	if repo == nil {
 		return "", nil // all-repo mode
 	}
 	return repo.ID, nil
@@ -139,8 +157,11 @@ func resolveRepoIDForLookup() (string, error) {
 	if apiclient.IsRemoteTarget() {
 		return "", nil // the client's cwd says nothing about the remote's repos
 	}
-	repo, err := config.CurrentRepo()
+	repo, err := optionalCurrentRepo()
 	if err != nil {
+		return "", err
+	}
+	if repo == nil {
 		return "", nil // all-repo mode, guarded by the ambiguity check
 	}
 	return repo.ID, nil

--- a/api/repo_resolution_test.go
+++ b/api/repo_resolution_test.go
@@ -29,6 +29,7 @@ func TestProjectScopeResolversPropagateGitDiscoveryErrors(t *testing.T) {
 	previousDaemonURL := apiclient.FlagDaemonURL
 	apiclient.FlagDaemonURL = ""
 	t.Cleanup(func() { apiclient.FlagDaemonURL = previousDaemonURL })
+	t.Setenv("AF_DAEMON_URL", "")
 
 	tests := []struct {
 		name    string

--- a/api/repo_resolution_test.go
+++ b/api/repo_resolution_test.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/apiclient"
+	"github.com/sachiniyer/agent-factory/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProjectScopeResolversPropagateGitDiscoveryErrors pins the fail-closed
+// half of optional project discovery. Being outside Git is the one condition
+// that may widen a command to all projects; broken repository metadata must not
+// turn a scoped task/session operation into an unscoped one (#3134).
+func TestProjectScopeResolversPropagateGitDiscoveryErrors(t *testing.T) {
+	resetScopeFlags(t)
+	t.Chdir(t.TempDir())
+	t.Setenv("GIT_DIR", filepath.Join(t.TempDir(), "missing-git-dir"))
+
+	_, discoveryErr := config.CurrentRepo()
+	require.Error(t, discoveryErr, "fixture must make Git discovery fail")
+	require.False(t, errors.Is(discoveryErr, config.ErrNotGitRepository),
+		"fixture must exercise a real Git failure, not the allowed outside-repository fallback")
+
+	previousDaemonURL := apiclient.FlagDaemonURL
+	apiclient.FlagDaemonURL = ""
+	t.Cleanup(func() { apiclient.FlagDaemonURL = previousDaemonURL })
+
+	tests := []struct {
+		name    string
+		resolve func() error
+	}{
+		{
+			name: "task scope",
+			resolve: func() error {
+				_, err := resolveProjectScope(false)
+				return err
+			},
+		},
+		{
+			name: "local write scope",
+			resolve: func() error {
+				_, err := resolveRepoID()
+				return err
+			},
+		},
+		{
+			name: "local read scope",
+			resolve: func() error {
+				_, err := resolveRepoIDForLookup()
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.resolve()
+			require.Error(t, err, "ambiguous Git failure must fail closed")
+			assert.Contains(t, err.Error(), "resolve current repository")
+			assert.NotErrorIs(t, err, config.ErrNotGitRepository)
+		})
+	}
+}

--- a/api/scope.go
+++ b/api/scope.go
@@ -84,9 +84,9 @@ func resolveProjectScope(allFlag bool) (projectScope, error) {
 		}
 		return projectScope{Repo: repo}, nil
 	}
-	repo, err := config.CurrentRepo()
+	repo, err := optionalCurrentRepo()
 	if err != nil {
-		return projectScope{}, nil // rule 3: no project context
+		return projectScope{}, err
 	}
 	return projectScope{Repo: repo}, nil
 }

--- a/config/repo.go
+++ b/config/repo.go
@@ -54,6 +54,10 @@ func ValidateRepoID(repoID string) error {
 func resolveMainRepoRoot(pathArgs ...string) (string, error) {
 	// Get the toplevel for the current location
 	topCmd := exec.Command("git", append(pathArgs, "rev-parse", "--show-toplevel")...)
+	// The outside-repository classification below parses Git's diagnostic. Force
+	// that one command to the locale the parser expects so a translated stderr
+	// cannot turn ordinary absence into a fatal scope-resolution error (#3134).
+	topCmd.Env = append(os.Environ(), "LC_ALL=C")
 	topOut, err := topCmd.Output()
 	if err != nil {
 		var exitErr *exec.ExitError

--- a/config/repo_test.go
+++ b/config/repo_test.go
@@ -118,6 +118,31 @@ func TestResolveMainRepoRoot_Public(t *testing.T) {
 	assert.Equal(t, mainDir, root)
 }
 
+// TestResolveMainRepoRootForcesStableGitDiagnostics pins the locale-independent
+// outside-repository classification. The resolver may parse Git's diagnostic to
+// distinguish ordinary absence from broken metadata, so the command must force
+// the language that parser expects (#3134 review).
+func TestResolveMainRepoRootForcesStableGitDiagnostics(t *testing.T) {
+	binDir := t.TempDir()
+	fakeGit := filepath.Join(binDir, "git")
+	require.NoError(t, os.WriteFile(fakeGit, []byte(`#!/bin/sh
+if [ "$LC_ALL" = "C" ]; then
+	printf '%s\n' 'fatal: not a git repository (or any of the parent directories): .git' >&2
+else
+	printf '%s\n' 'fatal: Kein Git-Repository (oder irgendeines der Elternverzeichnisse): .git' >&2
+fi
+exit 128
+`), 0o755))
+	t.Setenv("PATH", binDir)
+	t.Setenv("LC_ALL", "de_DE.UTF-8")
+	t.Chdir(t.TempDir())
+
+	_, err := CurrentRepo()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotGitRepository,
+		"an ordinary outside-repository result must not become a fatal scope error under a translated locale")
+}
+
 func TestRepoIDFromRoot(t *testing.T) {
 	id := RepoIDFromRoot("/some/path")
 	assert.Len(t, id, 12) // 6 bytes = 12 hex chars


### PR DESCRIPTION
Summary:
- centralize optional cwd-project resolution so only `ErrNotGitRepository` widens to unscoped mode
- propagate all other Git discovery errors through task scopes and local session read/write scopes
- preserve the deliberate remote-read exemption from client cwd scoping
- force a stable Git diagnostic locale so ordinary outside-repo use remains locale-independent

Fail-first proof:
- on master, `TestProjectScopeResolversPropagateGitDiscoveryErrors` failed because task, local-write, and local-read resolvers all returned nil for a confirmed non-sentinel Git error
- the locale regression then failed before its fix because translated Git stderr produced only `exit status 128`, not `ErrNotGitRepository`
- both Codex reviewer reproductions now pass, including inherited `AF_DAEMON_URL`

Local checks:
- `go test ./api ./config -count=1`
- `gofmt -l .` (empty)
- `go build ./...`
- `golangci-lint run --timeout=3m --fast`
- `scripts/lint-file-length.sh`

Closes #3134