### PR TITLE
fix(web): surface PTY input delivery failures

### DIFF
--- a/daemon/ws_pty.go
+++ b/daemon/ws_pty.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/coder/websocket"
 	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 )
 
@@ -291,15 +292,32 @@ func servePTYStream(binding ptyTabBinding, sub session.PTYSubscription, conn *we
 	defer cancel()
 	defer func() { _ = sub.Close() }()
 
+	readerDone := make(chan error, 1)
 	var wg sync.WaitGroup
 	wg.Add(2)
-	go func() { defer wg.Done(); defer cancel(); readPTYClient(ctx, binding, conn) }()
+	go func() {
+		defer wg.Done()
+		err := readPTYClient(ctx, binding, conn)
+		readerDone <- err
+		cancel()
+	}()
 	go func() { defer wg.Done(); defer cancel(); keepalivePTY(ctx, conn) }()
 
 	writePTYStream(ctx, sub, conn)
 
 	cancel()
-	_ = conn.Close(websocket.StatusNormalClosure, "")
+	closeStatus := websocket.StatusNormalClosure
+	closeReason := ""
+	select {
+	case err := <-readerDone:
+		if err != nil {
+			log.WarningLog.Printf("PTY input delivery failed; closing web stream so the client can reconnect: %v", err)
+			closeStatus = websocket.StatusInternalError
+			closeReason = "PTY input delivery failed"
+		}
+	default:
+	}
+	_ = conn.Close(closeStatus, closeReason)
 	wg.Wait()
 }
 
@@ -406,29 +424,32 @@ func writePTYStream(ctx context.Context, sub session.PTYSubscription, conn *webs
 
 // readPTYClient handles client → server frames: INPUT and RESIZE are applied to
 // the agent-server (multi-writer, from any subscriber); a detach control frame or
-// any read error ends the connection.
-func readPTYClient(ctx context.Context, binding ptyTabBinding, conn *websocket.Conn) {
+// any read error ends the connection. A failed INPUT ends the stream with an
+// error so the client can reconnect rather than silently losing later keys.
+func readPTYClient(ctx context.Context, binding ptyTabBinding, conn *websocket.Conn) error {
 	for {
 		msg, err := agentproto.ReadMessage(ctx, conn)
 		if err != nil {
-			return
+			return nil
 		}
 		if msg.Binary {
 			// The binding re-resolves the tab per frame (#1738): for a ?tab_id=
 			// connection each keystroke/resize lands on wherever THAT tab now sits, so a
 			// mid-connection reorder/close can't misroute it. A tab that has since been
-			// closed no longer resolves — the op errors (ErrTabGone) and the frame is
-			// dropped rather than routed to whatever tab now holds the old ordinal.
+			// closed no longer resolves — the op errors (ErrTabGone) and this stream is
+			// closed rather than routing later keys to whatever tab now holds the ordinal.
 			switch msg.Frame.Op {
 			case agentproto.OpInput:
-				_ = binding.input(msg.Frame.Data)
+				if err := binding.input(msg.Frame.Data); err != nil {
+					return fmt.Errorf("apply PTY input: %w", err)
+				}
 			case agentproto.OpResize:
 				_ = binding.resize(msg.Frame.Rows, msg.Frame.Cols)
 			}
 			continue
 		}
 		if t, _ := agentproto.MessageTypeOf(msg.Text); t == agentproto.MsgDetach {
-			return
+			return nil
 		}
 	}
 }

--- a/daemon/ws_pty_input_error_test.go
+++ b/daemon/ws_pty_input_error_test.go
@@ -1,0 +1,94 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+type rejectingPTYInputBinding struct {
+	err    error
+	called chan []byte
+}
+
+func (*rejectingPTYInputBinding) subscribe(session.Seq) (session.PTYSubscription, error) {
+	return nil, errors.New("subscribe is not used by servePTYStream")
+}
+
+func (b *rejectingPTYInputBinding) input(p []byte) error {
+	b.called <- append([]byte(nil), p...)
+	return b.err
+}
+
+func (*rejectingPTYInputBinding) resize(uint16, uint16) error { return nil }
+
+type waitingPTYSubscription struct{}
+
+func (*waitingPTYSubscription) NextEvent(ctx context.Context) (session.PTYEvent, error) {
+	<-ctx.Done()
+	return session.PTYEvent{}, ctx.Err()
+}
+
+func (*waitingPTYSubscription) Seq() session.Seq { return 0 }
+func (*waitingPTYSubscription) Close() error     { return nil }
+
+// TestServePTYStreamInputErrorClosesWebSocket proves a failed input delivery is
+// observable to the web terminal. The reconnecting client can hold subsequent
+// keys only if the server closes this failed stream instead of silently reading
+// and dropping every later OpInput frame (#3138).
+func TestServePTYStreamInputErrorClosesWebSocket(t *testing.T) {
+	binding := &rejectingPTYInputBinding{
+		err:    errors.New("tmux rejected input"),
+		called: make(chan []byte, 1),
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			return
+		}
+		servePTYStream(binding, &waitingPTYSubscription{}, conn)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial PTY stream: %v", err)
+	}
+	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "") }()
+
+	hello, err := agentproto.ReadMessage(ctx, conn)
+	if err != nil {
+		t.Fatalf("read stream hello: %v", err)
+	}
+	if !hello.Binary || hello.Frame.Op != agentproto.OpHello {
+		t.Fatalf("first message = %+v, want OpHello", hello)
+	}
+
+	want := []byte("typed")
+	if err := agentproto.WriteFrame(ctx, conn, agentproto.InputFrame(want)); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	select {
+	case got := <-binding.called:
+		if string(got) != string(want) {
+			t.Fatalf("binding input = %q, want %q", got, want)
+		}
+	case <-ctx.Done():
+		t.Fatalf("binding did not receive input: %v", ctx.Err())
+	}
+
+	_, _, err = conn.Read(ctx)
+	if got := websocket.CloseStatus(err); got != websocket.StatusInternalError {
+		t.Fatalf("input failure close status = %v (err %v), want %v", got, err, websocket.StatusInternalError)
+	}
+}


### PR DESCRIPTION
Summary:
- propagate PTY input delivery errors out of the WebSocket reader instead of discarding them
- log the failed delivery and close only that client stream with an internal-error status so the web terminal reconnects and holds subsequent input
- add a hermetic WebSocket regression that proves rejected input is delivered to the binding and made observable to the client

Reachability:
- 500-character titles do survive current branch/worktree creation because title-derived Git and filesystem components are bounded before use
- the 512-byte value is AF chunking headroom, not tmux rejection enforcement; a created session has already sent the same name in a larger new-session command, so this PR does not add a speculative 512-byte title refusal
- binding.input failures are independently reachable, including ErrTabGone and tmux delivery errors, and were discarded at the WebSocket call site

Fail-first proof:
- test-only head 28142b0f23d5f4979e1368f1c76e31e3e8c60d52 was pushed before the production fix
- CI Test job https://github.com/sachiniyer/agent-factory/actions/runs/31286777057/job/93176935904 failed TestServePTYStreamInputErrorClosesWebSocket after the binding returned tmux rejected input
- observed failure: client timed out with close status -1 instead of StatusInternalError, proving the delivery error was silently discarded
- daemon tests were not run on the maintainer host; replacement-head CI owns the passing proof

Local non-daemon checks:
- gofmt -l . (empty)
- go build ./...
- golangci-lint run --timeout=3m --fast
- scripts/lint-file-length.sh

Closes #3138