### PR TITLE
fix(daemon): refuse reset while symlinked orphan daemon lives

### DIFF
--- a/daemon/stopall.go
+++ b/daemon/stopall.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/pathutil"
 	"github.com/sachiniyer/agent-factory/internal/proctree"
 	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 	"github.com/sachiniyer/agent-factory/log"
@@ -317,18 +318,17 @@ func verifyScopedDaemon(pid, uid int, wantHome string) daemonScope {
 // while naming the same directory: relative vs absolute (GetConfigDir does not
 // absolutize — #1873), or through a symlink (/tmp vs /private/tmp on macOS).
 //
-// EvalSymlinks is best-effort: it fails on a path that does not exist, which is
-// legitimate here (an AF home that has not been created yet), so a failure
-// falls back to the lexical form rather than failing the comparison.
+// ResolveForCompare resolves the deepest existing ancestor before re-joining a
+// missing remainder. That missing-leaf behavior is load-bearing here: an
+// orphan daemon can outlive its deleted AF home, and reset still has to prove
+// that the symlinked spelling in its environment identifies THIS home before
+// it may wipe anything.
 func canonicalDir(dir string) (string, error) {
 	abs, err := filepath.Abs(dir)
 	if err != nil {
 		return "", err
 	}
-	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
-		return resolved, nil
-	}
-	return filepath.Clean(abs), nil
+	return pathutil.ResolveForCompare(abs), nil
 }
 
 // processUID returns the uid owning pid. The second return is false when

--- a/daemon/stopall_test.go
+++ b/daemon/stopall_test.go
@@ -3,6 +3,8 @@ package daemon
 import (
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -115,6 +117,58 @@ func TestVerifyScopedDaemon_MatchesOnlyOurHome(t *testing.T) {
 	foreign := spawnFakeDaemonWithHome(t, otherHome)
 	if got := verifyScopedDaemon(foreign, uid, want); got != daemonForeign {
 		t.Errorf("daemon for a different AF home classified %v, want daemonForeign", got)
+	}
+}
+
+// TestAssertNoLiveDaemon_RefusesOrphanThroughSymlinkedParent exercises the
+// destructive reset barrier, not just path normalization in isolation. A
+// daemon keeps the spelling of AGENT_FACTORY_HOME from its startup environment;
+// after that home is deleted, a plain EvalSymlinks fallback cannot tell that a
+// symlinked spelling and the real spelling still name the same missing path.
+// Calling that daemon foreign lets reset proceed while its single writer is
+// alive over state reset is about to remove.
+func TestAssertNoLiveDaemon_RefusesOrphanThroughSymlinkedParent(t *testing.T) {
+	if _, err := os.Stat("/proc"); err != nil {
+		t.Skip("scoping by AF home needs /proc")
+	}
+
+	base := t.TempDir()
+	realRoot := filepath.Join(base, "real")
+	if err := os.Mkdir(realRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkRoot := filepath.Join(base, "link")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	realHome := filepath.Join(realRoot, "af-home")
+	if err := os.Mkdir(realHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkHome := filepath.Join(linkRoot, "af-home")
+	pid := spawnFakeDaemonWithHome(t, linkHome)
+
+	// Reproduce the orphan state: the process remains live, but the home it
+	// started against is gone before reset performs its final liveness proof.
+	if err := os.Remove(realHome); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := filepath.EvalSymlinks(linkHome); err == nil {
+		t.Fatal("sanity: EvalSymlinks unexpectedly resolved the deleted AF home")
+	}
+
+	origScan := scopedDaemonScanFn
+	t.Cleanup(func() { scopedDaemonScanFn = origScan })
+	scopedDaemonScanFn = func() ([]int, error) { return []int{pid}, nil }
+
+	err := AssertNoLiveDaemon(realHome)
+	if err == nil {
+		t.Fatalf("AssertNoLiveDaemon allowed reset while orphaned daemon pid %d was still live", pid)
+	}
+	want := "af daemon(s) still running for this AF home: " + strconv.Itoa(pid)
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("AssertNoLiveDaemon refusal = %q, want proven-home refusal containing %q", err, want)
 	}
 }
 

--- a/daemon/stopall_test.go
+++ b/daemon/stopall_test.go
@@ -161,6 +161,10 @@ func TestAssertNoLiveDaemon_RefusesOrphanThroughSymlinkedParent(t *testing.T) {
 	origScan := scopedDaemonScanFn
 	t.Cleanup(func() { scopedDaemonScanFn = origScan })
 	scopedDaemonScanFn = func() ([]int, error) { return []int{pid}, nil }
+	// AssertNoLiveDaemon probes the control socket before the injected scan.
+	// Keep that probe inside this throwaway home so an ambient developer daemon
+	// cannot satisfy the assertion for an unrelated reason.
+	t.Setenv("AGENT_FACTORY_HOME", realHome)
 
 	err := AssertNoLiveDaemon(realHome)
 	if err == nil {


### PR DESCRIPTION
## Summary

- replace reset daemon scoping path comparison with the repository canonical missing-leaf identity helper
- preserve absolute normalization so relative and absolute AF home spellings still compare correctly
- add a lifecycle regression that starts a daemon against a symlinked home, deletes that home, and proves reset refuses while the orphan is live

## Fail-first proof

- Linux CI on the master-derived test-only head failed the new regression for the intended reason: AssertNoLiveDaemon allowed reset while the orphaned daemon was still live
- https://github.com/sachiniyer/agent-factory/actions/runs/31287085656/job/93177768477

## Verification

- gofmt -l .
- go build ./...
- golangci-lint run --timeout=3m --fast
- scripts/lint-file-length.sh
- daemon package tests intentionally not run on the host; final CI owns those tests

Closes #3136