### PR TITLE
fix(daemon): make event queue compaction crash-durable

### DIFF
--- a/daemon/eventqueue.go
+++ b/daemon/eventqueue.go
@@ -95,6 +95,7 @@ type eventQueue struct {
 	appendRecord   func(path string, rec []byte) (int, error)
 	appendBoundary func(path string, rec []byte) (int, error)
 	truncate       func(path string, size int64) error
+	syncDirectory  func(string) error
 
 	mu      sync.Mutex
 	offset  int64 // byte offset of the first undelivered event
@@ -136,6 +137,7 @@ func newEventQueue(dir, taskID string) *eventQueue {
 		appendRecord:   appendRecordToFile,
 		appendBoundary: appendRecordToFile,
 		truncate:       os.Truncate,
+		syncDirectory:  syncEventQueueDirectory,
 		now:            time.Now,
 	}
 	q.load()
@@ -547,7 +549,7 @@ func (q *eventQueue) compactLocked() error {
 	// fallback persists q.offset again; it must write 0 beside the compacted file,
 	// never the pre-compaction offset that points into a different byte layout.
 	q.offset, q.size = 0, n
-	if err := syncEventQueueDirectory(filepath.Dir(q.path)); err != nil {
+	if err := q.syncDirectory(filepath.Dir(q.path)); err != nil {
 		return fmt.Errorf("sync event-queue directory after compaction: %w", err)
 	}
 	return nil

--- a/daemon/eventqueue.go
+++ b/daemon/eventqueue.go
@@ -484,14 +484,15 @@ func (q *eventQueue) removeDrainedFilesLocked() (bool, error) {
 }
 
 // compactLocked rewrites the queue file to just its pending suffix, dropping
-// the delivered prefix: copy suffix → temp file → persist cursor 0 → rename
-// over the original → reset the in-memory offset. Crash safety comes from the
-// cursor-before-rename ordering (#1537): the post-compaction cursor is 0, and
-// it is made durable BEFORE the rename shrinks the file, so no crash can leave
-// the small compacted file beside a stale offset that points mid-record. Every
-// crash point leaves a record-aligned (file, cursor) pair; the worst case
-// redelivers an already-delivered prefix (at-least-once, never loss). Callers
-// hold q.mu.
+// the delivered prefix: copy suffix → sync and close temp file → persist cursor
+// 0 → rename over the original → commit the matching in-memory offset → sync
+// the containing directory. Crash safety comes from both halves of that
+// publication: the compacted contents reach stable storage before rename, and
+// the directory entry does afterward. The cursor-before-rename ordering (#1537)
+// separately ensures no crash can leave the small compacted file beside a stale
+// offset that points mid-record. Every crash point therefore preserves the pending
+// suffix; the worst case redelivers an already-delivered prefix (at-least-once,
+// never loss). Callers hold q.mu.
 func (q *eventQueue) compactLocked() error {
 	src, err := os.Open(q.path)
 	if err != nil {
@@ -507,6 +508,11 @@ func (q *eventQueue) compactLocked() error {
 	}
 	tmpName := tmp.Name()
 	n, err := io.Copy(tmp, src)
+	if err == nil {
+		if syncErr := tmp.Sync(); syncErr != nil {
+			err = fmt.Errorf("sync compacted event queue: %w", syncErr)
+		}
+	}
 	if closeErr := tmp.Close(); err == nil {
 		err = closeErr
 	}
@@ -536,7 +542,29 @@ func (q *eventQueue) compactLocked() error {
 		}
 		return err
 	}
+	// Rename is already visible, so commit the matching in-memory cursor before
+	// attempting the directory sync. If that sync fails, advance's optimization
+	// fallback persists q.offset again; it must write 0 beside the compacted file,
+	// never the pre-compaction offset that points into a different byte layout.
 	q.offset, q.size = 0, n
+	if err := syncEventQueueDirectory(filepath.Dir(q.path)); err != nil {
+		return fmt.Errorf("sync event-queue directory after compaction: %w", err)
+	}
+	return nil
+}
+
+func syncEventQueueDirectory(dir string) error {
+	handle, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", dir, err)
+	}
+	if err := handle.Sync(); err != nil {
+		_ = handle.Close()
+		return fmt.Errorf("fsync %s: %w", dir, err)
+	}
+	if err := handle.Close(); err != nil {
+		return fmt.Errorf("close %s after fsync: %w", dir, err)
+	}
 	return nil
 }
 

--- a/daemon/eventqueue.go
+++ b/daemon/eventqueue.go
@@ -487,14 +487,15 @@ func (q *eventQueue) removeDrainedFilesLocked() (bool, error) {
 
 // compactLocked rewrites the queue file to just its pending suffix, dropping
 // the delivered prefix: copy suffix → sync and close temp file → persist cursor
-// 0 → rename over the original → commit the matching in-memory offset → sync
-// the containing directory. Crash safety comes from both halves of that
-// publication: the compacted contents reach stable storage before rename, and
-// the directory entry does afterward. The cursor-before-rename ordering (#1537)
-// separately ensures no crash can leave the small compacted file beside a stale
-// offset that points mid-record. Every crash point therefore preserves the pending
-// suffix; the worst case redelivers an already-delivered prefix (at-least-once,
-// never loss). Callers hold q.mu.
+// 0 → sync its directory entry → rename over the original → commit the matching
+// in-memory offset → sync the containing directory. Crash safety comes from both
+// halves of that publication: the cursor reset and compacted contents reach
+// stable storage before the queue rename, and the queue's new directory entry
+// does afterward. The cursor-before-rename ordering (#1537) separately ensures
+// no crash can leave the small compacted file beside a stale offset that points
+// mid-record. Every crash point therefore preserves the pending suffix; the
+// worst case redelivers an already-delivered prefix (at-least-once, never loss).
+// Callers hold q.mu.
 func (q *eventQueue) compactLocked() error {
 	src, err := os.Open(q.path)
 	if err != nil {
@@ -533,6 +534,14 @@ func (q *eventQueue) compactLocked() error {
 	if err := q.persistCursorValueLocked(0); err != nil {
 		_ = os.Remove(tmpName)
 		return err
+	}
+	// AtomicWriteFile's directory sync is intentionally best-effort for its
+	// general callers. Compaction needs a stronger cross-file guarantee: cursor
+	// 0 must be durable before the shortened queue can become durable, or a
+	// crash could pair the new queue with the old nonzero cursor and skip events.
+	if err := q.syncDirectory(filepath.Dir(q.curPath)); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("sync event-queue cursor directory before compaction: %w", err)
 	}
 	if err := os.Rename(tmpName, q.path); err != nil {
 		_ = os.Remove(tmpName)

--- a/daemon/eventqueue.go
+++ b/daemon/eventqueue.go
@@ -486,16 +486,17 @@ func (q *eventQueue) removeDrainedFilesLocked() (bool, error) {
 }
 
 // compactLocked rewrites the queue file to just its pending suffix, dropping
-// the delivered prefix: copy suffix → sync and close temp file → persist cursor
-// 0 → sync its directory entry → rename over the original → commit the matching
-// in-memory offset → sync the containing directory. Crash safety comes from both
-// halves of that publication: the cursor reset and compacted contents reach
-// stable storage before the queue rename, and the queue's new directory entry
-// does afterward. The cursor-before-rename ordering (#1537) separately ensures
-// no crash can leave the small compacted file beside a stale offset that points
-// mid-record. Every crash point therefore preserves the pending suffix; the
-// worst case redelivers an already-delivered prefix (at-least-once, never loss).
-// Callers hold q.mu.
+// the delivered prefix: persist cursor 0 → sync its directory entry → create,
+// copy, sync, and close the temp file → rename over the original → commit the
+// matching in-memory offset → sync the containing directory. Crash safety comes
+// from both halves of that publication: the cursor reset and compacted contents
+// reach stable storage before the queue rename, and the queue's new directory
+// entry does afterward. Creating the temp only after the cursor fence prevents
+// that fence from also making an abandoned compact-file name durable. The
+// cursor-before-rename ordering (#1537) separately ensures no crash can leave
+// the small compacted file beside a stale offset that points mid-record. Every
+// crash point therefore preserves the pending suffix; the worst case redelivers
+// an already-delivered prefix (at-least-once, never loss). Callers hold q.mu.
 func (q *eventQueue) compactLocked() error {
 	src, err := os.Open(q.path)
 	if err != nil {
@@ -504,6 +505,26 @@ func (q *eventQueue) compactLocked() error {
 	defer func() { _ = src.Close() }()
 	if _, err := src.Seek(q.offset, 0); err != nil {
 		return err
+	}
+	// Persist the post-compaction cursor (0) durably BEFORE the rename shrinks
+	// the file, closing the crash window that used to wedge the queue (#1537).
+	// The old ordering renamed first and left the caller to persist the cursor
+	// after, so a crash in between paired the small compacted file with a stale
+	// pre-compaction offset pointing mid-record. Cursor-before-rename makes every
+	// crash point consistent and record-aligned: before this write, old file +
+	// old offset; after it but before the rename, old file + cursor 0 (redelivers
+	// the delivered prefix); after the rename, compacted file + cursor 0.
+	if err := q.persistCursorValueLocked(0); err != nil {
+		return err
+	}
+	// AtomicWriteFile's directory sync is intentionally best-effort for its
+	// general callers. Compaction needs a stronger cross-file guarantee: cursor
+	// 0 must be durable before the shortened queue can become durable, or a
+	// crash could pair the new queue with the old nonzero cursor and skip events.
+	// Fence it before creating the compact temp so this sync cannot also persist
+	// an abandoned temp-file name if the daemon crashes before the queue rename.
+	if err := q.syncDirectory(filepath.Dir(q.curPath)); err != nil {
+		return fmt.Errorf("sync event-queue cursor directory before compaction: %w", err)
 	}
 	tmp, err := os.CreateTemp(filepath.Dir(q.path), q.taskID+".compact-*")
 	if err != nil {
@@ -522,26 +543,6 @@ func (q *eventQueue) compactLocked() error {
 	if err != nil {
 		_ = os.Remove(tmpName)
 		return err
-	}
-	// Persist the post-compaction cursor (0) durably BEFORE the rename shrinks
-	// the file, closing the crash window that used to wedge the queue (#1537).
-	// The old ordering renamed first and left the caller to persist the cursor
-	// after, so a crash in between paired the small compacted file with a stale
-	// pre-compaction offset pointing mid-record. Cursor-before-rename makes every
-	// crash point consistent and record-aligned: before this write, old file +
-	// old offset; after it but before the rename, old file + cursor 0 (redelivers
-	// the delivered prefix); after the rename, compacted file + cursor 0.
-	if err := q.persistCursorValueLocked(0); err != nil {
-		_ = os.Remove(tmpName)
-		return err
-	}
-	// AtomicWriteFile's directory sync is intentionally best-effort for its
-	// general callers. Compaction needs a stronger cross-file guarantee: cursor
-	// 0 must be durable before the shortened queue can become durable, or a
-	// crash could pair the new queue with the old nonzero cursor and skip events.
-	if err := q.syncDirectory(filepath.Dir(q.curPath)); err != nil {
-		_ = os.Remove(tmpName)
-		return fmt.Errorf("sync event-queue cursor directory before compaction: %w", err)
 	}
 	if err := os.Rename(tmpName, q.path); err != nil {
 		_ = os.Remove(tmpName)

--- a/daemon/eventqueue_compaction_test.go
+++ b/daemon/eventqueue_compaction_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -56,5 +57,52 @@ func TestEventQueue_CompactionStopsBeforeQueueRenameWhenCursorBarrierFails(t *te
 	event, _, ok, err := reopened.peek()
 	if err != nil || !ok || event.Line != "pending" {
 		t.Fatalf("reopened head = %q ok=%v err=%v, want pending", event.Line, ok, err)
+	}
+}
+
+// TestEventQueue_CompactionCursorFenceCannotPersistOrphanTemp models a crash
+// immediately after the cursor-directory fence. The fence must run before the
+// compact temporary file is created, or that fsync also makes the temporary
+// directory entry durable and startup has no task-scoped way to reclaim it.
+func TestEventQueue_CompactionCursorFenceCannotPersistOrphanTemp(t *testing.T) {
+	previousThreshold := watcherQueueCompactBytes
+	watcherQueueCompactBytes = 1
+	t.Cleanup(func() { watcherQueueCompactBytes = previousThreshold })
+
+	dir := t.TempDir()
+	const taskID = "ab313302"
+	q := newEventQueue(dir, taskID)
+	for _, line := range []string{"delivered", "pending"} {
+		if err := q.enqueue(line); err != nil {
+			t.Fatalf("enqueue %q: %v", line, err)
+		}
+	}
+	_, cursor, ok, err := q.peek()
+	if err != nil || !ok {
+		t.Fatalf("peek: ok=%v err=%v", ok, err)
+	}
+
+	const simulatedCrash = "simulated crash after cursor-directory fence"
+	q.syncDirectory = func(dir string) error {
+		if err := syncEventQueueDirectory(dir); err != nil {
+			return err
+		}
+		panic(simulatedCrash)
+	}
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		_, _ = q.advance(cursor)
+	}()
+	if recovered != simulatedCrash {
+		t.Fatalf("recovered panic = %v, want %q", recovered, simulatedCrash)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(dir, taskID+".compact-*"))
+	if err != nil {
+		t.Fatalf("glob compact files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("cursor fence made abandoned compact files durable: %v", matches)
 	}
 }

--- a/daemon/eventqueue_compaction_test.go
+++ b/daemon/eventqueue_compaction_test.go
@@ -1,0 +1,60 @@
+package daemon
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+// TestEventQueue_CompactionStopsBeforeQueueRenameWhenCursorBarrierFails proves
+// the cursor reset is durable before compaction may publish a shortened queue.
+// Otherwise a crash can preserve the new queue beside the old nonzero cursor;
+// if that offset is also a record boundary in the new layout, reload silently
+// skips pending events.
+func TestEventQueue_CompactionStopsBeforeQueueRenameWhenCursorBarrierFails(t *testing.T) {
+	previousThreshold := watcherQueueCompactBytes
+	watcherQueueCompactBytes = 1
+	t.Cleanup(func() { watcherQueueCompactBytes = previousThreshold })
+
+	dir := t.TempDir()
+	q := newEventQueue(dir, "ab313301")
+	for _, line := range []string{"delivered", "pending"} {
+		if err := q.enqueue(line); err != nil {
+			t.Fatalf("enqueue %q: %v", line, err)
+		}
+	}
+	originalQueue, err := os.ReadFile(q.path)
+	if err != nil {
+		t.Fatalf("read original queue: %v", err)
+	}
+
+	barrierCalls := 0
+	q.syncDirectory = func(string) error {
+		barrierCalls++
+		return errors.New("simulated cursor-directory sync failure")
+	}
+	_, cursor, ok, err := q.peek()
+	if err != nil || !ok {
+		t.Fatalf("peek: ok=%v err=%v", ok, err)
+	}
+	advanced, err := q.advance(cursor)
+	if err != nil || !advanced {
+		t.Fatalf("advance after rejected compaction: advanced=%v err=%v", advanced, err)
+	}
+	if barrierCalls != 1 {
+		t.Fatalf("strict directory barrier calls = %d, want 1 before queue rename", barrierCalls)
+	}
+
+	queueAfterFailure, err := os.ReadFile(q.path)
+	if err != nil {
+		t.Fatalf("read queue after rejected compaction: %v", err)
+	}
+	if string(queueAfterFailure) != string(originalQueue) {
+		t.Fatal("compaction replaced the queue before the cursor-directory barrier succeeded")
+	}
+	reopened := newEventQueue(dir, "ab313301")
+	event, _, ok, err := reopened.peek()
+	if err != nil || !ok || event.Line != "pending" {
+		t.Fatalf("reopened head = %q ok=%v err=%v, want pending", event.Line, ok, err)
+	}
+}

--- a/daemon/eventqueue_durability_linux_test.go
+++ b/daemon/eventqueue_durability_linux_test.go
@@ -1,0 +1,105 @@
+//go:build linux
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+const (
+	eventQueueDurabilityHelperEnv = "AF_TEST_EVENT_QUEUE_COMPACTION_DURABILITY"
+	eventQueueDurabilityTaskID    = "ab313300"
+)
+
+// TestEventQueue_CompactionPublishesDurably observes the actual Linux write
+// barriers around compaction. A rewritten inode must be synced before it is
+// renamed over the durable queue, and the containing directory must be synced
+// after that rename publishes the new entry.
+func TestEventQueue_CompactionPublishesDurably(t *testing.T) {
+	if os.Getenv(eventQueueDurabilityHelperEnv) == "1" {
+		runEventQueueDurabilityHelper(t)
+		return
+	}
+
+	strace, err := exec.LookPath("strace")
+	if err != nil {
+		t.Skip("strace is required to observe compaction durability barriers")
+	}
+	dir := t.TempDir()
+	cmd := exec.Command(
+		strace,
+		"-f", "-qq", "-yy", "-s", "4096",
+		"-e", "trace=fsync,fdatasync,rename,renameat,renameat2",
+		os.Args[0], "-test.run=^TestEventQueue_CompactionPublishesDurably$",
+	)
+	cmd.Env = append(os.Environ(),
+		eventQueueDurabilityHelperEnv+"=1",
+		"AF_TEST_EVENT_QUEUE_DIR="+dir,
+	)
+	trace, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("trace compaction helper: %v\n%s", err, trace)
+	}
+
+	lines := strings.Split(string(trace), "\n")
+	tempSync, queueRename, directorySync := -1, -1, -1
+	compactName := eventQueueDurabilityTaskID + ".compact-"
+	queueName := eventQueueDurabilityTaskID + ".jsonl"
+	for index, line := range lines {
+		isSync := strings.Contains(line, "fsync(") || strings.Contains(line, "fdatasync(")
+		if isSync && strings.Contains(line, compactName) {
+			tempSync = index
+		}
+		if strings.Contains(line, "rename") && strings.Contains(line, compactName) && strings.Contains(line, queueName) {
+			queueRename = index
+		}
+		if queueRename >= 0 && index > queueRename && isSync && strings.Contains(line, "<"+dir+">") {
+			directorySync = index
+			break
+		}
+	}
+	if tempSync < 0 {
+		t.Fatalf("compaction renamed an unsynced temporary queue file; trace:\n%s", trace)
+	}
+	if queueRename < 0 {
+		t.Fatalf("trace did not contain the compacted queue rename; trace:\n%s", trace)
+	}
+	if tempSync > queueRename {
+		t.Fatalf("temporary queue sync happened after publication; trace:\n%s", trace)
+	}
+	if directorySync < 0 {
+		t.Fatalf("compaction did not sync %s after publishing the queue entry; trace:\n%s", dir, trace)
+	}
+}
+
+func runEventQueueDurabilityHelper(t *testing.T) {
+	dir := os.Getenv("AF_TEST_EVENT_QUEUE_DIR")
+	if dir == "" {
+		t.Fatal("AF_TEST_EVENT_QUEUE_DIR is empty")
+	}
+	previousThreshold := watcherQueueCompactBytes
+	watcherQueueCompactBytes = 1
+	t.Cleanup(func() { watcherQueueCompactBytes = previousThreshold })
+
+	q := newEventQueue(dir, eventQueueDurabilityTaskID)
+	for index := 0; index < 2; index++ {
+		if err := q.enqueue(fmt.Sprintf("event-%d", index)); err != nil {
+			t.Fatalf("enqueue %d: %v", index, err)
+		}
+	}
+	_, cursor, ok, err := q.peek()
+	if err != nil || !ok {
+		t.Fatalf("peek: ok=%v err=%v", ok, err)
+	}
+	advanced, err := q.advance(cursor)
+	if err != nil || !advanced {
+		t.Fatalf("advance through compaction: advanced=%v err=%v", advanced, err)
+	}
+	if q.pendingCount() != 1 {
+		t.Fatalf("pending after compaction = %d, want 1", q.pendingCount())
+	}
+}

--- a/daemon/eventqueue_durability_linux_test.go
+++ b/daemon/eventqueue_durability_linux_test.go
@@ -51,11 +51,12 @@ func TestEventQueue_CompactionPublishesDurably(t *testing.T) {
 	queueName := eventQueueDurabilityTaskID + ".jsonl"
 	for index, line := range lines {
 		isSync := strings.Contains(line, "fsync(") || strings.Contains(line, "fdatasync(")
-		syncSucceeded := isSync && strings.HasSuffix(strings.TrimSpace(line), "= 0")
+		syscallSucceeded := strings.HasSuffix(strings.TrimSpace(line), "= 0")
+		syncSucceeded := isSync && syscallSucceeded
 		if syncSucceeded && strings.Contains(line, compactName) {
 			tempSync = index
 		}
-		if strings.Contains(line, "rename") && strings.Contains(line, compactName) && strings.Contains(line, queueName) {
+		if syscallSucceeded && strings.Contains(line, "rename") && strings.Contains(line, compactName) && strings.Contains(line, queueName) {
 			queueRename = index
 		}
 		if queueRename >= 0 && index > queueRename && syncSucceeded && strings.Contains(line, "<"+dir+">") {

--- a/daemon/eventqueue_durability_linux_test.go
+++ b/daemon/eventqueue_durability_linux_test.go
@@ -51,13 +51,14 @@ func TestEventQueue_CompactionPublishesDurably(t *testing.T) {
 	queueName := eventQueueDurabilityTaskID + ".jsonl"
 	for index, line := range lines {
 		isSync := strings.Contains(line, "fsync(") || strings.Contains(line, "fdatasync(")
-		if isSync && strings.Contains(line, compactName) {
+		syncSucceeded := isSync && strings.HasSuffix(strings.TrimSpace(line), "= 0")
+		if syncSucceeded && strings.Contains(line, compactName) {
 			tempSync = index
 		}
 		if strings.Contains(line, "rename") && strings.Contains(line, compactName) && strings.Contains(line, queueName) {
 			queueRename = index
 		}
-		if queueRename >= 0 && index > queueRename && isSync && strings.Contains(line, "<"+dir+">") {
+		if queueRename >= 0 && index > queueRename && syncSucceeded && strings.Contains(line, "<"+dir+">") {
 			directorySync = index
 			break
 		}


### PR DESCRIPTION
## Why the loss is real

The JSONL queue is the only durable copy after a watcher event fails or is deferred. Startup reconstructs pending work only by loading that file, and the drainer advances it only after successful delivery. There is no scheduler ledger that can rebuild a lost suffix; a missing record is silently gone unless an external producer independently emits the same line again.

Compaction made that risk broader than a recent append: it copied the entire pending suffix, up to 500 events / 256 KiB, into a fresh inode and renamed that inode over the queue without syncing it first. That could reset the durability of long-lived pending records all at once.

## Durable compaction transaction

The publication order is now explicit:

1. Open the old queue and seek to its pending suffix.
2. Atomically persist cursor 0, then strictly `Sync` its directory entry.
3. Only after that fence, create a same-directory compact file, copy the pending suffix into it, then `Sync` and close the inode.
4. Rename the compacted inode over the queue and immediately commit the matching in-memory offset.
5. Strictly `Sync` the containing directory so the replacement entry survives a host crash.

The cursor and its strict directory barrier remain before the queue rename, preserving #1537 and closing the cross-file durability window. A crash before publication can only pair the old queue with cursor 0 and redeliver its delivered prefix. Creating the compact file after that fence also prevents the fence from making an abandoned `*.compact-*` entry durable at its new crash point. After publication, both cursor 0 and the compacted bytes are already stable; the final directory sync makes the new queue entry stable too. If that post-rename sync reports an error, the in-memory offset is already 0, so the optimization fallback cannot write a stale pre-compaction cursor beside the new layout.

This PR does not add an fsync to every queue append. That is a distinct latency/durability contract on the hot outage-enqueue path; it is not required to stop compaction from replacing an already-populated suffix with an unsynced inode.

## Fail-first proof

- Exact test-only head `e192ba0c` failed Linux CI run `31302974903` in `TestEventQueue_CompactionPublishesDurably` for the intended reason: the syscall trace contained the compact-file rename and post-rename directory fsync, but no `fsync`/`fdatasync` of `ab313300.compact-*` before publication.
- Exact review-regression head `0552b9f3` failed Linux CI run `31304730501` in `TestEventQueue_CompactionStopsBeforeQueueRenameWhenCursorBarrierFails` in 0.01s with `compaction replaced the queue before the cursor-directory barrier succeeded`. The existing syscall durability regression passed in that same package run.
- Exact orphan-regression head `9438b3ca` failed Linux CI run `31305472498` in `TestEventQueue_CompactionCursorFenceCannotPersistOrphanTemp` in 0.00s and printed the abandoned `ab313302.compact-*` path. Both earlier compaction regressions passed in that same package run.

The regressions cover the real Linux publication barriers, failure propagation before queue replacement, and the cursor-fence crash point.

## Verification

Local, on final implementation:

- `gofmt -l .` (empty)
- `go build ./...`
- `golangci-lint run --timeout=3m --fast`
- `scripts/lint-file-length.sh`
- No `go test ./daemon/...` was run on the maintainer host; daemon tests are CI-only.

Closes #3133