### PR TITLE
docs(upgrade): explain --allow-rejected scope

### DIFF
--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -117,6 +117,15 @@ than the running binary — which happens when you switch from the preview
 channel back to stable — the upgrade is a no-op with an explanation. Pass
 --allow-downgrade to install the older release anyway.
 
+A manual upgrade also refuses to install a build this machine has already rolled
+back, so this repair path does not silently reinstall the bytes the rollback just
+recovered from. Publishing a corrected build is the normal fix; pass
+--allow-rejected to install the rejected build anyway.
+
+The same refusal protects launch auto-update and the daemon's transactional
+upgrade. Neither unattended path can override it; only af upgrade offers
+--allow-rejected because a human is present to make that choice.
+
 af upgrade restarts the running daemon after the swap, and always has: the
 daemon keeps executing the old code until something restarts it, so a fix that
 does not reach it is not really installed. Live sessions survive — they run in

--- a/commands/upgrade_test.go
+++ b/commands/upgrade_test.go
@@ -470,6 +470,23 @@ func TestShouldUpgrade(t *testing.T) {
 	}
 }
 
+func TestUpgradeHelpExplainsRejectedCandidates(t *testing.T) {
+	help := strings.Join(strings.Fields(upgradeCmd.Long), " ")
+	for _, want := range []string{
+		"already rolled back",
+		"Publishing a corrected build is the normal fix",
+		"--allow-rejected",
+		"launch auto-update",
+		"daemon's transactional upgrade",
+		"Neither unattended path can override it",
+		"only af upgrade offers --allow-rejected",
+	} {
+		if !strings.Contains(help, want) {
+			t.Errorf("af upgrade long help is missing %q:\n%s", want, upgradeCmd.Long)
+		}
+	}
+}
+
 func makeTarGz(t *testing.T, files map[string][]byte) []byte {
 	t.Helper()
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2534,6 +2534,15 @@ than the running binary — which happens when you switch from the preview
 channel back to stable — the upgrade is a no-op with an explanation. Pass
 --allow-downgrade to install the older release anyway.
 
+A manual upgrade also refuses to install a build this machine has already rolled
+back, so this repair path does not silently reinstall the bytes the rollback just
+recovered from. Publishing a corrected build is the normal fix; pass
+--allow-rejected to install the rejected build anyway.
+
+The same refusal protects launch auto-update and the daemon's transactional
+upgrade. Neither unattended path can override it; only af upgrade offers
+--allow-rejected because a human is present to make that choice.
+
 af upgrade restarts the running daemon after the swap, and always has: the
 daemon keeps executing the old code until something restarts it, so a fix that
 does not reach it is not really installed. Live sessions survive — they run in


### PR DESCRIPTION
## Summary

- explain why `af upgrade` refuses an exact build this machine already rolled back
- document publishing a corrected build as the normal fix and `--allow-rejected` as the manual escape hatch
- state that launch auto-update and the daemon transactional upgrade share the refusal and cannot override it
- regenerate `docs/reference/cli.md` from `upgradeCmd.Long`

## Behavior verification

- launch auto-update calls `CandidateRejected` directly and passes `allowRejected=false` to the guarded swap
- the daemon update driver refuses rejected bytes before activation, and `upgradetxn.Prepare` repeats the refusal under the preparation lock without an override parameter
- only the manual `af upgrade` command registers `--allow-rejected` and propagates the override

## Failing-first evidence

Before the source help change, `go test ./commands/ -run '^TestUpgradeHelpExplainsRejectedCandidates$' -count=1` failed because `upgradeCmd.Long` contained none of the rejected-build context. The focused test passes after the source update.

## Verification

- `gofmt -l .` (empty)
- `go build ./...`
- `golangci-lint run --timeout=3m --fast`
- `scripts/lint-file-length.sh`
- `go test ./commands/ -count=1`
- `scripts/gen-docs.sh` (idempotent)

## Supersedes

Supersedes #3149. That bot PR edited `docs/reference/cli.md` directly, but the file is generated and its prose is stripped by `scripts/gen-docs.sh`. This PR moves the explanation to the authoritative `upgradeCmd.Long` source and commits the regenerated reference.