### PR TITLE
fix: clean up failed hook host pins

### DIFF
--- a/session/backend_hook_provision.go
+++ b/session/backend_hook_provision.go
@@ -260,6 +260,19 @@ func (p *hookProvisioner) provisionHost() (ProvisionResult, error) {
 	if err != nil {
 		return ProvisionResult{}, fmt.Errorf("backend=hook: %w", err)
 	}
+	// No failed provision returns a teardown closure to own this directory, so
+	// establish its fallback owner before the call that creates it. Keeping one
+	// guard around the rest of the function means a new error return below cannot
+	// silently add another leak. The guard stays armed through
+	// reapProvisionFailure: that reap stops the transport first, but may still need
+	// this pin while it does so. It is disarmed only at the successful handoff to
+	// the teardown closure below.
+	removeKnownHostsOnFailure := true
+	defer func() {
+		if removeKnownHostsOnFailure {
+			_ = os.RemoveAll(dir)
+		}
+	}()
 	knownHosts, err := hookProvisionKnownHosts(dir, host, port, record.HostKey)
 	if err != nil {
 		return ProvisionResult{}, fmt.Errorf("backend=hook: %w", err)
@@ -311,6 +324,7 @@ func (p *hookProvisioner) provisionHost() (ProvisionResult, error) {
 	}
 	res.Teardown = teardown
 	res.Backend = p.provisionedBackend(teardown)
+	removeKnownHostsOnFailure = false
 	return res, nil
 }
 

--- a/session/backend_hook_provision_cleanup_test.go
+++ b/session/backend_hook_provision_cleanup_test.go
@@ -1,0 +1,85 @@
+package session
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A provision failure returns no session and therefore no teardown closure. The
+// per-session host-key directory must leave with that failed attempt, including
+// failures added below the point where the pin is created in the future.
+func TestHookProvisionFailureRemovesKnownHostsDirectory(t *testing.T) {
+	newProvisioner := func(t *testing.T) (*hookProvisioner, string) {
+		t.Helper()
+		home := t.TempDir()
+		t.Setenv("AGENT_FACTORY_HOME", home)
+		record := `{"host":"10.0.0.7","host_key":"` + provisionKey + `"}`
+		h := newHookState(t, "printf '%s' '"+record+"'\n", "")
+		p := newHookProvisioner(h, t.Name())
+		p.hooks.LaunchCmd = ""
+		p.hooks.ProvisionCmd = h.launch
+		return p, filepath.Join(home, "hook-hosts", p.slug)
+	}
+
+	t.Run("known_hosts write fails", func(t *testing.T) {
+		p, dir := newProvisioner(t)
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "known_hosts"), 0o700))
+
+		_, err := p.provisionHost()
+		require.ErrorContains(t, err, "cannot write the per-session known_hosts")
+		assert.NoDirExists(t, dir, "the directory created before the write failed leaked")
+	})
+
+	t.Run("af binary lookup fails", func(t *testing.T) {
+		p, dir := newProvisioner(t)
+		lookupErr := errors.New("binary lookup failed")
+		previous := sshSelfBinary
+		sshSelfBinary = func() (string, error) { return "", lookupErr }
+		t.Cleanup(func() { sshSelfBinary = previous })
+
+		_, err := p.provisionHost()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, lookupErr)
+		assert.NoDirExists(t, dir, "the unused pin leaked after binary lookup failed")
+	})
+
+	t.Run("partial sandbox provisioning is reaped", func(t *testing.T) {
+		p, dir := newProvisioner(t)
+		provisionErr := errors.New("remote git configuration failed")
+		previous := newHookSandboxProvisioner
+		calls := 0
+		newHookSandboxProvisioner = func(spec ProvisionSpec, sshCmd, afBin, program string) *sandboxProvisioner {
+			sp := previous(spec, sshCmd, afBin, program)
+			sp.runCommandFn = func(_ time.Duration, script string, _ io.Reader, _ bool) ([]byte, error) {
+				assert.FileExists(t, filepath.Join(dir, "known_hosts"),
+					"sandbox provisioning and its failure reap still need the pin")
+				calls++
+				switch calls {
+				case 1:
+					return []byte("/remote/session\n"), nil
+				case 2:
+					return nil, provisionErr
+				default:
+					// reap requires the remote challenge transformed to uppercase.
+					return []byte(strings.ToUpper(script)), nil
+				}
+			}
+			return sp
+		}
+		t.Cleanup(func() { newHookSandboxProvisioner = previous })
+
+		_, err := p.provisionHost()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, provisionErr)
+		assert.Equal(t, 3, calls, "the partial workspace must be reaped before returning")
+		assert.NoDirExists(t, dir, "the pin leaked after the transport stopped and reaped")
+	})
+}

--- a/session/backend_hook_provision_e2e_test.go
+++ b/session/backend_hook_provision_e2e_test.go
@@ -317,6 +317,9 @@ func TestProvisionedHostFailsFastRatherThanPrompting(t *testing.T) {
 // This composes exactly as provisionHost does, then actually connects.
 func TestProvisionedHostConnectsWithAnEmbeddedPort(t *testing.T) {
 	port, hostPubKey := throwawaySSHD(t)
+	hostStore := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", hostStore)
+	preservedKnownHosts := filepath.Join(t.TempDir(), "known_hosts")
 
 	// Drives the REAL provisionHost, so the assertion cannot be satisfied by
 	// restating its normalization: the seam captures whatever command
@@ -324,7 +327,16 @@ func TestProvisionedHostConnectsWithAnEmbeddedPort(t *testing.T) {
 	var composed string
 	prev := newHookSandboxProvisioner
 	newHookSandboxProvisioner = func(spec ProvisionSpec, sshCmd, afBin, program string) *sandboxProvisioner {
-		composed = sshCmd
+		// provisionHost is deliberately failed below, so its per-session pin is
+		// removed before this test makes the later connection. Preserve a test-owned
+		// copy while the provisioning seam still has access to it; relying on the
+		// production failure path to leak the file is not part of this E2E contract.
+		actualKnownHosts := filepath.Join(hostStore, "hook-hosts", Slugify("embedded port"), "known_hosts")
+		body, err := os.ReadFile(actualKnownHosts)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(preservedKnownHosts, body, 0o600))
+		composed = strings.Replace(sshCmd, actualKnownHosts, preservedKnownHosts, 1)
+		require.NotEqual(t, sshCmd, composed, "the captured command must use the test-owned pin")
 		sp := prev(spec, sshCmd, afBin, program)
 		// ABORT before any remote step runs. The provisioning pipeline's second
 		// step is configureGit, which executes `git config --global` — and the


### PR DESCRIPTION
## Summary

- remove the per-session known_hosts directory on every failed hook-host provision path
- keep the pin alive through partial sandbox cleanup and hand ownership to teardown only on success
- update the embedded-port E2E fixture so it no longer depends on the leaked production file

## Regression proof

The new cleanup regression failed against master on known_hosts write failure, af binary lookup failure, and partial sandbox provisioning; each left the directory behind. It passes after the guarded ownership handoff.

## Local verification

- `gofmt -l .`
- `go build ./...`
- `golangci-lint run --timeout=3m --fast`
- `scripts/lint-file-length.sh`
- `go test ./session`

Closes #3154