### PR TITLE
fix: preserve reset and resume failures

### DIFF
--- a/commands/reset.go
+++ b/commands/reset.go
@@ -437,8 +437,9 @@ func pauseAutostartForReset(out io.Writer, configDir string) (bool, func(*error)
 		fmt.Fprintf(out, "\nACTION REQUIRED: the daemon autostart unit was paused for the wipe and could NOT be "+
 			"resumed after %d attempts (%v).\nYour daemon is STOPPED. Run `systemctl --user start %s` "+
 			"(or `af daemon install`) to bring it back.\n", autostartResumeAttempts, lastErr, daemonUnitName)
-		if errp != nil && *errp == nil {
-			*errp = fmt.Errorf("the daemon autostart unit was paused but could not be resumed: %w", lastErr)
+		if errp != nil {
+			resumeErr := fmt.Errorf("the daemon autostart unit was paused but could not be resumed: %w", lastErr)
+			*errp = errors.Join(*errp, resumeErr)
 		}
 	}
 }

--- a/commands/reset_daemon_test.go
+++ b/commands/reset_daemon_test.go
@@ -420,9 +420,10 @@ func TestFactoryReset_ResumeFailureIsLoudAndFails(t *testing.T) {
 	autostartUnitServesHomeFn = func(string) (bool, bool, error) { return true, true, nil }
 	pauseAutostartUnitFn = func() error { return nil }
 	attempts := 0
+	resumeErr := errors.New("systemctl --user start failed: unit not found")
 	resumeAutostartUnitFn = func() error {
 		attempts++
-		return errors.New("systemctl --user start failed: unit not found")
+		return resumeErr
 	}
 
 	out, err := runResetCapture(t)
@@ -432,8 +433,8 @@ func TestFactoryReset_ResumeFailureIsLoudAndFails(t *testing.T) {
 	if !strings.Contains(out, "ACTION REQUIRED") || !strings.Contains(out, "STOPPED") {
 		t.Errorf("a failed resume did not shout about the stopped daemon:\n%s", out)
 	}
-	if err == nil {
-		t.Error("runReset returned nil after leaving the daemon stopped; a scripted caller would never notice")
+	if !errors.Is(err, resumeErr) {
+		t.Errorf("runReset error = %v, want the resume failure reachable", err)
 	}
 }
 

--- a/commands/reset_resume_error_test.go
+++ b/commands/reset_resume_error_test.go
@@ -1,0 +1,33 @@
+package commands
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// A failed reset does not make a failed autostart resume redundant: the caller
+// needs both the reset outcome and the fact that its daemon was left stopped.
+func TestFactoryReset_ResetAndResumeFailuresAreBothReturned(t *testing.T) {
+	seedResetHome(t)
+	fakeDaemonSeams(t)
+
+	autostartInstalledFn = func() bool { return true }
+	autostartUnitServesHomeFn = func(string) (bool, bool, error) { return true, true, nil }
+	pauseAutostartUnitFn = func() error { return nil }
+	resetErr := errors.New("daemon stop failed")
+	stopDaemonFn = func() (bool, error) { return false, resetErr }
+	resumeErr := errors.New("systemctl could not restart the unit")
+	resumeAutostartUnitFn = func() error { return resumeErr }
+
+	out, err := runResetCapture(t)
+	if !errors.Is(err, resetErr) {
+		t.Errorf("runReset error = %v, want the reset failure reachable", err)
+	}
+	if !errors.Is(err, resumeErr) {
+		t.Errorf("runReset error = %v, want the resume failure reachable", err)
+	}
+	if !strings.Contains(out, "ACTION REQUIRED") || !strings.Contains(out, "STOPPED") {
+		t.Errorf("the stopped-daemon message must remain unconditional:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

- join an autostart resume failure into the reset command return error even when reset already failed
- preserve both causes for `errors.Is` callers without changing the unconditional ACTION REQUIRED output
- cover reset-ok/resume-failed and reset-failed/resume-failed orderings

## Regression proof

The dual-failure regression failed against master because the returned error exposed only `daemon stop failed`; the resume sentinel was unreachable. Both orderings pass after joining the errors.

## Local verification

- `gofmt -l .`
- `go build ./...`
- `golangci-lint run --timeout=3m --fast`
- `scripts/lint-file-length.sh`
- `go test ./commands`

Closes #3153