### PR TITLE
test: retry preview listener fixture binds

### DIFF
--- a/daemon/listener_reload_test.go
+++ b/daemon/listener_reload_test.go
@@ -421,13 +421,24 @@ func TestApplyConfigTokenlessNetworkWarnsAndBinds(t *testing.T) {
 }
 
 // grabFreeLoopbackAddr returns a currently-free 127.0.0.1:port address by binding
-// and immediately releasing it. A tiny race exists (the port could be taken before
-// the caller rebinds it); it is acceptable for a test on an otherwise-idle box.
+// and immediately releasing it. Callers that require a later bind to succeed must
+// retry the complete reserve-and-bind operation; retrying this reservation alone
+// cannot close the release/rebind race.
 func grabFreeLoopbackAddr(t *testing.T) string {
 	t.Helper()
-	l, err := net.Listen("tcp", "127.0.0.1:0")
+	addr, err := freeLoopbackAddr()
 	require.NoError(t, err)
-	addr := l.Addr().String()
-	require.NoError(t, l.Close())
 	return addr
+}
+
+func freeLoopbackAddr() (string, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", err
+	}
+	addr := l.Addr().String()
+	if err := l.Close(); err != nil {
+		return "", err
+	}
+	return addr, nil
 }

--- a/daemon/preview_fixture_retry_test.go
+++ b/daemon/preview_fixture_retry_test.go
@@ -2,10 +2,15 @@ package daemon
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+const previewFixtureBindAttempts = 4
+
+var errPreviewFixtureListenerUnbound = errors.New("preview listener did not bind")
 
 func TestRetryPreviewFixtureBindRecoversFromTransientFailures(t *testing.T) {
 	transient := errors.New("address already in use")
@@ -37,8 +42,17 @@ func TestRetryPreviewFixtureBindStopsAtBound(t *testing.T) {
 	require.Equal(t, 3, attempts, "a persistent bind failure must not loop forever")
 }
 
-// retryPreviewFixtureBind is initially the fixture's historical one-shot bind.
-// The tests above pin the bounded retry behavior before the fixture adopts it.
-func retryPreviewFixtureBind(_ int, bind func() error) error {
-	return bind()
+// retryPreviewFixtureBind retries the complete reserve-and-bind attempt. Retrying
+// only the initial :0 reservation would leave the release/rebind race unchanged.
+func retryPreviewFixtureBind(maxAttempts int, bind func() error) error {
+	if maxAttempts < 1 {
+		return fmt.Errorf("preview listener bind has invalid attempt bound %d", maxAttempts)
+	}
+	var err error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if err = bind(); err == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("preview listener did not bind after %d attempts: %w", maxAttempts, err)
 }

--- a/daemon/preview_fixture_retry_test.go
+++ b/daemon/preview_fixture_retry_test.go
@@ -1,0 +1,44 @@
+package daemon
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryPreviewFixtureBindRecoversFromTransientFailures(t *testing.T) {
+	transient := errors.New("address already in use")
+	attempts := 0
+
+	err := retryPreviewFixtureBind(4, func() error {
+		attempts++
+		if attempts <= 2 {
+			return transient
+		}
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 3, attempts, "the successful bind must stop the retry loop")
+}
+
+func TestRetryPreviewFixtureBindStopsAtBound(t *testing.T) {
+	transient := errors.New("address already in use")
+	attempts := 0
+
+	err := retryPreviewFixtureBind(3, func() error {
+		attempts++
+		return transient
+	})
+
+	require.ErrorIs(t, err, transient)
+	require.ErrorContains(t, err, "after 3 attempts")
+	require.Equal(t, 3, attempts, "a persistent bind failure must not loop forever")
+}
+
+// retryPreviewFixtureBind is initially the fixture's historical one-shot bind.
+// The tests above pin the bounded retry behavior before the fixture adopts it.
+func retryPreviewFixtureBind(_ int, bind func() error) error {
+	return bind()
+}

--- a/daemon/preview_origin_test.go
+++ b/daemon/preview_origin_test.go
@@ -125,18 +125,58 @@ func newPreviewDaemonWithTabs(t *testing.T, tune func(*config.Config), targets .
 
 	cfg := config.DefaultConfig()
 	cfg.ListenAddr = "127.0.0.1:0"
+	const autoPreviewListenAddr = "preview-fixture:auto"
 	// A CONCRETE preview port, not ":0". Editor origins are withheld on an ephemeral
 	// port on purpose — an origin is scheme+host+PORT, so a port the kernel re-picks
 	// every bind cannot carry the stable origin an editor's browser state depends on.
 	// A test that wants to exercise editor origins therefore has to configure the port
 	// a real operator would; grabbing a free one keeps that faithful without pinning a
-	// fixed number that concurrent tests would collide on.
-	cfg.PreviewListenAddr = grabFreeLoopbackAddr(t)
+	// fixed number that concurrent tests would collide on. The sentinel lets the tune
+	// hook opt out by supplying its own address: disabled and deliberately-conflicted
+	// fixtures must stay one-shot, while only this helper-owned address is retried.
+	cfg.PreviewListenAddr = autoPreviewListenAddr
 	if tune != nil {
 		tune(cfg)
 	}
-	m, err = NewManager(cfg)
+	autoPreview := cfg.PreviewListenAddr == autoPreviewListenAddr
+
+	var closeHTTP func() error
+	startHTTP := func(attemptCfg *config.Config, requirePreview bool) error {
+		candidate, err := NewManager(attemptCfg)
+		if err != nil {
+			return err
+		}
+		closeCandidate, err := startHTTPServer(candidate, newTaskScheduler(), nil)
+		if err != nil {
+			return err
+		}
+		if requirePreview && !candidate.lifecycle.snapshot().listeners.PreviewBound {
+			if closeErr := closeCandidate(); closeErr != nil {
+				return fmt.Errorf("%w (and closing the failed attempt: %v)",
+					errPreviewFixtureListenerUnbound, closeErr)
+			}
+			return errPreviewFixtureListenerUnbound
+		}
+		m = candidate
+		closeHTTP = closeCandidate
+		return nil
+	}
+
+	if autoPreview {
+		err = retryPreviewFixtureBind(previewFixtureBindAttempts, func() error {
+			addr, acquireErr := freeLoopbackAddr()
+			if acquireErr != nil {
+				return acquireErr
+			}
+			attemptCfg := *cfg
+			attemptCfg.PreviewListenAddr = addr
+			return startHTTP(&attemptCfg, true)
+		})
+	} else {
+		err = startHTTP(cfg, false)
+	}
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, closeHTTP()) })
 
 	const title = "previeworigin"
 	inst := startedLocalTabInstance(t, m, repo.ID, repoPath, title, "af_"+title+"_agent")
@@ -152,10 +192,6 @@ func newPreviewDaemonWithTabs(t *testing.T, tune func(*config.Config), targets .
 		require.NotEmpty(t, tabs[i+1].ID, "the preview origin is derived from the tab's STABLE id")
 		tabIDs = append(tabIDs, tabs[i+1].ID)
 	}
-
-	closeHTTP, err := startHTTPServer(m, newTaskScheduler(), nil)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, closeHTTP()) })
 
 	// Deliberately NOT asserting PreviewBound here: the withhold tests tune the
 	// config so the listener is disabled or its bind fails, and they need a REAL tab


### PR DESCRIPTION
## Summary

- fix the shared `newPreviewDaemonWithTabs` acquisition path used by the concrete-origin test family
- retry the complete reserve-and-bind cycle up to four times when the helper-generated address loses its port race
- keep caller-supplied disabled, occupied, or network listener configurations one-shot
- deterministically cover transient recovery and bounded give-up with an injected bind

## Verification

- Fail first: [Linux PR CI on `0f3a2fb4`](https://github.com/sachiniyer/agent-factory/actions/runs/31351237388/job/93342338727) failed both injected tests against the historical one-shot path
- `gofmt -l .`
- `go build ./...`
- `golangci-lint run --timeout=3m --fast`
- `scripts/lint-file-length.sh`
- No host-side `go test`: the changed package is `daemon`; isolated PR CI covers it

Closes #3157